### PR TITLE
[core] Fix regex for lambda id() replacement

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -263,7 +263,7 @@ class TimePeriodMinutes(TimePeriod):
     pass
 
 
-LAMBDA_PROG = re.compile(r"id\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\)(\.?)")
+LAMBDA_PROG = re.compile(r"\bid\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\)(\.?)")
 
 
 class Lambda:

--- a/tests/components/host/common.yaml
+++ b/tests/components/host/common.yaml
@@ -8,3 +8,10 @@ logger:
 
 host:
   mac_address: "62:23:45:AF:B3:DD"
+
+esphome:
+  on_boot:
+    - lambda: |-
+        static const uint8_t my_addr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+        if (!mac_address_is_valid(my_addr))
+          ESP_LOGD("test", "Invalid mac address %X", my_addr[0]); // etc.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The current regex that looks for `id(...)` replacements in lambdas incorrectly matches function calls with names that end in `id`, see example below.

Add a word-boundary element to the regex to fix this.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://community.home-assistant.io/t/code-not-compiling-although-yaml-syntax-is-correct/909217

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
  on_boot:
    - lambda: |-
        static const uint8_t my_addr[6] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
        if (!mac_address_is_valid(my_addr))
          ESP_LOGD("test", "Invalid mac address %X", my_addr[0]); // etc.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
