### PR TITLE
[bluetooth_proxy] Fix service discovery cache pollution and descriptor count parameter bug

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -108,7 +108,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   if (total_char_count == 0) {
     // No characteristics, just send the service response
     api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
-    return
+    return;
   }
 
   // Reserve space and process characteristics

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -104,16 +104,12 @@ void BluetoothConnection::send_service_for_discovery_() {
       esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
                                    service_result.start_handle, service_result.end_handle, 0, &total_char_count);
 
-  if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
-    // Only reserve if we successfully got a count
-    service_resp.characteristics.reserve(total_char_count);
-  } else if (char_count_status != ESP_GATT_OK) {
+  if (char_count_status != ESP_GATT_OK) {
     ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
              this->address_str().c_str(), char_count_status);
-  }
-
-  // Now process characteristics
-  if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
+  } else if (total_char_count > 0) {
+    // Reserve space and process characteristics
+    service_resp.characteristics.reserve(total_char_count);
     uint16_t char_offset = 0;
     esp_gattc_char_elem_t char_result;
     while (true) {  // characteristics
@@ -146,46 +142,39 @@ void BluetoothConnection::send_service_for_discovery_() {
           esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
                                        service_result.end_handle, 0, &total_desc_count);
 
-      if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
-        // Only reserve if we successfully got a count
-        characteristic_resp.descriptors.reserve(total_desc_count);
-      } else if (desc_count_status != ESP_GATT_OK) {
+      if (desc_count_status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_result.char_handle, desc_count_status);
-      }
+      } else if (total_desc_count > 0) {
+        // Reserve space and process descriptors
+        characteristic_resp.descriptors.reserve(total_desc_count);
+        uint16_t desc_offset = 0;
+        esp_gattc_descr_elem_t desc_result;
+        while (true) {  // descriptors
+          uint16_t desc_count = 1;
+          esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+              this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+          if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+            break;
+          }
+          if (desc_status != ESP_GATT_OK) {
+            ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
+                     this->address_str().c_str(), desc_status);
+            break;
+          }
+          if (desc_count == 0) {
+            break;
+          }
 
-      // Skip descriptor processing if there are no descriptors
-      if (desc_count_status != ESP_GATT_OK || total_desc_count == 0) {
-        continue;
-      }
-
-      // Now process descriptors
-      uint16_t desc_offset = 0;
-      esp_gattc_descr_elem_t desc_result;
-      while (true) {  // descriptors
-        uint16_t desc_count = 1;
-        esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-            this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-        if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
-          break;
+          characteristic_resp.descriptors.emplace_back();
+          auto &descriptor_resp = characteristic_resp.descriptors.back();
+          fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+          descriptor_resp.handle = desc_result.handle;
+          desc_offset++;
         }
-        if (desc_status != ESP_GATT_OK) {
-          ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
-                   this->address_str().c_str(), desc_status);
-          break;
-        }
-        if (desc_count == 0) {
-          break;
-        }
-
-        characteristic_resp.descriptors.emplace_back();
-        auto &descriptor_resp = characteristic_resp.descriptors.back();
-        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-        descriptor_resp.handle = desc_result.handle;
-        desc_offset++;
-      }
+      }  // end else if (total_desc_count > 0)
     }
-  }  // end if (char_count_status == ESP_GATT_OK && total_char_count > 0)
+  }  // end else if (total_char_count > 0)
 
   // Send the message (we already checked api_conn is not null at the beginning)
   api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -115,12 +115,14 @@ void BluetoothConnection::send_service_for_discovery_() {
       esp_gatt_status_t char_status =
           esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
                                      service_result.end_handle, &char_result, &char_count, char_offset);
-      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND || char_count == 0) {
+      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
         break;
       } else if (char_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_status);
         return;
+      } else if (char_count == 0) {
+        break;
       }
 
       service_resp.characteristics.emplace_back();
@@ -141,31 +143,35 @@ void BluetoothConnection::send_service_for_discovery_() {
                  this->address_str().c_str(), char_result.char_handle, desc_count_status);
         return;
       }
+      if (total_desc_count == 0) {
+        // No descriptors, continue to next characteristic
+        continue;
+      }
 
-      if (total_desc_count > 0) {
-        // Reserve space and process descriptors
-        characteristic_resp.descriptors.reserve(total_desc_count);
-        uint16_t desc_offset = 0;
-        esp_gattc_descr_elem_t desc_result;
-        while (true) {  // descriptors
-          uint16_t desc_count = 1;
-          esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-              this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-          if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND || desc_count == 0) {
-            break;
-          } else if (desc_status != ESP_GATT_OK) {
-            ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
-                     this->address_str().c_str(), desc_status);
-            return;
-          }
-
-          characteristic_resp.descriptors.emplace_back();
-          auto &descriptor_resp = characteristic_resp.descriptors.back();
-          fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-          descriptor_resp.handle = desc_result.handle;
-          desc_offset++;
+      // Reserve space and process descriptors
+      characteristic_resp.descriptors.reserve(total_desc_count);
+      uint16_t desc_offset = 0;
+      esp_gattc_descr_elem_t desc_result;
+      while (true) {  // descriptors
+        uint16_t desc_count = 1;
+        esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+            this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+        if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+          break;
+        } else if (desc_status != ESP_GATT_OK) {
+          ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
+                   this->address_str().c_str(), desc_status);
+          return;
+        } else if (desc_count == 0) {
+          break;  // No more descriptors
         }
-      }  // end else if (total_desc_count > 0)
+
+        characteristic_resp.descriptors.emplace_back();
+        auto &descriptor_resp = characteristic_resp.descriptors.back();
+        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+        descriptor_resp.handle = desc_result.handle;
+        desc_offset++;
+      }
     }
   }  // end else if (total_char_count > 0)
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -102,8 +102,6 @@ void BluetoothConnection::send_service_for_discovery_() {
   if (char_count_status != ESP_GATT_OK) {
     ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
              this->address_str().c_str(), char_count_status);
-    // Send the message (we already checked api_conn is not null at the beginning)
-    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
     return;
   }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -105,75 +105,79 @@ void BluetoothConnection::send_service_for_discovery_() {
     return;
   }
 
-  if (total_char_count > 0) {
-    // Reserve space and process characteristics
-    service_resp.characteristics.reserve(total_char_count);
-    uint16_t char_offset = 0;
-    esp_gattc_char_elem_t char_result;
-    while (true) {  // characteristics
-      uint16_t char_count = 1;
-      esp_gatt_status_t char_status =
-          esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
-                                     service_result.end_handle, &char_result, &char_count, char_offset);
-      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
-        break;
-      } else if (char_status != ESP_GATT_OK) {
-        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
-                 this->address_str().c_str(), char_status);
-        return;
-      } else if (char_count == 0) {
-        break;
-      }
+  if (total_char_count == 0) {
+    // No characteristics, just send the service response
+    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
+    return
+  }
 
-      service_resp.characteristics.emplace_back();
-      auto &characteristic_resp = service_resp.characteristics.back();
-      fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
-      characteristic_resp.handle = char_result.char_handle;
-      characteristic_resp.properties = char_result.properties;
-      char_offset++;
-
-      // Get the number of descriptors directly with one call
-      uint16_t total_desc_count = 0;
-      esp_gatt_status_t desc_count_status =
-          esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
-                                       service_result.end_handle, 0, &total_desc_count);
-
-      if (desc_count_status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
-                 this->address_str().c_str(), char_result.char_handle, desc_count_status);
-        return;
-      }
-      if (total_desc_count == 0) {
-        // No descriptors, continue to next characteristic
-        continue;
-      }
-
-      // Reserve space and process descriptors
-      characteristic_resp.descriptors.reserve(total_desc_count);
-      uint16_t desc_offset = 0;
-      esp_gattc_descr_elem_t desc_result;
-      while (true) {  // descriptors
-        uint16_t desc_count = 1;
-        esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-            this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-        if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
-          break;
-        } else if (desc_status != ESP_GATT_OK) {
-          ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
-                   this->address_str().c_str(), desc_status);
-          return;
-        } else if (desc_count == 0) {
-          break;  // No more descriptors
-        }
-
-        characteristic_resp.descriptors.emplace_back();
-        auto &descriptor_resp = characteristic_resp.descriptors.back();
-        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-        descriptor_resp.handle = desc_result.handle;
-        desc_offset++;
-      }
+  // Reserve space and process characteristics
+  service_resp.characteristics.reserve(total_char_count);
+  uint16_t char_offset = 0;
+  esp_gattc_char_elem_t char_result;
+  while (true) {  // characteristics
+    uint16_t char_count = 1;
+    esp_gatt_status_t char_status =
+        esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
+                                   service_result.end_handle, &char_result, &char_count, char_offset);
+    if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
+      break;
+    } else if (char_status != ESP_GATT_OK) {
+      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
+               this->address_str().c_str(), char_status);
+      return;
+    } else if (char_count == 0) {
+      break;
     }
-  }  // end else if (total_char_count > 0)
+
+    service_resp.characteristics.emplace_back();
+    auto &characteristic_resp = service_resp.characteristics.back();
+    fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
+    characteristic_resp.handle = char_result.char_handle;
+    characteristic_resp.properties = char_result.properties;
+    char_offset++;
+
+    // Get the number of descriptors directly with one call
+    uint16_t total_desc_count = 0;
+    esp_gatt_status_t desc_count_status =
+        esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
+                                     service_result.end_handle, 0, &total_desc_count);
+
+    if (desc_count_status != ESP_GATT_OK) {
+      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
+               this->address_str().c_str(), char_result.char_handle, desc_count_status);
+      return;
+    }
+    if (total_desc_count == 0) {
+      // No descriptors, continue to next characteristic
+      continue;
+    }
+
+    // Reserve space and process descriptors
+    characteristic_resp.descriptors.reserve(total_desc_count);
+    uint16_t desc_offset = 0;
+    esp_gattc_descr_elem_t desc_result;
+    while (true) {  // descriptors
+      uint16_t desc_count = 1;
+      esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+          this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+      if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+        break;
+      } else if (desc_status != ESP_GATT_OK) {
+        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
+                 this->address_str().c_str(), desc_status);
+        return;
+      } else if (desc_count == 0) {
+        break;  // No more descriptors
+      }
+
+      characteristic_resp.descriptors.emplace_back();
+      auto &descriptor_resp = characteristic_resp.descriptors.back();
+      fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+      descriptor_resp.handle = desc_result.handle;
+      desc_offset++;
+    }
+  }
 
   // Send the message (we already checked api_conn is not null at the beginning)
   api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -80,15 +80,10 @@ void BluetoothConnection::send_service_for_discovery_() {
                                                                &service_result, &service_count, this->send_service_);
   this->send_service_++;
 
-  if (service_status != ESP_GATT_OK) {
-    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service error at offset=%d, status=%d", this->connection_index_,
-             this->address_str().c_str(), this->send_service_ - 1, service_status);
-    return;
-  }
-
-  if (service_count == 0) {
-    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service missing, service_count=%d", this->connection_index_,
-             this->address_str().c_str(), service_count);
+  if (service_status != ESP_GATT_OK || service_count == 0) {
+    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service %s, status=%d, service_count=%d, offset=%d",
+             this->connection_index_, this->address_str().c_str(), service_status != ESP_GATT_OK ? "error" : "missing",
+             service_status, service_count, this->send_service_ - 1);
     return;
   }
 
@@ -107,7 +102,12 @@ void BluetoothConnection::send_service_for_discovery_() {
   if (char_count_status != ESP_GATT_OK) {
     ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
              this->address_str().c_str(), char_count_status);
-  } else if (total_char_count > 0) {
+    // Send the message (we already checked api_conn is not null at the beginning)
+    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
+    return;
+  }
+
+  if (total_char_count > 0) {
     // Reserve space and process characteristics
     service_resp.characteristics.reserve(total_char_count);
     uint16_t char_offset = 0;
@@ -117,14 +117,11 @@ void BluetoothConnection::send_service_for_discovery_() {
       esp_gatt_status_t char_status =
           esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
                                      service_result.end_handle, &char_result, &char_count, char_offset);
-      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
+      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND || char_count == 0) {
         break;
       } else if (char_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_status);
-        break;
-      }
-      if (char_count == 0) {
         break;
       }
 
@@ -153,14 +150,11 @@ void BluetoothConnection::send_service_for_discovery_() {
           uint16_t desc_count = 1;
           esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
               this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-          if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+          if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND || desc_count == 0) {
             break;
           } else if (desc_status != ESP_GATT_OK) {
             ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                      this->address_str().c_str(), desc_status);
-            break;
-          }
-          if (desc_count == 0) {
             break;
           }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -141,9 +141,8 @@ void BluetoothConnection::send_service_for_discovery_() {
 
     // Get the number of descriptors directly with one call
     uint16_t total_desc_count = 0;
-    esp_gatt_status_t desc_count_status =
-        esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
-                                     service_result.end_handle, 0, &total_desc_count);
+    esp_gatt_status_t desc_count_status = esp_ble_gattc_get_attr_count(
+        this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, 0, 0, char_result.char_handle, &total_desc_count);
 
     if (desc_count_status != ESP_GATT_OK) {
       ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -120,7 +120,7 @@ void BluetoothConnection::send_service_for_discovery_() {
       } else if (char_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_status);
-        break;
+        return;
       }
 
       service_resp.characteristics.emplace_back();
@@ -139,7 +139,10 @@ void BluetoothConnection::send_service_for_discovery_() {
       if (desc_count_status != ESP_GATT_OK) {
         ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_result.char_handle, desc_count_status);
-      } else if (total_desc_count > 0) {
+        return;
+      }
+
+      if (total_desc_count > 0) {
         // Reserve space and process descriptors
         characteristic_resp.descriptors.reserve(total_desc_count);
         uint16_t desc_offset = 0;
@@ -153,7 +156,7 @@ void BluetoothConnection::send_service_for_discovery_() {
           } else if (desc_status != ESP_GATT_OK) {
             ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                      this->address_str().c_str(), desc_status);
-            break;
+            return;
           }
 
           characteristic_resp.descriptors.emplace_back();

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -119,8 +119,7 @@ void BluetoothConnection::send_service_for_discovery_() {
                                      service_result.end_handle, &char_result, &char_count, char_offset);
       if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
         break;
-      }
-      if (char_status != ESP_GATT_OK) {
+      } else if (char_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_status);
         break;
@@ -156,8 +155,7 @@ void BluetoothConnection::send_service_for_discovery_() {
               this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
           if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
             break;
-          }
-          if (desc_status != ESP_GATT_OK) {
+          } else if (desc_status != ESP_GATT_OK) {
             ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                      this->address_str().c_str(), desc_status);
             break;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -122,11 +122,13 @@ void BluetoothConnection::send_service_for_discovery_() {
                                    service_result.end_handle, &char_result, &char_count, char_offset);
     if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
       break;
-    } else if (char_status != ESP_GATT_OK) {
+    }
+    if (char_status != ESP_GATT_OK) {
       ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                this->address_str().c_str(), char_status);
       return;
-    } else if (char_count == 0) {
+    }
+    if (char_count == 0) {
       break;
     }
 
@@ -163,11 +165,13 @@ void BluetoothConnection::send_service_for_discovery_() {
           this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
       if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
         break;
-      } else if (desc_status != ESP_GATT_OK) {
+      }
+      if (desc_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                  this->address_str().c_str(), desc_status);
         return;
-      } else if (desc_count == 0) {
+      }
+      if (desc_count == 0) {
         break;  // No more descriptors
       }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -113,72 +113,79 @@ void BluetoothConnection::send_service_for_discovery_() {
   }
 
   // Now process characteristics
-  uint16_t char_offset = 0;
-  esp_gattc_char_elem_t char_result;
-  while (true) {  // characteristics
-    uint16_t char_count = 1;
-    esp_gatt_status_t char_status =
-        esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
-                                   service_result.end_handle, &char_result, &char_count, char_offset);
-    if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
-      break;
-    }
-    if (char_status != ESP_GATT_OK) {
-      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
-               this->address_str().c_str(), char_status);
-      break;
-    }
-    if (char_count == 0) {
-      break;
-    }
-
-    service_resp.characteristics.emplace_back();
-    auto &characteristic_resp = service_resp.characteristics.back();
-    fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
-    characteristic_resp.handle = char_result.char_handle;
-    characteristic_resp.properties = char_result.properties;
-    char_offset++;
-
-    // Get the number of descriptors directly with one call
-    uint16_t total_desc_count = 0;
-    esp_gatt_status_t desc_count_status =
-        esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
-                                     service_result.end_handle, 0, &total_desc_count);
-
-    if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
-      // Only reserve if we successfully got a count
-      characteristic_resp.descriptors.reserve(total_desc_count);
-    } else if (desc_count_status != ESP_GATT_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
-               this->address_str().c_str(), char_result.char_handle, desc_count_status);
-    }
-
-    // Now process descriptors
-    uint16_t desc_offset = 0;
-    esp_gattc_descr_elem_t desc_result;
-    while (true) {  // descriptors
-      uint16_t desc_count = 1;
-      esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-          this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-      if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+  if (char_count_status == ESP_GATT_OK && total_char_count > 0) {
+    uint16_t char_offset = 0;
+    esp_gattc_char_elem_t char_result;
+    while (true) {  // characteristics
+      uint16_t char_count = 1;
+      esp_gatt_status_t char_status =
+          esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
+                                     service_result.end_handle, &char_result, &char_count, char_offset);
+      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
         break;
       }
-      if (desc_status != ESP_GATT_OK) {
-        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
-                 this->address_str().c_str(), desc_status);
+      if (char_status != ESP_GATT_OK) {
+        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
+                 this->address_str().c_str(), char_status);
         break;
       }
-      if (desc_count == 0) {
+      if (char_count == 0) {
         break;
       }
 
-      characteristic_resp.descriptors.emplace_back();
-      auto &descriptor_resp = characteristic_resp.descriptors.back();
-      fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-      descriptor_resp.handle = desc_result.handle;
-      desc_offset++;
+      service_resp.characteristics.emplace_back();
+      auto &characteristic_resp = service_resp.characteristics.back();
+      fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
+      characteristic_resp.handle = char_result.char_handle;
+      characteristic_resp.properties = char_result.properties;
+      char_offset++;
+
+      // Get the number of descriptors directly with one call
+      uint16_t total_desc_count = 0;
+      esp_gatt_status_t desc_count_status =
+          esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, char_result.char_handle,
+                                       service_result.end_handle, 0, &total_desc_count);
+
+      if (desc_count_status == ESP_GATT_OK && total_desc_count > 0) {
+        // Only reserve if we successfully got a count
+        characteristic_resp.descriptors.reserve(total_desc_count);
+      } else if (desc_count_status != ESP_GATT_OK) {
+        ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
+                 this->address_str().c_str(), char_result.char_handle, desc_count_status);
+      }
+
+      // Skip descriptor processing if there are no descriptors
+      if (desc_count_status != ESP_GATT_OK || total_desc_count == 0) {
+        continue;
+      }
+
+      // Now process descriptors
+      uint16_t desc_offset = 0;
+      esp_gattc_descr_elem_t desc_result;
+      while (true) {  // descriptors
+        uint16_t desc_count = 1;
+        esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+            this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+        if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+          break;
+        }
+        if (desc_status != ESP_GATT_OK) {
+          ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
+                   this->address_str().c_str(), desc_status);
+          break;
+        }
+        if (desc_count == 0) {
+          break;
+        }
+
+        characteristic_resp.descriptors.emplace_back();
+        auto &descriptor_resp = characteristic_resp.descriptors.back();
+        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+        descriptor_resp.handle = desc_result.handle;
+        desc_offset++;
+      }
     }
-  }
+  }  // end if (char_count_status == ESP_GATT_OK && total_char_count > 0)
 
   // Send the message (we already checked api_conn is not null at the beginning)
   api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes two issues:

1. **Cache pollution bug**: Incomplete Bluetooth GATT service discovery data could be sent to clients when errors occur during the discovery process, causing cache pollution. This is a follow-up to #9697 which addressed service discovery issues during disconnection events.

2. **Descriptor count parameter bug**: The `esp_ble_gattc_get_attr_count` call for `ESP_GATT_DB_DESCRIPTOR` was passing parameters in the wrong order. The characteristic handle was being passed as 0 (in the 6th parameter position) while the actual handle was incorrectly placed in the 4th parameter position. [According to ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/bluetooth/esp_gattc.html#_CPPv428esp_ble_gattc_get_attr_count13esp_gatt_if_t8uint16_t23esp_gatt_db_attr_type_t8uint16_t8uint16_t8uint16_tP8uint16_t), for descriptor queries the 4th and 5th parameters are ignored and only the 6th parameter (char_handle) is used. This caused `total_desc_count` to always be 0, preventing the pre-allocation optimization from working.

When service discovery encounters errors (e.g., failing to get characteristic count or descriptor information), the previous code would send partial service data to the client. Clients would then cache this incomplete information, leading to persistent issues with future connections.

Additionally, this PR optimizes memory usage by avoiding unnecessary vector operations when there are no characteristics or descriptors to process.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #9697 (Bluetooth proxy fixes)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
bluetooth_proxy:
```

## Key Changes:

1. **Fixed cache pollution bug**: Service discovery now returns immediately on any error without sending partial data
   - Previously: Would send incomplete service/characteristic lists on errors
   - Now: Returns without sending, allowing client to timeout and retry cleanly

2. **Fixed descriptor count parameter order**: Corrected the parameter order for `esp_ble_gattc_get_attr_count` when querying descriptors
   - Previously: `char_handle` was passed as 0, causing descriptor count to always be 0
   - Now: `char_handle` is correctly passed in the 6th parameter position
   - This fixes the pre-allocation optimization that was never working for descriptors

3. **Optimized vector operations**: Skip processing when characteristic/descriptor counts are zero
   - Avoids unnecessary `emplace_back()` calls
   - Already reserves exact capacity when counts are known
   - Descriptor vector pre-allocation now works correctly due to fix 2

4. **Consistent error handling**: All error paths now return immediately instead of breaking and sending partial data
   - Service fetch errors
   - Characteristic count errors  
   - Characteristic fetch errors
   - Descriptor count errors
   - Descriptor fetch errors

5. **Code cleanup**: 
   - Combined redundant condition checks
   - Consolidated error messages with conditional formatting
   - Reduced flash usage despite additional functionality

## Impact:

This ensures Bluetooth clients maintain clean caches and don't store incomplete service information that would affect future connections. The atomic nature of service discovery (complete success or complete failure) improves reliability of the Bluetooth proxy component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).