### PR TITLE
[core] Fix component state documentation and add state helper method

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -236,6 +236,9 @@ class Component {
   virtual void call_setup();
   virtual void call_dump_config();
 
+  /// Helper to set component state (clears state bits and sets new state)
+  void set_component_state_(uint8_t state);
+
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f every interval ms. Can be cancelled via CancelInterval().
@@ -405,10 +408,10 @@ class Component {
   const char *component_source_{nullptr};
   uint16_t warn_if_blocking_over_{WARN_IF_BLOCKING_OVER_MS};  ///< Warn if blocked for this many ms (max 65.5s)
   /// State of this component - each bit has a purpose:
-  /// Bits 0-1: Component state (0x00=CONSTRUCTION, 0x01=SETUP, 0x02=LOOP, 0x03=FAILED)
-  /// Bit 2: STATUS_LED_WARNING
-  /// Bit 3: STATUS_LED_ERROR
-  /// Bits 4-7: Unused - reserved for future expansion (50% of the bits are free)
+  /// Bits 0-2: Component state (0x00=CONSTRUCTION, 0x01=SETUP, 0x02=LOOP, 0x03=FAILED, 0x04=LOOP_DONE)
+  /// Bit 3: STATUS_LED_WARNING
+  /// Bit 4: STATUS_LED_ERROR
+  /// Bits 5-7: Unused - reserved for future expansion
   uint8_t component_state_{0x00};
   volatile bool pending_enable_loop_{false};  ///< ISR-safe flag for enable_loop_soon_any_context
 };


### PR DESCRIPTION
# What does this implement/fix?

This PR improves code maintainability in the Component class by:
1. Fixing a stale comment that incorrectly documented the component state bit layout
2. Adding a helper method to encapsulate component state changes
3. Cleaning up redundant code in the state machine switch statement

The stale comment claimed component state used bits 0-1 (4 states), but the implementation actually uses bits 0-2 (8 states) with 5 states currently defined. This PR updates the documentation to match reality and refactors the state-setting code to be more maintainable.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation detail)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This refactoring:
- Saves 4 bytes of flash memory (521082 → 521078 bytes)
- Makes the code more maintainable by eliminating repetitive bit manipulation
- Fixes documentation to match implementation
- Removes clang-tidy NOLINT comments by addressing the root cause