### PR TITLE
[mmc5603] Fix incorrect factor for value calculation in MMC5603 component

### DIFF
--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -128,21 +128,21 @@ void MMC5603Component::update() {
   raw_x |= buffer[1] << 4;
   raw_x |= buffer[2] << 0;
 
-  const float x = 0.0625 * (raw_x - 524288);
+  const float x = 0.00625 * (raw_x - 524288);
 
   int32_t raw_y = 0;
   raw_y |= buffer[3] << 12;
   raw_y |= buffer[4] << 4;
   raw_y |= buffer[5] << 0;
 
-  const float y = 0.0625 * (raw_y - 524288);
+  const float y = 0.00625 * (raw_y - 524288);
 
   int32_t raw_z = 0;
   raw_z |= buffer[6] << 12;
   raw_z |= buffer[7] << 4;
   raw_z |= buffer[8] << 0;
 
-  const float z = 0.0625 * (raw_z - 524288);
+  const float z = 0.00625 * (raw_z - 524288);
 
   const float heading = atan2f(0.0f - x, y) * 180.0f / M_PI;
   ESP_LOGD(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f°", x, y, z, heading);


### PR DESCRIPTION
The factor for converting the LSB in µT is not correct. It should be 0,00625. Per Datasheet the conversion factor is 0,0625mG per LSB. Converted to µT the factor is 0,00625µT/LSB.

0.0625 mG × 0.1 µT/mG = 0.00625 µT

With the current implementation all values are wrong by factor 10.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
