### PR TITLE
[esp32_ble_client] Connect immediately on READY_TO_CONNECT to reduce latency

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -45,8 +45,10 @@ void BLEClientBase::set_state(espbt::ClientState st) {
   ESPBTClient::set_state(st);
 
   if (st == espbt::ClientState::READY_TO_CONNECT) {
-    // Enable loop when we need to connect
+    // Enable loop for state processing
     this->enable_loop();
+    // Connect immediately instead of waiting for next loop
+    this->connect();
   }
 }
 
@@ -62,11 +64,6 @@ void BLEClientBase::loop() {
       this->mark_failed();
     }
     this->set_state(espbt::ClientState::IDLE);
-  }
-  // READY_TO_CONNECT means we have discovered the device
-  // and the scanner has been stopped by the tracker.
-  else if (this->state_ == espbt::ClientState::READY_TO_CONNECT) {
-    this->connect();
   }
   // If its idle, we can disable the loop as set_state
   // will enable it again when we need to connect.


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the BLE connection flow by eliminating one loop iteration when transitioning from READY_TO_CONNECT state to actually connecting. Previously, when the state was set to READY_TO_CONNECT, the component would enable the loop and wait for the next iteration to call `connect()`. Now it calls `connect()` immediately, reducing connection latency.

The change maintains the existing state machine and READY_TO_CONNECT state (used by bluetooth_proxy for connection queuing), but eliminates the unnecessary delay between state transition and connection attempt.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
bluetooth_proxy:

esp32_ble_tracker:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).