### PR TITLE
OTA: Clamp MSS to 536 to keep more packets in flight

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -328,6 +328,15 @@ def run_ota_impl_(remote_host, remote_port, password, filename):
         sock = socket.socket(af, socktype)
         sock.settimeout(10.0)
         try:
+            # Clamp TCP MSS so more packets fit into the small
+            # receive window of the embedded devices.
+            # This allows to keep more than ≥4 segments in flight,
+            # making fast retransmit more likely and reducing
+            # the amount of RTO backoffs on loss.
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, 536)
+        except (AttributeError, OSError) as err:
+            _LOGGER.debug("Could not set TCP MSS: %s", err)
+        try:
             sock.connect(sa)
         except OSError as err:
             sock.close()


### PR DESCRIPTION
# What does this implement/fix?

Embedded devices use a very small receive window, leading to a very low number of packets in flight reducing the MSS will allow for more packets to fit in the same receive window and more acks, allowing for quicker recovery on packet loss.

The reason for this is, that TCP needs 3 acks after a lost package to do a fast recovery if not it may fall back to RTO backoffs, which take a long time and run into timeouts.

For full analysis and rationale, see https://github.com/esphome/esphome/pull/10152#issuecomment-3172771468

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
