### PR TITLE
[ld2450] Set ``accuracy_decimals=0`` as default for "target" entities

### DIFF
--- a/esphome/components/ld2450/sensor.py
+++ b/esphome/components/ld2450/sensor.py
@@ -43,12 +43,15 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
             icon=ICON_ACCOUNT_GROUP,
+            accuracy_decimals=0,
         ),
         cv.Optional(CONF_STILL_TARGET_COUNT): sensor.sensor_schema(
             icon=ICON_HUMAN_GREETING_PROXIMITY,
+            accuracy_decimals=0,
         ),
         cv.Optional(CONF_MOVING_TARGET_COUNT): sensor.sensor_schema(
             icon=ICON_ACCOUNT_SWITCH,
+            accuracy_decimals=0,
         ),
     }
 )
@@ -95,12 +98,15 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
             {
                 cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
                     icon=ICON_MAP_MARKER_ACCOUNT,
+                    accuracy_decimals=0,
                 ),
                 cv.Optional(CONF_STILL_TARGET_COUNT): sensor.sensor_schema(
                     icon=ICON_MAP_MARKER_ACCOUNT,
+                    accuracy_decimals=0,
                 ),
                 cv.Optional(CONF_MOVING_TARGET_COUNT): sensor.sensor_schema(
                     icon=ICON_MAP_MARKER_ACCOUNT,
+                    accuracy_decimals=0,
                 ),
             }
         )


### PR DESCRIPTION
# What does this implement/fix?

This sets the default accuracy_decimals to zero for the LD2450 component "target entities". This is needed because without it, they will default to one decimal place such as 1.0 when a target can only ever be an integer such as 0,1,2 or 3.

**Problem:** Users cannot remove these decimal places through Home Assistant's UI precision settings for these specific sensors, making dashboards look inconsistent and unprofessional.

**Solution:** Added `accuracy_decimals=0` to the sensor schemas for `target_count`, `still_target_count`, and `moving_target_count` to properly display these values as integers without decimal places.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/ApolloAutomation/MTR-1/issues/52 and helps anyone else using LD2450 component.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
