### PR TITLE
[substitutions] Add some safe built-in functions to jinja parsing

### DIFF
--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -25,19 +25,17 @@ def has_jinja(st):
     return detect_jinja_re.search(st) is not None
 
 
-"""
-SAFE_GLOBAL_FUNCTIONS defines a allowlist of built-in functions that are considered safe to expose
-in Jinja templates or other sandboxed evaluation contexts. Only functions that do not allow
-arbitrary code execution, file access, or other security risks are included.
-
-The following functions are considered safe:
-  - ord: Converts a character to its Unicode code point integer.
-  - chr: Converts an integer to its corresponding Unicode character.
-  - len: Returns the length of a sequence or collection.
-
-These functions were chosen because they are pure, have no side effects, and do not provide access
-to the file system, environment, or other potentially sensitive resources.
-"""
+# SAFE_GLOBAL_FUNCTIONS defines a allowlist of built-in functions that are considered safe to expose
+# in Jinja templates or other sandboxed evaluation contexts. Only functions that do not allow
+# arbitrary code execution, file access, or other security risks are included.
+#
+# The following functions are considered safe:
+#   - ord: Converts a character to its Unicode code point integer.
+#   - chr: Converts an integer to its corresponding Unicode character.
+#   - len: Returns the length of a sequence or collection.
+#
+# These functions were chosen because they are pure, have no side effects, and do not provide access
+# to the file system, environment, or other potentially sensitive resources.
 SAFE_GLOBAL_FUNCTIONS = {
     "ord": ord,
     "chr": chr,

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -25,6 +25,19 @@ def has_jinja(st):
     return detect_jinja_re.search(st) is not None
 
 
+"""
+SAFE_GLOBAL_FUNCTIONS defines a whitelist of built-in functions that are considered safe to expose
+in Jinja templates or other sandboxed evaluation contexts. Only functions that do not allow
+arbitrary code execution, file access, or other security risks are included.
+
+The following functions are considered safe:
+  - ord: Converts a character to its Unicode code point integer.
+  - chr: Converts an integer to its corresponding Unicode character.
+  - len: Returns the length of a sequence or collection.
+
+These functions were chosen because they are pure, have no side effects, and do not provide access
+to the file system, environment, or other potentially sensitive resources.
+"""
 SAFE_GLOBAL_FUNCTIONS = {
     "ord": ord,
     "chr": chr,

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -25,6 +25,13 @@ def has_jinja(st):
     return detect_jinja_re.search(st) is not None
 
 
+SAFE_GLOBAL_FUNCTIONS = {
+    "ord": ord,
+    "chr": chr,
+    "len": len,
+}
+
+
 class JinjaStr(str):
     """
     Wraps a string containing an unresolved Jinja expression,
@@ -66,7 +73,11 @@ class Jinja:
         self.env.add_extension("jinja2.ext.do")
         self.env.globals["math"] = math  # Inject entire math module
         self.context_vars = {**context_vars}
-        self.env.globals = {**self.env.globals, **self.context_vars}
+        self.env.globals = {
+            **self.env.globals,
+            **self.context_vars,
+            **SAFE_GLOBAL_FUNCTIONS,
+        }
 
     def expand(self, content_str):
         """

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -26,7 +26,7 @@ def has_jinja(st):
 
 
 """
-SAFE_GLOBAL_FUNCTIONS defines a whitelist of built-in functions that are considered safe to expose
+SAFE_GLOBAL_FUNCTIONS defines a allowlist of built-in functions that are considered safe to expose
 in Jinja templates or other sandboxed evaluation contexts. Only functions that do not allow
 arbitrary code execution, file access, or other security risks are included.
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds `ord`, `chr` and `len` to be usable inside substitutions/jinja.

Useful for converting a letter to an index and back =)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5223

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
