### PR TITLE
[esp32_ble_tracker] Simplify state machine guards with helper functions

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -582,23 +582,7 @@ void ESP32BLETracker::dump_config() {
                 "  Continuous Scanning: %s",
                 this->scan_duration_, this->scan_interval_ * 0.625f, this->scan_window_ * 0.625f,
                 this->scan_active_ ? "ACTIVE" : "PASSIVE", YESNO(this->scan_continuous_));
-  switch (this->scanner_state_) {
-    case ScannerState::IDLE:
-      ESP_LOGCONFIG(TAG, "  Scanner State: IDLE");
-      break;
-    case ScannerState::STARTING:
-      ESP_LOGCONFIG(TAG, "  Scanner State: STARTING");
-      break;
-    case ScannerState::RUNNING:
-      ESP_LOGCONFIG(TAG, "  Scanner State: RUNNING");
-      break;
-    case ScannerState::STOPPING:
-      ESP_LOGCONFIG(TAG, "  Scanner State: STOPPING");
-      break;
-    case ScannerState::FAILED:
-      ESP_LOGCONFIG(TAG, "  Scanner State: FAILED");
-      break;
-  }
+  ESP_LOGCONFIG(TAG, "  Scanner State: %s", this->scanner_state_to_string_(this->scanner_state_));
   ESP_LOGCONFIG(TAG, "  Connecting: %d, discovered: %d, searching: %d, disconnecting: %d",
                 this->client_state_counts_.connecting, this->client_state_counts_.discovered,
                 this->client_state_counts_.searching, this->client_state_counts_.disconnecting);
@@ -796,17 +780,17 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
 const char *ESP32BLETracker::scanner_state_to_string_(ScannerState state) const {
   switch (state) {
     case ScannerState::IDLE:
-      return "idle";
+      return "IDLE";
     case ScannerState::STARTING:
-      return "starting";
+      return "STARTING";
     case ScannerState::RUNNING:
-      return "running";
+      return "RUNNING";
     case ScannerState::STOPPING:
-      return "stopping";
+      return "STOPPING";
     case ScannerState::FAILED:
-      return "failed";
+      return "FAILED";
     default:
-      return "unknown";
+      return "UNKNOWN";
   }
 }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -136,13 +136,7 @@ void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); 
 
 void ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {
-    if (this->scanner_state_ == ScannerState::IDLE) {
-      ESP_LOGE(TAG, "Scan is already stopped while trying to stop.");
-    } else if (this->scanner_state_ == ScannerState::STARTING) {
-      ESP_LOGE(TAG, "Scan is starting while trying to stop.");
-    } else if (this->scanner_state_ == ScannerState::STOPPING) {
-      ESP_LOGE(TAG, "Scan is already stopping while trying to stop.");
-    }
+    ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
     return;
   }
   this->cancel_timeout("scan");
@@ -160,15 +154,7 @@ void ESP32BLETracker::start_scan_(bool first) {
     return;
   }
   if (this->scanner_state_ != ScannerState::IDLE) {
-    if (this->scanner_state_ == ScannerState::STARTING) {
-      ESP_LOGE(TAG, "Cannot start scan while already starting.");
-    } else if (this->scanner_state_ == ScannerState::RUNNING) {
-      ESP_LOGE(TAG, "Cannot start scan while already running.");
-    } else if (this->scanner_state_ == ScannerState::STOPPING) {
-      ESP_LOGE(TAG, "Cannot start scan while already stopping.");
-    } else if (this->scanner_state_ == ScannerState::FAILED) {
-      ESP_LOGE(TAG, "Cannot start scan while already failed.");
-    }
+    this->log_unexpected_state_("start scan", ScannerState::IDLE);
     return;
   }
   this->set_scanner_state_(ScannerState::STARTING);
@@ -275,15 +261,7 @@ void ESP32BLETracker::gap_scan_event_handler(const BLEScanResult &scan_result) {
   } else if (scan_result.search_evt == ESP_GAP_SEARCH_INQ_CMPL_EVT) {
     // Scan finished on its own
     if (this->scanner_state_ != ScannerState::RUNNING) {
-      if (this->scanner_state_ == ScannerState::STOPPING) {
-        ESP_LOGE(TAG, "Scan was not running when scan completed.");
-      } else if (this->scanner_state_ == ScannerState::STARTING) {
-        ESP_LOGE(TAG, "Scan was not started when scan completed.");
-      } else if (this->scanner_state_ == ScannerState::FAILED) {
-        ESP_LOGE(TAG, "Scan was in failed state when scan completed.");
-      } else if (this->scanner_state_ == ScannerState::IDLE) {
-        ESP_LOGE(TAG, "Scan was idle when scan completed.");
-      }
+      this->log_unexpected_state_("scan complete", ScannerState::RUNNING);
     }
     // Scan completed naturally, perform cleanup and transition to IDLE
     this->cleanup_scan_state_(false);
@@ -305,15 +283,7 @@ void ESP32BLETracker::gap_scan_start_complete_(const esp_ble_gap_cb_param_t::ble
   ESP_LOGV(TAG, "gap_scan_start_complete - status %d", param.status);
   this->scan_start_failed_ = param.status;
   if (this->scanner_state_ != ScannerState::STARTING) {
-    if (this->scanner_state_ == ScannerState::RUNNING) {
-      ESP_LOGE(TAG, "Scan was already running when start complete.");
-    } else if (this->scanner_state_ == ScannerState::STOPPING) {
-      ESP_LOGE(TAG, "Scan was stopping when start complete.");
-    } else if (this->scanner_state_ == ScannerState::FAILED) {
-      ESP_LOGE(TAG, "Scan was in failed state when start complete.");
-    } else if (this->scanner_state_ == ScannerState::IDLE) {
-      ESP_LOGE(TAG, "Scan was idle when start complete.");
-    }
+    this->log_unexpected_state_("start complete", ScannerState::STARTING);
   }
   if (param.status == ESP_BT_STATUS_SUCCESS) {
     this->scan_start_fail_count_ = 0;
@@ -331,15 +301,7 @@ void ESP32BLETracker::gap_scan_stop_complete_(const esp_ble_gap_cb_param_t::ble_
   // This allows us to safely transition to IDLE state and perform cleanup without race conditions
   ESP_LOGV(TAG, "gap_scan_stop_complete - status %d", param.status);
   if (this->scanner_state_ != ScannerState::STOPPING) {
-    if (this->scanner_state_ == ScannerState::RUNNING) {
-      ESP_LOGE(TAG, "Scan was not running when stop complete.");
-    } else if (this->scanner_state_ == ScannerState::STARTING) {
-      ESP_LOGE(TAG, "Scan was not started when stop complete.");
-    } else if (this->scanner_state_ == ScannerState::FAILED) {
-      ESP_LOGE(TAG, "Scan was in failed state when stop complete.");
-    } else if (this->scanner_state_ == ScannerState::IDLE) {
-      ESP_LOGE(TAG, "Scan was idle when stop complete.");
-    }
+    this->log_unexpected_state_("stop complete", ScannerState::STOPPING);
   }
 
   // Perform cleanup and transition to IDLE
@@ -829,6 +791,28 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
     client->set_state(ClientState::READY_TO_CONNECT);
     break;
   }
+}
+
+const char *ESP32BLETracker::scanner_state_to_string_(ScannerState state) const {
+  switch (state) {
+    case ScannerState::IDLE:
+      return "idle";
+    case ScannerState::STARTING:
+      return "starting";
+    case ScannerState::RUNNING:
+      return "running";
+    case ScannerState::STOPPING:
+      return "stopping";
+    case ScannerState::FAILED:
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+void ESP32BLETracker::log_unexpected_state_(const char *operation, ScannerState expected_state) const {
+  ESP_LOGE(TAG, "Unexpected state: %s on %s, expected: %s", this->scanner_state_to_string_(this->scanner_state_),
+           operation, this->scanner_state_to_string_(expected_state));
 }
 
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -297,6 +297,10 @@ class ESP32BLETracker : public Component,
   void handle_scanner_failure_();
   /// Try to promote discovered clients to ready to connect
   void try_promote_discovered_clients_();
+  /// Convert scanner state enum to string for logging
+  const char *scanner_state_to_string_(ScannerState state) const;
+  /// Log an unexpected scanner state
+  void log_unexpected_state_(const char *operation, ScannerState expected_state) const;
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   /// Update BLE coexistence preference
   void update_coex_preference_(bool force_ble);


### PR DESCRIPTION
# What does this implement/fix?

This PR continues the cleanup effort of the ESP32 BLE tracker component by simplifying state machine error handling and improving logging consistency.

The verbose if-else chains for state validation have been replaced with a cleaner helper-based approach that:
- Reduces code duplication significantly  
- Provides consistent error messages following ESPHome logging guidelines
- Makes the state machine logic easier to read and maintain
- **Saves 960 bytes of flash memory** through reduced code duplication

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This is part of an ongoing effort to analyze and cleanup the ESP32 BLE tracker component. Previous PRs in this series:
- #10074 - Refactor loop() method for improved readability and performance
- #10085 - Add missing USE_ESP32_BLE_DEVICE guard for already_discovered_ member
- #10061 - Optimize connection by promoting client immediately after scan stop trigger
- #10057 - Eliminate redundant ring buffer for lower latency
- #10055 - Remove unnecessary STOPPED scanner state to reduce latency

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal code quality improvement only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
esp32_ble_tracker:
  scan_parameters:
    active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).