### PR TITLE
[api] Reduce code duplication in protobuf dump methods with helper functions

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -67,7 +67,7 @@ static void dump_field(std::string &out, const char *field_name, float value, in
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%llu", value);
+  snprintf(buffer, 64, "%" PRIu64, value);
   append_with_newline(out, buffer);
 }
 

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -64,13 +64,6 @@ static void dump_field(std::string &out, const char *field_name, float value, in
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
-  char buffer[64];
-  append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%g", value);
-  append_with_newline(out, buffer);
-}
-
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -19,6 +19,71 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
   out.append("'");
 }
 
+// Helper functions to reduce code duplication in dump methods
+static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%" PRId32, value);
+  out.append(buffer);
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%" PRIu32, value);
+  out.append(buffer);
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%g", value);
+  out.append(buffer);
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%g", value);
+  out.append(buffer);
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%llu", value);
+  out.append(buffer);
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append(YESNO(value));
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append("'").append(value).append("'");
+  out.append("\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  append_quoted_string(out, value);
+  out.append("\n");
+}
+
+template<typename T> static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append(proto_enum_to_string<T>(value));
+  out.append("\n");
+}
+
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
     case enums::ENTITY_CATEGORY_NONE:
@@ -558,61 +623,25 @@ template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateC
 #endif
 
 void HelloRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("HelloRequest {\n");
-  out.append("  client_info: ");
-  out.append("'").append(this->client_info).append("'");
-  out.append("\n");
+  dump_field(out, "client_info", this->client_info);
+  dump_field(out, "api_version_major", this->api_version_major);
 
-  out.append("  api_version_major: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_major);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  api_version_minor: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_minor);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "api_version_minor", this->api_version_minor);
   out.append("}");
 }
 void HelloResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("HelloResponse {\n");
-  out.append("  api_version_major: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_major);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "api_version_major", this->api_version_major);
 
-  out.append("  api_version_minor: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->api_version_minor);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "api_version_minor", this->api_version_minor);
 
-  out.append("  server_info: ");
-  append_quoted_string(out, this->server_info_ref_);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
+  dump_field(out, "server_info", this->server_info_ref_);
+  dump_field(out, "name", this->name_ref_);
   out.append("}");
 }
-void ConnectRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("ConnectRequest {\n");
-  out.append("  password: ");
-  out.append("'").append(this->password).append("'");
-  out.append("\n");
-  out.append("}");
-}
-void ConnectResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("ConnectResponse {\n");
-  out.append("  invalid_password: ");
-  out.append(YESNO(this->invalid_password));
-  out.append("\n");
-  out.append("}");
-}
+void ConnectRequest::dump_to(std::string &out) const { dump_field(out, "password", this->password); }
+void ConnectResponse::dump_to(std::string &out) const { dump_field(out, "invalid_password", this->invalid_password); }
 void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
 void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
 void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
@@ -620,131 +649,66 @@ void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}
 void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
 #ifdef USE_AREAS
 void AreaInfo::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("AreaInfo {\n");
-  out.append("  area_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->area_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "area_id", this->area_id);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
   out.append("}");
 }
 #endif
 #ifdef USE_DEVICES
 void DeviceInfo::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DeviceInfo {\n");
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  area_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->area_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "area_id", this->area_id);
   out.append("}");
 }
 #endif
 void DeviceInfoResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DeviceInfoResponse {\n");
 #ifdef USE_API_PASSWORD
-  out.append("  uses_password: ");
-  out.append(YESNO(this->uses_password));
-  out.append("\n");
+  dump_field(out, "uses_password", this->uses_password);
 
 #endif
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  mac_address: ");
-  append_quoted_string(out, this->mac_address_ref_);
-  out.append("\n");
-
-  out.append("  esphome_version: ");
-  append_quoted_string(out, this->esphome_version_ref_);
-  out.append("\n");
-
-  out.append("  compilation_time: ");
-  append_quoted_string(out, this->compilation_time_ref_);
-  out.append("\n");
-
-  out.append("  model: ");
-  append_quoted_string(out, this->model_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "mac_address", this->mac_address_ref_);
+  dump_field(out, "esphome_version", this->esphome_version_ref_);
+  dump_field(out, "compilation_time", this->compilation_time_ref_);
+  dump_field(out, "model", this->model_ref_);
 #ifdef USE_DEEP_SLEEP
-  out.append("  has_deep_sleep: ");
-  out.append(YESNO(this->has_deep_sleep));
-  out.append("\n");
+  dump_field(out, "has_deep_sleep", this->has_deep_sleep);
 
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  out.append("  project_name: ");
-  append_quoted_string(out, this->project_name_ref_);
-  out.append("\n");
-
+  dump_field(out, "project_name", this->project_name_ref_);
 #endif
 #ifdef ESPHOME_PROJECT_NAME
-  out.append("  project_version: ");
-  append_quoted_string(out, this->project_version_ref_);
-  out.append("\n");
-
+  dump_field(out, "project_version", this->project_version_ref_);
 #endif
 #ifdef USE_WEBSERVER
-  out.append("  webserver_port: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->webserver_port);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "webserver_port", this->webserver_port);
 
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  out.append("  bluetooth_proxy_feature_flags: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->bluetooth_proxy_feature_flags);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "bluetooth_proxy_feature_flags", this->bluetooth_proxy_feature_flags);
 
 #endif
-  out.append("  manufacturer: ");
-  append_quoted_string(out, this->manufacturer_ref_);
-  out.append("\n");
-
-  out.append("  friendly_name: ");
-  append_quoted_string(out, this->friendly_name_ref_);
-  out.append("\n");
-
+  dump_field(out, "manufacturer", this->manufacturer_ref_);
+  dump_field(out, "friendly_name", this->friendly_name_ref_);
 #ifdef USE_VOICE_ASSISTANT
-  out.append("  voice_assistant_feature_flags: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->voice_assistant_feature_flags);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "voice_assistant_feature_flags", this->voice_assistant_feature_flags);
 
 #endif
 #ifdef USE_AREAS
-  out.append("  suggested_area: ");
-  append_quoted_string(out, this->suggested_area_ref_);
-  out.append("\n");
-
+  dump_field(out, "suggested_area", this->suggested_area_ref_);
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-  out.append("  bluetooth_mac_address: ");
-  append_quoted_string(out, this->bluetooth_mac_address_ref_);
-  out.append("\n");
-
+  dump_field(out, "bluetooth_mac_address", this->bluetooth_mac_address_ref_);
 #endif
 #ifdef USE_API_NOISE
-  out.append("  api_encryption_supported: ");
-  out.append(YESNO(this->api_encryption_supported));
-  out.append("\n");
+  dump_field(out, "api_encryption_supported", this->api_encryption_supported);
 
 #endif
 #ifdef USE_DEVICES
@@ -776,73 +740,37 @@ void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("Lis
 void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesBinarySensorResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "device_class", this->device_class_ref_);
+  dump_field(out, "is_status_binary_sensor", this->is_status_binary_sensor);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
-  out.append("  is_status_binary_sensor: ");
-  out.append(YESNO(this->is_status_binary_sensor));
-  out.append("\n");
-
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void BinarySensorStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BinarySensorStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -850,130 +778,65 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCoverResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "assumed_state", this->assumed_state);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
+  dump_field(out, "supports_position", this->supports_position);
 
-  out.append("  assumed_state: ");
-  out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  dump_field(out, "supports_tilt", this->supports_tilt);
 
-  out.append("  supports_position: ");
-  out.append(YESNO(this->supports_position));
-  out.append("\n");
-
-  out.append("  supports_tilt: ");
-  out.append(YESNO(this->supports_tilt));
-  out.append("\n");
-
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "device_class", this->device_class_ref_);
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  supports_stop: ");
-  out.append(YESNO(this->supports_stop));
-  out.append("\n");
+  dump_field(out, "supports_stop", this->supports_stop);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void CoverStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("CoverStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  position: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->position);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "position", this->position);
 
-  out.append("  tilt: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->tilt);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "tilt", this->tilt);
 
-  out.append("  current_operation: ");
-  out.append(proto_enum_to_string<enums::CoverOperation>(this->current_operation));
-  out.append("\n");
+  dump_field(out, "current_operation", static_cast<enums::CoverOperation>(this->current_operation));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void CoverCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("CoverCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_position: ");
-  out.append(YESNO(this->has_position));
-  out.append("\n");
+  dump_field(out, "has_position", this->has_position);
 
-  out.append("  position: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->position);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "position", this->position);
 
-  out.append("  has_tilt: ");
-  out.append(YESNO(this->has_tilt));
-  out.append("\n");
+  dump_field(out, "has_tilt", this->has_tilt);
 
-  out.append("  tilt: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->tilt);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "tilt", this->tilt);
 
-  out.append("  stop: ");
-  out.append(YESNO(this->stop));
-  out.append("\n");
+  dump_field(out, "stop", this->stop);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -981,159 +844,80 @@ void CoverCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesFanResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "supports_oscillation", this->supports_oscillation);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
+  dump_field(out, "supports_speed", this->supports_speed);
 
-  out.append("  supports_oscillation: ");
-  out.append(YESNO(this->supports_oscillation));
-  out.append("\n");
+  dump_field(out, "supports_direction", this->supports_direction);
 
-  out.append("  supports_speed: ");
-  out.append(YESNO(this->supports_speed));
-  out.append("\n");
+  dump_field(out, "supported_speed_count", this->supported_speed_count);
 
-  out.append("  supports_direction: ");
-  out.append(YESNO(this->supports_direction));
-  out.append("\n");
-
-  out.append("  supported_speed_count: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->supported_speed_count);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
   for (const auto &it : this->supported_preset_modes) {
-    out.append("  supported_preset_modes: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "supported_preset_modes", it, 4);
   }
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void FanStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("FanStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  oscillating: ");
-  out.append(YESNO(this->oscillating));
-  out.append("\n");
+  dump_field(out, "oscillating", this->oscillating);
 
-  out.append("  direction: ");
-  out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
-  out.append("\n");
+  dump_field(out, "direction", static_cast<enums::FanDirection>(this->direction));
 
-  out.append("  speed_level: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->speed_level);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "speed_level", this->speed_level);
 
-  out.append("  preset_mode: ");
-  append_quoted_string(out, this->preset_mode_ref_);
-  out.append("\n");
-
+  dump_field(out, "preset_mode", this->preset_mode_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void FanCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("FanCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_state: ");
-  out.append(YESNO(this->has_state));
-  out.append("\n");
+  dump_field(out, "has_state", this->has_state);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  has_oscillating: ");
-  out.append(YESNO(this->has_oscillating));
-  out.append("\n");
+  dump_field(out, "has_oscillating", this->has_oscillating);
 
-  out.append("  oscillating: ");
-  out.append(YESNO(this->oscillating));
-  out.append("\n");
+  dump_field(out, "oscillating", this->oscillating);
 
-  out.append("  has_direction: ");
-  out.append(YESNO(this->has_direction));
-  out.append("\n");
+  dump_field(out, "has_direction", this->has_direction);
 
-  out.append("  direction: ");
-  out.append(proto_enum_to_string<enums::FanDirection>(this->direction));
-  out.append("\n");
+  dump_field(out, "direction", static_cast<enums::FanDirection>(this->direction));
 
-  out.append("  has_speed_level: ");
-  out.append(YESNO(this->has_speed_level));
-  out.append("\n");
+  dump_field(out, "has_speed_level", this->has_speed_level);
 
-  out.append("  speed_level: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->speed_level);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "speed_level", this->speed_level);
 
-  out.append("  has_preset_mode: ");
-  out.append(YESNO(this->has_preset_mode));
-  out.append("\n");
+  dump_field(out, "has_preset_mode", this->has_preset_mode);
 
-  out.append("  preset_mode: ");
-  out.append("'").append(this->preset_mode).append("'");
-  out.append("\n");
-
+  dump_field(out, "preset_mode", this->preset_mode);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -1141,268 +925,126 @@ void FanCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLightResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
   for (const auto &it : this->supported_color_modes) {
-    out.append("  supported_color_modes: ");
-    out.append(proto_enum_to_string<enums::ColorMode>(it));
-    out.append("\n");
+    dump_field(out, "supported_color_modes", static_cast<enums::ColorMode>(it), 4);
   }
 
-  out.append("  min_mireds: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->min_mireds);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "min_mireds", this->min_mireds);
 
-  out.append("  max_mireds: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->max_mireds);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "max_mireds", this->max_mireds);
 
   for (const auto &it : this->effects) {
-    out.append("  effects: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "effects", it, 4);
   }
 
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void LightStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("LightStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  brightness: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->brightness);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "brightness", this->brightness);
 
-  out.append("  color_mode: ");
-  out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
-  out.append("\n");
+  dump_field(out, "color_mode", static_cast<enums::ColorMode>(this->color_mode));
 
-  out.append("  color_brightness: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->color_brightness);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "color_brightness", this->color_brightness);
 
-  out.append("  red: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->red);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "red", this->red);
 
-  out.append("  green: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->green);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "green", this->green);
 
-  out.append("  blue: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->blue);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "blue", this->blue);
 
-  out.append("  white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "white", this->white);
 
-  out.append("  color_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->color_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "color_temperature", this->color_temperature);
 
-  out.append("  cold_white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->cold_white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "cold_white", this->cold_white);
 
-  out.append("  warm_white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->warm_white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "warm_white", this->warm_white);
 
-  out.append("  effect: ");
-  append_quoted_string(out, this->effect_ref_);
-  out.append("\n");
-
+  dump_field(out, "effect", this->effect_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void LightCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("LightCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_state: ");
-  out.append(YESNO(this->has_state));
-  out.append("\n");
+  dump_field(out, "has_state", this->has_state);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  has_brightness: ");
-  out.append(YESNO(this->has_brightness));
-  out.append("\n");
+  dump_field(out, "has_brightness", this->has_brightness);
 
-  out.append("  brightness: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->brightness);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "brightness", this->brightness);
 
-  out.append("  has_color_mode: ");
-  out.append(YESNO(this->has_color_mode));
-  out.append("\n");
+  dump_field(out, "has_color_mode", this->has_color_mode);
 
-  out.append("  color_mode: ");
-  out.append(proto_enum_to_string<enums::ColorMode>(this->color_mode));
-  out.append("\n");
+  dump_field(out, "color_mode", static_cast<enums::ColorMode>(this->color_mode));
 
-  out.append("  has_color_brightness: ");
-  out.append(YESNO(this->has_color_brightness));
-  out.append("\n");
+  dump_field(out, "has_color_brightness", this->has_color_brightness);
 
-  out.append("  color_brightness: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->color_brightness);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "color_brightness", this->color_brightness);
 
-  out.append("  has_rgb: ");
-  out.append(YESNO(this->has_rgb));
-  out.append("\n");
+  dump_field(out, "has_rgb", this->has_rgb);
 
-  out.append("  red: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->red);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "red", this->red);
 
-  out.append("  green: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->green);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "green", this->green);
 
-  out.append("  blue: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->blue);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "blue", this->blue);
 
-  out.append("  has_white: ");
-  out.append(YESNO(this->has_white));
-  out.append("\n");
+  dump_field(out, "has_white", this->has_white);
 
-  out.append("  white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "white", this->white);
 
-  out.append("  has_color_temperature: ");
-  out.append(YESNO(this->has_color_temperature));
-  out.append("\n");
+  dump_field(out, "has_color_temperature", this->has_color_temperature);
 
-  out.append("  color_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->color_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "color_temperature", this->color_temperature);
 
-  out.append("  has_cold_white: ");
-  out.append(YESNO(this->has_cold_white));
-  out.append("\n");
+  dump_field(out, "has_cold_white", this->has_cold_white);
 
-  out.append("  cold_white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->cold_white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "cold_white", this->cold_white);
 
-  out.append("  has_warm_white: ");
-  out.append(YESNO(this->has_warm_white));
-  out.append("\n");
+  dump_field(out, "has_warm_white", this->has_warm_white);
 
-  out.append("  warm_white: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->warm_white);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "warm_white", this->warm_white);
 
-  out.append("  has_transition_length: ");
-  out.append(YESNO(this->has_transition_length));
-  out.append("\n");
+  dump_field(out, "has_transition_length", this->has_transition_length);
 
-  out.append("  transition_length: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->transition_length);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "transition_length", this->transition_length);
 
-  out.append("  has_flash_length: ");
-  out.append(YESNO(this->has_flash_length));
-  out.append("\n");
+  dump_field(out, "has_flash_length", this->has_flash_length);
 
-  out.append("  flash_length: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flash_length);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "flash_length", this->flash_length);
 
-  out.append("  has_effect: ");
-  out.append(YESNO(this->has_effect));
-  out.append("\n");
+  dump_field(out, "has_effect", this->has_effect);
 
-  out.append("  effect: ");
-  out.append("'").append(this->effect).append("'");
-  out.append("\n");
-
+  dump_field(out, "effect", this->effect);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -1410,87 +1052,42 @@ void LightCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSensorResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  unit_of_measurement: ");
-  append_quoted_string(out, this->unit_of_measurement_ref_);
-  out.append("\n");
+  dump_field(out, "unit_of_measurement", this->unit_of_measurement_ref_);
+  dump_field(out, "accuracy_decimals", this->accuracy_decimals);
 
-  out.append("  accuracy_decimals: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->accuracy_decimals);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "force_update", this->force_update);
 
-  out.append("  force_update: ");
-  out.append(YESNO(this->force_update));
-  out.append("\n");
+  dump_field(out, "device_class", this->device_class_ref_);
+  dump_field(out, "state_class", static_cast<enums::SensorStateClass>(this->state_class));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  state_class: ");
-  out.append(proto_enum_to_string<enums::SensorStateClass>(this->state_class));
-  out.append("\n");
-
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
-
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SensorStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SensorStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->state);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -1498,90 +1095,47 @@ void SensorStateResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSwitchResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  assumed_state: ");
-  out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  dump_field(out, "assumed_state", this->assumed_state);
 
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SwitchStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SwitchStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SwitchCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SwitchCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -1589,92 +1143,49 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextSensorResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void TextSensorStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("TextSensorStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  append_quoted_string(out, this->state_ref_);
-  out.append("\n");
-
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "state", this->state_ref_);
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 #endif
 void SubscribeLogsRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SubscribeLogsRequest {\n");
-  out.append("  level: ");
-  out.append(proto_enum_to_string<enums::LogLevel>(this->level));
-  out.append("\n");
+  dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
 
-  out.append("  dump_config: ");
-  out.append(YESNO(this->dump_config));
-  out.append("\n");
+  dump_field(out, "dump_config", this->dump_config);
   out.append("}");
 }
 void SubscribeLogsResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SubscribeLogsResponse {\n");
-  out.append("  level: ");
-  out.append(proto_enum_to_string<enums::LogLevel>(this->level));
-  out.append("\n");
+  dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
 
   out.append("  message: ");
   out.append(format_hex_pretty(this->message_ptr_, this->message_len_));
@@ -1683,44 +1194,26 @@ void SubscribeLogsResponse::dump_to(std::string &out) const {
 }
 #ifdef USE_API_NOISE
 void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("NoiseEncryptionSetKeyRequest {\n");
   out.append("  key: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->key.data()), this->key.size()));
   out.append("\n");
   out.append("}");
 }
-void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("NoiseEncryptionSetKeyResponse {\n");
-  out.append("  success: ");
-  out.append(YESNO(this->success));
-  out.append("\n");
-  out.append("}");
-}
+void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const { dump_field(out, "success", this->success); }
 #endif
 void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
 }
 void HomeassistantServiceMap::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceMap {\n");
-  out.append("  key: ");
-  append_quoted_string(out, this->key_ref_);
-  out.append("\n");
-
-  out.append("  value: ");
-  append_quoted_string(out, this->value_ref_);
-  out.append("\n");
+  dump_field(out, "key", this->key_ref_);
+  dump_field(out, "value", this->value_ref_);
   out.append("}");
 }
 void HomeassistantServiceResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("HomeassistantServiceResponse {\n");
-  out.append("  service: ");
-  append_quoted_string(out, this->service_ref_);
-  out.append("\n");
-
+  dump_field(out, "service", this->service_ref_);
   for (const auto &it : this->data) {
     out.append("  data: ");
     it.dump_to(out);
@@ -1739,80 +1232,39 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
     out.append("\n");
   }
 
-  out.append("  is_event: ");
-  out.append(YESNO(this->is_event));
-  out.append("\n");
+  dump_field(out, "is_event", this->is_event);
   out.append("}");
 }
 void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
 }
 void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SubscribeHomeAssistantStateResponse {\n");
-  out.append("  entity_id: ");
-  append_quoted_string(out, this->entity_id_ref_);
-  out.append("\n");
-
-  out.append("  attribute: ");
-  append_quoted_string(out, this->attribute_ref_);
-  out.append("\n");
-
-  out.append("  once: ");
-  out.append(YESNO(this->once));
-  out.append("\n");
+  dump_field(out, "entity_id", this->entity_id_ref_);
+  dump_field(out, "attribute", this->attribute_ref_);
+  dump_field(out, "once", this->once);
   out.append("}");
 }
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("HomeAssistantStateResponse {\n");
-  out.append("  entity_id: ");
-  out.append("'").append(this->entity_id).append("'");
-  out.append("\n");
-
-  out.append("  state: ");
-  out.append("'").append(this->state).append("'");
-  out.append("\n");
-
-  out.append("  attribute: ");
-  out.append("'").append(this->attribute).append("'");
-  out.append("\n");
+  dump_field(out, "entity_id", this->entity_id);
+  dump_field(out, "state", this->state);
+  dump_field(out, "attribute", this->attribute);
   out.append("}");
 }
 void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
-void GetTimeResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("GetTimeResponse {\n");
-  out.append("  epoch_seconds: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
-  out.append(buffer);
-  out.append("\n");
-  out.append("}");
-}
+void GetTimeResponse::dump_to(std::string &out) const { dump_field(out, "epoch_seconds", this->epoch_seconds); }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesArgument {\n");
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  type: ");
-  out.append(proto_enum_to_string<enums::ServiceArgType>(this->type));
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "type", static_cast<enums::ServiceArgType>(this->type));
   out.append("}");
 }
 void ListEntitiesServicesResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesServicesResponse {\n");
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "key", this->key);
 
   for (const auto &it : this->args) {
     out.append("  args: ");
@@ -1822,65 +1274,36 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 void ExecuteServiceArgument::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ExecuteServiceArgument {\n");
-  out.append("  bool_: ");
-  out.append(YESNO(this->bool_));
-  out.append("\n");
+  dump_field(out, "bool_", this->bool_);
 
-  out.append("  legacy_int: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->legacy_int);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "legacy_int", this->legacy_int);
 
-  out.append("  float_: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->float_);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "float_", this->float_);
 
-  out.append("  string_: ");
-  out.append("'").append(this->string_).append("'");
-  out.append("\n");
-
-  out.append("  int_: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->int_);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "string_", this->string_);
+  dump_field(out, "int_", this->int_);
 
   for (const auto it : this->bool_array) {
-    out.append("  bool_array: ");
-    out.append(YESNO(it));
-    out.append("\n");
+    dump_field(out, "bool_array", it, 4);
   }
 
   for (const auto &it : this->int_array) {
-    out.append("  int_array: ");
-    snprintf(buffer, sizeof(buffer), "%" PRId32, it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "int_array", it, 4);
   }
 
   for (const auto &it : this->float_array) {
-    out.append("  float_array: ");
-    snprintf(buffer, sizeof(buffer), "%g", it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "float_array", it, 4);
   }
 
   for (const auto &it : this->string_array) {
-    out.append("  string_array: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "string_array", it, 4);
   }
   out.append("}");
 }
 void ExecuteServiceRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ExecuteServiceRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
   for (const auto &it : this->args) {
     out.append("  args: ");
@@ -1892,380 +1315,192 @@ void ExecuteServiceRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesCameraResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void CameraImageResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("CameraImageResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
 
-  out.append("  done: ");
-  out.append(YESNO(this->done));
-  out.append("\n");
+  dump_field(out, "done", this->done);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void CameraImageRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("CameraImageRequest {\n");
-  out.append("  single: ");
-  out.append(YESNO(this->single));
-  out.append("\n");
+  dump_field(out, "single", this->single);
 
-  out.append("  stream: ");
-  out.append(YESNO(this->stream));
-  out.append("\n");
+  dump_field(out, "stream", this->stream);
   out.append("}");
 }
 #endif
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesClimateResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "name", this->name_ref_);
+  dump_field(out, "supports_current_temperature", this->supports_current_temperature);
 
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
-  out.append("  supports_current_temperature: ");
-  out.append(YESNO(this->supports_current_temperature));
-  out.append("\n");
-
-  out.append("  supports_two_point_target_temperature: ");
-  out.append(YESNO(this->supports_two_point_target_temperature));
-  out.append("\n");
+  dump_field(out, "supports_two_point_target_temperature", this->supports_two_point_target_temperature);
 
   for (const auto &it : this->supported_modes) {
-    out.append("  supported_modes: ");
-    out.append(proto_enum_to_string<enums::ClimateMode>(it));
-    out.append("\n");
+    dump_field(out, "supported_modes", static_cast<enums::ClimateMode>(it), 4);
   }
 
-  out.append("  visual_min_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_min_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_min_temperature", this->visual_min_temperature);
 
-  out.append("  visual_max_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_max_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_max_temperature", this->visual_max_temperature);
 
-  out.append("  visual_target_temperature_step: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_target_temperature_step);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_target_temperature_step", this->visual_target_temperature_step);
 
-  out.append("  supports_action: ");
-  out.append(YESNO(this->supports_action));
-  out.append("\n");
+  dump_field(out, "supports_action", this->supports_action);
 
   for (const auto &it : this->supported_fan_modes) {
-    out.append("  supported_fan_modes: ");
-    out.append(proto_enum_to_string<enums::ClimateFanMode>(it));
-    out.append("\n");
+    dump_field(out, "supported_fan_modes", static_cast<enums::ClimateFanMode>(it), 4);
   }
 
   for (const auto &it : this->supported_swing_modes) {
-    out.append("  supported_swing_modes: ");
-    out.append(proto_enum_to_string<enums::ClimateSwingMode>(it));
-    out.append("\n");
+    dump_field(out, "supported_swing_modes", static_cast<enums::ClimateSwingMode>(it), 4);
   }
 
   for (const auto &it : this->supported_custom_fan_modes) {
-    out.append("  supported_custom_fan_modes: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "supported_custom_fan_modes", it, 4);
   }
 
   for (const auto &it : this->supported_presets) {
-    out.append("  supported_presets: ");
-    out.append(proto_enum_to_string<enums::ClimatePreset>(it));
-    out.append("\n");
+    dump_field(out, "supported_presets", static_cast<enums::ClimatePreset>(it), 4);
   }
 
   for (const auto &it : this->supported_custom_presets) {
-    out.append("  supported_custom_presets: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "supported_custom_presets", it, 4);
   }
 
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  visual_current_temperature_step: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_current_temperature_step);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_current_temperature_step", this->visual_current_temperature_step);
 
-  out.append("  supports_current_humidity: ");
-  out.append(YESNO(this->supports_current_humidity));
-  out.append("\n");
+  dump_field(out, "supports_current_humidity", this->supports_current_humidity);
 
-  out.append("  supports_target_humidity: ");
-  out.append(YESNO(this->supports_target_humidity));
-  out.append("\n");
+  dump_field(out, "supports_target_humidity", this->supports_target_humidity);
 
-  out.append("  visual_min_humidity: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_min_humidity);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_min_humidity", this->visual_min_humidity);
 
-  out.append("  visual_max_humidity: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->visual_max_humidity);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "visual_max_humidity", this->visual_max_humidity);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void ClimateStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ClimateStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
-  out.append("\n");
+  dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
 
-  out.append("  current_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->current_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "current_temperature", this->current_temperature);
 
-  out.append("  target_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature", this->target_temperature);
 
-  out.append("  target_temperature_low: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_low);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature_low", this->target_temperature_low);
 
-  out.append("  target_temperature_high: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_high);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature_high", this->target_temperature_high);
 
-  out.append("  action: ");
-  out.append(proto_enum_to_string<enums::ClimateAction>(this->action));
-  out.append("\n");
+  dump_field(out, "action", static_cast<enums::ClimateAction>(this->action));
 
-  out.append("  fan_mode: ");
-  out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
-  out.append("\n");
+  dump_field(out, "fan_mode", static_cast<enums::ClimateFanMode>(this->fan_mode));
 
-  out.append("  swing_mode: ");
-  out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
-  out.append("\n");
+  dump_field(out, "swing_mode", static_cast<enums::ClimateSwingMode>(this->swing_mode));
 
-  out.append("  custom_fan_mode: ");
-  append_quoted_string(out, this->custom_fan_mode_ref_);
-  out.append("\n");
+  dump_field(out, "custom_fan_mode", this->custom_fan_mode_ref_);
+  dump_field(out, "preset", static_cast<enums::ClimatePreset>(this->preset));
 
-  out.append("  preset: ");
-  out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
-  out.append("\n");
+  dump_field(out, "custom_preset", this->custom_preset_ref_);
+  dump_field(out, "current_humidity", this->current_humidity);
 
-  out.append("  custom_preset: ");
-  append_quoted_string(out, this->custom_preset_ref_);
-  out.append("\n");
-
-  out.append("  current_humidity: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->current_humidity);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  target_humidity: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_humidity);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_humidity", this->target_humidity);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void ClimateCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ClimateCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_mode: ");
-  out.append(YESNO(this->has_mode));
-  out.append("\n");
+  dump_field(out, "has_mode", this->has_mode);
 
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::ClimateMode>(this->mode));
-  out.append("\n");
+  dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
 
-  out.append("  has_target_temperature: ");
-  out.append(YESNO(this->has_target_temperature));
-  out.append("\n");
+  dump_field(out, "has_target_temperature", this->has_target_temperature);
 
-  out.append("  target_temperature: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature", this->target_temperature);
 
-  out.append("  has_target_temperature_low: ");
-  out.append(YESNO(this->has_target_temperature_low));
-  out.append("\n");
+  dump_field(out, "has_target_temperature_low", this->has_target_temperature_low);
 
-  out.append("  target_temperature_low: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_low);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature_low", this->target_temperature_low);
 
-  out.append("  has_target_temperature_high: ");
-  out.append(YESNO(this->has_target_temperature_high));
-  out.append("\n");
+  dump_field(out, "has_target_temperature_high", this->has_target_temperature_high);
 
-  out.append("  target_temperature_high: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_temperature_high);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_temperature_high", this->target_temperature_high);
 
-  out.append("  has_fan_mode: ");
-  out.append(YESNO(this->has_fan_mode));
-  out.append("\n");
+  dump_field(out, "has_fan_mode", this->has_fan_mode);
 
-  out.append("  fan_mode: ");
-  out.append(proto_enum_to_string<enums::ClimateFanMode>(this->fan_mode));
-  out.append("\n");
+  dump_field(out, "fan_mode", static_cast<enums::ClimateFanMode>(this->fan_mode));
 
-  out.append("  has_swing_mode: ");
-  out.append(YESNO(this->has_swing_mode));
-  out.append("\n");
+  dump_field(out, "has_swing_mode", this->has_swing_mode);
 
-  out.append("  swing_mode: ");
-  out.append(proto_enum_to_string<enums::ClimateSwingMode>(this->swing_mode));
-  out.append("\n");
+  dump_field(out, "swing_mode", static_cast<enums::ClimateSwingMode>(this->swing_mode));
 
-  out.append("  has_custom_fan_mode: ");
-  out.append(YESNO(this->has_custom_fan_mode));
-  out.append("\n");
+  dump_field(out, "has_custom_fan_mode", this->has_custom_fan_mode);
 
-  out.append("  custom_fan_mode: ");
-  out.append("'").append(this->custom_fan_mode).append("'");
-  out.append("\n");
+  dump_field(out, "custom_fan_mode", this->custom_fan_mode);
+  dump_field(out, "has_preset", this->has_preset);
 
-  out.append("  has_preset: ");
-  out.append(YESNO(this->has_preset));
-  out.append("\n");
+  dump_field(out, "preset", static_cast<enums::ClimatePreset>(this->preset));
 
-  out.append("  preset: ");
-  out.append(proto_enum_to_string<enums::ClimatePreset>(this->preset));
-  out.append("\n");
+  dump_field(out, "has_custom_preset", this->has_custom_preset);
 
-  out.append("  has_custom_preset: ");
-  out.append(YESNO(this->has_custom_preset));
-  out.append("\n");
+  dump_field(out, "custom_preset", this->custom_preset);
+  dump_field(out, "has_target_humidity", this->has_target_humidity);
 
-  out.append("  custom_preset: ");
-  out.append("'").append(this->custom_preset).append("'");
-  out.append("\n");
-
-  out.append("  has_target_humidity: ");
-  out.append(YESNO(this->has_target_humidity));
-  out.append("\n");
-
-  out.append("  target_humidity: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->target_humidity);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "target_humidity", this->target_humidity);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2273,115 +1508,56 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesNumberResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  min_value: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->min_value);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "min_value", this->min_value);
 
-  out.append("  max_value: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->max_value);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "max_value", this->max_value);
 
-  out.append("  step: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->step);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "step", this->step);
 
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  unit_of_measurement: ");
-  append_quoted_string(out, this->unit_of_measurement_ref_);
-  out.append("\n");
+  dump_field(out, "unit_of_measurement", this->unit_of_measurement_ref_);
+  dump_field(out, "mode", static_cast<enums::NumberMode>(this->mode));
 
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::NumberMode>(this->mode));
-  out.append("\n");
-
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void NumberStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("NumberStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->state);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void NumberCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("NumberCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->state);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2389,92 +1565,48 @@ void NumberCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSelectResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
   for (const auto &it : this->options) {
-    out.append("  options: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "options", it, 4);
   }
 
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SelectStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SelectStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  append_quoted_string(out, this->state_ref_);
-  out.append("\n");
-
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "state", this->state_ref_);
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SelectCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SelectCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append("'").append(this->state).append("'");
-  out.append("\n");
-
+  dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2482,126 +1614,65 @@ void SelectCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesSirenResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
   for (const auto &it : this->tones) {
-    out.append("  tones: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "tones", it, 4);
   }
 
-  out.append("  supports_duration: ");
-  out.append(YESNO(this->supports_duration));
-  out.append("\n");
+  dump_field(out, "supports_duration", this->supports_duration);
 
-  out.append("  supports_volume: ");
-  out.append(YESNO(this->supports_volume));
-  out.append("\n");
+  dump_field(out, "supports_volume", this->supports_volume);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SirenStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SirenStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void SirenCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SirenCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_state: ");
-  out.append(YESNO(this->has_state));
-  out.append("\n");
+  dump_field(out, "has_state", this->has_state);
 
-  out.append("  state: ");
-  out.append(YESNO(this->state));
-  out.append("\n");
+  dump_field(out, "state", this->state);
 
-  out.append("  has_tone: ");
-  out.append(YESNO(this->has_tone));
-  out.append("\n");
+  dump_field(out, "has_tone", this->has_tone);
 
-  out.append("  tone: ");
-  out.append("'").append(this->tone).append("'");
-  out.append("\n");
+  dump_field(out, "tone", this->tone);
+  dump_field(out, "has_duration", this->has_duration);
 
-  out.append("  has_duration: ");
-  out.append(YESNO(this->has_duration));
-  out.append("\n");
+  dump_field(out, "duration", this->duration);
 
-  out.append("  duration: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->duration);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "has_volume", this->has_volume);
 
-  out.append("  has_volume: ");
-  out.append(YESNO(this->has_volume));
-  out.append("\n");
-
-  out.append("  volume: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->volume);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "volume", this->volume);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2609,106 +1680,54 @@ void SirenCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesLockResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  assumed_state: ");
-  out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  dump_field(out, "assumed_state", this->assumed_state);
 
-  out.append("  supports_open: ");
-  out.append(YESNO(this->supports_open));
-  out.append("\n");
+  dump_field(out, "supports_open", this->supports_open);
 
-  out.append("  requires_code: ");
-  out.append(YESNO(this->requires_code));
-  out.append("\n");
+  dump_field(out, "requires_code", this->requires_code);
 
-  out.append("  code_format: ");
-  append_quoted_string(out, this->code_format_ref_);
-  out.append("\n");
-
+  dump_field(out, "code_format", this->code_format_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void LockStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("LockStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(proto_enum_to_string<enums::LockState>(this->state));
-  out.append("\n");
+  dump_field(out, "state", static_cast<enums::LockState>(this->state));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void LockCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("LockCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  command: ");
-  out.append(proto_enum_to_string<enums::LockCommand>(this->command));
-  out.append("\n");
+  dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
 
-  out.append("  has_code: ");
-  out.append(YESNO(this->has_code));
-  out.append("\n");
+  dump_field(out, "has_code", this->has_code);
 
-  out.append("  code: ");
-  out.append("'").append(this->code).append("'");
-  out.append("\n");
-
+  dump_field(out, "code", this->code);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2716,61 +1735,31 @@ void LockCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesButtonResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void ButtonCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ButtonCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2778,65 +1767,31 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_MEDIA_PLAYER
 void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerSupportedFormat {\n");
-  out.append("  format: ");
-  append_quoted_string(out, this->format_ref_);
-  out.append("\n");
+  dump_field(out, "format", this->format_ref_);
+  dump_field(out, "sample_rate", this->sample_rate);
 
-  out.append("  sample_rate: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->sample_rate);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "num_channels", this->num_channels);
 
-  out.append("  num_channels: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->num_channels);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "purpose", static_cast<enums::MediaPlayerFormatPurpose>(this->purpose));
 
-  out.append("  purpose: ");
-  out.append(proto_enum_to_string<enums::MediaPlayerFormatPurpose>(this->purpose));
-  out.append("\n");
-
-  out.append("  sample_bytes: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->sample_bytes);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "sample_bytes", this->sample_bytes);
   out.append("}");
 }
 void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesMediaPlayerResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  supports_pause: ");
-  out.append(YESNO(this->supports_pause));
-  out.append("\n");
+  dump_field(out, "supports_pause", this->supports_pause);
 
   for (const auto &it : this->supported_formats) {
     out.append("  supported_formats: ");
@@ -2845,90 +1800,48 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   }
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void MediaPlayerStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(proto_enum_to_string<enums::MediaPlayerState>(this->state));
-  out.append("\n");
+  dump_field(out, "state", static_cast<enums::MediaPlayerState>(this->state));
 
-  out.append("  volume: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->volume);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "volume", this->volume);
 
-  out.append("  muted: ");
-  out.append(YESNO(this->muted));
-  out.append("\n");
+  dump_field(out, "muted", this->muted);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void MediaPlayerCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("MediaPlayerCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_command: ");
-  out.append(YESNO(this->has_command));
-  out.append("\n");
+  dump_field(out, "has_command", this->has_command);
 
-  out.append("  command: ");
-  out.append(proto_enum_to_string<enums::MediaPlayerCommand>(this->command));
-  out.append("\n");
+  dump_field(out, "command", static_cast<enums::MediaPlayerCommand>(this->command));
 
-  out.append("  has_volume: ");
-  out.append(YESNO(this->has_volume));
-  out.append("\n");
+  dump_field(out, "has_volume", this->has_volume);
 
-  out.append("  volume: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->volume);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "volume", this->volume);
 
-  out.append("  has_media_url: ");
-  out.append(YESNO(this->has_media_url));
-  out.append("\n");
+  dump_field(out, "has_media_url", this->has_media_url);
 
-  out.append("  media_url: ");
-  out.append("'").append(this->media_url).append("'");
-  out.append("\n");
+  dump_field(out, "media_url", this->media_url);
+  dump_field(out, "has_announcement", this->has_announcement);
 
-  out.append("  has_announcement: ");
-  out.append(YESNO(this->has_announcement));
-  out.append("\n");
-
-  out.append("  announcement: ");
-  out.append(YESNO(this->announcement));
-  out.append("\n");
+  dump_field(out, "announcement", this->announcement);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -2936,31 +1849,17 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SubscribeBluetoothLEAdvertisementsRequest {\n");
-  out.append("  flags: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "flags", this->flags);
   out.append("}");
 }
 void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothLERawAdvertisement {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  rssi: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->rssi);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "rssi", this->rssi);
 
-  out.append("  address_type: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->address_type);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address_type", this->address_type);
 
   out.append("  data: ");
   out.append(format_hex_pretty(this->data, this->data_len));
@@ -2968,7 +1867,6 @@ void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothLERawAdvertisementsResponse {\n");
   for (const auto &it : this->advertisements) {
     out.append("  advertisements: ");
@@ -2978,94 +1876,46 @@ void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothDeviceRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  request_type: ");
-  out.append(proto_enum_to_string<enums::BluetoothDeviceRequestType>(this->request_type));
-  out.append("\n");
+  dump_field(out, "request_type", static_cast<enums::BluetoothDeviceRequestType>(this->request_type));
 
-  out.append("  has_address_type: ");
-  out.append(YESNO(this->has_address_type));
-  out.append("\n");
+  dump_field(out, "has_address_type", this->has_address_type);
 
-  out.append("  address_type: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->address_type);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address_type", this->address_type);
   out.append("}");
 }
 void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceConnectionResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  connected: ");
-  out.append(YESNO(this->connected));
-  out.append("\n");
+  dump_field(out, "connected", this->connected);
 
-  out.append("  mtu: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->mtu);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "mtu", this->mtu);
 
-  out.append("  error: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
-void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("BluetoothGATTGetServicesRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
-  out.append("}");
-}
+void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const { dump_field(out, "address", this->address); }
 void BluetoothGATTDescriptor::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTDescriptor {\n");
   for (const auto &it : this->uuid) {
-    out.append("  uuid: ");
-    snprintf(buffer, sizeof(buffer), "%llu", it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "uuid", it, 4);
   }
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTCharacteristic {\n");
   for (const auto &it : this->uuid) {
-    out.append("  uuid: ");
-    snprintf(buffer, sizeof(buffer), "%llu", it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "uuid", it, 4);
   }
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
-  out.append("  properties: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->properties);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "properties", this->properties);
 
   for (const auto &it : this->descriptors) {
     out.append("  descriptors: ");
@@ -3075,19 +1925,12 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTService::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTService {\n");
   for (const auto &it : this->uuid) {
-    out.append("  uuid: ");
-    snprintf(buffer, sizeof(buffer), "%llu", it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "uuid", it, 4);
   }
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
   for (const auto &it : this->characteristics) {
     out.append("  characteristics: ");
@@ -3097,12 +1940,8 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTGetServicesResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
   for (const auto &it : this->services) {
     out.append("  services: ");
@@ -3112,40 +1951,22 @@ void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTGetServicesDoneResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
   out.append("}");
 }
 void BluetoothGATTReadRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTReadResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
@@ -3153,21 +1974,12 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
-  out.append("  response: ");
-  out.append(YESNO(this->response));
-  out.append("\n");
+  dump_field(out, "response", this->response);
 
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
@@ -3175,31 +1987,17 @@ void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTReadDescriptorRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteDescriptorRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
@@ -3207,35 +2005,19 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   out.append("}");
 }
 void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyRequest {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
-  out.append("  enable: ");
-  out.append(YESNO(this->enable));
-  out.append("\n");
+  dump_field(out, "enable", this->enable);
   out.append("}");
 }
 void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyDataResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
@@ -3246,240 +2028,129 @@ void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
 }
 void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothConnectionsFreeResponse {\n");
-  out.append("  free: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->free);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "free", this->free);
 
-  out.append("  limit: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->limit);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "limit", this->limit);
 
   for (const auto &it : this->allocated) {
-    out.append("  allocated: ");
-    snprintf(buffer, sizeof(buffer), "%llu", it);
-    out.append(buffer);
-    out.append("\n");
+    dump_field(out, "allocated", it, 4);
   }
   out.append("}");
 }
 void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTErrorResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
 
-  out.append("  error: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTWriteResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothGATTNotifyResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  handle: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->handle);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothDevicePairingResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  paired: ");
-  out.append(YESNO(this->paired));
-  out.append("\n");
+  dump_field(out, "paired", this->paired);
 
-  out.append("  error: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceUnpairingResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  success: ");
-  out.append(YESNO(this->success));
-  out.append("\n");
+  dump_field(out, "success", this->success);
 
-  out.append("  error: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
 void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
 }
 void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothDeviceClearCacheResponse {\n");
-  out.append("  address: ");
-  snprintf(buffer, sizeof(buffer), "%llu", this->address);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "address", this->address);
 
-  out.append("  success: ");
-  out.append(YESNO(this->success));
-  out.append("\n");
+  dump_field(out, "success", this->success);
 
-  out.append("  error: ");
-  snprintf(buffer, sizeof(buffer), "%" PRId32, this->error);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothScannerStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothScannerStateResponse {\n");
-  out.append("  state: ");
-  out.append(proto_enum_to_string<enums::BluetoothScannerState>(this->state));
-  out.append("\n");
+  dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
 
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::BluetoothScannerMode>(this->mode));
-  out.append("\n");
+  dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
   out.append("}");
 }
 void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("BluetoothScannerSetModeRequest {\n");
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::BluetoothScannerMode>(this->mode));
-  out.append("\n");
+  dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
   out.append("}");
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("SubscribeVoiceAssistantRequest {\n");
-  out.append("  subscribe: ");
-  out.append(YESNO(this->subscribe));
-  out.append("\n");
+  dump_field(out, "subscribe", this->subscribe);
 
-  out.append("  flags: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "flags", this->flags);
   out.append("}");
 }
 void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantAudioSettings {\n");
-  out.append("  noise_suppression_level: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->noise_suppression_level);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "noise_suppression_level", this->noise_suppression_level);
 
-  out.append("  auto_gain: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->auto_gain);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "auto_gain", this->auto_gain);
 
-  out.append("  volume_multiplier: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->volume_multiplier);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "volume_multiplier", this->volume_multiplier);
   out.append("}");
 }
 void VoiceAssistantRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantRequest {\n");
-  out.append("  start: ");
-  out.append(YESNO(this->start));
-  out.append("\n");
+  dump_field(out, "start", this->start);
 
-  out.append("  conversation_id: ");
-  append_quoted_string(out, this->conversation_id_ref_);
-  out.append("\n");
-
-  out.append("  flags: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->flags);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "conversation_id", this->conversation_id_ref_);
+  dump_field(out, "flags", this->flags);
 
   out.append("  audio_settings: ");
   this->audio_settings.dump_to(out);
   out.append("\n");
 
-  out.append("  wake_word_phrase: ");
-  append_quoted_string(out, this->wake_word_phrase_ref_);
-  out.append("\n");
+  dump_field(out, "wake_word_phrase", this->wake_word_phrase_ref_);
   out.append("}");
 }
 void VoiceAssistantResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantResponse {\n");
-  out.append("  port: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->port);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "port", this->port);
 
-  out.append("  error: ");
-  out.append(YESNO(this->error));
-  out.append("\n");
+  dump_field(out, "error", this->error);
   out.append("}");
 }
 void VoiceAssistantEventData::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantEventData {\n");
-  out.append("  name: ");
-  out.append("'").append(this->name).append("'");
-  out.append("\n");
-
-  out.append("  value: ");
-  out.append("'").append(this->value).append("'");
-  out.append("\n");
+  dump_field(out, "name", this->name);
+  dump_field(out, "value", this->value);
   out.append("}");
 }
 void VoiceAssistantEventResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantEventResponse {\n");
-  out.append("  event_type: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantEvent>(this->event_type));
-  out.append("\n");
+  dump_field(out, "event_type", static_cast<enums::VoiceAssistantEvent>(this->event_type));
 
   for (const auto &it : this->data) {
     out.append("  data: ");
@@ -3489,7 +2160,6 @@ void VoiceAssistantEventResponse::dump_to(std::string &out) const {
   out.append("}");
 }
 void VoiceAssistantAudio::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantAudio {\n");
   out.append("  data: ");
   if (this->data_ptr_ != nullptr) {
@@ -3499,84 +2169,37 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
   }
   out.append("\n");
 
-  out.append("  end: ");
-  out.append(YESNO(this->end));
-  out.append("\n");
+  dump_field(out, "end", this->end);
   out.append("}");
 }
 void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantTimerEventResponse {\n");
-  out.append("  event_type: ");
-  out.append(proto_enum_to_string<enums::VoiceAssistantTimerEvent>(this->event_type));
-  out.append("\n");
+  dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
 
-  out.append("  timer_id: ");
-  out.append("'").append(this->timer_id).append("'");
-  out.append("\n");
+  dump_field(out, "timer_id", this->timer_id);
+  dump_field(out, "name", this->name);
+  dump_field(out, "total_seconds", this->total_seconds);
 
-  out.append("  name: ");
-  out.append("'").append(this->name).append("'");
-  out.append("\n");
+  dump_field(out, "seconds_left", this->seconds_left);
 
-  out.append("  total_seconds: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->total_seconds);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  seconds_left: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->seconds_left);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  is_active: ");
-  out.append(YESNO(this->is_active));
-  out.append("\n");
+  dump_field(out, "is_active", this->is_active);
   out.append("}");
 }
 void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantAnnounceRequest {\n");
-  out.append("  media_id: ");
-  out.append("'").append(this->media_id).append("'");
-  out.append("\n");
-
-  out.append("  text: ");
-  out.append("'").append(this->text).append("'");
-  out.append("\n");
-
-  out.append("  preannounce_media_id: ");
-  out.append("'").append(this->preannounce_media_id).append("'");
-  out.append("\n");
-
-  out.append("  start_conversation: ");
-  out.append(YESNO(this->start_conversation));
-  out.append("\n");
+  dump_field(out, "media_id", this->media_id);
+  dump_field(out, "text", this->text);
+  dump_field(out, "preannounce_media_id", this->preannounce_media_id);
+  dump_field(out, "start_conversation", this->start_conversation);
   out.append("}");
 }
-void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
-  out.append("VoiceAssistantAnnounceFinished {\n");
-  out.append("  success: ");
-  out.append(YESNO(this->success));
-  out.append("\n");
-  out.append("}");
-}
+void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const { dump_field(out, "success", this->success); }
 void VoiceAssistantWakeWord::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantWakeWord {\n");
-  out.append("  id: ");
-  append_quoted_string(out, this->id_ref_);
-  out.append("\n");
-
-  out.append("  wake_word: ");
-  append_quoted_string(out, this->wake_word_ref_);
-  out.append("\n");
-
+  dump_field(out, "id", this->id_ref_);
+  dump_field(out, "wake_word", this->wake_word_ref_);
   for (const auto &it : this->trained_languages) {
-    out.append("  trained_languages: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "trained_languages", it, 4);
   }
   out.append("}");
 }
@@ -3584,7 +2207,6 @@ void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
   out.append("VoiceAssistantConfigurationRequest {}");
 }
 void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantConfigurationResponse {\n");
   for (const auto &it : this->available_wake_words) {
     out.append("  available_wake_words: ");
@@ -3593,123 +2215,67 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
   }
 
   for (const auto &it : this->active_wake_words) {
-    out.append("  active_wake_words: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "active_wake_words", it, 4);
   }
 
-  out.append("  max_active_wake_words: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->max_active_wake_words);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "max_active_wake_words", this->max_active_wake_words);
   out.append("}");
 }
 void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("VoiceAssistantSetConfiguration {\n");
   for (const auto &it : this->active_wake_words) {
-    out.append("  active_wake_words: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "active_wake_words", it, 4);
   }
   out.append("}");
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesAlarmControlPanelResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  supported_features: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->supported_features);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "supported_features", this->supported_features);
 
-  out.append("  requires_code: ");
-  out.append(YESNO(this->requires_code));
-  out.append("\n");
+  dump_field(out, "requires_code", this->requires_code);
 
-  out.append("  requires_code_to_arm: ");
-  out.append(YESNO(this->requires_code_to_arm));
-  out.append("\n");
+  dump_field(out, "requires_code_to_arm", this->requires_code_to_arm);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("AlarmControlPanelStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append(proto_enum_to_string<enums::AlarmControlPanelState>(this->state));
-  out.append("\n");
+  dump_field(out, "state", static_cast<enums::AlarmControlPanelState>(this->state));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("AlarmControlPanelCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  command: ");
-  out.append(proto_enum_to_string<enums::AlarmControlPanelStateCommand>(this->command));
-  out.append("\n");
+  dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
 
-  out.append("  code: ");
-  out.append("'").append(this->code).append("'");
-  out.append("\n");
-
+  dump_field(out, "code", this->code);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -3717,104 +2283,51 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTextResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  min_length: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->min_length);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "min_length", this->min_length);
 
-  out.append("  max_length: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->max_length);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "max_length", this->max_length);
 
-  out.append("  pattern: ");
-  append_quoted_string(out, this->pattern_ref_);
-  out.append("\n");
-
-  out.append("  mode: ");
-  out.append(proto_enum_to_string<enums::TextMode>(this->mode));
-  out.append("\n");
+  dump_field(out, "pattern", this->pattern_ref_);
+  dump_field(out, "mode", static_cast<enums::TextMode>(this->mode));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void TextStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("TextStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  append_quoted_string(out, this->state_ref_);
-  out.append("\n");
-
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "state", this->state_ref_);
+  dump_field(out, "missing_state", this->missing_state);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void TextCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("TextCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  state: ");
-  out.append("'").append(this->state).append("'");
-  out.append("\n");
-
+  dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -3822,108 +2335,54 @@ void TextCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void DateStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DateStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
-  out.append("  year: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->year);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "year", this->year);
 
-  out.append("  month: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->month);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "month", this->month);
 
-  out.append("  day: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->day);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "day", this->day);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void DateCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DateCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  year: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->year);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "year", this->year);
 
-  out.append("  month: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->month);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "month", this->month);
 
-  out.append("  day: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->day);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "day", this->day);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -3931,108 +2390,54 @@ void DateCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesTimeResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void TimeStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("TimeStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
-  out.append("  hour: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->hour);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "hour", this->hour);
 
-  out.append("  minute: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->minute);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "minute", this->minute);
 
-  out.append("  second: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->second);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "second", this->second);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void TimeCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("TimeCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  hour: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->hour);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "hour", this->hour);
 
-  out.append("  minute: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->minute);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "minute", this->minute);
 
-  out.append("  second: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->second);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "second", this->second);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -4040,71 +2445,36 @@ void TimeCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesEventResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
   for (const auto &it : this->event_types) {
-    out.append("  event_types: ");
-    append_quoted_string(out, StringRef(it));
-    out.append("\n");
+    dump_field(out, "event_types", it, 4);
   }
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void EventResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("EventResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  event_type: ");
-  append_quoted_string(out, this->event_type_ref_);
-  out.append("\n");
-
+  dump_field(out, "event_type", this->event_type_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -4112,112 +2482,57 @@ void EventResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesValveResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
+  dump_field(out, "device_class", this->device_class_ref_);
+  dump_field(out, "assumed_state", this->assumed_state);
 
-  out.append("  assumed_state: ");
-  out.append(YESNO(this->assumed_state));
-  out.append("\n");
+  dump_field(out, "supports_position", this->supports_position);
 
-  out.append("  supports_position: ");
-  out.append(YESNO(this->supports_position));
-  out.append("\n");
-
-  out.append("  supports_stop: ");
-  out.append(YESNO(this->supports_stop));
-  out.append("\n");
+  dump_field(out, "supports_stop", this->supports_stop);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void ValveStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ValveStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  position: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->position);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "position", this->position);
 
-  out.append("  current_operation: ");
-  out.append(proto_enum_to_string<enums::ValveOperation>(this->current_operation));
-  out.append("\n");
+  dump_field(out, "current_operation", static_cast<enums::ValveOperation>(this->current_operation));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void ValveCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ValveCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  has_position: ");
-  out.append(YESNO(this->has_position));
-  out.append("\n");
+  dump_field(out, "has_position", this->has_position);
 
-  out.append("  position: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->position);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "position", this->position);
 
-  out.append("  stop: ");
-  out.append(YESNO(this->stop));
-  out.append("\n");
+  dump_field(out, "stop", this->stop);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -4225,88 +2540,46 @@ void ValveCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesDateTimeResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void DateTimeStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DateTimeStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
-  out.append("  epoch_seconds: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "epoch_seconds", this->epoch_seconds);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void DateTimeCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("DateTimeCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  epoch_seconds: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->epoch_seconds);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "epoch_seconds", this->epoch_seconds);
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
@@ -4314,119 +2587,56 @@ void DateTimeCommandRequest::dump_to(std::string &out) const {
 #endif
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("ListEntitiesUpdateResponse {\n");
-  out.append("  object_id: ");
-  append_quoted_string(out, this->object_id_ref_);
-  out.append("\n");
+  dump_field(out, "object_id", this->object_id_ref_);
+  dump_field(out, "key", this->key);
 
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
-
-  out.append("  name: ");
-  append_quoted_string(out, this->name_ref_);
-  out.append("\n");
-
+  dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
-  out.append("  icon: ");
-  append_quoted_string(out, this->icon_ref_);
-  out.append("\n");
-
+  dump_field(out, "icon", this->icon_ref_);
 #endif
-  out.append("  disabled_by_default: ");
-  out.append(YESNO(this->disabled_by_default));
-  out.append("\n");
+  dump_field(out, "disabled_by_default", this->disabled_by_default);
 
-  out.append("  entity_category: ");
-  out.append(proto_enum_to_string<enums::EntityCategory>(this->entity_category));
-  out.append("\n");
+  dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 
-  out.append("  device_class: ");
-  append_quoted_string(out, this->device_class_ref_);
-  out.append("\n");
-
+  dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void UpdateStateResponse::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("UpdateStateResponse {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  missing_state: ");
-  out.append(YESNO(this->missing_state));
-  out.append("\n");
+  dump_field(out, "missing_state", this->missing_state);
 
-  out.append("  in_progress: ");
-  out.append(YESNO(this->in_progress));
-  out.append("\n");
+  dump_field(out, "in_progress", this->in_progress);
 
-  out.append("  has_progress: ");
-  out.append(YESNO(this->has_progress));
-  out.append("\n");
+  dump_field(out, "has_progress", this->has_progress);
 
-  out.append("  progress: ");
-  snprintf(buffer, sizeof(buffer), "%g", this->progress);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "progress", this->progress);
 
-  out.append("  current_version: ");
-  append_quoted_string(out, this->current_version_ref_);
-  out.append("\n");
-
-  out.append("  latest_version: ");
-  append_quoted_string(out, this->latest_version_ref_);
-  out.append("\n");
-
-  out.append("  title: ");
-  append_quoted_string(out, this->title_ref_);
-  out.append("\n");
-
-  out.append("  release_summary: ");
-  append_quoted_string(out, this->release_summary_ref_);
-  out.append("\n");
-
-  out.append("  release_url: ");
-  append_quoted_string(out, this->release_url_ref_);
-  out.append("\n");
-
+  dump_field(out, "current_version", this->current_version_ref_);
+  dump_field(out, "latest_version", this->latest_version_ref_);
+  dump_field(out, "title", this->title_ref_);
+  dump_field(out, "release_summary", this->release_summary_ref_);
+  dump_field(out, "release_url", this->release_url_ref_);
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");
 }
 void UpdateCommandRequest::dump_to(std::string &out) const {
-  __attribute__((unused)) char buffer[64];
   out.append("UpdateCommandRequest {\n");
-  out.append("  key: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->key);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "key", this->key);
 
-  out.append("  command: ");
-  out.append(proto_enum_to_string<enums::UpdateCommand>(this->command));
-  out.append("\n");
+  dump_field(out, "command", static_cast<enums::UpdateCommand>(this->command));
 
 #ifdef USE_DEVICES
-  out.append("  device_id: ");
-  snprintf(buffer, sizeof(buffer), "%" PRIu32, this->device_id);
-  out.append(buffer);
-  out.append("\n");
+  dump_field(out, "device_id", this->device_id);
 
 #endif
   out.append("}");

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -67,7 +67,7 @@ static void dump_field(std::string &out, const char *field_name, float value, in
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRIu64, value);
+  snprintf(buffer, 64, "%llu", value);
   append_with_newline(out, buffer);
 }
 

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -19,67 +19,72 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
   out.append("'");
 }
 
+// Common helpers for dump_field functions
+static inline void append_field_prefix(std::string &out, const char *field_name, int indent) {
+  out.append(indent, ' ').append(field_name).append(": ");
+}
+
+static inline void append_with_newline(std::string &out, const char *str) {
+  out.append(str);
+  out.append("\n");
+}
+
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRId32, value);
-  out.append(buffer);
-  out.append("\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu32, value);
-  out.append(buffer);
-  out.append("\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
-  out.append(buffer);
-  out.append("\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
-  out.append(buffer);
-  out.append("\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%llu", value);
-  out.append(buffer);
-  out.append("\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append(YESNO(value));
   out.append("\n");
 }
 
 static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append("'").append(value).append("'");
   out.append("\n");
 }
 
 static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   append_quoted_string(out, value);
   out.append("\n");
 }
 
 template<typename T> static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append(proto_enum_to_string<T>(value));
   out.append("\n");
 }

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -29,6 +29,19 @@ static inline void append_with_newline(std::string &out, const char *str) {
   out.append("\n");
 }
 
+// RAII helper for message dump formatting
+class MessageDumpHelper {
+ public:
+  MessageDumpHelper(std::string &out, const char *message_name) : out_(out) {
+    out_.append(message_name);
+    out_.append(" {\n");
+  }
+  ~MessageDumpHelper() { out_.append(" }"); }
+
+ private:
+  std::string &out_;
+};
+
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
   char buffer[64];
@@ -628,19 +641,17 @@ template<> const char *proto_enum_to_string<enums::UpdateCommand>(enums::UpdateC
 #endif
 
 void HelloRequest::dump_to(std::string &out) const {
-  out.append("HelloRequest {\n");
+  MessageDumpHelper helper(out, "HelloRequest");
   dump_field(out, "client_info", this->client_info);
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
-  out.append("}");
 }
 void HelloResponse::dump_to(std::string &out) const {
-  out.append("HelloResponse {\n");
+  MessageDumpHelper helper(out, "HelloResponse");
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
   dump_field(out, "server_info", this->server_info_ref_);
   dump_field(out, "name", this->name_ref_);
-  out.append("}");
 }
 void ConnectRequest::dump_to(std::string &out) const { dump_field(out, "password", this->password); }
 void ConnectResponse::dump_to(std::string &out) const { dump_field(out, "invalid_password", this->invalid_password); }
@@ -651,23 +662,21 @@ void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}
 void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
 #ifdef USE_AREAS
 void AreaInfo::dump_to(std::string &out) const {
-  out.append("AreaInfo {\n");
+  MessageDumpHelper helper(out, "AreaInfo");
   dump_field(out, "area_id", this->area_id);
   dump_field(out, "name", this->name_ref_);
-  out.append("}");
 }
 #endif
 #ifdef USE_DEVICES
 void DeviceInfo::dump_to(std::string &out) const {
-  out.append("DeviceInfo {\n");
+  MessageDumpHelper helper(out, "DeviceInfo");
   dump_field(out, "device_id", this->device_id);
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "area_id", this->area_id);
-  out.append("}");
 }
 #endif
 void DeviceInfoResponse::dump_to(std::string &out) const {
-  out.append("DeviceInfoResponse {\n");
+  MessageDumpHelper helper(out, "DeviceInfoResponse");
 #ifdef USE_API_PASSWORD
   dump_field(out, "uses_password", this->uses_password);
 #endif
@@ -724,14 +733,13 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   this->area.dump_to(out);
   out.append("\n");
 #endif
-  out.append("}");
 }
 void ListEntitiesRequest::dump_to(std::string &out) const { out.append("ListEntitiesRequest {}"); }
 void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("ListEntitiesDoneResponse {}"); }
 void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesBinarySensorResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesBinarySensorResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -745,22 +753,20 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void BinarySensorStateResponse::dump_to(std::string &out) const {
-  out.append("BinarySensorStateResponse {\n");
+  MessageDumpHelper helper(out, "BinarySensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesCoverResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesCoverResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -777,10 +783,9 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void CoverStateResponse::dump_to(std::string &out) const {
-  out.append("CoverStateResponse {\n");
+  MessageDumpHelper helper(out, "CoverStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
   dump_field(out, "tilt", this->tilt);
@@ -788,10 +793,9 @@ void CoverStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void CoverCommandRequest::dump_to(std::string &out) const {
-  out.append("CoverCommandRequest {\n");
+  MessageDumpHelper helper(out, "CoverCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
   dump_field(out, "position", this->position);
@@ -801,12 +805,11 @@ void CoverCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesFanResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesFanResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -825,10 +828,9 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void FanStateResponse::dump_to(std::string &out) const {
-  out.append("FanStateResponse {\n");
+  MessageDumpHelper helper(out, "FanStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
   dump_field(out, "oscillating", this->oscillating);
@@ -838,10 +840,9 @@ void FanStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void FanCommandRequest::dump_to(std::string &out) const {
-  out.append("FanCommandRequest {\n");
+  MessageDumpHelper helper(out, "FanCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
   dump_field(out, "state", this->state);
@@ -856,12 +857,11 @@ void FanCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesLightResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesLightResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -881,10 +881,9 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void LightStateResponse::dump_to(std::string &out) const {
-  out.append("LightStateResponse {\n");
+  MessageDumpHelper helper(out, "LightStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
   dump_field(out, "brightness", this->brightness);
@@ -901,10 +900,9 @@ void LightStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void LightCommandRequest::dump_to(std::string &out) const {
-  out.append("LightCommandRequest {\n");
+  MessageDumpHelper helper(out, "LightCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
   dump_field(out, "state", this->state);
@@ -935,12 +933,11 @@ void LightCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesSensorResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesSensorResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -957,22 +954,20 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SensorStateResponse::dump_to(std::string &out) const {
-  out.append("SensorStateResponse {\n");
+  MessageDumpHelper helper(out, "SensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesSwitchResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesSwitchResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -986,30 +981,27 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SwitchStateResponse::dump_to(std::string &out) const {
-  out.append("SwitchStateResponse {\n");
+  MessageDumpHelper helper(out, "SwitchStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SwitchCommandRequest::dump_to(std::string &out) const {
-  out.append("SwitchCommandRequest {\n");
+  MessageDumpHelper helper(out, "SwitchCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesTextSensorResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesTextSensorResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1022,40 +1014,35 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void TextSensorStateResponse::dump_to(std::string &out) const {
-  out.append("TextSensorStateResponse {\n");
+  MessageDumpHelper helper(out, "TextSensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 void SubscribeLogsRequest::dump_to(std::string &out) const {
-  out.append("SubscribeLogsRequest {\n");
+  MessageDumpHelper helper(out, "SubscribeLogsRequest");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   dump_field(out, "dump_config", this->dump_config);
-  out.append("}");
 }
 void SubscribeLogsResponse::dump_to(std::string &out) const {
-  out.append("SubscribeLogsResponse {\n");
+  MessageDumpHelper helper(out, "SubscribeLogsResponse");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   out.append("  message: ");
   out.append(format_hex_pretty(this->message_ptr_, this->message_len_));
   out.append("\n");
-  out.append("}");
 }
 #ifdef USE_API_NOISE
 void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
-  out.append("NoiseEncryptionSetKeyRequest {\n");
+  MessageDumpHelper helper(out, "NoiseEncryptionSetKeyRequest");
   out.append("  key: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->key.data()), this->key.size()));
   out.append("\n");
-  out.append("}");
 }
 void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const { dump_field(out, "success", this->success); }
 #endif
@@ -1063,13 +1050,12 @@ void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
 }
 void HomeassistantServiceMap::dump_to(std::string &out) const {
-  out.append("HomeassistantServiceMap {\n");
+  MessageDumpHelper helper(out, "HomeassistantServiceMap");
   dump_field(out, "key", this->key_ref_);
   dump_field(out, "value", this->value_ref_);
-  out.append("}");
 }
 void HomeassistantServiceResponse::dump_to(std::string &out) const {
-  out.append("HomeassistantServiceResponse {\n");
+  MessageDumpHelper helper(out, "HomeassistantServiceResponse");
   dump_field(out, "service", this->service_ref_);
   for (const auto &it : this->data) {
     out.append("  data: ");
@@ -1087,36 +1073,32 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
     out.append("\n");
   }
   dump_field(out, "is_event", this->is_event);
-  out.append("}");
 }
 void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
 }
 void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
-  out.append("SubscribeHomeAssistantStateResponse {\n");
+  MessageDumpHelper helper(out, "SubscribeHomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id_ref_);
   dump_field(out, "attribute", this->attribute_ref_);
   dump_field(out, "once", this->once);
-  out.append("}");
 }
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
-  out.append("HomeAssistantStateResponse {\n");
+  MessageDumpHelper helper(out, "HomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id);
   dump_field(out, "state", this->state);
   dump_field(out, "attribute", this->attribute);
-  out.append("}");
 }
 void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
 void GetTimeResponse::dump_to(std::string &out) const { dump_field(out, "epoch_seconds", this->epoch_seconds); }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {
-  out.append("ListEntitiesServicesArgument {\n");
+  MessageDumpHelper helper(out, "ListEntitiesServicesArgument");
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "type", static_cast<enums::ServiceArgType>(this->type));
-  out.append("}");
 }
 void ListEntitiesServicesResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesServicesResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesServicesResponse");
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "key", this->key);
   for (const auto &it : this->args) {
@@ -1124,10 +1106,9 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void ExecuteServiceArgument::dump_to(std::string &out) const {
-  out.append("ExecuteServiceArgument {\n");
+  MessageDumpHelper helper(out, "ExecuteServiceArgument");
   dump_field(out, "bool_", this->bool_);
   dump_field(out, "legacy_int", this->legacy_int);
   dump_field(out, "float_", this->float_);
@@ -1145,22 +1126,20 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   for (const auto &it : this->string_array) {
     dump_field(out, "string_array", it, 4);
   }
-  out.append("}");
 }
 void ExecuteServiceRequest::dump_to(std::string &out) const {
-  out.append("ExecuteServiceRequest {\n");
+  MessageDumpHelper helper(out, "ExecuteServiceRequest");
   dump_field(out, "key", this->key);
   for (const auto &it : this->args) {
     out.append("  args: ");
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 #endif
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesCameraResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesCameraResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1172,10 +1151,9 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void CameraImageResponse::dump_to(std::string &out) const {
-  out.append("CameraImageResponse {\n");
+  MessageDumpHelper helper(out, "CameraImageResponse");
   dump_field(out, "key", this->key);
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
@@ -1184,18 +1162,16 @@ void CameraImageResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void CameraImageRequest::dump_to(std::string &out) const {
-  out.append("CameraImageRequest {\n");
+  MessageDumpHelper helper(out, "CameraImageRequest");
   dump_field(out, "single", this->single);
   dump_field(out, "stream", this->stream);
-  out.append("}");
 }
 #endif
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesClimateResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesClimateResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1236,10 +1212,9 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void ClimateStateResponse::dump_to(std::string &out) const {
-  out.append("ClimateStateResponse {\n");
+  MessageDumpHelper helper(out, "ClimateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
   dump_field(out, "current_temperature", this->current_temperature);
@@ -1257,10 +1232,9 @@ void ClimateStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void ClimateCommandRequest::dump_to(std::string &out) const {
-  out.append("ClimateCommandRequest {\n");
+  MessageDumpHelper helper(out, "ClimateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_mode", this->has_mode);
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
@@ -1285,12 +1259,11 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesNumberResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesNumberResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1308,31 +1281,28 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void NumberStateResponse::dump_to(std::string &out) const {
-  out.append("NumberStateResponse {\n");
+  MessageDumpHelper helper(out, "NumberStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void NumberCommandRequest::dump_to(std::string &out) const {
-  out.append("NumberCommandRequest {\n");
+  MessageDumpHelper helper(out, "NumberCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesSelectResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesSelectResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1347,31 +1317,28 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SelectStateResponse::dump_to(std::string &out) const {
-  out.append("SelectStateResponse {\n");
+  MessageDumpHelper helper(out, "SelectStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SelectCommandRequest::dump_to(std::string &out) const {
-  out.append("SelectCommandRequest {\n");
+  MessageDumpHelper helper(out, "SelectCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesSirenResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesSirenResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1388,19 +1355,17 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SirenStateResponse::dump_to(std::string &out) const {
-  out.append("SirenStateResponse {\n");
+  MessageDumpHelper helper(out, "SirenStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void SirenCommandRequest::dump_to(std::string &out) const {
-  out.append("SirenCommandRequest {\n");
+  MessageDumpHelper helper(out, "SirenCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
   dump_field(out, "state", this->state);
@@ -1413,12 +1378,11 @@ void SirenCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesLockResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesLockResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1434,19 +1398,17 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void LockStateResponse::dump_to(std::string &out) const {
-  out.append("LockStateResponse {\n");
+  MessageDumpHelper helper(out, "LockStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::LockState>(this->state));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void LockCommandRequest::dump_to(std::string &out) const {
-  out.append("LockCommandRequest {\n");
+  MessageDumpHelper helper(out, "LockCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
   dump_field(out, "has_code", this->has_code);
@@ -1454,12 +1416,11 @@ void LockCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesButtonResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesButtonResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1472,29 +1433,26 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void ButtonCommandRequest::dump_to(std::string &out) const {
-  out.append("ButtonCommandRequest {\n");
+  MessageDumpHelper helper(out, "ButtonCommandRequest");
   dump_field(out, "key", this->key);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
 void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
-  out.append("MediaPlayerSupportedFormat {\n");
+  MessageDumpHelper helper(out, "MediaPlayerSupportedFormat");
   dump_field(out, "format", this->format_ref_);
   dump_field(out, "sample_rate", this->sample_rate);
   dump_field(out, "num_channels", this->num_channels);
   dump_field(out, "purpose", static_cast<enums::MediaPlayerFormatPurpose>(this->purpose));
   dump_field(out, "sample_bytes", this->sample_bytes);
-  out.append("}");
 }
 void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesMediaPlayerResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesMediaPlayerResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1512,10 +1470,9 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void MediaPlayerStateResponse::dump_to(std::string &out) const {
-  out.append("MediaPlayerStateResponse {\n");
+  MessageDumpHelper helper(out, "MediaPlayerStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::MediaPlayerState>(this->state));
   dump_field(out, "volume", this->volume);
@@ -1523,10 +1480,9 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void MediaPlayerCommandRequest::dump_to(std::string &out) const {
-  out.append("MediaPlayerCommandRequest {\n");
+  MessageDumpHelper helper(out, "MediaPlayerCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_command", this->has_command);
   dump_field(out, "command", static_cast<enums::MediaPlayerCommand>(this->command));
@@ -1539,61 +1495,54 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
-  out.append("SubscribeBluetoothLEAdvertisementsRequest {\n");
+  MessageDumpHelper helper(out, "SubscribeBluetoothLEAdvertisementsRequest");
   dump_field(out, "flags", this->flags);
-  out.append("}");
 }
 void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
-  out.append("BluetoothLERawAdvertisement {\n");
+  MessageDumpHelper helper(out, "BluetoothLERawAdvertisement");
   dump_field(out, "address", this->address);
   dump_field(out, "rssi", this->rssi);
   dump_field(out, "address_type", this->address_type);
   out.append("  data: ");
   out.append(format_hex_pretty(this->data, this->data_len));
   out.append("\n");
-  out.append("}");
 }
 void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
-  out.append("BluetoothLERawAdvertisementsResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothLERawAdvertisementsResponse");
   for (const auto &it : this->advertisements) {
     out.append("  advertisements: ");
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void BluetoothDeviceRequest::dump_to(std::string &out) const {
-  out.append("BluetoothDeviceRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothDeviceRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "request_type", static_cast<enums::BluetoothDeviceRequestType>(this->request_type));
   dump_field(out, "has_address_type", this->has_address_type);
   dump_field(out, "address_type", this->address_type);
-  out.append("}");
 }
 void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
-  out.append("BluetoothDeviceConnectionResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothDeviceConnectionResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "connected", this->connected);
   dump_field(out, "mtu", this->mtu);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const { dump_field(out, "address", this->address); }
 void BluetoothGATTDescriptor::dump_to(std::string &out) const {
-  out.append("BluetoothGATTDescriptor {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTDescriptor");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
   dump_field(out, "handle", this->handle);
-  out.append("}");
 }
 void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
-  out.append("BluetoothGATTCharacteristic {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTCharacteristic");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
@@ -1604,10 +1553,9 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void BluetoothGATTService::dump_to(std::string &out) const {
-  out.append("BluetoothGATTService {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTService");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
@@ -1617,162 +1565,141 @@ void BluetoothGATTService::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTGetServicesResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTGetServicesResponse");
   dump_field(out, "address", this->address);
   for (const auto &it : this->services) {
     out.append("  services: ");
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTGetServicesDoneResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTGetServicesDoneResponse");
   dump_field(out, "address", this->address);
-  out.append("}");
 }
 void BluetoothGATTReadRequest::dump_to(std::string &out) const {
-  out.append("BluetoothGATTReadRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTReadRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("}");
 }
 void BluetoothGATTReadResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTReadResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTReadResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
-  out.append("}");
 }
 void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
-  out.append("BluetoothGATTWriteRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTWriteRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "response", this->response);
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
   out.append("\n");
-  out.append("}");
 }
 void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
-  out.append("BluetoothGATTReadDescriptorRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTReadDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("}");
 }
 void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
-  out.append("BluetoothGATTWriteDescriptorRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTWriteDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
   out.append("\n");
-  out.append("}");
 }
 void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
-  out.append("BluetoothGATTNotifyRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTNotifyRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "enable", this->enable);
-  out.append("}");
 }
 void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTNotifyDataResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTNotifyDataResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
-  out.append("}");
 }
 void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
 }
 void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
-  out.append("BluetoothConnectionsFreeResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothConnectionsFreeResponse");
   dump_field(out, "free", this->free);
   dump_field(out, "limit", this->limit);
   for (const auto &it : this->allocated) {
     dump_field(out, "allocated", it, 4);
   }
-  out.append("}");
 }
 void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTErrorResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTErrorResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTWriteResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTWriteResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("}");
 }
 void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
-  out.append("BluetoothGATTNotifyResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothGATTNotifyResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("}");
 }
 void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
-  out.append("BluetoothDevicePairingResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothDevicePairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "paired", this->paired);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
-  out.append("BluetoothDeviceUnpairingResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothDeviceUnpairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
 }
 void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
-  out.append("BluetoothDeviceClearCacheResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothDeviceClearCacheResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void BluetoothScannerStateResponse::dump_to(std::string &out) const {
-  out.append("BluetoothScannerStateResponse {\n");
+  MessageDumpHelper helper(out, "BluetoothScannerStateResponse");
   dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
-  out.append("}");
 }
 void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
-  out.append("BluetoothScannerSetModeRequest {\n");
+  MessageDumpHelper helper(out, "BluetoothScannerSetModeRequest");
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
-  out.append("}");
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
 void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
-  out.append("SubscribeVoiceAssistantRequest {\n");
+  MessageDumpHelper helper(out, "SubscribeVoiceAssistantRequest");
   dump_field(out, "subscribe", this->subscribe);
   dump_field(out, "flags", this->flags);
-  out.append("}");
 }
 void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
-  out.append("VoiceAssistantAudioSettings {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantAudioSettings");
   dump_field(out, "noise_suppression_level", this->noise_suppression_level);
   dump_field(out, "auto_gain", this->auto_gain);
   dump_field(out, "volume_multiplier", this->volume_multiplier);
-  out.append("}");
 }
 void VoiceAssistantRequest::dump_to(std::string &out) const {
-  out.append("VoiceAssistantRequest {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantRequest");
   dump_field(out, "start", this->start);
   dump_field(out, "conversation_id", this->conversation_id_ref_);
   dump_field(out, "flags", this->flags);
@@ -1780,32 +1707,28 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   this->audio_settings.dump_to(out);
   out.append("\n");
   dump_field(out, "wake_word_phrase", this->wake_word_phrase_ref_);
-  out.append("}");
 }
 void VoiceAssistantResponse::dump_to(std::string &out) const {
-  out.append("VoiceAssistantResponse {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantResponse");
   dump_field(out, "port", this->port);
   dump_field(out, "error", this->error);
-  out.append("}");
 }
 void VoiceAssistantEventData::dump_to(std::string &out) const {
-  out.append("VoiceAssistantEventData {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantEventData");
   dump_field(out, "name", this->name);
   dump_field(out, "value", this->value);
-  out.append("}");
 }
 void VoiceAssistantEventResponse::dump_to(std::string &out) const {
-  out.append("VoiceAssistantEventResponse {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantEvent>(this->event_type));
   for (const auto &it : this->data) {
     out.append("  data: ");
     it.dump_to(out);
     out.append("\n");
   }
-  out.append("}");
 }
 void VoiceAssistantAudio::dump_to(std::string &out) const {
-  out.append("VoiceAssistantAudio {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantAudio");
   out.append("  data: ");
   if (this->data_ptr_ != nullptr) {
     out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
@@ -1814,41 +1737,37 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
   }
   out.append("\n");
   dump_field(out, "end", this->end);
-  out.append("}");
 }
 void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
-  out.append("VoiceAssistantTimerEventResponse {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantTimerEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
   dump_field(out, "timer_id", this->timer_id);
   dump_field(out, "name", this->name);
   dump_field(out, "total_seconds", this->total_seconds);
   dump_field(out, "seconds_left", this->seconds_left);
   dump_field(out, "is_active", this->is_active);
-  out.append("}");
 }
 void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
-  out.append("VoiceAssistantAnnounceRequest {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantAnnounceRequest");
   dump_field(out, "media_id", this->media_id);
   dump_field(out, "text", this->text);
   dump_field(out, "preannounce_media_id", this->preannounce_media_id);
   dump_field(out, "start_conversation", this->start_conversation);
-  out.append("}");
 }
 void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const { dump_field(out, "success", this->success); }
 void VoiceAssistantWakeWord::dump_to(std::string &out) const {
-  out.append("VoiceAssistantWakeWord {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantWakeWord");
   dump_field(out, "id", this->id_ref_);
   dump_field(out, "wake_word", this->wake_word_ref_);
   for (const auto &it : this->trained_languages) {
     dump_field(out, "trained_languages", it, 4);
   }
-  out.append("}");
 }
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
   out.append("VoiceAssistantConfigurationRequest {}");
 }
 void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
-  out.append("VoiceAssistantConfigurationResponse {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantConfigurationResponse");
   for (const auto &it : this->available_wake_words) {
     out.append("  available_wake_words: ");
     it.dump_to(out);
@@ -1858,19 +1777,17 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
     dump_field(out, "active_wake_words", it, 4);
   }
   dump_field(out, "max_active_wake_words", this->max_active_wake_words);
-  out.append("}");
 }
 void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
-  out.append("VoiceAssistantSetConfiguration {\n");
+  MessageDumpHelper helper(out, "VoiceAssistantSetConfiguration");
   for (const auto &it : this->active_wake_words) {
     dump_field(out, "active_wake_words", it, 4);
   }
-  out.append("}");
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesAlarmControlPanelResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesAlarmControlPanelResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1885,31 +1802,28 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
-  out.append("AlarmControlPanelStateResponse {\n");
+  MessageDumpHelper helper(out, "AlarmControlPanelStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::AlarmControlPanelState>(this->state));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
-  out.append("AlarmControlPanelCommandRequest {\n");
+  MessageDumpHelper helper(out, "AlarmControlPanelCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
   dump_field(out, "code", this->code);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesTextResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesTextResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1925,31 +1839,28 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void TextStateResponse::dump_to(std::string &out) const {
-  out.append("TextStateResponse {\n");
+  MessageDumpHelper helper(out, "TextStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void TextCommandRequest::dump_to(std::string &out) const {
-  out.append("TextCommandRequest {\n");
+  MessageDumpHelper helper(out, "TextCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesDateResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesDateResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -1961,10 +1872,9 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void DateStateResponse::dump_to(std::string &out) const {
-  out.append("DateStateResponse {\n");
+  MessageDumpHelper helper(out, "DateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
   dump_field(out, "year", this->year);
@@ -1973,10 +1883,9 @@ void DateStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void DateCommandRequest::dump_to(std::string &out) const {
-  out.append("DateCommandRequest {\n");
+  MessageDumpHelper helper(out, "DateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "year", this->year);
   dump_field(out, "month", this->month);
@@ -1984,12 +1893,11 @@ void DateCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesTimeResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesTimeResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -2001,10 +1909,9 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void TimeStateResponse::dump_to(std::string &out) const {
-  out.append("TimeStateResponse {\n");
+  MessageDumpHelper helper(out, "TimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
   dump_field(out, "hour", this->hour);
@@ -2013,10 +1920,9 @@ void TimeStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void TimeCommandRequest::dump_to(std::string &out) const {
-  out.append("TimeCommandRequest {\n");
+  MessageDumpHelper helper(out, "TimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "hour", this->hour);
   dump_field(out, "minute", this->minute);
@@ -2024,12 +1930,11 @@ void TimeCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesEventResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesEventResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -2045,21 +1950,19 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void EventResponse::dump_to(std::string &out) const {
-  out.append("EventResponse {\n");
+  MessageDumpHelper helper(out, "EventResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "event_type", this->event_type_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesValveResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesValveResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -2075,20 +1978,18 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void ValveStateResponse::dump_to(std::string &out) const {
-  out.append("ValveStateResponse {\n");
+  MessageDumpHelper helper(out, "ValveStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
   dump_field(out, "current_operation", static_cast<enums::ValveOperation>(this->current_operation));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void ValveCommandRequest::dump_to(std::string &out) const {
-  out.append("ValveCommandRequest {\n");
+  MessageDumpHelper helper(out, "ValveCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
   dump_field(out, "position", this->position);
@@ -2096,12 +1997,11 @@ void ValveCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesDateTimeResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesDateTimeResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -2113,31 +2013,28 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void DateTimeStateResponse::dump_to(std::string &out) const {
-  out.append("DateTimeStateResponse {\n");
+  MessageDumpHelper helper(out, "DateTimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
   dump_field(out, "epoch_seconds", this->epoch_seconds);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void DateTimeCommandRequest::dump_to(std::string &out) const {
-  out.append("DateTimeCommandRequest {\n");
+  MessageDumpHelper helper(out, "DateTimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "epoch_seconds", this->epoch_seconds);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
-  out.append("ListEntitiesUpdateResponse {\n");
+  MessageDumpHelper helper(out, "ListEntitiesUpdateResponse");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
   dump_field(out, "name", this->name_ref_);
@@ -2150,10 +2047,9 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void UpdateStateResponse::dump_to(std::string &out) const {
-  out.append("UpdateStateResponse {\n");
+  MessageDumpHelper helper(out, "UpdateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
   dump_field(out, "in_progress", this->in_progress);
@@ -2167,16 +2063,14 @@ void UpdateStateResponse::dump_to(std::string &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 void UpdateCommandRequest::dump_to(std::string &out) const {
-  out.append("UpdateCommandRequest {\n");
+  MessageDumpHelper helper(out, "UpdateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::UpdateCommand>(this->command));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
-  out.append("}");
 }
 #endif
 

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -720,7 +720,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("  area: ");
   this->area.dump_to(out);
   out.append("\n");
-
 #endif
   out.append("}");
 }
@@ -1187,7 +1186,6 @@ void CameraImageResponse::dump_to(std::string &out) const {
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
-
   dump_field(out, "done", this->done);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -1799,7 +1797,6 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("  audio_settings: ");
   this->audio_settings.dump_to(out);
   out.append("\n");
-
   dump_field(out, "wake_word_phrase", this->wake_word_phrase_ref_);
   out.append("}");
 }
@@ -1834,7 +1831,6 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
     out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
   }
   out.append("\n");
-
   dump_field(out, "end", this->end);
   out.append("}");
 }

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -706,7 +706,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-
 #endif
 #ifdef USE_AREAS
   for (const auto &it : this->areas) {
@@ -714,7 +713,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-
 #endif
 #ifdef USE_AREAS
   out.append("  area: ");
@@ -819,7 +817,6 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   for (const auto &it : this->supported_preset_modes) {
     dump_field(out, "supported_preset_modes", it, 4);
   }
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
@@ -866,13 +863,11 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   for (const auto &it : this->supported_color_modes) {
     dump_field(out, "supported_color_modes", static_cast<enums::ColorMode>(it), 4);
   }
-
   dump_field(out, "min_mireds", this->min_mireds);
   dump_field(out, "max_mireds", this->max_mireds);
   for (const auto &it : this->effects) {
     dump_field(out, "effects", it, 4);
   }
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
@@ -1076,19 +1071,16 @@ void HomeassistantServiceResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-
   for (const auto &it : this->data_template) {
     out.append("  data_template: ");
     it.dump_to(out);
     out.append("\n");
   }
-
   for (const auto &it : this->variables) {
     out.append("  variables: ");
     it.dump_to(out);
     out.append("\n");
   }
-
   dump_field(out, "is_event", this->is_event);
   out.append("}");
 }
@@ -1139,15 +1131,12 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   for (const auto it : this->bool_array) {
     dump_field(out, "bool_array", it, 4);
   }
-
   for (const auto &it : this->int_array) {
     dump_field(out, "int_array", it, 4);
   }
-
   for (const auto &it : this->float_array) {
     dump_field(out, "float_array", it, 4);
   }
-
   for (const auto &it : this->string_array) {
     dump_field(out, "string_array", it, 4);
   }
@@ -1210,7 +1199,6 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   for (const auto &it : this->supported_modes) {
     dump_field(out, "supported_modes", static_cast<enums::ClimateMode>(it), 4);
   }
-
   dump_field(out, "visual_min_temperature", this->visual_min_temperature);
   dump_field(out, "visual_max_temperature", this->visual_max_temperature);
   dump_field(out, "visual_target_temperature_step", this->visual_target_temperature_step);
@@ -1218,23 +1206,18 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   for (const auto &it : this->supported_fan_modes) {
     dump_field(out, "supported_fan_modes", static_cast<enums::ClimateFanMode>(it), 4);
   }
-
   for (const auto &it : this->supported_swing_modes) {
     dump_field(out, "supported_swing_modes", static_cast<enums::ClimateSwingMode>(it), 4);
   }
-
   for (const auto &it : this->supported_custom_fan_modes) {
     dump_field(out, "supported_custom_fan_modes", it, 4);
   }
-
   for (const auto &it : this->supported_presets) {
     dump_field(out, "supported_presets", static_cast<enums::ClimatePreset>(it), 4);
   }
-
   for (const auto &it : this->supported_custom_presets) {
     dump_field(out, "supported_custom_presets", it, 4);
   }
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
@@ -1354,7 +1337,6 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   for (const auto &it : this->options) {
     dump_field(out, "options", it, 4);
   }
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
 #ifdef USE_DEVICES
@@ -1395,7 +1377,6 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   for (const auto &it : this->tones) {
     dump_field(out, "tones", it, 4);
   }
-
   dump_field(out, "supports_duration", this->supports_duration);
   dump_field(out, "supports_volume", this->supports_volume);
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
@@ -1523,7 +1504,6 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
@@ -1604,7 +1584,6 @@ void BluetoothGATTDescriptor::dump_to(std::string &out) const {
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
-
   dump_field(out, "handle", this->handle);
   out.append("}");
 }
@@ -1613,7 +1592,6 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
-
   dump_field(out, "handle", this->handle);
   dump_field(out, "properties", this->properties);
   for (const auto &it : this->descriptors) {
@@ -1628,7 +1606,6 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
-
   dump_field(out, "handle", this->handle);
   for (const auto &it : this->characteristics) {
     out.append("  characteristics: ");
@@ -1872,11 +1849,9 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-
   for (const auto &it : this->active_wake_words) {
     dump_field(out, "active_wake_words", it, 4);
   }
-
   dump_field(out, "max_active_wake_words", this->max_active_wake_words);
   out.append("}");
 }
@@ -2062,7 +2037,6 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   for (const auto &it : this->event_types) {
     dump_field(out, "event_types", it, 4);
   }
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -626,16 +626,13 @@ void HelloRequest::dump_to(std::string &out) const {
   out.append("HelloRequest {\n");
   dump_field(out, "client_info", this->client_info);
   dump_field(out, "api_version_major", this->api_version_major);
-
   dump_field(out, "api_version_minor", this->api_version_minor);
   out.append("}");
 }
 void HelloResponse::dump_to(std::string &out) const {
   out.append("HelloResponse {\n");
   dump_field(out, "api_version_major", this->api_version_major);
-
   dump_field(out, "api_version_minor", this->api_version_minor);
-
   dump_field(out, "server_info", this->server_info_ref_);
   dump_field(out, "name", this->name_ref_);
   out.append("}");
@@ -651,7 +648,6 @@ void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfo
 void AreaInfo::dump_to(std::string &out) const {
   out.append("AreaInfo {\n");
   dump_field(out, "area_id", this->area_id);
-
   dump_field(out, "name", this->name_ref_);
   out.append("}");
 }
@@ -660,7 +656,6 @@ void AreaInfo::dump_to(std::string &out) const {
 void DeviceInfo::dump_to(std::string &out) const {
   out.append("DeviceInfo {\n");
   dump_field(out, "device_id", this->device_id);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "area_id", this->area_id);
   out.append("}");
@@ -670,7 +665,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   out.append("DeviceInfoResponse {\n");
 #ifdef USE_API_PASSWORD
   dump_field(out, "uses_password", this->uses_password);
-
 #endif
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "mac_address", this->mac_address_ref_);
@@ -679,7 +673,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   dump_field(out, "model", this->model_ref_);
 #ifdef USE_DEEP_SLEEP
   dump_field(out, "has_deep_sleep", this->has_deep_sleep);
-
 #endif
 #ifdef ESPHOME_PROJECT_NAME
   dump_field(out, "project_name", this->project_name_ref_);
@@ -689,17 +682,14 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_WEBSERVER
   dump_field(out, "webserver_port", this->webserver_port);
-
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   dump_field(out, "bluetooth_proxy_feature_flags", this->bluetooth_proxy_feature_flags);
-
 #endif
   dump_field(out, "manufacturer", this->manufacturer_ref_);
   dump_field(out, "friendly_name", this->friendly_name_ref_);
 #ifdef USE_VOICE_ASSISTANT
   dump_field(out, "voice_assistant_feature_flags", this->voice_assistant_feature_flags);
-
 #endif
 #ifdef USE_AREAS
   dump_field(out, "suggested_area", this->suggested_area_ref_);
@@ -709,7 +699,6 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
 #endif
 #ifdef USE_API_NOISE
   dump_field(out, "api_encryption_supported", this->api_encryption_supported);
-
 #endif
 #ifdef USE_DEVICES
   for (const auto &it : this->devices) {
@@ -743,35 +732,26 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesBinarySensorResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "device_class", this->device_class_ref_);
   dump_field(out, "is_status_binary_sensor", this->is_status_binary_sensor);
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void BinarySensorStateResponse::dump_to(std::string &out) const {
   out.append("BinarySensorStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -781,63 +761,43 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesCoverResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "assumed_state", this->assumed_state);
-
   dump_field(out, "supports_position", this->supports_position);
-
   dump_field(out, "supports_tilt", this->supports_tilt);
-
   dump_field(out, "device_class", this->device_class_ref_);
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "supports_stop", this->supports_stop);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void CoverStateResponse::dump_to(std::string &out) const {
   out.append("CoverStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "position", this->position);
-
   dump_field(out, "tilt", this->tilt);
-
   dump_field(out, "current_operation", static_cast<enums::CoverOperation>(this->current_operation));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void CoverCommandRequest::dump_to(std::string &out) const {
   out.append("CoverCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_position", this->has_position);
-
   dump_field(out, "position", this->position);
-
   dump_field(out, "has_tilt", this->has_tilt);
-
   dump_field(out, "tilt", this->tilt);
-
   dump_field(out, "stop", this->stop);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -847,78 +807,53 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesFanResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "supports_oscillation", this->supports_oscillation);
-
   dump_field(out, "supports_speed", this->supports_speed);
-
   dump_field(out, "supports_direction", this->supports_direction);
-
   dump_field(out, "supported_speed_count", this->supported_speed_count);
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   for (const auto &it : this->supported_preset_modes) {
     dump_field(out, "supported_preset_modes", it, 4);
   }
 
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void FanStateResponse::dump_to(std::string &out) const {
   out.append("FanStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "oscillating", this->oscillating);
-
   dump_field(out, "direction", static_cast<enums::FanDirection>(this->direction));
-
   dump_field(out, "speed_level", this->speed_level);
-
   dump_field(out, "preset_mode", this->preset_mode_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void FanCommandRequest::dump_to(std::string &out) const {
   out.append("FanCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_state", this->has_state);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "has_oscillating", this->has_oscillating);
-
   dump_field(out, "oscillating", this->oscillating);
-
   dump_field(out, "has_direction", this->has_direction);
-
   dump_field(out, "direction", static_cast<enums::FanDirection>(this->direction));
-
   dump_field(out, "has_speed_level", this->has_speed_level);
-
   dump_field(out, "speed_level", this->speed_level);
-
   dump_field(out, "has_preset_mode", this->has_preset_mode);
-
   dump_field(out, "preset_mode", this->preset_mode);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -928,124 +863,78 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesLightResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   for (const auto &it : this->supported_color_modes) {
     dump_field(out, "supported_color_modes", static_cast<enums::ColorMode>(it), 4);
   }
 
   dump_field(out, "min_mireds", this->min_mireds);
-
   dump_field(out, "max_mireds", this->max_mireds);
-
   for (const auto &it : this->effects) {
     dump_field(out, "effects", it, 4);
   }
 
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void LightStateResponse::dump_to(std::string &out) const {
   out.append("LightStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "brightness", this->brightness);
-
   dump_field(out, "color_mode", static_cast<enums::ColorMode>(this->color_mode));
-
   dump_field(out, "color_brightness", this->color_brightness);
-
   dump_field(out, "red", this->red);
-
   dump_field(out, "green", this->green);
-
   dump_field(out, "blue", this->blue);
-
   dump_field(out, "white", this->white);
-
   dump_field(out, "color_temperature", this->color_temperature);
-
   dump_field(out, "cold_white", this->cold_white);
-
   dump_field(out, "warm_white", this->warm_white);
-
   dump_field(out, "effect", this->effect_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void LightCommandRequest::dump_to(std::string &out) const {
   out.append("LightCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_state", this->has_state);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "has_brightness", this->has_brightness);
-
   dump_field(out, "brightness", this->brightness);
-
   dump_field(out, "has_color_mode", this->has_color_mode);
-
   dump_field(out, "color_mode", static_cast<enums::ColorMode>(this->color_mode));
-
   dump_field(out, "has_color_brightness", this->has_color_brightness);
-
   dump_field(out, "color_brightness", this->color_brightness);
-
   dump_field(out, "has_rgb", this->has_rgb);
-
   dump_field(out, "red", this->red);
-
   dump_field(out, "green", this->green);
-
   dump_field(out, "blue", this->blue);
-
   dump_field(out, "has_white", this->has_white);
-
   dump_field(out, "white", this->white);
-
   dump_field(out, "has_color_temperature", this->has_color_temperature);
-
   dump_field(out, "color_temperature", this->color_temperature);
-
   dump_field(out, "has_cold_white", this->has_cold_white);
-
   dump_field(out, "cold_white", this->cold_white);
-
   dump_field(out, "has_warm_white", this->has_warm_white);
-
   dump_field(out, "warm_white", this->warm_white);
-
   dump_field(out, "has_transition_length", this->has_transition_length);
-
   dump_field(out, "transition_length", this->transition_length);
-
   dump_field(out, "has_flash_length", this->has_flash_length);
-
   dump_field(out, "flash_length", this->flash_length);
-
   dump_field(out, "has_effect", this->has_effect);
-
   dump_field(out, "effect", this->effect);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1055,40 +944,29 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesSensorResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "unit_of_measurement", this->unit_of_measurement_ref_);
   dump_field(out, "accuracy_decimals", this->accuracy_decimals);
-
   dump_field(out, "force_update", this->force_update);
-
   dump_field(out, "device_class", this->device_class_ref_);
   dump_field(out, "state_class", static_cast<enums::SensorStateClass>(this->state_class));
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SensorStateResponse::dump_to(std::string &out) const {
   out.append("SensorStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1098,45 +976,34 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesSwitchResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "assumed_state", this->assumed_state);
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SwitchStateResponse::dump_to(std::string &out) const {
   out.append("SwitchStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SwitchCommandRequest::dump_to(std::string &out) const {
   out.append("SwitchCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1146,32 +1013,25 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesTextSensorResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void TextSensorStateResponse::dump_to(std::string &out) const {
   out.append("TextSensorStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1179,14 +1039,12 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
 void SubscribeLogsRequest::dump_to(std::string &out) const {
   out.append("SubscribeLogsRequest {\n");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
-
   dump_field(out, "dump_config", this->dump_config);
   out.append("}");
 }
 void SubscribeLogsResponse::dump_to(std::string &out) const {
   out.append("SubscribeLogsResponse {\n");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
-
   out.append("  message: ");
   out.append(format_hex_pretty(this->message_ptr_, this->message_len_));
   out.append("\n");
@@ -1265,7 +1123,6 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesServicesResponse {\n");
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "key", this->key);
-
   for (const auto &it : this->args) {
     out.append("  args: ");
     it.dump_to(out);
@@ -1276,14 +1133,10 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
 void ExecuteServiceArgument::dump_to(std::string &out) const {
   out.append("ExecuteServiceArgument {\n");
   dump_field(out, "bool_", this->bool_);
-
   dump_field(out, "legacy_int", this->legacy_int);
-
   dump_field(out, "float_", this->float_);
-
   dump_field(out, "string_", this->string_);
   dump_field(out, "int_", this->int_);
-
   for (const auto it : this->bool_array) {
     dump_field(out, "bool_array", it, 4);
   }
@@ -1304,7 +1157,6 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
 void ExecuteServiceRequest::dump_to(std::string &out) const {
   out.append("ExecuteServiceRequest {\n");
   dump_field(out, "key", this->key);
-
   for (const auto &it : this->args) {
     out.append("  args: ");
     it.dump_to(out);
@@ -1318,41 +1170,33 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesCameraResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void CameraImageResponse::dump_to(std::string &out) const {
   out.append("CameraImageResponse {\n");
   dump_field(out, "key", this->key);
-
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
 
   dump_field(out, "done", this->done);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void CameraImageRequest::dump_to(std::string &out) const {
   out.append("CameraImageRequest {\n");
   dump_field(out, "single", this->single);
-
   dump_field(out, "stream", this->stream);
   out.append("}");
 }
@@ -1362,24 +1206,17 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesClimateResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
   dump_field(out, "supports_current_temperature", this->supports_current_temperature);
-
   dump_field(out, "supports_two_point_target_temperature", this->supports_two_point_target_temperature);
-
   for (const auto &it : this->supported_modes) {
     dump_field(out, "supported_modes", static_cast<enums::ClimateMode>(it), 4);
   }
 
   dump_field(out, "visual_min_temperature", this->visual_min_temperature);
-
   dump_field(out, "visual_max_temperature", this->visual_max_temperature);
-
   dump_field(out, "visual_target_temperature_step", this->visual_target_temperature_step);
-
   dump_field(out, "supports_action", this->supports_action);
-
   for (const auto &it : this->supported_fan_modes) {
     dump_field(out, "supported_fan_modes", static_cast<enums::ClimateFanMode>(it), 4);
   }
@@ -1401,107 +1238,66 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
   }
 
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "visual_current_temperature_step", this->visual_current_temperature_step);
-
   dump_field(out, "supports_current_humidity", this->supports_current_humidity);
-
   dump_field(out, "supports_target_humidity", this->supports_target_humidity);
-
   dump_field(out, "visual_min_humidity", this->visual_min_humidity);
-
   dump_field(out, "visual_max_humidity", this->visual_max_humidity);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void ClimateStateResponse::dump_to(std::string &out) const {
   out.append("ClimateStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
-
   dump_field(out, "current_temperature", this->current_temperature);
-
   dump_field(out, "target_temperature", this->target_temperature);
-
   dump_field(out, "target_temperature_low", this->target_temperature_low);
-
   dump_field(out, "target_temperature_high", this->target_temperature_high);
-
   dump_field(out, "action", static_cast<enums::ClimateAction>(this->action));
-
   dump_field(out, "fan_mode", static_cast<enums::ClimateFanMode>(this->fan_mode));
-
   dump_field(out, "swing_mode", static_cast<enums::ClimateSwingMode>(this->swing_mode));
-
   dump_field(out, "custom_fan_mode", this->custom_fan_mode_ref_);
   dump_field(out, "preset", static_cast<enums::ClimatePreset>(this->preset));
-
   dump_field(out, "custom_preset", this->custom_preset_ref_);
   dump_field(out, "current_humidity", this->current_humidity);
-
   dump_field(out, "target_humidity", this->target_humidity);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void ClimateCommandRequest::dump_to(std::string &out) const {
   out.append("ClimateCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_mode", this->has_mode);
-
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
-
   dump_field(out, "has_target_temperature", this->has_target_temperature);
-
   dump_field(out, "target_temperature", this->target_temperature);
-
   dump_field(out, "has_target_temperature_low", this->has_target_temperature_low);
-
   dump_field(out, "target_temperature_low", this->target_temperature_low);
-
   dump_field(out, "has_target_temperature_high", this->has_target_temperature_high);
-
   dump_field(out, "target_temperature_high", this->target_temperature_high);
-
   dump_field(out, "has_fan_mode", this->has_fan_mode);
-
   dump_field(out, "fan_mode", static_cast<enums::ClimateFanMode>(this->fan_mode));
-
   dump_field(out, "has_swing_mode", this->has_swing_mode);
-
   dump_field(out, "swing_mode", static_cast<enums::ClimateSwingMode>(this->swing_mode));
-
   dump_field(out, "has_custom_fan_mode", this->has_custom_fan_mode);
-
   dump_field(out, "custom_fan_mode", this->custom_fan_mode);
   dump_field(out, "has_preset", this->has_preset);
-
   dump_field(out, "preset", static_cast<enums::ClimatePreset>(this->preset));
-
   dump_field(out, "has_custom_preset", this->has_custom_preset);
-
   dump_field(out, "custom_preset", this->custom_preset);
   dump_field(out, "has_target_humidity", this->has_target_humidity);
-
   dump_field(out, "target_humidity", this->target_humidity);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1511,54 +1307,39 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesNumberResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "min_value", this->min_value);
-
   dump_field(out, "max_value", this->max_value);
-
   dump_field(out, "step", this->step);
-
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "unit_of_measurement", this->unit_of_measurement_ref_);
   dump_field(out, "mode", static_cast<enums::NumberMode>(this->mode));
-
   dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void NumberStateResponse::dump_to(std::string &out) const {
   out.append("NumberStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void NumberCommandRequest::dump_to(std::string &out) const {
   out.append("NumberCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1568,7 +1349,6 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesSelectResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
@@ -1578,36 +1358,28 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   }
 
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SelectStateResponse::dump_to(std::string &out) const {
   out.append("SelectStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SelectCommandRequest::dump_to(std::string &out) const {
   out.append("SelectCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1617,63 +1389,45 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesSirenResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   for (const auto &it : this->tones) {
     dump_field(out, "tones", it, 4);
   }
 
   dump_field(out, "supports_duration", this->supports_duration);
-
   dump_field(out, "supports_volume", this->supports_volume);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SirenStateResponse::dump_to(std::string &out) const {
   out.append("SirenStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void SirenCommandRequest::dump_to(std::string &out) const {
   out.append("SirenCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_state", this->has_state);
-
   dump_field(out, "state", this->state);
-
   dump_field(out, "has_tone", this->has_tone);
-
   dump_field(out, "tone", this->tone);
   dump_field(out, "has_duration", this->has_duration);
-
   dump_field(out, "duration", this->duration);
-
   dump_field(out, "has_volume", this->has_volume);
-
   dump_field(out, "volume", this->volume);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1683,52 +1437,38 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesLockResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "assumed_state", this->assumed_state);
-
   dump_field(out, "supports_open", this->supports_open);
-
   dump_field(out, "requires_code", this->requires_code);
-
   dump_field(out, "code_format", this->code_format_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void LockStateResponse::dump_to(std::string &out) const {
   out.append("LockStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", static_cast<enums::LockState>(this->state));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void LockCommandRequest::dump_to(std::string &out) const {
   out.append("LockCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
-
   dump_field(out, "has_code", this->has_code);
-
   dump_field(out, "code", this->code);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1738,29 +1478,23 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesButtonResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void ButtonCommandRequest::dump_to(std::string &out) const {
   out.append("ButtonCommandRequest {\n");
   dump_field(out, "key", this->key);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1770,11 +1504,8 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   out.append("MediaPlayerSupportedFormat {\n");
   dump_field(out, "format", this->format_ref_);
   dump_field(out, "sample_rate", this->sample_rate);
-
   dump_field(out, "num_channels", this->num_channels);
-
   dump_field(out, "purpose", static_cast<enums::MediaPlayerFormatPurpose>(this->purpose));
-
   dump_field(out, "sample_bytes", this->sample_bytes);
   out.append("}");
 }
@@ -1782,17 +1513,13 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesMediaPlayerResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "supports_pause", this->supports_pause);
-
   for (const auto &it : this->supported_formats) {
     out.append("  supported_formats: ");
     it.dump_to(out);
@@ -1801,48 +1528,33 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
 
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void MediaPlayerStateResponse::dump_to(std::string &out) const {
   out.append("MediaPlayerStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", static_cast<enums::MediaPlayerState>(this->state));
-
   dump_field(out, "volume", this->volume);
-
   dump_field(out, "muted", this->muted);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void MediaPlayerCommandRequest::dump_to(std::string &out) const {
   out.append("MediaPlayerCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_command", this->has_command);
-
   dump_field(out, "command", static_cast<enums::MediaPlayerCommand>(this->command));
-
   dump_field(out, "has_volume", this->has_volume);
-
   dump_field(out, "volume", this->volume);
-
   dump_field(out, "has_media_url", this->has_media_url);
-
   dump_field(out, "media_url", this->media_url);
   dump_field(out, "has_announcement", this->has_announcement);
-
   dump_field(out, "announcement", this->announcement);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -1856,11 +1568,8 @@ void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const 
 void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   out.append("BluetoothLERawAdvertisement {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "rssi", this->rssi);
-
   dump_field(out, "address_type", this->address_type);
-
   out.append("  data: ");
   out.append(format_hex_pretty(this->data, this->data_len));
   out.append("\n");
@@ -1878,22 +1587,16 @@ void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
 void BluetoothDeviceRequest::dump_to(std::string &out) const {
   out.append("BluetoothDeviceRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "request_type", static_cast<enums::BluetoothDeviceRequestType>(this->request_type));
-
   dump_field(out, "has_address_type", this->has_address_type);
-
   dump_field(out, "address_type", this->address_type);
   out.append("}");
 }
 void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
   out.append("BluetoothDeviceConnectionResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "connected", this->connected);
-
   dump_field(out, "mtu", this->mtu);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
@@ -1914,9 +1617,7 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   }
 
   dump_field(out, "handle", this->handle);
-
   dump_field(out, "properties", this->properties);
-
   for (const auto &it : this->descriptors) {
     out.append("  descriptors: ");
     it.dump_to(out);
@@ -1931,7 +1632,6 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   }
 
   dump_field(out, "handle", this->handle);
-
   for (const auto &it : this->characteristics) {
     out.append("  characteristics: ");
     it.dump_to(out);
@@ -1942,7 +1642,6 @@ void BluetoothGATTService::dump_to(std::string &out) const {
 void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTGetServicesResponse {\n");
   dump_field(out, "address", this->address);
-
   for (const auto &it : this->services) {
     out.append("  services: ");
     it.dump_to(out);
@@ -1958,16 +1657,13 @@ void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
 void BluetoothGATTReadRequest::dump_to(std::string &out) const {
   out.append("BluetoothGATTReadRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTReadResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
@@ -1976,11 +1672,8 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
 void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   out.append("BluetoothGATTWriteRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   dump_field(out, "response", this->response);
-
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
   out.append("\n");
@@ -1989,16 +1682,13 @@ void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
 void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
   out.append("BluetoothGATTReadDescriptorRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   out.append("BluetoothGATTWriteDescriptorRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   out.append("  data: ");
   out.append(format_hex_pretty(reinterpret_cast<const uint8_t *>(this->data.data()), this->data.size()));
   out.append("\n");
@@ -2007,18 +1697,14 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
 void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
   out.append("BluetoothGATTNotifyRequest {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   dump_field(out, "enable", this->enable);
   out.append("}");
 }
 void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTNotifyDataResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   out.append("  data: ");
   out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
   out.append("\n");
@@ -2030,9 +1716,7 @@ void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
 void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
   out.append("BluetoothConnectionsFreeResponse {\n");
   dump_field(out, "free", this->free);
-
   dump_field(out, "limit", this->limit);
-
   for (const auto &it : this->allocated) {
     dump_field(out, "allocated", it, 4);
   }
@@ -2041,41 +1725,33 @@ void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
 void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTErrorResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTWriteResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
   out.append("BluetoothGATTNotifyResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "handle", this->handle);
   out.append("}");
 }
 void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
   out.append("BluetoothDevicePairingResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "paired", this->paired);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
   out.append("BluetoothDeviceUnpairingResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "success", this->success);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
@@ -2085,16 +1761,13 @@ void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) cons
 void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
   out.append("BluetoothDeviceClearCacheResponse {\n");
   dump_field(out, "address", this->address);
-
   dump_field(out, "success", this->success);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
 void BluetoothScannerStateResponse::dump_to(std::string &out) const {
   out.append("BluetoothScannerStateResponse {\n");
   dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
-
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
   out.append("}");
 }
@@ -2108,26 +1781,21 @@ void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
 void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("SubscribeVoiceAssistantRequest {\n");
   dump_field(out, "subscribe", this->subscribe);
-
   dump_field(out, "flags", this->flags);
   out.append("}");
 }
 void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
   out.append("VoiceAssistantAudioSettings {\n");
   dump_field(out, "noise_suppression_level", this->noise_suppression_level);
-
   dump_field(out, "auto_gain", this->auto_gain);
-
   dump_field(out, "volume_multiplier", this->volume_multiplier);
   out.append("}");
 }
 void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("VoiceAssistantRequest {\n");
   dump_field(out, "start", this->start);
-
   dump_field(out, "conversation_id", this->conversation_id_ref_);
   dump_field(out, "flags", this->flags);
-
   out.append("  audio_settings: ");
   this->audio_settings.dump_to(out);
   out.append("\n");
@@ -2138,7 +1806,6 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
 void VoiceAssistantResponse::dump_to(std::string &out) const {
   out.append("VoiceAssistantResponse {\n");
   dump_field(out, "port", this->port);
-
   dump_field(out, "error", this->error);
   out.append("}");
 }
@@ -2151,7 +1818,6 @@ void VoiceAssistantEventData::dump_to(std::string &out) const {
 void VoiceAssistantEventResponse::dump_to(std::string &out) const {
   out.append("VoiceAssistantEventResponse {\n");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantEvent>(this->event_type));
-
   for (const auto &it : this->data) {
     out.append("  data: ");
     it.dump_to(out);
@@ -2175,13 +1841,10 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
 void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   out.append("VoiceAssistantTimerEventResponse {\n");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
-
   dump_field(out, "timer_id", this->timer_id);
   dump_field(out, "name", this->name);
   dump_field(out, "total_seconds", this->total_seconds);
-
   dump_field(out, "seconds_left", this->seconds_left);
-
   dump_field(out, "is_active", this->is_active);
   out.append("}");
 }
@@ -2234,49 +1897,36 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesAlarmControlPanelResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "supported_features", this->supported_features);
-
   dump_field(out, "requires_code", this->requires_code);
-
   dump_field(out, "requires_code_to_arm", this->requires_code_to_arm);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
   out.append("AlarmControlPanelStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", static_cast<enums::AlarmControlPanelState>(this->state));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
   out.append("AlarmControlPanelCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
-
   dump_field(out, "code", this->code);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2286,49 +1936,37 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesTextResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "min_length", this->min_length);
-
   dump_field(out, "max_length", this->max_length);
-
   dump_field(out, "pattern", this->pattern_ref_);
   dump_field(out, "mode", static_cast<enums::TextMode>(this->mode));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void TextStateResponse::dump_to(std::string &out) const {
   out.append("TextStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state_ref_);
   dump_field(out, "missing_state", this->missing_state);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void TextCommandRequest::dump_to(std::string &out) const {
   out.append("TextCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2338,52 +1976,37 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesDateResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void DateStateResponse::dump_to(std::string &out) const {
   out.append("DateStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "missing_state", this->missing_state);
-
   dump_field(out, "year", this->year);
-
   dump_field(out, "month", this->month);
-
   dump_field(out, "day", this->day);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void DateCommandRequest::dump_to(std::string &out) const {
   out.append("DateCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "year", this->year);
-
   dump_field(out, "month", this->month);
-
   dump_field(out, "day", this->day);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2393,52 +2016,37 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesTimeResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void TimeStateResponse::dump_to(std::string &out) const {
   out.append("TimeStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "missing_state", this->missing_state);
-
   dump_field(out, "hour", this->hour);
-
   dump_field(out, "minute", this->minute);
-
   dump_field(out, "second", this->second);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void TimeCommandRequest::dump_to(std::string &out) const {
   out.append("TimeCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "hour", this->hour);
-
   dump_field(out, "minute", this->minute);
-
   dump_field(out, "second", this->second);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2448,15 +2056,12 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesEventResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
   for (const auto &it : this->event_types) {
     dump_field(out, "event_types", it, 4);
@@ -2464,18 +2069,15 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
 
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void EventResponse::dump_to(std::string &out) const {
   out.append("EventResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "event_type", this->event_type_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2485,55 +2087,39 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesValveResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
   dump_field(out, "assumed_state", this->assumed_state);
-
   dump_field(out, "supports_position", this->supports_position);
-
   dump_field(out, "supports_stop", this->supports_stop);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void ValveStateResponse::dump_to(std::string &out) const {
   out.append("ValveStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "position", this->position);
-
   dump_field(out, "current_operation", static_cast<enums::ValveOperation>(this->current_operation));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void ValveCommandRequest::dump_to(std::string &out) const {
   out.append("ValveCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "has_position", this->has_position);
-
   dump_field(out, "position", this->position);
-
   dump_field(out, "stop", this->stop);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2543,44 +2129,33 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesDateTimeResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void DateTimeStateResponse::dump_to(std::string &out) const {
   out.append("DateTimeStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "missing_state", this->missing_state);
-
   dump_field(out, "epoch_seconds", this->epoch_seconds);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void DateTimeCommandRequest::dump_to(std::string &out) const {
   out.append("DateTimeCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "epoch_seconds", this->epoch_seconds);
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
@@ -2590,34 +2165,25 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   out.append("ListEntitiesUpdateResponse {\n");
   dump_field(out, "object_id", this->object_id_ref_);
   dump_field(out, "key", this->key);
-
   dump_field(out, "name", this->name_ref_);
 #ifdef USE_ENTITY_ICON
   dump_field(out, "icon", this->icon_ref_);
 #endif
   dump_field(out, "disabled_by_default", this->disabled_by_default);
-
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
-
   dump_field(out, "device_class", this->device_class_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void UpdateStateResponse::dump_to(std::string &out) const {
   out.append("UpdateStateResponse {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "missing_state", this->missing_state);
-
   dump_field(out, "in_progress", this->in_progress);
-
   dump_field(out, "has_progress", this->has_progress);
-
   dump_field(out, "progress", this->progress);
-
   dump_field(out, "current_version", this->current_version_ref_);
   dump_field(out, "latest_version", this->latest_version_ref_);
   dump_field(out, "title", this->title_ref_);
@@ -2625,19 +2191,15 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   dump_field(out, "release_url", this->release_url_ref_);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }
 void UpdateCommandRequest::dump_to(std::string &out) const {
   out.append("UpdateCommandRequest {\n");
   dump_field(out, "key", this->key);
-
   dump_field(out, "command", static_cast<enums::UpdateCommand>(this->command));
-
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
-
 #endif
   out.append("}");
 }

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1726,9 +1726,8 @@ def build_message_type(
             dump_impl += f" {dump[0]} "
         else:
             dump_impl += "\n"
-            dump_impl += f'  out.append("{desc.name} {{\\n");\n'
+            dump_impl += f'  MessageDumpHelper helper(out, "{desc.name}");\n'
             dump_impl += indent("\n".join(dump)) + "\n"
-            dump_impl += '  out.append("}");\n'
     else:
         o2 = f'out.append("{desc.name} {{}}");'
         if len(dump_impl) + len(o2) + 3 < 120:
@@ -2094,6 +2093,19 @@ static inline void append_with_newline(std::string &out, const char *str) {
   out.append(str);
   out.append("\\n");
 }
+
+// RAII helper for message dump formatting
+class MessageDumpHelper {
+ public:
+  MessageDumpHelper(std::string &out, const char *message_name) : out_(out) {
+    out_.append(message_name);
+    out_.append(" {\\n");
+  }
+  ~MessageDumpHelper() { out_.append(" }"); }
+
+ private:
+  std::string &out_;
+};
 
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -620,7 +620,7 @@ class StringType(TypeInfo):
         # For SOURCE_BOTH, we need custom logic
         o = f'out.append("  {self.name}: ");\n'
         o += self.dump(f"this->{self.field_name}") + "\n"
-        o += 'out.append("\\n");\n'
+        o += 'out.append("\\n");'
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
@@ -689,7 +689,7 @@ class MessageType(TypeInfo):
     def dump_content(self) -> str:
         o = f'out.append("  {self.name}: ");\n'
         o += f"this->{self.field_name}.dump_to(out);\n"
-        o += 'out.append("\\n");\n'
+        o += 'out.append("\\n");'
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
@@ -768,7 +768,7 @@ class BytesType(TypeInfo):
     def dump_content(self) -> str:
         o = f'out.append("  {self.name}: ");\n'
         o += self.dump(f"this->{self.field_name}") + "\n"
-        o += 'out.append("\\n");\n'
+        o += 'out.append("\\n");'
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2129,13 +2129,6 @@ static void dump_field(std::string &out, const char *field_name, float value, in
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
-  char buffer[64];
-  append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%g", value);
-  append_with_newline(out, buffer);
-}
-
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -224,12 +224,26 @@ class TypeInfo(ABC):
 
     encode_func = None
 
+    @classmethod
+    def can_use_dump_field(cls) -> bool:
+        """Whether this type can use the dump_field helper functions.
+
+        Returns True for simple types that have dump_field overloads.
+        Complex types like messages and bytes should return False.
+        """
+        return True
+
+    def dump_field_value(self, value: str) -> str:
+        """Get the value expression to pass to dump_field.
+
+        Most types just pass the value directly, but some (like enums) need a cast.
+        """
+        return value
+
     @property
     def dump_content(self) -> str:
-        o = f'out.append("  {self.name}: ");\n'
-        o += self.dump(f"this->{self.field_name}") + "\n"
-        o += 'out.append("\\n");\n'
-        return o
+        # Default implementation - subclasses can override if they need special handling
+        return f'dump_field(out, "{self.name}", {self.dump_field_value(f"this->{self.field_name}")});\n'
 
     @abstractmethod
     def dump(self, name: str) -> str:
@@ -593,6 +607,22 @@ class StringType(TypeInfo):
             f"}}"
         )
 
+    @property
+    def dump_content(self) -> str:
+        # For SOURCE_CLIENT only, use std::string
+        if not self._needs_encode:
+            return f'dump_field(out, "{self.name}", this->{self.field_name});'
+
+        # For SOURCE_SERVER, use StringRef with _ref_ suffix
+        if not self._needs_decode:
+            return f'dump_field(out, "{self.name}", this->{self.field_name}_ref_);'
+
+        # For SOURCE_BOTH, we need custom logic
+        o = f'out.append("  {self.name}: ");\n'
+        o += self.dump(f"this->{self.field_name}") + "\n"
+        o += 'out.append("\\n");\n'
+        return o
+
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         # For SOURCE_CLIENT only messages, use the string field directly
         if not self._needs_encode:
@@ -615,6 +645,10 @@ class StringType(TypeInfo):
 
 @register_type(11)
 class MessageType(TypeInfo):
+    @classmethod
+    def can_use_dump_field(cls) -> bool:
+        return False
+
     @property
     def cpp_type(self) -> str:
         return self._field.type_name[1:]
@@ -651,6 +685,13 @@ class MessageType(TypeInfo):
         o = f"{name}.dump_to(out);"
         return o
 
+    @property
+    def dump_content(self) -> str:
+        o = f'out.append("  {self.name}: ");\n'
+        o += f"this->{self.field_name}.dump_to(out);\n"
+        o += 'out.append("\\n");\n'
+        return o
+
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_simple_size_calculation(name, force, "add_message_object")
 
@@ -664,6 +705,10 @@ class MessageType(TypeInfo):
 
 @register_type(12)
 class BytesType(TypeInfo):
+    @classmethod
+    def can_use_dump_field(cls) -> bool:
+        return False
+
     cpp_type = "std::string"
     default_value = ""
     reference_type = "std::string &"
@@ -719,6 +764,13 @@ class BytesType(TypeInfo):
             f"  }}"
         )
 
+    @property
+    def dump_content(self) -> str:
+        o = f'out.append("  {self.name}: ");\n'
+        o += self.dump(f"this->{self.field_name}") + "\n"
+        o += 'out.append("\\n");\n'
+        return o
+
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return f"ProtoSize::add_bytes_field(total_size, {self.calculate_field_id_size()}, this->{self.field_name}_len_);"
 
@@ -728,6 +780,10 @@ class BytesType(TypeInfo):
 
 class FixedArrayBytesType(TypeInfo):
     """Special type for fixed-size byte arrays."""
+
+    @classmethod
+    def can_use_dump_field(cls) -> bool:
+        return False
 
     def __init__(self, field: descriptor.FieldDescriptorProto, size: int) -> None:
         super().__init__(field)
@@ -776,6 +832,13 @@ class FixedArrayBytesType(TypeInfo):
 
     def dump(self, name: str) -> str:
         o = f"out.append(format_hex_pretty({name}, {name}_len));"
+        return o
+
+    @property
+    def dump_content(self) -> str:
+        o = f'out.append("  {self.name}: ");\n'
+        o += f"out.append(format_hex_pretty(this->{self.field_name}, this->{self.field_name}_len));\n"
+        o += 'out.append("\\n");\n'
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
@@ -849,6 +912,10 @@ class EnumType(TypeInfo):
     def dump(self, name: str) -> str:
         o = f"out.append(proto_enum_to_string<{self.cpp_type}>({name}));"
         return o
+
+    def dump_field_value(self, value: str) -> str:
+        # Enums need explicit cast for the template
+        return f"static_cast<{self.cpp_type}>({value})"
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return self._get_simple_size_calculation(
@@ -947,6 +1014,27 @@ class SInt64Type(TypeInfo):
         return self.calculate_field_id_size() + 3  # field ID + 3 bytes typical varint
 
 
+def _generate_array_dump_content(
+    ti, field_name: str, name: str, is_bool: bool = False
+) -> str:
+    """Generate dump content for array types (repeated or fixed array).
+
+    Shared helper to avoid code duplication between RepeatedTypeInfo and FixedArrayRepeatedType.
+    """
+    o = f"for (const auto {'' if is_bool else '&'}it : {field_name}) {{\n"
+    # Check if underlying type can use dump_field
+    if type(ti).can_use_dump_field():
+        # For types that have dump_field overloads, use them with extra indent
+        o += f'  dump_field(out, "{name}", {ti.dump_field_value("it")}, 4);\n'
+    else:
+        # For complex types (messages, bytes), use the old pattern
+        o += f'  out.append("  {name}: ");\n'
+        o += indent(ti.dump("it")) + "\n"
+        o += '  out.append("\\n");\n'
+    o += "}\n"
+    return o
+
+
 class FixedArrayRepeatedType(TypeInfo):
     """Special type for fixed-size repeated fields using std::array.
 
@@ -1013,12 +1101,9 @@ class FixedArrayRepeatedType(TypeInfo):
 
     @property
     def dump_content(self) -> str:
-        o = f"for (const auto &it : this->{self.field_name}) {{\n"
-        o += f'  out.append("  {self.name}: ");\n'
-        o += indent(self._ti.dump("it")) + "\n"
-        o += '  out.append("\\n");\n'
-        o += "}\n"
-        return o
+        return _generate_array_dump_content(
+            self._ti, f"this->{self.field_name}", self.name, is_bool=False
+        )
 
     def dump(self, name: str) -> str:
         # This is used when dumping the array itself (not its elements)
@@ -1144,12 +1229,9 @@ class RepeatedTypeInfo(TypeInfo):
 
     @property
     def dump_content(self) -> str:
-        o = f"for (const auto {'' if self._ti_is_bool else '&'}it : this->{self.field_name}) {{\n"
-        o += f'  out.append("  {self.name}: ");\n'
-        o += indent(self._ti.dump("it")) + "\n"
-        o += '  out.append("\\n");\n'
-        o += "}\n"
-        return o
+        return _generate_array_dump_content(
+            self._ti, f"this->{self.field_name}", self.name, is_bool=self._ti_is_bool
+        )
 
     def dump(self, _: str):
         pass
@@ -1644,7 +1726,6 @@ def build_message_type(
             dump_impl += f" {dump[0]} "
         else:
             dump_impl += "\n"
-            dump_impl += "  __attribute__((unused)) char buffer[64];\n"
             dump_impl += f'  out.append("{desc.name} {{\\n");\n'
             dump_impl += indent("\n".join(dump)) + "\n"
             dump_impl += '  out.append("}");\n'
@@ -2002,6 +2083,72 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
     out.append(ref.c_str());
   }
   out.append("'");
+}
+
+// Helper functions to reduce code duplication in dump methods
+static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%" PRId32, value);
+  out.append(buffer);
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%" PRIu32, value);
+  out.append(buffer);
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%g", value);
+  out.append(buffer);
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%g", value);
+  out.append(buffer);
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
+  char buffer[64];
+  out.append(indent, ' ').append(field_name).append(": ");
+  snprintf(buffer, 64, "%llu", value);
+  out.append(buffer);
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append(YESNO(value));
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append("'").append(value).append("'");
+  out.append("\\n");
+}
+
+static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  append_quoted_string(out, value);
+  out.append("\\n");
+}
+
+template<typename T>
+static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
+  out.append(indent, ' ').append(field_name).append(": ");
+  out.append(proto_enum_to_string<T>(value));
+  out.append("\\n");
 }
 
 """

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -243,7 +243,7 @@ class TypeInfo(ABC):
     @property
     def dump_content(self) -> str:
         # Default implementation - subclasses can override if they need special handling
-        return f'dump_field(out, "{self.name}", {self.dump_field_value(f"this->{self.field_name}")});\n'
+        return f'dump_field(out, "{self.name}", {self.dump_field_value(f"this->{self.field_name}")});'
 
     @abstractmethod
     def dump(self, name: str) -> str:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1031,7 +1031,7 @@ def _generate_array_dump_content(
         o += f'  out.append("  {name}: ");\n'
         o += indent(ti.dump("it")) + "\n"
         o += '  out.append("\\n");\n'
-    o += "}\n"
+    o += "}"
     return o
 
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -838,7 +838,7 @@ class FixedArrayBytesType(TypeInfo):
     def dump_content(self) -> str:
         o = f'out.append("  {self.name}: ");\n'
         o += f"out.append(format_hex_pretty(this->{self.field_name}, this->{self.field_name}_len));\n"
-        o += 'out.append("\\n");\n'
+        o += 'out.append("\\n");'
         return o
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2085,68 +2085,73 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
   out.append("'");
 }
 
+// Common helpers for dump_field functions
+static inline void append_field_prefix(std::string &out, const char *field_name, int indent) {
+  out.append(indent, ' ').append(field_name).append(": ");
+}
+
+static inline void append_with_newline(std::string &out, const char *str) {
+  out.append(str);
+  out.append("\\n");
+}
+
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRId32, value);
-  out.append(buffer);
-  out.append("\\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu32, value);
-  out.append(buffer);
-  out.append("\\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
-  out.append(buffer);
-  out.append("\\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, double value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
-  out.append(buffer);
-  out.append("\\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%llu", value);
-  out.append(buffer);
-  out.append("\\n");
+  append_with_newline(out, buffer);
 }
 
 static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append(YESNO(value));
   out.append("\\n");
 }
 
 static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append("'").append(value).append("'");
   out.append("\\n");
 }
 
 static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   append_quoted_string(out, value);
   out.append("\\n");
 }
 
 template<typename T>
 static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
-  out.append(indent, ' ').append(field_name).append(": ");
+  append_field_prefix(out, field_name, indent);
   out.append(proto_enum_to_string<T>(value));
   out.append("\\n");
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR significantly reduces code duplication in the generated API protobuf dump methods by introducing reusable helper functions and patterns. The changes improve maintainability while also reducing flash usage by ~13KB.

## Summary of Changes

### 1. Added dump_field Helper Functions
Introduced overloaded `dump_field` helper functions for all basic types (int32_t, uint32_t, float, double, uint64_t, bool, std::string, StringRef, and enums) that replace repetitive snprintf patterns throughout api_pb2_dump.cpp.

### 2. Additional Inline Helpers
- `append_field_prefix()` - Handles the common pattern of appending indent, field name, and colon separator
- `append_with_newline()` - Appends a string followed by a newline

### 3. RAII MessageDumpHelper Class
Implemented a RAII helper class that automatically handles the opening and closing braces for message dumps, ensuring consistent formatting and reducing code at each call site.

### 4. Fixed Multi-line Logging Alignment
Fixed the closing brace alignment in multi-line dump output by adding a single space before `}`, ensuring proper visual alignment when logged through `ESP_LOGVV`.

## Results

- **Source code reduction**: 53% fewer lines (4,439 → 2,080)
- **Flash savings**: 12,976 bytes (0.7% reduction)
- **RAM usage**: Unchanged
- **Runtime performance**: ~4% improvement in benchmarks
- **Better maintainability**: DRY principle, RAII pattern, consistent formatting

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a code generation improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

