### PR TITLE
[heatpumpir] Fix issue with IRremoteESP8266 being included on ESP32

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -127,5 +127,5 @@ async def to_code(config):
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
 
     cg.add_library("tonia/HeatpumpIR", "1.0.37")
-    if CORE.is_libretiny:
+    if CORE.is_libretiny or CORE.is_esp32:
         CORE.add_platformio_option("lib_ignore", "IRremoteESP8266")


### PR DESCRIPTION
# What does this implement/fix?

Fix issue with IRremoteESP8266 being included on ESP32, force platformio to ignore the library. 

Because https://github.com/crankyoldgit/IRremoteESP8266/blob/master/library.json lists espressif32 as a valid platform and if the library is there I guess platformio tries to build it unless we tell platformio not to. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9945

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
