### PR TITLE
[esp32_touch] Restore get_value() for ESP32-S2/S3 variants

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -234,9 +234,7 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
   touch_pad_t get_touch_pad() const { return this->touch_pad_; }
   uint32_t get_threshold() const { return this->threshold_; }
   void set_threshold(uint32_t threshold) { this->threshold_ = threshold; }
-#ifdef USE_ESP32_VARIANT_ESP32
   uint32_t get_value() const { return this->value_; }
-#endif
   uint32_t get_wakeup_threshold() const { return this->wakeup_threshold_; }
 
  protected:
@@ -245,9 +243,7 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
   touch_pad_t touch_pad_{TOUCH_PAD_MAX};
   uint32_t threshold_{0};
   uint32_t benchmark_{};
-#ifdef USE_ESP32_VARIANT_ESP32
   uint32_t value_{0};
-#endif
   bool last_state_{false};
   const uint32_t wakeup_threshold_{0};
 

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -234,7 +234,13 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
   touch_pad_t get_touch_pad() const { return this->touch_pad_; }
   uint32_t get_threshold() const { return this->threshold_; }
   void set_threshold(uint32_t threshold) { this->threshold_ = threshold; }
+
+  /// Get the raw touch measurement value.
+  /// @note Although this method may appear unused within the component, it is a public API
+  /// used by lambdas in user configurations for custom touch value processing.
+  /// @return The current raw touch sensor reading
   uint32_t get_value() const { return this->value_; }
+
   uint32_t get_wakeup_threshold() const { return this->wakeup_threshold_; }
 
  protected:
@@ -243,6 +249,7 @@ class ESP32TouchBinarySensor : public binary_sensor::BinarySensor {
   touch_pad_t touch_pad_{TOUCH_PAD_MAX};
   uint32_t threshold_{0};
   uint32_t benchmark_{};
+  /// Stores the last raw touch measurement value.
   uint32_t value_{0};
   bool last_state_{false};
   const uint32_t wakeup_threshold_{0};

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -171,8 +171,8 @@ class ESP32TouchComponent : public Component {
   // based on the filter configuration
   uint32_t read_touch_value(touch_pad_t pad) const;
 
-  // Helper to update touch state with a known state
-  void update_touch_state_(ESP32TouchBinarySensor *child, bool is_touched);
+  // Helper to update touch state with a known state and value
+  void update_touch_state_(ESP32TouchBinarySensor *child, bool is_touched, uint32_t value);
 
   // Helper to read touch value and update state for a given child
   bool check_and_update_touch_state_(ESP32TouchBinarySensor *child);

--- a/esphome/components/esp32_touch/esp32_touch_common.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_common.cpp
@@ -100,6 +100,8 @@ void ESP32TouchComponent::process_setup_mode_logging_(uint32_t now) {
 #else
       // Read the value being used for touch detection
       uint32_t value = this->read_touch_value(child->get_touch_pad());
+      // Store the value for get_value() access in lambdas
+      child->value_ = value;
       ESP_LOGD(TAG, "Touch Pad '%s' (T%d): %d", child->get_name().c_str(), child->get_touch_pad(), value);
 #endif
     }

--- a/esphome/components/esp32_touch/esp32_touch_v2.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v2.cpp
@@ -21,7 +21,7 @@ void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, boo
     child->last_state_ = is_touched;
     child->publish_state(is_touched);
     if (is_touched) {
-      // For logging, show the current value if available, otherwise show just the state
+      // Use stored value for logging (should be updated by caller)
       ESP_LOGV(TAG, "Touch Pad '%s' state: ON (value: %" PRIu32 " > threshold: %" PRIu32 ")", child->get_name().c_str(),
                child->value_, child->threshold_ + child->benchmark_);
     } else {

--- a/esphome/components/esp32_touch/esp32_touch_v2.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v2.cpp
@@ -21,12 +21,9 @@ void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, boo
     child->last_state_ = is_touched;
     child->publish_state(is_touched);
     if (is_touched) {
-      // Read and store the value for logging and get_value() access
-      uint32_t value = this->read_touch_value(child->touch_pad_);
-      child->value_ = value;
-      // ESP32-S2/S3 v2: touched when value > threshold
+      // For logging, show the current value if available, otherwise show just the state
       ESP_LOGV(TAG, "Touch Pad '%s' state: ON (value: %" PRIu32 " > threshold: %" PRIu32 ")", child->get_name().c_str(),
-               value, child->threshold_ + child->benchmark_);
+               child->value_, child->threshold_ + child->benchmark_);
     } else {
       ESP_LOGV(TAG, "Touch Pad '%s' state: OFF", child->get_name().c_str());
     }
@@ -302,6 +299,8 @@ void ESP32TouchComponent::loop() {
           this->check_and_update_touch_state_(child);
         } else if (event.intr_mask & TOUCH_PAD_INTR_MASK_ACTIVE) {
           // We only get ACTIVE interrupts now, releases are detected by timeout
+          // Read and store the value for get_value() access
+          child->value_ = this->read_touch_value(child->touch_pad_);
           this->update_touch_state_(child, true);  // Always touched for ACTIVE interrupts
         }
         break;

--- a/esphome/components/esp32_touch/esp32_touch_v2.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v2.cpp
@@ -21,9 +21,12 @@ void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, boo
     child->last_state_ = is_touched;
     child->publish_state(is_touched);
     if (is_touched) {
+      // Read and store the value for logging and get_value() access
+      uint32_t value = this->read_touch_value(child->touch_pad_);
+      child->value_ = value;
       // ESP32-S2/S3 v2: touched when value > threshold
       ESP_LOGV(TAG, "Touch Pad '%s' state: ON (value: %" PRIu32 " > threshold: %" PRIu32 ")", child->get_name().c_str(),
-               this->read_touch_value(child->touch_pad_), child->threshold_ + child->benchmark_);
+               value, child->threshold_ + child->benchmark_);
     } else {
       ESP_LOGV(TAG, "Touch Pad '%s' state: OFF", child->get_name().c_str());
     }
@@ -34,6 +37,9 @@ void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, boo
 bool ESP32TouchComponent::check_and_update_touch_state_(ESP32TouchBinarySensor *child) {
   // Read current touch value
   uint32_t value = this->read_touch_value(child->touch_pad_);
+
+  // Store the value for get_value() access in lambdas
+  child->value_ = value;
 
   // ESP32-S2/S3 v2: Touch is detected when value > threshold + benchmark
   ESP_LOGV(TAG,

--- a/esphome/components/esp32_touch/esp32_touch_v2.cpp
+++ b/esphome/components/esp32_touch/esp32_touch_v2.cpp
@@ -10,8 +10,11 @@ namespace esp32_touch {
 
 static const char *const TAG = "esp32_touch";
 
-// Helper to update touch state with a known state
-void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, bool is_touched) {
+// Helper to update touch state with a known state and value
+void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, bool is_touched, uint32_t value) {
+  // Store the value for get_value() access in lambdas
+  child->value_ = value;
+
   // Always update timer when touched
   if (is_touched) {
     child->last_touch_time_ = App.get_loop_component_start_time();
@@ -21,9 +24,8 @@ void ESP32TouchComponent::update_touch_state_(ESP32TouchBinarySensor *child, boo
     child->last_state_ = is_touched;
     child->publish_state(is_touched);
     if (is_touched) {
-      // Use stored value for logging (should be updated by caller)
       ESP_LOGV(TAG, "Touch Pad '%s' state: ON (value: %" PRIu32 " > threshold: %" PRIu32 ")", child->get_name().c_str(),
-               child->value_, child->threshold_ + child->benchmark_);
+               value, child->threshold_ + child->benchmark_);
     } else {
       ESP_LOGV(TAG, "Touch Pad '%s' state: OFF", child->get_name().c_str());
     }
@@ -35,16 +37,13 @@ bool ESP32TouchComponent::check_and_update_touch_state_(ESP32TouchBinarySensor *
   // Read current touch value
   uint32_t value = this->read_touch_value(child->touch_pad_);
 
-  // Store the value for get_value() access in lambdas
-  child->value_ = value;
-
   // ESP32-S2/S3 v2: Touch is detected when value > threshold + benchmark
   ESP_LOGV(TAG,
            "Checking touch state for '%s' (T%d): value = %" PRIu32 ", threshold = %" PRIu32 ", benchmark = %" PRIu32,
            child->get_name().c_str(), child->touch_pad_, value, child->threshold_, child->benchmark_);
   bool is_touched = value > child->benchmark_ + child->threshold_;
 
-  this->update_touch_state_(child, is_touched);
+  this->update_touch_state_(child, is_touched, value);
   return is_touched;
 }
 
@@ -299,9 +298,9 @@ void ESP32TouchComponent::loop() {
           this->check_and_update_touch_state_(child);
         } else if (event.intr_mask & TOUCH_PAD_INTR_MASK_ACTIVE) {
           // We only get ACTIVE interrupts now, releases are detected by timeout
-          // Read and store the value for get_value() access
-          child->value_ = this->read_touch_value(child->touch_pad_);
-          this->update_touch_state_(child, true);  // Always touched for ACTIVE interrupts
+          // Read the current value
+          uint32_t value = this->read_touch_value(child->touch_pad_);
+          this->update_touch_state_(child, true, value);  // Always touched for ACTIVE interrupts
         }
         break;
       }

--- a/tests/components/esp32_touch/common-get-value.yaml
+++ b/tests/components/esp32_touch/common-get-value.yaml
@@ -1,0 +1,18 @@
+binary_sensor:
+  - platform: esp32_touch
+    name: ESP32 Touch Pad Get Value
+    pin: ${pin}
+    threshold: 1000
+    id: esp32_touch_pad_get_value
+    on_press:
+      then:
+        - lambda: |-
+            // Test that get_value() compiles and works
+            uint32_t value = id(esp32_touch_pad_get_value).get_value();
+            ESP_LOGD("test", "Touch value on press: %u", value);
+    on_release:
+      then:
+        - lambda: |-
+            // Test get_value() on release
+            uint32_t value = id(esp32_touch_pad_get_value).get_value();
+            ESP_LOGD("test", "Touch value on release: %u", value);

--- a/tests/components/esp32_touch/test.esp32-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-idf.yaml
@@ -2,3 +2,4 @@ substitutions:
   pin: GPIO27
 
 <<: !include common.yaml
+<<: !include common-get-value.yaml

--- a/tests/components/esp32_touch/test.esp32-s2-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-s2-idf.yaml
@@ -2,3 +2,4 @@ substitutions:
   pin: GPIO12
 
 <<: !include common-variants.yaml
+<<: !include common-get-value.yaml

--- a/tests/components/esp32_touch/test.esp32-s3-idf.yaml
+++ b/tests/components/esp32_touch/test.esp32-s3-idf.yaml
@@ -2,3 +2,4 @@ substitutions:
   pin: GPIO12
 
 <<: !include common-variants.yaml
+<<: !include common-get-value.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR restores the `get_value()` method for ESP32-S2 and ESP32-S3 touch sensor variants, which was optimized away in 2025.7.x as dead code because visual inspection of the code showed the `value_` member was never read within the component itself.

The `get_value()` method worked for all ESP32 variants in 2025.6.x but was inadvertently limited to only the original ESP32 variant in 2025.7.x when `#ifdef USE_ESP32_VARIANT_ESP32` guards were added around both the `value_` member variable and its accessor method. While these appear unused from the component's perspective, they're designed as a public API for user lambdas to access raw touch sensor values for custom calculations (e.g., water level sensing, custom threshold logic). This broke existing user configurations that depend on this functionality.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10047

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- No documentation changes needed - the method already exists and is documented, this just makes it work on more variants

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_touch:
  setup_mode: false

binary_sensor:
  - platform: esp32_touch
    name: "Touch Sensor"
    pin: GPIO2
    threshold: 1000
    id: touch_sensor

sensor:
  - platform: template
    name: "Water Level"
    lambda: |-
      // get_value() now works on ESP32-S2/S3!
      float raw_cap = (float) round((id(touch_sensor).get_value()) / 10000);
      return (float) ((raw_cap * 0.0189) - 0.6575);
    update_interval: 1s
    unit_of_measurement: "inches"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This is a regression fix - the functionality worked in 2025.6.x but was broken in 2025.7.x when the `value_` member variable was optimized away as dead code. During code cleanup, the developer noticed through visual inspection that the value was being written but never read within the component, so it appeared to be dead code. They didn't realize that the value was being read through the public `get_value()` method in user lambdas.

The `get_value()` method has been part of the public API since 2019 (PR #631), making this a significant regression that breaks long-standing functionality.

The fix involved:
1. Removing the `#ifdef USE_ESP32_VARIANT_ESP32` guards from the `value_` member and `get_value()` method
2. Updating the ESP32-S2/S3 implementation to store touch values when read (this logic was lost when the code was refactored)
3. Adding test coverage for all three ESP32 variants (ESP32, ESP32-S2, ESP32-S3) that specifically use `get_value()` in lambdas to prevent future regressions

The new tests ensure that `get_value()` will be recognized as used code in the future, preventing accidental removal during code cleanup.

The implementation ensures the value is updated whenever:
- A touch event is processed
- Touch state is checked during timeout handling  
- Setup mode logging reads values

This restores the 2025.6.x behavior where `get_value()` works on all ESP32 variants, not just the original ESP32.