### PR TITLE
[mipi] Keep models from different drivers separate

### DIFF
--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -234,6 +234,15 @@ class DriverChip:
         self.defaults = defaults
         DriverChip.models[name] = self
 
+    @classmethod
+    def get_models(cls):
+        """
+        Return the current set of models and reset the models dictionary.
+        """
+        models = cls.models
+        cls.models = {}
+        return models
+
     def extend(self, name, **kwargs) -> "DriverChip":
         defaults = self.defaults.copy()
         if (

--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -1,4 +1,6 @@
+import importlib
 import logging
+import pkgutil
 
 from esphome import pins
 import esphome.codegen as cg
@@ -52,8 +54,7 @@ from esphome.core import CORE
 from esphome.cpp_generator import TemplateArguments
 from esphome.final_validate import full_config
 
-from . import CONF_BUS_MODE, CONF_SPI_16, DOMAIN
-from .models import adafruit, amoled, cyd, ili, jc, lanbon, lilygo, waveshare
+from . import CONF_BUS_MODE, CONF_SPI_16, DOMAIN, models
 
 DEPENDENCIES = ["spi"]
 
@@ -91,10 +92,11 @@ BusTypes = {
 
 DriverChip("CUSTOM")
 
-MODELS = DriverChip.models
-# This loop is a noop, but suppresses linting of side-effect-only imports
-for _ in (ili, jc, amoled, lilygo, lanbon, cyd, waveshare, adafruit):
-    pass
+# Import all models dynamically from the models package
+for module_info in pkgutil.iter_modules(models.__path__):
+    importlib.import_module(f".models.{module_info.name}", package=__package__)
+
+MODELS = DriverChip.get_models()
 
 
 DISPLAY_18BIT = "18bit"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When running pytest and potentially if two different display drivers were configured in the same module, the MODELS list could get polluted.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
