### PR TITLE
[api] Reduce flash usage through targeted optimizations

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1647,6 +1647,8 @@ void APIConnection::process_batch_() {
     return;
   }
 
+  // Get shared buffer reference once to avoid multiple calls
+  auto &shared_buf = this->parent_->get_shared_buffer_ref();
   size_t num_items = this->deferred_batch_.size();
 
   // Fast path for single message - allocate exact size needed
@@ -1657,8 +1659,7 @@ void APIConnection::process_batch_() {
     uint16_t payload_size =
         item.creator(item.entity, this, std::numeric_limits<uint16_t>::max(), true, item.message_type);
 
-    if (payload_size > 0 &&
-        this->send_buffer(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()}, item.message_type)) {
+    if (payload_size > 0 && this->send_buffer(ProtoWriteBuffer{&shared_buf}, item.message_type)) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
       // Log messages after send attempt for VV debugging
       // It's safe to use the buffer for logging at this point regardless of send result
@@ -1685,20 +1686,17 @@ void APIConnection::process_batch_() {
   const uint8_t footer_size = this->helper_->frame_footer_size();
 
   // Initialize buffer and tracking variables
-  this->parent_->get_shared_buffer_ref().clear();
+  shared_buf.clear();
 
   // Pre-calculate exact buffer size needed based on message types
-  uint32_t total_estimated_size = 0;
-  for (size_t i = 0; i < this->deferred_batch_.size(); i++) {
-    const auto &item = this->deferred_batch_[i];
+  uint32_t total_estimated_size = num_items * (header_padding + footer_size);
+  for (const auto &item : this->deferred_batch_.items) {
     total_estimated_size += item.estimated_size;
   }
 
   // Calculate total overhead for all messages
-  uint32_t total_overhead = (header_padding + footer_size) * num_items;
-
   // Reserve based on estimated size (much more accurate than 24-byte worst-case)
-  this->parent_->get_shared_buffer_ref().reserve(total_estimated_size + total_overhead);
+  shared_buf.reserve(total_estimated_size);
   this->flags_.batch_first_message = true;
 
   size_t items_processed = 0;
@@ -1740,7 +1738,7 @@ void APIConnection::process_batch_() {
     remaining_size -= payload_size;
     // Calculate where the next message's header padding will start
     // Current buffer size + footer space (that prepare_message_buffer will add for this message)
-    current_offset = this->parent_->get_shared_buffer_ref().size() + footer_size;
+    current_offset = shared_buf.size() + footer_size;
   }
 
   if (items_processed == 0) {
@@ -1750,12 +1748,11 @@ void APIConnection::process_batch_() {
 
   // Add footer space for the last message (for Noise protocol MAC)
   if (footer_size > 0) {
-    auto &shared_buf = this->parent_->get_shared_buffer_ref();
     shared_buf.resize(shared_buf.size() + footer_size);
   }
 
   // Send all collected packets
-  APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&this->parent_->get_shared_buffer_ref()},
+  APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&shared_buf},
                                                        std::span<const PacketInfo>(packet_info, packet_count));
   if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
     on_fatal_error();

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -112,8 +112,7 @@ void APIConnection::start() {
   APIError err = this->helper_->init();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Helper init failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
-             errno);
+    this->log_warning_("Helper init failed", err);
     return;
   }
   this->client_info_.peername = helper_->getpeername();
@@ -144,8 +143,7 @@ void APIConnection::loop() {
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Socket operation failed %s errno=%d", this->get_client_combined_info().c_str(),
-             api_error_to_str(err), errno);
+    this->log_socket_operation_failed_(err);
     return;
   }
 
@@ -161,8 +159,7 @@ void APIConnection::loop() {
         break;
       } else if (err != APIError::OK) {
         on_fatal_error();
-        ESP_LOGW(TAG, "%s: Reading failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
-                 errno);
+        this->log_warning_("Reading failed", err);
         return;
       } else {
         this->last_traffic_ = now;
@@ -1540,8 +1537,7 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Socket operation failed %s errno=%d", this->get_client_combined_info().c_str(),
-             api_error_to_str(err), errno);
+    this->log_socket_operation_failed_(err);
     return false;
   }
   if (this->helper_->can_write_without_blocking())
@@ -1561,8 +1557,7 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
     return false;
   if (err != APIError::OK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Packet write failed %s errno=%d", this->get_client_combined_info().c_str(),
-             api_error_to_str(err), errno);
+    this->log_warning_("Packet write failed", err);
     return false;
   }
   // Do not set last_traffic_ on send
@@ -1756,8 +1751,7 @@ void APIConnection::process_batch_() {
                                                        std::span<const PacketInfo>(packet_info, packet_count));
   if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
     on_fatal_error();
-    ESP_LOGW(TAG, "%s: Batch write failed %s errno=%d", this->get_client_combined_info().c_str(), api_error_to_str(err),
-             errno);
+    this->log_warning_("Batch write failed", err);
   }
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1834,6 +1828,12 @@ void APIConnection::process_state_subscriptions_() {
   }
 }
 #endif  // USE_API_HOMEASSISTANT_STATES
+
+void APIConnection::log_warning_(const char *message, APIError err) {
+  ESP_LOGW(TAG, "%s: %s %s errno=%d", this->get_client_combined_info().c_str(), message, api_error_to_str(err), errno);
+}
+
+void APIConnection::log_socket_operation_failed_(APIError err) { this->log_warning_("Socket operation failed", err); }
 
 }  // namespace esphome::api
 #endif

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1685,7 +1685,8 @@ void APIConnection::process_batch_() {
 
   // Pre-calculate exact buffer size needed based on message types
   uint32_t total_estimated_size = num_items * (header_padding + footer_size);
-  for (const auto &item : this->deferred_batch_.items) {
+  for (size_t i = 0; i < this->deferred_batch_.size(); i++) {
+    const auto &item = this->deferred_batch_[i];
     total_estimated_size += item.estimated_size;
   }
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -736,6 +736,11 @@ class APIConnection : public APIServerConnection {
     this->deferred_batch_.add_item_front(entity, MessageCreator(function_ptr), message_type, estimated_size);
     return this->schedule_batch_();
   }
+
+  // Helper function to log API errors with errno
+  void log_warning_(const char *message, APIError err);
+  // Specific helper for duplicated error message
+  void log_socket_operation_failed_(APIError err);
 };
 
 }  // namespace esphome::api


### PR DESCRIPTION
# What does this implement/fix?

This PR continues the ongoing effort to reduce API overhead, implementing targeted optimizations that achieve a 256-byte reduction in flash usage. These changes are part of a larger initiative that has successfully reduced the API to nearly 40% of its original size for small devices with few entity types.

The optimizations in this PR include:
1. Simplified reserve calculation logic in `process_batch_()`
2. Reduced function calls by caching the shared buffer reference 
3. Consolidated duplicated error logging into helper functions to eliminate repeated code

As we near the completion of this optimization effort, these refinements help squeeze out the final unnecessary bytes while maintaining all existing functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Flash Usage Results

**Before optimization:** 518,330 bytes  
**After optimization:** 518,074 bytes  
**Total savings:** 256 bytes
