### PR TITLE
[lvgl] Bugfix for tileview

### DIFF
--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -738,7 +738,7 @@ lvgl:
                     id: bar_id
                     value: !lambda return (int)((float)rand() / RAND_MAX * 100);
                     start_value: !lambda return (int)((float)rand() / RAND_MAX * 100);
-                    mode: symmetrical
+                    mode: range
                 - logger.log:
                     format: "bar value %f"
                     args: [x]


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

LVGL 8.x has a bug in tileview handling that manifests itself if the screen size changes, which does happen in LVGL since the initial screen creation is done with default dimensions, then it is resized in `setup()`

The bug is fixed in LVGL9, but this PR adds code to work around it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
