### PR TITLE
[lvgl] fix allocation of reduced size buffer with rotation

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -451,7 +451,8 @@ void LvglComponent::setup() {
   if (buffer == nullptr && this->buffer_frac_ == 0) {
     frac = MIN_BUFFER_FRAC;
     buffer_pixels /= MIN_BUFFER_FRAC;
-    buffer = lv_custom_mem_alloc(buf_bytes / MIN_BUFFER_FRAC);  // NOLINT
+    buf_bytes /= MIN_BUFFER_FRAC;
+    buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
   }
   if (buffer == nullptr) {
     this->status_set_error("Memory allocation failure");


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When LVGL used a fallback to reduce the buffer size when a full size buffer was not available, if a rotation buffer was also needed, its size was not correspondingly reduced.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10124

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
