### PR TITLE
[esp32_rmt_led_strip] Work around IDFGH-16195

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -42,9 +42,6 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
         symbols[i] = params->bit0;
       }
     }
-    if ((index + 1) >= size && params->reset.duration0 == 0 && params->reset.duration1 == 0) {
-      *done = true;
-    }
     return RMT_SYMBOLS_PER_BYTE;
   }
 
@@ -110,7 +107,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
   memset(&encoder, 0, sizeof(encoder));
   encoder.callback = encoder_callback;
   encoder.arg = &this->params_;
-  encoder.min_chunk_size = 8;
+  encoder.min_chunk_size = RMT_SYMBOLS_PER_BYTE;
   if (rmt_new_simple_encoder(&encoder, &this->encoder_) != ESP_OK) {
     ESP_LOGE(TAG, "Encoder creation failed");
     this->mark_failed();


### PR DESCRIPTION
# What does this implement/fix?

Work around https://github.com/espressif/esp-idf/issues/17244

Send reset every time even if it is zero, avoids triggering the above issue.

https://discord.com/channels/429907082951524364/1062229382275530762/1402182688978243675

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
