### PR TITLE
[esp32_ble_tracker] Optimize member variable ordering to reduce memory padding

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -333,33 +333,37 @@ class ESP32BLETracker : public Component,
     return counts;
   }
 
-  uint8_t app_id_{0};
-
+  // Group 1: Large objects (12+ bytes) - vectors and callback manager
+  std::vector<ESPBTDeviceListener *> listeners_;
+  std::vector<ESPBTClient *> clients_;
+  CallbackManager<void(ScannerState)> scanner_state_callbacks_;
 #ifdef USE_ESP32_BLE_DEVICE
   /// Vector of addresses that have already been printed in print_bt_device_info
   std::vector<uint64_t> already_discovered_;
 #endif
-  std::vector<ESPBTDeviceListener *> listeners_;
-  /// Client parameters.
-  std::vector<ESPBTClient *> clients_;
+
+  // Group 2: Structs (aligned to 4 bytes)
   /// A structure holding the ESP BLE scan parameters.
   esp_ble_scan_params_t scan_params_;
+  ClientStateCounts client_state_counts_;
+
+  // Group 3: 4-byte types
   /// The interval in seconds to perform scans.
   uint32_t scan_duration_;
   uint32_t scan_interval_;
   uint32_t scan_window_;
+  esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
+  esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
+
+  // Group 4: 1-byte types (enums, uint8_t, bool)
+  uint8_t app_id_{0};
   uint8_t scan_start_fail_count_{0};
+  ScannerState scanner_state_{ScannerState::IDLE};
   bool scan_continuous_;
   bool scan_active_;
-  ScannerState scanner_state_{ScannerState::IDLE};
-  CallbackManager<void(ScannerState)> scanner_state_callbacks_;
   bool ble_was_disabled_{true};
   bool raw_advertisements_{false};
   bool parse_advertisements_{false};
-
-  esp_bt_status_t scan_start_failed_{ESP_BT_STATUS_SUCCESS};
-  esp_bt_status_t scan_set_param_failed_{ESP_BT_STATUS_SUCCESS};
-  ClientStateCounts client_state_counts_;
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   bool coex_prefer_ble_{false};
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Reorders member variables in the `ESP32BLETracker` class to reduce memory padding from 7 bytes to 3 bytes, saving 4 bytes total per instance. While the savings are minimal for this singleton class, it follows best practices for memory layout optimization in embedded systems.

The reordering groups members by size and alignment requirements:
1. Large objects (vectors, callback manager) - 12+ bytes
2. Structs - aligned to 4 bytes  
3. 4-byte types (uint32_t, enums)
4. 1-byte types (uint8_t, bool, small enums) packed together

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
esp32_ble_tracker:
  scan_parameters:
    active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).