### PR TITLE
[api] Reduce code duplication in send_noise_encryption_set_key_response

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1538,19 +1538,18 @@ void APIConnection::execute_service(const ExecuteServiceRequest &msg) {
 #endif
 #ifdef USE_API_NOISE
 bool APIConnection::send_noise_encryption_set_key_response(const NoiseEncryptionSetKeyRequest &msg) {
-  psk_t psk{};
   NoiseEncryptionSetKeyResponse resp;
+  resp.success = false;
+
+  psk_t psk{};
   if (base64_decode(msg.key, psk.data(), msg.key.size()) != psk.size()) {
     ESP_LOGW(TAG, "Invalid encryption key length");
-    resp.success = false;
-    return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
-  }
-  if (!this->parent_->save_noise_psk(psk, true)) {
+  } else if (!this->parent_->save_noise_psk(psk, true)) {
     ESP_LOGW(TAG, "Failed to save encryption key");
-    resp.success = false;
-    return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
+  } else {
+    resp.success = true;
   }
-  resp.success = true;
+
   return this->send_message(resp, NoiseEncryptionSetKeyResponse::MESSAGE_TYPE);
 }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces code duplication in the `send_noise_encryption_set_key_response` function, resulting in a small reduction in flash usage.

The function previously had three separate return statements with identical `send_message()` calls. This refactor consolidates them into a single return statement at the end of the function, improving code maintainability and reducing flash usage by 8 bytes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).