### PR TITLE
[esp32_ble] Fix BLE connection slot waste by aligning ESP-IDF timeout with client timeout

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -168,7 +168,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.SplitDefault(CONF_DISABLE_BT_LOGS, esp32_idf=True): cv.All(
             cv.only_with_esp_idf, cv.boolean
         ),
-        cv.Optional(CONF_CONNECTION_TIMEOUT, default="20s"): cv.All(
+        cv.SplitDefault(CONF_CONNECTION_TIMEOUT, esp32_idf="20s"): cv.All(
             cv.only_with_esp_idf,
             cv.positive_time_period_seconds,
             cv.Range(min=TimePeriod(seconds=1), max=TimePeriod(seconds=180)),

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -6,7 +6,7 @@ import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_ON_BOOT, CONF_ESPHOME, CONF_ID, CONF_NAME
-from esphome.core import CORE
+from esphome.core import CORE, TimePeriod
 from esphome.core.config import CONF_NAME_ADD_MAC_SUFFIX
 import esphome.final_validate as fv
 
@@ -117,6 +117,7 @@ CONF_BLE_ID = "ble_id"
 CONF_IO_CAPABILITY = "io_capability"
 CONF_ADVERTISING_CYCLE_TIME = "advertising_cycle_time"
 CONF_DISABLE_BT_LOGS = "disable_bt_logs"
+CONF_CONNECTION_TIMEOUT = "connection_timeout"
 
 NO_BLUETOOTH_VARIANTS = [const.VARIANT_ESP32S2]
 
@@ -166,6 +167,11 @@ CONFIG_SCHEMA = cv.Schema(
         ): cv.positive_time_period_milliseconds,
         cv.SplitDefault(CONF_DISABLE_BT_LOGS, esp32_idf=True): cv.All(
             cv.only_with_esp_idf, cv.boolean
+        ),
+        cv.Optional(CONF_CONNECTION_TIMEOUT, default="20s"): cv.All(
+            cv.only_with_esp_idf,
+            cv.positive_time_period_seconds,
+            cv.Range(min=TimePeriod(seconds=1), max=TimePeriod(seconds=180)),
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)
@@ -254,6 +260,17 @@ async def to_code(config):
             for logger in BTLoggers:
                 if logger not in _required_loggers:
                     add_idf_sdkconfig_option(f"{logger.value}_NONE", True)
+
+        # Set BLE connection establishment timeout to match aioesphomeapi/bleak-retry-connector
+        # Default is 20 seconds instead of ESP-IDF's 30 seconds. Because there is no way to
+        # cancel a BLE connection in progress, when aioesphomeapi times out at 20 seconds,
+        # the connection slot remains occupied for the remaining time, preventing new connection
+        # attempts and wasting valuable connection slots.
+        if CONF_CONNECTION_TIMEOUT in config:
+            timeout_seconds = int(config[CONF_CONNECTION_TIMEOUT].total_seconds)
+            add_idf_sdkconfig_option(
+                "CONFIG_BT_BLE_ESTAB_LINK_CONN_TOUT", timeout_seconds
+            )
 
     cg.add_define("USE_ESP32_BLE")
 

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -171,7 +171,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.SplitDefault(CONF_CONNECTION_TIMEOUT, esp32_idf="20s"): cv.All(
             cv.only_with_esp_idf,
             cv.positive_time_period_seconds,
-            cv.Range(min=TimePeriod(seconds=1), max=TimePeriod(seconds=180)),
+            cv.Range(min=TimePeriod(seconds=10), max=TimePeriod(seconds=180)),
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a configurable BLE connection establishment timeout to the `esp32_ble` component with a default of 20 seconds (down from ESP-IDF's default of 30 seconds).

The problem: When using ESPHome as a Bluetooth proxy, aioesphomeapi and bleak-retry-connector timeout BLE connection attempts after 20 seconds. However, ESP-IDF continues trying to connect for 30 seconds. Since there's no way to cancel a BLE connection in progress in ESP-IDF, this mismatch causes connection slots to remain occupied for an additional 10 seconds after the client has already given up. This wastes valuable connection slots and prevents new connection attempts during that time.

The solution: By aligning the ESP-IDF timeout with the client-side timeout (20 seconds), connection slots are freed immediately when the client times out, allowing for faster retries and better resource utilization.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes connection slot exhaustion when using ESPHome as a Bluetooth proxy with Home Assistant

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5196

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default configuration (20 second timeout)
esp32_ble:

# Custom timeout configuration
esp32_ble:
  connection_timeout: 25s  # Range: 1-180 seconds

# Example with Bluetooth proxy
esp32_ble:
  connection_timeout: 20s  # Matches aioesphomeapi/bleak-retry-connector timeout

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).