### PR TITLE
[bluetooth_proxy] Warn about BLE connection timeout mismatch on Arduino framework

### DIFF
--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -62,7 +62,10 @@ def validate_connections(config):
                 "      type: esp-idf\n"
                 "\n"
                 "For detailed migration instructions, see:\n"
-                f"{color(AnsiFore.BLUE, 'https://esphome.io/guides/esp32_arduino_to_idf.html')}"
+                "%s",
+                color(
+                    AnsiFore.BLUE, "https://esphome.io/guides/esp32_arduino_to_idf.html"
+                ),
             )
 
         return {

--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -62,9 +62,7 @@ def validate_connections(config):
                 "      type: esp-idf\n"
                 "\n"
                 "For detailed migration instructions, see:\n"
-                + color(
-                    AnsiFore.BLUE, "https://esphome.io/guides/esp32_arduino_to_idf.html"
-                )
+                f"{color(AnsiFore.BLUE, 'https://esphome.io/guides/esp32_arduino_to_idf.html')}"
             )
 
         return {

--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -1,13 +1,19 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components import esp32_ble, esp32_ble_client, esp32_ble_tracker
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components.esp32_ble import BTLoggers
 import esphome.config_validation as cv
 from esphome.const import CONF_ACTIVE, CONF_ID
+from esphome.core import CORE
+from esphome.log import AnsiFore, color
 
 AUTO_LOAD = ["esp32_ble_client", "esp32_ble_tracker"]
 DEPENDENCIES = ["api", "esp32"]
 CODEOWNERS = ["@jesserockz"]
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_CONNECTION_SLOTS = "connection_slots"
 CONF_CACHE_SERVICES = "cache_services"
@@ -41,6 +47,26 @@ def validate_connections(config):
         esp32_ble_tracker.consume_connection_slots(connection_slots, "bluetooth_proxy")(
             config
         )
+
+        # Warn about connection slot waste when using Arduino framework
+        if CORE.using_arduino and connection_slots:
+            _LOGGER.warning(
+                "Bluetooth Proxy with active connections on Arduino framework has suboptimal performance.\n"
+                "If BLE connections fail, they can waste connection slots for 10 seconds because\n"
+                "Arduino doesn't allow configuring the BLE connection timeout (fixed at 30s).\n"
+                "ESP-IDF framework allows setting it to 20s to match client timeouts.\n"
+                "\n"
+                "To switch to ESP-IDF, add this to your YAML:\n"
+                "  esp32:\n"
+                "    framework:\n"
+                "      type: esp-idf\n"
+                "\n"
+                "For detailed migration instructions, see:\n"
+                + color(
+                    AnsiFore.BLUE, "https://esphome.io/guides/esp32_arduino_to_idf.html"
+                )
+            )
+
         return {
             **config,
             CONF_CONNECTIONS: [CONNECTION_SCHEMA({}) for _ in range(connection_slots)],


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a warning when using the Bluetooth Proxy component with active connections on the Arduino framework. The warning explains that BLE performance is suboptimal because Arduino doesn't allow configuring the BLE connection establishment timeout.

This is a follow-up to #10013 which added configurable BLE connection timeouts for ESP-IDF. When using Arduino framework, the timeout remains fixed at 30 seconds while clients (aioesphomeapi and bleak-retry-connector) timeout after 20 seconds. This mismatch means that failed connections waste BLE connection slots for an extra 10 seconds, reducing the effective number of simultaneous connections.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10013 (BLE connection slot waste fix for ESP-IDF)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Uses existing migration guide

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration will trigger the warning
esphome:
  name: bluetooth-proxy

esp32:
  board: esp32dev
  framework:
    type: arduino  # Warning appears with Arduino framework

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

api:

bluetooth_proxy:
  active: true  # Warning only appears with active connections
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

