### PR TITLE
[mipi_dsi] Add dependencies

### DIFF
--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -57,7 +57,8 @@ from esphome.final_validate import full_config
 
 from . import mipi_dsi_ns, models
 
-DEPENDENCIES = ["esp32"]
+# Currently only ESP32-P4 is supported, so esp_ldo and psram are required
+DEPENDENCIES = ["esp32", "esp_ldo", "psram"]
 DOMAIN = "mipi_dsi"
 
 LOGGER = logging.getLogger(DOMAIN)

--- a/tests/components/mipi_dsi/test.esp32-p4-idf.yaml
+++ b/tests/components/mipi_dsi/test.esp32-p4-idf.yaml
@@ -12,6 +12,8 @@ display:
   #- platform: mipi_dsi
     #id: backlight_id
 
+psram:
+
 i2c:
   sda: GPIO7
   scl: GPIO8


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently `mipi_dsi` is supported only on the ESP32-P4, and for that platform the `esp_ldo` and `psram` components must be configured, so add those as dependencies, to circumvent support queries on "why is the display not working".


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
