### PR TITLE
2025.7.4

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.7.3
+PROJECT_NUMBER         = 2025.7.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -477,10 +477,11 @@ void LD2450Component::handle_periodic_data_() {
     // X
     start = TARGET_X + index * 8;
     is_moving = false;
+    // tx is used for further calculations, so always needs to be populated
+    val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
+    tx = val;
     sensor::Sensor *sx = this->move_x_sensors_[index];
     if (sx != nullptr) {
-      val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
-      tx = val;
       if (this->cached_target_data_[index].x != val) {
         sx->publish_state(val);
         this->cached_target_data_[index].x = val;
@@ -488,10 +489,11 @@ void LD2450Component::handle_periodic_data_() {
     }
     // Y
     start = TARGET_Y + index * 8;
+    // ty is used for further calculations, so always needs to be populated
+    val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
+    ty = val;
     sensor::Sensor *sy = this->move_y_sensors_[index];
     if (sy != nullptr) {
-      val = ld2450::decode_coordinate(this->buffer_data_[start], this->buffer_data_[start + 1]);
-      ty = val;
       if (this->cached_target_data_[index].y != val) {
         sy->publish_state(val);
         this->cached_target_data_[index].y = val;

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -400,6 +400,7 @@ CONF_LOGGER_LOG = "logger.log"
 LOGGER_LOG_ACTION_SCHEMA = cv.All(
     cv.maybe_simple_value(
         {
+            cv.GenerateID(CONF_LOGGER_ID): cv.use_id(Logger),
             cv.Required(CONF_FORMAT): cv.string,
             cv.Optional(CONF_ARGS, default=list): cv.ensure_list(cv.lambda_),
             cv.Optional(CONF_LEVEL, default="DEBUG"): cv.one_of(

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -86,10 +86,9 @@ void RemoteReceiverComponent::setup() {
 
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
   uint32_t max_filter_ns = 255u * 1000 / (RMT_CLK_FREQ / 1000000);
-  uint32_t max_idle_ns = 65535u * 1000;
   memset(&this->store_.config, 0, sizeof(this->store_.config));
   this->store_.config.signal_range_min_ns = std::min(this->filter_us_ * 1000, max_filter_ns);
-  this->store_.config.signal_range_max_ns = std::min(this->idle_us_ * 1000, max_idle_ns);
+  this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;
   this->store_.filter_symbols = this->filter_symbols_;
   this->store_.receive_size = this->receive_symbols_ * sizeof(rmt_symbol_word_t);
   this->store_.buffer_size = std::max((event_size + this->store_.receive_size) * 2, this->buffer_size_);

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.7.3"
+__version__ = "2025.7.4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -67,7 +67,10 @@ To bit_cast(const From &src) {
   return dst;
 }
 #endif
-using std::lerp;
+
+// clang-format off
+inline float lerp(float completion, float start, float end) = delete;  // Please use std::lerp. Notice that it has different order on arguments!
+// clang-format on
 
 // std::byteswap from C++23
 template<typename T> constexpr T byteswap(T n) {

--- a/script/setup
+++ b/script/setup
@@ -6,7 +6,7 @@ set -e
 cd "$(dirname "$0")/.."
 if [ ! -n "$VIRTUAL_ENV" ]; then
   if [ -x "$(command -v uv)" ]; then
-    uv venv venv
+    uv venv --seed venv
   else
     python3 -m venv venv
   fi

--- a/tests/component_tests/text/test_text.yaml
+++ b/tests/component_tests/text/test_text.yaml
@@ -4,6 +4,8 @@ esphome:
 esp32:
   board: esp32dev
 
+logger:
+
 text:
   - platform: template
     name: "test 1 text"


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
<details>
<summary>Show</summary>

- [remote_receiver] Fix idle validation [esphome#9819](https://github.com/esphome/esphome/pull/9819)
- [gt911] i2c fixes [esphome#9822](https://github.com/esphome/esphome/pull/9822)
- fix: non-optional x/y target calculation for ld2450 [esphome#9849](https://github.com/esphome/esphome/pull/9849)
- [logger] Don't allow ``logger.log`` actions without configuring the ``logger`` [esphome#9821](https://github.com/esphome/esphome/pull/9821)
- Add seed flag when running setup with uv present [esphome#9932](https://github.com/esphome/esphome/pull/9932)
- Fail with old lerp [esphome#9914](https://github.com/esphome/esphome/pull/9914)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
