### PR TITLE
[bluetooth_proxy] [esp32_ble_tracker] [esp32_ble] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -8,8 +8,7 @@
 
 #include "bluetooth_proxy.h"
 
-namespace esphome {
-namespace bluetooth_proxy {
+namespace esphome::bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy.connection";
 
@@ -422,7 +421,6 @@ esp32_ble_tracker::AdvertisementParserType BluetoothConnection::get_advertisemen
   return this->proxy_->get_advertisement_parser_type();
 }
 
-}  // namespace bluetooth_proxy
-}  // namespace esphome
+}  // namespace esphome::bluetooth_proxy
 
 #endif  // USE_ESP32

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -4,8 +4,7 @@
 
 #include "esphome/components/esp32_ble_client/ble_client_base.h"
 
-namespace esphome {
-namespace bluetooth_proxy {
+namespace esphome::bluetooth_proxy {
 
 class BluetoothProxy;
 
@@ -43,7 +42,6 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   // 1 byte used, 1 byte padding
 };
 
-}  // namespace bluetooth_proxy
-}  // namespace esphome
+}  // namespace esphome::bluetooth_proxy
 
 #endif  // USE_ESP32

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace bluetooth_proxy {
+namespace esphome::bluetooth_proxy {
 
 static const char *const TAG = "bluetooth_proxy";
 
@@ -502,7 +501,6 @@ void BluetoothProxy::bluetooth_scanner_set_mode(bool active) {
 
 BluetoothProxy *global_bluetooth_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace bluetooth_proxy
-}  // namespace esphome
+}  // namespace esphome::bluetooth_proxy
 
 #endif  // USE_ESP32

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -18,8 +18,7 @@
 #include <esp_bt.h>
 #include <esp_bt_device.h>
 
-namespace esphome {
-namespace bluetooth_proxy {
+namespace esphome::bluetooth_proxy {
 
 static const esp_err_t ESP_GATT_NOT_CONNECTED = -1;
 static const int DONE_SENDING_SERVICES = -2;
@@ -158,7 +157,6 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
 
 extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace bluetooth_proxy
-}  // namespace esphome
+}  // namespace esphome::bluetooth_proxy
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -19,8 +19,7 @@
 #include <esp32-hal-bt.h>
 #endif
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
@@ -538,7 +537,6 @@ uint64_t ble_addr_to_uint64(const esp_bd_addr_t address) {
 
 ESP32BLE *global_ble = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -21,8 +21,7 @@
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 // Maximum number of BLE scan results to buffer
 // Sized to handle bursts of advertisements while allowing for processing delays
@@ -191,7 +190,6 @@ template<typename... Ts> class BLEDisableAction : public Action<Ts...> {
   void play(Ts... x) override { global_ble->disable(); }
 };
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -8,8 +8,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble.advertising";
 
@@ -160,7 +159,6 @@ void BLEAdvertising::register_raw_advertisement_callback(std::function<void(bool
   this->raw_advertisements_callbacks_.push_back(std::move(callback));
 }
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_advertising.h
+++ b/esphome/components/esp32_ble/ble_advertising.h
@@ -10,8 +10,7 @@
 #include <esp_gap_ble_api.h>
 #include <esp_gatts_api.h>
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 using raw_adv_data_t = struct {
   uint8_t *data;
@@ -55,7 +54,6 @@ class BLEAdvertising {
   int8_t current_adv_index_{-1};  // -1 means standard scan response
 };
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -11,8 +11,7 @@
 
 #include "ble_scan_result.h"
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 // Compile-time verification that ESP-IDF scan complete events only contain a status field
 // This ensures our reinterpret_cast in ble.cpp is safe
@@ -395,7 +394,6 @@ static_assert(sizeof(esp_ble_sec_t) <= 73, "esp_ble_sec_t is larger than BLEScan
 
 // BLEEvent total size: 84 bytes (80 byte union + 1 byte type + 3 bytes padding)
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_scan_result.h
+++ b/esphome/components/esp32_ble/ble_scan_result.h
@@ -4,8 +4,7 @@
 
 #include <esp_gap_ble_api.h>
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 // Structure for BLE scan results - only fields we actually use
 struct __attribute__((packed)) BLEScanResult {
@@ -18,7 +17,6 @@ struct __attribute__((packed)) BLEScanResult {
   uint8_t search_evt;
 };  // ~73 bytes vs ~400 bytes for full esp_ble_gap_cb_param_t
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -7,8 +7,7 @@
 #include <cinttypes>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
@@ -189,7 +188,6 @@ std::string ESPBTUUID::to_string() const {
   return "";
 }
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -8,8 +8,7 @@
 #include <string>
 #include <esp_bt_defs.h>
 
-namespace esphome {
-namespace esp32_ble {
+namespace esphome::esp32_ble {
 
 class ESPBTUUID {
  public:
@@ -41,7 +40,6 @@ class ESPBTUUID {
   esp_bt_uuid_t uuid_;
 };
 
-}  // namespace esp32_ble
-}  // namespace esphome
+}  // namespace esphome::esp32_ble
 
 #endif

--- a/esphome/components/esp32_ble_tracker/automation.h
+++ b/esphome/components/esp32_ble_tracker/automation.h
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace esp32_ble_tracker {
+namespace esphome::esp32_ble_tracker {
 #ifdef USE_ESP32_BLE_DEVICE
 class ESPBTAdvertiseTrigger : public Trigger<const ESPBTDevice &>, public ESPBTDeviceListener {
  public:
@@ -108,7 +107,6 @@ template<typename... Ts> class ESP32BLEStopScanAction : public Action<Ts...>, pu
   void play(Ts... x) override { this->parent_->stop_scan(); }
 };
 
-}  // namespace esp32_ble_tracker
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_tracker
 
 #endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -35,8 +35,7 @@
 // bt_trace.h
 #undef TAG
 
-namespace esphome {
-namespace esp32_ble_tracker {
+namespace esphome::esp32_ble_tracker {
 
 static const char *const TAG = "esp32_ble_tracker";
 
@@ -882,7 +881,6 @@ bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
 }
 #endif  // USE_ESP32_BLE_DEVICE
 
-}  // namespace esp32_ble_tracker
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_tracker
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -22,8 +22,7 @@
 #include "esphome/components/esp32_ble/ble.h"
 #include "esphome/components/esp32_ble/ble_uuid.h"
 
-namespace esphome {
-namespace esp32_ble_tracker {
+namespace esphome::esp32_ble_tracker {
 
 using namespace esp32_ble;
 
@@ -321,7 +320,6 @@ class ESP32BLETracker : public Component,
 // NOLINTNEXTLINE
 extern ESP32BLETracker *global_esp32_ble_tracker;
 
-}  // namespace esp32_ble_tracker
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_tracker
 
 #endif

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -575,13 +575,15 @@ def lint_namespace(fname, content):
     expected_name = re.match(
         r"^esphome/components/([^/]+)/.*", fname.replace(os.path.sep, "/")
     ).group(1)
-    search = f"namespace {expected_name}"
-    if search in content:
+    # Check for both old style and C++17 nested namespace syntax
+    search_old = f"namespace {expected_name}"
+    search_new = f"namespace esphome::{expected_name}"
+    if search_old in content or search_new in content:
         return None
     return (
         "Invalid namespace found in C++ file. All integration C++ files should put all "
         "functions in a separate namespace that matches the integration's name. "
-        f"Please make sure the file contains {highlight(search)}"
+        f"Please make sure the file contains {highlight(search_old)} or {highlight(search_new)}"
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the namespace declarations in the Bluetooth components to use C++17's nested namespace definition syntax. This improves code readability and reduces boilerplate without changing any functionality.

I only did a few to make sure the ci-custom changes work.  We could do a few more in batches.

The change converts:
```cpp
namespace esphome {
namespace bluetooth_proxy {
// ...
}  // namespace bluetooth_proxy
}  // namespace esphome
```

To the more concise C++17 syntax:
```cpp
namespace esphome::bluetooth_proxy {
// ...
}  // namespace esphome::bluetooth_proxy
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a code style improvement only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional notes

This change affects the following components:
- `bluetooth_proxy`
- `esp32_ble_tracker`
- `esp32_ble`

The nested namespace definition syntax was introduced in C++17 and is fully supported by ESPHome's C++ standard (gnu++20). This change is purely cosmetic and does not affect the generated code or functionality.

