### PR TITLE
[deep_sleep] Added support for on_deep_sleep event in deep_sleep comp…

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -25,11 +25,14 @@ from esphome.const import (
     CONF_SECOND,
     CONF_SLEEP_DURATION,
     CONF_TIME_ID,
+    CONF_TRIGGER_ID,
     CONF_WAKEUP_PIN,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PlatformFramework,
 )
+
+CONF_ON_DEEP_SLEEP = "on_deep_sleep"
 
 WAKEUP_PINS = {
     VARIANT_ESP32: [
@@ -162,6 +165,10 @@ EXT1_WAKEUP_MODES = {
 }
 WakeupCauseToRunDuration = deep_sleep_ns.struct("WakeupCauseToRunDuration")
 
+DeepSleepTrigger = deep_sleep_ns.class_(
+    "DeepSleepTrigger", cg.PollingComponent, automation.Trigger.template()
+)
+
 CONF_WAKEUP_PIN_MODE = "wakeup_pin_mode"
 CONF_ESP32_EXT1_WAKEUP = "esp32_ext1_wakeup"
 CONF_TOUCH_WAKEUP = "touch_wakeup"
@@ -218,6 +225,11 @@ CONFIG_SCHEMA = cv.All(
                 ),
                 cv.boolean,
             ),
+            cv.Optional(CONF_ON_DEEP_SLEEP): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DeepSleepTrigger),
+                }
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266]),
@@ -271,6 +283,10 @@ async def to_code(config):
 
     if CONF_TOUCH_WAKEUP in config:
         cg.add(var.set_touch_wakeup(config[CONF_TOUCH_WAKEUP]))
+
+    for conf in config.get(CONF_ON_DEEP_SLEEP, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
 
     cg.add_define("USE_DEEP_SLEEP")
 

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -166,7 +166,7 @@ EXT1_WAKEUP_MODES = {
 WakeupCauseToRunDuration = deep_sleep_ns.struct("WakeupCauseToRunDuration")
 
 DeepSleepTrigger = deep_sleep_ns.class_(
-    "DeepSleepTrigger", cg.PollingComponent, automation.Trigger.template()
+    "DeepSleepTrigger", automation.Trigger.template()
 )
 
 CONF_WAKEUP_PIN_MODE = "wakeup_pin_mode"
@@ -228,7 +228,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_DEEP_SLEEP): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DeepSleepTrigger),
-                }
+                },
+                single=True,
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
@@ -284,7 +285,8 @@ async def to_code(config):
     if CONF_TOUCH_WAKEUP in config:
         cg.add(var.set_touch_wakeup(config[CONF_TOUCH_WAKEUP]))
 
-    for conf in config.get(CONF_ON_DEEP_SLEEP, []):
+    if CONF_ON_DEEP_SLEEP in config:
+        conf = config[CONF_ON_DEEP_SLEEP]
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
 

--- a/esphome/components/deep_sleep/deep_sleep_component.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_component.cpp
@@ -62,6 +62,11 @@ void DeepSleepComponent::begin_sleep(bool manual) {
   if (this->sleep_duration_.has_value()) {
     ESP_LOGI(TAG, "Sleeping for %" PRId64 "us", *this->sleep_duration_);
   }
+
+  if (this->enter_deep_sleep_callback_) {
+    this->enter_deep_sleep_callback_();
+  }
+
   App.run_safe_shutdown_hooks();
   // It's critical to teardown components cleanly for deep sleep to ensure
   // Home Assistant sees a clean disconnect instead of marking the device unavailable

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -103,6 +103,10 @@ class DeepSleepComponent : public Component {
   void prevent_deep_sleep();
   void allow_deep_sleep();
 
+  void set_enter_deep_sleep_callback(std::function<void()> callback) {
+    this->enter_deep_sleep_callback_ = std::move(callback);
+  }
+
  protected:
   // Returns nullopt if no run duration is set. Otherwise, returns the run
   // duration before entering deep sleep.
@@ -127,6 +131,8 @@ class DeepSleepComponent : public Component {
   optional<uint32_t> run_duration_;
   bool next_enter_deep_sleep_{false};
   bool prevent_{false};
+
+  std::function<void()> enter_deep_sleep_callback_;
 };
 
 extern bool global_has_deep_sleep;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -213,5 +219,11 @@ template<typename... Ts> class AllowDeepSleepAction : public Action<Ts...>, publ
   void play(Ts... x) override { this->parent_->allow_deep_sleep(); }
 };
 
+class DeepSleepTrigger : public Trigger<>, public Parented<DeepSleepComponent> {
+ public:
+  DeepSleepTrigger(DeepSleepComponent *ds) {
+    ds->set_enter_deep_sleep_callback([this]() { this->trigger(); });
+  }
+};
 }  // namespace deep_sleep
 }  // namespace esphome

--- a/esphome/components/deep_sleep/deep_sleep_component.h
+++ b/esphome/components/deep_sleep/deep_sleep_component.h
@@ -219,7 +219,7 @@ template<typename... Ts> class AllowDeepSleepAction : public Action<Ts...>, publ
   void play(Ts... x) override { this->parent_->allow_deep_sleep(); }
 };
 
-class DeepSleepTrigger : public Trigger<>, public Parented<DeepSleepComponent> {
+class DeepSleepTrigger : public Trigger<> {
  public:
   DeepSleepTrigger(DeepSleepComponent *ds) {
     ds->set_enter_deep_sleep_callback([this]() { this->trigger(); });


### PR DESCRIPTION
…onent to provide a way to execute some actions before going to deep sleep.

# What does this implement/fix?

This change adds support for `on_deep_sleep` trigger for deep_sleep component, so custom code/actions can be performed before going to deep sleep.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- implements [feature request](https://github.com/orgs/esphome/discussions/3256)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
deep_sleep:
  run_duration: 10s
  sleep_duration: 10s
  on_deep_sleep:
    - lambda: |-
        ESP_LOGI("deep_sleep", "!!!!!!!!! going to sleep!!!!!!!!!");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
