### PR TITLE
[esp32_ble_client] Fix connection failures with short discovery timeout devices and speed up BLE connections

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -5,6 +5,8 @@
 
 #ifdef USE_ESP32
 
+#include <esp_gap_ble_api.h>
+
 namespace esphome {
 namespace esp32_ble_client {
 
@@ -129,6 +131,25 @@ void BLEClientBase::connect() {
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Attempting BLE connection", this->connection_index_, this->address_str_.c_str(),
            this->remote_addr_type_);
   this->paired_ = false;
+
+  // For connections without cache, set fast connection parameters before connecting
+  // This ensures service discovery completes within the 10-second timeout that
+  // some devices like HomeKit BLE sensors enforce
+  if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+    auto ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_,
+                                                  0x06,   // min_int: 7.5ms
+                                                  0x06,   // max_int: 7.5ms
+                                                  0,      // latency: 0
+                                                  1000);  // timeout: 10s
+    if (ret != ESP_OK) {
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
+               this->address_str_.c_str(), ret);
+    } else {
+      ESP_LOGD(TAG, "[%d] [%s] Set preferred connection params for fast discovery (no cache)", this->connection_index_,
+               this->address_str_.c_str());
+    }
+  }
+
   auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
   if (ret) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_open error, status=%d", this->connection_index_, this->address_str_.c_str(),
@@ -278,12 +299,14 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
                  this->address_str_.c_str(), ret);
       }
       this->set_state(espbt::ClientState::CONNECTED);
+      ESP_LOGI(TAG, "[%d] [%s] Connection open", this->connection_index_, this->address_str_.c_str());
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        ESP_LOGI(TAG, "[%d] [%s] Connected", this->connection_index_, this->address_str_.c_str());
+        ESP_LOGI(TAG, "[%d] [%s] Using cached services", this->connection_index_, this->address_str_.c_str());
         // only set our state, subclients might have more stuff to do yet.
         this->state_ = espbt::ClientState::ESTABLISHED;
         break;
       }
+      ESP_LOGD(TAG, "[%d] [%s] Searching for services", this->connection_index_, this->address_str_.c_str());
       esp_ble_gattc_search_service(esp_gattc_if, param->cfg_mtu.conn_id, nullptr);
       break;
     }
@@ -296,8 +319,15 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_DISCONNECT_EVT: {
       if (!this->check_addr(param->disconnect.remote_bda))
         return false;
-      ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_DISCONNECT_EVT, reason %d", this->connection_index_,
-               this->address_str_.c_str(), param->disconnect.reason);
+      // Check if we were disconnected while waiting for service discovery
+      if (param->disconnect.reason == 0x13 &&  // 0x13 = ESP_GATT_CONN_TERMINATE_PEER
+          this->state_ == espbt::ClientState::CONNECTED) {
+        ESP_LOGW(TAG, "[%d] [%s] Disconnected by remote during service discovery", this->connection_index_,
+                 this->address_str_.c_str());
+      } else {
+        ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_DISCONNECT_EVT, reason 0x%02x", this->connection_index_,
+                 this->address_str_.c_str(), param->disconnect.reason);
+      }
       this->release_services();
       this->set_state(espbt::ClientState::IDLE);
       break;
@@ -353,7 +383,23 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         ESP_LOGV(TAG, "[%d] [%s]  start_handle: 0x%x  end_handle: 0x%x", this->connection_index_,
                  this->address_str_.c_str(), svc->start_handle, svc->end_handle);
       }
-      ESP_LOGI(TAG, "[%d] [%s] Connected", this->connection_index_, this->address_str_.c_str());
+      ESP_LOGI(TAG, "[%d] [%s] Service discovery complete", this->connection_index_, this->address_str_.c_str());
+
+      // For non-cached connections, restore default connection parameters after service discovery
+      // Now that we've discovered all services, we can use more balanced parameters
+      // that save power and reduce interference
+      if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+        esp_ble_conn_update_params_t conn_params = {0};
+        memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
+        conn_params.min_int = 0x0A;  // 12.5ms - ESP-IDF default minimum (BTM_BLE_CONN_INT_MIN_DEF)
+        conn_params.max_int = 0x0C;  // 15ms - ESP-IDF default maximum (BTM_BLE_CONN_INT_MAX_DEF)
+        conn_params.latency = 0;
+        conn_params.timeout = 600;  // 6s - ESP-IDF default timeout (BTM_BLE_CONN_TIMEOUT_DEF)
+        ESP_LOGD(TAG, "[%d] [%s] Restoring default connection parameters after service discovery",
+                 this->connection_index_, this->address_str_.c_str());
+        esp_ble_gap_update_conn_params(&conn_params);
+      }
+
       this->state_ = espbt::ClientState::ESTABLISHED;
       break;
     }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -389,7 +389,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       // Now that we've discovered all services, we can use more balanced parameters
       // that save power and reduce interference
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-        esp_ble_conn_update_params_t conn_params = {0};
+        esp_ble_conn_update_params_t conn_params = {{0}};
         memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
         conn_params.min_int = 0x0A;  // 12.5ms - ESP-IDF default minimum (BTM_BLE_CONN_INT_MIN_DEF)
         conn_params.max_int = 0x0C;  // 15ms - ESP-IDF default maximum (BTM_BLE_CONN_INT_MAX_DEF)

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -6,6 +6,7 @@
 #ifdef USE_ESP32
 
 #include <esp_gap_ble_api.h>
+#include <esp_gatt_defs.h>
 
 namespace esphome {
 namespace esp32_ble_client {
@@ -319,7 +320,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (!this->check_addr(param->disconnect.remote_bda))
         return false;
       // Check if we were disconnected while waiting for service discovery
-      if (param->disconnect.reason == 0x13 &&  // 0x13 = ESP_GATT_CONN_TERMINATE_PEER
+      if (param->disconnect.reason == ESP_GATT_CONN_TERMINATE_PEER_USER &&
           this->state_ == espbt::ClientState::CONNECTED) {
         ESP_LOGW(TAG, "[%d] [%s] Disconnected by remote during service discovery", this->connection_index_,
                  this->address_str_.c_str());

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -12,6 +12,16 @@ namespace esphome {
 namespace esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
+
+// Connection interval defaults matching ESP-IDF's BTM_BLE_CONN_INT_*_DEF
+static const uint16_t DEFAULT_MIN_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
+static const uint16_t DEFAULT_MAX_CONN_INTERVAL = 0x0C;  // 12 * 1.25ms = 15ms
+static const uint16_t DEFAULT_CONN_TIMEOUT = 600;        // 600 * 10ms = 6s
+
+// Fastest connection parameters for devices with short discovery timeouts
+static const uint16_t FAST_MIN_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms (BLE minimum)
+static const uint16_t FAST_MAX_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms
+static const uint16_t FAST_CONN_TIMEOUT = 1000;       // 1000 * 10ms = 10s
 static const esp_bt_uuid_t NOTIFY_DESC_UUID = {
     .len = ESP_UUID_LEN_16,
     .uuid =
@@ -145,11 +155,10 @@ void BLEClientBase::connect() {
     // This ensures service discovery completes within the 10-second timeout that
     // some devices like HomeKit BLE sensors enforce
     if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-      auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_,
-                                                          0x06,   // min_int: 7.5ms
-                                                          0x06,   // max_int: 7.5ms
-                                                          0,      // latency: 0
-                                                          1000);  // timeout: 10s
+      auto param_ret =
+          esp_ble_gap_set_prefer_conn_params(this->remote_bda_, FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL,
+                                             0,  // latency: 0
+                                             FAST_CONN_TIMEOUT);
       if (param_ret != ESP_OK) {
         ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
                  this->address_str_.c_str(), param_ret);
@@ -391,10 +400,10 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         esp_ble_conn_update_params_t conn_params = {{0}};
         memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
-        conn_params.min_int = 0x0A;  // 12.5ms - ESP-IDF default minimum (BTM_BLE_CONN_INT_MIN_DEF)
-        conn_params.max_int = 0x0C;  // 15ms - ESP-IDF default maximum (BTM_BLE_CONN_INT_MAX_DEF)
+        conn_params.min_int = DEFAULT_MIN_CONN_INTERVAL;
+        conn_params.max_int = DEFAULT_MAX_CONN_INTERVAL;
         conn_params.latency = 0;
-        conn_params.timeout = 600;  // 6s - ESP-IDF default timeout (BTM_BLE_CONN_TIMEOUT_DEF)
+        conn_params.timeout = DEFAULT_CONN_TIMEOUT;
         ESP_LOGD(TAG, "[%d] [%s] Restored default conn params", this->connection_index_, this->address_str_.c_str());
         esp_ble_gap_update_conn_params(&conn_params);
       }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -132,24 +132,6 @@ void BLEClientBase::connect() {
            this->remote_addr_type_);
   this->paired_ = false;
 
-  // For connections without cache, set fast connection parameters before connecting
-  // This ensures service discovery completes within the 10-second timeout that
-  // some devices like HomeKit BLE sensors enforce
-  if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-    auto ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_,
-                                                  0x06,   // min_int: 7.5ms
-                                                  0x06,   // max_int: 7.5ms
-                                                  0,      // latency: 0
-                                                  1000);  // timeout: 10s
-    if (ret != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
-               this->address_str_.c_str(), ret);
-    } else {
-      ESP_LOGD(TAG, "[%d] [%s] Set preferred connection params for fast discovery (no cache)", this->connection_index_,
-               this->address_str_.c_str());
-    }
-  }
-
   auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
   if (ret) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_open error, status=%d", this->connection_index_, this->address_str_.c_str(),
@@ -157,6 +139,23 @@ void BLEClientBase::connect() {
     this->set_state(espbt::ClientState::IDLE);
   } else {
     this->set_state(espbt::ClientState::CONNECTING);
+
+    // For connections without cache, set fast connection parameters after initiating connection
+    // This ensures service discovery completes within the 10-second timeout that
+    // some devices like HomeKit BLE sensors enforce
+    if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+      auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_,
+                                                          0x06,   // min_int: 7.5ms
+                                                          0x06,   // max_int: 7.5ms
+                                                          0,      // latency: 0
+                                                          1000);  // timeout: 10s
+      if (param_ret != ESP_OK) {
+        ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
+                 this->address_str_.c_str(), param_ret);
+      } else {
+        ESP_LOGD(TAG, "[%d] [%s] Set fast conn params", this->connection_index_, this->address_str_.c_str());
+      }
+    }
   }
 }
 
@@ -395,8 +394,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         conn_params.max_int = 0x0C;  // 15ms - ESP-IDF default maximum (BTM_BLE_CONN_INT_MAX_DEF)
         conn_params.latency = 0;
         conn_params.timeout = 600;  // 6s - ESP-IDF default timeout (BTM_BLE_CONN_TIMEOUT_DEF)
-        ESP_LOGD(TAG, "[%d] [%s] Restoring default connection parameters after service discovery",
-                 this->connection_index_, this->address_str_.c_str());
+        ESP_LOGD(TAG, "[%d] [%s] Restored default conn params", this->connection_index_, this->address_str_.c_str());
         esp_ble_gap_update_conn_params(&conn_params);
       }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR enables ESP32-S3/C3/C6/H2 variants to connect to BLE devices that have short service discovery timeouts (like HomeKit devices). Previously, these devices were completely unable to establish stable connections on these ESP32 variants because service discovery couldn't complete within the device's timeout window (typically 10 seconds).

The fix optimizes BLE connection parameters to ensure fast service discovery:
- Sets the fastest allowed connection interval (7.5ms) before connecting to V3_WITHOUT_CACHE devices
- Completes service discovery ~2x faster than default parameters (7.5ms vs 12.5-15ms interval)
- Restores power-efficient default parameters after service discovery completes
- Adds clearer logging to distinguish between connection establishment and service discovery phases

This is a significant improvement that makes a whole class of previously incompatible BLE devices now work reliably with ESP32-S3/C3/C6/H2. As an added benefit, it also speeds up connection establishment on ESP32 classic for non-cached devices.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes HomeKit BLE devices (EVE, Nanoleaf, etc.) failing to connect on ESP32-S3
- Fixes disconnect reason 0x13 (remote terminated) during service discovery

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).