### PR TITLE
[esp32_ble_client] Convert to C++17 nested namespace syntax

### DIFF
--- a/esphome/components/esp32_ble_client/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_client/ble_characteristic.cpp
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
 
@@ -93,7 +92,6 @@ esp_err_t BLECharacteristic::write_value(uint8_t *new_val, int16_t new_val_size)
   return write_value(new_val, new_val_size, ESP_GATT_WRITE_TYPE_NO_RSP);
 }
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_characteristic.h
+++ b/esphome/components/esp32_ble_client/ble_characteristic.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -33,7 +32,6 @@ class BLECharacteristic {
   BLEService *service;
 };
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -8,8 +8,7 @@
 #include <esp_gap_ble_api.h>
 #include <esp_gatt_defs.h>
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
 
@@ -696,7 +695,6 @@ BLEDescriptor *BLEClientBase::get_descriptor(uint16_t handle) {
   return nullptr;
 }
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -16,8 +16,7 @@
 #include <esp_gatt_common_api.h>
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -130,7 +129,6 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void restore_medium_conn_params_();
 };
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_descriptor.h
+++ b/esphome/components/esp32_ble_client/ble_descriptor.h
@@ -4,8 +4,7 @@
 
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -19,7 +18,6 @@ class BLEDescriptor {
   BLECharacteristic *characteristic;
 };
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_service.cpp
+++ b/esphome/components/esp32_ble_client/ble_service.cpp
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
 
@@ -71,7 +70,6 @@ void BLEService::parse_characteristics() {
   }
 }
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_service.h
+++ b/esphome/components/esp32_ble_client/ble_service.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace esp32_ble_client {
+namespace esphome::esp32_ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -30,7 +29,6 @@ class BLEService {
   BLECharacteristic *get_characteristic(uint16_t uuid);
 };
 
-}  // namespace esp32_ble_client
-}  // namespace esphome
+}  // namespace esphome::esp32_ble_client
 
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

This PR converts the `esp32_ble_client` component to use C++17 nested namespace syntax, replacing the old C++11 style nested namespace declarations with the more concise C++17 syntax.

**Before:**
```cpp
namespace esphome {
namespace esp32_ble_client {
// ...
}  // namespace esp32_ble_client
}  // namespace esphome
```

**After:**
```cpp
namespace esphome::esp32_ble_client {
// ...
}  // namespace esphome::esp32_ble_client
```

This modernization improves code readability and aligns with the C++17 standard that ESPHome uses.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes required

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is purely a code style update
# Example configuration remains the same:
esp32_ble_tracker:

ble_client:
  - mac_address: XX:XX:XX:XX:XX:XX
    id: my_ble_client
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).