### PR TITLE
[light] Reduce flash memory usage by optimizing validation and color mode logic

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -446,51 +446,35 @@ std::set<ColorMode> LightCall::get_suitable_color_modes_() {
   bool has_rgb = (this->has_color_brightness() && this->color_brightness_ > 0.0f) ||
                  (this->has_red() || this->has_green() || this->has_blue());
 
-  // Static sets that are only constructed once
-  static const std::set<ColorMode> MODES_WHITE_ONLY = {ColorMode::WHITE, ColorMode::RGB_WHITE,
-                                                       ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
-                                                       ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_CT_ONLY = {ColorMode::COLOR_TEMPERATURE, ColorMode::RGB_COLOR_TEMPERATURE,
-                                                    ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_WHITE_CT = {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLOR_TEMPERATURE,
-                                                     ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_CWWW_ONLY = {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_NONE = {
-      ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE, ColorMode::RGB,
-      ColorMode::WHITE,     ColorMode::COLOR_TEMPERATURE,     ColorMode::COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_RGB_WHITE = {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE,
-                                                      ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_RGB_CT = {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_RGB_CWWW = {ColorMode::RGB_COLD_WARM_WHITE};
-  static const std::set<ColorMode> MODES_RGB_ONLY = {ColorMode::RGB, ColorMode::RGB_WHITE,
-                                                     ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
-
 // Build key from flags: [rgb][cwww][ct][white]
 #define KEY(white, ct, cwww, rgb) ((white) << 0 | (ct) << 1 | (cwww) << 2 | (rgb) << 3)
 
   uint8_t key = KEY(has_white, has_ct, has_cwww, has_rgb);
 
   switch (key) {
-    case KEY(true, false, false, false):
-      return MODES_WHITE_ONLY;
-    case KEY(false, true, false, false):
-      return MODES_CT_ONLY;
-    case KEY(true, true, false, false):
-      return MODES_WHITE_CT;
-    case KEY(false, false, true, false):
-      return MODES_CWWW_ONLY;
-    case KEY(false, false, false, false):
-      return MODES_NONE;
-    case KEY(true, false, false, true):
-      return MODES_RGB_WHITE;
-    case KEY(false, true, false, true):
-      return MODES_RGB_CT;
-    case KEY(true, true, false, true):
-      return MODES_RGB_CT;
-    case KEY(false, false, true, true):
-      return MODES_RGB_CWWW;
-    case KEY(false, false, false, true):
-      return MODES_RGB_ONLY;
+    case KEY(true, false, false, false):  // white only
+      return {ColorMode::WHITE, ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
+              ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, true, false, false):  // ct only
+      return {ColorMode::COLOR_TEMPERATURE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
+              ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(true, true, false, false):  // white + ct
+      return {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, false, true, false):  // cwww only
+      return {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, false, false, false):  // none
+      return {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE, ColorMode::RGB,
+              ColorMode::WHITE,     ColorMode::COLOR_TEMPERATURE,     ColorMode::COLD_WARM_WHITE};
+    case KEY(true, false, false, true):  // rgb + white
+      return {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, true, false, true):  // rgb + ct
+      return {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(true, true, false, true):  // rgb + white + ct
+      return {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, false, true, true):  // rgb + cwww
+      return {ColorMode::RGB_COLD_WARM_WHITE};
+    case KEY(false, false, false, true):  // rgb only
+      return {ColorMode::RGB, ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
     default:
       return {};  // conflicting flags
   }

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -9,6 +9,11 @@ namespace light {
 
 static const char *const TAG = "light";
 
+// Helper function to reduce code size for validation warnings
+static void log_validation_warning(const char *name, const char *param_name, float val, float min, float max) {
+  ESP_LOGW(TAG, "'%s': %s value %.2f is out of range [%.1f - %.1f]", name, param_name, val, min, max);
+}
+
 // Macro to reduce repetitive setter code
 #define IMPLEMENT_LIGHT_CALL_SETTER(name, type, flag) \
   LightCall &LightCall::set_##name(optional<type>(name)) { \
@@ -223,8 +228,7 @@ LightColorValues LightCall::validate_() {
   if (this->has_##name_()) { \
     auto val = this->name_##_; \
     if (val < (min) || val > (max)) { \
-      ESP_LOGW(TAG, "'%s': %s value %.2f is out of range [%.1f - %.1f]", name, LOG_STR_LITERAL(upper_name), val, \
-               (min), (max)); \
+      log_validation_warning(name, LOG_STR_LITERAL(upper_name), val, (min), (max)); \
       this->name_##_ = clamp(val, (min), (max)); \
     } \
   }
@@ -442,41 +446,56 @@ std::set<ColorMode> LightCall::get_suitable_color_modes_() {
   bool has_rgb = (this->has_color_brightness() && this->color_brightness_ > 0.0f) ||
                  (this->has_red() || this->has_green() || this->has_blue());
 
+  // Static sets that are only constructed once
+  static const std::set<ColorMode> MODES_WHITE_ONLY = {ColorMode::WHITE, ColorMode::RGB_WHITE,
+                                                       ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
+                                                       ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_CT_ONLY = {ColorMode::COLOR_TEMPERATURE, ColorMode::RGB_COLOR_TEMPERATURE,
+                                                    ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_WHITE_CT = {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLOR_TEMPERATURE,
+                                                     ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_CWWW_ONLY = {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_NONE = {
+      ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE, ColorMode::RGB,
+      ColorMode::WHITE,     ColorMode::COLOR_TEMPERATURE,     ColorMode::COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_RGB_WHITE = {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE,
+                                                      ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_RGB_CT = {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_RGB_CWWW = {ColorMode::RGB_COLD_WARM_WHITE};
+  static const std::set<ColorMode> MODES_RGB_ONLY = {ColorMode::RGB, ColorMode::RGB_WHITE,
+                                                     ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
+
+// Build key from flags: [rgb][cwww][ct][white]
 #define KEY(white, ct, cwww, rgb) ((white) << 0 | (ct) << 1 | (cwww) << 2 | (rgb) << 3)
-#define ENTRY(white, ct, cwww, rgb, ...) \
-  std::make_tuple<uint8_t, std::set<ColorMode>>(KEY(white, ct, cwww, rgb), __VA_ARGS__)
 
-  // Flag order: white, color temperature, cwww, rgb
-  std::array<std::tuple<uint8_t, std::set<ColorMode>>, 10> lookup_table{
-      ENTRY(true, false, false, false,
-            {ColorMode::WHITE, ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
-             ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, true, false, false,
-            {ColorMode::COLOR_TEMPERATURE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE,
-             ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(true, true, false, false,
-            {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, false, true, false, {ColorMode::COLD_WARM_WHITE, ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, false, false, false,
-            {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE, ColorMode::RGB,
-             ColorMode::WHITE, ColorMode::COLOR_TEMPERATURE, ColorMode::COLD_WARM_WHITE}),
-      ENTRY(true, false, false, true,
-            {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, true, false, true, {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(true, true, false, true, {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, false, true, true, {ColorMode::RGB_COLD_WARM_WHITE}),
-      ENTRY(false, false, false, true,
-            {ColorMode::RGB, ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE}),
-  };
+  uint8_t key = KEY(has_white, has_ct, has_cwww, has_rgb);
 
-  auto key = KEY(has_white, has_ct, has_cwww, has_rgb);
-  for (auto &item : lookup_table) {
-    if (std::get<0>(item) == key)
-      return std::get<1>(item);
+  switch (key) {
+    case KEY(true, false, false, false):
+      return MODES_WHITE_ONLY;
+    case KEY(false, true, false, false):
+      return MODES_CT_ONLY;
+    case KEY(true, true, false, false):
+      return MODES_WHITE_CT;
+    case KEY(false, false, true, false):
+      return MODES_CWWW_ONLY;
+    case KEY(false, false, false, false):
+      return MODES_NONE;
+    case KEY(true, false, false, true):
+      return MODES_RGB_WHITE;
+    case KEY(false, true, false, true):
+      return MODES_RGB_CT;
+    case KEY(true, true, false, true):
+      return MODES_RGB_CT;
+    case KEY(false, false, true, true):
+      return MODES_RGB_CWWW;
+    case KEY(false, false, false, true):
+      return MODES_RGB_ONLY;
+    default:
+      return {};  // conflicting flags
   }
 
-  // This happens if there are conflicting flags given.
-  return {};
+#undef KEY
 }
 
 LightCall &LightCall::set_effect(const std::string &effect) {

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -468,8 +468,7 @@ std::set<ColorMode> LightCall::get_suitable_color_modes_() {
     case KEY(true, false, false, true):  // rgb + white
       return {ColorMode::RGB_WHITE, ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
     case KEY(false, true, false, true):  // rgb + ct
-      return {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
-    case KEY(true, true, false, true):  // rgb + white + ct
+    case KEY(true, true, false, true):   // rgb + white + ct
       return {ColorMode::RGB_COLOR_TEMPERATURE, ColorMode::RGB_COLD_WARM_WHITE};
     case KEY(false, false, true, true):  // rgb + cwww
       return {ColorMode::RGB_COLD_WARM_WHITE};

--- a/tests/integration/test_light_calls.py
+++ b/tests/integration/test_light_calls.py
@@ -180,6 +180,69 @@ async def test_light_calls(
         state = await wait_for_state_change(rgb_light.key)
         assert state.state is False
 
+        # Test color mode combinations to verify get_suitable_color_modes optimization
+
+        # Test 22: White only mode
+        client.light_command(key=rgbcw_light.key, state=True, white=0.5)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 23: Color temperature only mode
+        client.light_command(key=rgbcw_light.key, state=True, color_temperature=300)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.color_temperature == pytest.approx(300)
+
+        # Test 24: Cold/warm white only mode
+        client.light_command(
+            key=rgbcw_light.key, state=True, cold_white=0.6, warm_white=0.4
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.cold_white == pytest.approx(0.6)
+        assert state.warm_white == pytest.approx(0.4)
+
+        # Test 25: RGB only mode
+        client.light_command(key=rgb_light.key, state=True, rgb=(0.5, 0.5, 0.5))
+        state = await wait_for_state_change(rgb_light.key)
+        assert state.state is True
+
+        # Test 26: RGB + white combination
+        client.light_command(
+            key=rgbcw_light.key, state=True, rgb=(0.3, 0.3, 0.3), white=0.5
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 27: RGB + color temperature combination
+        client.light_command(
+            key=rgbcw_light.key, state=True, rgb=(0.4, 0.4, 0.4), color_temperature=280
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 28: RGB + cold/warm white combination
+        client.light_command(
+            key=rgbcw_light.key,
+            state=True,
+            rgb=(0.2, 0.2, 0.2),
+            cold_white=0.5,
+            warm_white=0.5,
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 29: White + color temperature combination
+        client.light_command(
+            key=rgbcw_light.key, state=True, white=0.6, color_temperature=320
+        )
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+
+        # Test 30: No specific color parameters (tests default mode selection)
+        client.light_command(key=rgbcw_light.key, state=True, brightness=0.75)
+        state = await wait_for_state_change(rgbcw_light.key)
+        assert state.state is True
+        assert state.brightness == pytest.approx(0.75)
+
         # Final cleanup - turn all lights off
         for light in lights:
             client.light_command(


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the light component to significantly reduce flash memory usage by:

1. **Extracting validation logging to a helper function** - The `VALIDATE_RANGE` macro was generating duplicate logging code for each validation. By extracting the logging to a shared helper function, we reduce code duplication.

2. **Optimizing `get_suitable_color_modes_()`** - Replaced the heavy `std::array` of `std::tuple` with a simple switch statement that builds sets on the fly. This eliminates the complex data structure overhead and reduces code size without using additional RAM.

The optimizations achieve the following reductions (measured on ESP32):
- `LightCall::validate_()`: 2,586 B → 2,243 B (-343 B, -13%) -- ⚠️  **There is still a lot more that could be done here**
- `LightCall::get_suitable_color_modes_()`: 1,558 B → 375 B (-1,183 B, -76%)
- **Total flash savings: 1,496 bytes** (1,226,762 → 1,225,266 bytes)
- **RAM usage: No change** (47,692 bytes before and after)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses memory optimization needs for ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
light:
  - platform: rgb
    name: "RGB Light"
    red: red_channel
    green: green_channel
    blue: blue_channel
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Added comprehensive color mode tests to `tests/integration/test_light_calls.py`
    - Verified all 16 possible color mode combinations produce identical results with host platform test

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-facing changes