### PR TITLE
[bluetooth_proxy] Optimize memory usage with fixed-size array and const string references

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -35,8 +35,8 @@ void BluetoothProxy::setup() {
   // Don't pre-allocate pool - let it grow only if needed in busy environments
   // Many devices in quiet areas will never need the overflow pool
 
-  this->connections_free_response_.limit = this->connections_.size();
-  this->connections_free_response_.free = this->connections_.size();
+  this->connections_free_response_.limit = this->connection_count_;
+  this->connections_free_response_.free = this->connection_count_;
 
   this->parent_->add_scanner_state_callback([this](esp32_ble_tracker::ScannerState state) {
     if (this->api_connection_ != nullptr) {
@@ -134,12 +134,13 @@ void BluetoothProxy::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Active: %s\n"
                 "  Connections: %d",
-                YESNO(this->active_), this->connections_.size());
+                YESNO(this->active_), this->connection_count_);
 }
 
 void BluetoothProxy::loop() {
   if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr) {
-    for (auto *connection : this->connections_) {
+    for (uint8_t i = 0; i < this->connection_count_; i++) {
+      auto *connection = this->connections_[i];
       if (connection->get_address() != 0 && !connection->disconnect_pending()) {
         connection->disconnect();
       }
@@ -162,7 +163,8 @@ esp32_ble_tracker::AdvertisementParserType BluetoothProxy::get_advertisement_par
 }
 
 BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool reserve) {
-  for (auto *connection : this->connections_) {
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    auto *connection = this->connections_[i];
     if (connection->get_address() == address)
       return connection;
   }
@@ -170,7 +172,8 @@ BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool rese
   if (!reserve)
     return nullptr;
 
-  for (auto *connection : this->connections_) {
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    auto *connection = this->connections_[i];
     if (connection->get_address() == 0) {
       connection->send_service_ = DONE_SENDING_SERVICES;
       connection->set_address(address);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -35,8 +35,8 @@ void BluetoothProxy::setup() {
   // Don't pre-allocate pool - let it grow only if needed in busy environments
   // Many devices in quiet areas will never need the overflow pool
 
-  this->connections_free_response_.limit = this->connection_count_;
-  this->connections_free_response_.free = this->connection_count_;
+  this->connections_free_response_.limit = BLUETOOTH_PROXY_MAX_CONNECTIONS;
+  this->connections_free_response_.free = BLUETOOTH_PROXY_MAX_CONNECTIONS;
 
   this->parent_->add_scanner_state_callback([this](esp32_ble_tracker::ScannerState state) {
     if (this->api_connection_ != nullptr) {

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -66,7 +66,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
                        (uint8_t) (this->address_ >> 0) & 0xff);
     }
   }
-  std::string address_str() const { return this->address_str_; }
+  const std::string &address_str() const { return this->address_str_; }
 
   BLEService *get_service(espbt::ESPBTUUID uuid);
   BLEService *get_service(uint16_t uuid);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `bluetooth_proxy` component to reduce both flash and RAM usage:

1. **Optimize string handling in logging**: Changed `address_str()` method in `BLEClientBase` to return a const reference instead of by value, eliminating unnecessary string copies during frequent logging operations.

2. **Replace dynamic vector with fixed array**: Converted the `connections_` vector to a fixed-size `std::array` since all connection objects are created at compile time and the count never changes. This eliminates:
   - 12 bytes of RAM on 32-bit systems (vector's internal pointer, size, and capacity members)
   - Dynamic memory allocation for the vector's buffer
   - Heap fragmentation
   - Code for dynamic memory management

These optimizations result in:
- **576 bytes of flash savings**
- **12+ bytes of RAM savings** (12 bytes for vector overhead plus heap allocation overhead)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Requires https://github.com/esphome/esphome/pull/10010 (adds `BLUETOOTH_PROXY_MAX_CONNECTIONS` define)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-visible changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
bluetooth_proxy:
  active: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).