### PR TITLE
[esp32_dac] Always use esp-idf APIs

### DIFF
--- a/esphome/components/esp32_dac/esp32_dac.cpp
+++ b/esphome/components/esp32_dac/esp32_dac.cpp
@@ -2,11 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_ESP32
-
-#ifdef USE_ARDUINO
-#include <esp32-hal-dac.h>
-#endif
+#if defined(USE_ESP32_VARIANT_ESP32) || defined(USE_ESP32_VARIANT_ESP32S2)
 
 namespace esphome {
 namespace esp32_dac {
@@ -24,18 +20,12 @@ void ESP32DAC::setup() {
   this->pin_->setup();
   this->turn_off();
 
-#ifdef USE_ESP_IDF
   const dac_channel_t channel = this->pin_->get_pin() == DAC0_PIN ? DAC_CHAN_0 : DAC_CHAN_1;
   const dac_oneshot_config_t oneshot_cfg{channel};
   dac_oneshot_new_channel(&oneshot_cfg, &this->dac_handle_);
-#endif
 }
 
-void ESP32DAC::on_safe_shutdown() {
-#ifdef USE_ESP_IDF
-  dac_oneshot_del_channel(this->dac_handle_);
-#endif
-}
+void ESP32DAC::on_safe_shutdown() { dac_oneshot_del_channel(this->dac_handle_); }
 
 void ESP32DAC::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 DAC:");
@@ -49,15 +39,10 @@ void ESP32DAC::write_state(float state) {
 
   state = state * 255;
 
-#ifdef USE_ESP_IDF
   dac_oneshot_output_voltage(this->dac_handle_, state);
-#endif
-#ifdef USE_ARDUINO
-  dacWrite(this->pin_->get_pin(), state);
-#endif
 }
 
 }  // namespace esp32_dac
 }  // namespace esphome
 
-#endif
+#endif  // USE_ESP32_VARIANT_ESP32 || USE_ESP32_VARIANT_ESP32S2

--- a/esphome/components/esp32_dac/esp32_dac.h
+++ b/esphome/components/esp32_dac/esp32_dac.h
@@ -1,15 +1,13 @@
 #pragma once
 
+#include "esphome/components/output/float_output.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
-#include "esphome/core/automation.h"
-#include "esphome/components/output/float_output.h"
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32_VARIANT_ESP32) || defined(USE_ESP32_VARIANT_ESP32S2)
 
-#ifdef USE_ESP_IDF
 #include <driver/dac_oneshot.h>
-#endif
 
 namespace esphome {
 namespace esp32_dac {
@@ -29,12 +27,10 @@ class ESP32DAC : public output::FloatOutput, public Component {
   void write_state(float state) override;
 
   InternalGPIOPin *pin_;
-#ifdef USE_ESP_IDF
   dac_oneshot_handle_t dac_handle_;
-#endif
 };
 
 }  // namespace esp32_dac
 }  // namespace esphome
 
-#endif
+#endif  // USE_ESP32_VARIANT_ESP32 || USE_ESP32_VARIANT_ESP32S2


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

With esp-idf and arduino in sync now, there is no reason to use the Arduino API here

Also add pre-proccessing to only make the code available on the correct variants

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
