### PR TITLE
[gt911] i2c fixes

### DIFF
--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -18,8 +18,7 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 #define ERROR_CHECK(err) \
   if ((err) != i2c::ERROR_OK) { \
-    ESP_LOGE(TAG, "Failed to communicate!"); \
-    this->status_set_warning(); \
+    this->status_set_warning("Communication failure"); \
     return; \
   }
 
@@ -46,11 +45,15 @@ void GT911Touchscreen::setup() {
 
   // check the configuration of the int line.
   uint8_t data[4];
-  err = this->write(GET_SWITCHES, 2);
+  err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
+  if (err != i2c::ERROR_OK && this->address_ == 0x5D) {
+    this->address_ = 0x14;
+    err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
+  }
   if (err == i2c::ERROR_OK) {
     err = this->read(data, 1);
     if (err == i2c::ERROR_OK) {
-      ESP_LOGD(TAG, "Read from switches: 0x%02X", data[0]);
+      ESP_LOGD(TAG, "Read from switches at address 0x%02X: 0x%02X", this->address_, data[0]);
       if (this->interrupt_pin_ != nullptr) {
         // datasheet says NOT to use pullup/down on the int line.
         this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT);
@@ -63,7 +66,7 @@ void GT911Touchscreen::setup() {
   if (this->x_raw_max_ == 0 || this->y_raw_max_ == 0) {
     // no calibration? Attempt to read the max values from the touchscreen.
     if (err == i2c::ERROR_OK) {
-      err = this->write(GET_MAX_VALUES, 2);
+      err = this->write(GET_MAX_VALUES, sizeof(GET_MAX_VALUES));
       if (err == i2c::ERROR_OK) {
         err = this->read(data, sizeof(data));
         if (err == i2c::ERROR_OK) {
@@ -75,15 +78,12 @@ void GT911Touchscreen::setup() {
       }
     }
     if (err != i2c::ERROR_OK) {
-      ESP_LOGE(TAG, "Failed to read calibration values from touchscreen!");
-      this->mark_failed();
+      this->mark_failed("Failed to read calibration");
       return;
     }
   }
   if (err != i2c::ERROR_OK) {
-    ESP_LOGE(TAG, "Failed to communicate!");
-    this->mark_failed();
-    return;
+    this->mark_failed("Failed to communicate");
   }
 
   ESP_LOGCONFIG(TAG, "GT911 Touchscreen setup complete");
@@ -94,7 +94,7 @@ void GT911Touchscreen::update_touches() {
   uint8_t touch_state = 0;
   uint8_t data[MAX_TOUCHES + 1][8];  // 8 bytes each for each point, plus extra space for the key byte
 
-  err = this->write(GET_TOUCH_STATE, sizeof(GET_TOUCH_STATE), false);
+  err = this->write(GET_TOUCH_STATE, sizeof(GET_TOUCH_STATE));
   ERROR_CHECK(err);
   err = this->read(&touch_state, 1);
   ERROR_CHECK(err);
@@ -106,7 +106,7 @@ void GT911Touchscreen::update_touches() {
     return;
   }
 
-  err = this->write(GET_TOUCHES, sizeof(GET_TOUCHES), false);
+  err = this->write(GET_TOUCHES, sizeof(GET_TOUCHES));
   ERROR_CHECK(err);
   // num_of_touches is guaranteed to be 0..5. Also read the key data
   err = this->read(data[0], sizeof(data[0]) * num_of_touches + 1);

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -31,18 +31,17 @@ void GT911Touchscreen::setup() {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {
-      // The interrupt pin is used as an input during reset to select the I2C address.
+      // temporarily set the interrupt pin to output to control address selection
       this->interrupt_pin_->pin_mode(gpio::FLAG_OUTPUT);
-      this->interrupt_pin_->setup();
       this->interrupt_pin_->digital_write(false);
     }
     delay(2);
     this->reset_pin_->digital_write(true);
     delay(50);  // NOLINT
-    if (this->interrupt_pin_ != nullptr) {
-      this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT);
-      this->interrupt_pin_->setup();
-    }
+  }
+  if (this->interrupt_pin_ != nullptr) {
+    // set pre-configured input mode
+    this->interrupt_pin_->setup();
   }
 
   // check the configuration of the int line.
@@ -57,9 +56,6 @@ void GT911Touchscreen::setup() {
     if (err == i2c::ERROR_OK) {
       ESP_LOGD(TAG, "Read from switches at address 0x%02X: 0x%02X", this->address_, data[0]);
       if (this->interrupt_pin_ != nullptr) {
-        // datasheet says NOT to use pullup/down on the int line.
-        this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT);
-        this->interrupt_pin_->setup();
         this->attach_interrupt_(this->interrupt_pin_,
                                 (data[0] & 1) ? gpio::INTERRUPT_FALLING_EDGE : gpio::INTERRUPT_RISING_EDGE);
       }

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -8,6 +8,8 @@ namespace gt911 {
 
 static const char *const TAG = "gt911.touchscreen";
 
+static const uint8_t PRIMARY_ADDRESS = 0x5D;    // default I2C address for GT911
+static const uint8_t SECONDARY_ADDRESS = 0x14;  // secondary I2C address for GT911
 static const uint8_t GET_TOUCH_STATE[2] = {0x81, 0x4E};
 static const uint8_t CLEAR_TOUCH_STATE[3] = {0x81, 0x4E, 0x00};
 static const uint8_t GET_TOUCHES[2] = {0x81, 0x4F};
@@ -46,8 +48,8 @@ void GT911Touchscreen::setup() {
   // check the configuration of the int line.
   uint8_t data[4];
   err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
-  if (err != i2c::ERROR_OK && this->address_ == 0x5D) {
-    this->address_ = 0x14;
+  if (err != i2c::ERROR_OK && this->address_ == PRIMARY_ADDRESS) {
+    this->address_ = SECONDARY_ADDRESS;
     err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
   }
   if (err == i2c::ERROR_OK) {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -130,6 +130,7 @@ void GT911Touchscreen::dump_config() {
   ESP_LOGCONFIG(TAG, "GT911 Touchscreen:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
 }
 
 }  // namespace gt911


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The GT911 touch controller has two possible addresses, and it's not always possible to be sure
which one it will come up in, if the board has not been designed with the correct hardware interface. In addition, communication sometimes fails even after the chip has been initialised.

* Try the alternate address if the primary one fails during setup
* Don't use i2c restart - all transfers end with stop.
* Clean up warnings to avoid spamming the log

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
