### PR TITLE
[CI] Allow multiple grep options for clang-tidy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
             pio_cache_key: tidyesp32-idf
           - id: clang-tidy
             name: Run script/clang-tidy for ZEPHYR
-            options: --environment nrf52-tidy --grep USE_ZEPHYR
+            options: --environment nrf52-tidy --grep USE_ZEPHYR --grep USE_NRF52
             pio_cache_key: tidy-zephyr
             ignore_errors: false
 

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -205,7 +205,12 @@ def main():
     parser.add_argument(
         "-c", "--changed", action="store_true", help="only run on changed files"
     )
-    parser.add_argument("-g", "--grep", help="only run on files containing value")
+    parser.add_argument(
+        "-g",
+        "--grep",
+        action="append",
+        help="only run on files containing value",
+    )
     parser.add_argument(
         "--split-num", type=int, help="split the files into X jobs.", default=None
     )

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -338,12 +338,12 @@ def filter_changed(files: list[str]) -> list[str]:
     return files
 
 
-def filter_grep(files: list[str], value: str) -> list[str]:
+def filter_grep(files: list[str], value: list[str]) -> list[str]:
     matched = []
     for file in files:
         with open(file, encoding="utf-8") as handle:
             contents = handle.read()
-        if value in contents:
+        if any(v in contents for v in value):
             matched.append(file)
     return matched
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
