### PR TITLE
prometheus: escape text sensor values

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -129,6 +129,27 @@ void PrometheusHandler::add_friendly_name_label_(AsyncResponseStream *stream, st
   }
 }
 
+// Escape Prometheus label values per exposition format:
+// backslash, double quote and line feed.
+void PrometheusHandler::add_escaped_label_value_(AsyncResponseStream *stream, std::string &value) {
+  for (char c : value) {
+    switch (c) {
+      case '\\':
+        stream->print(F("\\\\"));
+        break;
+      case '\"':
+        stream->print(F("\\\""));
+        break;
+      case '\n':
+        stream->print(F("\\n"));
+        break;
+      default:
+        stream->print(c);
+        break;
+    }
+  }
+}
+
 // Type-specific implementation
 #ifdef USE_SENSOR
 void PrometheusHandler::sensor_type_(AsyncResponseStream *stream) {
@@ -529,7 +550,7 @@ void PrometheusHandler::text_sensor_row_(AsyncResponseStream *stream, text_senso
     stream->print(F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(F("\",value=\""));
-    stream->print(obj->state.c_str());
+    add_escaped_label_value_(stream, obj->state);
     stream->print(F("\"} "));
     stream->print(F("1.0"));
     stream->print(F("\n"));

--- a/esphome/components/prometheus/prometheus_handler.h
+++ b/esphome/components/prometheus/prometheus_handler.h
@@ -40,6 +40,13 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
    */
   void add_label_name(EntityBase *obj, const std::string &value) { relabel_map_name_.insert({obj, value}); }
 
+  /** Escape Prometheus label values per exposition format
+   *
+   * @param obj The entity for which to escape the label value
+   * @param value The value which should be escaped
+   */
+  void add_escaped_label_value(EntityBase *obj, const std::string &value) { relabel_map_name_.insert({obj, value}); }
+
   bool canHandle(AsyncWebServerRequest *request) const override {
     if (request->method() == HTTP_GET) {
       if (request->url() == "/metrics")
@@ -66,6 +73,7 @@ class PrometheusHandler : public AsyncWebHandler, public Component {
   void add_area_label_(AsyncResponseStream *stream, std::string &area);
   void add_node_label_(AsyncResponseStream *stream, std::string &node);
   void add_friendly_name_label_(AsyncResponseStream *stream, std::string &friendly_name);
+  void add_escaped_label_value_(AsyncResponseStream *stream, std::string &value);
 
 #ifdef USE_SENSOR
   /// Return the type for prometheus


### PR DESCRIPTION
This fixes a problem where the generate prometheus exposition format becomes invalid when the text sensor value contains a “, \n or \.

Details: https://prometheus.io/docs/instrumenting/exposition_formats/#line-format

# What does this implement/fix?

The prometheus integration breaks when a text sensor contains a double quote ("), newline (\n) or backslash (\) in its value/state.

##  Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
