### PR TITLE
[pcf8574] Add interrupt pin support

### DIFF
--- a/esphome/components/pcf8574/__init__.py
+++ b/esphome/components/pcf8574/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
+    CONF_INTERRUPT_PIN,
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
@@ -26,6 +27,9 @@ CONFIG_SCHEMA = (
         {
             cv.Required(CONF_ID): cv.declare_id(PCF8574Component),
             cv.Optional(CONF_PCF8575, default=False): cv.boolean,
+            cv.Optional(CONF_INTERRUPT_PIN): cv.All(
+                pins.internal_gpio_input_pin_schema
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -38,6 +42,9 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
     cg.add(var.set_pcf8575(config[CONF_PCF8575]))
+    if CONF_INTERRUPT_PIN in config:
+        pin_intr = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])
+        cg.add(var.set_interrupt_pin(pin_intr))
 
 
 def validate_mode(value):

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -18,6 +18,12 @@ void PCF8574Component::setup() {
   this->read_gpio_();
 }
 void PCF8574Component::loop() {
+  if (this->first_loop_) {
+    // Set unused ports as outputs
+    this->mode_mask_ = this->input_mask_;
+    this->write_gpio_();
+    this->first_loop_ = false;
+  }
   if (this->mode_mask_) {
     this->read_gpio_();
   }
@@ -46,11 +52,13 @@ void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
     // Set mode mask bit
     this->mode_mask_ |= 1 << pin;
+    this->input_mask_ |= 1 << pin;
     // Write GPIO to enable input mode
     this->write_gpio_();
   } else if (flags == gpio::FLAG_OUTPUT) {
     // Clear mode mask bit
     this->mode_mask_ &= ~(1 << pin);
+    this->input_mask_ &= ~(1 << pin);
   }
 }
 bool PCF8574Component::read_gpio_() {

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -40,13 +40,13 @@ void PCF8574Component::digital_write(uint8_t pin, bool value) {
 }
 void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
-    // Clear mode mask bit
-    this->mode_mask_ &= ~(1 << pin);
+    // Set mode mask bit
+    this->mode_mask_ |= 1 << pin;
     // Write GPIO to enable input mode
     this->write_gpio_();
   } else if (flags == gpio::FLAG_OUTPUT) {
-    // Set mode mask bit
-    this->mode_mask_ |= 1 << pin;
+    // Clear mode mask bit
+    this->mode_mask_ &= ~(1 << pin);
   }
 }
 bool PCF8574Component::read_gpio_() {
@@ -73,11 +73,9 @@ bool PCF8574Component::write_gpio_() {
   if (this->is_failed())
     return false;
 
-  uint16_t value = 0;
-  // Pins in OUTPUT mode and where pin is HIGH.
-  value |= this->mode_mask_ & this->output_mask_;
-  // Pins in INPUT mode must also be set here
-  value |= ~this->mode_mask_;
+  // Combine pins in input mode (that must always be set to HIGH)
+  // with pins in output mode where state is HIGH
+  uint16_t value = this->mode_mask_ | this->output_mask_;
 
   uint8_t data[2];
   data[0] = value;

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -27,13 +27,13 @@ void PCF8574Component::dump_config() {
 }
 bool PCF8574Component::digital_read(uint8_t pin) {
   this->read_gpio_();
-  return this->input_mask_ & (1 << pin);
+  return this->input_state_ & (1 << pin);
 }
 void PCF8574Component::digital_write(uint8_t pin, bool value) {
   if (value) {
-    this->output_mask_ |= (1 << pin);
+    this->output_state_ |= (1 << pin);
   } else {
-    this->output_mask_ &= ~(1 << pin);
+    this->output_state_ &= ~(1 << pin);
   }
 
   this->write_gpio_();
@@ -56,10 +56,10 @@ bool PCF8574Component::read_gpio_() {
   uint8_t data[2];
   if (this->pcf8575_) {
     success = this->read_bytes_raw(data, 2);
-    this->input_mask_ = (uint16_t(data[1]) << 8) | (uint16_t(data[0]) << 0);
+    this->input_state_ = (uint16_t(data[1]) << 8) | (uint16_t(data[0]) << 0);
   } else {
     success = this->read_bytes_raw(data, 1);
-    this->input_mask_ = data[0];
+    this->input_state_ = data[0];
   }
 
   if (!success) {
@@ -75,7 +75,7 @@ bool PCF8574Component::write_gpio_() {
 
   // Combine pins in input mode (that must always be set to HIGH)
   // with pins in output mode where state is HIGH
-  uint16_t value = this->mode_mask_ | this->output_mask_;
+  uint16_t value = this->mode_mask_ | this->output_state_;
 
   uint8_t data[2];
   data[0] = value;

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -8,7 +8,7 @@ namespace pcf8574 {
 static const char *const TAG = "pcf8574";
 
 void IRAM_ATTR HOT PCF8574ComponentStore::gpio_intr(PCF8574ComponentStore *arg) {
-  arg->changes++;
+  arg->changes = arg->changes + 1;
   // Try to get our loop() to be called asap
   arg->high_freq.start();
 }
@@ -54,7 +54,7 @@ void PCF8574Component::loop() {
     }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
     if (changes > 1) {
-      ESP_LOGVV(TAG, "Missed %d events", changes-1);
+      ESP_LOGVV(TAG, "Missed %d events", changes - 1);
     }
 #endif
   }

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -17,6 +17,11 @@ void PCF8574Component::setup() {
   this->write_gpio_();
   this->read_gpio_();
 }
+void PCF8574Component::loop() {
+  if (this->mode_mask_) {
+    this->read_gpio_();
+  }
+}
 void PCF8574Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCF8574:");
   LOG_I2C_DEVICE(this)
@@ -26,7 +31,6 @@ void PCF8574Component::dump_config() {
   }
 }
 bool PCF8574Component::digital_read(uint8_t pin) {
-  this->read_gpio_();
   return this->input_state_ & (1 << pin);
 }
 void PCF8574Component::digital_write(uint8_t pin, bool value) {

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -15,6 +15,8 @@ void IRAM_ATTR HOT PCF8574ComponentStore::gpio_intr(PCF8574ComponentStore *arg) 
   arg->high_freq.start();
 }
 
+// PCF8574Component
+
 void PCF8574Component::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
   if (!this->read_gpio_()) {
@@ -33,6 +35,7 @@ void PCF8574Component::setup() {
     this->pin_intr_->attach_interrupt(PCF8574ComponentStore::gpio_intr, &this->store_, gpio::INTERRUPT_RISING_EDGE);
   }
 }
+
 void PCF8574Component::loop() {
   if (this->first_loop_) {
     // Set unused ports as outputs
@@ -72,6 +75,7 @@ void PCF8574Component::loop() {
   }
   this->read_gpio_();
 }
+
 void PCF8574Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCF8574:");
   LOG_I2C_DEVICE(this)
@@ -85,9 +89,9 @@ void PCF8574Component::dump_config() {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }
 }
-bool PCF8574Component::digital_read(uint8_t pin) {
-  return this->input_state_ & (1 << pin);
-}
+
+bool PCF8574Component::digital_read(uint8_t pin) { return this->input_state_ & (1 << pin); }
+
 void PCF8574Component::digital_write(uint8_t pin, bool value) {
   if (value) {
     this->output_state_ |= (1 << pin);
@@ -97,6 +101,7 @@ void PCF8574Component::digital_write(uint8_t pin, bool value) {
 
   this->write_gpio_();
 }
+
 void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
     // Set mode mask bit
@@ -112,6 +117,7 @@ void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   // Pickup runtime changes
   this->first_loop_ = true;
 }
+
 bool PCF8574Component::read_gpio_() {
   if (this->is_failed())
     return false;
@@ -132,6 +138,7 @@ bool PCF8574Component::read_gpio_() {
   this->status_clear_warning();
   return true;
 }
+
 bool PCF8574Component::write_gpio_() {
   if (this->is_failed())
     return false;
@@ -150,12 +157,19 @@ bool PCF8574Component::write_gpio_() {
   this->status_clear_warning();
   return true;
 }
+
 float PCF8574Component::get_setup_priority() const { return setup_priority::IO; }
 
+// PCF8574GPIOPin
+
 void PCF8574GPIOPin::setup() { pin_mode(flags_); }
+
 void PCF8574GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }
+
 bool PCF8574GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
+
 void PCF8574GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
+
 std::string PCF8574GPIOPin::dump_summary() const {
   char buffer[32];
   snprintf(buffer, sizeof(buffer), "%u via PCF8574", pin_);

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -1,10 +1,17 @@
 #include "pcf8574.h"
 #include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace pcf8574 {
 
 static const char *const TAG = "pcf8574";
+
+void IRAM_ATTR HOT PCF8574ComponentStore::gpio_intr(PCF8574ComponentStore *arg) {
+  arg->changes++;
+  // Try to get our loop() to be called asap
+  arg->high_freq.start();
+}
 
 void PCF8574Component::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
@@ -16,6 +23,12 @@ void PCF8574Component::setup() {
 
   this->write_gpio_();
   this->read_gpio_();
+
+  if (this->pin_intr_ != nullptr) {
+    this->pin_intr_->setup();
+    this->store_.pin_intr = this->pin_intr_->to_isr();
+    this->pin_intr_->attach_interrupt(PCF8574ComponentStore::gpio_intr, &this->store_, gpio::INTERRUPT_RISING_EDGE);
+  }
 }
 void PCF8574Component::loop() {
   if (this->first_loop_) {
@@ -24,14 +37,38 @@ void PCF8574Component::loop() {
     this->write_gpio_();
     this->first_loop_ = false;
   }
-  if (this->mode_mask_) {
-    this->read_gpio_();
+  if (!this->mode_mask_) {
+    return;
   }
+  if (this->pin_intr_ != nullptr) {
+    // Check if interrupt fired as "no interrupt" means "no need to read device"
+    uint16_t changes;
+    {
+      InterruptLock lock;
+      changes = this->store_.changes;
+      if (changes == 0) {
+        return;
+      }
+      this->store_.changes = 0;
+      this->store_.high_freq.stop();
+    }
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+    if (changes > 1) {
+      ESP_LOGVV(TAG, "Missed %d events", changes-1);
+    }
+#endif
+  }
+  this->read_gpio_();
 }
 void PCF8574Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PCF8574:");
   LOG_I2C_DEVICE(this)
   ESP_LOGCONFIG(TAG, "  Is PCF8575: %s", YESNO(this->pcf8575_));
+  if (this->pin_intr_ != nullptr) {
+    LOG_PIN("  Interrupt pin: ", this->pin_intr_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Interrupt pin: DISABLED");
+  }
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
   }

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -112,7 +112,7 @@ bool PCF8574Component::read_gpio_() {
   }
 
   if (!success) {
-    this->status_set_warning();
+    this->status_set_warning("read from i2c device failed");
     return false;
   }
   this->status_clear_warning();
@@ -130,10 +130,9 @@ bool PCF8574Component::write_gpio_() {
   data[0] = value;
   data[1] = value >> 8;
   if (this->write(data, this->pcf8575_ ? 2 : 1) != i2c::ERROR_OK) {
-    this->status_set_warning();
+    this->status_set_warning("write to i2c device failed");
     return false;
   }
-
   this->status_clear_warning();
   return true;
 }

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -9,6 +9,8 @@ static const char *const TAG = "pcf8574";
 
 void IRAM_ATTR HOT PCF8574ComponentStore::gpio_intr(PCF8574ComponentStore *arg) {
   arg->changes = arg->changes + 1;
+  // Wake up the component from its disabled loop state
+  arg->component->enable_loop_soon_any_context();
   // Try to get our loop() to be called asap
   arg->high_freq.start();
 }
@@ -27,6 +29,7 @@ void PCF8574Component::setup() {
   if (this->pin_intr_ != nullptr) {
     this->pin_intr_->setup();
     this->store_.pin_intr = this->pin_intr_->to_isr();
+    this->store_.component = this;
     this->pin_intr_->attach_interrupt(PCF8574ComponentStore::gpio_intr, &this->store_, gpio::INTERRUPT_RISING_EDGE);
   }
 }
@@ -36,9 +39,14 @@ void PCF8574Component::loop() {
     this->mode_mask_ = this->input_mask_;
     this->write_gpio_();
     this->first_loop_ = false;
-  }
-  if (!this->mode_mask_) {
-    return;
+    if (!this->mode_mask_) {
+      // No need for loop if there are no inputs to read
+      ESP_LOGD(TAG, "No inputs, disable loop");
+      this->disable_loop();
+      return;
+    } else {
+      this->enable_loop();
+    }
   }
   if (this->pin_intr_ != nullptr) {
     // Check if interrupt fired as "no interrupt" means "no need to read device"
@@ -46,11 +54,15 @@ void PCF8574Component::loop() {
     {
       InterruptLock lock;
       changes = this->store_.changes;
-      if (changes == 0) {
-        return;
+      if (changes > 0) {
+        this->store_.changes = 0;
+        this->store_.high_freq.stop();
       }
-      this->store_.changes = 0;
-      this->store_.high_freq.stop();
+    }
+    if (changes == 0) {
+      // No changes, disable the loop until the next interrupt
+      this->disable_loop();
+      return;
     }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
     if (changes > 1) {
@@ -97,6 +109,8 @@ void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->mode_mask_ &= ~(1 << pin);
     this->input_mask_ &= ~(1 << pin);
   }
+  // Pickup runtime changes
+  this->first_loop_ = true;
 }
 bool PCF8574Component::read_gpio_() {
   if (this->is_failed())

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -47,8 +47,6 @@ void PCF8574Component::loop() {
       ESP_LOGD(TAG, "No inputs, disable loop");
       this->disable_loop();
       return;
-    } else {
-      this->enable_loop();
     }
   }
   if (this->pin_intr_ != nullptr) {
@@ -114,8 +112,9 @@ void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->mode_mask_ &= ~(1 << pin);
     this->input_mask_ &= ~(1 << pin);
   }
-  // Pickup runtime changes
+  // This could be a change during runtime, be sure to pickup changes
   this->first_loop_ = true;
+  this->enable_loop();
 }
 
 bool PCF8574Component::read_gpio_() {

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -31,12 +31,12 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
 
   bool write_gpio_();
 
-  /// Mask for the pin mode - 1 means output, 0 means input
-  uint16_t mode_mask_{0x00};
+  /// Mask for the pin mode - 0 means output, 1 means input
+  uint16_t mode_mask_{0xFFFF};
   /// The mask to write as output state - 1 means HIGH, 0 means LOW
-  uint16_t output_mask_{0x00};
+  uint16_t output_mask_{0x0000};
   /// The state read in read_gpio_ - 1 means HIGH, 0 means LOW
-  uint16_t input_mask_{0x00};
+  uint16_t input_mask_{0x0000};
   bool pcf8575_;  ///< TRUE->16-channel PCF8575, FALSE->8-channel PCF8574
 };
 

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -7,11 +7,21 @@
 namespace esphome {
 namespace pcf8574 {
 
+// Helper class for the interrupt handler
+struct PCF8574ComponentStore {
+  ISRInternalGPIOPin pin_intr;
+  volatile uint16_t changes{0};
+  HighFrequencyLoopRequester high_freq;
+
+  static void gpio_intr(PCF8574ComponentStore *arg);
+};
+
 class PCF8574Component : public Component, public i2c::I2CDevice {
  public:
   PCF8574Component() = default;
 
   void set_pcf8575(bool pcf8575) { pcf8575_ = pcf8575; }
+  void set_interrupt_pin(InternalGPIOPin *pin_intr) { pin_intr_ = pin_intr; }
 
   /// Check i2c availability and setup masks
   void setup() override;
@@ -49,6 +59,11 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
 
   bool pcf8575_;  ///< TRUE->16-channel PCF8575, FALSE->8-channel PCF8574
   bool first_loop_{true};
+
+  /// Interrupt pin
+  InternalGPIOPin *pin_intr_{nullptr};
+  /// Store for the interrupt handler
+  PCF8574ComponentStore store_{};
 };
 
 /// Helper class to expose a PCF8574 pin as an internal input GPIO pin.

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -33,10 +33,10 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
 
   /// Mask for the pin mode - 0 means output, 1 means input
   uint16_t mode_mask_{0xFFFF};
-  /// The mask to write as output state - 1 means HIGH, 0 means LOW
-  uint16_t output_mask_{0x0000};
+  /// The value to write as output state - 1 means HIGH, 0 means LOW
+  uint16_t output_state_{0x0000};
   /// The state read in read_gpio_ - 1 means HIGH, 0 means LOW
-  uint16_t input_mask_{0x0000};
+  uint16_t input_state_{0x0000};
   bool pcf8575_;  ///< TRUE->16-channel PCF8575, FALSE->8-channel PCF8574
 };
 

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -12,7 +12,7 @@ struct PCF8574ComponentStore {
   ISRInternalGPIOPin pin_intr;
   volatile uint16_t changes{0};
   HighFrequencyLoopRequester high_freq;
-
+  Component *component{nullptr};
   static void gpio_intr(PCF8574ComponentStore *arg);
 };
 

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -34,12 +34,21 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
   bool write_gpio_();
 
   /// Mask for the pin mode - 0 means output, 1 means input
+  /// To prevent flapping of outputs during setup, this initializes as all inputs
+  /// As datasheet says unused ports must be outputs, this is corrected from
+  /// input_mask_ after setup (on the first loop).
   uint16_t mode_mask_{0xFFFF};
+  /// Mask for inputs configured in YAML - 0 means output, 1 means input
+  /// This becomes the mode_mask_ after setup (in first loop).
+  uint16_t input_mask_{0x0000};
+
   /// The value to write as output state - 1 means HIGH, 0 means LOW
   uint16_t output_state_{0x0000};
   /// The state read in read_gpio_ - 1 means HIGH, 0 means LOW
   uint16_t input_state_{0x0000};
+
   bool pcf8575_;  ///< TRUE->16-channel PCF8575, FALSE->8-channel PCF8574
+  bool first_loop_{true};
 };
 
 /// Helper class to expose a PCF8574 pin as an internal input GPIO pin.

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -15,6 +15,8 @@ class PCF8574Component : public Component, public i2c::I2CDevice {
 
   /// Check i2c availability and setup masks
   void setup() override;
+  // Read values every loop
+  void loop() override;
   /// Helper function to read the value of a pin.
   bool digital_read(uint8_t pin);
   /// Helper function to write the value of a pin.


### PR DESCRIPTION
# What does this implement/fix?

Add interrupt pin support to pcf8574 devices and only read from i2c when necessary. Disable the loop when there's nothing to read.

The first few patches prepare the code to properly support the interrupt pin as all unused pins must be set to outputs to prevent (millions of) spurious interrupts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5165

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

All commits up to the loop disabling have been in production use for almost 2 years.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
pcf8574:
  - id: 'pcf8574_hub'
    address: 0x21
    pcf8575: false
    interrupt_pin:
      number: 2
      mode: INPUT_PULLUP
      inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
