### PR TITLE
[esp32_ble] Fix spurious BLE 5.0 event warnings on ESP32-S3

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -468,6 +468,8 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
     // Ignore these GAP events as they are not relevant for our use case
     case ESP_GAP_BLE_UPDATE_CONN_PARAMS_EVT:
     case ESP_GAP_BLE_SET_PKT_LENGTH_COMPLETE_EVT:
+    case ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT:       // BLE 5.0 PHY update complete
+    case ESP_GAP_BLE_CHANNEL_SELECT_ALGORITHM_EVT:  // BLE 5.0 channel selection algorithm
       return;
 
     default:


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes spurious warning messages that appear when using BLE on ESP32-S3 and other ESP32 variants that support Bluetooth 5.0. The warnings occur because ESP-IDF sends BLE 5.0 specific GAP events that ESPHome doesn't currently handle:

```
[W][esp32_ble:476][BTC_TASK]: Ignoring unexpected GAP event type: 60
[W][esp32_ble:476][BTC_TASK]: Ignoring unexpected GAP event type: 55
```

These events are:
- Event 55: `ESP_GAP_BLE_PHY_UPDATE_COMPLETE_EVT` - Sent when BLE PHY (physical layer) update completes
- Event 60: `ESP_GAP_BLE_CHANNEL_SELECT_ALGORITHM_EVT` - Sent to indicate the channel selection algorithm used

Since ESPHome doesn't need to handle these BLE 5.0 specific events, this PR adds them to the explicitly ignored events list to suppress the warnings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if one exists)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable - no user-visible changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fix applies automatically to any ESP32 variant with BLE enabled

esp32_ble_tracker:
  scan_parameters:
    active: true

# or

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).