### PR TITLE
OTA: Increase connection timeout

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -326,7 +326,7 @@ def run_ota_impl_(remote_host, remote_port, password, filename):
         af, socktype, _, _, sa = r
         _LOGGER.info("Connecting to %s port %s...", sa[0], sa[1])
         sock = socket.socket(af, socktype)
-        sock.settimeout(10.0)
+        sock.settimeout(60.0)
         try:
             sock.connect(sa)
         except OSError as err:


### PR DESCRIPTION

# What does this implement/fix?

I often see timeouts on connect, despite the node being online, due to the rather short timeout here.

Increase it to 60 seconds doesn't hurt and allows TCP to send more SYNs to connect.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
