### PR TITLE
[esp32] Fix threading model for single-core variants (S2, C3, C6, H2)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -98,6 +98,16 @@ ARDUINO_ALLOWED_VARIANTS = [
     VARIANT_ESP32S3,
 ]
 
+# Single-core ESP32 variants
+SINGLE_CORE_VARIANTS = frozenset(
+    [
+        VARIANT_ESP32S2,
+        VARIANT_ESP32C3,
+        VARIANT_ESP32C6,
+        VARIANT_ESP32H2,
+    ]
+)
+
 
 def get_cpu_frequencies(*frequencies):
     return [str(x) + "MHZ" for x in frequencies]
@@ -714,7 +724,11 @@ async def to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
     cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[config[CONF_VARIANT]])
-    cg.add_define(CoreModel.MULTI_ATOMICS)
+    # Set threading model based on core count
+    if config[CONF_VARIANT] in SINGLE_CORE_VARIANTS:
+        cg.add_define(CoreModel.SINGLE)
+    else:
+        cg.add_define(CoreModel.MULTI_ATOMICS)
 
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the ESP32 component to use the correct threading model based on the variant's core count. Previously, all ESP32 variants were using `ESPHOME_CORES_MULTI_ATOMICS`, which added unnecessary overhead on single-core variants.

The fix sets:
- `ESPHOME_CORES_SINGLE` for single-core variants (ESP32-S2, ESP32-C3, ESP32-C6, ESP32-H2)
- `ESPHOME_CORES_MULTI_ATOMICS` for multi-core variants (ESP32, ESP32-S3, ESP32-P4)

This optimization removes unnecessary atomic operations and synchronization overhead on single-core processors, improving performance without affecting functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - No user-visible changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
esphome:
  name: test-device

esp32:
  board: esp32-c3-devkitm-1  # Single-core - will use ESPHOME_CORES_SINGLE
  # board: esp32dev          # Dual-core - will use ESPHOME_CORES_MULTI_ATOMICS
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing performed

Verified the correct threading model is set for different ESP32 variants by checking the generated `defines.h`:

- ESP32-C3 (single-core): Correctly generates `#define ESPHOME_CORES_SINGLE`
- ESP32 (dual-core): Correctly generates `#define ESPHOME_CORES_MULTI_ATOMICS`  
- ESP32-S3 (dual-core): Correctly generates `#define ESPHOME_CORES_MULTI_ATOMICS`