### PR TITLE
[bluetooth_proxy] Remove unnecessary heap allocation for response object

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -25,12 +25,9 @@ static_assert(sizeof(((api::BluetoothLERawAdvertisement *) nullptr)->data) == 62
 BluetoothProxy::BluetoothProxy() { global_bluetooth_proxy = this; }
 
 void BluetoothProxy::setup() {
-  // Pre-allocate response object
-  this->response_ = std::make_unique<api::BluetoothLERawAdvertisementsResponse>();
-
   // Reserve capacity but start with size 0
   // Reserve 50% since we'll grow naturally and flush at FLUSH_BATCH_SIZE
-  this->response_->advertisements.reserve(FLUSH_BATCH_SIZE / 2);
+  this->response_.advertisements.reserve(FLUSH_BATCH_SIZE / 2);
 
   // Don't pre-allocate pool - let it grow only if needed in busy environments
   // Many devices in quiet areas will never need the overflow pool
@@ -65,7 +62,7 @@ bool BluetoothProxy::parse_devices(const esp32_ble::BLEScanResult *scan_results,
   if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr)
     return false;
 
-  auto &advertisements = this->response_->advertisements;
+  auto &advertisements = this->response_.advertisements;
 
   for (size_t i = 0; i < count; i++) {
     auto &result = scan_results[i];
@@ -109,7 +106,7 @@ void BluetoothProxy::flush_pending_advertisements() {
   if (this->advertisement_count_ == 0 || !api::global_api_server->is_connected() || this->api_connection_ == nullptr)
     return;
 
-  auto &advertisements = this->response_->advertisements;
+  auto &advertisements = this->response_.advertisements;
 
   // Return any items beyond advertisement_count_ to the pool
   if (advertisements.size() > this->advertisement_count_) {
@@ -123,7 +120,7 @@ void BluetoothProxy::flush_pending_advertisements() {
   }
 
   // Send the message
-  this->api_connection_->send_message(*this->response_, api::BluetoothLERawAdvertisementsResponse::MESSAGE_TYPE);
+  this->api_connection_->send_message(this->response_, api::BluetoothLERawAdvertisementsResponse::MESSAGE_TYPE);
 
   // Reset count - existing items will be overwritten in next batch
   this->advertisement_count_ = 0;

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -146,7 +146,7 @@ class BluetoothProxy : public esp32_ble_tracker::ESPBTDeviceListener, public Com
 
   // BLE advertisement batching
   std::vector<api::BluetoothLERawAdvertisement> advertisement_pool_;
-  std::unique_ptr<api::BluetoothLERawAdvertisementsResponse> response_;
+  api::BluetoothLERawAdvertisementsResponse response_;
 
   // Group 3: 4-byte types
   uint32_t last_advertisement_flush_time_{0};


### PR DESCRIPTION
# What does this implement/fix?

This PR removes an unnecessary heap allocation in the BluetoothProxy component by converting the `response_` member from a `std::unique_ptr` to a direct member variable.

The BluetoothProxy class is already heap-allocated, so using a `unique_ptr` for the response object creates a second unnecessary heap allocation. This change:
- Eliminates the double heap allocation
- Removes pointer indirection when accessing the response
- Reduces flash usage by 44 bytes
- Simplifies the code by removing the allocation in `setup()`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

