### PR TITLE
[fan] Allow setting zero speed in FanCall

### DIFF
--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -68,7 +68,7 @@ void FanCall::validate_() {
   auto traits = this->parent_.get_traits();
 
   if (this->speed_.has_value()) {
-    this->speed_ = clamp(*this->speed_, 1, traits.supported_speed_count());
+    this->speed_ = clamp(*this->speed_, 0, traits.supported_speed_count());
 
     // https://developers.home-assistant.io/docs/core/entity/fan/#preset-modes
     // "Manually setting a speed must disable any set preset mode"


### PR DESCRIPTION
# What does this implement/fix?

Fan entities are unable to distinguish between speed `0` and `1` due to inconsistent clamping of speed values generated by Home Assistant. In the Home Assistant user interface, a fan with fixed speeds can generate calls to `set_speed` with a value of zero set. This value is accepted by [MQTT fan](https://github.com/esphome/esphome/blob/06eba96fdce7a69afc0d5ba2ca16542383768ef5/esphome/components/mqtt/mqtt_fan.cpp#L102-L105) but then [clamped to be `>= 1`](https://github.com/esphome/esphome/blob/06eba96fdce7a69afc0d5ba2ca16542383768ef5/esphome/components/fan/fan.cpp#L45) inside `FanCall`. This results in changes between speed `0` (off in the UI) and `1` (low in the UI when using 3 fixed speeds) to be indistinguishable, though both trigger state changes in esphome.

This changes makes the clamping within `FanCall` to reflect the allowed range generated by MQTT Fan. The setting of a `0` speed is supported both by the Home Assistant user interface design and by the [underlying service/action code](https://github.com/home-assistant/core/blob/4cc4bd3b9a5999a804dcd878148dcf8aadf85bf1/homeassistant/components/fan/__init__.py#L133) that allow speed in the range of `0` to `100` inclusive.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#4285
- esphome/issues#3115, esphome/issues#6586
- esphome/issues#6647, #8086

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
fan:
  - platform: template
    speed_count: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
