### PR TITLE
[bluetooth_proxy] Batch BLE service discovery messages for 67% reduction in API traffic

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1505,7 +1505,7 @@ message BluetoothGATTGetServicesResponse {
   option (ifdef) = "USE_BLUETOOTH_PROXY";
 
   uint64 address = 1;
-  repeated BluetoothGATTService services = 2 [(fixed_array_size) = 1];
+  repeated BluetoothGATTService services = 2;
 }
 
 message BluetoothGATTGetServicesDoneResponse {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1929,11 +1929,13 @@ void BluetoothGATTService::calculate_size(ProtoSize &size) const {
 }
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
-  buffer.encode_message(2, this->services[0], true);
+  for (auto &it : this->services) {
+    buffer.encode_message(2, it, true);
+  }
 }
 void BluetoothGATTGetServicesResponse::calculate_size(ProtoSize &size) const {
   size.add_uint64(1, this->address);
-  size.add_message_object_force(1, this->services[0]);
+  size.add_repeated_message(1, this->services);
 }
 void BluetoothGATTGetServicesDoneResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1895,12 +1895,12 @@ class BluetoothGATTService : public ProtoMessage {
 class BluetoothGATTGetServicesResponse : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 71;
-  static constexpr uint8_t ESTIMATED_SIZE = 21;
+  static constexpr uint8_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_gatt_get_services_response"; }
 #endif
   uint64_t address{0};
-  std::array<BluetoothGATTService, 1> services{};
+  std::vector<BluetoothGATTService> services{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -78,8 +78,9 @@ void BluetoothConnection::send_service_for_discovery_() {
   resp.address = this->address_;
 
   // Process up to 3 services in this iteration
-  static constexpr int MAX_SERVICES_PER_BATCH = 3;
-  int services_to_process = std::min(MAX_SERVICES_PER_BATCH, this->service_count_ - this->send_service_);
+  uint8_t services_to_process =
+      std::min(MAX_SERVICES_PER_BATCH, static_cast<uint8_t>(this->service_count_ - this->send_service_));
+  uint8_t services_processed = 0;
   resp.services.reserve(services_to_process);
 
   for (int service_idx = 0; service_idx < services_to_process; service_idx++) {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -93,11 +93,7 @@ void BluetoothConnection::send_service_for_discovery_() {
       ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service %s, status=%d, service_count=%d, offset=%d",
                this->connection_index_, this->address_str().c_str(),
                service_status != ESP_GATT_OK ? "error" : "missing", service_status, service_count, this->send_service_);
-      // If first service fails, return. If second fails, send what we have.
-      if (services_processed == 0) {
-        return;
-      }
-      break;
+      return;
     }
 
     this->send_service_++;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -70,6 +70,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Early return if no API connection
   auto *api_conn = this->proxy_->get_api_connection();
   if (api_conn == nullptr) {
+    this->send_service_ = DONE_SENDING_SERVICES;
     return;
   }
 
@@ -92,6 +93,7 @@ void BluetoothConnection::send_service_for_discovery_() {
       ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service %s, status=%d, service_count=%d, offset=%d",
                this->connection_index_, this->address_str().c_str(),
                service_status != ESP_GATT_OK ? "error" : "missing", service_status, service_count, this->send_service_);
+      this->send_service_ = DONE_SENDING_SERVICES;
       return;
     }
 
@@ -108,8 +110,9 @@ void BluetoothConnection::send_service_for_discovery_() {
                                      service_result.start_handle, service_result.end_handle, 0, &total_char_count);
 
     if (char_count_status != ESP_GATT_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
+      ESP_LOGE(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
                this->address_str().c_str(), char_count_status);
+      this->send_service_ = DONE_SENDING_SERVICES;
       return;
     }
 
@@ -133,6 +136,7 @@ void BluetoothConnection::send_service_for_discovery_() {
       if (char_status != ESP_GATT_OK) {
         ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_status);
+        this->send_service_ = DONE_SENDING_SERVICES;
         return;
       }
       if (char_count == 0) {
@@ -152,8 +156,9 @@ void BluetoothConnection::send_service_for_discovery_() {
           this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, 0, 0, char_result.char_handle, &total_desc_count);
 
       if (desc_count_status != ESP_GATT_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
+        ESP_LOGE(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
                  this->address_str().c_str(), char_result.char_handle, desc_count_status);
+        this->send_service_ = DONE_SENDING_SERVICES;
         return;
       }
       if (total_desc_count == 0) {
@@ -175,6 +180,7 @@ void BluetoothConnection::send_service_for_discovery_() {
         if (desc_status != ESP_GATT_OK) {
           ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
                    this->address_str().c_str(), desc_status);
+          this->send_service_ = DONE_SENDING_SERVICES;
           return;
         }
         if (desc_count == 0) {

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -80,7 +80,6 @@ void BluetoothConnection::send_service_for_discovery_() {
   // Process up to 3 services in this iteration
   uint8_t services_to_process =
       std::min(MAX_SERVICES_PER_BATCH, static_cast<uint8_t>(this->service_count_ - this->send_service_));
-  uint8_t services_processed = 0;
   resp.services.reserve(services_to_process);
 
   for (int service_idx = 0; service_idx < services_to_process; service_idx++) {
@@ -116,7 +115,6 @@ void BluetoothConnection::send_service_for_discovery_() {
 
     if (total_char_count == 0) {
       // No characteristics, continue to next service
-      services_processed++;
       continue;
     }
 
@@ -190,8 +188,6 @@ void BluetoothConnection::send_service_for_discovery_() {
         desc_offset++;
       }
     }
-
-    services_processed++;
   }
 
   // Send the message with 1-3 services

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -199,9 +199,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   }
 
   // Send the message with 1-3 services
-  if (services_processed > 0) {
-    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
-  }
+  api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
 }
 
 bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -57,7 +57,7 @@ void BluetoothConnection::reset_connection_(esp_err_t reason) {
 }
 
 void BluetoothConnection::send_service_for_discovery_() {
-  if (this->send_service_ == this->service_count_) {
+  if (this->send_service_ >= this->service_count_) {
     this->send_service_ = DONE_SENDING_SERVICES;
     this->proxy_->send_gatt_services_done(this->address_);
     if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
@@ -73,117 +73,134 @@ void BluetoothConnection::send_service_for_discovery_() {
     return;
   }
 
-  // Send next service
-  esp_gattc_service_elem_t service_result;
-  uint16_t service_count = 1;
-  esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->gattc_if_, this->conn_id_, nullptr,
-                                                               &service_result, &service_count, this->send_service_);
-  this->send_service_++;
-
-  if (service_status != ESP_GATT_OK || service_count == 0) {
-    ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service %s, status=%d, service_count=%d, offset=%d",
-             this->connection_index_, this->address_str().c_str(), service_status != ESP_GATT_OK ? "error" : "missing",
-             service_status, service_count, this->send_service_ - 1);
-    return;
-  }
-
+  // Prepare response for up to 3 services
   api::BluetoothGATTGetServicesResponse resp;
   resp.address = this->address_;
-  auto &service_resp = resp.services[0];
-  fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
-  service_resp.handle = service_result.start_handle;
 
-  // Get the number of characteristics directly with one call
-  uint16_t total_char_count = 0;
-  esp_gatt_status_t char_count_status =
-      esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
-                                   service_result.start_handle, service_result.end_handle, 0, &total_char_count);
+  // Process up to 3 services in this iteration
+  static constexpr int MAX_SERVICES_PER_BATCH = 3;
+  int services_to_process = std::min(MAX_SERVICES_PER_BATCH, this->service_count_ - this->send_service_);
+  resp.services.reserve(services_to_process);
 
-  if (char_count_status != ESP_GATT_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
-             this->address_str().c_str(), char_count_status);
-    return;
-  }
+  for (int service_idx = 0; service_idx < services_to_process; service_idx++) {
+    esp_gattc_service_elem_t service_result;
+    uint16_t service_count = 1;
+    esp_gatt_status_t service_status = esp_ble_gattc_get_service(this->gattc_if_, this->conn_id_, nullptr,
+                                                                 &service_result, &service_count, this->send_service_);
 
-  if (total_char_count == 0) {
-    // No characteristics, just send the service response
-    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
-    return;
-  }
-
-  // Reserve space and process characteristics
-  service_resp.characteristics.reserve(total_char_count);
-  uint16_t char_offset = 0;
-  esp_gattc_char_elem_t char_result;
-  while (true) {  // characteristics
-    uint16_t char_count = 1;
-    esp_gatt_status_t char_status =
-        esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
-                                   service_result.end_handle, &char_result, &char_count, char_offset);
-    if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
-      break;
-    }
-    if (char_status != ESP_GATT_OK) {
-      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
-               this->address_str().c_str(), char_status);
-      return;
-    }
-    if (char_count == 0) {
+    if (service_status != ESP_GATT_OK || service_count == 0) {
+      ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_service %s, status=%d, service_count=%d, offset=%d",
+               this->connection_index_, this->address_str().c_str(),
+               service_status != ESP_GATT_OK ? "error" : "missing", service_status, service_count, this->send_service_);
+      // If first service fails, return. If second fails, send what we have.
+      if (services_processed == 0) {
+        return;
+      }
       break;
     }
 
-    service_resp.characteristics.emplace_back();
-    auto &characteristic_resp = service_resp.characteristics.back();
-    fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
-    characteristic_resp.handle = char_result.char_handle;
-    characteristic_resp.properties = char_result.properties;
-    char_offset++;
+    this->send_service_++;
+    resp.services.emplace_back();
+    auto &service_resp = resp.services.back();
+    fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
+    service_resp.handle = service_result.start_handle;
 
-    // Get the number of descriptors directly with one call
-    uint16_t total_desc_count = 0;
-    esp_gatt_status_t desc_count_status = esp_ble_gattc_get_attr_count(
-        this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, 0, 0, char_result.char_handle, &total_desc_count);
+    // Get the number of characteristics directly with one call
+    uint16_t total_char_count = 0;
+    esp_gatt_status_t char_count_status =
+        esp_ble_gattc_get_attr_count(this->gattc_if_, this->conn_id_, ESP_GATT_DB_CHARACTERISTIC,
+                                     service_result.start_handle, service_result.end_handle, 0, &total_char_count);
 
-    if (desc_count_status != ESP_GATT_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
-               this->address_str().c_str(), char_result.char_handle, desc_count_status);
+    if (char_count_status != ESP_GATT_OK) {
+      ESP_LOGW(TAG, "[%d] [%s] Error getting characteristic count, status=%d", this->connection_index_,
+               this->address_str().c_str(), char_count_status);
       return;
     }
-    if (total_desc_count == 0) {
-      // No descriptors, continue to next characteristic
+
+    if (total_char_count == 0) {
+      // No characteristics, continue to next service
+      services_processed++;
       continue;
     }
 
-    // Reserve space and process descriptors
-    characteristic_resp.descriptors.reserve(total_desc_count);
-    uint16_t desc_offset = 0;
-    esp_gattc_descr_elem_t desc_result;
-    while (true) {  // descriptors
-      uint16_t desc_count = 1;
-      esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
-          this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
-      if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+    // Reserve space and process characteristics
+    service_resp.characteristics.reserve(total_char_count);
+    uint16_t char_offset = 0;
+    esp_gattc_char_elem_t char_result;
+    while (true) {  // characteristics
+      uint16_t char_count = 1;
+      esp_gatt_status_t char_status =
+          esp_ble_gattc_get_all_char(this->gattc_if_, this->conn_id_, service_result.start_handle,
+                                     service_result.end_handle, &char_result, &char_count, char_offset);
+      if (char_status == ESP_GATT_INVALID_OFFSET || char_status == ESP_GATT_NOT_FOUND) {
         break;
       }
-      if (desc_status != ESP_GATT_OK) {
-        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
-                 this->address_str().c_str(), desc_status);
+      if (char_status != ESP_GATT_OK) {
+        ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_char error, status=%d", this->connection_index_,
+                 this->address_str().c_str(), char_status);
         return;
       }
-      if (desc_count == 0) {
-        break;  // No more descriptors
+      if (char_count == 0) {
+        break;
       }
 
-      characteristic_resp.descriptors.emplace_back();
-      auto &descriptor_resp = characteristic_resp.descriptors.back();
-      fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-      descriptor_resp.handle = desc_result.handle;
-      desc_offset++;
+      service_resp.characteristics.emplace_back();
+      auto &characteristic_resp = service_resp.characteristics.back();
+      fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
+      characteristic_resp.handle = char_result.char_handle;
+      characteristic_resp.properties = char_result.properties;
+      char_offset++;
+
+      // Get the number of descriptors directly with one call
+      uint16_t total_desc_count = 0;
+      esp_gatt_status_t desc_count_status = esp_ble_gattc_get_attr_count(
+          this->gattc_if_, this->conn_id_, ESP_GATT_DB_DESCRIPTOR, 0, 0, char_result.char_handle, &total_desc_count);
+
+      if (desc_count_status != ESP_GATT_OK) {
+        ESP_LOGW(TAG, "[%d] [%s] Error getting descriptor count for char handle %d, status=%d", this->connection_index_,
+                 this->address_str().c_str(), char_result.char_handle, desc_count_status);
+        return;
+      }
+      if (total_desc_count == 0) {
+        // No descriptors, continue to next characteristic
+        continue;
+      }
+
+      // Reserve space and process descriptors
+      characteristic_resp.descriptors.reserve(total_desc_count);
+      uint16_t desc_offset = 0;
+      esp_gattc_descr_elem_t desc_result;
+      while (true) {  // descriptors
+        uint16_t desc_count = 1;
+        esp_gatt_status_t desc_status = esp_ble_gattc_get_all_descr(
+            this->gattc_if_, this->conn_id_, char_result.char_handle, &desc_result, &desc_count, desc_offset);
+        if (desc_status == ESP_GATT_INVALID_OFFSET || desc_status == ESP_GATT_NOT_FOUND) {
+          break;
+        }
+        if (desc_status != ESP_GATT_OK) {
+          ESP_LOGE(TAG, "[%d] [%s] esp_ble_gattc_get_all_descr error, status=%d", this->connection_index_,
+                   this->address_str().c_str(), desc_status);
+          return;
+        }
+        if (desc_count == 0) {
+          break;  // No more descriptors
+        }
+
+        characteristic_resp.descriptors.emplace_back();
+        auto &descriptor_resp = characteristic_resp.descriptors.back();
+        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+        descriptor_resp.handle = desc_result.handle;
+        desc_offset++;
+      }
     }
+
+    services_processed++;
   }
 
-  // Send the message (we already checked api_conn is not null at the beginning)
-  api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
+  // Send the message with 1-3 services
+  if (services_processed > 0) {
+    api_conn->send_message(resp, api::BluetoothGATTGetServicesResponse::MESSAGE_TYPE);
+  }
 }
 
 bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -22,6 +22,7 @@ namespace esphome::bluetooth_proxy {
 
 static const esp_err_t ESP_GATT_NOT_CONNECTED = -1;
 static const int DONE_SENDING_SERVICES = -2;
+static const uint8_t MAX_SERVICES_PER_BATCH = 3;
 
 using namespace esp32_ble_client;
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes BLE service discovery in the bluetooth_proxy component by batching multiple services per API message, reducing discovery time by ~67%.

Previously, each BLE service was sent in a separate API message during discovery. This one-at-a-time approach was implemented to address memory pressure issues when sending all services at once. While sending all services in a single message is still problematic for memory-constrained devices, recent optimizations to the protobuf structure (particularly the switch from vectors to arrays for UUIDs) now allow us to safely batch a small number of services per message. This PR implements batching of up to 3 services per message, providing significant performance improvements while maintaining memory safety.

**Performance improvement:** Testing with a HomeKit device with 17 services showed a **120ms reduction** in discovery time. This optimization is particularly beneficial for WiFi-based proxies where BLE and WiFi share air time - reducing the number of messages from 17 to 6 significantly reduces WiFi traffic during BLE discovery.

**Technical changes:**
- Removed `fixed_array_size` constraint from the protobuf definition to use `std::vector`
- Modified `send_service_for_discovery_()` to process up to 3 services per iteration
- Maintained all existing error handling to prevent incomplete service data from being cached
- Added `MAX_SERVICES_PER_BATCH` constant for easy tuning
- Fixed busy loop behavior on discovery failures by properly aborting discovery on any error

**Memory safety:** Batching 3 services provides a good balance between performance and memory usage, leveraging the reduced memory footprint from recent protobuf optimizations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - No user-visible changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-exposed changes