### PR TITLE
[logger] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -8,8 +8,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -283,5 +282,4 @@ void Logger::set_log_level(uint8_t level) {
 
 Logger *global_logger = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -34,9 +34,7 @@
 struct device;
 #endif
 
-namespace esphome {
-
-namespace logger {
+namespace esphome::logger {
 
 // Color and letter constants for log levels
 static const char *const LOG_LEVEL_COLORS[] = {
@@ -411,6 +409,4 @@ class LoggerMessageTrigger : public Trigger<uint8_t, const char *, const char *>
   uint8_t level_;
 };
 
-}  // namespace logger
-
-}  // namespace esphome
+}  // namespace esphome::logger

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -29,8 +29,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -206,6 +205,5 @@ const char *const UART_SELECTIONS[] = {
 
 const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -2,8 +2,7 @@
 #include "logger.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -40,6 +39,5 @@ const char *const UART_SELECTIONS[] = {"UART0", "UART1", "UART0_SWAP"};
 
 const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_host.cpp
+++ b/esphome/components/logger/logger_host.cpp
@@ -1,8 +1,7 @@
 #if defined(USE_HOST)
 #include "logger.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 void HOT Logger::write_msg_(const char *msg) {
   time_t rawtime;
@@ -18,7 +17,6 @@ void HOT Logger::write_msg_(const char *msg) {
 
 void Logger::pre_setup() { global_logger = this; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 
 #endif

--- a/esphome/components/logger/logger_libretiny.cpp
+++ b/esphome/components/logger/logger_libretiny.cpp
@@ -1,8 +1,7 @@
 #ifdef USE_LIBRETINY
 #include "logger.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -56,7 +55,6 @@ const char *const UART_SELECTIONS[] = {"DEFAULT", "UART0", "UART1", "UART2"};
 
 const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 
 #endif  // USE_LIBRETINY

--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -2,8 +2,7 @@
 #include "logger.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -34,6 +33,5 @@ const char *const UART_SELECTIONS[] = {"UART0", "UART1", "USB_CDC"};
 
 const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 #endif  // USE_RP2040

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -8,8 +8,7 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/usb/usb_device.h>
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 static const char *const TAG = "logger";
 
@@ -82,7 +81,6 @@ const char *const UART_SELECTIONS[] = {"UART0", "UART1", "USB_CDC"};
 
 const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 
 #endif

--- a/esphome/components/logger/select/logger_level_select.cpp
+++ b/esphome/components/logger/select/logger_level_select.cpp
@@ -1,7 +1,6 @@
 #include "logger_level_select.h"
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 void LoggerLevelSelect::publish_state(int level) {
   auto value = this->at(level);
@@ -23,5 +22,4 @@ void LoggerLevelSelect::control(const std::string &value) {
   this->parent_->set_log_level(level.value());
 }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger

--- a/esphome/components/logger/select/logger_level_select.h
+++ b/esphome/components/logger/select/logger_level_select.h
@@ -3,13 +3,11 @@
 #include "esphome/components/select/select.h"
 #include "esphome/core/component.h"
 #include "esphome/components/logger/logger.h"
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 class LoggerLevelSelect : public Component, public select::Select, public Parented<Logger> {
  public:
   void publish_state(int level);
   void setup() override;
   void control(const std::string &value) override;
 };
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger

--- a/esphome/components/logger/task_log_buffer.cpp
+++ b/esphome/components/logger/task_log_buffer.cpp
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 TaskLogBuffer::TaskLogBuffer(size_t total_buffer_size) {
   // Store the buffer size
@@ -132,7 +131,6 @@ bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uin
   return true;
 }
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 
 #endif  // USE_ESPHOME_TASK_LOG_BUFFER

--- a/esphome/components/logger/task_log_buffer.h
+++ b/esphome/components/logger/task_log_buffer.h
@@ -11,8 +11,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/ringbuf.h>
 
-namespace esphome {
-namespace logger {
+namespace esphome::logger {
 
 class TaskLogBuffer {
  public:
@@ -63,7 +62,6 @@ class TaskLogBuffer {
   mutable uint16_t last_processed_counter_{0};  // Tracks last processed message
 };
 
-}  // namespace logger
-}  // namespace esphome
+}  // namespace esphome::logger
 
 #endif  // USE_ESPHOME_TASK_LOG_BUFFER


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the logger component to use C++17 nested namespace syntax, following the pattern established in #9825 for the bluetooth components. This modernizes the code and improves readability by replacing the traditional nested namespace blocks with the more concise C++17 syntax.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #9825 (which did the same for bluetooth components)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Additional testing:**
- [x] Host platform (tested successfully)

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is purely a code style update
logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary of changes

Updated all C++ files in the logger component to use C++17 nested namespace syntax:
- `namespace esphome { namespace logger {` → `namespace esphome::logger {`
- `} // namespace logger } // namespace esphome` → `} // namespace esphome::logger`

Files changed:
- esphome/components/logger/logger.h
- esphome/components/logger/logger.cpp
- esphome/components/logger/logger_esp32.cpp
- esphome/components/logger/logger_esp8266.cpp
- esphome/components/logger/logger_host.cpp
- esphome/components/logger/logger_libretiny.cpp
- esphome/components/logger/logger_rp2040.cpp
- esphome/components/logger/logger_zephyr.cpp
- esphome/components/logger/task_log_buffer.h
- esphome/components/logger/task_log_buffer.cpp
- esphome/components/logger/select/logger_level_select.h
- esphome/components/logger/select/logger_level_select.cpp