### PR TITLE
[ci] Support C++17 nested namespace syntax in linter

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -575,13 +575,15 @@ def lint_namespace(fname, content):
     expected_name = re.match(
         r"^esphome/components/([^/]+)/.*", fname.replace(os.path.sep, "/")
     ).group(1)
-    search = f"namespace {expected_name}"
-    if search in content:
+    # Check for both old style and C++17 nested namespace syntax
+    search_old = f"namespace {expected_name}"
+    search_new = f"namespace esphome::{expected_name}"
+    if search_old in content or search_new in content:
         return None
     return (
         "Invalid namespace found in C++ file. All integration C++ files should put all "
         "functions in a separate namespace that matches the integration's name. "
-        f"Please make sure the file contains {highlight(search)}"
+        f"Please make sure the file contains {highlight(search_old)} or {highlight(search_new)}"
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the CI linter to support C++17 nested namespace syntax, enabling modernization of the codebase's namespace declarations.

Currently, the CI linter (`script/ci-custom.py`) only recognizes traditional C++ namespace declarations:
```cpp
namespace component_name {
```

This change allows it to also recognize C++17 nested namespace syntax:
```cpp
namespace esphome::component_name {
```

This is a prerequisite for PR #9825, which modernizes namespace declarations in Bluetooth components to use C++17 syntax.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** Enables #9825

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this only affects the CI linter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Information

The change modifies the `lint_namespace` function in `script/ci-custom.py` to check for both traditional and C++17 nested namespace syntax. This ensures backward compatibility while allowing new code to use modern C++ features.

C++17's nested namespace definition syntax has been available since C++17 and is fully supported by ESPHome's C++ standard (gnu++20). This change allows developers to write cleaner, more concise namespace declarations without triggering CI failures.