### PR TITLE
[esp32_ble_client] Conditionally compile BLE service classes to reduce flash usage

### DIFF
--- a/esphome/components/esp32_ble_client/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_client/ble_characteristic.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
+#ifdef USE_ESP32_BLE_DEVICE
 
 namespace esphome::esp32_ble_client {
 
@@ -94,4 +95,5 @@ esp_err_t BLECharacteristic::write_value(uint8_t *new_val, int16_t new_val_size)
 
 }  // namespace esphome::esp32_ble_client
 
+#endif  // USE_ESP32_BLE_DEVICE
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_characteristic.h
+++ b/esphome/components/esp32_ble_client/ble_characteristic.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 #ifdef USE_ESP32
+#ifdef USE_ESP32_BLE_DEVICE
 
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
@@ -34,4 +37,5 @@ class BLECharacteristic {
 
 }  // namespace esphome::esp32_ble_client
 
+#endif  // USE_ESP32_BLE_DEVICE
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -5,7 +5,9 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/core/component.h"
 
+#ifdef USE_ESP32_BLE_DEVICE
 #include "ble_service.h"
+#endif
 
 #include <array>
 #include <string>
@@ -67,6 +69,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   }
   const std::string &address_str() const { return this->address_str_; }
 
+#ifdef USE_ESP32_BLE_DEVICE
   BLEService *get_service(espbt::ESPBTUUID uuid);
   BLEService *get_service(uint16_t uuid);
   BLECharacteristic *get_characteristic(espbt::ESPBTUUID service, espbt::ESPBTUUID chr);
@@ -77,6 +80,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   BLEDescriptor *get_descriptor(uint16_t handle);
   // Get the configuration descriptor for the given characteristic handle.
   BLEDescriptor *get_config_descriptor(uint16_t handle);
+#endif
 
   float parse_char_value(uint8_t *value, uint16_t length);
 
@@ -103,7 +107,9 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
 
   // Group 2: Container types (grouped for memory optimization)
   std::string address_str_{};
+#ifdef USE_ESP32_BLE_DEVICE
   std::vector<BLEService *> services_;
+#endif
 
   // Group 3: 4-byte types
   int gattc_if_;

--- a/esphome/components/esp32_ble_client/ble_descriptor.h
+++ b/esphome/components/esp32_ble_client/ble_descriptor.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 #ifdef USE_ESP32
+#ifdef USE_ESP32_BLE_DEVICE
 
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
@@ -20,4 +23,5 @@ class BLEDescriptor {
 
 }  // namespace esphome::esp32_ble_client
 
+#endif  // USE_ESP32_BLE_DEVICE
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_service.cpp
+++ b/esphome/components/esp32_ble_client/ble_service.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
+#ifdef USE_ESP32_BLE_DEVICE
 
 namespace esphome::esp32_ble_client {
 
@@ -72,4 +73,5 @@ void BLEService::parse_characteristics() {
 
 }  // namespace esphome::esp32_ble_client
 
+#endif  // USE_ESP32_BLE_DEVICE
 #endif  // USE_ESP32

--- a/esphome/components/esp32_ble_client/ble_service.h
+++ b/esphome/components/esp32_ble_client/ble_service.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 #ifdef USE_ESP32
+#ifdef USE_ESP32_BLE_DEVICE
 
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
@@ -31,4 +34,5 @@ class BLEService {
 
 }  // namespace esphome::esp32_ble_client
 
+#endif  // USE_ESP32_BLE_DEVICE
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage for `bluetooth_proxy` by conditionally compiling BLE service discovery classes (`BLEService`, `BLECharacteristic`, `BLEDescriptor`) only when they are actually needed.

The `bluetooth_proxy` component works at a lower GATT level and doesn't use these higher-level abstractions, but they were being compiled and linked anyway. This change wraps these classes with `#ifdef USE_ESP32_BLE_DEVICE`, which is only defined when components register as BLE device listeners or clients using the full API.

**Flash savings**: ~440 bytes per device using bluetooth_proxy without other BLE client components

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Breaking change note**: This is technically a breaking change if custom components were using these classes without properly registering as BLE device listeners/clients, but this usage pattern would be incorrect and unlikely.

**Related issue or feature (if applicable):** None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** Not needed - internal implementation change

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example bluetooth_proxy configuration that will benefit from reduced flash usage
esphome:
  name: my-bluetooth-proxy

esp32:
  board: esp32dev
  framework:
    type: arduino

logger:

esp32_ble_tracker:

bluetooth_proxy:

# Example ble_client configuration that will still have full functionality
esphome:
  name: my-ble-client

esp32:
  board: esp32dev
  framework:
    type: arduino

logger:

esp32_ble_tracker:

ble_client:
  - mac_address: AA:BB:CC:DD:EE:FF
    id: my_ble_client
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Technical Details

### Changes made:
1. Added `#include "esphome/core/defines.h"` to BLE class headers to ensure defines are visible
2. Wrapped class definitions and implementations with `#ifdef USE_ESP32_BLE_DEVICE`
3. Conditionally included `ble_service.h` in `ble_client_base.h`
4. Wrapped all methods in `BLEClientBase` that use these classes
5. Wrapped the `services_` vector member variable
6. Wrapped code that creates or iterates over services

### Components affected:
- **Still have access** (use `register_client` or `register_ble_device`):
  - `ble_client` - Uses for write operations  
  - `bedjet` - Uses `get_characteristic()`
  - Other BLE sensor/control components

- **Won't have access** (use `register_raw_client` or `register_raw_ble_device`):
  - `bluetooth_proxy` - Works at raw GATT level

