### PR TITLE
[bluetooth_proxy] Reduce flash usage by consolidating duplicate logging

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -33,6 +33,10 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   void send_service_for_discovery_();
   void reset_connection_(esp_err_t reason);
   void update_allocated_slot_(uint64_t find_value, uint64_t set_value);
+  void log_connection_error_(const char *operation, esp_gatt_status_t status);
+  void log_connection_warning_(const char *operation, esp_err_t err);
+  void log_gatt_not_connected_(const char *action, const char *type);
+  void log_gatt_operation_error_(const char *operation, uint16_t handle, esp_gatt_status_t status);
 
   // Memory optimized layout for 32-bit systems
   // Group 1: Pointers (4 bytes each, naturally aligned)


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash memory usage in the bluetooth_proxy component by consolidating duplicate logging statements into helper functions.

The bluetooth_proxy component had numerous repetitive error logging patterns that were consuming unnecessary flash memory. By creating targeted helper functions, we've eliminated string duplication and reduced the binary size.

**Changes made:**
- Added `log_connection_error_()` helper for ESP-IDF GATT error logging (4 instances consolidated)
- Added `log_connection_warning_()` helper for ESP-IDF operation warnings (4 instances consolidated)
- Added `log_gatt_not_connected_()` helper for "not connected" messages (5 instances consolidated)
- Added `log_gatt_operation_error_()` helper for GATT operation errors with handles (4 instances consolidated)

**Results:**
- **17 duplicate logging statements** consolidated into **4 helper functions**
- **Saved 564 bytes of flash memory** with no impact on RAM usage

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This is part of an ongoing effort to optimize flash memory usage in ESPHome components.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal code optimization only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).