### PR TITLE
[udp] Move ``on_receive`` to const

### DIFF
--- a/esphome/components/const/__init__.py
+++ b/esphome/components/const/__init__.py
@@ -5,5 +5,6 @@ CODEOWNERS = ["@esphome/core"]
 CONF_BYTE_ORDER = "byte_order"
 CONF_COLOR_DEPTH = "color_depth"
 CONF_DRAW_ROUNDING = "draw_rounding"
+CONF_ON_RECEIVE = "on_receive"
 CONF_ON_STATE_CHANGE = "on_state_change"
 CONF_REQUEST_HEADERS = "request_headers"

--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -1,6 +1,7 @@
 from esphome import automation
 from esphome.automation import Trigger
 import esphome.codegen as cg
+from esphome.components.const import CONF_ON_RECEIVE
 from esphome.components.packet_transport import (
     CONF_BINARY_SENSORS,
     CONF_ENCRYPTION,
@@ -27,7 +28,6 @@ trigger_args = cg.std_vector.template(cg.uint8)
 CONF_ADDRESSES = "addresses"
 CONF_LISTEN_ADDRESS = "listen_address"
 CONF_UDP_ID = "udp_id"
-CONF_ON_RECEIVE = "on_receive"
 CONF_LISTEN_PORT = "listen_port"
 CONF_BROADCAST_PORT = "broadcast_port"
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
