### PR TITLE
[config_validation] extend should combine extra validations

### DIFF
--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -225,9 +225,10 @@ class _Schema(vol.Schema):
             return ret
 
         schema = schemas[0]
+        extra_schemas = self._extra_schemas.copy()
+        if isinstance(schema, _Schema):
+            extra_schemas.extend(schema._extra_schemas)
         if isinstance(schema, vol.Schema):
             schema = schema.schema
         ret = super().extend(schema, extra=extra)
-        return _Schema(
-            ret.schema, extra=ret.extra, extra_schemas=self._extra_schemas.copy()
-        )
+        return _Schema(ret.schema, extra=ret.extra, extra_schemas=extra_schemas)

--- a/tests/component_tests/config_validation/test_config.py
+++ b/tests/component_tests/config_validation/test_config.py
@@ -1,0 +1,42 @@
+"""
+Test ESP32 configuration
+"""
+
+from typing import Any
+
+import esphome.config_validation as cv
+
+
+def test_config_extend() -> None:
+    """Test that schema.extend correctly merges schemas with extras."""
+
+    def func1(data: dict[str, Any]) -> dict[str, Any]:
+        data["extra_1"] = "value1"
+        return data
+
+    def func2(data: dict[str, Any]) -> dict[str, Any]:
+        data["extra_2"] = "value2"
+        return data
+
+    schema1 = cv.Schema(
+        {
+            cv.Required("key1"): cv.string,
+        }
+    )
+    schema1.add_extra(func1)
+    schema2 = cv.Schema(
+        {
+            cv.Required("key2"): cv.string,
+        }
+    )
+    schema2.add_extra(func2)
+    extended_schema1 = schema1.extend(schema2)
+    config = {
+        "key1": "initial_value1",
+        "key2": "initial_value2",
+    }
+    config = extended_schema1(config)
+    assert config["key1"] == "initial_value1"
+    assert config["key2"] == "initial_value2"
+    assert config["extra_1"] == "value1"
+    assert config["extra_2"] == "value2"

--- a/tests/component_tests/config_validation/test_config.py
+++ b/tests/component_tests/config_validation/test_config.py
@@ -30,13 +30,22 @@ def test_config_extend() -> None:
         }
     )
     schema2.add_extra(func2)
-    extended_schema1 = schema1.extend(schema2)
+    extended_schema = schema1.extend(schema2)
     config = {
         "key1": "initial_value1",
         "key2": "initial_value2",
     }
-    config = extended_schema1(config)
-    assert config["key1"] == "initial_value1"
-    assert config["key2"] == "initial_value2"
-    assert config["extra_1"] == "value1"
-    assert config["extra_2"] == "value2"
+    validated = extended_schema(config)
+    assert validated["key1"] == "initial_value1"
+    assert validated["key2"] == "initial_value2"
+    assert validated["extra_1"] == "value1"
+    assert validated["extra_2"] == "value2"
+
+    # Check the opposite order of extension
+    extended_schema = schema2.extend(schema1)
+
+    validated = extended_schema(config)
+    assert validated["key1"] == "initial_value1"
+    assert validated["key2"] == "initial_value2"
+    assert validated["extra_1"] == "value1"
+    assert validated["extra_2"] == "value2"

--- a/tests/component_tests/config_validation/test_config.py
+++ b/tests/component_tests/config_validation/test_config.py
@@ -1,5 +1,5 @@
 """
-Test ESP32 configuration
+Test schema.extend functionality in esphome.config_validation.
 """
 
 from typing import Any


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This PR fixes a bug in the configuration validation system where the `extend` method on schemas wasn't properly combining extra validation functions from both schemas. The fix ensures that when extending a schema, the extra validators from both the base schema and the extending schema are merged together.

- Fixed the `extend` method in `_Schema` class to properly merge `_extra_schemas` from both schemas
- Added test coverage to verify the fix works correctly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1399180500915978331

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
