### PR TITLE
[esp32_ble] Make BLE notification limit configurable to fix ESP_GATT_NO_RESOURCES errors

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -355,11 +355,6 @@ async def to_code(config):
         add_idf_sdkconfig_option(
             "CONFIG_BTDM_CTRL_BLE_MAX_CONN", config[CONF_MAX_CONNECTIONS]
         )
-        # CONFIG_BT_GATTC_NOTIF_REG_MAX controls the number of
-        # max notifications in 5.x, setting CONFIG_BT_ACL_CONNECTIONS
-        # is enough in 4.x
-        # https://github.com/esphome/issues/issues/6808
-        add_idf_sdkconfig_option("CONFIG_BT_GATTC_NOTIF_REG_MAX", 9)
 
     cg.add_define("USE_OTA_STATE_CALLBACK")  # To be notified when an OTA update starts
     cg.add_define("USE_ESP32_BLE_CLIENT")


### PR DESCRIPTION
# What does this implement/fix?

This PR makes the BLE notification registration limit configurable and increases the default from 9 to 12. Previously, the limit was hardcoded in `esp32_ble_tracker`, which caused issues when devices attempted to register for more than 9 notifications across all BLE connections.

The error manifests as status code 128 (`ESP_GATT_NO_RESOURCES`) when trying to register for notifications:
```
[W][bluetooth_proxy.connection:335]: [1] [D1:F8:2D:12:33:66] Error registering notifications for handle 0x58, status=128
```

This was particularly problematic for users with multiple BLE devices or devices that expose many characteristics requiring notifications. A common scenario is when multiple HomeKit and SwitchBot services are connected at once - the ones connecting later don't work because the notification registration fails.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6808 (Didn't go high enough by default in original fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5208

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Configure the BLE notification limit (default: 12, max: 64)
esp32_ble:
  max_notifications: 20  # Increase if you have many BLE devices or devices with many characteristics

esp32_ble_tracker:
  # No longer needs manual configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).