### PR TITLE
[mdns] Conditionally compile extra services to reduce flash usage

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -93,6 +93,9 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 
+    if config[CONF_SERVICES]:
+        cg.add_define("USE_MDNS_EXTRA_SERVICES")
+
     for service in config[CONF_SERVICES]:
         txt = [
             cg.StructInitializer(

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -104,7 +104,9 @@ void MDNSComponent::compile_records_() {
   }
 #endif
 
+#ifdef USE_MDNS_EXTRA_SERVICES
   this->services_.insert(this->services_.end(), this->services_extra_.begin(), this->services_extra_.end());
+#endif
 
   if (this->services_.empty()) {
     // Publish "http" service if not using native API

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -35,14 +35,18 @@ class MDNSComponent : public Component {
 #endif
   float get_setup_priority() const override { return setup_priority::AFTER_CONNECTION; }
 
+#ifdef USE_MDNS_EXTRA_SERVICES
   void add_extra_service(MDNSService service) { services_extra_.push_back(std::move(service)); }
+#endif
 
   std::vector<MDNSService> get_services();
 
   void on_shutdown() override;
 
  protected:
+#ifdef USE_MDNS_EXTRA_SERVICES
   std::vector<MDNSService> services_extra_{};
+#endif
   std::vector<MDNSService> services_{};
   std::string hostname_;
   void compile_records_();


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the mDNS component by conditionally compiling the extra services feature that most users don't use.

Changes:
- Added `USE_MDNS_EXTRA_SERVICES` define when custom mDNS services are configured
- Conditionally compile `services_extra_` vector and related code only when needed

These changes save 840 bytes of flash memory and 12 bytes of RAM on ESP8266 for users who don't define custom mDNS services (the vast majority).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Custom mDNS services still work exactly the same:
mdns:
  services:
    - service: "_custom"
      protocol: "_tcp"
      port: 1234
      txt:
        key: value
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Information

Resource usage measurements on ESP8266:
- Flash: 517,325 → 516,485 bytes (saved 840 bytes)
- RAM: Saves 12 bytes (std::vector overhead)

The optimization works by:
1. Only defining `USE_MDNS_EXTRA_SERVICES` when users configure custom mDNS services
2. Conditionally compiling the `services_extra_` vector and all related code
3. Since most users don't define custom services, this saves significant flash for the common case