### PR TITLE
[bluetooth_proxy] Optimize connection loop to reduce CPU usage

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -107,13 +107,25 @@ void BluetoothConnection::set_address(uint64_t address) {
 void BluetoothConnection::loop() {
   BLEClientBase::loop();
 
-  // Early return if no active connection or not in service discovery phase
-  if (this->address_ == 0 || this->send_service_ < 0 || this->send_service_ > this->service_count_) {
+  // Early return if no active connection
+  if (this->address_ == 0) {
     return;
   }
 
-  // Handle service discovery
-  this->send_service_for_discovery_();
+  // Handle service discovery if in valid range
+  if (this->send_service_ >= 0 && this->send_service_ <= this->service_count_) {
+    this->send_service_for_discovery_();
+  }
+
+  // Check if we should disable the loop
+  // - For V3_WITH_CACHE: Services are never sent, disable immediately once connected
+  // - For other connections: Disable only after service discovery is complete
+  //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
+  if ((this->state() == espbt::ClientState::ESTABLISHED || this->state() == espbt::ClientState::CONNECTED) &&
+      (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
+       this->send_service_ == DONE_SENDING_SERVICES)) {
+    this->disable_loop();
+  }
 }
 
 void BluetoothConnection::reset_connection_(esp_err_t reason) {
@@ -127,7 +139,7 @@ void BluetoothConnection::reset_connection_(esp_err_t reason) {
   // to detect incomplete service discovery rather than relying on us to
   // tell them about a partial list.
   this->set_address(0);
-  this->send_service_ = DONE_SENDING_SERVICES;
+  this->send_service_ = INIT_SENDING_SERVICES;
   this->proxy_->send_connections_free();
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -118,12 +118,11 @@ void BluetoothConnection::loop() {
   }
 
   // Check if we should disable the loop
-  // - For V3_WITH_CACHE: Services are never sent, disable immediately once connected
+  // - For V3_WITH_CACHE: Services are never sent, disable after INIT state
   // - For other connections: Disable only after service discovery is complete
   //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
-  if ((this->state() == espbt::ClientState::ESTABLISHED || this->state() == espbt::ClientState::CONNECTED) &&
-      (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
-       this->send_service_ == DONE_SENDING_SERVICES)) {
+  if (this->state_ != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
+                                                   this->send_service_ == DONE_SENDING_SERVICES)) {
     this->disable_loop();
   }
 }

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.h
@@ -44,7 +44,7 @@ class BluetoothConnection : public esp32_ble_client::BLEClientBase {
   BluetoothProxy *proxy_;
 
   // Group 2: 2-byte types
-  int16_t send_service_{-2};  // Needs to handle negative values and service count
+  int16_t send_service_{-3};  // -3 = INIT_SENDING_SERVICES, -2 = DONE_SENDING_SERVICES, >=0 = service index
 
   // Group 3: 1-byte types
   bool seen_mtu_or_services_{false};

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -192,7 +192,7 @@ BluetoothConnection *BluetoothProxy::get_connection_(uint64_t address, bool rese
   for (uint8_t i = 0; i < this->connection_count_; i++) {
     auto *connection = this->connections_[i];
     if (connection->get_address() == 0) {
-      connection->send_service_ = DONE_SENDING_SERVICES;
+      connection->send_service_ = INIT_SENDING_SERVICES;
       connection->set_address(address);
       // All connections must start at INIT
       // We only set the state if we allocate the connection
@@ -373,8 +373,7 @@ void BluetoothProxy::bluetooth_gatt_send_services(const api::BluetoothGATTGetSer
     this->send_gatt_services_done(msg.address);
     return;
   }
-  if (connection->send_service_ ==
-      DONE_SENDING_SERVICES)  // Only start sending services if we're not already sending them
+  if (connection->send_service_ == INIT_SENDING_SERVICES)  // Start sending services if not started yet
     connection->send_service_ = 0;
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -23,6 +23,7 @@ namespace esphome::bluetooth_proxy {
 
 static const esp_err_t ESP_GATT_NOT_CONNECTED = -1;
 static const int DONE_SENDING_SERVICES = -2;
+static const int INIT_SENDING_SERVICES = -3;
 
 using namespace esp32_ble_client;
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the Bluetooth proxy connection loop to reduce CPU usage by disabling the loop once connections are established and service discovery is complete. Previously, each active connection would run its loop approximately 7,000 times per minute even when idle, causing significant CPU overhead especially during Home Assistant startup when many integrations reconnect simultaneously (the "thundering herd" problem).

The optimization:
- For V3_WITH_CACHE connections: Disables the loop immediately upon connection (services are never sent)
- For other connections: Disables the loop after service discovery completes
- Properly tracks connection state using a new INIT_SENDING_SERVICES constant to distinguish between "not started" (-3) and "done" (-2) states

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional context

During testing, we observed that each established Bluetooth connection was running its loop ~7,000 times per minute even when idle. With the ESP32 Bluetooth proxy typically supporting 3 simultaneous connections, this resulted in ~21,000 unnecessary loop iterations per minute (350 per second).

This overhead is particularly problematic during Home Assistant restarts when many integrations attempt to reconnect simultaneously, creating a "thundering herd" scenario where all connection slots are occupied. The wasted CPU cycles from these empty loops reduced the system's ability to handle the reconnection surge efficiently.

After this optimization:
- V3_WITH_CACHE connections disable their loop immediately upon connection
- V3_WITHOUT_CACHE connections disable their loop after service discovery completes
- CPU resources are freed up for actual Bluetooth operations
- Better handling of the startup reconnection surge