### PR TITLE
[core] Allow extra args on cli and just ignore them

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1033,11 +1033,11 @@ def parse_args(argv):
     arguments = argv[1:]
 
     argcomplete.autocomplete(parser)
-    return parser.parse_args(arguments)
+    return parser.parse_known_args(arguments)
 
 
 def run_esphome(argv):
-    args = parse_args(argv)
+    args, _ = parse_args(argv)
     CORE.dashboard = args.dashboard
 
     # Override log level if verbose is set

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1040,7 +1040,7 @@ def parse_args(argv):
 
     argcomplete.autocomplete(parser)
 
-    if any(arg in SIMPLE_CONFIG_ACTIONS for arg in arguments):
+    if arguments and arguments[0] in SIMPLE_CONFIG_ACTIONS:
         args, unknown_args = parser.parse_known_args(arguments)
         if unknown_args:
             _LOGGER.warning("Ignored unrecognized arguments: %s", unknown_args)

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1040,7 +1040,7 @@ def parse_args(argv):
 
     argcomplete.autocomplete(parser)
 
-    if arguments and arguments[0] in SIMPLE_CONFIG_ACTIONS:
+    if len(arguments) > 0 and arguments[0] in SIMPLE_CONFIG_ACTIONS:
         args, unknown_args = parser.parse_known_args(arguments)
         if unknown_args:
             _LOGGER.warning("Ignored unrecognized arguments: %s", unknown_args)

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -768,6 +768,12 @@ POST_CONFIG_ACTIONS = {
     "discover": command_discover,
 }
 
+SIMPLE_CONFIG_ACTIONS = [
+    "clean",
+    "clean-mqtt",
+    "config",
+]
+
 
 def parse_args(argv):
     options_parser = argparse.ArgumentParser(add_help=False)
@@ -1033,11 +1039,15 @@ def parse_args(argv):
     arguments = argv[1:]
 
     argcomplete.autocomplete(parser)
-    return parser.parse_known_args(arguments)
+    args, _ = parser.parse_known_args(arguments)
+    if args.command not in SIMPLE_CONFIG_ACTIONS:
+        return parser.parse_args(arguments)
+
+    return args
 
 
 def run_esphome(argv):
-    args, _ = parse_args(argv)
+    args = parse_args(argv)
     CORE.dashboard = args.dashboard
 
     # Override log level if verbose is set

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1039,11 +1039,14 @@ def parse_args(argv):
     arguments = argv[1:]
 
     argcomplete.autocomplete(parser)
-    args, _ = parser.parse_known_args(arguments)
-    if args.command not in SIMPLE_CONFIG_ACTIONS:
-        return parser.parse_args(arguments)
 
-    return args
+    if any(arg in SIMPLE_CONFIG_ACTIONS for arg in arguments):
+        args, unknown_args = parser.parse_known_args(arguments)
+        if unknown_args:
+            _LOGGER.warning("Ignored unrecognized arguments: %s", unknown_args)
+        return args
+
+    return parser.parse_args(arguments)
 
 
 def run_esphome(argv):


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This ignores any unknown arguments when using `config`, `clean`, or `clean-mqtt`. It will still throw `unrecognized arguments:` for all other commands.

This is useful when using the cli and running something like `esphome run config/blah.yaml --device ...` then using the shell history to go back and only change `run` to `clean` when needed without having to remove the device arg.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
