### PR TITLE
[core] Convert components, devices, and areas vectors to static allocation

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -454,12 +454,7 @@ class Application {
   const char *comment_{nullptr};
   const char *compilation_time_{nullptr};
 
-  // size_t members
-  size_t dump_config_at_{SIZE_MAX};
-
-  // Vectors (largest members)
-  StaticVector<Component *, ESPHOME_COMPONENT_COUNT> components_{};
-
+  // std::vector (3 pointers each: begin, end, capacity)
   // Partitioned vector design for looping components
   // =================================================
   // Components are partitioned into [active | inactive] sections:
@@ -477,6 +472,48 @@ class Application {
   //   and active_end_ is incremented
   // - This eliminates branch mispredictions from flag checking in the hot loop
   std::vector<Component *> looping_components_{};
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
+#endif
+
+  // std::string members (typically 24-32 bytes each)
+  std::string name_;
+  std::string friendly_name_;
+
+  // size_t members
+  size_t dump_config_at_{SIZE_MAX};
+
+  // 4-byte members
+  uint32_t last_loop_{0};
+  uint32_t loop_component_start_time_{0};
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  int max_fd_{-1};  // Highest file descriptor number for select()
+#endif
+
+  // 2-byte members (grouped together for alignment)
+  uint16_t loop_interval_{16};                 // Loop interval in ms (max 65535ms = 65.5 seconds)
+  uint16_t looping_components_active_end_{0};  // Index marking end of active components in looping_components_
+  uint16_t current_loop_index_{0};             // For safe reentrant modifications during iteration
+
+  // 1-byte members (grouped together to minimize padding)
+  uint8_t app_state_{0};
+  bool name_add_mac_suffix_;
+  bool in_loop_{false};
+  volatile bool has_pending_enable_loop_requests_{false};
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
+#endif
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  // Variable-sized members
+  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
+  fd_set read_fds_{};       // Working fd_set for select(), copied from base_read_fds_
+#endif
+
+  // StaticVectors (largest members - contain actual array data inline)
+  StaticVector<Component *, ESPHOME_COMPONENT_COUNT> components_{};
 
 #ifdef USE_DEVICES
   StaticVector<Device *, ESPHOME_DEVICE_COUNT> devices_{};
@@ -547,41 +584,6 @@ class Application {
 #endif
 #ifdef USE_UPDATE
   StaticVector<update::UpdateEntity *, ESPHOME_ENTITY_UPDATE_COUNT> updates_{};
-#endif
-
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
-#endif
-
-  // String members
-  std::string name_;
-  std::string friendly_name_;
-
-  // 4-byte members
-  uint32_t last_loop_{0};
-  uint32_t loop_component_start_time_{0};
-
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  int max_fd_{-1};  // Highest file descriptor number for select()
-#endif
-
-  // 2-byte members (grouped together for alignment)
-  uint16_t loop_interval_{16};  // Loop interval in ms (max 65535ms = 65.5 seconds)
-  uint16_t looping_components_active_end_{0};
-  uint16_t current_loop_index_{0};  // For safe reentrant modifications during iteration
-
-  // 1-byte members (grouped together to minimize padding)
-  uint8_t app_state_{0};
-  bool name_add_mac_suffix_;
-  bool in_loop_{false};
-  volatile bool has_pending_enable_loop_requests_{false};
-
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
-
-  // Variable-sized members at end
-  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
-  fd_set read_fds_{};       // Working fd_set for select(), copied from base_read_fds_
 #endif
 };
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -214,14 +214,6 @@ class Application {
 #endif
 
   /// Reserve space for components to avoid memory fragmentation
-  void reserve_components(size_t count) { this->components_.reserve(count); }
-
-#ifdef USE_AREAS
-  void reserve_area(size_t count) { this->areas_.reserve(count); }
-#endif
-#ifdef USE_DEVICES
-  void reserve_device(size_t count) { this->devices_.reserve(count); }
-#endif
 
   /// Register the component in this Application instance.
   template<class C> C *register_component(C *c) {
@@ -316,7 +308,7 @@ class Application {
     } \
     return nullptr; \
   }
-  const std::vector<Device *> &get_devices() { return this->devices_; }
+  const auto &get_devices() { return this->devices_; }
 #else
 #define GET_ENTITY_METHOD(entity_type, entity_name, entities_member) \
   entity_type *get_##entity_name##_by_key(uint32_t key, bool include_internal = false) { \
@@ -328,7 +320,7 @@ class Application {
   }
 #endif  // USE_DEVICES
 #ifdef USE_AREAS
-  const std::vector<Area *> &get_areas() { return this->areas_; }
+  const auto &get_areas() { return this->areas_; }
 #endif
 #ifdef USE_BINARY_SENSOR
   auto &get_binary_sensors() const { return this->binary_sensors_; }
@@ -466,7 +458,7 @@ class Application {
   size_t dump_config_at_{SIZE_MAX};
 
   // Vectors (largest members)
-  std::vector<Component *> components_{};
+  StaticVector<Component *, ESPHOME_COMPONENT_COUNT> components_{};
 
   // Partitioned vector design for looping components
   // =================================================
@@ -487,10 +479,10 @@ class Application {
   std::vector<Component *> looping_components_{};
 
 #ifdef USE_DEVICES
-  std::vector<Device *> devices_{};
+  StaticVector<Device *, ESPHOME_DEVICE_COUNT> devices_{};
 #endif
 #ifdef USE_AREAS
-  std::vector<Area *> areas_{};
+  StaticVector<Area *, ESPHOME_AREA_COUNT> areas_{};
 #endif
 #ifdef USE_BINARY_SENSOR
   StaticVector<binary_sensor::BinarySensor *, ESPHOME_ENTITY_BINARY_SENSOR_COUNT> binary_sensors_{};

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -444,10 +444,8 @@ async def to_code(config: ConfigType) -> None:
             config[CONF_NAME_ADD_MAC_SUFFIX],
         )
     )
-    # Reserve space for components to avoid reallocation during registration
-    cg.add(
-        cg.RawStatement(f"App.reserve_components({len(CORE.component_ids)});"),
-    )
+    # Define component count for static allocation
+    cg.add_define("ESPHOME_COMPONENT_COUNT", len(CORE.component_ids))
 
     CORE.add_job(_add_platform_reserves)
 
@@ -516,8 +514,8 @@ async def to_code(config: ConfigType) -> None:
     all_areas.extend(config[CONF_AREAS])
 
     if all_areas:
-        cg.add(cg.RawStatement(f"App.reserve_area({len(all_areas)});"))
         cg.add_define("USE_AREAS")
+        cg.add_define("ESPHOME_AREA_COUNT", len(all_areas))
 
         for area_conf in all_areas:
             area_id: core.ID = area_conf[CONF_ID]
@@ -534,9 +532,9 @@ async def to_code(config: ConfigType) -> None:
     if not devices:
         return
 
-    # Reserve space for devices
-    cg.add(cg.RawStatement(f"App.reserve_device({len(devices)});"))
+    # Define device count for static allocation
     cg.add_define("USE_DEVICES")
+    cg.add_define("ESPHOME_DEVICE_COUNT", len(devices))
 
     # Process each device
     for dev_conf in devices:

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -240,7 +240,10 @@
 
 #define USE_DASHBOARD_IMPORT
 
-// Default entity counts for static analysis
+// Default counts for static analysis
+#define ESPHOME_COMPONENT_COUNT 50
+#define ESPHOME_DEVICE_COUNT 10
+#define ESPHOME_AREA_COUNT 10
 #define ESPHOME_ENTITY_ALARM_CONTROL_PANEL_COUNT 1
 #define ESPHOME_ENTITY_BINARY_SENSOR_COUNT 1
 #define ESPHOME_ENTITY_BUTTON_COUNT 1

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <string>
@@ -100,6 +101,8 @@ template<typename T, size_t N> class StaticVector {
   using value_type = T;
   using iterator = typename std::array<T, N>::iterator;
   using const_iterator = typename std::array<T, N>::const_iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
  private:
   std::array<T, N> data_{};
@@ -114,6 +117,7 @@ template<typename T, size_t N> class StaticVector {
   }
 
   size_t size() const { return count_; }
+  bool empty() const { return count_ == 0; }
 
   T &operator[](size_t i) { return data_[i]; }
   const T &operator[](size_t i) const { return data_[i]; }
@@ -123,6 +127,12 @@ template<typename T, size_t N> class StaticVector {
   iterator end() { return data_.begin() + count_; }
   const_iterator begin() const { return data_.begin(); }
   const_iterator end() const { return data_.begin() + count_; }
+
+  // Reverse iterators
+  reverse_iterator rbegin() { return reverse_iterator(end()); }
+  reverse_iterator rend() { return reverse_iterator(begin()); }
+  const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+  const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
 };
 
 ///@}


### PR DESCRIPTION
# What does this implement/fix?

This PR extends the static allocation optimization from #10018 to the `components_`, `devices_`, and `areas_` vectors in the Application class. These vectors are now allocated with a fixed size at compile time based on the actual counts from the YAML configuration, eliminating heap allocations and fragmentation.

**Key improvements:**
- Converts `std::vector` to `StaticVector` for deterministic memory usage
- Eliminates heap allocation overhead and fragmentation
- Provides compile-time memory allocation based on YAML configuration
- Reduces flash usage by removing dynamic allocation code

**Memory impact:**
- Small configs: ~264 bytes flash saved, minimal net RAM change
- Large configs: ~924 bytes flash saved, significant heap memory freed
- All configs: Eliminates heap fragmentation and provides predictable memory usage

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** 

- Follow-up to #10018

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** 

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# The defines are automatically generated based on your existing configuration

# Example showing areas and devices that benefit from this optimization:
esphome:
  name: my-device
  area: Living Room

area:
  - id: bedroom
    name: "Bedroom"
  - id: kitchen
    name: "Kitchen"

device:
  - id: lamp1
    name: "Bedroom Lamp"
    area_id: bedroom
  - id: lamp2
    name: "Kitchen Light"
    area_id: kitchen
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Implementation Details

### Changes Made:

1. **Added compile-time defines** in `core/config.py`:
   - `ESPHOME_COMPONENT_COUNT` - based on `len(CORE.component_ids)`
   - `ESPHOME_DEVICE_COUNT` - based on devices in YAML
   - `ESPHOME_AREA_COUNT` - based on areas in YAML

2. **Enhanced StaticVector** in `core/helpers.h`:
   - Added `empty()` method
   - Added reverse iterator support (`rbegin()`, `rend()`)
   - Added `<iterator>` include for `std::reverse_iterator`

3. **Converted vectors** in `core/application.h`:
   - `std::vector<Component *>` → `StaticVector<Component *, ESPHOME_COMPONENT_COUNT>`
   - `std::vector<Device *>` → `StaticVector<Device *, ESPHOME_DEVICE_COUNT>`
   - `std::vector<Area *>` → `StaticVector<Area *, ESPHOME_AREA_COUNT>`

4. **Updated member ordering** in `application.h`:
   - Reordered members by size to minimize padding
   - Moved StaticVectors to the end (largest members with inline arrays)
   - Preserved important comments (partitioned vector design)

5. **Added default counts** in `core/defines.h` for static analysis:
   - `ESPHOME_COMPONENT_COUNT 50`
   - `ESPHOME_DEVICE_COUNT 10`
   - `ESPHOME_AREA_COUNT 10`

### Testing Results:

**Small Device (ESP32-IDF):**
- Flash: 517,226 → 516,962 bytes (-264 bytes)
- Static RAM: 16,060 → 16,124 bytes (+64 bytes)
- Heap free: 302,732 → 302,808 bytes (+76 bytes)
- Net RAM saved: 12 bytes

**Large Device (ESP32-IDF):**
- Flash: 1,095,150 → 1,094,226 bytes (-924 bytes)
- Static RAM: 35,156 → 35,436 bytes (+280 bytes)
- Heap measurements show variability but trend toward more free heap

The optimization successfully reduces flash usage and eliminates heap fragmentation while maintaining compatibility with all existing configurations.