### PR TITLE
fix: non-optional x/y target calculation for ld2450

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -477,10 +477,11 @@ void LD2450Component::handle_periodic_data_() {
     // X
     start = TARGET_X + index * 8;
     is_moving = false;
+    // tx is used for further calculations, so always needs to be populated
+    val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
+    tx = val;
     sensor::Sensor *sx = this->move_x_sensors_[index];
     if (sx != nullptr) {
-      val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
-      tx = val;
       if (this->cached_target_data_[index].x != val) {
         sx->publish_state(val);
         this->cached_target_data_[index].x = val;
@@ -488,10 +489,11 @@ void LD2450Component::handle_periodic_data_() {
     }
     // Y
     start = TARGET_Y + index * 8;
+    // ty is used for further calculations, so always needs to be populated
+    val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
+    ty = val;
     sensor::Sensor *sy = this->move_y_sensors_[index];
     if (sy != nullptr) {
-      val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
-      ty = val;
       if (this->cached_target_data_[index].y != val) {
         sy->publish_state(val);
         this->cached_target_data_[index].y = val;


### PR DESCRIPTION
# What does this implement/fix?

As the target X and Y positions are re-used for other sensors, they cannot be treated as optional calculations.
Even if the x/y movement sensors are not configured, the values are now calculated and can be re-used by others to avoid re-calculating the values or using default values (0).

This fixes (at least) the still target, still target count, presence, and target angle sensors when a configuration does not include target x/y sensors for all possible targets.

## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9847

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**


## Test Environment

- [x ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:
see https://github.com/esphome/esphome/issues/9847

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
