### PR TITLE
[scheduler] Eliminate more runtime string allocations from retry

### DIFF
--- a/tests/integration/fixtures/scheduler_retry_test.yaml
+++ b/tests/integration/fixtures/scheduler_retry_test.yaml
@@ -37,6 +37,15 @@ globals:
   - id: multiple_same_name_counter
     type: int
     initial_value: '0'
+  - id: const_char_retry_counter
+    type: int
+    initial_value: '0'
+  - id: static_char_retry_counter
+    type: int
+    initial_value: '0'
+  - id: mixed_cancel_result
+    type: bool
+    initial_value: 'false'
 
 # Using different component types for each test to ensure isolation
 sensor:
@@ -229,6 +238,56 @@ script:
               return RetryResult::RETRY;
             });
 
+      # Test 8: Const char* overloads
+      - logger.log: "=== Test 8: Const char* overloads ==="
+      - lambda: |-
+          auto *component = id(simple_retry_sensor);
+
+          // Test 8a: Direct string literal
+          App.scheduler.set_retry(component, "const_char_test", 30, 2,
+            [](uint8_t retry_countdown) {
+              id(const_char_retry_counter)++;
+              ESP_LOGI("test", "Const char retry %d", id(const_char_retry_counter));
+              return RetryResult::DONE;
+            });
+
+      # Test 9: Static const char* variable
+      - logger.log: "=== Test 9: Static const char* ==="
+      - lambda: |-
+          auto *component = id(backoff_retry_sensor);
+
+          static const char* STATIC_NAME = "static_retry_test";
+          App.scheduler.set_retry(component, STATIC_NAME, 20, 1,
+            [](uint8_t retry_countdown) {
+              id(static_char_retry_counter)++;
+              ESP_LOGI("test", "Static const char retry %d", id(static_char_retry_counter));
+              return RetryResult::DONE;
+            });
+
+          // Cancel with same static const char*
+          App.scheduler.set_timeout(component, "static_cancel", 10, []() {
+            static const char* STATIC_NAME = "static_retry_test";
+            bool result = App.scheduler.cancel_retry(id(backoff_retry_sensor), STATIC_NAME);
+            ESP_LOGI("test", "Static cancel result: %s", result ? "true" : "false");
+          });
+
+      # Test 10: Mix string and const char* cancel
+      - logger.log: "=== Test 10: Mixed string/const char* ==="
+      - lambda: |-
+          auto *component = id(immediate_done_sensor);
+
+          // Set with std::string
+          std::string str_name = "mixed_retry";
+          App.scheduler.set_retry(component, str_name, 40, 3,
+            [](uint8_t retry_countdown) {
+              ESP_LOGI("test", "Mixed retry - should be cancelled");
+              return RetryResult::RETRY;
+            });
+
+          // Cancel with const char*
+          id(mixed_cancel_result) = App.scheduler.cancel_retry(component, "mixed_retry");
+          ESP_LOGI("test", "Mixed cancel result: %s", id(mixed_cancel_result) ? "true" : "false");
+
       # Wait for all tests to complete before reporting
       - delay: 500ms
 
@@ -242,4 +301,7 @@ script:
           ESP_LOGI("test", "Empty name retry counter: %d (expected 1-2)", id(empty_name_retry_counter));
           ESP_LOGI("test", "Component retry counter: %d (expected 2)", id(script_retry_counter));
           ESP_LOGI("test", "Multiple same name counter: %d (expected 20+)", id(multiple_same_name_counter));
+          ESP_LOGI("test", "Const char retry counter: %d (expected 1)", id(const_char_retry_counter));
+          ESP_LOGI("test", "Static char retry counter: %d (expected 1)", id(static_char_retry_counter));
+          ESP_LOGI("test", "Mixed cancel result: %s (expected true)", id(mixed_cancel_result) ? "true" : "false");
           ESP_LOGI("test", "All retry tests completed");


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the scheduler's retry mechanism by eliminating runtime string concatenation operations that were causing heap allocations. While flash usage increases slightly by 32 bytes, this tradeoff eliminates more dynamic memory allocations during retry scheduling, improving runtime performance and reducing heap fragmentation.

The main changes:
- Added `is_retry` flag to SchedulerItem to identify retry timeouts (uses existing padding bits, no RAM increase)
- Eliminated "retry$" string prefix concatenation that was creating temporary string objects on the heap
- Implemented `set_retry_common_` to share code between std::string and const char* versions
- Added const char* overloads for `set_retry()` and `cancel_retry()` to allow direct use of string literals
- Updated `cancel_item_locked_` and `matches_item_` to support retry-specific matching via `match_retry` parameter
- Added comprehensive integration tests for const char* overloads

This change eliminates runtime heap allocations for the strings without altering the user-facing API or behavior. The optimization is particularly beneficial for memory-constrained devices like ESP8266 where heap fragmentation can cause issues.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces flash usage for ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Existing retry functionality remains unchanged

# Example usage (already supported):
switch:
  - platform: template
    name: "Test Switch"
    turn_on_action:
      - lambda: |-
          // Retry logic continues to work as before
          id(my_component).retry_operation();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

### Performance Impact
- Flash usage increased by 32 bytes (516246 → 516278 bytes) - a worthwhile tradeoff
- Eliminates runtime heap allocations from string concatenation ("retry$" + name)
- Improves runtime performance by avoiding string operations
- RAM usage unchanged (uses existing padding bits in SchedulerItem)
- Benefits are especially important for memory-constrained devices where heap fragmentation is a concern

### Technical Details
The optimization works by:
1. Using a bit flag instead of string concatenation to identify retry timeouts
2. Providing const char* overloads to avoid string object creation when called with string literals
3. Sharing common code between string and const char* implementations

### Testing
- All existing retry tests pass without modification
- Added new integration tests for const char* overloads (tests 8-10 in `scheduler_retry_test.yaml`)
- Verified string literal usage, static const char* variables, and mixed string/const char* operations
- Tested cancellation across different string types
- Confirmed no null pointer dereferences
- Validated that non-retry cancellations don't match retry items