### PR TITLE
[logger] remove unnecessary call to setTxTimeoutMs

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -119,9 +119,6 @@ void Logger::pre_setup() {
 #ifdef USE_LOGGER_USB_CDC
       case UART_SELECTION_USB_CDC:
         this->hw_serial_ = &Serial;
-#if ARDUINO_USB_CDC_ON_BOOT
-        Serial.setTxTimeoutMs(0);  // workaround for 2.0.9 crash when there's no data connection
-#endif
         Serial.begin(this->baud_rate_);
         break;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

There was a condition in the logger targeting Arduino on ESP32 with USB-CDC enabled at boot:

```cpp
#if ARDUINO_USB_CDC_ON_BOOT
        Serial.setTxTimeoutMs(0);  // workaround for 2.0.9 crash when there's no data connection
#endif
```

Doing this apparently fixed a crash that occurred when nothing was connected to serial via USB. However, in newer versions of the Arduino framework this seems to have been fixed per my own testing, and setting a TX timeout of 0 actually causes additional issues. Since it does not wait for writes to complete before unblocking, data is sent out of order or lost entirely. Removing these lines fixes that issue.

Since ESPHome no longer targets Arduino 2.x and it causes issues in 3.1.3, this is safe to remove.

[Relevant discussion on Discord](https://discord.com/channels/429907082951524364/1397726832798863391)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
