### PR TITLE
[esp32_ble_client] Fix BLE connection stability for WiFi-based proxies

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -18,6 +18,9 @@ static const char *const TAG = "esp32_ble_client";
 // causing disconnections. These medium parameters balance responsiveness with bandwidth usage.
 static const uint16_t MEDIUM_MIN_CONN_INTERVAL = 0x08;  // 8 * 1.25ms = 10ms
 static const uint16_t MEDIUM_MAX_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
+// The timeout value was increased from 6s to 8s to address stability issues observed
+// in certain BLE devices when operating through WiFi-based BLE proxies. The longer
+// timeout reduces the likelihood of disconnections during periods of high latency.
 static const uint16_t MEDIUM_CONN_TIMEOUT = 800;        // 800 * 10ms = 8s
 
 // Fastest connection parameters for devices with short discovery timeouts

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -13,10 +13,12 @@ namespace esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
 
-// Connection interval defaults matching ESP-IDF's BTM_BLE_CONN_INT_*_DEF
-static const uint16_t DEFAULT_MIN_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
-static const uint16_t DEFAULT_MAX_CONN_INTERVAL = 0x0C;  // 12 * 1.25ms = 15ms
-static const uint16_t DEFAULT_CONN_TIMEOUT = 600;        // 600 * 10ms = 6s
+// Intermediate connection parameters for standard operation
+// ESP-IDF defaults (12.5-15ms) are too slow for stable connections through WiFi-based BLE proxies,
+// causing disconnections. These medium parameters balance responsiveness with bandwidth usage.
+static const uint16_t MEDIUM_MIN_CONN_INTERVAL = 0x08;  // 8 * 1.25ms = 10ms
+static const uint16_t MEDIUM_MAX_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
+static const uint16_t MEDIUM_CONN_TIMEOUT = 800;        // 800 * 10ms = 8s
 
 // Fastest connection parameters for devices with short discovery timeouts
 static const uint16_t FAST_MIN_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms (BLE minimum)
@@ -151,20 +153,32 @@ void BLEClientBase::connect() {
   } else {
     this->set_state(espbt::ClientState::CONNECTING);
 
-    // For connections without cache, set fast connection parameters after initiating connection
-    // This ensures service discovery completes within the 10-second timeout that
-    // some devices like HomeKit BLE sensors enforce
+    // Always set connection parameters to ensure stable operation
+    // Use FAST for V3_WITHOUT_CACHE (devices that need lowest latency)
+    // Use MEDIUM for all other connections (balanced performance)
+    uint16_t min_interval, max_interval, timeout;
+    const char *param_type;
+
     if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-      auto param_ret =
-          esp_ble_gap_set_prefer_conn_params(this->remote_bda_, FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL,
-                                             0,  // latency: 0
-                                             FAST_CONN_TIMEOUT);
-      if (param_ret != ESP_OK) {
-        ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
-                 this->address_str_.c_str(), param_ret);
-      } else {
-        ESP_LOGD(TAG, "[%d] [%s] Set fast conn params", this->connection_index_, this->address_str_.c_str());
-      }
+      min_interval = FAST_MIN_CONN_INTERVAL;
+      max_interval = FAST_MAX_CONN_INTERVAL;
+      timeout = FAST_CONN_TIMEOUT;
+      param_type = "fast";
+    } else {
+      min_interval = MEDIUM_MIN_CONN_INTERVAL;
+      max_interval = MEDIUM_MAX_CONN_INTERVAL;
+      timeout = MEDIUM_CONN_TIMEOUT;
+      param_type = "medium";
+    }
+
+    auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_, min_interval, max_interval,
+                                                        0,  // latency: 0
+                                                        timeout);
+    if (param_ret != ESP_OK) {
+      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
+               this->address_str_.c_str(), param_ret);
+    } else {
+      ESP_LOGD(TAG, "[%d] [%s] Set %s conn params", this->connection_index_, this->address_str_.c_str(), param_type);
     }
   }
 }
@@ -394,17 +408,17 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       }
       ESP_LOGI(TAG, "[%d] [%s] Service discovery complete", this->connection_index_, this->address_str_.c_str());
 
-      // For non-cached connections, restore default connection parameters after service discovery
-      // Now that we've discovered all services, we can use more balanced parameters
-      // that save power and reduce interference
+      // For non-cached connections, restore to medium connection parameters after service discovery
+      // This balances performance with bandwidth usage after the critical discovery phase
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         esp_ble_conn_update_params_t conn_params = {{0}};
         memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
-        conn_params.min_int = DEFAULT_MIN_CONN_INTERVAL;
-        conn_params.max_int = DEFAULT_MAX_CONN_INTERVAL;
+        conn_params.min_int = MEDIUM_MIN_CONN_INTERVAL;
+        conn_params.max_int = MEDIUM_MAX_CONN_INTERVAL;
         conn_params.latency = 0;
-        conn_params.timeout = DEFAULT_CONN_TIMEOUT;
-        ESP_LOGD(TAG, "[%d] [%s] Restored default conn params", this->connection_index_, this->address_str_.c_str());
+        conn_params.timeout = MEDIUM_CONN_TIMEOUT;
+        ESP_LOGD(TAG, "[%d] [%s] Restored medium conn params after service discovery", this->connection_index_,
+                 this->address_str_.c_str());
         esp_ble_gap_update_conn_params(&conn_params);
       }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -21,7 +21,7 @@ static const uint16_t MEDIUM_MAX_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
 // The timeout value was increased from 6s to 8s to address stability issues observed
 // in certain BLE devices when operating through WiFi-based BLE proxies. The longer
 // timeout reduces the likelihood of disconnections during periods of high latency.
-static const uint16_t MEDIUM_CONN_TIMEOUT = 800;        // 800 * 10ms = 8s
+static const uint16_t MEDIUM_CONN_TIMEOUT = 800;  // 800 * 10ms = 8s
 
 // Fastest connection parameters for devices with short discovery timeouts
 static const uint16_t FAST_MIN_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms (BLE minimum)


### PR DESCRIPTION
# What does this implement/fix?

This PR improves BLE connection stability during normal operation by using optimized connection parameters. This is a follow-up to #9971 which fixed service discovery timeouts.

The ESP-IDF default connection intervals (12.5-15ms) are too slow for stable connections through WiFi-based BLE proxies, causing frequent disconnections. This PR introduces intermediate "medium" connection parameters (10-12.5ms) that balance responsiveness with bandwidth usage.

**Example of the issue - Nanoleaf strip disconnecting after successful connection:**
```
[15:58:48][I][esp32_ble_client:311]: [0] [EA:4E:E0:82:16:59] Connection open
[15:58:48][I][esp32_ble_client:313]: [0] [EA:4E:E0:82:16:59] Using cached services
[15:58:48][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_READ_CHAR_EVT
[15:58:49][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_READ_DESCR_EVT
[15:58:49][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_WRITE_CHAR_EVT
[15:58:49][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_READ_CHAR_EVT
[15:58:54][I][esp32_ble_client:196]: [0] [EA:4E:E0:82:16:59] Disconnecting (conn_id: 0).
[15:58:54][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_CLOSE_EVT
```

**After fix - stable connection maintained:**
```
[16:01:54][I][esp32_ble_client:311]: [0] [EA:4E:E0:82:16:59] Connection open
[16:01:54][D][esp32_ble_client:318]: [0] [EA:4E:E0:82:16:59] Searching for services
[16:01:54][I][esp32_ble_client:395]: [0] [EA:4E:E0:82:16:59] Service discovery complete
[16:01:55][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_READ_CHAR_EVT
[16:01:55][D][esp32_ble_client:240]: [0] [EA:4E:E0:82:16:59] ESP_GATTC_WRITE_CHAR_EVT
# ... connection continues stably for minutes ...
```

**Changes:**
- Always set connection parameters on connect (instead of only for V3_WITHOUT_CACHE)
- Use MEDIUM parameters (10-12.5ms) for standard connections
- Use FAST parameters (7.5ms) for V3_WITHOUT_CACHE during service discovery
- After service discovery, V3_WITHOUT_CACHE connections switch to MEDIUM parameters
- Remove unused DEFAULT connection parameter constants

This fixes disconnection issues with devices like Nanoleaf strips when used through BLE proxies.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows up on #9971 (which fixed service discovery)
- Fixes connection stability issues reported with Nanoleaf strips and other BLE devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example bluetooth proxy config:
esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-exposed functionality changes