### PR TITLE
Add seed flag when running setup with uv present

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -6,7 +6,7 @@ set -e
 cd "$(dirname "$0")/.."
 if [ ! -n "$VIRTUAL_ENV" ]; then
   if [ -x "$(command -v uv)" ]; then
-    uv venv venv
+    uv venv --seed venv
   else
     python3 -m venv venv
   fi


### PR DESCRIPTION
# What does this implement/fix?

This adds the `--seed` flag to the `uv venv` command that is run when setting up the esphome venv with uv present on the system.  This causes uv to install tools like `pip`, `setuptools`, and `wheel` into the venv.  Without this, there is no pip present and while the setup script will complete, attempting to use `esphome run ./path/to/config.yaml` will result in an error. I am unsure if this happens with other non P4 chips with the ESP IDF or if this is some "P4 specific" behavior in the IDF.

```
HARDWARE: ESP32P4 360MHz, 500KB RAM, 16MB Flash
 - framework-espidf @ 3.50402.0 (5.4.2) 
 - tool-cmake @ 3.30.2 
 - tool-esp-rom-elfs @ 2024.10.11 
 - tool-esptoolpy @ 5.0.0 
 - tool-ninja @ 1.10.2 
 - tool-scons @ 4.40801.0 (4.8.1) 
 - toolchain-esp32ulp @ 2.35.0-20220830 
 - toolchain-riscv32-esp @ 14.2.0+20241119
/home/cryptk/Documents/sourcecode/esphome/esphome/venv/bin/python: No module named pip
CalledProcessError: Command '['/home/cryptk/Documents/sourcecode/esphome/esphome/venv/bin/python', '-m', 'pip', 'list', '--format=json', '--disable-pip-version-check']' returned non-zero exit status 1.:
  File "/home/cryptk/Documents/sourcecode/esphome/esphome/venv/lib/python3.13/site-packages/platformio/builder/main.py", line 173:
    env.SConscript("$BUILD_SCRIPT")
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/cryptk/.platformio/platforms/espressif32/builder/main.py", line 526:
    target_elf = env.BuildProgram()
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/cryptk/Documents/sourcecode/esphome/esphome/venv/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 62:
    env.ProcessProgramDeps()
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/cryptk/Documents/sourcecode/esphome/esphome/venv/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 142:
    env.BuildFrameworks(env.get("PIOFRAMEWORK"))
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Util/envs.py", line 252:
    return self.method(*nargs, **kwargs)
  File "/home/cryptk/Documents/sourcecode/esphome/esphome/venv/lib/python3.13/site-packages/platformio/builder/tools/piobuild.py", line 352:
    SConscript(env.GetFrameworkScript(name), exports="env")
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 684:
    return method(*args, **kw)
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 620:
    return _SConscript(self.fs, *files, **subst_kw)
  File "/home/cryptk/.platformio/packages/tool-scons/scons-local-4.8.1/SCons/Script/SConscript.py", line 280:
    exec(compile(scriptdata, scriptname, 'exec'), call_stack[-1].globals)
  File "/home/cryptk/.platformio/platforms/espressif32/builder/frameworks/espidf.py", line 119:
    install_standard_python_deps()
  File "/home/cryptk/.platformio/platforms/espressif32/builder/frameworks/espidf.py", line 92:
    installed_packages = _get_installed_standard_pip_packages()
  File "/home/cryptk/.platformio/platforms/espressif32/builder/frameworks/espidf.py", line 63:
    pip_output = subprocess.check_output(
  File "/usr/lib/python3.13/subprocess.py", line 472:
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.13/subprocess.py", line 577:
    raise CalledProcessError(retcode, process.args,
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://discord.com/channels/429907082951524364/429907082955718657/1398430556093677691

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
