### PR TITLE
[core] Initialize ``looping_components_`` before setup blocking phase

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -55,6 +55,9 @@ void Application::setup() {
     return a->get_actual_setup_priority() > b->get_actual_setup_priority();
   });
 
+  // Initialize looping_components_ early so enable_pending_loops_() works during setup
+  this->calculate_looping_components_();
+
   for (uint32_t i = 0; i < this->components_.size(); i++) {
     Component *component = this->components_[i];
 
@@ -97,7 +100,6 @@ void Application::setup() {
   clear_setup_priority_overrides();
 
   this->schedule_dump_config();
-  this->calculate_looping_components_();
 }
 void Application::loop() {
   uint8_t new_app_state = 0;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -271,24 +271,16 @@ void Application::calculate_looping_components_() {
   // Pre-reserve vector to avoid reallocations
   this->looping_components_.reserve(total_looping);
 
-  // First add all active components
+  // Add all components with loop override
+  // When called at start of setup, all components are in CONSTRUCTION state
+  // so none will be LOOP_DONE yet - they'll all go in the active section
   for (auto *obj : this->components_) {
-    if (obj->has_overridden_loop() &&
-        (obj->get_component_state() & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
+    if (obj->has_overridden_loop()) {
       this->looping_components_.push_back(obj);
     }
   }
 
   this->looping_components_active_end_ = this->looping_components_.size();
-
-  // Then add all inactive (LOOP_DONE) components
-  // This handles components that called disable_loop() during setup, before this method runs
-  for (auto *obj : this->components_) {
-    if (obj->has_overridden_loop() &&
-        (obj->get_component_state() & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE) {
-      this->looping_components_.push_back(obj);
-    }
-  }
 }
 
 void Application::disable_component_loop_(Component *component) {


### PR DESCRIPTION
# What does this implement/fix?

This completes the fix from #9787 by ensuring `looping_components_` is initialized before the setup blocking phase. Without this change, touch/GPIO interrupts that occur during WiFi connection (or any other blocking setup phase) are not processed because `enable_pending_loops_()` iterates over an empty vector.

The issue was that `calculate_looping_components_()` was only called at the end of setup, but the mechanism to process pending loop enables (added in #9787) needs this vector to be populated during setup.

This change also optimizes `calculate_looping_components_()` by removing an unnecessary loop. When called at the beginning of setup, no components can be in `LOOP_DONE` state yet, so we don't need to check for them separately.

**Flash savings: 76 bytes**
```
Before: Flash: [=======   ]  70.1% (used 1286690 bytes from 1835008 bytes)
After:  Flash: [=======   ]  70.1% (used 1286614 bytes from 1835008 bytes)
```

(Apologies - I had this change on another branch where I was testing the optimization. The fix in #9787 appeared to work during my testing because this change was already integrated in my test branch, but the PR was incomplete without it.)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9786

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation fix

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test configuration to reproduce the issue
esp32_touch:
  setup_mode: false

binary_sensor:
  - platform: esp32_touch
    name: "Touch Pad 1"
    pin: GPIO4
    threshold: 1000
    on_press:
      then:
        - logger.log: "Touch detected during WiFi setup!"

wifi:
  ssid: "test_ssid"
  password: "test_password"

logger:
  level: VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).