### PR TITLE
[web_server] Reduce binary size by using EntityBase and minimizing template instantiations

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -376,23 +376,31 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 }
 #endif
 
-#define set_json_id(root, obj, sensor, start_config) \
-  (root)["id"] = sensor; \
-  if (((start_config) == DETAIL_ALL)) { \
-    (root)["name"] = (obj)->get_name(); \
-    (root)["icon"] = (obj)->get_icon(); \
-    (root)["entity_category"] = (obj)->get_entity_category(); \
-    if ((obj)->is_disabled_by_default()) \
-      (root)["is_disabled_by_default"] = (obj)->is_disabled_by_default(); \
+// Helper functions to reduce code size by avoiding macro expansion
+static void set_json_id(JsonObject &root, EntityBase *obj, const std::string &id, JsonDetail start_config) {
+  root["id"] = id;
+  if (start_config == DETAIL_ALL) {
+    root["name"] = obj->get_name();
+    root["icon"] = obj->get_icon();
+    root["entity_category"] = obj->get_entity_category();
+    if (obj->is_disabled_by_default())
+      root["is_disabled_by_default"] = obj->is_disabled_by_default();
   }
+}
 
-#define set_json_value(root, obj, sensor, value, start_config) \
-  set_json_id((root), (obj), sensor, start_config); \
-  (root)["value"] = value;
+template<typename T>
+static void set_json_value(JsonObject &root, EntityBase *obj, const std::string &id, const T &value,
+                           JsonDetail start_config) {
+  set_json_id(root, obj, id, start_config);
+  root["value"] = value;
+}
 
-#define set_json_icon_state_value(root, obj, sensor, state, value, start_config) \
-  set_json_value(root, obj, sensor, value, start_config); \
-  (root)["state"] = state;
+template<typename T>
+static void set_json_icon_state_value(JsonObject &root, EntityBase *obj, const std::string &id,
+                                      const std::string &state, const T &value, JsonDetail start_config) {
+  set_json_value(root, obj, id, value, start_config);
+  root["state"] = state;
+}
 
 // Helper to get request detail parameter
 static JsonDetail get_request_detail(AsyncWebServerRequest *request) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -383,8 +383,9 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const std::string &id
     root["name"] = obj->get_name();
     root["icon"] = obj->get_icon();
     root["entity_category"] = obj->get_entity_category();
-    if (obj->is_disabled_by_default())
-      root["is_disabled_by_default"] = obj->is_disabled_by_default();
+    bool is_disabled = obj->is_disabled_by_default();
+    if (is_disabled)
+      root["is_disabled_by_default"] = is_disabled;
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the web_server component's JSON generation code to reduce binary size by:
- Converting macros to functions that accept `EntityBase*` pointers
- Using templates only for the value parameter where type variation is needed
- Eliminating repeated macro expansion at each call site

The optimization leverages the fact that all ESPHome entities inherit from `EntityBase`, allowing us to write common code once rather than having it duplicated through macro expansion. Templates are only used for the `value` parameter to handle different types (bool, float, string, enums), minimizing template instantiations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
web_server:
  port: 80
```

## Results

Flash usage reduction: **2,820 bytes** (measured on ESP32)
- Before: 1,093,078 bytes (59.6%)
- After: 1,090,258 bytes (59.4%)

## Technical Details

Changed from:
```cpp
// Macros that expand inline at every call site
#define set_json_id(root, obj, sensor, start_config) \
  (root)["id"] = sensor; \
  if (((start_config) == DETAIL_ALL)) { \
    (root)["name"] = (obj)->get_name(); \
    // ... more code
  }
```

To:
```cpp
// Function using EntityBase* - single copy in binary
static void set_json_id(JsonObject &root, EntityBase *obj, 
                       const std::string &id, JsonDetail start_config) {
  root["id"] = id;
  if (start_config == DETAIL_ALL) {
    root["name"] = obj->get_name();
    // ... more code
  }
}

// Template only for value parameter to handle different types
template<typename T>
static void set_json_icon_state_value(JsonObject &root, EntityBase *obj,
                                     const std::string &id,
                                     const std::string &state, const T &value, 
                                     JsonDetail start_config) {
  set_json_value(root, obj, id, value, start_config);
  root["state"] = state;
}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).