### PR TITLE
[web_server_idf] Replace std::find_if with simple loop to reduce binary size

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -423,14 +423,14 @@ void AsyncEventSourceResponse::destroy(void *ptr) {
 void AsyncEventSourceResponse::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
   DeferredEvent item(source, message_generator);
 
-  auto iter = std::find_if(this->deferred_queue_.begin(), this->deferred_queue_.end(),
-                           [&item](const DeferredEvent &test) -> bool { return test == item; });
-
-  if (iter != this->deferred_queue_.end()) {
-    (*iter) = item;
-  } else {
-    this->deferred_queue_.push_back(item);
+  // Replace std::find_if with simple loop to reduce binary size
+  for (auto &event : this->deferred_queue_) {
+    if (event == item) {
+      event = item;
+      return;
+    }
   }
+  this->deferred_queue_.push_back(item);
 }
 
 void AsyncEventSourceResponse::process_deferred_queue_() {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -423,7 +423,7 @@ void AsyncEventSourceResponse::destroy(void *ptr) {
 void AsyncEventSourceResponse::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
   DeferredEvent item(source, message_generator);
 
-  // Replace std::find_if with simple loop to reduce binary size
+  // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
   for (auto &event : this->deferred_queue_) {
     if (event == item) {
       event = item;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `deq_push_back_with_dedup_` function in the ESP-IDF web server implementation by replacing `std::find_if` with a lambda with a simple range-based for loop. This reduces the binary size by eliminating template instantiation and lambda capture overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Information

This optimization was identified while analyzing the largest symbols in the web_server_idf component. The `deq_push_back_with_dedup_` function was consuming 451 bytes of flash memory, making it the largest symbol in the component.

### Before:
- Flash: 511850 bytes (27.9%)
- Used `std::find_if` with lambda expression

### After:  
- Flash: 511566 bytes (27.9%)
- Uses simple range-based for loop
- **Saves: 284 bytes**

The functionality remains exactly the same - the function still deduplicates entries in the deferred event queue by checking if an item with the same source and message_generator already exists before adding it.