### PR TITLE
[esp32_touch] Work around ESP-IDF v5.4 regression in `touch_pad_read_filtered`

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch_v1.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v1.cpp
@@ -201,15 +201,13 @@ void IRAM_ATTR ESP32TouchComponent::touch_isr_handler(void *arg) {
     touch_pad_t pad = child->get_touch_pad();
 
     // Read current value using ISR-safe API
-    uint32_t value;
-    if (component->iir_filter_enabled_()) {
-      uint16_t temp_value = 0;
-      touch_pad_read_filtered(pad, &temp_value);
-      value = temp_value;
-    } else {
-      // Use low-level HAL function when filter is not enabled
-      value = touch_ll_read_raw_data(pad);
-    }
+    // IMPORTANT: ESP-IDF v5.4 regression - touch_pad_read_filtered() is no longer ISR-safe
+    // In v5.3 and earlier it was ISR-safe, but v5.4 added mutex protection that causes:
+    // "assert failed: xQueueSemaphoreTake queue.c:1718"
+    // We must use raw values even when filter is enabled as a workaround.
+    // Users should adjust thresholds to compensate for the lack of IIR filtering.
+    // See: https://github.com/espressif/esp-idf/issues/17045
+    uint32_t value = touch_ll_read_raw_data(pad);
 
     // Skip pads that aren’t in the trigger mask
     if (((mask >> pad) & 1) == 0) {

--- a/esphome/components/esp32_touch/esp32_touch_v1.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v1.cpp
@@ -202,7 +202,7 @@ void IRAM_ATTR ESP32TouchComponent::touch_isr_handler(void *arg) {
 
     // Read current value using ISR-safe API
     // IMPORTANT: ESP-IDF v5.4 regression - touch_pad_read_filtered() is no longer ISR-safe
-    // In v5.3 and earlier it was ISR-safe, but v5.4 added mutex protection that causes:
+    // In ESP-IDF v5.3 and earlier it was ISR-safe, but ESP-IDF v5.4 added mutex protection that causes:
     // "assert failed: xQueueSemaphoreTake queue.c:1718"
     // We must use raw values even when filter is enabled as a workaround.
     // Users should adjust thresholds to compensate for the lack of IIR filtering.


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a crash during OTA updates on ESP32 when using touch sensors with IIR filtering enabled. The crash occurs because `touch_pad_read_filtered()` is called from an ISR context, but [ESP-IDF v5.4 added mutex protection](https://github.com/espressif/esp-idf/commit/f1903f095a005c6d9aaa8e37ebc41e693fb28893) to this function, making it no longer ISR-safe [despite documentation claims](https://docs.espressif.com/projects/esp-idf/en/release-v5.4/esp32/api-reference/peripherals/touch_pad.html#_CPPv423touch_pad_read_filtered11touch_pad_tP8uint16_t). "This function can be called from ISR"

The fix uses raw touch sensor values in the ISR to avoid the mutex issue. This is a workaround for an ESP-IDF v5.4 regression where `touch_pad_read_filtered()` became non-ISR-safe.

**⚠️ BREAKING CHANGE**: Users with ESP32 touch sensors using IIR filtering will need to adjust their threshold values, as the ISR now uses raw (unfiltered) values for touch detection. The filtered values are still computed but cannot be safely accessed from the interrupt handler.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes ESP-IDF regression: https://github.com/espressif/esp-idf/issues/17045

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a workaround for an upstream bug

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# BREAKING CHANGE: Touch thresholds need adjustment when using IIR filtering
# Raw values are typically more noisy and variable than filtered values

esp32_touch:
  setup_mode: false
  iir_filter: 10ms  # Note: Due to ESP-IDF bug, filtering happens but ISR uses raw values

binary_sensor:
  - platform: esp32_touch
    name: "Touch Pad GPIO27"
    pin: GPIO27
    threshold: 1000  # May need adjustment due to raw values being used
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This is a workaround for an ESP-IDF v5.4 regression. In ESP-IDF v5.3 and earlier, `touch_pad_read_filtered()` was truly ISR-safe (no mutex). However, v5.4 added `xSemaphoreTake()`/`xSemaphoreGive()` calls which cannot be used in ISR context, causing this assertion failure:

```
assert failed: xQueueSemaphoreTake queue.c:1718 (!( ( xTaskGetSchedulerState() == ( ( BaseType_t ) 0 ) ) && ( xTicksToWait != 0 ) ))
```

The workaround uses `touch_ll_read_raw_data()` which is ISR-safe but returns unfiltered values. Users may need to adjust touch thresholds to compensate for the lack of IIR filtering in the ISR.