### PR TITLE
[ade7880] Fix duplicate sensor name validation error

### DIFF
--- a/tests/components/ade7880/common.yaml
+++ b/tests/components/ade7880/common.yaml
@@ -12,12 +12,12 @@ sensor:
     frequency: 60Hz
     phase_a:
       name: Channel A
-      voltage: Channel A Voltage
-      current: Channel A Current
-      active_power: Channel A Active Power
-      power_factor: Channel A Power Factor
-      forward_active_energy: Channel A Forward Active Energy
-      reverse_active_energy: Channel A Reverse Active Energy
+      voltage: Voltage
+      current: Current
+      active_power: Active Power
+      power_factor: Power Factor
+      forward_active_energy: Forward Active Energy
+      reverse_active_energy: Reverse Active Energy
       calibration:
         current_gain: 3116628
         voltage_gain: -757178
@@ -25,12 +25,12 @@ sensor:
         phase_angle: 188
     phase_b:
       name: Channel B
-      voltage: Channel B Voltage
-      current: Channel B Current
-      active_power: Channel B Active Power
-      power_factor: Channel B Power Factor
-      forward_active_energy: Channel B Forward Active Energy
-      reverse_active_energy: Channel B Reverse Active Energy
+      voltage: Voltage
+      current: Current
+      active_power: Active Power
+      power_factor: Power Factor
+      forward_active_energy: Forward Active Energy
+      reverse_active_energy: Reverse Active Energy
       calibration:
         current_gain: 3133655
         voltage_gain: -755235
@@ -38,12 +38,12 @@ sensor:
         phase_angle: 188
     phase_c:
       name: Channel C
-      voltage: Channel C Voltage
-      current: Channel C Current
-      active_power: Channel C Active Power
-      power_factor: Channel C Power Factor
-      forward_active_energy: Channel C Forward Active Energy
-      reverse_active_energy: Channel C Reverse Active Energy
+      voltage: Voltage
+      current: Current
+      active_power: Active Power
+      power_factor: Power Factor
+      forward_active_energy: Forward Active Energy
+      reverse_active_energy: Reverse Active Energy
       calibration:
         current_gain: 3111158
         voltage_gain: -743813
@@ -51,6 +51,6 @@ sensor:
         phase_angle: 180
     neutral:
       name: Neutral
-      current: Neutral Current
+      current: Current
       calibration:
         current_gain: 3189


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a configuration validation issue with the ADE7880 component where sensor names were being modified after the duplicate entity validation had already run, causing false positive "Duplicate sensor entity" errors.

The component's `final_validate` function was prefixing sensor names with channel names (e.g., "L1 Voltage", "L2 Voltage") too late in the validation process. This fix moves the name prefixing to occur during schema validation, before the duplicate check runs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10151

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config that previously failed with duplicate sensor error
sensor:
  - id: ade7880_device
    platform: ade7880
    update_interval: 5s
    irq0_pin:
      number: GPIO13
    irq1_pin:
      number: GPIO12
    reset_pin:
      number: GPIO16
    frequency: 50Hz
    phase_a:
      name: "L1"
      voltage:
        name: "Voltage"  # Will be prefixed to "L1 Voltage"
        icon: mdi:alpha-v
      calibration:
        current_gain: 5110
        voltage_gain: 5133
        power_gain: 21097
        phase_angle: 0
    phase_b:
      name: "L2"
      voltage:
        name: "Voltage"  # Will be prefixed to "L2 Voltage"
        icon: mdi:alpha-v
      calibration:
        current_gain: 5095
        voltage_gain: 5123
        power_gain: 21147
        phase_angle: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

