### PR TITLE
[esp32_ble_client] Fix connection parameter timing by setting preferences before connection

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -145,6 +145,36 @@ void BLEClientBase::connect() {
            this->remote_addr_type_);
   this->paired_ = false;
 
+  // Set preferred connection parameters before connecting
+  // Use FAST for all V3 connections (better latency and reliability)
+  // Use MEDIUM for V1/legacy connections (balanced performance)
+  uint16_t min_interval, max_interval, timeout;
+  const char *param_type;
+
+  if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE ||
+      this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
+    min_interval = FAST_MIN_CONN_INTERVAL;
+    max_interval = FAST_MAX_CONN_INTERVAL;
+    timeout = FAST_CONN_TIMEOUT;
+    param_type = "fast";
+  } else {
+    min_interval = MEDIUM_MIN_CONN_INTERVAL;
+    max_interval = MEDIUM_MAX_CONN_INTERVAL;
+    timeout = MEDIUM_CONN_TIMEOUT;
+    param_type = "medium";
+  }
+
+  auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_, min_interval, max_interval,
+                                                      0,  // latency: 0
+                                                      timeout);
+  if (param_ret != ESP_OK) {
+    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
+             this->address_str_.c_str(), param_ret);
+  } else {
+    ESP_LOGD(TAG, "[%d] [%s] Set %s conn params", this->connection_index_, this->address_str_.c_str(), param_type);
+  }
+
+  // Now open the connection
   auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
   if (ret) {
     ESP_LOGW(TAG, "[%d] [%s] esp_ble_gattc_open error, status=%d", this->connection_index_, this->address_str_.c_str(),
@@ -152,35 +182,6 @@ void BLEClientBase::connect() {
     this->set_state(espbt::ClientState::IDLE);
   } else {
     this->set_state(espbt::ClientState::CONNECTING);
-
-    // Always set connection parameters to ensure stable operation
-    // Use FAST for all V3 connections (better latency and reliability)
-    // Use MEDIUM for V1/legacy connections (balanced performance)
-    uint16_t min_interval, max_interval, timeout;
-    const char *param_type;
-
-    if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE ||
-        this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-      min_interval = FAST_MIN_CONN_INTERVAL;
-      max_interval = FAST_MAX_CONN_INTERVAL;
-      timeout = FAST_CONN_TIMEOUT;
-      param_type = "fast";
-    } else {
-      min_interval = MEDIUM_MIN_CONN_INTERVAL;
-      max_interval = MEDIUM_MAX_CONN_INTERVAL;
-      timeout = MEDIUM_CONN_TIMEOUT;
-      param_type = "medium";
-    }
-
-    auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_, min_interval, max_interval,
-                                                        0,  // latency: 0
-                                                        timeout);
-    if (param_ret != ESP_OK) {
-      ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
-               this->address_str_.c_str(), param_ret);
-    } else {
-      ESP_LOGD(TAG, "[%d] [%s] Set %s conn params", this->connection_index_, this->address_str_.c_str(), param_type);
-    }
   }
 }
 
@@ -255,6 +256,19 @@ void BLEClientBase::log_event_(const char *name) {
   ESP_LOGD(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_.c_str(), name);
 }
 
+void BLEClientBase::restore_medium_conn_params_() {
+  // Restore to medium connection parameters after initial connection phase
+  // This balances performance with bandwidth usage for normal operation
+  esp_ble_conn_update_params_t conn_params = {{0}};
+  memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
+  conn_params.min_int = MEDIUM_MIN_CONN_INTERVAL;
+  conn_params.max_int = MEDIUM_MAX_CONN_INTERVAL;
+  conn_params.latency = 0;
+  conn_params.timeout = MEDIUM_CONN_TIMEOUT;
+  ESP_LOGD(TAG, "[%d] [%s] Restoring medium conn params", this->connection_index_, this->address_str_.c_str());
+  esp_ble_gap_update_conn_params(&conn_params);
+}
+
 bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
                                         esp_ble_gattc_cb_param_t *param) {
   if (event == ESP_GATTC_REG_EVT && this->app_id != param->reg.app_id)
@@ -326,6 +340,10 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       ESP_LOGI(TAG, "[%d] [%s] Connection open", this->connection_index_, this->address_str_.c_str());
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
         ESP_LOGI(TAG, "[%d] [%s] Using cached services", this->connection_index_, this->address_str_.c_str());
+
+        // Restore to medium connection parameters for cached connections too
+        this->restore_medium_conn_params_();
+
         // only set our state, subclients might have more stuff to do yet.
         this->state_ = espbt::ClientState::ESTABLISHED;
         break;
@@ -413,15 +431,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       // This balances performance with bandwidth usage after the critical discovery phase
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE ||
           this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        esp_ble_conn_update_params_t conn_params = {{0}};
-        memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
-        conn_params.min_int = MEDIUM_MIN_CONN_INTERVAL;
-        conn_params.max_int = MEDIUM_MAX_CONN_INTERVAL;
-        conn_params.latency = 0;
-        conn_params.timeout = MEDIUM_CONN_TIMEOUT;
-        ESP_LOGD(TAG, "[%d] [%s] Restored medium conn params after service discovery", this->connection_index_,
-                 this->address_str_.c_str());
-        esp_ble_gap_update_conn_params(&conn_params);
+        this->restore_medium_conn_params_();
       }
 
       this->state_ = espbt::ClientState::ESTABLISHED;

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -127,6 +127,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   // 6 bytes used, 2 bytes padding
 
   void log_event_(const char *name);
+  void restore_medium_conn_params_();
 };
 
 }  // namespace esp32_ble_client


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes two issues with BLE connection parameter handling:

1. **Fixes the order of BLE connection operations** by calling `esp_ble_gap_set_prefer_conn_params` BEFORE `esp_ble_gattc_open`, as required by the ESP-IDF API documentation. This eliminates L2CAP warnings during connection.

2. **Ensures consistent connection parameter restoration** for both cached and non-cached V3 connections. Previously, cached connections would stay on FAST parameters indefinitely, while non-cached connections would restore to MEDIUM after service discovery.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of BLE connection latency optimization efforts
- Depends on #10055

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation fix

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
bluetooth_proxy:
  active: true

esp32_ble_tracker:
  scan_parameters:
    active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

**Additional context:**

The ESP-IDF documentation for `esp_ble_gap_set_prefer_conn_params` states:
> "This function is called to set the preferred connection parameters when default connection parameter is not desired **before connecting**."

Previously, we were calling this function after starting the connection, which could lead to:

1. **L2CAP warnings** during connection:
   ```
   E (33372) BT_L2CAP: upd_ll_conn_params: HANDLE=0 min_conn_int=6 max_conn_int=6 slave_latency=0 supervision_tout=1000
   ```

2. **Improper parameter negotiation**: The BLE stack may not honor the preferred parameters if they're set after connection initiation

Additionally, V3 connections with cached services were not restoring to MEDIUM parameters, keeping FAST parameters (7.5ms interval) indefinitely which could impact power consumption.

**Changes made:**
- Set preferred connection parameters before calling `esp_ble_gattc_open`
- Added `restore_medium_conn_params_()` helper to avoid code duplication
- Ensured both cached and non-cached V3 connections restore to MEDIUM parameters after initial connection phase

**Test results show the fix working correctly:**

Before (with warnings):
```
[19:35:57][I][esp32_ble_client:144]: [0] [E3:D8:3F:82:3A:AF] 0x01 Attempting BLE connection
[19:35:57][D][esp32_ble_client:182]: [0] [E3:D8:3F:82:3A:AF] Set fast conn params
[19:36:04][D][esp-idf:000][BTU_TASK]: E (33372) BT_L2CAP: upd_ll_conn_params: HANDLE=0 min_conn_int=6 max_conn_int=6
```

After (no warnings):
```
[19:46:15][I][esp32_ble_client:144]: [0] [E3:D8:3F:82:3A:AF] 0x01 Attempting BLE connection
[19:46:15][D][esp32_ble_client:174]: [0] [E3:D8:3F:82:3A:AF] Set fast conn params
[19:46:16][D][esp32_ble_client:256]: [0] [E3:D8:3F:82:3A:AF] ESP_GATTC_CONNECT_EVT
[19:46:16][D][esp32_ble_client:256]: [0] [E3:D8:3F:82:3A:AF] ESP_GATTC_OPEN_EVT
[19:46:16][I][esp32_ble_client:327]: [0] [E3:D8:3F:82:3A:AF] Connection open
```
