### PR TITLE
Fail with old lerp

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -68,7 +68,11 @@ To bit_cast(const From &src) {
   return dst;
 }
 #endif
-using std::lerp;
+
+[[deprecated("Use std::lerp instead. Note! Different order of arguments")]] float lerp(float completion, float start,
+                                                                                       float end) {
+  return start + (end - start) * completion;
+}
 
 // std::byteswap from C++23
 template<typename T> constexpr T byteswap(T n) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -69,10 +69,8 @@ To bit_cast(const From &src) {
 }
 #endif
 
-[[deprecated("Use std::lerp instead. Note! Different order of arguments")]] inline float lerp(float completion,
-                                                                                              float start, float end) {
-  return start + (end - start) * completion;
-}
+inline float lerp(float completion, float start,
+                  float end) = delete;  // Please use std::lerp. Notice that it has different order on arguments!
 
 // std::byteswap from C++23
 template<typename T> constexpr T byteswap(T n) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -69,8 +69,8 @@ To bit_cast(const From &src) {
 }
 #endif
 
-[[deprecated("Use std::lerp instead. Note! Different order of arguments")]] float lerp(float completion, float start,
-                                                                                       float end) {
+[[deprecated("Use std::lerp instead. Note! Different order of arguments")]] inline float lerp(float completion,
+                                                                                              float start, float end) {
   return start + (end - start) * completion;
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -69,8 +69,9 @@ To bit_cast(const From &src) {
 }
 #endif
 
-inline float lerp(float completion, float start,
-                  float end) = delete;  // Please use std::lerp. Notice that it has different order on arguments!
+// clang-format off
+inline float lerp(float completion, float start, float end) = delete;  // Please use std::lerp. Notice that it has different order on arguments!
+// clang-format on
 
 // std::byteswap from C++23
 template<typename T> constexpr T byteswap(T n) {


### PR DESCRIPTION
# What does this implement/fix?

Added lerp implementation that fails with comment to use std::lerp instead

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
