### PR TITLE
[gt911] Use timeout instead of delay, shortened log msg

### DIFF
--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -93,11 +93,11 @@ void GT911Touchscreen::setup_internal_() {
 }
 
 void GT911Touchscreen::update_touches() {
+  this->skip_update_ = true;  // skip send touch events by default, set to false after successful error checks
   if (!this->setup_done_) {
     return;
   }
 
-  this->skip_update_ = true;  // skip send touch events by default, set to false after successful error checks
   i2c::ErrorCode err;
   uint8_t touch_state = 0;
   uint8_t data[MAX_TOUCHES + 1][8];  // 8 bytes each for each point, plus extra space for the key byte

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -26,8 +26,6 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 void GT911Touchscreen::setup() {
   if (this->reset_pin_ != nullptr) {
-    // pull reset pin low for 2ms
-    this->status_set_warning("reset");
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {
@@ -36,19 +34,14 @@ void GT911Touchscreen::setup() {
       this->interrupt_pin_->digital_write(false);
     }
     delay(2);
-    this->reset_pin_->digital_write(true);
-    // continue setup 50ms after reset
+    this->reset_pin_->digital_write(true);  // wait 50ms after reset
     this->set_timeout(50, [this] { this->setup_internal_(); });
     return;
   }
-
-  // continue setup
   this->setup_internal_();
 }
 
 void GT911Touchscreen::setup_internal_() {
-  this->status_clear_warning();
-
   if (this->interrupt_pin_ != nullptr) {
     // set pre-configured input mode
     this->interrupt_pin_->setup();
@@ -96,17 +89,15 @@ void GT911Touchscreen::setup_internal_() {
     this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
     return;
   }
-
   this->setup_done_ = true;
 }
 
 void GT911Touchscreen::update_touches() {
-  this->skip_update_ = true;  // skip send touch events, touchscreen is not ready yet.
-
   if (!this->setup_done_) {
     return;
   }
 
+  this->skip_update_ = true;  // skip send touch events by default, set to false after successful error checks
   i2c::ErrorCode err;
   uint8_t touch_state = 0;
   uint8_t data[MAX_TOUCHES + 1][8];  // 8 bytes each for each point, plus extra space for the key byte
@@ -128,8 +119,7 @@ void GT911Touchscreen::update_touches() {
   err = this->read(data[0], sizeof(data[0]) * num_of_touches + 1);
   ERROR_CHECK(err);
 
-  // All error checks passed, send touch events
-  this->skip_update_ = false;
+  this->skip_update_ = false;  // All error checks passed, send touch events
   for (uint8_t i = 0; i != num_of_touches; i++) {
     uint16_t id = data[i][0];
     uint16_t x = encode_uint16(data[i][2], data[i][1]);

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -49,8 +49,7 @@ void GT911Touchscreen::setup_internal_() {
 
   // check the configuration of the int line.
   uint8_t data[4];
-  i2c::ErrorCode err;
-  err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
+  i2c::ErrorCode err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
   if (err != i2c::ERROR_OK && this->address_ == PRIMARY_ADDRESS) {
     this->address_ = SECONDARY_ADDRESS;
     err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -20,13 +20,15 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 #define ERROR_CHECK(err) \
   if ((err) != i2c::ERROR_OK) { \
-    this->status_set_warning("Communication failure"); \
+    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL); \
     return; \
   }
 
 void GT911Touchscreen::setup() {
   i2c::ErrorCode err;
   if (this->reset_pin_ != nullptr) {
+    // pull reset pin low for 2ms
+    this->status_set_warning("resetting");
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {
@@ -36,8 +38,18 @@ void GT911Touchscreen::setup() {
     }
     delay(2);
     this->reset_pin_->digital_write(true);
-    delay(50);  // NOLINT
+    // continue setup 50ms after reset
+    this->set_timeout(50, [this] { this->setup_internal_(); });
+    return;
   }
+
+  // continue setup
+  this->setup_internal_();
+}
+
+void GT911Touchscreen::setup_internal_() {
+  this->status_clear_warning();
+
   if (this->interrupt_pin_ != nullptr) {
     // set pre-configured input mode
     this->interrupt_pin_->setup();
@@ -45,7 +57,7 @@ void GT911Touchscreen::setup() {
 
   // check the configuration of the int line.
   uint8_t data[4];
-  err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
+  i2c::ErrorCode err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
   if (err != i2c::ERROR_OK && this->address_ == PRIMARY_ADDRESS) {
     this->address_ = SECONDARY_ADDRESS;
     err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
@@ -53,7 +65,7 @@ void GT911Touchscreen::setup() {
   if (err == i2c::ERROR_OK) {
     err = this->read(data, 1);
     if (err == i2c::ERROR_OK) {
-      ESP_LOGD(TAG, "Read from switches at address 0x%02X: 0x%02X", this->address_, data[0]);
+      ESP_LOGD(TAG, "Switches ADDR: 0x%02X DATA: 0x%02X", this->address_, data[0]);
       if (this->interrupt_pin_ != nullptr) {
         this->attach_interrupt_(this->interrupt_pin_,
                                 (data[0] & 1) ? gpio::INTERRUPT_FALLING_EDGE : gpio::INTERRUPT_RISING_EDGE);
@@ -75,16 +87,26 @@ void GT911Touchscreen::setup() {
       }
     }
     if (err != i2c::ERROR_OK) {
-      this->mark_failed("Failed to read calibration");
+      this->mark_failed("Calibration error");
       return;
     }
   }
+
   if (err != i2c::ERROR_OK) {
-    this->mark_failed("Failed to communicate");
+    this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
+    return;
   }
+
+  this->setup_done_ = true;
 }
 
 void GT911Touchscreen::update_touches() {
+  this->skip_update_ = true;  // skip send touch events, touchscreen is not ready yet.
+
+  if (!this->setup_done_) {
+    return;
+  }
+
   i2c::ErrorCode err;
   uint8_t touch_state = 0;
   uint8_t data[MAX_TOUCHES + 1][8];  // 8 bytes each for each point, plus extra space for the key byte
@@ -97,7 +119,6 @@ void GT911Touchscreen::update_touches() {
   uint8_t num_of_touches = touch_state & 0x07;
 
   if ((touch_state & 0x80) == 0 || num_of_touches > MAX_TOUCHES) {
-    this->skip_update_ = true;  // skip send touch events, touchscreen is not ready yet.
     return;
   }
 
@@ -107,6 +128,8 @@ void GT911Touchscreen::update_touches() {
   err = this->read(data[0], sizeof(data[0]) * num_of_touches + 1);
   ERROR_CHECK(err);
 
+  // All error checks passed, send touch events
+  this->skip_update_ = false;
   for (uint8_t i = 0; i != num_of_touches; i++) {
     uint16_t id = data[i][0];
     uint16_t x = encode_uint16(data[i][2], data[i][1]);

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -25,7 +25,6 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
   }
 
 void GT911Touchscreen::setup() {
-  i2c::ErrorCode err;
   if (this->reset_pin_ != nullptr) {
     // pull reset pin low for 2ms
     this->status_set_warning("resetting");
@@ -57,7 +56,8 @@ void GT911Touchscreen::setup_internal_() {
 
   // check the configuration of the int line.
   uint8_t data[4];
-  i2c::ErrorCode err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
+  i2c::ErrorCode err;
+  err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
   if (err != i2c::ERROR_OK && this->address_ == PRIMARY_ADDRESS) {
     this->address_ = SECONDARY_ADDRESS;
     err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -27,7 +27,7 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 void GT911Touchscreen::setup() {
   if (this->reset_pin_ != nullptr) {
     // pull reset pin low for 2ms
-    this->status_set_warning("resetting");
+    this->status_set_warning("reset");
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -28,7 +28,6 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
   /// is called to complete the initialization.
   void setup() override;
   void dump_config() override;
-  bool can_proceed() override { return this->setup_done_; }
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
   void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -28,6 +28,7 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
   /// is called to complete the initialization.
   void setup() override;
   void dump_config() override;
+  bool can_proceed() override { return this->setup_done_; }
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
   void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -15,6 +15,17 @@ class GT911ButtonListener {
 
 class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice {
  public:
+  /// @brief Initialize the GT911 touchscreen.
+  ///
+  /// If @ref reset_pin_ is set, the touchscreen will be hardware reset,
+  /// and the rest of the setup will be scheduled to run 50ms later using @ref set_timeout()
+  /// to allow the device to stabilize after reset.
+  ///
+  /// If @ref interrupt_pin_ is set, it will be temporarily configured during reset
+  /// to control I2C address selection.
+  ///
+  /// After the timeout, or immediately if no reset is performed, @ref setup_internal_()
+  /// is called to complete the initialization.
   void setup() override;
   void dump_config() override;
 
@@ -25,8 +36,20 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
  protected:
   void update_touches() override;
 
-  InternalGPIOPin *interrupt_pin_{};
-  GPIOPin *reset_pin_{};
+  /// @brief Perform the internal setup routine for the GT911 touchscreen.
+  ///
+  /// This function checks the I2C address, configures the interrupt pin (if available),
+  /// reads the touchscreen mode from the controller, and attempts to read calibration
+  /// data (maximum X and Y values) if not already set.
+  ///
+  /// On success, sets @ref setup_done_ to true.
+  /// On failure, calls @ref mark_failed() with an appropriate error message.
+  void setup_internal_();
+  /// @brief True if the touchscreen setup has completed successfully.
+  bool setup_done_{false};
+
+  InternalGPIOPin *interrupt_pin_{nullptr};
+  GPIOPin *reset_pin_{nullptr};
   std::vector<GT911ButtonListener *> button_listeners_;
   uint8_t button_state_{0xFF};  // last button state. Initial FF guarantees first update.
 };


### PR DESCRIPTION
# What does this implement/fix?

SSIA, a step towards https://github.com/esphome/backlog/issues/38

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
