### PR TITLE
[cover] Reduce flash usage by optimizing validation messages

### DIFF
--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -99,43 +99,39 @@ const optional<float> &CoverCall::get_tilt() const { return this->tilt_; }
 const optional<bool> &CoverCall::get_toggle() const { return this->toggle_; }
 void CoverCall::validate_() {
   auto traits = this->parent_->get_traits();
+  const char *name = this->parent_->get_name().c_str();
+
   if (this->position_.has_value()) {
     auto pos = *this->position_;
     if (!traits.get_supports_position() && pos != COVER_OPEN && pos != COVER_CLOSED) {
-      ESP_LOGW(TAG, "'%s' - This cover device does not support setting position!", this->parent_->get_name().c_str());
+      ESP_LOGW(TAG, "'%s': position unsupported", name);
       this->position_.reset();
     } else if (pos < 0.0f || pos > 1.0f) {
-      ESP_LOGW(TAG, "'%s' - Position %.2f is out of range [0.0 - 1.0]", this->parent_->get_name().c_str(), pos);
+      ESP_LOGW(TAG, "'%s': position %.2f out of range", name, pos);
       this->position_ = clamp(pos, 0.0f, 1.0f);
     }
   }
   if (this->tilt_.has_value()) {
     auto tilt = *this->tilt_;
     if (!traits.get_supports_tilt()) {
-      ESP_LOGW(TAG, "'%s' - This cover device does not support tilt!", this->parent_->get_name().c_str());
+      ESP_LOGW(TAG, "'%s': tilt unsupported", name);
       this->tilt_.reset();
     } else if (tilt < 0.0f || tilt > 1.0f) {
-      ESP_LOGW(TAG, "'%s' - Tilt %.2f is out of range [0.0 - 1.0]", this->parent_->get_name().c_str(), tilt);
+      ESP_LOGW(TAG, "'%s': tilt %.2f out of range", name, tilt);
       this->tilt_ = clamp(tilt, 0.0f, 1.0f);
     }
   }
   if (this->toggle_.has_value()) {
     if (!traits.get_supports_toggle()) {
-      ESP_LOGW(TAG, "'%s' - This cover device does not support toggle!", this->parent_->get_name().c_str());
+      ESP_LOGW(TAG, "'%s': toggle unsupported", name);
       this->toggle_.reset();
     }
   }
   if (this->stop_) {
-    if (this->position_.has_value()) {
-      ESP_LOGW(TAG, "Cannot set position when stopping a cover!");
+    if (this->position_.has_value() || this->tilt_.has_value() || this->toggle_.has_value()) {
+      ESP_LOGW(TAG, "'%s': cannot position/tilt/toggle when stopping", name);
       this->position_.reset();
-    }
-    if (this->tilt_.has_value()) {
-      ESP_LOGW(TAG, "Cannot set tilt when stopping a cover!");
       this->tilt_.reset();
-    }
-    if (this->toggle_.has_value()) {
-      ESP_LOGW(TAG, "Cannot set toggle when stopping a cover!");
       this->toggle_.reset();
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the cover component by optimizing the `validate_()` function:

- Cache device name instead of calling `get_name().c_str()` multiple times
- Use shorter, more concise warning messages
- Consolidate stop validation logic

These changes save 272 bytes of flash memory on ESP8266 while maintaining the same validation behavior.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
cover:
  - platform: template
    name: "Test Cover"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Information

Flash usage measurements on ESP8266:
- Before: 517,325 bytes (49.5%)
- After: 517,053 bytes (49.5%)
- Saved: 272 bytes

The optimization works by:
1. Caching `parent_->get_name().c_str()` to avoid 7 repeated calls
2. Shortening warning messages while keeping them informative
3. Consolidating the stop validation to use a single condition and warning

All validation logic remains unchanged - only the warning messages are more concise.