### PR TITLE
[api] Fix OTA progress updates not being sent when main loop is blocked

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -708,8 +708,11 @@ class APIConnection : public APIServerConnection {
     // 2. OR: We should try to send immediately (should_try_send_immediately = true)
     //        AND Batch delay is 0 (user has opted in to immediate sending)
     // 3. AND: Buffer has space available
-    if ((message_type == UpdateStateResponse::MESSAGE_TYPE ||
-         (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0)) &&
+    if ((
+#ifdef USE_UPDATE
+            message_type == UpdateStateResponse::MESSAGE_TYPE ||
+#endif
+            (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0)) &&
         this->helper_->can_write_without_blocking()) {
       // Now actually encode and send
       if (creator(entity, this, MAX_BATCH_PACKET_SIZE, true) &&

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -703,10 +703,13 @@ class APIConnection : public APIServerConnection {
   bool send_message_smart_(EntityBase *entity, MessageCreatorPtr creator, uint8_t message_type,
                            uint8_t estimated_size) {
     // Try to send immediately if:
-    // 1. We should try to send immediately (should_try_send_immediately = true)
-    // 2. Batch delay is 0 (user has opted in to immediate sending)
-    // 3. Buffer has space available
-    if (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0 &&
+    // 1. It's an UpdateStateResponse (always send immediately to handle cases where
+    //    the main loop is blocked, e.g., during OTA updates)
+    // 2. OR: We should try to send immediately (should_try_send_immediately = true)
+    //        AND Batch delay is 0 (user has opted in to immediate sending)
+    // 3. AND: Buffer has space available
+    if ((message_type == UpdateStateResponse::MESSAGE_TYPE ||
+         (this->flags_.should_try_send_immediately && this->get_batch_delay_ms_() == 0)) &&
         this->helper_->can_write_without_blocking()) {
       // Now actually encode and send
       if (creator(entity, this, MAX_BATCH_PACKET_SIZE, true) &&


### PR DESCRIPTION
# What does this implement/fix?

This PR ensures that `UpdateStateResponse` messages are always sent immediately, bypassing the batching mechanism. This fixes an issue where OTA progress updates are not sent to Home Assistant when `OtaHttpRequestComponent::flash` blocks the main loop.

When the main loop is blocked during OTA updates, the batch processing timer never runs, preventing any batched messages from being sent. However, OTA components still send progress callbacks that need to reach Home Assistant. By forcing immediate transmission of `UpdateStateResponse` messages, we ensure these progress updates are delivered even when the main loop is blocked.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes OTA progress not being reported when using HTTP OTA components that block the main loop

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal implementation detail)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fix applies to all OTA configurations automatically

ota:
  - platform: http_request

api:
  # Progress updates will now be sent immediately during OTA
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).