### PR TITLE
[bluetooth_proxy] Replace std::find with simple loop for small fixed array

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -80,9 +80,11 @@ void BluetoothConnection::dump_config() {
 
 void BluetoothConnection::update_allocated_slot_(uint64_t find_value, uint64_t set_value) {
   auto &allocated = this->proxy_->connections_free_response_.allocated;
-  auto *it = std::find(allocated.begin(), allocated.end(), find_value);
-  if (it != allocated.end()) {
-    *it = set_value;
+  for (auto &slot : allocated) {
+    if (slot == find_value) {
+      slot = set_value;
+      return;
+    }
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `update_allocated_slot_` function in the Bluetooth proxy component by replacing `std::find` with a simple loop. Since the `allocated` array is a fixed-size array with only 3 elements (`BLUETOOTH_PROXY_MAX_CONNECTIONS`), the overhead of using STL algorithms is unnecessary.

This change reduces flash usage by 108 bytes on ESP32 while maintaining identical functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
bluetooth_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).