### PR TITLE
OTA: increase timeout on the sending side for OTA

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -247,7 +247,7 @@ def perform_ota(
         receive_exactly(sock, 1, "auth result", RESPONSE_AUTH_OK)
 
     # Set higher timeout during upload
-    sock.settimeout(30.0)
+    sock.settimeout(600.0)
 
     upload_size = len(upload_contents)
     upload_size_encoded = [


### PR DESCRIPTION

# What does this implement/fix?

Remove constant timeouts on minor Wifi hiccups which leads to temporarily slow transmission speeds of TCP, despite overall good wifi links.

For full analysis and rationale, see https://github.com/esphome/esphome/pull/10152#issuecomment-3172771468


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840



## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
