### PR TITLE
[nextion] Minimize `delay` calls

### DIFF
--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -11,7 +11,6 @@ static const char *const TAG = "nextion.upload";
 bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Upload successful");
-    delay(1500);  // NOLINT
     App.safe_reboot();
   } else {
     ESP_LOGE(TAG, "Upload failed");


### PR DESCRIPTION
# What does this implement/fix?

Supporting esphome/backlog#38
> Calls to `delay(...)` block the main loop, we don't like that.

So this PR will try to minimize those on the Nextion component:
- ~File esphome/components/nextion/nextion_upload.cpp~
  - ~esphome/components/nextion/nextion_upload.cpp:14:2: lint: delay(1500);~
- File esphome/components/nextion/nextion_upload_arduino.cpp
  - esphome/components/nextion/nextion_upload_arduino.cpp:220:2: lint: delay(100);
  - esphome/components/nextion/nextion_upload_arduino.cpp:226:2: lint: delay(250);
  - esphome/components/nextion/nextion_upload_arduino.cpp:260:2: lint: delay(250);
  - esphome/components/nextion/nextion_upload_arduino.cpp:273:2: lint: delay(250);
- File esphome/components/nextion/nextion_upload_idf.cpp (not mapped in esphome/backlog#38)
  - esphome/components/nextion/nextion_upload_idf.cpp:252:2: lint: vTaskDelay(pdMS_TO_TICKS(250));
  - esphome/components/nextion/nextion_upload_idf.cpp:265:2: lint: vTaskDelay(pdMS_TO_TICKS(250));

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- helps with esphome/backlog#38

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
