### PR TITLE
Optimize subprocess performance with close_fds=False

### DIFF
--- a/docker/build.py
+++ b/docker/build.py
@@ -90,7 +90,7 @@ def main():
     def run_command(*cmd, ignore_error: bool = False):
         print(f"$ {shlex.join(list(cmd))}")
         if not args.dry_run:
-            rc = subprocess.call(list(cmd))
+            rc = subprocess.call(list(cmd), close_fds=False)
             if rc != 0 and not ignore_error:
                 print("Command failed")
                 sys.exit(1)

--- a/esphome/components/sdl/display.py
+++ b/esphome/components/sdl/display.py
@@ -36,7 +36,9 @@ def get_sdl_options(value):
     if value != "":
         return value
     try:
-        return subprocess.check_output(["sdl2-config", "--cflags", "--libs"]).decode()
+        return subprocess.check_output(
+            ["sdl2-config", "--cflags", "--libs"], close_fds=False
+        ).decode()
     except Exception as e:
         raise cv.Invalid("Unable to run sdl2-config - have you installed sdl2?") from e
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -229,6 +229,7 @@ class EsphomeCommandWebSocket(tornado.websocket.WebSocketHandler):
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                close_fds=False,
             )
             stdout_thread = threading.Thread(target=self._stdout_thread)
             stdout_thread.daemon = True

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -17,7 +17,9 @@ _LOGGER = logging.getLogger(__name__)
 def run_git_command(cmd, cwd=None) -> str:
     _LOGGER.debug("Running git command: %s", " ".join(cmd))
     try:
-        ret = subprocess.run(cmd, cwd=cwd, capture_output=True, check=False)
+        ret = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, check=False, close_fds=False
+        )
     except FileNotFoundError as err:
         raise cv.Invalid(
             "git is not installed but required for external_components.\n"

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -114,7 +114,9 @@ def cpp_string_escape(string, encoding="utf-8"):
 def run_system_command(*args):
     import subprocess
 
-    with subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
+    with subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=False
+    ) as p:
         stdout, stderr = p.communicate()
         rc = p.returncode
         return rc, stdout, stderr

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -211,7 +211,7 @@ def _decode_pc(config, addr):
         return
     command = [idedata.addr2line_path, "-pfiaC", "-e", idedata.firmware_elf_path, addr]
     try:
-        translation = subprocess.check_output(command).decode().strip()
+        translation = subprocess.check_output(command, close_fds=False).decode().strip()
     except Exception:  # pylint: disable=broad-except
         _LOGGER.debug("Caught exception for command %s", command, exc_info=1)
         return

--- a/esphome/util.py
+++ b/esphome/util.py
@@ -239,7 +239,12 @@ def run_external_process(*cmd: str, **kwargs: Any) -> int | str:
 
     try:
         proc = subprocess.run(
-            cmd, stdout=sub_stdout, stderr=sub_stderr, encoding="utf-8", check=False
+            cmd,
+            stdout=sub_stdout,
+            stderr=sub_stderr,
+            encoding="utf-8",
+            check=False,
+            close_fds=False,
         )
         return proc.stdout if capture_stdout else proc.returncode
     except KeyboardInterrupt:  # pylint: disable=try-except-raise

--- a/script/clang-format
+++ b/script/clang-format
@@ -31,7 +31,11 @@ def run_format(executable, args, queue, lock, failed_files):
         invocation.append(path)
 
         proc = subprocess.run(
-            invocation, capture_output=True, encoding="utf-8", check=False
+            invocation,
+            capture_output=True,
+            encoding="utf-8",
+            check=False,
+            close_fds=False,
         )
         if proc.returncode != 0:
             with lock:

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -158,7 +158,11 @@ def run_tidy(executable, args, options, tmpdir, path_queue, lock, failed_files):
         invocation.extend(options)
 
         proc = subprocess.run(
-            invocation, capture_output=True, encoding="utf-8", check=False
+            invocation,
+            capture_output=True,
+            encoding="utf-8",
+            check=False,
+            close_fds=False,
         )
         if proc.returncode != 0:
             with lock:
@@ -320,9 +324,11 @@ def main():
         print("Applying fixes ...")
         try:
             try:
-                subprocess.call(["clang-apply-replacements-18", tmpdir])
+                subprocess.call(
+                    ["clang-apply-replacements-18", tmpdir], close_fds=False
+                )
             except FileNotFoundError:
-                subprocess.call(["clang-apply-replacements", tmpdir])
+                subprocess.call(["clang-apply-replacements", tmpdir], close_fds=False)
         except FileNotFoundError:
             print(
                 "Error please install clang-apply-replacements-18 or clang-apply-replacements.\n",

--- a/script/platformio_install_deps.py
+++ b/script/platformio_install_deps.py
@@ -55,4 +55,6 @@ for section in config.sections():
             tools.append("-t")
             tools.append(tool)
 
-subprocess.check_call(["platformio", "pkg", "install", "-g", *libs, *platforms, *tools])
+subprocess.check_call(
+    ["platformio", "pkg", "install", "-g", *libs, *platforms, *tools], close_fds=False
+)

--- a/script/run-in-env.py
+++ b/script/run-in-env.py
@@ -13,7 +13,7 @@ def find_and_activate_virtualenv():
     try:
         # Get the top-level directory of the git repository
         my_path = subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"], text=True
+            ["git", "rev-parse", "--show-toplevel"], text=True, close_fds=False
         ).strip()
     except subprocess.CalledProcessError:
         print(
@@ -44,7 +44,7 @@ def find_and_activate_virtualenv():
 def run_command():
     # Execute the remaining arguments in the new environment
     if len(sys.argv) > 1:
-        subprocess.run(sys.argv[1:], check=False)
+        subprocess.run(sys.argv[1:], check=False, close_fds=False)
     else:
         print(
             "No command provided to run in the virtual environment.",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -105,6 +105,7 @@ logger:
                     check=True,
                     cwd=init_dir,
                     env=env,
+                    close_fds=False,
                 )
 
         # Lock is held until here, ensuring cache is fully populated before any test proceeds
@@ -245,6 +246,7 @@ async def compile_esphome(
                 # Start in a new process group to isolate signal handling
                 start_new_session=True,
                 env=env,
+                close_fds=False,
             )
             await proc.wait()
 
@@ -477,6 +479,7 @@ async def run_binary_and_wait_for_port(
         # Start in a new process group to isolate signal handling
         start_new_session=True,
         pass_fds=(device_fd,),
+        close_fds=False,
     )
 
     # Close the device end in the parent process


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes subprocess performance by setting `close_fds=False` on subprocess calls throughout the codebase. This avoids the performance overhead of closing all file descriptors before exec, which prevents Python from using the efficient `posix_spawn()` system call path.

Prior to Python 3.13, when `close_fds=True` (the default since Python 3.2), Python must use the slower `fork()` + `exec()` path instead of `posix_spawn()`. The fork approach requires copying the entire process memory space before replacing it with the subprocess, which can be very slow for large Python processes.

## Performance Impact

Based on the posix-spawn library benchmarks and Python issue #113117:
- `fork()` + `exec()` can be extremely slow for large parent processes
- `posix_spawn()` with `close_fds=False` executes in constant time regardless of parent process size
- Performance improvement is especially significant during compilation and when running multiple subprocesses

Python 3.13 improves this situation by using `posix_spawn()` even with `close_fds=True` on systems that support `posix_spawn_file_actions_addclosefrom_np()`, but ESPHome supports Python 3.11+ where this optimization provides immediate benefits.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

This change only affects the host platform (Linux/macOS/Windows) where ESPHome runs, not the target microcontrollers.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal performance optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Summary of Changes

Set `close_fds=False` on subprocess calls in:
- `esphome/platformio_api.py` - addr2line subprocess for stack trace decoding
- `esphome/git.py` - Git commands for external components
- `esphome/helpers.py` - run_system_command helper
- `esphome/dashboard/web_server.py` - Dashboard subprocess for ESPHome commands
- `esphome/components/sdl/display.py` - SDL configuration subprocess
- `docker/build.py` - Docker build commands
- `script/run-in-env.py` - Virtual environment activation script
- `script/clang-format` - Code formatting subprocess
- `script/clang-tidy` - Code linting subprocesses
- `script/platformio_install_deps.py` - PlatformIO dependency installation
- `tests/integration/conftest.py` - Test compilation and execution subprocesses

## Safety Considerations

`close_fds=False` is safe for these use cases because:
1. All subprocess calls are short-lived utility commands (git, compiler tools, linters)
2. None create long-running daemons that could leak file descriptors
3. The subprocesses don't handle sensitive file descriptors that need isolation
4. We're not passing security-sensitive data through inherited file descriptors

