### PR TITLE
update espressif's esp32-camera library to 2.1.1

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -345,7 +345,7 @@ async def to_code(config):
     cg.add_define("USE_CAMERA")
 
     if CORE.using_esp_idf:
-        add_idf_component(name="espressif/esp32-camera", ref="2.1.0")
+        add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -2,7 +2,7 @@ dependencies:
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:
-    version: 2.1.0
+    version: 2.1.1
   espressif/mdns:
     version: 1.8.2
   espressif/esp_wifi_remote:


### PR DESCRIPTION
# What does this implement/fix?

Update library version, mostly bugfixes.

One new feature: 

The PSRAM DMA mode is now available via a flag, and allows for faster copy into frame buffer and with less CPU involvement. Previously, it was implicitly activated if the XCLK frequency was set to 16 MHz.

I've added a lot of fixes, so this mode does not crash anymore, but the images are corrupted still, see https://github.com/espressif/esp32-camera/pull/776#issuecomment-3153332168 for an example.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

## Related:

New feature option for DMA directly from the camera to PSRAM is filed as separate PR:

https://github.com/esphome/esphome/pull/9771

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
