### PR TITLE
[wifi] Replace std::stable_sort with insertion sort to save 2.4KB flash

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -507,7 +507,7 @@ void WiFiComponent::start_scanning() {
 
 // Helper function for WiFi scan result comparison
 // Returns true if 'a' should be placed before 'b' in the sorted order
-static bool wifi_scan_result_is_better(const WiFiScanResult &a, const WiFiScanResult &b) {
+[[nodiscard]] inline static bool wifi_scan_result_is_better(const WiFiScanResult &a, const WiFiScanResult &b) {
   // Matching networks always come before non-matching
   if (a.get_matches() && !b.get_matches())
     return true;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -505,6 +505,54 @@ void WiFiComponent::start_scanning() {
   this->state_ = WIFI_COMPONENT_STATE_STA_SCANNING;
 }
 
+// Helper function for WiFi scan result comparison
+// Returns true if 'a' should be placed before 'b' in the sorted order
+static bool wifi_scan_result_is_better(const WiFiScanResult &a, const WiFiScanResult &b) {
+  // Matching networks always come before non-matching
+  if (a.get_matches() && !b.get_matches())
+    return true;
+  if (!a.get_matches() && b.get_matches())
+    return false;
+
+  if (a.get_matches() && b.get_matches()) {
+    // For APs with the same SSID, always prefer stronger signal
+    // This helps with mesh networks and multiple APs
+    if (a.get_ssid() == b.get_ssid()) {
+      return a.get_rssi() > b.get_rssi();
+    }
+
+    // For different SSIDs, check priority first
+    if (a.get_priority() != b.get_priority())
+      return a.get_priority() > b.get_priority();
+    // If priorities are equal, prefer stronger signal
+    return a.get_rssi() > b.get_rssi();
+  }
+
+  // Both don't match - sort by signal strength
+  return a.get_rssi() > b.get_rssi();
+}
+
+// Helper function for insertion sort of WiFi scan results
+// Using insertion sort instead of std::stable_sort saves flash memory
+// by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)
+// IMPORTANT: This sort is stable (preserves relative order of equal elements)
+static void insertion_sort_scan_results(std::vector<WiFiScanResult> &results) {
+  const size_t size = results.size();
+  for (size_t i = 1; i < size; i++) {
+    // Make a copy to avoid issues with move semantics during comparison
+    WiFiScanResult key = results[i];
+    int32_t j = i - 1;
+
+    // Move elements that are worse than key to the right
+    // For stability, we only move if key is strictly better than results[j]
+    while (j >= 0 && wifi_scan_result_is_better(key, results[j])) {
+      results[j + 1] = results[j];
+      j--;
+    }
+    results[j + 1] = key;
+  }
+}
+
 void WiFiComponent::check_scanning_finished() {
   if (!this->scan_done_) {
     if (millis() - this->action_started_ > 30000) {
@@ -535,30 +583,8 @@ void WiFiComponent::check_scanning_finished() {
     }
   }
 
-  std::stable_sort(this->scan_result_.begin(), this->scan_result_.end(),
-                   [](const WiFiScanResult &a, const WiFiScanResult &b) {
-                     // return true if a is better than b
-                     if (a.get_matches() && !b.get_matches())
-                       return true;
-                     if (!a.get_matches() && b.get_matches())
-                       return false;
-
-                     if (a.get_matches() && b.get_matches()) {
-                       // For APs with the same SSID, always prefer stronger signal
-                       // This helps with mesh networks and multiple APs
-                       if (a.get_ssid() == b.get_ssid()) {
-                         return a.get_rssi() > b.get_rssi();
-                       }
-
-                       // For different SSIDs, check priority first
-                       if (a.get_priority() != b.get_priority())
-                         return a.get_priority() > b.get_priority();
-                       // If priorities are equal, prefer stronger signal
-                       return a.get_rssi() > b.get_rssi();
-                     }
-
-                     return a.get_rssi() > b.get_rssi();
-                   });
+  // Sort scan results using insertion sort for better memory efficiency
+  insertion_sort_scan_results(this->scan_result_);
 
   for (auto &res : this->scan_result_) {
     char bssid_s[18];


### PR DESCRIPTION
# What does this implement/fix?

This PR replaces `std::stable_sort` with a custom insertion sort implementation for WiFi scan results, saving 2,440 bytes of flash memory and eliminating heap allocations on ESP32.

Following the same optimization approach as #10035, this targets another instance of `std::stable_sort` that has two major issues:
1. Causes unnecessary STL template instantiations consuming flash memory
2. Would allocate heap memory when >32 networks are found (malloc/new on ESP32)

WiFi scans typically return 5-60 networks, where insertion sort provides multiple benefits:
- **5-10 networks**: 20-24% faster than `std::stable_sort`
- **20 networks**: Similar performance
- **30+ networks**: `std::stable_sort` becomes faster, but still only ~0.5-1.7 microseconds difference
- **Zero heap allocations**: Avoids memory fragmentation regardless of network count

The optimization is ideal because:
1. Most home/office environments have 10-30 visible networks
2. Prevents heap allocation in crowded WiFi environments (>32 networks)
3. The sort happens once per scan (not in a hot loop)
4. Trading 2.4KB permanent flash and heap allocation avoidance for microseconds during scan is worthwhile
5. Maintains exact same behavior including stability

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation detail)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
wifi:
  ssid: "MyNetwork"
  password: "MyPassword"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

## Additional Testing

Comprehensive testing was performed to ensure the insertion sort produces identical results:

1. **Correctness verification**: Created test programs that verify both sorts produce identical output for all scenarios
2. **Stability testing**: Confirmed that networks with equal sort keys maintain their relative order
3. **Real-world scenarios**: Tested with realistic WiFi scan data including:
   - Multiple APs with same SSID (mesh networks)
   - Networks with different priorities
   - Hidden networks
   - 60+ network environments

4. **Performance benchmarks**:
   ```
   Networks | std::stable_sort | insertion_sort | Speedup
   ---------|------------------|----------------|--------
         5  |      61.1 ns     |     50.8 ns    | 1.20x
        10  |     130.8 ns     |    105.2 ns    | 1.24x
        20  |     305.2 ns     |    309.5 ns    | 0.99x
        30  |     414.8 ns     |    555.2 ns    | 0.75x
        60  |     837.2 ns     |   1734.8 ns    | 0.48x
   ```

5. **Flash memory savings** (ESP32, Arduino framework):
   - Before: 961,670 bytes
   - After: 959,230 bytes
   - **Savings: 2,440 bytes**

All tests confirm the optimization maintains identical behavior while providing meaningful flash savings.

