### PR TITLE
ULN2003 - Enable pump mode option

### DIFF
--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -6,15 +6,13 @@ namespace uln2003 {
 
 static const char *const TAG = "uln2003";
 
-void ULN2003Component::set_mode(ULN2003Mode mode) {
-  this->mode_ = mode;
-}
+void ULN2003Component::set_mode(ULN2003Mode mode) { this->mode_ = mode; }
 
 void ULN2003::setup() {
   if (this->mode_ == ULN2003Mode::PUMP) {
-  // Setup for pump mode
-  // Example: Setup only control pin (if you have one), otherwise do minimal setup
-  return;
+    // Setup for pump mode
+    // Example: Setup only control pin (if you have one), otherwise do minimal setup
+    return;
   }
   this->pin_a_->setup();
   this->pin_b_->setup();
@@ -24,8 +22,8 @@ void ULN2003::setup() {
 }
 void ULN2003::loop() {
   if (this->mode_ == ULN2003Mode::PUMP) {
-  // Pump mode logic or just return early if irrelevant here
-  return;
+    // Pump mode logic or just return early if irrelevant here
+    return;
   }
   int dir = this->should_step_();
   if (dir == 0 && this->has_reached_target()) {
@@ -48,8 +46,7 @@ void ULN2003::loop() {
 }
 void ULN2003::dump_config() {
   ESP_LOGCONFIG(TAG, "ULN2003:");
-  ESP_LOGCONFIG(TAG, "ULN2003 mode: %s",
-    this->mode_ == ULN2003Mode::PUMP ? "Pump" : "Stepper");
+  ESP_LOGCONFIG(TAG, "ULN2003 mode: %s", this->mode_ == ULN2003Mode::PUMP ? "Pump" : "Stepper");
   LOG_PIN("  Pin A: ", this->pin_a_);
   LOG_PIN("  Pin B: ", this->pin_b_);
   LOG_PIN("  Pin C: ", this->pin_c_);
@@ -74,8 +71,8 @@ void ULN2003::dump_config() {
 }
 void ULN2003::write_step_(int32_t step) {
   if (this->mode_ == ULN2003Mode::PUMP) {
-  // Pump mode logic or just return early if irrelevant here
-  return;
+    // Pump mode logic or just return early if irrelevant here
+    return;
   }
   int32_t n = this->step_mode_ == ULN2003_STEP_MODE_HALF_STEP ? 8 : 4;
   auto i = static_cast<uint32_t>((step % n + n) % n);

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -6,7 +6,16 @@ namespace uln2003 {
 
 static const char *const TAG = "uln2003.stepper";
 
+void ULN2003Component::set_mode(ULN2003Mode mode) {
+  this->mode_ = mode;
+}
+
 void ULN2003::setup() {
+  if (this->mode_ == ULN2003Mode::PUMP) {
+  // Setup for pump mode
+  // Example: Setup only control pin (if you have one), otherwise do minimal setup
+  return;
+}
   this->pin_a_->setup();
   this->pin_b_->setup();
   this->pin_c_->setup();
@@ -14,6 +23,10 @@ void ULN2003::setup() {
   this->loop();
 }
 void ULN2003::loop() {
+  if (this->mode_ == ULN2003Mode::PUMP) {
+  // Pump mode logic or just return early if irrelevant here
+  return;
+}
   int dir = this->should_step_();
   if (dir == 0 && this->has_reached_target()) {
     this->high_freq_.stop();
@@ -58,6 +71,10 @@ void ULN2003::dump_config() {
   ESP_LOGCONFIG(TAG, "  Step Mode: %s", step_mode_s);
 }
 void ULN2003::write_step_(int32_t step) {
+  if (this->mode_ == ULN2003Mode::PUMP) {
+  // Pump mode logic or just return early if irrelevant here
+  return;
+}
   int32_t n = this->step_mode_ == ULN2003_STEP_MODE_HALF_STEP ? 8 : 4;
   auto i = static_cast<uint32_t>((step % n + n) % n);
   uint8_t res = 0;

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace uln2003 {
 
-static const char *const TAG = "uln2003.stepper";
+static const char *const TAG = "uln2003";
 
 void ULN2003Component::set_mode(ULN2003Mode mode) {
   this->mode_ = mode;
@@ -15,7 +15,7 @@ void ULN2003::setup() {
   // Setup for pump mode
   // Example: Setup only control pin (if you have one), otherwise do minimal setup
   return;
-}
+  }
   this->pin_a_->setup();
   this->pin_b_->setup();
   this->pin_c_->setup();
@@ -26,7 +26,7 @@ void ULN2003::loop() {
   if (this->mode_ == ULN2003Mode::PUMP) {
   // Pump mode logic or just return early if irrelevant here
   return;
-}
+  }
   int dir = this->should_step_();
   if (dir == 0 && this->has_reached_target()) {
     this->high_freq_.stop();
@@ -48,6 +48,8 @@ void ULN2003::loop() {
 }
 void ULN2003::dump_config() {
   ESP_LOGCONFIG(TAG, "ULN2003:");
+  ESP_LOGCONFIG(TAG, "ULN2003 mode: %s",
+    this->mode_ == ULN2003Mode::PUMP ? "Pump" : "Stepper");
   LOG_PIN("  Pin A: ", this->pin_a_);
   LOG_PIN("  Pin B: ", this->pin_b_);
   LOG_PIN("  Pin C: ", this->pin_c_);
@@ -74,7 +76,7 @@ void ULN2003::write_step_(int32_t step) {
   if (this->mode_ == ULN2003Mode::PUMP) {
   // Pump mode logic or just return early if irrelevant here
   return;
-}
+  }
   int32_t n = this->step_mode_ == ULN2003_STEP_MODE_HALF_STEP ? 8 : 4;
   auto i = static_cast<uint32_t>((step % n + n) % n);
   uint8_t res = 0;

--- a/esphome/components/uln2003/uln2003.h
+++ b/esphome/components/uln2003/uln2003.h
@@ -14,6 +14,13 @@ enum class ULN2003Mode {
   PUMP
 };
 
+class ULN2003Component : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+
+  void set_mode(ULN2003Mode mode);
+
 enum ULN2003StepMode {
   ULN2003_STEP_MODE_FULL_STEP,
   ULN2003_STEP_MODE_HALF_STEP,

--- a/esphome/components/uln2003/uln2003.h
+++ b/esphome/components/uln2003/uln2003.h
@@ -33,6 +33,7 @@ class ULN2003 : public stepper::Stepper, public Component {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void set_sleep_when_done(bool sleep_when_done) { this->sleep_when_done_ = sleep_when_done; }
   void set_step_mode(ULN2003StepMode step_mode) { this->step_mode_ = step_mode; }
+  void set_mode(ULN2003Mode mode);
 
  protected:
   void write_step_(int32_t step);
@@ -45,6 +46,7 @@ class ULN2003 : public stepper::Stepper, public Component {
   ULN2003StepMode step_mode_{ULN2003_STEP_MODE_FULL_STEP};
   HighFrequencyLoopRequester high_freq_;
   int32_t current_uln_pos_{0};
+  ULN2003Mode mode_{ULN2003Mode::STEPPER};
 };
 
 }  // namespace uln2003

--- a/esphome/components/uln2003/uln2003.h
+++ b/esphome/components/uln2003/uln2003.h
@@ -3,9 +3,16 @@
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/stepper/stepper.h"
+#include "uln2003_pump.h"
+
 
 namespace esphome {
 namespace uln2003 {
+
+enum class ULN2003Mode {
+  STEPPER,
+  PUMP
+};
 
 enum ULN2003StepMode {
   ULN2003_STEP_MODE_FULL_STEP,

--- a/esphome/components/uln2003/uln2003.h
+++ b/esphome/components/uln2003/uln2003.h
@@ -5,14 +5,10 @@
 #include "esphome/components/stepper/stepper.h"
 #include "uln2003_pump.h"
 
-
 namespace esphome {
 namespace uln2003 {
 
-enum class ULN2003Mode {
-  STEPPER,
-  PUMP
-};
+enum class ULN2003Mode { STEPPER, PUMP };
 
 class ULN2003Component : public Component {
  public:
@@ -21,40 +17,40 @@ class ULN2003Component : public Component {
 
   void set_mode(ULN2003Mode mode);
 
-enum ULN2003StepMode {
-  ULN2003_STEP_MODE_FULL_STEP,
-  ULN2003_STEP_MODE_HALF_STEP,
-  ULN2003_STEP_MODE_WAVE_DRIVE,
-};
+  enum ULN2003StepMode {
+    ULN2003_STEP_MODE_FULL_STEP,
+    ULN2003_STEP_MODE_HALF_STEP,
+    ULN2003_STEP_MODE_WAVE_DRIVE,
+  };
 
-class ULN2003 : public stepper::Stepper, public Component {
- public:
-  void set_pin_a(GPIOPin *pin_a) { pin_a_ = pin_a; }
-  void set_pin_b(GPIOPin *pin_b) { pin_b_ = pin_b; }
-  void set_pin_c(GPIOPin *pin_c) { pin_c_ = pin_c; }
-  void set_pin_d(GPIOPin *pin_d) { pin_d_ = pin_d; }
+  class ULN2003 : public stepper::Stepper, public Component {
+   public:
+    void set_pin_a(GPIOPin *pin_a) { pin_a_ = pin_a; }
+    void set_pin_b(GPIOPin *pin_b) { pin_b_ = pin_b; }
+    void set_pin_c(GPIOPin *pin_c) { pin_c_ = pin_c; }
+    void set_pin_d(GPIOPin *pin_d) { pin_d_ = pin_d; }
 
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::HARDWARE; }
-  void set_sleep_when_done(bool sleep_when_done) { this->sleep_when_done_ = sleep_when_done; }
-  void set_step_mode(ULN2003StepMode step_mode) { this->step_mode_ = step_mode; }
-  void set_mode(ULN2003Mode mode);
+    void setup() override;
+    void loop() override;
+    void dump_config() override;
+    float get_setup_priority() const override { return setup_priority::HARDWARE; }
+    void set_sleep_when_done(bool sleep_when_done) { this->sleep_when_done_ = sleep_when_done; }
+    void set_step_mode(ULN2003StepMode step_mode) { this->step_mode_ = step_mode; }
+    void set_mode(ULN2003Mode mode);
 
- protected:
-  void write_step_(int32_t step);
+   protected:
+    void write_step_(int32_t step);
 
-  bool sleep_when_done_{false};
-  GPIOPin *pin_a_;
-  GPIOPin *pin_b_;
-  GPIOPin *pin_c_;
-  GPIOPin *pin_d_;
-  ULN2003StepMode step_mode_{ULN2003_STEP_MODE_FULL_STEP};
-  HighFrequencyLoopRequester high_freq_;
-  int32_t current_uln_pos_{0};
-  ULN2003Mode mode_{ULN2003Mode::STEPPER};
-};
+    bool sleep_when_done_{false};
+    GPIOPin *pin_a_;
+    GPIOPin *pin_b_;
+    GPIOPin *pin_c_;
+    GPIOPin *pin_d_;
+    ULN2003StepMode step_mode_{ULN2003_STEP_MODE_FULL_STEP};
+    HighFrequencyLoopRequester high_freq_;
+    int32_t current_uln_pos_{0};
+    ULN2003Mode mode_{ULN2003Mode::STEPPER};
+  };
 
 }  // namespace uln2003
 }  // namespace esphome

--- a/esphome/components/uln2003/uln2003_pump.h
+++ b/esphome/components/uln2003/uln2003_pump.h
@@ -1,0 +1,15 @@
+class ULN2003Pump : public Component, public switch_::Switch {
+ public:
+  void setup() override {
+    pinMode(this->control_pin_, OUTPUT);
+    digitalWrite(this->control_pin_, LOW);
+  }
+
+  void write_state(bool state) override {
+    digitalWrite(this->control_pin_, state ? HIGH : LOW);
+    publish_state(state);
+  }
+
+ protected:
+  GPIOPin *control_pin_;
+};

--- a/esphome/components/uln2003/uln2003_pump.h
+++ b/esphome/components/uln2003/uln2003_pump.h
@@ -1,15 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/gpio.h"
+
+namespace esphome {
+namespace uln2003 {
+
 class ULN2003Pump : public Component, public switch_::Switch {
  public:
-  void setup() override {
-    pinMode(this->control_pin_, OUTPUT);
-    digitalWrite(this->control_pin_, LOW);
-  }
+  void set_control_pin(GPIOPin *pin) { this->control_pin_ = pin; }
 
-  void write_state(bool state) override {
-    digitalWrite(this->control_pin_, state ? HIGH : LOW);
-    publish_state(state);
-  }
+  void setup() override;
+  void dump_config() override;
+  void write_state(bool state) override;
 
  protected:
   GPIOPin *control_pin_;
 };
+
+}  // namespace uln2003
+}  // namespace esphome

--- a/esphome/components/uln2003/uln2003_pump.h
+++ b/esphome/components/uln2003/uln2003_pump.h
@@ -1,18 +1,16 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/switch/switch.h"
 #include "esphome/core/gpio.h"
 
 namespace esphome {
 namespace uln2003 {
 
-class ULN2003Pump : public Component, public switch_::Switch {
+class ULN2003Pump : public Component, {
  public:
   void set_control_pin(GPIOPin *pin) { this->control_pin_ = pin; }
 
   void setup() override;
-  void dump_config() override;
   void write_state(bool state) override;
 
  protected:

--- a/esphome/components/uln2003/uln2003_pump.h
+++ b/esphome/components/uln2003/uln2003_pump.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/core/gpio.h"
 
 namespace esphome {
 namespace uln2003 {
 
-class ULN2003Pump : public Component, {
+class ULN2003Pump : public switch_::Switch, public Component, {
  public:
   void set_control_pin(GPIOPin *pin) { this->control_pin_ = pin; }
 

--- a/esphome/components/uln2003/uln_2003_pump.cpp
+++ b/esphome/components/uln2003/uln_2003_pump.cpp
@@ -1,4 +1,6 @@
 #include "uln2003_pump.h"
+#include "esphome.h"
+#include "uln2003.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -6,20 +8,33 @@ namespace uln2003 {
 
 static const char *const TAG = "uln2003.pump";
 
-void ULN2003Pump::setup() {
-  this->control_pin_->setup();
-  this->control_pin_->digital_write(false);  // Start OFF
+ULN2003Mode parse_mode(std::string mode_str) {
+  if (mode_str == "pump") {
+    return ULN2003Mode::PUMP;
+  }
+  return ULN2003Mode::STEPPER;
 }
 
-void ULN2003Pump::write_state(bool state) {
-  this->control_pin_->digital_write(state);
-  ESP_LOGD(TAG, "Pump turned %s", state ? "ON" : "OFF");
-  this->publish_state(state);
-}
+switch_::Switch *setup_uln2003_switch(const std::map<std::string, esphome::BaseType> &config) {
+  auto mode = ULN2003Mode::STEPPER;
+  if (config.count("mode")) {
+    mode = parse_mode(config.at("mode").as<std::string>());
+  }
 
-void ULN2003Pump::dump_config() {
-  ESP_LOGCONFIG(TAG, "ULN2003 Pump Mode:");
-  LOG_PIN("  Control Pin: ", this->control_pin_);
+  if (mode == ULN2003Mode::PUMP) {
+    auto *pump = new ULN2003Pump();
+    pump->set_control_pin(config.at("control_pin").as<GPIOPin>());
+    App.register_component(pump);
+    ESP_LOGCONFIG(TAG, "Setting up ULN2003 Pump");
+    return pump;
+  }
+
+  // Default stepper creation, needs pins setup as before
+  auto *stepper = new ULN2003Component();
+  // Set pins from config as before (e.g., 4 stepper pins)
+  App.register_component(stepper);
+  ESP_LOGCONFIG(TAG, "Setting up ULN2003 Stepper");
+  return stepper;
 }
 
 }  // namespace uln2003

--- a/esphome/components/uln2003/uln_2003_pump.cpp
+++ b/esphome/components/uln2003/uln_2003_pump.cpp
@@ -1,3 +1,4 @@
+#include "uln2003.h"
 #include "uln2003_pump.h"
 #include "esphome/core/log.h"
 
@@ -7,32 +8,30 @@ namespace uln2003 {
 static const char *const TAG = "uln2003.pump";
 
 ULN2003Mode parse_mode(std::string mode_str) {
-  if (mode_str == "pump") {
-    return ULN2003Mode::PUMP;
-  }
+  if (mode_str == "pump") return ULN2003Mode::PUMP;
   return ULN2003Mode::STEPPER;
 }
 
-switch_::Switch *setup_uln2003_switch(const std::map<std::string, esphome::BaseType> &config) {
-  auto mode = ULN2003Mode::STEPPER;
+ULN2003Pump *create_uln2003_pump(const std::map<std::string, esphome::BaseType> &config) {
+  auto *pump = new ULN2003Pump();
+  pump->set_control_pin(config.at("control_pin").as<GPIOPin *>());
+  App.register_component(pump);
+  return pump;
+}
+
+Component *create_uln2003_component(const std::map<std::string, esphome::BaseType> &config) {
+  ULN2003Mode mode = ULN2003Mode::STEPPER;
   if (config.count("mode")) {
     mode = parse_mode(config.at("mode").as<std::string>());
   }
 
   if (mode == ULN2003Mode::PUMP) {
-    auto *pump = new ULN2003Pump();
-    pump->set_control_pin(config.at("control_pin").as<GPIOPin>());
-    App.register_component(pump);
-    ESP_LOGCONFIG(TAG, "Setting up ULN2003 Pump");
-    return pump;
+    ESP_LOGCONFIG("uln2003", "Setting up pump mode.");
+    return create_uln2003_pump(config);
   }
 
-  // Default stepper creation, needs pins setup as before
-  auto *stepper = new ULN2003Component();
-  // Set pins from config as before (e.g., 4 stepper pins)
-  App.register_component(stepper);
-  ESP_LOGCONFIG(TAG, "Setting up ULN2003 Stepper");
-  return stepper;
+  ESP_LOGCONFIG("uln2003", "Setting up stepper mode.");
+  return create_uln2003_stepper(config);
 }
 
 }  // namespace uln2003

--- a/esphome/components/uln2003/uln_2003_pump.cpp
+++ b/esphome/components/uln2003/uln_2003_pump.cpp
@@ -1,0 +1,26 @@
+#include "uln2003_pump.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace uln2003 {
+
+static const char *const TAG = "uln2003.pump";
+
+void ULN2003Pump::setup() {
+  this->control_pin_->setup();
+  this->control_pin_->digital_write(false);  // Start OFF
+}
+
+void ULN2003Pump::write_state(bool state) {
+  this->control_pin_->digital_write(state);
+  ESP_LOGD(TAG, "Pump turned %s", state ? "ON" : "OFF");
+  this->publish_state(state);
+}
+
+void ULN2003Pump::dump_config() {
+  ESP_LOGCONFIG(TAG, "ULN2003 Pump Mode:");
+  LOG_PIN("  Control Pin: ", this->control_pin_);
+}
+
+}  // namespace uln2003
+}  // namespace esphome

--- a/esphome/components/uln2003/uln_2003_pump.cpp
+++ b/esphome/components/uln2003/uln_2003_pump.cpp
@@ -8,7 +8,8 @@ namespace uln2003 {
 static const char *const TAG = "uln2003.pump";
 
 ULN2003Mode parse_mode(std::string mode_str) {
-  if (mode_str == "pump") return ULN2003Mode::PUMP;
+  if (mode_str == "pump")
+    return ULN2003Mode::PUMP;
   return ULN2003Mode::STEPPER;
 }
 

--- a/esphome/components/uln2003/uln_2003_pump.cpp
+++ b/esphome/components/uln2003/uln_2003_pump.cpp
@@ -1,6 +1,4 @@
 #include "uln2003_pump.h"
-#include "esphome.h"
-#include "uln2003.h"
 #include "esphome/core/log.h"
 
 namespace esphome {


### PR DESCRIPTION
# What does this implement/fix?

Adding ULN2003 mode option which allows usage of this controller as stepper controller or as switch (which can control peristaltic pump per input/output). 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** 
https://github.com/orgs/esphome/discussions/3251 

- fixes NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
