### PR TITLE
[api] Add missing USE_API_PASSWORD guards to reduce flash usage

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1590,10 +1590,12 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   // Do not set last_traffic_ on send
   return true;
 }
+#ifdef USE_API_PASSWORD
 void APIConnection::on_unauthenticated_access() {
   this->on_fatal_error();
   ESP_LOGD(TAG, "%s access without authentication", this->get_client_combined_info().c_str());
 }
+#endif
 void APIConnection::on_no_setup_connection() {
   this->on_fatal_error();
   ESP_LOGD(TAG, "%s access without full connection", this->get_client_combined_info().c_str());

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -228,7 +228,9 @@ class APIConnection : public APIServerConnection {
   }
   uint8_t get_log_subscription_level() const { return this->flags_.log_subscription; }
   void on_fatal_error() override;
+#ifdef USE_API_PASSWORD
   void on_unauthenticated_access() override;
+#endif
   void on_no_setup_connection() override;
   ProtoWriteBuffer create_buffer(uint32_t reserve_size) override {
     // FIXME: ensure no recursive writes can happen

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -860,7 +860,9 @@ class ProtoService {
   virtual bool is_authenticated() = 0;
   virtual bool is_connection_setup() = 0;
   virtual void on_fatal_error() = 0;
+#ifdef USE_API_PASSWORD
   virtual void on_unauthenticated_access() = 0;
+#endif
   virtual void on_no_setup_connection() = 0;
   /**
    * Create a buffer with a reserved size.
@@ -901,10 +903,12 @@ class ProtoService {
     if (!this->check_connection_setup_()) {
       return false;
     }
+#ifdef USE_API_PASSWORD
     if (!this->is_authenticated()) {
       this->on_unauthenticated_access();
       return false;
     }
+#endif
     return true;
   }
 };

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -900,17 +900,17 @@ class ProtoService {
   }
 
   bool check_authenticated_() {
+#ifdef USE_API_PASSWORD
     if (!this->check_connection_setup_()) {
       return false;
     }
-#ifdef USE_API_PASSWORD
     if (!this->is_authenticated()) {
       this->on_unauthenticated_access();
       return false;
     }
     return true;
 #else
-    return true;
+    return this->check_connection_setup_();
 #endif
   }
 };

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -908,8 +908,10 @@ class ProtoService {
       this->on_unauthenticated_access();
       return false;
     }
-#endif
     return true;
+#else
+    return true;
+#endif
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds missing `USE_API_PASSWORD` guards around authentication-related code in the API component. When password authentication is not enabled, there's no need for authentication checks or handlers for unauthenticated access. This reduces flash usage by 124 bytes when `USE_API_PASSWORD` is not defined.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces flash usage when password authentication is not enabled

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- Tested on host platform

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
# This optimization applies automatically when api.password is not set

api:
  # password not set - authentication code will be excluded
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary of Changes

1. **Guarded `on_unauthenticated_access()` function** - Both declaration and implementation are now wrapped with `#ifdef USE_API_PASSWORD`

2. **Modified `check_authenticated_()` function** - When `USE_API_PASSWORD` is not defined, it only checks connection setup without authentication

3. **Guarded virtual function in proto.h** - The pure virtual `on_unauthenticated_access()` is also guarded

This ensures that when password authentication is disabled, the unnecessary authentication code is completely excluded from the build, saving flash space.

