### PR TITLE
[packages] add example from documentation to component tests

### DIFF
--- a/tests/components/packages/garage-door.yaml
+++ b/tests/components/packages/garage-door.yaml
@@ -1,0 +1,5 @@
+switch:
+  - name: ${door_name} Garage Door Switch
+    platform: gpio
+    pin: ${door_pin}
+    id: ${door_id}

--- a/tests/components/packages/test-vars.esp32-idf.yaml
+++ b/tests/components/packages/test-vars.esp32-idf.yaml
@@ -1,0 +1,19 @@
+packages:
+  left_garage_door: !include
+    file: garage-door.yaml
+    vars:
+      door_name: Left
+      door_pin: 1
+      door_id: left_garage_door
+  middle_garage_door: !include
+    file: garage-door.yaml
+    vars:
+      door_name: Middle
+      door_pin: 2
+      door_id: middle_garage_door
+  right_garage_door: !include
+    file: garage-door.yaml
+    vars:
+      door_name: Right
+      door_pin: 3
+      door_id: right_garage_door


### PR DESCRIPTION
# What does this implement/fix?

There was no tests for `vars:` in component test. I added one to check how it works.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
