### PR TITLE
[core] Optimize Application::pre_setup() to reduce duplicate MAC address operations

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -101,12 +101,9 @@ class Application {
     arch_init();
     this->name_add_mac_suffix_ = name_add_mac_suffix;
     if (name_add_mac_suffix) {
-      this->name_ = name + "-" + get_mac_address().substr(6);
-      if (friendly_name.empty()) {
-        this->friendly_name_ = "";
-      } else {
-        this->friendly_name_ = friendly_name + " " + get_mac_address().substr(6);
-      }
+      const std::string mac_suffix = get_mac_address().substr(6);
+      this->name_ = name + "-" + mac_suffix;
+      this->friendly_name_ = friendly_name.empty() ? "" : friendly_name + " " + mac_suffix;
     } else {
       this->name_ = name;
       this->friendly_name_ = friendly_name;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `Application::pre_setup()` function to reduce flash usage by eliminating duplicate MAC address operations when adding MAC suffixes to device names.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Details

The optimization reduces flash usage by:
1. Calling `get_mac_address()` only once instead of twice when `name_add_mac_suffix` is enabled
2. Storing the MAC suffix in a local variable to avoid duplicate string operations
3. Using a ternary operator for cleaner conditional logic

### Measurements
- Before: Flash usage 511946 bytes
- After: Flash usage 511850 bytes
- **Savings: 96 bytes**

This change maintains identical functionality while reducing code size through more efficient string handling.