### PR TITLE
Generate md5 checksums for firmware bins

### DIFF
--- a/esphome/components/esp32/post_build.py.script
+++ b/esphome/components/esp32/post_build.py.script
@@ -1,5 +1,6 @@
 Import("env")  # noqa: F821
 
+import hashlib  # noqa: E402
 import itertools  # noqa: E402
 import json  # noqa: E402
 import os  # noqa: E402
@@ -109,6 +110,8 @@ def merge_factory_bin(source, target, env):
 
     if result == 0:
         print(f"Successfully created {output_path}")
+        # Create MD5 checksum for factory binary
+        create_ota_bin_md5(str(output_path))
     else:
         print(f"Error: esptool merge_bin failed with code {result}")
 
@@ -121,7 +124,32 @@ def esp32_copy_ota_bin(source, target, env):
     new_file_name = env.subst("$BUILD_DIR/${PROGNAME}.ota.bin")
     shutil.copyfile(firmware_name, new_file_name)
     print(f"Copied firmware to {new_file_name}")
+    # Create MD5 checksum for OTA binary
+    create_ota_bin_md5(new_file_name)
 
+def create_ota_bin_md5(original_file_name):
+    """
+    Calculate an md5 hash for the specified file, storing in {original_file_name}.md5 .
+    """
+    file_path = pathlib.Path(original_file_name)
+    if not file_path.exists():
+        print(f"Warning: File {original_file_name} not found - skipping MD5 calculation")
+        return
+
+    # Calculate MD5 hash
+    md5_hash = hashlib.md5()
+    with file_path.open('rb') as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            md5_hash.update(chunk)
+
+    calculated_hash = md5_hash.hexdigest()
+
+    # Write hash to .md5 file, following the gnu format. Compatible with md5sum.
+    md5_file_path = file_path.with_suffix(file_path.suffix + '.md5')
+    with md5_file_path.open('w') as f:
+        f.write(f"{calculated_hash} *{file_path.name}\n")
+
+    print(f"Calculated md5 hash for {original_file_name}: {calculated_hash}")
 
 # Run merge first, then ota copy second
 env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", merge_factory_bin)  # noqa: F821

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -716,7 +716,11 @@ class DownloadBinaryRequestHandler(BaseHandler):
 
         download_name = download_name + ".gz" if compressed else download_name
 
-        self.set_header("Content-Type", "application/octet-stream")
+        if file_name.endswith(".md5"):
+            self.set_header("Content-Type", "text/plain")
+        else:
+            self.set_header("Content-Type", "application/octet-stream")
+
         self.set_header(
             "Content-Disposition", f'attachment; filename="{download_name}"'
         )
@@ -725,8 +729,13 @@ class DownloadBinaryRequestHandler(BaseHandler):
             self.send_error(404)
             return
 
-        data = await loop.run_in_executor(None, self._load_file, path, compressed)
-        self.write(data)
+        # MD5 files should not be compressed and are text files
+        if file_name.endswith(".md5"):
+            with open(path, encoding="utf-8") as f:
+                self.write(f.read())
+        else:
+            data = await loop.run_in_executor(None, self._load_file, path, compressed)
+            self.write(data)
 
         self.finish()
 


### PR DESCRIPTION
# What does this implement/fix?

In order to allow `ota.http_request` to pull (pre-compiled) firmware directly from esphome, we need md5s available. So this adds md5 file generation to the post_build script -- which can then be download via the /download.bin endpoint.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none as far as i know :)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>
- ^^ TODO, definitely should update docs.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  name: testing-c6-2
  friendly_name: testing-c6-2

esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf
...

http_request:

ota:
  - platform: http_request

...

binary_sensor:
  - platform: gpio
    pin: GPIO09
    name: "ESP Toggle Button"
    on_press:
      then:
        - ota.http_request.flash:
            md5_url: http://homeassistant.local:6052/download.bin?configuration=testing-c6-2.yaml&file=firmware.ota.bin.md5&download=firmware.ota.bin.md5
            url: http://homeassistant.local:6052/download.bin?configuration=testing-c6-2.yaml&file=firmware.ota.bin&download=firmware.ota.bin
        - logger.log: "This message should be not displayed because the device reboots"


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - ^ DEFINITELY SHOULD DO PRE-MERGE