### PR TITLE
[i2s_audio] Use high-pass filter for dc offset correction

### DIFF
--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -378,33 +378,53 @@ void I2SAudioMicrophone::mic_task(void *params) {
 }
 
 void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
+  /**
+   * From https://www.musicdsp.org/en/latest/Filters/135-dc-filter.html:
+   *
+   *     y(n) = x(n) - x(n-1) + R * y(n-1)
+   *     R = 1 - (pi * 2 * frequency / samplerate)
+   *
+   * From https://en.wikipedia.org/wiki/Hearing_range:
+   *     The human range is commonly given as 20Hz up.
+   *
+   * From https://en.wikipedia.org/wiki/High-resolution_audio:
+   *     A reasonable upper bound for sample rate seems to be 96kHz.
+   *
+   * Calculate R value for 20Hz on a 96kHz sample rate:
+   *     R = 1 - (pi * 2 * 20 / 96000)
+   *     R = 0.9986910031
+   *
+   * Transform floating point to bit-shifting approximation:
+   *     output = input - prev_input + R * prev_output
+   *     output = input - prev_input + (prev_output - (prev_output >> S))
+   *
+   * Approximate bit-shift value S from R:
+   *     R = 1 - (1 >> S)
+   *     R = 1 - (1 / 2^S)
+   *     R = 1 - 2^-S
+   *     0.9986910031 = 1 - 2^-S
+   *     S = 9.57732 ~= 10
+   *
+   * Actual R from S:
+   *     R = 1 - 2^-10 = 0.9990234375
+   *
+   * Confirm this has effect outside human hearing on 96000kHz sample:
+   *     0.9990234375 = 1 - (pi * 2 * f / 96000)
+   *     f = 14.9208Hz
+   *
+   * Confirm this has effect outside human hearing on PDM 16kHz sample:
+   *     0.9990234375 = 1 - (pi * 2 * f / 16000)
+   *     f = 2.4868Hz
+   *
+   */
+  const uint8_t dc_filter_shift = 10;
   const size_t bytes_per_sample = this->audio_stream_info_.samples_to_bytes(1);
   const uint32_t total_samples = this->audio_stream_info_.bytes_to_samples(data.size());
   for (uint32_t sample_index = 0; sample_index < total_samples; ++sample_index) {
-    /**
-     * From https://www.musicdsp.org/en/latest/Filters/135-dc-filter.html:
-     *
-     *     y(n) = x(n) - x(n-1) + R * y(n-1)
-     *     R = 1 - (pi * 2 * frequency / samplerate)
-     *
-     * Calculate R value for 40Hz on a 16kHz sample rate:
-     *     R = 1 - (pi * 2 * 40 / 16000)
-     *     R = 0.9842920367
-     *
-     * Transform floating point to bit-shifting approximation:
-     *     output = input - prev_input + R * prev_output
-     *     output = input - prev_input + (prev_output - (prev_output >> S))
-     *
-     * Approximate bit-shift value from R:
-     *     R = 1 - (1 >> S)
-     *     R = 1 - 2^-S
-     *     0.9842920367 = 1 - 2^-S
-     *     S ≈ 6
-     */
     const uint32_t byte_index = sample_index * bytes_per_sample;
     int32_t input = audio::unpack_audio_sample_to_q31(&data[byte_index], bytes_per_sample);
-    int32_t output =
-        input - this->dc_offset_prev_input_ + (this->dc_offset_prev_output_ - (this->dc_offset_prev_output_ >> 6));
+    int32_t output = input - this->dc_offset_prev_input_ +
+                     (this->dc_offset_prev_output_ - (this->dc_offset_prev_output_ >> dc_filter_shift));
     this->dc_offset_prev_input_ = input;
     this->dc_offset_prev_output_ = output;
     audio::pack_q31_as_audio_sample(output, &data[byte_index], bytes_per_sample);

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -24,9 +24,6 @@ static const uint32_t READ_DURATION_MS = 16;
 static const size_t TASK_STACK_SIZE = 4096;
 static const ssize_t TASK_PRIORITY = 23;
 
-// Use an exponential moving average to correct a DC offset with weight factor 1/1000
-static const int32_t DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR = 1000;
-
 static const char *const TAG = "i2s_audio.microphone";
 
 enum MicrophoneEventGroupBits : uint32_t {
@@ -383,24 +380,15 @@ void I2SAudioMicrophone::mic_task(void *params) {
 void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
   const size_t bytes_per_sample = this->audio_stream_info_.samples_to_bytes(1);
   const uint32_t total_samples = this->audio_stream_info_.bytes_to_samples(data.size());
-
-  if (total_samples == 0) {
-    return;
-  }
-
-  int64_t offset_accumulator = 0;
   for (uint32_t sample_index = 0; sample_index < total_samples; ++sample_index) {
     const uint32_t byte_index = sample_index * bytes_per_sample;
     int32_t sample = audio::unpack_audio_sample_to_q31(&data[byte_index], bytes_per_sample);
-    offset_accumulator += sample;
+    // Update dc offset, 11 = ~40Hz at 16kHz sample rate
+    this->dc_offset_ += (sample - this->dc_offset_) >> 11;
+    // Apply dc offset
     sample -= this->dc_offset_;
     audio::pack_q31_as_audio_sample(sample, &data[byte_index], bytes_per_sample);
   }
-
-  const int32_t new_offset = offset_accumulator / total_samples;
-  this->dc_offset_ = new_offset / DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR +
-                     (DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR - 1) * this->dc_offset_ /
-                         DC_OFFSET_MOVING_AVERAGE_COEFFICIENT_DENOMINATOR;
 }
 
 size_t I2SAudioMicrophone::read_(uint8_t *buf, size_t len, TickType_t ticks_to_wait) {

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -381,13 +381,33 @@ void I2SAudioMicrophone::fix_dc_offset_(std::vector<uint8_t> &data) {
   const size_t bytes_per_sample = this->audio_stream_info_.samples_to_bytes(1);
   const uint32_t total_samples = this->audio_stream_info_.bytes_to_samples(data.size());
   for (uint32_t sample_index = 0; sample_index < total_samples; ++sample_index) {
+    /**
+     * From https://www.musicdsp.org/en/latest/Filters/135-dc-filter.html:
+     *
+     *     y(n) = x(n) - x(n-1) + R * y(n-1)
+     *     R = 1 - (pi * 2 * frequency / samplerate)
+     *
+     * Calculate R value for 40Hz on a 16kHz sample rate:
+     *     R = 1 - (pi * 2 * 40 / 16000)
+     *     R = 0.9842920367
+     *
+     * Transform floating point to bit-shifting approximation:
+     *     output = input - prev_input + R * prev_output
+     *     output = input - prev_input + (prev_output - (prev_output >> S))
+     *
+     * Approximate bit-shift value from R:
+     *     R = 1 - (1 >> S)
+     *     R = 1 - 2^-S
+     *     0.9842920367 = 1 - 2^-S
+     *     S ≈ 6
+     */
     const uint32_t byte_index = sample_index * bytes_per_sample;
-    int32_t sample = audio::unpack_audio_sample_to_q31(&data[byte_index], bytes_per_sample);
-    // Update dc offset, 11 = ~40Hz at 16kHz sample rate
-    this->dc_offset_ += (sample - this->dc_offset_) >> 11;
-    // Apply dc offset
-    sample -= this->dc_offset_;
-    audio::pack_q31_as_audio_sample(sample, &data[byte_index], bytes_per_sample);
+    int32_t input = audio::unpack_audio_sample_to_q31(&data[byte_index], bytes_per_sample);
+    int32_t output =
+        input - this->dc_offset_prev_input_ + (this->dc_offset_prev_output_ - (this->dc_offset_prev_output_ >> 6));
+    this->dc_offset_prev_input_ = input;
+    this->dc_offset_prev_output_ = output;
+    audio::pack_q31_as_audio_sample(output, &data[byte_index], bytes_per_sample);
   }
 }
 

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.h
@@ -82,7 +82,8 @@ class I2SAudioMicrophone : public I2SAudioIn, public microphone::Microphone, pub
 
   bool correct_dc_offset_;
   bool locked_driver_{false};
-  int32_t dc_offset_{0};
+  int32_t dc_offset_prev_input_{0};
+  int32_t dc_offset_prev_output_{0};
 };
 
 }  // namespace i2s_audio


### PR DESCRIPTION
Change exponential moving average for a high pass filter to correct dc offset based around 16khz sample rate of PDM.

Should give a faster response and work for both negative and positive offsets.

Tested with an M5 Atom Echo with PDM mic where existing solution did not correct dc offset.

# What does this implement/fix?

Existing solution did not work on an M5 Atom Echo with a negative offset.  I believe using a high-pass filter is a more 'standard' way of correcting dc offsets, so have implemented the simplest one I could.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
microphone:
  - id: echo_microphone
    platform: i2s_audio
    adc_type: external
    i2s_din_pin: GPIO23
    pdm: true
    channel: stereo
    correct_dc_offset: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
