### PR TITLE
[core] Revert #9851 and rename ESPHOME_CORES to ESPHOME_THREAD

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -31,7 +31,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_ESP32,
-    CoreModel,
+    ThreadModel,
     __version__,
 )
 from esphome.core import CORE, HexInt, TimePeriod
@@ -97,16 +97,6 @@ ARDUINO_ALLOWED_VARIANTS = [
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 ]
-
-# Single-core ESP32 variants
-SINGLE_CORE_VARIANTS = frozenset(
-    [
-        VARIANT_ESP32S2,
-        VARIANT_ESP32C3,
-        VARIANT_ESP32C6,
-        VARIANT_ESP32H2,
-    ]
-)
 
 
 def get_cpu_frequencies(*frequencies):
@@ -724,11 +714,7 @@ async def to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
     cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[config[CONF_VARIANT]])
-    # Set threading model based on core count
-    if config[CONF_VARIANT] in SINGLE_CORE_VARIANTS:
-        cg.add_define(CoreModel.SINGLE)
-    else:
-        cg.add_define(CoreModel.MULTI_ATOMICS)
+    cg.add_define(ThreadModel.MULTI_ATOMICS)
 
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")

--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -15,7 +15,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_ESP8266,
-    CoreModel,
+    ThreadModel,
 )
 from esphome.core import CORE, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed
@@ -188,7 +188,7 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "ESP8266")
-    cg.add_define(CoreModel.SINGLE)
+    cg.add_define(ThreadModel.SINGLE)
 
     cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
 

--- a/esphome/components/host/__init__.py
+++ b/esphome/components/host/__init__.py
@@ -7,7 +7,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_HOST,
-    CoreModel,
+    ThreadModel,
 )
 from esphome.core import CORE
 
@@ -44,7 +44,7 @@ async def to_code(config):
     cg.add_define("USE_ESPHOME_HOST_MAC_ADDRESS", config[CONF_MAC_ADDRESS].parts)
     cg.add_build_flag("-std=gnu++20")
     cg.add_define("ESPHOME_BOARD", "host")
-    cg.add_define(CoreModel.MULTI_ATOMICS)
+    cg.add_define(ThreadModel.MULTI_ATOMICS)
     cg.add_platformio_option("platform", "platformio/native")
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "strict")

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -20,7 +20,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
-    CoreModel,
+    ThreadModel,
     __version__,
 )
 from esphome.core import CORE
@@ -261,7 +261,7 @@ async def component_to_code(config):
     cg.add_build_flag(f"-DUSE_LIBRETINY_VARIANT_{config[CONF_FAMILY]}")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", FAMILY_FRIENDLY[config[CONF_FAMILY]])
-    cg.add_define(CoreModel.MULTI_NO_ATOMICS)
+    cg.add_define(ThreadModel.MULTI_NO_ATOMICS)
 
     # force using arduino framework
     cg.add_platformio_option("framework", "arduino")

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -23,7 +23,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_NRF52,
-    CoreModel,
+    ThreadModel,
 )
 from esphome.core import CORE, EsphomeError, coroutine_with_priority
 from esphome.storage_json import StorageJSON
@@ -110,7 +110,7 @@ async def to_code(config: ConfigType) -> None:
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "NRF52")
     # nRF52 processors are single-core
-    cg.add_define(CoreModel.SINGLE)
+    cg.add_define(ThreadModel.SINGLE)
     cg.add_platformio_option(CONF_FRAMEWORK, CORE.data[KEY_CORE][KEY_TARGET_FRAMEWORK])
     cg.add_platformio_option(
         "platform",

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -16,7 +16,7 @@ from esphome.const import (
     KEY_TARGET_FRAMEWORK,
     KEY_TARGET_PLATFORM,
     PLATFORM_RP2040,
-    CoreModel,
+    ThreadModel,
 )
 from esphome.core import CORE, EsphomeError, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, mkdir_p, read_file, write_file
@@ -172,7 +172,7 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", "RP2040")
-    cg.add_define(CoreModel.SINGLE)
+    cg.add_define(ThreadModel.SINGLE)
 
     cg.add_platformio_option("extra_scripts", ["post:post_build.py"])
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -35,12 +35,12 @@ class Framework(StrEnum):
     ZEPHYR = "zephyr"
 
 
-class CoreModel(StrEnum):
-    """Core model identifiers for ESPHome scheduler."""
+class ThreadModel(StrEnum):
+    """Threading model identifiers for ESPHome scheduler."""
 
-    SINGLE = "ESPHOME_CORES_SINGLE"
-    MULTI_NO_ATOMICS = "ESPHOME_CORES_MULTI_NO_ATOMICS"
-    MULTI_ATOMICS = "ESPHOME_CORES_MULTI_ATOMICS"
+    SINGLE = "ESPHOME_THREAD_SINGLE"
+    MULTI_NO_ATOMICS = "ESPHOME_THREAD_MULTI_NO_ATOMICS"
+    MULTI_ATOMICS = "ESPHOME_THREAD_MULTI_ATOMICS"
 
 
 class PlatformFramework(Enum):

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -15,8 +15,8 @@
 #define ESPHOME_VARIANT "ESP32"
 #define ESPHOME_DEBUG_SCHEDULER
 
-// Default threading model for static analysis (ESP32 is multi-core with atomics)
-#define ESPHOME_CORES_MULTI_ATOMICS
+// Default threading model for static analysis (ESP32 is multi-threaded with atomics)
+#define ESPHOME_THREAD_MULTI_ATOMICS
 
 // logger
 #define ESPHOME_LOG_LEVEL ESPHOME_LOG_LEVEL_VERY_VERBOSE

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include <cstring>
 #include <deque>
-#ifdef ESPHOME_CORES_MULTI_ATOMICS
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
 #include <atomic>
 #endif
 
@@ -200,13 +200,13 @@ class Scheduler {
   Mutex lock_;
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;
-#ifndef ESPHOME_CORES_SINGLE
+#ifndef ESPHOME_THREAD_SINGLE
   // Single-core platforms don't need the defer queue and save 40 bytes of RAM
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
-#endif                                                      /* ESPHOME_CORES_SINGLE */
+#endif                                                      /* ESPHOME_THREAD_SINGLE */
   uint32_t to_remove_{0};
 
-#ifdef ESPHOME_CORES_MULTI_ATOMICS
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
   /*
    * Multi-threaded platforms with atomic support: last_millis_ needs atomic for lock-free updates
    *
@@ -218,10 +218,10 @@ class Scheduler {
    * it also observes the corresponding increment of `millis_major_`.
    */
   std::atomic<uint32_t> last_millis_{0};
-#else  /* not ESPHOME_CORES_MULTI_ATOMICS */
+#else  /* not ESPHOME_THREAD_MULTI_ATOMICS */
   // Platforms without atomic support or single-threaded platforms
   uint32_t last_millis_{0};
-#endif /* else ESPHOME_CORES_MULTI_ATOMICS */
+#endif /* else ESPHOME_THREAD_MULTI_ATOMICS */
 
   /*
    * Upper 16 bits of the 64-bit millis counter. Incremented only while holding
@@ -229,11 +229,11 @@ class Scheduler {
    * Ordering relative to `last_millis_` is provided by its release store and the
    * corresponding acquire loads.
    */
-#ifdef ESPHOME_CORES_MULTI_ATOMICS
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint16_t> millis_major_{0};
-#else  /* not ESPHOME_CORES_MULTI_ATOMICS */
+#else  /* not ESPHOME_THREAD_MULTI_ATOMICS */
   uint16_t millis_major_{0};
-#endif /* else ESPHOME_CORES_MULTI_ATOMICS */
+#endif /* else ESPHOME_THREAD_MULTI_ATOMICS */
 };
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR reverts #9851 and renames the `ESPHOME_CORES_*` defines to `ESPHOME_THREAD_*` to better reflect their actual purpose.

## Background

PR #9851 incorrectly optimized ESP32 single-core variants (S2, C3, C6, H2) to use `ESPHOME_CORES_SINGLE` instead of `ESPHOME_CORES_MULTI_ATOMICS`. This optimization was based on the mistaken assumption that single-core processors don't need atomic operations.

However, even single-core ESP32 variants run FreeRTOS with preemptive multitasking. This means:
- Task switching still occurs on single-core processors
- Race conditions are possible when a task is interrupted mid-operation
- Atomic operations are still necessary to ensure data consistency

The root cause was the misleading name `ESPHOME_CORES_*` which implies it's about CPU core count, when it's actually about the threading/concurrency model.

Since these defines were just added this week and haven't been included in any stable releases yet, we can safely rename them now without any backwards compatibility concerns. Additionally, stable releases don't have any thread safety in the time calculation code at all, so the lack of obvious issues with PR #9851 doesn't indicate correctness - it just means the race conditions weren't immediately apparent in testing.

The most critical race condition occurs at the 32-bit millisecond rollover (every ~49.7 days), which makes it extremely difficult to catch in testing. While the likelihood of hitting this race on single-core platforms is low, maintaining correct time calculation and scheduler behavior is crucial for system reliability.

## Changes

1. **Reverted PR #9851**: All ESP32 variants now correctly use the multi-threaded with atomics model
2. **Renamed defines for clarity**:
   - `ESPHOME_CORES_SINGLE` → `ESPHOME_THREAD_SINGLE`
   - `ESPHOME_CORES_MULTI_NO_ATOMICS` → `ESPHOME_THREAD_MULTI_NO_ATOMICS`
   - `ESPHOME_CORES_MULTI_ATOMICS` → `ESPHOME_THREAD_MULTI_ATOMICS`
3. **Renamed Python enum**: `CoreModel` → `ThreadModel`
4. **Updated all references** in platform components and scheduler code
5. **Updated comments** to reflect threading model instead of core count

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reverts #9851

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
