### PR TITLE
Set output_power for BK72XX chips

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -315,7 +315,7 @@ CONFIG_SCHEMA = cv.All(
             ): cv.enum(WIFI_POWER_SAVE_MODES, upper=True),
             cv.Optional(CONF_FAST_CONNECT, default=False): cv.boolean,
             cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
-            cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0): cv.All(
+            cv.SplitDefault(CONF_OUTPUT_POWER, esp8266=20.0, bk72xx=17.0): cv.All(
                 cv.decibel, cv.float_range(min=8.5, max=20.5)
             ),
             cv.SplitDefault(CONF_ENABLE_BTM, esp32_idf=False): cv.All(


### PR DESCRIPTION
Looking at the [BK7231T COB Hardware Design Guideline](https://developer.tuya.com/en/docs/iot/bk7231t-cob-hardware-design-guideline?id=Ka97u6dz0h8b8) the maximum output power is `+17 dBm`. Also after looking at the [BK7231N datasheet](https://images.tuyacn.com/smart/Hardware_Developer/%E8%8A%AF%E7%89%87%E8%B5%84%E6%96%99/BK7231N_Datasheet_V1.0.pdf) (with machine translations) it seems like 17 dBm is the most commonly used option.

Personally I did have stability issues with BK7231T chips not able to connect to WiFi without a hard 20 minute poweroff and after changing the max output power to 17 dBm did seems to help with stability and latency.

# What does this implement/fix?

Set the output power for `BK7XX` to `17 dB`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This _might_ fix issue https://github.com/esphome/issues/issues/5217

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No need to change anything but it's the equivalent of:

```yaml
# Example config.yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  output_power: 17 dB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
