### PR TITLE
[i2c] Use ``i2c_master_probe`` to scan i2c bus

### DIFF
--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -94,7 +94,7 @@ class I2CBus {
  protected:
   /// @brief Scans the I2C bus for devices. Devices presence is kept in an array of std::pair
   /// that contains the address and the corresponding bool presence flag.
-  void i2c_scan_() {
+  virtual void i2c_scan_() {
     for (uint8_t address = 8; address < 120; address++) {
       auto err = writev(address, nullptr, 0);
       if (err == ERROR_OK) {

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -94,7 +94,7 @@ class I2CBus {
  protected:
   /// @brief Scans the I2C bus for devices. Devices presence is kept in an array of std::pair
   /// that contains the address and the corresponding bool presence flag.
-  virtual void i2c_scan_() {
+  virtual void i2c_scan() {
     for (uint8_t address = 8; address < 120; address++) {
       auto err = writev(address, nullptr, 0);
       if (err == ERROR_OK) {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -42,7 +42,7 @@ void ArduinoI2CBus::setup() {
   this->initialized_ = true;
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning bus for active devices");
-    this->i2c_scan_();
+    this->i2c_scan();
   }
 }
 

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -78,7 +78,7 @@ void IDFI2CBus::setup() {
 
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning for devices");
-    this->i2c_scan_();
+    this->i2c_scan();
   }
 #else
 #if SOC_HP_I2C_NUM > 1
@@ -125,7 +125,7 @@ void IDFI2CBus::setup() {
   initialized_ = true;
   if (this->scan_) {
     ESP_LOGV(TAG, "Scanning bus for active devices");
-    this->i2c_scan_();
+    this->i2c_scan();
   }
 #endif
 }
@@ -168,7 +168,7 @@ void IDFI2CBus::dump_config() {
 }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
-void IDFI2CBus::i2c_scan_() {
+void IDFI2CBus::i2c_scan() {
   for (uint8_t address = 8; address < 120; address++) {
     auto err = i2c_master_probe(this->bus_, address, 20);
     if (err == ESP_OK) {

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -1,13 +1,13 @@
 #ifdef USE_ESP_IDF
 
 #include "i2c_bus_esp_idf.h"
+#include <driver/gpio.h>
 #include <cinttypes>
 #include <cstring>
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <driver/gpio.h>
 
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
 #define SOC_HP_I2C_NUM SOC_I2C_NUM
@@ -166,6 +166,17 @@ void IDFI2CBus::dump_config() {
     }
   }
 }
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
+void IDFI2CBus::i2c_scan_() {
+  for (uint8_t address = 8; address < 120; address++) {
+    auto err = i2c_master_probe(this->bus_, address, 20);
+    if (err == ESP_OK) {
+      this->scan_results_.emplace_back(address, true);
+    }
+  }
+}
+#endif
 
 ErrorCode IDFI2CBus::readv(uint8_t address, ReadBuffer *buffers, size_t cnt) {
   // logging is only enabled with vv level, if warnings are shown the caller

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -2,9 +2,9 @@
 
 #ifdef USE_ESP_IDF
 
+#include "esp_idf_version.h"
 #include "esphome/core/component.h"
 #include "i2c_bus.h"
-#include "esp_idf_version.h"
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
 #include <driver/i2c_master.h>
 #else
@@ -46,6 +46,7 @@ class IDFI2CBus : public InternalI2CBus, public Component {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
   i2c_master_dev_handle_t dev_;
   i2c_master_bus_handle_t bus_;
+  void i2c_scan_() override;
 #endif
   i2c_port_t port_;
   uint8_t sda_pin_;

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -46,7 +46,7 @@ class IDFI2CBus : public InternalI2CBus, public Component {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
   i2c_master_dev_handle_t dev_;
   i2c_master_bus_handle_t bus_;
-  void i2c_scan_() override;
+  void i2c_scan() override;
 #endif
   i2c_port_t port_;
   uint8_t sda_pin_;


### PR DESCRIPTION
# What does this implement/fix?

`i2c_master_probe` sets a flag to not log bad ack during a probe of the address and returns `ESP_OK` or `ESP_ERR_NOT_FOUND`

Fixes logging a massive wall of this during setup
```
[19:07:36][D][esp-idf:000]: E (1871) i2c.master: I2C transaction unexpected nack detected
[19:07:36][D][esp-idf:000]: E (1872) i2c.master: s_i2c_synchronous_transaction(945): I2C transaction failed
[19:07:36][D][esp-idf:000]: E (1873) i2c.master: i2c_master_execute_defined_operations(1366): I2C transaction failed
```

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
