### PR TITLE
[core] Fix compilation errors when platform sections have no entities

### DIFF
--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -348,4 +348,3 @@ async def alarm_control_panel_is_armed_to_code(
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(alarm_control_panel_ns.using)
-    cg.add_define("USE_ALARM_CONTROL_PANEL")

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -654,7 +654,6 @@ async def binary_sensor_is_off_to_code(config, condition_id, template_arg, args)
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_BINARY_SENSOR")
     cg.add_global(binary_sensor_ns.using)
 
 

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -137,4 +137,3 @@ async def button_press_to_code(config, action_id, template_arg, args):
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(button_ns.using)
-    cg.add_define("USE_BUTTON")

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -519,5 +519,4 @@ async def climate_control_to_code(config, action_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_CLIMATE")
     cg.add_global(climate_ns.using)

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -265,5 +265,4 @@ async def cover_control_to_code(config, action_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_COVER")
     cg.add_global(cover_ns.using)

--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -164,7 +164,6 @@ async def register_datetime(var, config):
     cg.add(getattr(cg.App, f"register_{entity_type}")(var))
     CORE.register_platform_component(entity_type, var)
     await setup_datetime_core_(var, config)
-    cg.add_define(f"USE_DATETIME_{config[CONF_TYPE]}")
 
 
 async def new_datetime(config, *args):
@@ -175,7 +174,6 @@ async def new_datetime(config, *args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_DATETIME")
     cg.add_global(datetime_ns.using)
 
 

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -145,5 +145,4 @@ async def event_fire_to_code(config, action_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_EVENT")
     cg.add_global(event_ns.using)

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -400,5 +400,4 @@ async def fan_is_on_off_to_code(config, condition_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_FAN")
     cg.add_global(fan_ns.using)

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -285,5 +285,4 @@ async def new_light(config, *args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_LIGHT")
     cg.add_global(light_ns.using)

--- a/esphome/components/lock/__init__.py
+++ b/esphome/components/lock/__init__.py
@@ -158,4 +158,3 @@ async def lock_is_off_to_code(config, condition_id, template_arg, args):
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(lock_ns.using)
-    cg.add_define("USE_LOCK")

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -323,7 +323,6 @@ async def number_in_range_to_code(config, condition_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_NUMBER")
     cg.add_global(number_ns.using)
 
 

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -126,7 +126,6 @@ async def new_select(config, *, options: list[str]):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_SELECT")
     cg.add_global(select_ns.using)
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -1139,5 +1139,4 @@ def _lstsq(a, b):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_SENSOR")
     cg.add_global(sensor_ns.using)

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -202,4 +202,3 @@ async def switch_is_off_to_code(config, condition_id, template_arg, args):
 @coroutine_with_priority(100.0)
 async def to_code(config):
     cg.add_global(switch_ns.using)
-    cg.add_define("USE_SWITCH")

--- a/esphome/components/text/__init__.py
+++ b/esphome/components/text/__init__.py
@@ -151,7 +151,6 @@ async def new_text(
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_TEXT")
     cg.add_global(text_ns.using)
 
 

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -232,7 +232,6 @@ async def new_text_sensor(config, *args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_TEXT_SENSOR")
     cg.add_global(text_sensor_ns.using)
 
 

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -126,7 +126,6 @@ async def new_update(config):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_UPDATE")
     cg.add_global(update_ns.using)
 
 

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -235,5 +235,4 @@ async def valve_control_to_code(config, action_id, template_arg, args):
 
 @coroutine_with_priority(100.0)
 async def to_code(config):
-    cg.add_define("USE_VALVE")
     cg.add_global(valve_ns.using)

--- a/tests/components/datetime/common.yaml
+++ b/tests/components/datetime/common.yaml
@@ -1,3 +1,5 @@
 datetime:
 
+date:
+
 time:

--- a/tests/components/datetime/common.yaml
+++ b/tests/components/datetime/common.yaml
@@ -1,5 +1,3 @@
 datetime:
 
-date:
-
 time:


### PR DESCRIPTION
# What does this implement/fix?

This fixes a compilation error introduced in #10018 where empty platform sections (e.g., `text:`, `binary_sensor:`) in YAML configurations would cause build failures due to missing `ESPHOME_ENTITY_*_COUNT` defines.

**More importantly**, this PR also fixes a significant code bloat issue: Previously, if a component loaded a platform (like `binary_sensor:`) but created no entities, ESPHome would still compile all the binary sensor code into the firmware. This resulted in unnecessary flash usage and memory overhead from dead code that could never be used.

The issue occurred because:
1. Empty platform sections still load their components, which previously added `USE_*` defines unconditionally
2. These `USE_*` defines caused all platform-specific code to be compiled, even with zero entities
3. After #10018, this also caused compilation errors due to missing `ESPHOME_ENTITY_*_COUNT` defines

This PR moves the responsibility of adding `USE_*` defines from individual platform components to the core config system, ensuring they are only defined when actual entities exist. This means:
- No compilation errors from missing count defines
- No dead code compiled for platforms with zero entities
- Reduced flash usage and memory footprint

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes compilation errors when using empty platform sections after #10018

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration would previously fail to compile after #10018
esphome:
  name: test-device

esp32:
  board: esp32dev

# Empty platform sections - no actual entities defined
binary_sensor:
switch:
text:
sensor:

# Platform with actual entities
datetime:
  - platform: template
    id: my_date
    type: date
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).