### PR TITLE
[config] Fix reversion of excessive yaml output after error

### DIFF
--- a/esphome/log.py
+++ b/esphome/log.py
@@ -37,6 +37,8 @@ class AnsiStyle(Enum):
 
 
 def color(col: AnsiFore, msg: str, reset: bool = True) -> str:
+    if col == AnsiFore.KEEP:
+        return msg
     s = col.value + msg
     if reset and col:
         s += AnsiStyle.RESET_ALL.value

--- a/tests/unit_tests/test_log.py
+++ b/tests/unit_tests/test_log.py
@@ -1,0 +1,80 @@
+import pytest
+
+from esphome.log import AnsiFore, AnsiStyle, color
+
+
+def test_color_keep_returns_unchanged_message() -> None:
+    """Test that AnsiFore.KEEP returns the message unchanged."""
+    msg = "test message"
+    result = color(AnsiFore.KEEP, msg)
+    assert result == msg
+
+
+def test_color_keep_ignores_reset_parameter() -> None:
+    """Test that reset parameter is ignored when using AnsiFore.KEEP."""
+    msg = "test message"
+    result_with_reset = color(AnsiFore.KEEP, msg, reset=True)
+    result_without_reset = color(AnsiFore.KEEP, msg, reset=False)
+    assert result_with_reset == msg
+    assert result_without_reset == msg
+
+
+def test_color_applies_color_code() -> None:
+    """Test that color codes are properly applied to messages."""
+    msg = "test message"
+    result = color(AnsiFore.RED, msg, reset=False)
+    assert result == f"{AnsiFore.RED.value}{msg}"
+
+
+def test_color_applies_reset_when_requested() -> None:
+    """Test that RESET_ALL is added when reset=True."""
+    msg = "test message"
+    result = color(AnsiFore.GREEN, msg, reset=True)
+    expected = f"{AnsiFore.GREEN.value}{msg}{AnsiStyle.RESET_ALL.value}"
+    assert result == expected
+
+
+def test_color_no_reset_when_not_requested() -> None:
+    """Test that RESET_ALL is not added when reset=False."""
+    msg = "test message"
+    result = color(AnsiFore.BLUE, msg, reset=False)
+    expected = f"{AnsiFore.BLUE.value}{msg}"
+    assert result == expected
+
+
+def test_color_with_empty_message() -> None:
+    """Test color function with empty message."""
+    result = color(AnsiFore.YELLOW, "", reset=True)
+    expected = f"{AnsiFore.YELLOW.value}{AnsiStyle.RESET_ALL.value}"
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "col",
+    [
+        AnsiFore.BLACK,
+        AnsiFore.RED,
+        AnsiFore.GREEN,
+        AnsiFore.YELLOW,
+        AnsiFore.BLUE,
+        AnsiFore.MAGENTA,
+        AnsiFore.CYAN,
+        AnsiFore.WHITE,
+        AnsiFore.RESET,
+    ],
+)
+def test_all_ansi_colors(col: AnsiFore) -> None:
+    """Test that all AnsiFore colors work correctly."""
+    msg = "test"
+    result = color(col, msg, reset=True)
+    expected = f"{col.value}{msg}{AnsiStyle.RESET_ALL.value}"
+    assert result == expected
+
+
+def test_ansi_fore_keep_is_enum_member() -> None:
+    """Ensure AnsiFore.KEEP is an Enum member and evaluates to truthy."""
+    assert isinstance(AnsiFore.KEEP, AnsiFore)
+    # Enum members are truthy, even with empty string values
+    assert bool(AnsiFore.KEEP) is True
+    # But the value itself is still an empty string
+    assert AnsiFore.KEEP.value == ""


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

A previous PR #6736 fixed an issue where excessive yaml was being output after an error, thus scrolling the error message out of view.

A more recent PR #8708 broke this; This change:
```
-class AnsiFore:
+class AnsiFore(Enum):
     KEEP = ""

```

had the presumably unintended side-effect of changing `AnsiFore.KEEP` from a falsey to a truthy value, which meant that unnecessary escape sequences were being added to *all* lines in the yaml, which broke the test for the last error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
