### PR TITLE
[wifi] Reduce flash usage by optimizing logging

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -457,9 +457,11 @@ void WiFiComponent::print_connect_params_() {
                                                                         "  Signal strength: %d dB %s",
                 bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5], App.get_name().c_str(), rssi,
                 LOG_STR_ARG(get_signal_bars(rssi)));
+#ifdef ESPHOME_LOG_HAS_VERBOSE
   if (this->selected_ap_.get_bssid().has_value()) {
     ESP_LOGV(TAG, "  Priority: %.1f", this->get_sta_priority(*this->selected_ap_.get_bssid()));
   }
+#endif
   ESP_LOGCONFIG(TAG,
                 "  Channel: %" PRId32 "\n"
                 "  Subnet: %s\n"
@@ -594,8 +596,10 @@ void WiFiComponent::check_scanning_finished() {
     if (res.get_matches()) {
       ESP_LOGI(TAG, "- '%s' %s" LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(),
                res.get_is_hidden() ? "(HIDDEN) " : "", bssid_s, LOG_STR_ARG(get_signal_bars(res.get_rssi())));
-      ESP_LOGD(TAG, "    Channel: %u", res.get_channel());
-      ESP_LOGD(TAG, "    RSSI: %d dB", res.get_rssi());
+      ESP_LOGD(TAG,
+               "    Channel: %u\n"
+               "    RSSI: %d dB",
+               res.get_channel(), res.get_rssi());
     } else {
       ESP_LOGD(TAG, "- " LOG_SECRET("'%s'") " " LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(), bssid_s,
                LOG_STR_ARG(get_signal_bars(res.get_rssi())));


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the WiFi component by optimizing logging code:

- Combined multiple log calls into single multi-line format strings
- Wrapped verbose-only logging with compile-time conditionals

These changes save 16 bytes of flash memory on ESP8266 without affecting functionality or user experience.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
wifi:
  ssid: "MyNetwork"
  password: "MyPassword"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Information

Flash usage measurements on ESP8266:
- Before: 517,325 bytes (49.5%)
- After: 517,309 bytes (49.5%)
- Saved: 16 bytes

Changes made:
1. Combined two `ESP_LOGD` calls in `check_scanning_finished()` into a single multi-line call
2. Wrapped verbose priority logging in `print_connect_params_()` with `#ifdef ESPHOME_LOG_HAS_VERBOSE`

The `check_scanning_finished()` function remains the largest symbol (1,203 bytes) in the WiFi component. Further significant reductions would require changing what information is logged at info level during network scanning, which would impact the user experience.