### PR TITLE
Add myself to multiple bluetooth codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,7 +69,7 @@ esphome/components/bl0939/* @ziceva
 esphome/components/bl0940/* @tobias-
 esphome/components/bl0942/* @dbuezas @dwmw2
 esphome/components/ble_client/* @buxtronix @clydebarrow
-esphome/components/bluetooth_proxy/* @jesserockz
+esphome/components/bluetooth_proxy/* @bdraco @jesserockz
 esphome/components/bme280_base/* @esphome/core
 esphome/components/bme280_spi/* @apbodrov
 esphome/components/bme680_bsec/* @trvrnrth
@@ -144,9 +144,10 @@ esphome/components/es8156/* @kbx81
 esphome/components/es8311/* @kahrendt @kroimon
 esphome/components/es8388/* @P4uLT
 esphome/components/esp32/* @esphome/core
-esphome/components/esp32_ble/* @Rapsssito @jesserockz
-esphome/components/esp32_ble_client/* @jesserockz
+esphome/components/esp32_ble/* @Rapsssito @bdraco @jesserockz
+esphome/components/esp32_ble_client/* @bdraco @jesserockz
 esphome/components/esp32_ble_server/* @Rapsssito @clydebarrow @jesserockz
+esphome/components/esp32_ble_tracker/* @bdraco
 esphome/components/esp32_camera_web_server/* @ayufan
 esphome/components/esp32_can/* @Sympatron
 esphome/components/esp32_hosted/* @swoboda1337

--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -11,7 +11,7 @@ from esphome.log import AnsiFore, color
 
 AUTO_LOAD = ["esp32_ble_client", "esp32_ble_tracker"]
 DEPENDENCIES = ["api", "esp32"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@bdraco"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -11,7 +11,7 @@ from esphome.core.config import CONF_NAME_ADD_MAC_SUFFIX
 import esphome.final_validate as fv
 
 DEPENDENCIES = ["esp32"]
-CODEOWNERS = ["@jesserockz", "@Rapsssito"]
+CODEOWNERS = ["@jesserockz", "@Rapsssito", "@bdraco"]
 
 
 class BTLoggers(Enum):

--- a/esphome/components/esp32_ble_client/__init__.py
+++ b/esphome/components/esp32_ble_client/__init__.py
@@ -2,7 +2,7 @@ import esphome.codegen as cg
 from esphome.components import esp32_ble_tracker
 
 AUTO_LOAD = ["esp32_ble_tracker"]
-CODEOWNERS = ["@jesserockz"]
+CODEOWNERS = ["@jesserockz", "@bdraco"]
 DEPENDENCIES = ["esp32"]
 
 esp32_ble_client_ns = cg.esphome_ns.namespace("esp32_ble_client")

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -36,6 +36,7 @@ from esphome.types import ConfigType
 
 AUTO_LOAD = ["esp32_ble"]
 DEPENDENCIES = ["esp32"]
+CODEOWNERS = ["@bdraco"]
 
 KEY_ESP32_BLE_TRACKER = "esp32_ble_tracker"
 KEY_USED_CONNECTION_SLOTS = "used_connection_slots"


### PR DESCRIPTION
# What does this implement/fix?

I made a lot of changes to the ESP32 BLE components this cycle and want to keep tabs on any issues that come up.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

N/A - CODEOWNERS change only

## Example entry for `config.yaml`:

```yaml
# N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

