### PR TITLE
replace os.getlogin() with getpass.getuser()

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -2,6 +2,7 @@
 import argparse
 from datetime import datetime
 import functools
+import getpass
 import importlib
 import logging
 import os
@@ -335,7 +336,7 @@ def check_permissions(port):
             raise EsphomeError(
                 "You do not have read or write permission on the selected serial port. "
                 "To resolve this issue, you can add your user to the dialout group "
-                f"by running the following command: sudo usermod -a -G dialout {os.getlogin()}. "
+                f"by running the following command: sudo usermod -a -G dialout {getpass.getuser()}. "
                 "You will need to log out & back in or reboot to activate the new group access."
             )
 


### PR DESCRIPTION
# What does this implement/fix?

fixes 'OSError: [Errno 6] No such device or address' that is triggered if the function check_permissions is printing the error message that the user needs to be added to dialout. I stumbeled upon this error while trying to upload a project in my wsl. Appears to be a rare issue 
As suggested by the python documentation ([link](https://docs.python.org/3/library/os.html#os.getlogin)):

> For most purposes, it is more useful to use [getpass.getuser()](https://docs.python.org/3/library/getpass.html#getpass.getuser) since the latter checks the environment variables LOGNAME or USERNAME to find out who the user is, and falls back to pwd.getpwuid(os.getuid())[0] to get the login name of the current real user id.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

