### PR TITLE
[i2c] Fix logging level for bus scan results in dump_config

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -159,7 +159,7 @@ void IDFI2CBus::dump_config() {
         if (s.second) {
           ESP_LOGCONFIG(TAG, "Found device at address 0x%02X", s.first);
         } else {
-          ESP_LOGCONFIG(TAG, "Unknown error at address 0x%02X", s.first);
+          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.first);
         }
       }
     }

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -151,15 +151,15 @@ void IDFI2CBus::dump_config() {
       break;
   }
   if (this->scan_) {
-    ESP_LOGI(TAG, "Results from bus scan:");
+    ESP_LOGCONFIG(TAG, "Results from bus scan:");
     if (scan_results_.empty()) {
-      ESP_LOGI(TAG, "Found no devices");
+      ESP_LOGCONFIG(TAG, "Found no devices");
     } else {
       for (const auto &s : scan_results_) {
         if (s.second) {
-          ESP_LOGI(TAG, "Found device at address 0x%02X", s.first);
+          ESP_LOGCONFIG(TAG, "Found device at address 0x%02X", s.first);
         } else {
-          ESP_LOGE(TAG, "Unknown error at address 0x%02X", s.first);
+          ESP_LOGCONFIG(TAG, "Unknown error at address 0x%02X", s.first);
         }
       }
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes incorrect logging levels in the I2C bus scan results output. The scan results were using `ESP_LOGI` (info level) when they should be using `ESP_LOGCONFIG` since they are displayed within the `dump_config()` method.

before
<img width="449" height="118" alt="Screenshot 2025-07-25 at 6 29 37 PM" src="https://github.com/user-attachments/assets/b7e2599c-2fe0-4b69-9eb2-5bf55c4cc5af" />

after
<img width="457" height="144" alt="Screenshot 2025-07-25 at 6 29 47 PM" src="https://github.com/user-attachments/assets/32e88251-f8d6-4fcb-9f08-1a8dd01c3182" />


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed for this logging fix

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example showing I2C configuration that triggers the scan output
i2c:
  - id: i2c_bus
    sda: GPIO21
    scl: GPIO22
    scan: true
    frequency: 50kHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).