### PR TITLE
[midea] Use c++17 constexpr and inline static in IrFollowMeData

### DIFF
--- a/esphome/components/midea/ir_transmitter.h
+++ b/esphome/components/midea/ir_transmitter.h
@@ -54,15 +54,15 @@ class IrFollowMeData : public IrData {
   void set_fahrenheit(bool val) { this->set_mask_(2, val, 32); }
 
  protected:
-  static const uint8_t MIN_TEMP_C = 0;
-  static const uint8_t MAX_TEMP_C = 37;
+  inline static constexpr uint8_t MIN_TEMP_C = 0;
+  inline static constexpr uint8_t MAX_TEMP_C = 37;
 
   // see
   // https://github.com/crankyoldgit/IRremoteESP8266/blob/9bdf8abcb465268c5409db99dc83a26df64c7445/src/ir_Midea.h#L116
-  static const uint8_t MIN_TEMP_F = 32;
+  inline static constexpr uint8_t MIN_TEMP_F = 32;
   // see
   // https://github.com/crankyoldgit/IRremoteESP8266/blob/9bdf8abcb465268c5409db99dc83a26df64c7445/src/ir_Midea.h#L117
-  static const uint8_t MAX_TEMP_F = 99;
+  inline static constexpr uint8_t MAX_TEMP_F = 99;
 };
 
 class IrSpecialData : public IrData {


### PR DESCRIPTION
# What does this implement/fix?

Changed static const members to inline static constexpr to allow header-only definitions and avoid linker errors with C++17.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #9673 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
