### PR TITLE
[esp32_ble_tracker] Fix false reboots when event loop is blocked

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -367,6 +367,14 @@ class ESP32BLETracker : public Component,
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
   bool coex_prefer_ble_{false};
 #endif
+  // Scan timeout state machine
+  enum class ScanTimeoutState : uint8_t {
+    INACTIVE,       // No timeout monitoring
+    MONITORING,     // Actively monitoring for timeout
+    EXCEEDED_WAIT,  // Timeout exceeded, waiting one loop before reboot
+  };
+  uint32_t scan_start_time_{0};
+  ScanTimeoutState scan_timeout_state_{ScanTimeoutState::INACTIVE};
 };
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a race condition in the ESP32 BLE tracker where the device would incorrectly reboot when the event loop was blocked. 

Previously, the scan timeout was monitored using the scheduler's `set_timeout()` mechanism. When the event loop was blocked (e.g., due to heavy processing or network delays), the scheduler would fire immediately upon unblocking, before the ESP32 BLE tracker's `loop()` method could process any pending scan completion events. This caused false positive timeouts and unnecessary reboots.

The fix moves the timeout monitoring from the scheduler into the ESP32 BLE tracker's `loop()` method using a state machine. When a timeout is detected, it now waits one additional loop iteration before rebooting, ensuring all components (particularly `esp32_ble`) have had a chance to process pending events.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal bugfix
esp32_ble_tracker:
  scan_parameters:
    duration: 5min  # Timeout is 2x this value (10 minutes)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

