### PR TITLE
[remote_receiver] Fix idle validation

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -86,10 +86,9 @@ void RemoteReceiverComponent::setup() {
 
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
   uint32_t max_filter_ns = 255u * 1000 / (RMT_CLK_FREQ / 1000000);
-  uint32_t max_idle_ns = 65535u * 1000;
   memset(&this->store_.config, 0, sizeof(this->store_.config));
   this->store_.config.signal_range_min_ns = std::min(this->filter_us_ * 1000, max_filter_ns);
-  this->store_.config.signal_range_max_ns = std::min(this->idle_us_ * 1000, max_idle_ns);
+  this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;
   this->store_.filter_symbols = this->filter_symbols_;
   this->store_.receive_size = this->receive_symbols_ * sizeof(rmt_symbol_word_t);
   this->store_.buffer_size = std::max((event_size + this->store_.receive_size) * 2, this->buffer_size_);


### PR DESCRIPTION
# What does this implement/fix?

After reviewing RMT idle time in more detail some changes are needed. Max idle time is different on some variants can be scaled by clock resolution. 

Validate idle in python, remove the min from the code and update the docs. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9708

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5144

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
