### PR TITLE
[bluetooth_proxy] Optimize UUID transmission with efficient short_uuid field

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1485,12 +1485,11 @@ message BluetoothGATTDescriptor {
   repeated uint64 uuid = 1 [(fixed_array_size) = 2, (fixed_array_skip_zero) = true];
   uint32 handle = 2;
 
-  // New fields for efficient UUID (v1.12+)
-  // Only one of uuid, uuid16, or uuid32 will be set.
-  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // New field for efficient UUID (v1.12+)
+  // Only one of uuid or short_uuid will be set.
+  // short_uuid is used for both 16-bit and 32-bit UUIDs with v1.12+ clients.
   // 128-bit UUIDs always use the uuid field for backwards compatibility.
-  uint32 uuid16 = 3;  // 16-bit UUID
-  uint32 uuid32 = 4;  // 32-bit UUID
+  uint32 short_uuid = 3;  // 16-bit or 32-bit UUID
 }
 
 message BluetoothGATTCharacteristic {
@@ -1499,12 +1498,11 @@ message BluetoothGATTCharacteristic {
   uint32 properties = 3;
   repeated BluetoothGATTDescriptor descriptors = 4;
 
-  // New fields for efficient UUID (v1.12+)
-  // Only one of uuid, uuid16, or uuid32 will be set.
-  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // New field for efficient UUID (v1.12+)
+  // Only one of uuid or short_uuid will be set.
+  // short_uuid is used for both 16-bit and 32-bit UUIDs with v1.12+ clients.
   // 128-bit UUIDs always use the uuid field for backwards compatibility.
-  uint32 uuid16 = 5;  // 16-bit UUID
-  uint32 uuid32 = 6;  // 32-bit UUID
+  uint32 short_uuid = 5;  // 16-bit or 32-bit UUID
 }
 
 message BluetoothGATTService {
@@ -1512,12 +1510,11 @@ message BluetoothGATTService {
   uint32 handle = 2;
   repeated BluetoothGATTCharacteristic characteristics = 3;
 
-  // New fields for efficient UUID (v1.12+)
-  // Only one of uuid, uuid16, or uuid32 will be set.
-  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // New field for efficient UUID (v1.12+)
+  // Only one of uuid or short_uuid will be set.
+  // short_uuid is used for both 16-bit and 32-bit UUIDs with v1.12+ clients.
   // 128-bit UUIDs always use the uuid field for backwards compatibility.
-  uint32 uuid16 = 4;  // 16-bit UUID
-  uint32 uuid32 = 5;  // 32-bit UUID
+  uint32 short_uuid = 4;  // 16-bit or 32-bit UUID
 }
 
 message BluetoothGATTGetServicesResponse {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1482,21 +1482,42 @@ message BluetoothGATTGetServicesRequest {
 }
 
 message BluetoothGATTDescriptor {
-  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2, (fixed_array_skip_zero) = true];
   uint32 handle = 2;
+
+  // New fields for efficient UUID (v1.12+)
+  // Only one of uuid, uuid16, or uuid32 will be set.
+  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // 128-bit UUIDs always use the uuid field for backwards compatibility.
+  uint32 uuid16 = 3;  // 16-bit UUID
+  uint32 uuid32 = 4;  // 32-bit UUID
 }
 
 message BluetoothGATTCharacteristic {
-  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2, (fixed_array_skip_zero) = true];
   uint32 handle = 2;
   uint32 properties = 3;
   repeated BluetoothGATTDescriptor descriptors = 4;
+
+  // New fields for efficient UUID (v1.12+)
+  // Only one of uuid, uuid16, or uuid32 will be set.
+  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // 128-bit UUIDs always use the uuid field for backwards compatibility.
+  uint32 uuid16 = 5;  // 16-bit UUID
+  uint32 uuid32 = 6;  // 32-bit UUID
 }
 
 message BluetoothGATTService {
-  repeated uint64 uuid = 1 [(fixed_array_size) = 2];
+  repeated uint64 uuid = 1 [(fixed_array_size) = 2, (fixed_array_skip_zero) = true];
   uint32 handle = 2;
   repeated BluetoothGATTCharacteristic characteristics = 3;
+
+  // New fields for efficient UUID (v1.12+)
+  // Only one of uuid, uuid16, or uuid32 will be set.
+  // uuid16/uuid32 are only used for 16/32-bit UUIDs with v1.12+ clients.
+  // 128-bit UUIDs always use the uuid field for backwards compatibility.
+  uint32 uuid16 = 4;  // 16-bit UUID
+  uint32 uuid32 = 5;  // 32-bit UUID
 }
 
 message BluetoothGATTGetServicesResponse {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1363,7 +1363,7 @@ bool APIConnection::send_hello_response(const HelloRequest &msg) {
 
   HelloResponse resp;
   resp.api_version_major = 1;
-  resp.api_version_minor = 11;
+  resp.api_version_minor = 12;
   // Temporary string for concatenation - will be valid during send_message call
   std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
   resp.set_server_info(StringRef(server_info));

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -235,6 +235,13 @@ class APIConnection : public APIServerConnection {
            this->is_authenticated();
   }
   uint8_t get_log_subscription_level() const { return this->flags_.log_subscription; }
+
+  // Get client API version for feature detection
+  bool client_supports_api_version(uint16_t major, uint16_t minor) const {
+    return this->client_api_version_major_ > major ||
+           (this->client_api_version_major_ == major && this->client_api_version_minor_ >= minor);
+  }
+
   void on_fatal_error() override;
 #ifdef USE_API_PASSWORD
   void on_unauthenticated_access() override;

--- a/esphome/components/api/api_options.proto
+++ b/esphome/components/api/api_options.proto
@@ -28,6 +28,7 @@ extend google.protobuf.FieldOptions {
     optional string field_ifdef = 1042;
     optional uint32 fixed_array_size = 50007;
     optional bool no_zero_copy = 50008 [default=false];
+    optional bool fixed_array_skip_zero = 50009 [default=false];
 
     // container_pointer: Zero-copy optimization for repeated fields.
     //

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1888,7 +1888,7 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarI
   return true;
 }
 void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     buffer.encode_uint64(1, this->uuid[0], true);
     buffer.encode_uint64(1, this->uuid[1], true);
   }
@@ -1897,7 +1897,7 @@ void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(4, this->uuid32);
 }
 void BluetoothGATTDescriptor::calculate_size(ProtoSize &size) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     size.add_uint64_force(1, this->uuid[0]);
     size.add_uint64_force(1, this->uuid[1]);
   }
@@ -1906,7 +1906,7 @@ void BluetoothGATTDescriptor::calculate_size(ProtoSize &size) const {
   size.add_uint32(1, this->uuid32);
 }
 void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     buffer.encode_uint64(1, this->uuid[0], true);
     buffer.encode_uint64(1, this->uuid[1], true);
   }
@@ -1919,7 +1919,7 @@ void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(6, this->uuid32);
 }
 void BluetoothGATTCharacteristic::calculate_size(ProtoSize &size) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     size.add_uint64_force(1, this->uuid[0]);
     size.add_uint64_force(1, this->uuid[1]);
   }
@@ -1930,7 +1930,7 @@ void BluetoothGATTCharacteristic::calculate_size(ProtoSize &size) const {
   size.add_uint32(1, this->uuid32);
 }
 void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     buffer.encode_uint64(1, this->uuid[0], true);
     buffer.encode_uint64(1, this->uuid[1], true);
   }
@@ -1942,7 +1942,7 @@ void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(5, this->uuid32);
 }
 void BluetoothGATTService::calculate_size(ProtoSize &size) const {
-  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+  if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     size.add_uint64_force(1, this->uuid[0]);
     size.add_uint64_force(1, this->uuid[1]);
   }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1893,8 +1893,7 @@ void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
     buffer.encode_uint64(1, this->uuid[1], true);
   }
   buffer.encode_uint32(2, this->handle);
-  buffer.encode_uint32(3, this->uuid16);
-  buffer.encode_uint32(4, this->uuid32);
+  buffer.encode_uint32(3, this->short_uuid);
 }
 void BluetoothGATTDescriptor::calculate_size(ProtoSize &size) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
@@ -1902,8 +1901,7 @@ void BluetoothGATTDescriptor::calculate_size(ProtoSize &size) const {
     size.add_uint64_force(1, this->uuid[1]);
   }
   size.add_uint32(1, this->handle);
-  size.add_uint32(1, this->uuid16);
-  size.add_uint32(1, this->uuid32);
+  size.add_uint32(1, this->short_uuid);
 }
 void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
@@ -1915,8 +1913,7 @@ void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->descriptors) {
     buffer.encode_message(4, it, true);
   }
-  buffer.encode_uint32(5, this->uuid16);
-  buffer.encode_uint32(6, this->uuid32);
+  buffer.encode_uint32(5, this->short_uuid);
 }
 void BluetoothGATTCharacteristic::calculate_size(ProtoSize &size) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
@@ -1926,8 +1923,7 @@ void BluetoothGATTCharacteristic::calculate_size(ProtoSize &size) const {
   size.add_uint32(1, this->handle);
   size.add_uint32(1, this->properties);
   size.add_repeated_message(1, this->descriptors);
-  size.add_uint32(1, this->uuid16);
-  size.add_uint32(1, this->uuid32);
+  size.add_uint32(1, this->short_uuid);
 }
 void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
@@ -1938,8 +1934,7 @@ void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->characteristics) {
     buffer.encode_message(3, it, true);
   }
-  buffer.encode_uint32(4, this->uuid16);
-  buffer.encode_uint32(5, this->uuid32);
+  buffer.encode_uint32(4, this->short_uuid);
 }
 void BluetoothGATTService::calculate_size(ProtoSize &size) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
@@ -1948,8 +1943,7 @@ void BluetoothGATTService::calculate_size(ProtoSize &size) const {
   }
   size.add_uint32(1, this->handle);
   size.add_repeated_message(1, this->characteristics);
-  size.add_uint32(1, this->uuid16);
-  size.add_uint32(1, this->uuid32);
+  size.add_uint32(1, this->short_uuid);
 }
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1888,44 +1888,68 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarI
   return true;
 }
 void BluetoothGATTDescriptor::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->uuid[0], true);
-  buffer.encode_uint64(1, this->uuid[1], true);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    buffer.encode_uint64(1, this->uuid[0], true);
+    buffer.encode_uint64(1, this->uuid[1], true);
+  }
   buffer.encode_uint32(2, this->handle);
+  buffer.encode_uint32(3, this->uuid16);
+  buffer.encode_uint32(4, this->uuid32);
 }
 void BluetoothGATTDescriptor::calculate_size(ProtoSize &size) const {
-  size.add_uint64_force(1, this->uuid[0]);
-  size.add_uint64_force(1, this->uuid[1]);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    size.add_uint64_force(1, this->uuid[0]);
+    size.add_uint64_force(1, this->uuid[1]);
+  }
   size.add_uint32(1, this->handle);
+  size.add_uint32(1, this->uuid16);
+  size.add_uint32(1, this->uuid32);
 }
 void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->uuid[0], true);
-  buffer.encode_uint64(1, this->uuid[1], true);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    buffer.encode_uint64(1, this->uuid[0], true);
+    buffer.encode_uint64(1, this->uuid[1], true);
+  }
   buffer.encode_uint32(2, this->handle);
   buffer.encode_uint32(3, this->properties);
   for (auto &it : this->descriptors) {
     buffer.encode_message(4, it, true);
   }
+  buffer.encode_uint32(5, this->uuid16);
+  buffer.encode_uint32(6, this->uuid32);
 }
 void BluetoothGATTCharacteristic::calculate_size(ProtoSize &size) const {
-  size.add_uint64_force(1, this->uuid[0]);
-  size.add_uint64_force(1, this->uuid[1]);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    size.add_uint64_force(1, this->uuid[0]);
+    size.add_uint64_force(1, this->uuid[1]);
+  }
   size.add_uint32(1, this->handle);
   size.add_uint32(1, this->properties);
   size.add_repeated_message(1, this->descriptors);
+  size.add_uint32(1, this->uuid16);
+  size.add_uint32(1, this->uuid32);
 }
 void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_uint64(1, this->uuid[0], true);
-  buffer.encode_uint64(1, this->uuid[1], true);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    buffer.encode_uint64(1, this->uuid[0], true);
+    buffer.encode_uint64(1, this->uuid[1], true);
+  }
   buffer.encode_uint32(2, this->handle);
   for (auto &it : this->characteristics) {
     buffer.encode_message(3, it, true);
   }
+  buffer.encode_uint32(4, this->uuid16);
+  buffer.encode_uint32(5, this->uuid32);
 }
 void BluetoothGATTService::calculate_size(ProtoSize &size) const {
-  size.add_uint64_force(1, this->uuid[0]);
-  size.add_uint64_force(1, this->uuid[1]);
+  if (!(this->uuid[0] == 0 && this->uuid[1] == 0)) {
+    size.add_uint64_force(1, this->uuid[0]);
+    size.add_uint64_force(1, this->uuid[1]);
+  }
   size.add_uint32(1, this->handle);
   size.add_repeated_message(1, this->characteristics);
+  size.add_uint32(1, this->uuid16);
+  size.add_uint32(1, this->uuid32);
 }
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1857,8 +1857,7 @@ class BluetoothGATTDescriptor : public ProtoMessage {
  public:
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
-  uint32_t uuid16{0};
-  uint32_t uuid32{0};
+  uint32_t short_uuid{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1873,8 +1872,7 @@ class BluetoothGATTCharacteristic : public ProtoMessage {
   uint32_t handle{0};
   uint32_t properties{0};
   std::vector<BluetoothGATTDescriptor> descriptors{};
-  uint32_t uuid16{0};
-  uint32_t uuid32{0};
+  uint32_t short_uuid{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1888,8 +1886,7 @@ class BluetoothGATTService : public ProtoMessage {
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
   std::vector<BluetoothGATTCharacteristic> characteristics{};
-  uint32_t uuid16{0};
-  uint32_t uuid32{0};
+  uint32_t short_uuid{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1857,6 +1857,8 @@ class BluetoothGATTDescriptor : public ProtoMessage {
  public:
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
+  uint32_t uuid16{0};
+  uint32_t uuid32{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1871,6 +1873,8 @@ class BluetoothGATTCharacteristic : public ProtoMessage {
   uint32_t handle{0};
   uint32_t properties{0};
   std::vector<BluetoothGATTDescriptor> descriptors{};
+  uint32_t uuid16{0};
+  uint32_t uuid32{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1884,6 +1888,8 @@ class BluetoothGATTService : public ProtoMessage {
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
   std::vector<BluetoothGATTCharacteristic> characteristics{};
+  uint32_t uuid16{0};
+  uint32_t uuid32{0};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1561,6 +1561,8 @@ void BluetoothGATTDescriptor::dump_to(std::string &out) const {
     dump_field(out, "uuid", it, 4);
   }
   dump_field(out, "handle", this->handle);
+  dump_field(out, "uuid16", this->uuid16);
+  dump_field(out, "uuid32", this->uuid32);
 }
 void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTCharacteristic");
@@ -1574,6 +1576,8 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
+  dump_field(out, "uuid16", this->uuid16);
+  dump_field(out, "uuid32", this->uuid32);
 }
 void BluetoothGATTService::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTService");
@@ -1586,6 +1590,8 @@ void BluetoothGATTService::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
+  dump_field(out, "uuid16", this->uuid16);
+  dump_field(out, "uuid32", this->uuid32);
 }
 void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesResponse");

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1561,8 +1561,7 @@ void BluetoothGATTDescriptor::dump_to(std::string &out) const {
     dump_field(out, "uuid", it, 4);
   }
   dump_field(out, "handle", this->handle);
-  dump_field(out, "uuid16", this->uuid16);
-  dump_field(out, "uuid32", this->uuid32);
+  dump_field(out, "short_uuid", this->short_uuid);
 }
 void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTCharacteristic");
@@ -1576,8 +1575,7 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-  dump_field(out, "uuid16", this->uuid16);
-  dump_field(out, "uuid32", this->uuid32);
+  dump_field(out, "short_uuid", this->short_uuid);
 }
 void BluetoothGATTService::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTService");
@@ -1590,8 +1588,7 @@ void BluetoothGATTService::dump_to(std::string &out) const {
     it.dump_to(out);
     out.append("\n");
   }
-  dump_field(out, "uuid16", this->uuid16);
-  dump_field(out, "uuid32", this->uuid32);
+  dump_field(out, "short_uuid", this->short_uuid);
 }
 void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesResponse");

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,6 +24,19 @@ static void fill_128bit_uuid_array(std::array<uint64_t, 2> &out, esp_bt_uuid_t u
            ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]);
 }
 
+// Helper to fill UUID in the appropriate format based on client support and UUID type
+static void fill_gatt_uuid(std::array<uint64_t, 2> &uuid_128, uint32_t &short_uuid, const esp_bt_uuid_t &uuid,
+                           bool use_efficient_uuids) {
+  if (!use_efficient_uuids || uuid.len == ESP_UUID_LEN_128) {
+    // Use 128-bit format for old clients or when UUID is already 128-bit
+    fill_128bit_uuid_array(uuid_128, uuid);
+  } else if (uuid.len == ESP_UUID_LEN_16) {
+    short_uuid = uuid.uuid.uuid16;
+  } else if (uuid.len == ESP_UUID_LEN_32) {
+    short_uuid = uuid.uuid.uuid32;
+  }
+}
+
 bool BluetoothConnection::supports_efficient_uuids_() const {
   auto *api_conn = this->proxy_->get_api_connection();
   return api_conn && api_conn->client_supports_api_version(1, 12);
@@ -109,14 +122,7 @@ void BluetoothConnection::send_service_for_discovery_() {
     resp.services.emplace_back();
     auto &service_resp = resp.services.back();
 
-    if (!use_efficient_uuids || service_result.uuid.len == ESP_UUID_LEN_128) {
-      // Use 128-bit format for old clients or when UUID is already 128-bit
-      fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
-    } else if (service_result.uuid.len == ESP_UUID_LEN_16) {
-      service_resp.short_uuid = service_result.uuid.uuid.uuid16;
-    } else if (service_result.uuid.len == ESP_UUID_LEN_32) {
-      service_resp.short_uuid = service_result.uuid.uuid.uuid32;
-    }
+    fill_gatt_uuid(service_resp.uuid, service_resp.short_uuid, service_result.uuid, use_efficient_uuids);
 
     service_resp.handle = service_result.start_handle;
 
@@ -163,14 +169,7 @@ void BluetoothConnection::send_service_for_discovery_() {
       service_resp.characteristics.emplace_back();
       auto &characteristic_resp = service_resp.characteristics.back();
 
-      if (!use_efficient_uuids || char_result.uuid.len == ESP_UUID_LEN_128) {
-        // Use 128-bit format for old clients or when UUID is already 128-bit
-        fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
-      } else if (char_result.uuid.len == ESP_UUID_LEN_16) {
-        characteristic_resp.short_uuid = char_result.uuid.uuid.uuid16;
-      } else if (char_result.uuid.len == ESP_UUID_LEN_32) {
-        characteristic_resp.short_uuid = char_result.uuid.uuid.uuid32;
-      }
+      fill_gatt_uuid(characteristic_resp.uuid, characteristic_resp.short_uuid, char_result.uuid, use_efficient_uuids);
 
       characteristic_resp.handle = char_result.char_handle;
       characteristic_resp.properties = char_result.properties;
@@ -216,14 +215,7 @@ void BluetoothConnection::send_service_for_discovery_() {
         characteristic_resp.descriptors.emplace_back();
         auto &descriptor_resp = characteristic_resp.descriptors.back();
 
-        if (!use_efficient_uuids || desc_result.uuid.len == ESP_UUID_LEN_128) {
-          // Use 128-bit format for old clients or when UUID is already 128-bit
-          fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
-        } else if (desc_result.uuid.len == ESP_UUID_LEN_16) {
-          descriptor_resp.short_uuid = desc_result.uuid.uuid.uuid16;
-        } else if (desc_result.uuid.len == ESP_UUID_LEN_32) {
-          descriptor_resp.short_uuid = desc_result.uuid.uuid.uuid32;
-        }
+        fill_gatt_uuid(descriptor_resp.uuid, descriptor_resp.short_uuid, desc_result.uuid, use_efficient_uuids);
 
         descriptor_resp.handle = desc_result.handle;
         desc_offset++;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,6 +24,13 @@ static void fill_128bit_uuid_array(std::array<uint64_t, 2> &out, esp_bt_uuid_t u
            ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]);
 }
 
+static bool supports_efficient_uuids(api::APIConnection *api_conn) {
+  if (!api_conn)
+    return false;
+  return api_conn->get_client_api_version_major() > 1 ||
+         (api_conn->get_client_api_version_major() == 1 && api_conn->get_client_api_version_minor() >= 12);
+}
+
 void BluetoothConnection::dump_config() {
   ESP_LOGCONFIG(TAG, "BLE Connection:");
   BLEClientBase::dump_config();
@@ -74,6 +81,9 @@ void BluetoothConnection::send_service_for_discovery_() {
     return;
   }
 
+  // Check if client supports efficient UUIDs
+  bool use_efficient_uuids = supports_efficient_uuids(api_conn);
+
   // Prepare response for up to 3 services
   api::BluetoothGATTGetServicesResponse resp;
   resp.address = this->address_;
@@ -100,7 +110,16 @@ void BluetoothConnection::send_service_for_discovery_() {
     this->send_service_++;
     resp.services.emplace_back();
     auto &service_resp = resp.services.back();
-    fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
+
+    if (!use_efficient_uuids || service_result.uuid.len == ESP_UUID_LEN_128) {
+      // Use 128-bit format for old clients or when UUID is already 128-bit
+      fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
+    } else if (service_result.uuid.len == ESP_UUID_LEN_16) {
+      service_resp.uuid16 = service_result.uuid.uuid.uuid16;
+    } else if (service_result.uuid.len == ESP_UUID_LEN_32) {
+      service_resp.uuid32 = service_result.uuid.uuid.uuid32;
+    }
+
     service_resp.handle = service_result.start_handle;
 
     // Get the number of characteristics directly with one call
@@ -145,7 +164,16 @@ void BluetoothConnection::send_service_for_discovery_() {
 
       service_resp.characteristics.emplace_back();
       auto &characteristic_resp = service_resp.characteristics.back();
-      fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
+
+      if (!use_efficient_uuids || char_result.uuid.len == ESP_UUID_LEN_128) {
+        // Use 128-bit format for old clients or when UUID is already 128-bit
+        fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
+      } else if (char_result.uuid.len == ESP_UUID_LEN_16) {
+        characteristic_resp.uuid16 = char_result.uuid.uuid.uuid16;
+      } else if (char_result.uuid.len == ESP_UUID_LEN_32) {
+        characteristic_resp.uuid32 = char_result.uuid.uuid.uuid32;
+      }
+
       characteristic_resp.handle = char_result.char_handle;
       characteristic_resp.properties = char_result.properties;
       char_offset++;
@@ -189,7 +217,16 @@ void BluetoothConnection::send_service_for_discovery_() {
 
         characteristic_resp.descriptors.emplace_back();
         auto &descriptor_resp = characteristic_resp.descriptors.back();
-        fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+
+        if (!use_efficient_uuids || desc_result.uuid.len == ESP_UUID_LEN_128) {
+          // Use 128-bit format for old clients or when UUID is already 128-bit
+          fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
+        } else if (desc_result.uuid.len == ESP_UUID_LEN_16) {
+          descriptor_resp.uuid16 = desc_result.uuid.uuid.uuid16;
+        } else if (desc_result.uuid.len == ESP_UUID_LEN_32) {
+          descriptor_resp.uuid32 = desc_result.uuid.uuid.uuid32;
+        }
+
         descriptor_resp.handle = desc_result.handle;
         desc_offset++;
       }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -24,11 +24,9 @@ static void fill_128bit_uuid_array(std::array<uint64_t, 2> &out, esp_bt_uuid_t u
            ((uint64_t) uuid.uuid.uuid128[1] << 8) | ((uint64_t) uuid.uuid.uuid128[0]);
 }
 
-static bool supports_efficient_uuids(api::APIConnection *api_conn) {
-  if (!api_conn)
-    return false;
-  return api_conn->get_client_api_version_major() > 1 ||
-         (api_conn->get_client_api_version_major() == 1 && api_conn->get_client_api_version_minor() >= 12);
+bool BluetoothConnection::supports_efficient_uuids_() const {
+  auto *api_conn = this->proxy_->get_api_connection();
+  return api_conn && api_conn->client_supports_api_version(1, 12);
 }
 
 void BluetoothConnection::dump_config() {
@@ -82,7 +80,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   }
 
   // Check if client supports efficient UUIDs
-  bool use_efficient_uuids = supports_efficient_uuids(api_conn);
+  bool use_efficient_uuids = this->supports_efficient_uuids_();
 
   // Prepare response for up to 3 services
   api::BluetoothGATTGetServicesResponse resp;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -113,9 +113,9 @@ void BluetoothConnection::send_service_for_discovery_() {
       // Use 128-bit format for old clients or when UUID is already 128-bit
       fill_128bit_uuid_array(service_resp.uuid, service_result.uuid);
     } else if (service_result.uuid.len == ESP_UUID_LEN_16) {
-      service_resp.uuid16 = service_result.uuid.uuid.uuid16;
+      service_resp.short_uuid = service_result.uuid.uuid.uuid16;
     } else if (service_result.uuid.len == ESP_UUID_LEN_32) {
-      service_resp.uuid32 = service_result.uuid.uuid.uuid32;
+      service_resp.short_uuid = service_result.uuid.uuid.uuid32;
     }
 
     service_resp.handle = service_result.start_handle;
@@ -167,9 +167,9 @@ void BluetoothConnection::send_service_for_discovery_() {
         // Use 128-bit format for old clients or when UUID is already 128-bit
         fill_128bit_uuid_array(characteristic_resp.uuid, char_result.uuid);
       } else if (char_result.uuid.len == ESP_UUID_LEN_16) {
-        characteristic_resp.uuid16 = char_result.uuid.uuid.uuid16;
+        characteristic_resp.short_uuid = char_result.uuid.uuid.uuid16;
       } else if (char_result.uuid.len == ESP_UUID_LEN_32) {
-        characteristic_resp.uuid32 = char_result.uuid.uuid.uuid32;
+        characteristic_resp.short_uuid = char_result.uuid.uuid.uuid32;
       }
 
       characteristic_resp.handle = char_result.char_handle;
@@ -220,9 +220,9 @@ void BluetoothConnection::send_service_for_discovery_() {
           // Use 128-bit format for old clients or when UUID is already 128-bit
           fill_128bit_uuid_array(descriptor_resp.uuid, desc_result.uuid);
         } else if (desc_result.uuid.len == ESP_UUID_LEN_16) {
-          descriptor_resp.uuid16 = desc_result.uuid.uuid.uuid16;
+          descriptor_resp.short_uuid = desc_result.uuid.uuid.uuid16;
         } else if (desc_result.uuid.len == ESP_UUID_LEN_32) {
-          descriptor_resp.uuid32 = desc_result.uuid.uuid.uuid32;
+          descriptor_resp.short_uuid = desc_result.uuid.uuid.uuid32;
         }
 
         descriptor_resp.handle = desc_result.handle;

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -27,6 +27,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
  protected:
   friend class BluetoothProxy;
 
+  bool supports_efficient_uuids_() const;
   void send_service_for_discovery_();
   void reset_connection_(esp_err_t reason);
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1075,6 +1075,11 @@ class FixedArrayRepeatedType(TypeInfo):
     def __init__(self, field: descriptor.FieldDescriptorProto, size: int) -> None:
         super().__init__(field)
         self.array_size = size
+        # Check if we should skip encoding when all elements are zero
+        # Use getattr to handle older versions of api_options_pb2
+        self.skip_zero = get_field_opt(
+            field, getattr(pb, "fixed_array_skip_zero", None), False
+        )
         # Create the element type info
         validate_field_type(field.type, field.name)
         self._ti: TypeInfo = TYPE_INFO[field.type](field)
@@ -1113,6 +1118,18 @@ class FixedArrayRepeatedType(TypeInfo):
             else:
                 return f"buffer.{self._ti.encode_func}({self.number}, {element}, true);"
 
+        # If skip_zero is enabled, wrap encoding in a zero check
+        if self.skip_zero:
+            # Build the condition to check if all elements are zero
+            zero_checks = " && ".join(
+                [f"this->{self.field_name}[{i}] == 0" for i in range(self.array_size)]
+            )
+            encode_lines = [
+                f"  {encode_element(f'this->{self.field_name}[{i}]')}"
+                for i in range(self.array_size)
+            ]
+            return f"if (!({zero_checks})) {{\n" + "\n".join(encode_lines) + "\n}"
+
         # Unroll small arrays for efficiency
         if self.array_size == 1:
             return encode_element(f"this->{self.field_name}[0]")
@@ -1141,6 +1158,18 @@ class FixedArrayRepeatedType(TypeInfo):
         return ""
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
+        # If skip_zero is enabled, wrap size calculation in a zero check
+        if self.skip_zero:
+            # Build the condition to check if all elements are zero
+            zero_checks = " && ".join(
+                [f"{name}[{i}] == 0" for i in range(self.array_size)]
+            )
+            size_lines = [
+                f"  {self._ti.get_size_calculation(f'{name}[{i}]', True)}"
+                for i in range(self.array_size)
+            ]
+            return f"if (!({zero_checks})) {{\n" + "\n".join(size_lines) + "\n}"
+
         # For fixed arrays, we always encode all elements
 
         # Special case for single-element arrays - no loop needed

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1120,15 +1120,15 @@ class FixedArrayRepeatedType(TypeInfo):
 
         # If skip_zero is enabled, wrap encoding in a zero check
         if self.skip_zero:
-            # Build the condition to check if all elements are zero
-            zero_checks = " && ".join(
-                [f"this->{self.field_name}[{i}] == 0" for i in range(self.array_size)]
+            # Build the condition to check if at least one element is non-zero
+            non_zero_checks = " || ".join(
+                [f"this->{self.field_name}[{i}] != 0" for i in range(self.array_size)]
             )
             encode_lines = [
                 f"  {encode_element(f'this->{self.field_name}[{i}]')}"
                 for i in range(self.array_size)
             ]
-            return f"if (!({zero_checks})) {{\n" + "\n".join(encode_lines) + "\n}"
+            return f"if ({non_zero_checks}) {{\n" + "\n".join(encode_lines) + "\n}"
 
         # Unroll small arrays for efficiency
         if self.array_size == 1:
@@ -1160,15 +1160,15 @@ class FixedArrayRepeatedType(TypeInfo):
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         # If skip_zero is enabled, wrap size calculation in a zero check
         if self.skip_zero:
-            # Build the condition to check if all elements are zero
-            zero_checks = " && ".join(
-                [f"{name}[{i}] == 0" for i in range(self.array_size)]
+            # Build the condition to check if at least one element is non-zero
+            non_zero_checks = " || ".join(
+                [f"{name}[{i}] != 0" for i in range(self.array_size)]
             )
             size_lines = [
                 f"  {self._ti.get_size_calculation(f'{name}[{i}]', True)}"
                 for i in range(self.array_size)
             ]
-            return f"if (!({zero_checks})) {{\n" + "\n".join(size_lines) + "\n}"
+            return f"if ({non_zero_checks}) {{\n" + "\n".join(size_lines) + "\n}"
 
         # For fixed arrays, we always encode all elements
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes Bluetooth UUID transmission during service discovery by sending UUIDs in their native 16/32-bit format instead of always expanding to 128-bit. This reduces API traffic by up to 75% for devices using standard Bluetooth UUIDs. The improvement varies depending on how many 128-bit uuids are used. For descriptors, they are almost all CCCD and use 16 bit.

**Key improvements:**
- Adds single `short_uuid` field to GATT messages for efficient UUID transmission (handles both 16-bit and 32-bit UUIDs)
- Implements API version negotiation (v1.12) for backwards compatibility
- Adds `fixed_array_skip_zero` protobuf option to avoid sending empty UUID arrays
- Maintains full compatibility with existing clients

**Performance impact:**
- 16-bit UUIDs: 16 bytes → 4 bytes (75% reduction)
- 32-bit UUIDs: 16 bytes → 4 bytes (75% reduction)  
- Typical BLE device with 60 UUIDs: ~960 bytes → ~240 bytes

**Memory optimization:**
- Uses single `uint32 short_uuid` field instead of separate `uuid16`/`uuid32` fields since protobuf wire format is the same
- Saves 4 bytes per GATT structure (only 4 bytes overhead instead of 8)
- Combined with switching from `std::vector` to `std::array` for UUID storage: net memory reduction overall (previous PR)

This optimization is particularly beneficial for WiFi-based proxies where reducing API traffic helps with airtime sharing between BLE and WiFi.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal optimization only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-exposed changes

## Technical Details:

**Changes made:**
1. Added single `short_uuid` field to `BluetoothGATTDescriptor`, `BluetoothGATTCharacteristic`, and `BluetoothGATTService` messages
2. Added `fixed_array_skip_zero` option to protobuf generator to skip encoding when UUID array is all zeros
3. Updated `send_service_for_discovery_()` to send UUIDs in their native format for API v1.12+ clients
4. Bumped API version from 1.11 to 1.12

**Protocol design:**
- Only one of `uuid` or `short_uuid` fields is populated per message (old clients always get the 128 bit one)
- 16-bit and 32-bit UUIDs both use `short_uuid` (no need to distinguish since they expand identically)
- 128-bit UUIDs always use the original `uuid` field for simplicity
- Zero UUID values are never valid, making field detection unambiguous
- Old clients ignore new fields and continue working with 128-bit UUIDs
- Protobuf wire format remains identical (same field numbers, same encoding)

**Memory impact:**
The `fixed_array_skip_zero` option ensures that when using efficient UUIDs, the old 128-bit UUID array (which remains zero) is not sent over the wire, saving an additional 16 bytes per UUID.