### PR TITLE
[esp32] Add framework migration warning for upcoming ESP-IDF default change

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -724,7 +724,7 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
         + color(AnsiFore.WHITE, "        type: esp-idf\n")
         + "\n"
         + color(AnsiFore.CYAN, "  Option 2")
-        + ": Keep using Arduino (100% supported)\n"
+        + ": Keep using Arduino (still supported)\n"
         + "    Add this to your YAML under 'esp32:':\n"
         + color(AnsiFore.WHITE, "      framework:\n")
         + color(AnsiFore.WHITE, "        type: arduino\n")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -680,6 +680,58 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
 )
 
 
+def _show_framework_migration_message(name: str, _shown: list[bool] = []) -> None:
+    """Show a friendly message about framework migration when defaulting to Arduino."""
+    if _shown:
+        return
+    _shown.append(True)
+
+    from esphome.log import AnsiFore, color
+
+    message = (
+        color(
+            AnsiFore.BOLD_CYAN,
+            f"💡 IMPORTANT: {name} doesn't have a framework specified!",
+        )
+        + "\n\n"
+        + "Currently, ESP32 defaults to the Arduino framework.\n"
+        + color(AnsiFore.YELLOW, "This will change to ESP-IDF in ESPHome 2026.1.0.\n")
+        + "\n"
+        + "Why change? ESP-IDF offers:\n"
+        + color(AnsiFore.GREEN, "  ✨ Up to 40% smaller binaries\n")
+        + color(AnsiFore.GREEN, "  🚀 Better performance and optimization\n")
+        + color(AnsiFore.GREEN, "  📦 Custom-built firmware for your exact needs\n")
+        + color(
+            AnsiFore.GREEN,
+            "  🔧 Active development and testing by ESPHome developers\n",
+        )
+        + "\n"
+        + "Trade-offs:\n"
+        + color(AnsiFore.YELLOW, "  ⏱️  Compile times are ~25% longer\n")
+        + color(AnsiFore.YELLOW, "  🔄 Some components need migration\n")
+        + "\n"
+        + "What should I do?\n"
+        + color(AnsiFore.CYAN, "  Option 1")
+        + ": Migrate to ESP-IDF (recommended)\n"
+        + "    Add this to your YAML under 'esp32:':\n"
+        + color(AnsiFore.WHITE, "      framework:\n")
+        + color(AnsiFore.WHITE, "        type: esp-idf\n")
+        + "\n"
+        + color(AnsiFore.CYAN, "  Option 2")
+        + ": Keep using Arduino (100% supported)\n"
+        + "    Add this to your YAML under 'esp32:':\n"
+        + color(AnsiFore.WHITE, "      framework:\n")
+        + color(AnsiFore.WHITE, "        type: arduino\n")
+        + "\n"
+        + "Need help? Check out the migration guide:\n"
+        + color(
+            AnsiFore.BLUE,
+            "https://esphome.io/guides/esp32_arduino_to_idf.html",
+        )
+    )
+    _LOGGER.warning(message)
+
+
 def _set_default_framework(config):
     if CONF_FRAMEWORK not in config:
         config = config.copy()
@@ -688,6 +740,8 @@ def _set_default_framework(config):
         if variant in ARDUINO_ALLOWED_VARIANTS:
             config[CONF_FRAMEWORK] = ARDUINO_FRAMEWORK_SCHEMA({})
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
+            # Show the migration message
+            _show_framework_migration_message(config.get(CONF_NAME, "Your device"))
         else:
             config[CONF_FRAMEWORK] = ESP_IDF_FRAMEWORK_SCHEMA({})
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ESP_IDF

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -748,7 +748,7 @@ def _set_default_framework(config):
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
             # Show the migration message
             _show_framework_migration_message(
-                config.get(CONF_NAME, "Your device"), variant
+                config.get(CONF_NAME, "This device"), variant
             )
         else:
             config[CONF_FRAMEWORK] = ESP_IDF_FRAMEWORK_SCHEMA({})

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -684,7 +684,7 @@ class _FrameworkMigrationWarning:
     shown = False
 
 
-def _show_framework_migration_message(name: str) -> None:
+def _show_framework_migration_message(name: str, variant: str) -> None:
     """Show a friendly message about framework migration when defaulting to Arduino."""
     if _FrameworkMigrationWarning.shown:
         return
@@ -698,8 +698,10 @@ def _show_framework_migration_message(name: str) -> None:
             f"💡 IMPORTANT: {name} doesn't have a framework specified!",
         )
         + "\n\n"
-        + "Currently, ESP32 defaults to the Arduino framework.\n"
+        + f"Currently, {variant} defaults to the Arduino framework.\n"
         + color(AnsiFore.YELLOW, "This will change to ESP-IDF in ESPHome 2026.1.0.\n")
+        + "\n"
+        + "Note: Newer ESP32 variants (C6, H2, P4, etc.) already use ESP-IDF by default.\n"
         + "\n"
         + "Why change? ESP-IDF offers:\n"
         + color(AnsiFore.GREEN, "  ✨ Up to 40% smaller binaries\n")
@@ -745,7 +747,9 @@ def _set_default_framework(config):
             config[CONF_FRAMEWORK] = ARDUINO_FRAMEWORK_SCHEMA({})
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
             # Show the migration message
-            _show_framework_migration_message(config.get(CONF_NAME, "Your device"))
+            _show_framework_migration_message(
+                config.get(CONF_NAME, "Your device"), variant
+            )
         else:
             config[CONF_FRAMEWORK] = ESP_IDF_FRAMEWORK_SCHEMA({})
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ESP_IDF

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -680,11 +680,15 @@ ESP_IDF_FRAMEWORK_SCHEMA = cv.All(
 )
 
 
-def _show_framework_migration_message(name: str, _shown: list[bool] = []) -> None:
+class _FrameworkMigrationWarning:
+    shown = False
+
+
+def _show_framework_migration_message(name: str) -> None:
     """Show a friendly message about framework migration when defaulting to Arduino."""
-    if _shown:
+    if _FrameworkMigrationWarning.shown:
         return
-    _shown.append(True)
+    _FrameworkMigrationWarning.shown = True
 
     from esphome.log import AnsiFore, color
 

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -345,5 +345,11 @@ def get_esp32_arduino_flash_error_help() -> str | None:
         + "2. Clean build files and compile again\n"
         + "\n"
         + "Note: ESP-IDF uses less flash space and provides better performance.\n"
-        + "Some Arduino-specific libraries may need alternatives.\n\n"
+        + "Some Arduino-specific libraries may need alternatives.\n"
+        + "\n"
+        + "For detailed migration instructions, see:\n"
+        + color(
+            AnsiFore.BLUE,
+            "https://esphome.io/guides/esp32_arduino_to_idf.html\n\n",
+        )
     )


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a warning message for ESP32 configurations that don't explicitly specify a framework, informing users about the upcoming default change from Arduino to ESP-IDF in ESPHome 2026.1.0.

**Why this change is needed:**

Currently, ESP32 classic, ESP32-S2, ESP32-S3, and ESP32-C3 default to Arduino framework, which creates several problems:
- **Poor first impression**: New users may encounter compilation failures on their first project because Arduino 3.x is so large it doesn't fit in flash
- **Suboptimal experience**: Users get unoptimized, bloated binaries when ESP-IDF would provide up to 40% smaller firmware
- **Adoption barriers**: Users trying to switch from other platforms to ESPHome may give up when they hit flash space errors immediately
- **Inconsistency**: Newer variants (C6, H2, etc.) already default to ESP-IDF, creating confusion
- **Development focus**: Most ESPHome development and testing now happens on ESP-IDF, so Arduino framework users may experience more bugs and slower issue resolution

The ESP32 classic and ESP32-S3 are still the most commonly deployed variants, so this poor default affects the majority of new users.

**Key Changes:**
- Displays a colorful, informative warning when ESP32 defaults to Arduino framework
- Explains benefits of ESP-IDF (up to 40% smaller binaries, better performance)
- Acknowledges trade-offs (25% longer compile times, some components need migration)
- Provides clear YAML examples for both migration options
- Links to comprehensive migration guide
- Updates the existing "out of flash space" error to also link to the migration guide

The warning helps users make an informed choice about their framework before the default changes, ensuring a smooth transition period.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This addresses the need to prepare users for the upcoming default framework change in 2026.1.0, giving them ample time to either migrate to ESP-IDF or explicitly choose to stay with Arduino.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5200

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

**Configuration without framework (triggers warning):**
```yaml
esphome:
  name: my-device

esp32:
  board: esp32dev
  # No framework specified - will show warning

logger:
api:
```

**Configuration with explicit framework (no warning):**
```yaml
esphome:
  name: my-device

esp32:
  board: esp32dev
  framework:
    type: esp-idf  # or arduino

logger:
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

The warning is designed to:
1. Only display once per compilation (prevents spam)
2. Use friendly, approachable language with emojis
3. Present both options equally while recommending ESP-IDF
4. Provide immediate actionable solutions
5. Link to comprehensive documentation for more details

This gives users approximately 6 months to prepare for the change, ensuring no one is surprised when the default switches in 2026.1.0.