### PR TITLE
[esp32_ble] Add PHY configuration and default to 1M for compatibility

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -117,8 +117,21 @@ CONF_BLE_ID = "ble_id"
 CONF_IO_CAPABILITY = "io_capability"
 CONF_ADVERTISING_CYCLE_TIME = "advertising_cycle_time"
 CONF_DISABLE_BT_LOGS = "disable_bt_logs"
+CONF_PREFERRED_PHY = "preferred_phy"
 
 NO_BLUETOOTH_VARIANTS = [const.VARIANT_ESP32S2]
+
+# ESP32 variants that support BLE
+BLE_VARIANTS = {
+    const.VARIANT_ESP32,
+    const.VARIANT_ESP32C3,
+    const.VARIANT_ESP32S3,
+    const.VARIANT_ESP32C6,
+    const.VARIANT_ESP32H2,
+}
+
+# ESP32 variants that support 2M PHY
+BLE_2M_PHY_VARIANTS = BLE_VARIANTS - {const.VARIANT_ESP32}
 
 esp32_ble_ns = cg.esphome_ns.namespace("esp32_ble")
 ESP32BLE = esp32_ble_ns.class_("ESP32BLE", cg.Component)
@@ -140,6 +153,13 @@ IO_CAPABILITY = {
     "display_yes_no": IoCapability.IO_CAP_IO,
 }
 
+BLEPhy = esp32_ble_ns.enum("BLEPhy")
+BLE_PHY_OPTIONS = {
+    "1m": BLEPhy.BLE_PHY_1M,
+    "2m": BLEPhy.BLE_PHY_2M,
+    "auto": BLEPhy.BLE_PHY_AUTO,
+}
+
 esp_power_level_t = cg.global_ns.enum("esp_power_level_t")
 
 TX_POWER_LEVELS = {
@@ -152,6 +172,18 @@ TX_POWER_LEVELS = {
     6: esp_power_level_t.ESP_PWR_LVL_P6,
     9: esp_power_level_t.ESP_PWR_LVL_P9,
 }
+
+
+def validate_phy(value: str) -> str:
+    """Validate PHY selection based on ESP32 variant."""
+    variant = get_esp32_variant()
+    if value == "2m" and variant not in BLE_2M_PHY_VARIANTS:
+        raise cv.Invalid(
+            f"2M PHY is not supported on {variant}. "
+            f"Only supported on: {', '.join(sorted(BLE_2M_PHY_VARIANTS))}"
+        )
+    return value
+
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -166,6 +198,10 @@ CONFIG_SCHEMA = cv.Schema(
         ): cv.positive_time_period_milliseconds,
         cv.SplitDefault(CONF_DISABLE_BT_LOGS, esp32_idf=True): cv.All(
             cv.only_with_esp_idf, cv.boolean
+        ),
+        cv.Optional(CONF_PREFERRED_PHY, default="1m"): cv.All(
+            cv.enum(BLE_PHY_OPTIONS, lower=True),
+            validate_phy,
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -237,6 +273,7 @@ async def to_code(config):
     cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
     cg.add(var.set_io_capability(config[CONF_IO_CAPABILITY]))
     cg.add(var.set_advertising_cycle_time(config[CONF_ADVERTISING_CYCLE_TIME]))
+    cg.add(var.set_preferred_phy(config[CONF_PREFERRED_PHY]))
     if (name := config.get(CONF_NAME)) is not None:
         cg.add(var.set_name(name))
     await cg.register_component(var, config)

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -23,6 +23,35 @@ namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble";
 
+static const char *phy_mode_to_string(BLEPhy phy) {
+  switch (phy) {
+    case BLE_PHY_1M:
+      return "1M";
+    case BLE_PHY_2M:
+      return "2M";
+    case BLE_PHY_AUTO:
+      return "AUTO";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
+    defined(USE_ESP32_VARIANT_ESP32H2)
+static uint8_t phy_mode_to_mask(BLEPhy phy) {
+  switch (phy) {
+    case BLE_PHY_1M:
+      return ESP_BLE_GAP_PHY_1M_PREF_MASK;
+    case BLE_PHY_2M:
+      return ESP_BLE_GAP_PHY_2M_PREF_MASK;
+    case BLE_PHY_AUTO:
+      return ESP_BLE_GAP_PHY_1M_PREF_MASK | ESP_BLE_GAP_PHY_2M_PREF_MASK;
+    default:
+      return ESP_BLE_GAP_PHY_1M_PREF_MASK;  // Default to 1M
+  }
+}
+#endif
+
 void ESP32BLE::setup() {
   global_ble = this;
   if (!ble_pre_setup_()) {
@@ -207,6 +236,23 @@ bool ESP32BLE::ble_setup_() {
     ESP_LOGE(TAG, "esp_ble_gap_set_security_param failed: %d", err);
     return false;
   }
+
+  // Configure PHY settings
+#if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
+    defined(USE_ESP32_VARIANT_ESP32H2)
+  // Only newer ESP32 variants support PHY configuration
+  if (this->preferred_phy_ != BLE_PHY_AUTO) {
+    uint8_t phy_mask = phy_mode_to_mask(this->preferred_phy_);
+
+    err = esp_ble_gap_set_preferred_default_phy(phy_mask, phy_mask);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "esp_ble_gap_set_preferred_default_phy failed: %d", err);
+      // Not a fatal error, continue
+    } else {
+      ESP_LOGD(TAG, "Set preferred PHY to %s", phy_mode_to_string(this->preferred_phy_));
+    }
+  }
+#endif
 
   // BLE takes some time to be fully set up, 200ms should be more than enough
   delay(200);  // NOLINT
@@ -515,8 +561,10 @@ void ESP32BLE::dump_config() {
     ESP_LOGCONFIG(TAG,
                   "BLE:\n"
                   "  MAC address: %s\n"
-                  "  IO Capability: %s",
-                  format_mac_address_pretty(mac_address).c_str(), io_capability_s);
+                  "  IO Capability: %s\n"
+                  "  Preferred PHY: %s",
+                  format_mac_address_pretty(mac_address).c_str(), io_capability_s,
+                  phy_mode_to_string(this->preferred_phy_));
   } else {
     ESP_LOGCONFIG(TAG, "Bluetooth stack is not enabled");
   }

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -261,10 +261,9 @@ bool ESP32BLE::ble_setup_() {
 #endif
 #endif
 
-
   esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
-  if (local_mtu_ret){
-      ESP_LOGE(TAG, "set local  MTU failed, error code = %x", local_mtu_ret);
+  if (local_mtu_ret) {
+    ESP_LOGE(TAG, "set local  MTU failed, error code = %x", local_mtu_ret);
   }
 
   // BLE takes some time to be fully set up, 200ms should be more than enough
@@ -533,12 +532,10 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
 =======
       ESP_LOGV(TAG, "Ignoring ESP_GAP_BLE_SET_PKT_LENGTH_COMPLETE_EVT");
       return;
-    case ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT:       // BLE 5.0 PHY update complete
+    case ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT:  // BLE 5.0 PHY update complete
 #ifdef CONFIG_BT_BLE_50_FEATURES_SUPPORTED
-      ESP_LOGW(TAG, "PHY Update Complete - status: %d, tx_phy: %d, rx_phy: %d", 
-               param->phy_update.status,
-               param->phy_update.tx_phy, 
-               param->phy_update.rx_phy);
+      ESP_LOGW(TAG, "PHY Update Complete - status: %d, tx_phy: %d, rx_phy: %d", param->phy_update.status,
+               param->phy_update.tx_phy, param->phy_update.rx_phy);
       // Log PHY values for debugging
       // PHY values: 1=1M, 2=2M, 3=Coded
       if (param->phy_update.tx_phy == 2 || param->phy_update.rx_phy == 2) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -10,6 +10,7 @@
 #include <esp_bt_device.h>
 #include <esp_bt_main.h>
 #include <esp_gap_ble_api.h>
+#include <esp_gatt_common_api.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/FreeRTOSConfig.h>
 #include <freertos/task.h>
@@ -38,6 +39,7 @@ static const char *phy_mode_to_string(BLEPhy phy) {
 
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
     defined(USE_ESP32_VARIANT_ESP32H2)
+#ifdef CONFIG_BT_BLE_50_FEATURES_SUPPORTED
 static uint8_t phy_mode_to_mask(BLEPhy phy) {
   switch (phy) {
     case BLE_PHY_1M:
@@ -50,6 +52,7 @@ static uint8_t phy_mode_to_mask(BLEPhy phy) {
       return ESP_BLE_GAP_PHY_1M_PREF_MASK;  // Default to 1M
   }
 }
+#endif
 #endif
 
 void ESP32BLE::setup() {
@@ -240,19 +243,29 @@ bool ESP32BLE::ble_setup_() {
   // Configure PHY settings
 #if defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32C6) || \
     defined(USE_ESP32_VARIANT_ESP32H2)
-  // Only newer ESP32 variants support PHY configuration
-  if (this->preferred_phy_ != BLE_PHY_AUTO) {
-    uint8_t phy_mask = phy_mode_to_mask(this->preferred_phy_);
+#ifdef CONFIG_BT_BLE_50_FEATURES_SUPPORTED
+  // Only configure PHY if BLE 5.0 features are enabled
+  uint8_t phy_mask = phy_mode_to_mask(this->preferred_phy_);
 
-    err = esp_ble_gap_set_preferred_default_phy(phy_mask, phy_mask);
-    if (err != ESP_OK) {
-      ESP_LOGW(TAG, "esp_ble_gap_set_preferred_default_phy failed: %d", err);
-      // Not a fatal error, continue
-    } else {
-      ESP_LOGD(TAG, "Set preferred PHY to %s", phy_mode_to_string(this->preferred_phy_));
-    }
+  // Always set PHY preferences to ensure proper configuration
+  // This is important to override any default behavior that might enable 2M or Coded PHY
+  err = esp_ble_gap_set_preferred_default_phy(phy_mask, phy_mask);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "esp_ble_gap_set_preferred_default_phy failed: %d", err);
+    // Not a fatal error, continue
+  } else {
+    ESP_LOGD(TAG, "Set preferred PHY to %s", phy_mode_to_string(this->preferred_phy_));
   }
+#else
+  ESP_LOGD(TAG, "BLE 5.0 features disabled, PHY configuration not available");
 #endif
+#endif
+
+
+  esp_err_t local_mtu_ret = esp_ble_gatt_set_local_mtu(500);
+  if (local_mtu_ret){
+      ESP_LOGE(TAG, "set local  MTU failed, error code = %x", local_mtu_ret);
+  }
 
   // BLE takes some time to be fully set up, 200ms should be more than enough
   delay(200);  // NOLINT
@@ -511,9 +524,36 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
       enqueue_ble_event(event, param);
       return;
 
-    // Ignore these GAP events as they are not relevant for our use case
+    // Log these GAP events for debugging
     case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT:
+      ESP_LOGV(TAG, "Ignoring ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT");
+      return;
     case ESP_GAP_BLE_SET_PKT_LENGTH_COMPLETE_EVT:
+<<<<<<< Updated upstream
+=======
+      ESP_LOGV(TAG, "Ignoring ESP_GAP_BLE_SET_PKT_LENGTH_COMPLETE_EVT");
+      return;
+    case ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT:       // BLE 5.0 PHY update complete
+#ifdef CONFIG_BT_BLE_50_FEATURES_SUPPORTED
+      ESP_LOGW(TAG, "PHY Update Complete - status: %d, tx_phy: %d, rx_phy: %d", 
+               param->phy_update.status,
+               param->phy_update.tx_phy, 
+               param->phy_update.rx_phy);
+      // Log PHY values for debugging
+      // PHY values: 1=1M, 2=2M, 3=Coded
+      if (param->phy_update.tx_phy == 2 || param->phy_update.rx_phy == 2) {
+        ESP_LOGW(TAG, "Device negotiated 2M PHY despite 1M preference!");
+      }
+      if (param->phy_update.tx_phy == 3 || param->phy_update.rx_phy == 3) {
+        ESP_LOGW(TAG, "Device negotiated Coded PHY!");
+      }
+#else
+      ESP_LOGV(TAG, "Ignoring ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT (BLE 5.0 disabled)");
+#endif
+      return;
+    case ESP_GAP_BLE_CHANNEL_SELECT_ALGORITHM_EVT:  // BLE 5.0 channel selection algorithm
+      ESP_LOGV(TAG, "Ignoring ESP_GAP_BLE_CHANNEL_SELECT_ALGORITHM_EVT");
+>>>>>>> Stashed changes
       return;
 
     default:

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -55,6 +55,12 @@ enum IoCapability {
   IO_CAP_KBDISP = ESP_IO_CAP_KBDISP,
 };
 
+enum BLEPhy : uint8_t {
+  BLE_PHY_1M = 0x01,
+  BLE_PHY_2M = 0x02,
+  BLE_PHY_AUTO = 0x03,
+};
+
 enum BLEComponentState : uint8_t {
   /** Nothing has been initialized yet. */
   BLE_COMPONENT_STATE_OFF = 0,
@@ -98,6 +104,7 @@ class BLEStatusEventHandler {
 class ESP32BLE : public Component {
  public:
   void set_io_capability(IoCapability io_capability) { this->io_cap_ = (esp_ble_io_cap_t) io_capability; }
+  void set_preferred_phy(BLEPhy phy) { this->preferred_phy_ = phy; }
 
   void set_advertising_cycle_time(uint32_t advertising_cycle_time) {
     this->advertising_cycle_time_ = advertising_cycle_time;
@@ -170,6 +177,7 @@ class ESP32BLE : public Component {
   // 1-byte aligned members (grouped together to minimize padding)
   BLEComponentState state_{BLE_COMPONENT_STATE_OFF};  // 1 byte (uint8_t enum)
   bool enable_on_boot_{};                             // 1 byte
+  BLEPhy preferred_phy_{BLE_PHY_1M};                  // 1 byte (uint8_t enum)
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -272,11 +272,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->conn_id_ = UNSET_CONN_ID;
         break;
       }
-      auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->open.conn_id);
-      if (ret) {
-        ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_send_mtu_req failed, status=%x", this->connection_index_,
-                 this->address_str_.c_str(), ret);
-      }
+
       this->set_state(espbt::ClientState::CONNECTED);
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
         ESP_LOGI(TAG, "[%d] [%s] Connected", this->connection_index_, this->address_str_.c_str());
@@ -284,13 +280,52 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->state_ = espbt::ClientState::ESTABLISHED;
         break;
       }
-      esp_ble_gattc_search_service(esp_gattc_if, param->cfg_mtu.conn_id, nullptr);
+      // For V3_WITHOUT_CACHE, we need to discover services to keep connection active
+      ESP_LOGD(TAG, "[%d] [%s] Searching for services", this->connection_index_,
+               this->address_str_.c_str());
+      auto search_ret = esp_ble_gattc_search_service(this->gattc_if_, this->conn_id_, nullptr);
+      if (search_ret != ESP_OK) {
+        ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_search_service failed: %d", this->connection_index_,
+                 this->address_str_.c_str(), search_ret);
+      }
       break;
     }
+    case ESP_GATTC_DIS_SRVC_CMPL_EVT:
+        ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_DIS_SRVC_CMPL_EVT", this->connection_index_, this->address_str_.c_str());
+        if (param->dis_srvc_cmpl.status != ESP_GATT_OK){
+            ESP_LOGE(TAG, "Service discover failed, status %d", param->dis_srvc_cmpl.status);
+            break;
+        }
+        ESP_LOGI(TAG, "Service discover complete, conn_id %d", param->dis_srvc_cmpl.conn_id);
+        // Don't search again - this seems redundant
+        // esp_ble_gattc_search_service(this->gattc_if_, param->dis_srvc_cmpl.conn_id, nullptr);
+        break;    
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
+      this->conn_id_ = param->connect.conn_id;
+      this->service_count_ = 0;
+      ESP_LOGI(TAG, "[%d] [%s] Connection established, conn_id %d",
+               this->connection_index_, this->address_str_.c_str(), this->conn_id_);
+      
+      // Update connection parameters for faster service discovery
+      esp_ble_conn_update_params_t conn_params = {0};
+      memcpy(conn_params.bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
+      conn_params.min_int = 0x06;  // 7.5ms - fastest interval
+      conn_params.max_int = 0x06;  // 7.5ms - fastest interval
+      conn_params.latency = 0;
+      conn_params.timeout = 1000;  // 10s timeout
+      ESP_LOGD(TAG, "[%d] [%s] Updating connection parameters for fast discovery", 
+               this->connection_index_, this->address_str_.c_str());
+      esp_ble_gap_update_conn_params(&conn_params);
+      
+      auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->connect.conn_id);
+      if (ret) {
+        ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_send_mtu_req failed, status=%x", this->connection_index_,
+                 this->address_str_.c_str(), ret);
+      }
+      ESP_LOGD(TAG, "[%d] [%s] Requesting MTU", this->connection_index_, this->address_str_.c_str());      
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {
@@ -304,6 +339,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     }
 
     case ESP_GATTC_CFG_MTU_EVT: {
+      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_CFG_MTU_EVT", this->connection_index_, this->address_str_.c_str());
       if (this->conn_id_ != param->cfg_mtu.conn_id)
         return false;
       if (param->cfg_mtu.status != ESP_GATT_OK) {
@@ -327,6 +363,8 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {
+      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_SEARCH_RES_EVT", this->connection_index_,
+               this->address_str_.c_str());
       if (this->conn_id_ != param->search_res.conn_id)
         return false;
       this->service_count_++;
@@ -432,7 +470,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
 
     default:
       // ideally would check all other events for matching conn_id
-      ESP_LOGD(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_.c_str(), event);
+      ESP_LOGV(TAG, "[%d] [%s] Unhandled event %d", this->connection_index_, this->address_str_.c_str(), event);
       break;
   }
   return true;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -281,8 +281,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         break;
       }
       // For V3_WITHOUT_CACHE, we need to discover services to keep connection active
-      ESP_LOGD(TAG, "[%d] [%s] Searching for services", this->connection_index_,
-               this->address_str_.c_str());
+      ESP_LOGD(TAG, "[%d] [%s] Searching for services", this->connection_index_, this->address_str_.c_str());
       auto search_ret = esp_ble_gattc_search_service(this->gattc_if_, this->conn_id_, nullptr);
       if (search_ret != ESP_OK) {
         ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_search_service failed: %d", this->connection_index_,
@@ -291,24 +290,24 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
     case ESP_GATTC_DIS_SRVC_CMPL_EVT:
-        ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_DIS_SRVC_CMPL_EVT", this->connection_index_, this->address_str_.c_str());
-        if (param->dis_srvc_cmpl.status != ESP_GATT_OK){
-            ESP_LOGE(TAG, "Service discover failed, status %d", param->dis_srvc_cmpl.status);
-            break;
-        }
-        ESP_LOGI(TAG, "Service discover complete, conn_id %d", param->dis_srvc_cmpl.conn_id);
-        // Don't search again - this seems redundant
-        // esp_ble_gattc_search_service(this->gattc_if_, param->dis_srvc_cmpl.conn_id, nullptr);
-        break;    
+      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_DIS_SRVC_CMPL_EVT", this->connection_index_, this->address_str_.c_str());
+      if (param->dis_srvc_cmpl.status != ESP_GATT_OK) {
+        ESP_LOGE(TAG, "Service discover failed, status %d", param->dis_srvc_cmpl.status);
+        break;
+      }
+      ESP_LOGI(TAG, "Service discover complete, conn_id %d", param->dis_srvc_cmpl.conn_id);
+      // Don't search again - this seems redundant
+      // esp_ble_gattc_search_service(this->gattc_if_, param->dis_srvc_cmpl.conn_id, nullptr);
+      break;
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
       this->log_event_("ESP_GATTC_CONNECT_EVT");
       this->conn_id_ = param->connect.conn_id;
       this->service_count_ = 0;
-      ESP_LOGI(TAG, "[%d] [%s] Connection established, conn_id %d",
-               this->connection_index_, this->address_str_.c_str(), this->conn_id_);
-      
+      ESP_LOGI(TAG, "[%d] [%s] Connection established, conn_id %d", this->connection_index_, this->address_str_.c_str(),
+               this->conn_id_);
+
       // Update connection parameters for faster service discovery
       esp_ble_conn_update_params_t conn_params = {0};
       memcpy(conn_params.bda, param->connect.remote_bda, sizeof(esp_bd_addr_t));
@@ -316,16 +315,16 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       conn_params.max_int = 0x06;  // 7.5ms - fastest interval
       conn_params.latency = 0;
       conn_params.timeout = 1000;  // 10s timeout
-      ESP_LOGD(TAG, "[%d] [%s] Updating connection parameters for fast discovery", 
-               this->connection_index_, this->address_str_.c_str());
+      ESP_LOGD(TAG, "[%d] [%s] Updating connection parameters for fast discovery", this->connection_index_,
+               this->address_str_.c_str());
       esp_ble_gap_update_conn_params(&conn_params);
-      
+
       auto ret = esp_ble_gattc_send_mtu_req(this->gattc_if_, param->connect.conn_id);
       if (ret) {
         ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_send_mtu_req failed, status=%x", this->connection_index_,
                  this->address_str_.c_str(), ret);
       }
-      ESP_LOGD(TAG, "[%d] [%s] Requesting MTU", this->connection_index_, this->address_str_.c_str());      
+      ESP_LOGD(TAG, "[%d] [%s] Requesting MTU", this->connection_index_, this->address_str_.c_str());
       break;
     }
     case ESP_GATTC_DISCONNECT_EVT: {
@@ -363,8 +362,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
     case ESP_GATTC_SEARCH_RES_EVT: {
-      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_SEARCH_RES_EVT", this->connection_index_,
-               this->address_str_.c_str());
+      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_SEARCH_RES_EVT", this->connection_index_, this->address_str_.c_str());
       if (this->conn_id_ != param->search_res.conn_id)
         return false;
       this->service_count_++;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -223,7 +223,7 @@ void ESP32BLETracker::loop() {
     if (this->coex_prefer_ble_) {
       this->coex_prefer_ble_ = false;
       ESP_LOGD(TAG, "NOT Setting coexistence preference to balanced.");
-      //esp_coex_preference_set(ESP_COEX_PREFER_BALANCE);  // Reset to default
+      // esp_coex_preference_set(ESP_COEX_PREFER_BALANCE);  // Reset to default
     }
 #endif
     if (this->scan_continuous_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -222,8 +222,8 @@ void ESP32BLETracker::loop() {
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
     if (this->coex_prefer_ble_) {
       this->coex_prefer_ble_ = false;
-      ESP_LOGD(TAG, "Setting coexistence preference to balanced.");
-      esp_coex_preference_set(ESP_COEX_PREFER_BALANCE);  // Reset to default
+      ESP_LOGD(TAG, "NOT Setting coexistence preference to balanced.");
+      //esp_coex_preference_set(ESP_COEX_PREFER_BALANCE);  // Reset to default
     }
 #endif
     if (this->scan_continuous_) {

--- a/tests/components/esp32_ble/common.yaml
+++ b/tests/components/esp32_ble/common.yaml
@@ -1,2 +1,3 @@
 esp32_ble:
   io_capability: keyboard_only
+  # Default configuration - should use 1m PHY

--- a/tests/components/esp32_ble/test.esp32-s3-ard.yaml
+++ b/tests/components/esp32_ble/test.esp32-s3-ard.yaml
@@ -1,0 +1,2 @@
+esp32_ble:
+  preferred_phy: 2m

--- a/tests/components/esp32_ble/test.esp32-s3-idf.yaml
+++ b/tests/components/esp32_ble/test.esp32-s3-idf.yaml
@@ -1,0 +1,2 @@
+esp32_ble:
+  preferred_phy: auto


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for configuring the Bluetooth Low Energy (BLE) PHY (Physical Layer) in the `esp32_ble` component, with a default of 1M PHY for maximum compatibility.

ESP32-S3 and other newer variants support both 1M and 2M PHY for BLE connections. However, the ESP32-S3 was auto-negotiating to 2M PHY with devices that claimed to support it, causing disconnections with many IoT devices (especially HomeKit accessories like Eve devices) that don't properly support 2M PHY or have issues with it.

**This has been a major pain point for users** - BLE fundamentally didn't work with many IoT devices when using an ESP32-S3, and the previous workaround was to tell people to use an ESP32 classic instead. This change finally makes ESP32-S3/C3/C6/H2 viable for BLE projects that need to interact with a wide range of devices.

By defaulting to 1M PHY, we ensure maximum compatibility with all BLE devices while still allowing users to opt into 2M PHY if they need higher throughput and have confirmed device support.

**Breaking Change**: This changes the default BLE PHY from auto-negotiation to 1M PHY on ESP32-S3/C3/C6/H2. While this is technically a breaking change, it's a beneficial one that will fix BLE connectivity issues for many users who have been unable to use newer ESP32 variants with their BLE devices. Users who specifically need 2M PHY can still enable it by setting `preferred_phy: 2m` or `preferred_phy: auto`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #[BLE disconnection issues with ESP32-S3/C3 and certain devices]

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5187

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default configuration (1M PHY for compatibility)
esp32_ble:

# Explicitly use 2M PHY for higher throughput (S3/C3/C6/H2 only)
esp32_ble:
  preferred_phy: 2m

# Let the ESP32 auto-negotiate PHY
esp32_ble:
  preferred_phy: auto
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).