### PR TITLE
[neopixelbus] Fix neopixelbus on esp32

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -225,6 +225,7 @@ async def to_code(config):
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
     # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions
     if CORE.is_esp32:
+        cg.add_define("ESP32_ARDUINO_NO_RGB_BUILTIN")
         cg.add_library("makuna/NeoPixelBus", "2.8.0")
     else:
         cg.add_library("makuna/NeoPixelBus", "2.7.3")

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -225,7 +225,9 @@ async def to_code(config):
     # https://github.com/Makuna/NeoPixelBus/blob/master/library.json
     # Version Listed Here: https://registry.platformio.org/libraries/makuna/NeoPixelBus/versions
     if CORE.is_esp32:
-        cg.add_define("ESP32_ARDUINO_NO_RGB_BUILTIN")
+        # disable built in rgb support as it uses the new RMT drivers and will
+        # conflict with NeoPixelBus which uses the legacy drivers
+        cg.add_build_flag("-DESP32_ARDUINO_NO_RGB_BUILTIN")
         cg.add_library("makuna/NeoPixelBus", "2.8.0")
     else:
         cg.add_library("makuna/NeoPixelBus", "2.7.3")


### PR DESCRIPTION
# What does this implement/fix?

On boards with a built in rgb led neopixelbus would cause a reset. Disable built in rgb support as it uses the new RMT drivers and will conflict with NeoPixelBus which uses the legacy drivers resulting in a reset. 

https://github.com/espressif/arduino-esp32/blob/3.2.1/cores/esp32/esp32-hal-gpio.c#L24

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10120

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
