### PR TITLE
[gpio_expander] Fix bank caching

### DIFF
--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <limits>
 #include "esphome/core/hal.h"
 
 namespace esphome {
@@ -18,11 +19,17 @@ namespace gpio_expander {
 template<typename T, T N> class CachedGpioExpander {
  public:
   bool digital_read(T pin) {
-    uint8_t bank = pin / (sizeof(T) * BITS_PER_BYTE);
-    if (this->read_cache_invalidated_[bank]) {
-      this->read_cache_invalidated_[bank] = false;
+    const uint8_t bank = pin / BANK_SIZE;
+    // Check if specific pin cache is valid
+    if (this->read_cache_valid_[bank] & (1 << (pin % BANK_SIZE))) {
+      // Invalidate pin
+      this->read_cache_valid_[bank] &= ~(1 << (pin % BANK_SIZE));
+    } else {
+      // Read whole bank from hardware
       if (!this->digital_read_hw(pin))
         return false;
+      // Mark bank cache as valid except the pin that is being returned now
+      this->read_cache_valid_[bank] = std::numeric_limits<T>::max() & ~(1 << (pin % BANK_SIZE));
     }
     return this->digital_read_cache(pin);
   }
@@ -36,17 +43,16 @@ template<typename T, T N> class CachedGpioExpander {
   virtual bool digital_read_cache(T pin) = 0;
   /// @brief Call component low level function to write GPIO state to device
   virtual void digital_write_hw(T pin, bool value) = 0;
-  const uint8_t cache_byte_size_ = N / (sizeof(T) * BITS_PER_BYTE);
 
   /// @brief Invalidate cache. This function should be called in component loop().
-  void reset_pin_cache_() {
-    for (T i = 0; i < this->cache_byte_size_; i++) {
-      this->read_cache_invalidated_[i] = true;
-    }
-  }
+  void reset_pin_cache_() { memset(this->read_cache_valid_, 0x00, CACHE_SIZE_BYTES); }
 
-  static const uint8_t BITS_PER_BYTE = 8;
-  std::array<bool, N / (sizeof(T) * BITS_PER_BYTE)> read_cache_invalidated_{};
+  static constexpr uint8_t BITS_PER_BYTE = 8;
+  static constexpr uint8_t BANK_SIZE = sizeof(T) * BITS_PER_BYTE;
+  static constexpr size_t BANKS = N / BANK_SIZE;
+  static constexpr size_t CACHE_SIZE_BYTES = BANKS * sizeof(T);
+
+  T read_cache_valid_[BANKS]{0};
 };
 
 }  // namespace gpio_expander

--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -5,8 +5,7 @@
 #include <limits>
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace gpio_expander {
+namespace esphome::gpio_expander {
 
 /// @brief A class to cache the read state of a GPIO expander.
 ///        This class caches reads between GPIO Pins which are on the same bank.
@@ -18,18 +17,22 @@ namespace gpio_expander {
 ///           N - Number of pins
 template<typename T, T N> class CachedGpioExpander {
  public:
+  /// @brief Read the state of the given pin. This will invalidate the cache for the given pin number.
+  /// @param pin Pin number to read
+  /// @return Pin state
   bool digital_read(T pin) {
     const uint8_t bank = pin / BANK_SIZE;
+    const T pin_mask = (1 << (pin % BANK_SIZE));
     // Check if specific pin cache is valid
-    if (this->read_cache_valid_[bank] & (1 << (pin % BANK_SIZE))) {
+    if (this->read_cache_valid_[bank] & pin_mask) {
       // Invalidate pin
-      this->read_cache_valid_[bank] &= ~(1 << (pin % BANK_SIZE));
+      this->read_cache_valid_[bank] &= ~pin_mask;
     } else {
       // Read whole bank from hardware
       if (!this->digital_read_hw(pin))
         return false;
       // Mark bank cache as valid except the pin that is being returned now
-      this->read_cache_valid_[bank] = std::numeric_limits<T>::max() & ~(1 << (pin % BANK_SIZE));
+      this->read_cache_valid_[bank] = std::numeric_limits<T>::max() & ~pin_mask;
     }
     return this->digital_read_cache(pin);
   }
@@ -55,5 +58,4 @@ template<typename T, T N> class CachedGpioExpander {
   T read_cache_valid_[BANKS]{0};
 };
 
-}  // namespace gpio_expander
-}  // namespace esphome
+}  // namespace esphome::gpio_expander

--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include "esphome/core/hal.h"
 

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component/__init__.py
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component/__init__.py
@@ -1,0 +1,25 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["gpio_expander"]
+
+gpio_expander_test_component_ns = cg.esphome_ns.namespace(
+    "gpio_expander_test_component"
+)
+
+GPIOExpanderTestComponent = gpio_expander_test_component_ns.class_(
+    "GPIOExpanderTestComponent", cg.Component
+)
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(GPIOExpanderTestComponent),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.cpp
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.cpp
@@ -1,0 +1,38 @@
+#include "gpio_expander_test_component.h"
+
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+
+namespace esphome::gpio_expander_test_component {
+
+static const char *const TAG = "gpio_expander_test";
+
+void GPIOExpanderTestComponent::setup() {
+  for (uint8_t pin = 0; pin < 32; pin++) {
+    this->digital_read(pin);
+  }
+
+  this->digital_read(3);
+  this->digital_read(3);
+  this->digital_read(4);
+  this->digital_read(3);
+  this->digital_read(10);
+  this->reset_pin_cache_();  // Reset cache to ensure next read is from hardware
+  this->digital_read(15);
+  this->digital_read(14);
+  this->digital_read(14);
+
+  ESP_LOGD(TAG, "DONE");
+}
+
+bool GPIOExpanderTestComponent::digital_read_hw(uint8_t pin) {
+  ESP_LOGD(TAG, "digital_read_hw pin=%d", pin);
+  return true;
+}
+
+bool GPIOExpanderTestComponent::digital_read_cache(uint8_t pin) {
+  ESP_LOGD(TAG, "digital_read_cache pin=%d", pin);
+  return true;
+}
+
+}  // namespace esphome::gpio_expander_test_component

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.h
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "esphome/components/gpio_expander/cached_gpio.h"
+#include "esphome/core/component.h"
+
+namespace esphome::gpio_expander_test_component {
+
+class GPIOExpanderTestComponent : public Component, public esphome::gpio_expander::CachedGpioExpander<uint8_t, 32> {
+ public:
+  void setup() override;
+
+ protected:
+  bool digital_read_hw(uint8_t pin) override;
+  bool digital_read_cache(uint8_t pin) override;
+  void digital_write_hw(uint8_t pin, bool value) override{};
+};
+
+}  // namespace esphome::gpio_expander_test_component

--- a/tests/integration/fixtures/gpio_expander_cache.yaml
+++ b/tests/integration/fixtures/gpio_expander_cache.yaml
@@ -1,0 +1,17 @@
+esphome:
+  name: gpio-expander-cache
+host:
+
+logger:
+  level: DEBUG
+
+api:
+
+# External component that uses gpio_expander::CachedGpioExpander
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+    components: [gpio_expander_test_component]
+
+gpio_expander_test_component:

--- a/tests/integration/test_gpio_expander_cache.py
+++ b/tests/integration/test_gpio_expander_cache.py
@@ -1,4 +1,4 @@
-"""Integration test for API custom services using CustomAPIDevice."""
+"""Integration test for CachedGPIOExpander to ensure correct behavior."""
 
 from __future__ import annotations
 

--- a/tests/integration/test_gpio_expander_cache.py
+++ b/tests/integration/test_gpio_expander_cache.py
@@ -1,0 +1,122 @@
+"""Integration test for API custom services using CustomAPIDevice."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_gpio_expander_cache(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test gpio_expander::CachedGpioExpander correctly calls hardware functions."""
+    # Get the path to the external components directory
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+
+    # Replace the placeholder in the YAML config with the actual path
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    logs_done = asyncio.Event()
+
+    # Patterns to match in logs
+    digital_read_hw_pattern = re.compile(r"digital_read_hw pin=(\d+)")
+    digital_read_cache_pattern = re.compile(r"digital_read_cache pin=(\d+)")
+
+    # ensure logs are in the expected order
+    log_order = [
+        (digital_read_hw_pattern, 0),
+        [(digital_read_cache_pattern, i) for i in range(0, 8)],
+        (digital_read_hw_pattern, 8),
+        [(digital_read_cache_pattern, i) for i in range(8, 16)],
+        (digital_read_hw_pattern, 16),
+        [(digital_read_cache_pattern, i) for i in range(16, 24)],
+        (digital_read_hw_pattern, 24),
+        [(digital_read_cache_pattern, i) for i in range(24, 32)],
+        (digital_read_hw_pattern, 3),
+        (digital_read_cache_pattern, 3),
+        (digital_read_hw_pattern, 3),
+        (digital_read_cache_pattern, 3),
+        (digital_read_cache_pattern, 4),
+        (digital_read_hw_pattern, 3),
+        (digital_read_cache_pattern, 3),
+        (digital_read_hw_pattern, 10),
+        (digital_read_cache_pattern, 10),
+        # full cache reset here for testing
+        (digital_read_hw_pattern, 15),
+        (digital_read_cache_pattern, 15),
+        (digital_read_cache_pattern, 14),
+        (digital_read_hw_pattern, 14),
+        (digital_read_cache_pattern, 14),
+    ]
+    # Flatten the log order for easier processing
+    log_order: list[tuple[re.Pattern, int]] = [
+        item
+        for sublist in log_order
+        for item in (sublist if isinstance(sublist, list) else [sublist])
+    ]
+
+    index = 0
+
+    def check_output(line: str) -> None:
+        """Check log output for expected messages."""
+        nonlocal index
+        if logs_done.is_set():
+            return
+
+        clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+
+        if "digital_read" in clean_line:
+            if index < len(log_order):
+                pattern, expected_pin = log_order[index]
+                match = pattern.search(line)
+                if match:
+                    pin = int(match.group(1))
+                    if pin == expected_pin:
+                        index += 1
+                    else:
+                        print(
+                            f"Unexpected pin number. Expected {expected_pin}, got {pin}"
+                        )
+                        logs_done.set()
+                else:
+                    print(f"Log line did not match next expected pattern: {clean_line}")
+                    logs_done.set()
+            else:
+                print(f"Received unexpected log line: {clean_line}")
+                index += 1
+                logs_done.set()
+
+        elif "DONE" in clean_line:
+            # Check if we reached the end of the expected log entries
+            logs_done.set()
+
+    # Run with log monitoring
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Verify device info
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "gpio-expander-cache"
+
+        try:
+            await asyncio.wait_for(logs_done.wait(), timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Timeout waiting for logs to complete")
+
+        assert index == len(log_order), (
+            f"Expected {len(log_order)} log entries, but got {index}"
+        )

--- a/tests/integration/test_gpio_expander_cache.py
+++ b/tests/integration/test_gpio_expander_cache.py
@@ -78,25 +78,26 @@ async def test_gpio_expander_cache(
         clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
 
         if "digital_read" in clean_line:
-            if index < len(log_order):
-                pattern, expected_pin = log_order[index]
-                match = pattern.search(line)
-                if match:
-                    pin = int(match.group(1))
-                    if pin == expected_pin:
-                        index += 1
-                    else:
-                        print(
-                            f"Unexpected pin number. Expected {expected_pin}, got {pin}"
-                        )
-                        logs_done.set()
-                else:
-                    print(f"Log line did not match next expected pattern: {clean_line}")
-                    logs_done.set()
-            else:
+            if index >= len(log_order):
                 print(f"Received unexpected log line: {clean_line}")
-                index += 1
                 logs_done.set()
+                return
+            
+            pattern, expected_pin = log_order[index]
+            match = pattern.search(clean_line)
+            
+            if not match:
+                print(f"Log line did not match next expected pattern: {clean_line}")
+                logs_done.set()
+                return
+            
+            pin = int(match.group(1))
+            if pin != expected_pin:
+                print(f"Unexpected pin number. Expected {expected_pin}, got {pin}")
+                logs_done.set()
+                return
+            
+            index += 1
 
         elif "DONE" in clean_line:
             # Check if we reached the end of the expected log entries

--- a/tests/integration/test_gpio_expander_cache.py
+++ b/tests/integration/test_gpio_expander_cache.py
@@ -82,21 +82,21 @@ async def test_gpio_expander_cache(
                 print(f"Received unexpected log line: {clean_line}")
                 logs_done.set()
                 return
-            
+
             pattern, expected_pin = log_order[index]
             match = pattern.search(clean_line)
-            
+
             if not match:
                 print(f"Log line did not match next expected pattern: {clean_line}")
                 logs_done.set()
                 return
-            
+
             pin = int(match.group(1))
             if pin != expected_pin:
                 print(f"Unexpected pin number. Expected {expected_pin}, got {pin}")
                 logs_done.set()
                 return
-            
+
             index += 1
 
         elif "DONE" in clean_line:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

#8003 added banking support, but removed the capability to read multiple pins from a single bank in the single cache, which defeated the entire purpose of this class.

This fixes that by checking if the specific pin cache is valid, if not reads the bank from hardware and marks all pins in the bank as valid except the newly read one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
