### PR TITLE
[remote_transmitter] Add digital_write automation

### DIFF
--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     CONF_PIN,
     CONF_RMT_SYMBOLS,
     CONF_USE_DMA,
+    CONF_VALUE,
     PlatformFramework,
 )
 from esphome.core import CORE
@@ -26,6 +27,11 @@ CONF_ON_COMPLETE = "on_complete"
 remote_transmitter_ns = cg.esphome_ns.namespace("remote_transmitter")
 RemoteTransmitterComponent = remote_transmitter_ns.class_(
     "RemoteTransmitterComponent", remote_base.RemoteTransmitterBase, cg.Component
+)
+DigitalWriteAction = remote_transmitter_ns.class_(
+    "DigitalWriteAction",
+    automation.Action,
+    cg.Parented.template(RemoteTransmitterComponent),
 )
 
 MULTI_CONF = True
@@ -62,6 +68,25 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(): cv.use_id(RemoteTransmitterComponent),
+        cv.Required(CONF_VALUE): cv.templatable(cv.boolean),
+    },
+    key=CONF_VALUE,
+)
+
+
+@automation.register_action(
+    "remote_transmitter.digital_write", DigitalWriteAction, DIGITAL_WRITE_ACTION_SCHEMA
+)
+async def digital_write_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_VALUE], args, bool)
+    cg.add(var.set_value(template_))
+    return var
 
 
 async def to_code(config):

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -23,6 +23,7 @@ AUTO_LOAD = ["remote_base"]
 CONF_EOT_LEVEL = "eot_level"
 CONF_ON_TRANSMIT = "on_transmit"
 CONF_ON_COMPLETE = "on_complete"
+CONF_TRANSMITTER_ID = remote_base.CONF_TRANSMITTER_ID
 
 remote_transmitter_ns = cg.esphome_ns.namespace("remote_transmitter")
 RemoteTransmitterComponent = remote_transmitter_ns.class_(
@@ -71,7 +72,7 @@ CONFIG_SCHEMA = cv.Schema(
 
 DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
     {
-        cv.GenerateID(): cv.use_id(RemoteTransmitterComponent),
+        cv.GenerateID(CONF_TRANSMITTER_ID): cv.use_id(RemoteTransmitterComponent),
         cv.Required(CONF_VALUE): cv.templatable(cv.boolean),
     },
     key=CONF_VALUE,
@@ -83,7 +84,7 @@ DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
 )
 async def digital_write_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
+    await cg.register_parented(var, config[CONF_TRANSMITTER_ID])
     template_ = await cg.templatable(config[CONF_VALUE], args, bool)
     cg.add(var.set_value(template_))
     return var

--- a/esphome/components/remote_transmitter/automation.h
+++ b/esphome/components/remote_transmitter/automation.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/automation.h"
 #include "esphome/components/remote_transmitter/remote_transmitter.h"
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace remote_transmitter {

--- a/esphome/components/remote_transmitter/automation.h
+++ b/esphome/components/remote_transmitter/automation.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/remote_transmitter/remote_transmitter.h"
+
+namespace esphome {
+namespace remote_transmitter {
+
+template<typename... Ts> class DigitalWriteAction : public Action<Ts...>, public Parented<RemoteTransmitterComponent> {
+ public:
+  TEMPLATABLE_VALUE(bool, value)
+  void play(Ts... x) override { this->parent_->digital_write(this->value_.value(x...)); }
+};
+
+}  // namespace remote_transmitter
+}  // namespace esphome

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -30,10 +30,11 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
   void set_carrier_duty_percent(uint8_t carrier_duty_percent) { this->carrier_duty_percent_ = carrier_duty_percent; }
 
+  void digital_write(bool value);
+
 #if defined(USE_ESP32)
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
-  void digital_write(bool value);
 #endif
 
   Trigger<> *get_transmit_trigger() const { return this->transmit_trigger_; };

--- a/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp8266.cpp
@@ -73,6 +73,8 @@ void RemoteTransmitterComponent::space_(uint32_t usec) {
   this->target_time_ += usec;
 }
 
+void RemoteTransmitterComponent::digital_write(bool value) { this->pin_->digital_write(value); }
+
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
   ESP_LOGD(TAG, "Sending remote code");
   uint32_t on_time, off_time;

--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -75,6 +75,8 @@ void RemoteTransmitterComponent::space_(uint32_t usec) {
   this->target_time_ += usec;
 }
 
+void RemoteTransmitterComponent::digital_write(bool value) { this->pin_->digital_write(value); }
+
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
   ESP_LOGD(TAG, "Sending remote code");
   uint32_t on_time, off_time;

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -208,4 +208,5 @@ button:
     name: Digital Write
     on_press:
       - remote_transmitter.digital_write: true
-      - remote_transmitter.digital_write: false
+      - remote_transmitter.digital_write:
+          value: false

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -204,3 +204,8 @@ button:
           command: 0xEC
           rc_code_1: 0x0D
           rc_code_2: 0x0D
+  - platform: template
+    name: Digital Write
+    on_press:
+      - remote_transmitter.digital_write: true
+      - remote_transmitter.digital_write: false


### PR DESCRIPTION
# What does this implement/fix?

Add digital_write automation which is useful when the pin is configured as open drain. At least two rf chips need this: sx127x and cc1101. 

In this example the pin is an open drain. The pin needs to be false when in entering transmit mode but needs to be set to true when finished (to release the pin) before entering receive mode:
```
remote_transmitter:
  pin:
    number: GPIO32
    mode:
      input: true
      output: true
      pullup: true
      open_drain: true
    allow_other_uses: true
  eot_level: false
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - sx127x.set_mode_standby
      - remote_transmitter.digital_write: false
      - sx127x.set_mode_tx
  on_complete:
    then:
      - sx127x.set_mode_standby
      - remote_transmitter.digital_write: true
      - sx127x.set_mode_rx
      
remote_receiver:
  id: rx_id
  pin:
    number: GPIO32
    mode:
      input: true
      output: true
      pullup: true
      open_drain: true
    allow_other_uses: true
  dump: raw
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5203

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
