### PR TITLE
[mqtt] Don’t log state topic subscription for buttons

### DIFF
--- a/esphome/components/mqtt/mqtt_button.cpp
+++ b/esphome/components/mqtt/mqtt_button.cpp
@@ -27,7 +27,7 @@ void MQTTButtonComponent::setup() {
 }
 void MQTTButtonComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT Button '%s': ", this->button_->get_name().c_str());
-  LOG_MQTT_COMPONENT(true, true);
+  LOG_MQTT_COMPONENT(false, true);
 }
 
 void MQTTButtonComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {


### PR DESCRIPTION
# What does this implement/fix?

Buttons only have a `command` MQTT topic, but they currently log subscription to a “ghost” `state` topic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#7196

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
