### PR TITLE
Fix WiFi to prefer strongest AP when multiple APs have same SSID

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -533,9 +533,17 @@ void WiFiComponent::check_scanning_finished() {
                        return false;
 
                      if (a.get_matches() && b.get_matches()) {
-                       // if both match, check priority
+                       // For APs with the same SSID, always prefer stronger signal
+                       // This helps with mesh networks and multiple APs
+                       if (a.get_ssid() == b.get_ssid()) {
+                         return a.get_rssi() > b.get_rssi();
+                       }
+                       
+                       // For different SSIDs, check priority first
                        if (a.get_priority() != b.get_priority())
                          return a.get_priority() > b.get_priority();
+                       // If priorities are equal, prefer stronger signal
+                       return a.get_rssi() > b.get_rssi();
                      }
 
                      return a.get_rssi() > b.get_rssi();

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -538,7 +538,7 @@ void WiFiComponent::check_scanning_finished() {
                        if (a.get_ssid() == b.get_ssid()) {
                          return a.get_rssi() > b.get_rssi();
                        }
-                       
+
                        // For different SSIDs, check priority first
                        if (a.get_priority() != b.get_priority())
                          return a.get_priority() > b.get_priority();


### PR DESCRIPTION
# What does this implement/fix?

When multiple access points share the same SSID (common in mesh networks and with repeaters), ESPHome now connects to the AP with the strongest signal. Previously, the priority system could cause connections to weaker APs even when stronger ones were available.

The fix ensures that for APs with the same SSID, signal strength (RSSI) is the primary sorting criterion, overriding the priority system. The priority system still functions normally for different SSIDs.

This improves connectivity in environments with multiple APs without requiring any configuration changes.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- just had a look at issues. i think this fixes #9732 

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
