### PR TITLE
OTA: rework uploader; extend log; increase timeouts

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -111,6 +111,14 @@ class ProgressBar:
         self._last_percent_int = percent_int
         self._last_segments = seg_pair
 
+    def get_last_percent_int(self) -> int | None:
+        """Return the most recent percent as an integer."""
+        return self._last_percent_int
+
+    def get_last_segments(self) -> tuple[int | None, int | None] | None:
+        """Return the most recent segment pair."""
+        return self._last_segments
+
     def done(self) -> None:
         """Finish the bar with a trailing newline."""
         self._finished = True
@@ -554,10 +562,9 @@ def perform_ota(
         except OTAError:
             sys.stderr.write("\n\n")
             raise
-        else:
-            if version < OTA_VERSION_2_0:
-                progress.update(1.0)
-            progress.done()
+        if version < OTA_VERSION_2_0:
+            progress.update(1.0)
+        progress.done()
 
         sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
@@ -745,37 +752,36 @@ def _transfer_with_acks(
                 percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
                 seg_pair = (None, None)
                 if (
-                    percent_int == progress._last_percent_int
-                    and seg_pair == progress._last_segments
+                    percent_int == progress.get_last_percent_int()
+                    and seg_pair == progress.get_last_segments()
                 ):
                     return False
                 with suppress(AttributeError, ValueError):
                     progress.update(ratio)
                 return True
-            else:
-                ours_outstanding = max(0, outq_now - outq_baseline)
-                acked_tcp = max(0, min(sent, sent - ours_outstanding))
-                ratio = acked_tcp / total
-                percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
-                seg_pair = (acked_segments, total_segments)
-                if (
-                    percent_int == progress._last_percent_int
-                    and seg_pair == progress._last_segments
-                ):
-                    return False
-                with suppress(AttributeError, ValueError):
-                    progress.update(
-                        ratio,
-                        acked_segments=acked_segments,
-                        total_segments=total_segments,
-                    )
-                return True
+            ours_outstanding = max(0, outq_now - outq_baseline)
+            acked_tcp = max(0, min(sent, sent - ours_outstanding))
+            ratio = acked_tcp / total
+            percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
+            seg_pair = (acked_segments, total_segments)
+            if (
+                percent_int == progress.get_last_percent_int()
+                and seg_pair == progress.get_last_segments()
+            ):
+                return False
+            with suppress(AttributeError, ValueError):
+                progress.update(
+                    ratio,
+                    acked_segments=acked_segments,
+                    total_segments=total_segments,
+                )
+            return True
         ratio = max(acked_device, acked_fallback) / total
         percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
         seg_pair = (None, None)
         if (
-            percent_int == progress._last_percent_int
-            and seg_pair == progress._last_segments
+            percent_int == progress.get_last_percent_int()
+            and seg_pair == progress.get_last_segments()
         ):
             return False
         with suppress(AttributeError, ValueError):

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -456,9 +456,7 @@ def perform_ota(
         _LOGGER.info("Connected to %s", remote_ip)
         break
     if sock is None:
-        raise OTAError(
-            f"Error connecting to {remote_host}:{remote_port}: {last_err}"
-        )
+        raise OTAError(f"Error connecting to {remote_host}:{remote_port}: {last_err}")
     try:
         sock.settimeout(OTA_IMAGE_TRANSFER_TIMEOUT)
 

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+from contextlib import suppress
 import gzip
 import hashlib
-import io
 import logging
 import random
+import selectors
 import socket
 import sys
 import time
@@ -45,53 +47,117 @@ MAGIC_BYTES = [0x6C, 0x26, 0xF7, 0x5C, 0x45]
 
 FEATURE_SUPPORTS_COMPRESSION = 0x01
 
-
-UPLOAD_BLOCK_SIZE = 8192
-UPLOAD_BUFFER_SIZE = UPLOAD_BLOCK_SIZE * 8
+OTA_IMAGE_ACK_SIZE_OTA_V2 = 8192
+OTA_IMAGE_TRANSFER_TIMEOUT = 600.0
+OTA_CONNECT_TIMEOUT = 60.0
+PROGRESS_UPDATE_THROTTLE_SEC = 0.1
+PROGRESS_TIMER_FORCE_SEC = 0.3
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class ProgressBar:
-    def __init__(self):
-        self.last_progress = None
+    """Render upload progress to stderr."""
 
-    def update(self, progress):
+    def __init__(self) -> None:
+        self._finished = False
+        self._last_percent_int: int | None = None
+        self._last_segments: tuple[int | None, int | None] | None = None
+
+    def update(
+        self,
+        progress: float,
+        *,
+        acked_segments: int | None = None,
+        total_segments: int | None = None,
+    ) -> None:
+        """Render the bar at the current progress ratio.
+
+        Args:
+            progress: Ratio of bytes transferred, between 0 and 1.
+            acked_segments: Segments acknowledged by the device. If omitted,
+                only the percent bar is shown.
+            total_segments: Total number of segments to transfer. Provide this
+                together with ``acked_segments`` to display the segment suffix.
+        """
+        if self._finished:
+            return
+
+        p = 1.0 if progress >= 1 else max(0.0, float(progress))
+        percent_int = int(round(p * 10000))
+        seg_pair = (acked_segments, total_segments)
+        if percent_int == self._last_percent_int and seg_pair == self._last_segments:
+            return
+
         bar_length = 60
         status = ""
-        if progress >= 1:
-            progress = 1
+        if p >= 1:
             status = "Done...\r\n"
-        new_progress = int(progress * 100)
-        if new_progress == self.last_progress:
-            return
-        self.last_progress = new_progress
-        block = int(round(bar_length * progress))
-        text = f"\rUploading: [{'=' * block + ' ' * (bar_length - block)}] {new_progress}% {status}"
+            self._finished = True
+        block = int(round(bar_length * (percent_int / 10000.0)))
+        if acked_segments is not None and total_segments is not None:
+            width = len(str(total_segments))
+            seg_text = f" - Segments: {acked_segments:>{width}}/{total_segments}"
+            percent = f"{round(p * 100, 2):6.2f} %"
+        else:
+            seg_text = ""
+            percent = f"{round(p * 100, 2):6.2f}%"
+        text = (
+            f"\rUploading: [{'=' * block + ' ' * (bar_length - block)}] "
+            f"{percent}{seg_text} {status}"
+        )
         sys.stderr.write(text)
         sys.stderr.flush()
+        self._last_percent_int = percent_int
+        self._last_segments = seg_pair
 
-    def done(self):
+    def done(self) -> None:
+        """Finish the bar with a trailing newline."""
+        self._finished = True
         sys.stderr.write("\n")
         sys.stderr.flush()
 
 
 class OTAError(EsphomeError):
-    pass
+    """Exception raised for OTA update errors."""
 
 
-def recv_decode(sock, amount, decode=True):
-    data = sock.recv(amount)
-    if not decode:
-        return data
-    return list(data)
+def recv_decode(sock: socket.socket, amount: int) -> bytes:
+    """Receive bytes from the socket.
+
+    Args:
+        sock: Socket to read from.
+        amount: Number of bytes to read.
+
+    Returns:
+        bytes: Bytes read from the socket.
+    """
+
+    return sock.recv(amount)
 
 
-def receive_exactly(sock, amount, msg, expect, decode=True):
-    data = [] if decode else b""
+def receive_exactly(
+    sock: socket.socket,
+    amount: int,
+    msg: str,
+    expect: Sequence[int] | int,
+) -> bytes:
+    """Receive a specific amount of bytes and validate against expected values.
+
+    Args:
+        sock: Socket to read from.
+        amount: Number of bytes to read.
+        msg: Contextual message for error reporting.
+        expect: Allowed response byte or sequence.
+
+    Returns:
+        bytes: Bytes read from the socket.
+    """
+
+    data = b""
 
     try:
-        data += recv_decode(sock, 1, decode=decode)
+        data += recv_decode(sock, 1)
     except OSError as err:
         raise OTAError(f"Error receiving acknowledge {msg}: {err}") from err
 
@@ -103,13 +169,20 @@ def receive_exactly(sock, amount, msg, expect, decode=True):
 
     while len(data) < amount:
         try:
-            data += recv_decode(sock, amount - len(data), decode=decode)
+            data += recv_decode(sock, amount - len(data))
         except OSError as err:
             raise OTAError(f"Error receiving {msg}: {err}") from err
     return data
 
 
-def check_error(data, expect):
+def check_error(data: bytes, expect: Sequence[int] | int) -> None:
+    """Raise OTAError if data does not match expected values.
+
+    Args:
+        data: First bytes received from the device.
+        expect: Allowed response byte or sequence.
+    """
+
     if not expect:
         return
     dat = data[0]
@@ -124,7 +197,7 @@ def check_error(data, expect):
         raise OTAError("Error: Authentication invalid. Is the password correct?")
     if dat == RESPONSE_ERROR_WRITING_FLASH:
         raise OTAError(
-            "Error: Wring OTA data to flash memory failed. See USB logs for more "
+            "Error: Writing OTA data to flash memory failed. See USB logs for more "
             "information."
         )
     if dat == RESPONSE_ERROR_UPDATE_END:
@@ -176,183 +249,621 @@ def check_error(data, expect):
         raise OTAError(f"Unexpected response from ESP: 0x{data[0]:02X}")
 
 
-def send_check(sock, data, msg):
-    try:
-        if isinstance(data, (list, tuple)):
-            data = bytes(data)
-        elif isinstance(data, int):
-            data = bytes([data])
-        elif isinstance(data, str):
-            data = data.encode("utf8")
+def _get_stream_handler(logger: logging.Logger) -> logging.StreamHandler | None:
+    """Return the first stream handler for a logger or its parents.
 
+    Args:
+        logger: Logger to inspect.
+
+    Returns:
+        logging.StreamHandler | None: First stream handler found, or ``None`` if none
+            exist.
+    """
+
+    cur = logger
+    while cur:
+        for handler in cur.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                return handler
+        if not cur.propagate:
+            break
+        cur = cur.parent
+    return None
+
+
+def _write_stream(handler: logging.StreamHandler | None, text: str) -> None:
+    """Write text to the handler or stdout if no handler exists.
+
+    Args:
+        handler: Stream handler to write to, or ``None`` for stdout.
+        text: Text to output without automatically appending a newline.
+    """
+
+    if handler is None:
+        print(text, end="", flush=True)
+        return
+    handler.acquire()
+    try:
+        handler.stream.write(text)
+        handler.flush()
+    finally:
+        handler.release()
+
+
+def log_info_inline(msg: str, logger: logging.Logger) -> None:
+    """Emit an INFO-prefixed message without a trailing newline.
+
+    Args:
+        msg: Message to write.
+        logger: Logger providing formatting and handler.
+    """
+
+    handler = _get_stream_handler(logger)
+    if handler is None:
+        _write_stream(None, f"INFO {msg}")
+        return
+    record = logger.makeRecord(logger.name, logging.INFO, "", 0, msg, (), None)
+    formatted = handler.format(record)
+    _write_stream(handler, formatted)
+
+
+def log_inline_append(logger: logging.Logger, msg: str) -> None:
+    """Append raw text to the current log line.
+
+    Args:
+        logger: Logger whose handler to write to.
+        msg: Text to append.
+    """
+
+    handler = _get_stream_handler(logger)
+    _write_stream(handler, msg)
+
+
+def log_newline(logger: logging.Logger) -> None:
+    """Terminate the current log line.
+
+    Args:
+        logger: Logger whose handler to write to.
+    """
+
+    handler = _get_stream_handler(logger)
+    _write_stream(handler, "\n")
+
+
+def _query_outq(sock: socket.socket, ioctl_cmd: int) -> int:
+    """Return bytes currently queued for sending on the socket.
+
+    Args:
+        sock: Socket to query.
+        ioctl_cmd: IOCTL command used to read the send queue.
+
+    Returns:
+        int: Number of bytes waiting in the kernel send queue.
+    """
+
+    import array
+    import fcntl
+
+    buf = array.array("I", [0])
+    fcntl.ioctl(sock.fileno(), ioctl_cmd, buf, True)
+    return int(buf[0])
+
+
+def send_check(sock: socket.socket, data: bytes | list[int], log: str) -> None:
+    """Send data over the socket and raise OTAError on failure.
+
+    Args:
+        sock: Socket to send over.
+        data: Bytes to transmit.
+        log: Description used in error messages.
+
+    Raises:
+        OTAError: If sending fails.
+    """
+
+    if isinstance(data, list):
+        data = bytes(data)
+    try:
         sock.sendall(data)
     except OSError as err:
-        raise OTAError(f"Error sending {msg}: {err}") from err
+        raise OTAError(f"Error sending {log}: {err}") from err
+
+
+def _generate_auth_response(password: str, nonce: str, cnonce: str) -> str:
+    """Return MD5 digest for password, nonce, and client nonce.
+
+    Args:
+        password: OTA password.
+        nonce: Challenge string from the device.
+        cnonce: Client-generated nonce.
+
+    Returns:
+        str: Hexadecimal MD5 digest string.
+    """
+
+    md5 = hashlib.md5()
+    md5.update(password.encode("utf-8"))
+    md5.update(nonce.encode())
+    md5.update(cnonce.encode())
+    return md5.hexdigest()
+
+
+def _encode_upload_size(size: int) -> list[int]:
+    """Encode an upload size as four big-endian bytes.
+
+    Args:
+        size: Upload size in bytes.
+
+    Returns:
+        list[int]: Four big-endian bytes.
+    """
+
+    return [
+        (size >> 24) & 0xFF,
+        (size >> 16) & 0xFF,
+        (size >> 8) & 0xFF,
+        size & 0xFF,
+    ]
 
 
 def perform_ota(
-    sock: socket.socket, password: str, file_handle: io.IOBase, filename: str
+    remote_host: str, remote_port: int, password: str, filename: str
 ) -> None:
-    file_contents = file_handle.read()
-    file_size = len(file_contents)
-    _LOGGER.info("Uploading %s (%s bytes)", filename, file_size)
+    """Send the OTA image to the remote host.
 
-    # Enable nodelay, we need it for phase 1
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-    send_check(sock, MAGIC_BYTES, "magic bytes")
+    Args:
+        remote_host: Target host name or IP address.
+        remote_port: OTA port on the device.
+        password: OTA password for authentication.
+        filename: Path to the firmware image file.
 
-    _, version = receive_exactly(sock, 2, "version", RESPONSE_OK)
-    _LOGGER.debug("Device support OTA version: %s", version)
-    supported_versions = (OTA_VERSION_1_0, OTA_VERSION_2_0)
-    if version not in supported_versions:
-        raise OTAError(
-            f"Device uses unsupported OTA version {version}, this ESPHome supports {supported_versions}"
-        )
+    Raises:
+        OTAError: If the upload fails.
+    """
 
-    # Features
-    send_check(sock, FEATURE_SUPPORTS_COMPRESSION, "features")
-    features = receive_exactly(
-        sock, 1, "features", [RESPONSE_HEADER_OK, RESPONSE_SUPPORTS_COMPRESSION]
-    )[0]
-
-    if features == RESPONSE_SUPPORTS_COMPRESSION:
-        upload_contents = gzip.compress(file_contents, compresslevel=9)
-        _LOGGER.info("Compressed to %s bytes", len(upload_contents))
-    else:
-        upload_contents = file_contents
-
-    (auth,) = receive_exactly(
-        sock, 1, "auth", [RESPONSE_REQUEST_AUTH, RESPONSE_AUTH_OK]
-    )
-    if auth == RESPONSE_REQUEST_AUTH:
-        if not password:
-            raise OTAError("ESP requests password, but no password given!")
-        nonce = receive_exactly(
-            sock, 32, "authentication nonce", [], decode=False
-        ).decode()
-        _LOGGER.debug("Auth: Nonce is %s", nonce)
-        cnonce = hashlib.md5(str(random.random()).encode()).hexdigest()
-        _LOGGER.debug("Auth: CNonce is %s", cnonce)
-
-        send_check(sock, cnonce, "auth cnonce")
-
-        result_md5 = hashlib.md5()
-        result_md5.update(password.encode("utf-8"))
-        result_md5.update(nonce.encode())
-        result_md5.update(cnonce.encode())
-        result = result_md5.hexdigest()
-        _LOGGER.debug("Auth: Result is %s", result)
-
-        send_check(sock, result, "auth result")
-        receive_exactly(sock, 1, "auth result", RESPONSE_AUTH_OK)
-
-    # Set higher timeout during upload
-    sock.settimeout(30.0)
-
-    upload_size = len(upload_contents)
-    upload_size_encoded = [
-        (upload_size >> 24) & 0xFF,
-        (upload_size >> 16) & 0xFF,
-        (upload_size >> 8) & 0xFF,
-        (upload_size >> 0) & 0xFF,
-    ]
-    send_check(sock, upload_size_encoded, "binary size")
-    receive_exactly(sock, 1, "binary size", RESPONSE_UPDATE_PREPARE_OK)
-
-    upload_md5 = hashlib.md5(upload_contents).hexdigest()
-    _LOGGER.debug("MD5 of upload is %s", upload_md5)
-
-    send_check(sock, upload_md5, "file checksum")
-    receive_exactly(sock, 1, "file checksum", RESPONSE_BIN_MD5_OK)
-
-    # Disable nodelay for transfer
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 0)
-    # Limit send buffer (usually around 100kB) in order to have progress bar
-    # show the actual progress
-
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, UPLOAD_BUFFER_SIZE)
-    start_time = time.perf_counter()
-
-    offset = 0
-    progress = ProgressBar()
-    while True:
-        chunk = upload_contents[offset : offset + UPLOAD_BLOCK_SIZE]
-        if not chunk:
+    addresses = resolve_ip_address(remote_host, remote_port)
+    remote_ip = None
+    for af, _socktype, _proto, _canonname, sa in addresses:
+        if af == socket.AF_INET:
+            remote_ip = sa[0]
             break
-        offset += len(chunk)
-
+    if remote_ip is None:
+        raise OTAError(f"Could not resolve IPv4 address for {remote_host}")
+    _LOGGER.info("Connecting to %s:%s...", remote_ip, remote_port)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(OTA_CONNECT_TIMEOUT)
         try:
-            sock.sendall(chunk)
-            if version >= OTA_VERSION_2_0:
-                receive_exactly(sock, 1, "chunk OK", RESPONSE_CHUNK_OK)
+            # Clamp TCP MSS so more packets fit into the device's small receive window.
+            # Keeping more segments in flight makes fast retransmit more likely
+            # and reduces the amount of RTO backoffs on loss.
+            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, 536)
+        except (AttributeError, OSError) as err:
+            _LOGGER.warning("Could not set TCP MSS: %s", err)
+        try:
+            sock.connect((remote_ip, remote_port))
         except OSError as err:
-            sys.stderr.write("\n")
+            raise OTAError(
+                f"Error connecting to {remote_ip}:{remote_port}: {err}"
+            ) from err
+
+        sock.settimeout(OTA_IMAGE_TRANSFER_TIMEOUT)
+
+        with open(filename, "rb") as file:
+            file_contents = file.read()
+        file_size = len(file_contents)
+        _LOGGER.info("Uploading %s (%s bytes)", filename, file_size)
+
+        log_info_inline("Asking node for OTA version...", logger=_LOGGER)
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        send_check(sock, MAGIC_BYTES, "magic bytes")
+        _, version = receive_exactly(sock, 2, "version", RESPONSE_OK)
+        log_inline_append(_LOGGER, " OK")
+        log_newline(_LOGGER)
+
+        _LOGGER.debug("Device support OTA version: %s", version)
+        if version not in (OTA_VERSION_1_0, OTA_VERSION_2_0):
+            raise OTAError(
+                f"The node only supports OTA version {version}. Please use an OTA upgradable version."
+            )
+
+        log_info_inline("Asking node for features...", logger=_LOGGER)
+        send_check(sock, [FEATURE_SUPPORTS_COMPRESSION], "features")
+        features = receive_exactly(
+            sock, 1, "features", [RESPONSE_HEADER_OK, RESPONSE_SUPPORTS_COMPRESSION]
+        )[0]
+        log_inline_append(_LOGGER, " OK")
+        log_newline(_LOGGER)
+
+        if features == RESPONSE_SUPPORTS_COMPRESSION:
+            log_info_inline("Compressing image file...", logger=_LOGGER)
+            upload_contents = gzip.compress(file_contents, compresslevel=9)
+            log_inline_append(
+                _LOGGER, f" OK: Compressed to {len(upload_contents)} bytes"
+            )
+            log_newline(_LOGGER)
+        else:
+            upload_contents = file_contents
+
+        auth = receive_exactly(
+            sock,
+            1,
+            "auth",
+            [RESPONSE_REQUEST_AUTH, RESPONSE_AUTH_OK],
+        )[0]
+        if auth == RESPONSE_REQUEST_AUTH:
+            if not password:
+                raise OTAError("ESP requests password, but no password given!")
+            nonce = receive_exactly(
+                sock,
+                32,
+                "authentication nonce",
+                [],
+            ).decode()
+            _LOGGER.debug("Auth: Nonce is %s", nonce)
+            cnonce = hashlib.md5(str(random.random()).encode()).hexdigest()
+            _LOGGER.debug("Auth: CNonce is %s", cnonce)
+            log_info_inline(
+                "Authorize with node to do the update...",
+                logger=_LOGGER,
+            )
+            send_check(sock, cnonce.encode(), "auth cnonce")
+            result = _generate_auth_response(password, nonce, cnonce)
+            send_check(sock, result.encode(), "auth result")
+            receive_exactly(sock, 1, "auth result", RESPONSE_AUTH_OK)
+            log_inline_append(_LOGGER, " OK")
+            log_newline(_LOGGER)
+
+        upload_size = len(upload_contents)
+        log_info_inline(
+            "Asking node if firmware image size can be accepted...",
+            logger=_LOGGER,
+        )
+        send_check(sock, _encode_upload_size(upload_size), "binary size")
+        receive_exactly(sock, 1, "binary size", RESPONSE_UPDATE_PREPARE_OK)
+        log_inline_append(_LOGGER, " OK")
+        log_newline(_LOGGER)
+
+        upload_md5 = hashlib.md5(upload_contents).hexdigest()
+        _LOGGER.debug("MD5 of upload is %s", upload_md5)
+        log_info_inline(
+            "Providing node with md5 checksum for firmware...", logger=_LOGGER
+        )
+        send_check(sock, upload_md5.encode(), "file checksum")
+        receive_exactly(sock, 1, "file checksum", RESPONSE_BIN_MD5_OK)
+        log_inline_append(_LOGGER, " OK")
+        log_newline(_LOGGER)
+
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
+        _LOGGER.info("Starting to send firmware image to node...")
+        progress = ProgressBar()
+        start_time = time.perf_counter()
+        try:
+            if version == OTA_VERSION_2_0:
+                image_transfer_with_device_acks_nonblocking(
+                    sock,
+                    upload_contents,
+                    progress=progress,
+                )
+            else:
+                sock.sendall(upload_contents)
+        except OSError as err:
+            sys.stderr.write("\n\n")
             raise OTAError(f"Error sending data: {err}") from err
+        except OTAError:
+            sys.stderr.write("\n\n")
+            raise
+        else:
+            if version < OTA_VERSION_2_0:
+                progress.update(1.0)
+            progress.done()
 
-        progress.update(offset / upload_size)
-    progress.done()
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
 
-    # Enable nodelay for last checks
-    sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-    duration = time.perf_counter() - start_time
+        receive_exactly(sock, 1, "receive OK", RESPONSE_RECEIVE_OK)
+        receive_exactly(sock, 1, "update end", RESPONSE_UPDATE_END_OK)
+        send_check(sock, [RESPONSE_OK], "end acknowledgement")
+        duration = time.perf_counter() - start_time
+        _LOGGER.info("Upload complete in %.2f seconds", duration)
+        _LOGGER.info("OTA successful")
+        time.sleep(1)
 
-    _LOGGER.info("Upload took %.2f seconds, waiting for result...", duration)
-
-    receive_exactly(sock, 1, "receive OK", RESPONSE_RECEIVE_OK)
-    receive_exactly(sock, 1, "Update end", RESPONSE_UPDATE_END_OK)
-    send_check(sock, RESPONSE_OK, "end acknowledgement")
-
-    _LOGGER.info("OTA successful")
-
-    # Do not connect logs until it is fully on
-    time.sleep(1)
+    finally:
+        sock.close()
 
 
-def run_ota_impl_(remote_host, remote_port, password, filename):
+def run_ota_impl_(
+    remote_host: str, remote_port: int, password: str, filename: str
+) -> int:
+    """Run OTA update implementation.
+
+    Args:
+        remote_host: Target host name or IP address.
+        remote_port: OTA port on the device.
+        password: OTA password for authentication.
+        filename: Path to the firmware image file.
+
+    Returns:
+        int: ``0`` on success, ``1`` on failure.
+    """
+
     try:
-        res = resolve_ip_address(remote_host, remote_port)
-    except EsphomeError as err:
-        _LOGGER.error(
-            "Error resolving IP address of %s. Is it connected to WiFi?",
-            remote_host,
-        )
-        _LOGGER.error(
-            "(If this error persists, please set a static IP address: "
-            "https://esphome.io/components/wifi.html#manual-ips)"
-        )
-        raise OTAError(err) from err
-
-    for r in res:
-        af, socktype, _, _, sa = r
-        _LOGGER.info("Connecting to %s port %s...", sa[0], sa[1])
-        sock = socket.socket(af, socktype)
-        sock.settimeout(10.0)
-        try:
-            sock.connect(sa)
-        except OSError as err:
-            sock.close()
-            _LOGGER.error("Connecting to %s port %s failed: %s", sa[0], sa[1], err)
-            continue
-
-        _LOGGER.info("Connected to %s", sa[0])
-        with open(filename, "rb") as file_handle:
-            try:
-                perform_ota(sock, password, file_handle, filename)
-            except OTAError as err:
-                _LOGGER.error(str(err))
-                return 1
-            finally:
-                sock.close()
-
-        return 0
-
-    _LOGGER.error("Connection failed.")
-    return 1
-
-
-def run_ota(remote_host, remote_port, password, filename):
-    try:
-        return run_ota_impl_(remote_host, remote_port, password, filename)
+        perform_ota(remote_host, remote_port, password, filename)
     except OTAError as err:
         _LOGGER.error(err)
         return 1
+    return 0
+
+
+def run_ota(remote_host: str, remote_port: int, password: str, filename: str) -> int:
+    """Convenience wrapper around ``run_ota_impl_``.
+
+    Args:
+        remote_host: Target host name or IP address.
+        remote_port: OTA port on the device.
+        password: OTA password for authentication.
+        filename: Path to the firmware image file.
+
+    Returns:
+        int: ``0`` on success, ``1`` on failure.
+    """
+
+    return run_ota_impl_(remote_host, remote_port, password, filename)
+
+
+def image_transfer_with_device_acks_nonblocking(
+    sock: socket.socket,
+    data: bytes,
+    *,
+    progress: ProgressBar | None = None,
+) -> None:
+    """Transfer firmware while processing device ACKs.
+
+    On Linux systems, attempt to track TCP ACKs via ``SIOCOUTQ`` for smoother
+    progress reporting. If unavailable, fall back to device ACK bytes.
+
+    Args:
+        sock: Connected socket to the device.
+        data: Firmware image bytes to send.
+        progress: Optional progress bar for updates.
+
+    Raises:
+        OTAError: If the device closes early or protocol errors occur.
+    """
+
+    ack_block_size = OTA_IMAGE_ACK_SIZE_OTA_V2
+    stall_timeout = float(OTA_IMAGE_TRANSFER_TIMEOUT)
+
+    _ack = RESPONSE_CHUNK_OK
+    if isinstance(_ack, int):
+        if not 0 <= _ack <= 255:
+            raise ValueError("RESPONSE_CHUNK_OK int must be in range 0..255")
+        ack_byte = bytes([_ack])
+    elif isinstance(_ack, (bytes, bytearray)) and len(_ack) == 1:
+        ack_byte = bytes(_ack)
+    else:
+        raise ValueError(
+            "RESPONSE_CHUNK_OK must be an int or a single-byte bytes object"
+        )
+
+    view = memoryview(data)
+    total = len(view)
+    prev_blocking = sock.getblocking()
+    sock.setblocking(False)
+
+    sel = selectors.DefaultSelector()
+    sel.register(sock, selectors.EVENT_READ | selectors.EVENT_WRITE)
+
+    use_sock_ack = False
+    outq_baseline = 0
+    ioctl_cmd = 0
+    if sys.platform.startswith("linux"):
+        ioctl_cmd = getattr(socket, "SIOCOUTQ", 0x5411)
+        try:
+            outq_baseline = _query_outq(sock, ioctl_cmd)
+        except OSError:
+            pass
+        else:
+            use_sock_ack = True
+
+    try:
+        _transfer_with_acks(
+            sel,
+            sock,
+            view,
+            total,
+            ack_block_size,
+            stall_timeout,
+            ack_byte[0],
+            progress,
+            use_sock_ack,
+            outq_baseline,
+            ioctl_cmd,
+        )
+    finally:
+        with suppress(KeyError):
+            sel.unregister(sock)
+        sock.setblocking(prev_blocking)
+
+
+def _transfer_with_acks(
+    sel: selectors.BaseSelector,
+    sock: socket.socket,
+    view: memoryview,
+    total: int,
+    ack_block_size: int,
+    stall_timeout: float,
+    ack_val: int,
+    progress: ProgressBar | None,
+    use_sock_ack: bool,
+    outq_baseline: int,
+    ioctl_cmd: int,
+) -> None:
+    """Send data while tracking progress via device ACKs or the TCP send queue.
+
+    Args:
+        sel: Selector monitoring socket readiness.
+        sock: Connected socket to the device.
+        view: Firmware image as a memoryview.
+        total: Total number of bytes to send.
+        ack_block_size: Bytes per device ACK segment.
+        stall_timeout: Seconds without activity before considering the transfer
+            stalled.
+        ack_val: Byte value used by the device for ACKs.
+        progress: Optional progress bar to update.
+        use_sock_ack: Whether TCP send queue tracking is enabled.
+        outq_baseline: Initial kernel send queue size for outstanding
+            calculation.
+        ioctl_cmd: ``SIOCOUTQ`` constant for querying the send queue.
+
+    Raises:
+        OTAError: If the transfer stalls or the device sends unexpected data.
+    """
+
+    sent = 0
+    acked_device = 0
+    acked_segments = 0
+    acked_tcp = 0
+    last_activity = time.perf_counter()
+    last_update = last_activity
+    next_force_at = last_update + PROGRESS_TIMER_FORCE_SEC
+    total_segments = (total + ack_block_size - 1) // ack_block_size
+    acked_fallback = 0
+
+    def _render_progress() -> bool:
+        nonlocal acked_tcp, use_sock_ack, acked_fallback
+        if progress is None:
+            return False
+        if use_sock_ack:
+            try:
+                outq_now = _query_outq(sock, ioctl_cmd)
+            except OSError:
+                use_sock_ack = False
+                acked_fallback = max(acked_fallback, acked_tcp)
+                ratio = max(acked_device, acked_fallback) / total
+                percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
+                seg_pair = (None, None)
+                if (
+                    percent_int == progress._last_percent_int
+                    and seg_pair == progress._last_segments
+                ):
+                    return False
+                with suppress(AttributeError, ValueError):
+                    progress.update(ratio)
+                return True
+            else:
+                ours_outstanding = max(0, outq_now - outq_baseline)
+                acked_tcp = max(0, min(sent, sent - ours_outstanding))
+                ratio = acked_tcp / total
+                percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
+                seg_pair = (acked_segments, total_segments)
+                if (
+                    percent_int == progress._last_percent_int
+                    and seg_pair == progress._last_segments
+                ):
+                    return False
+                with suppress(AttributeError, ValueError):
+                    progress.update(
+                        ratio,
+                        acked_segments=acked_segments,
+                        total_segments=total_segments,
+                    )
+                return True
+        ratio = max(acked_device, acked_fallback) / total
+        percent_int = int(round(min(max(0.0, ratio), 1.0) * 10000))
+        seg_pair = (None, None)
+        if (
+            percent_int == progress._last_percent_int
+            and seg_pair == progress._last_segments
+        ):
+            return False
+        with suppress(AttributeError, ValueError):
+            progress.update(ratio)
+        return True
+
+    while acked_device < total:
+        now = time.perf_counter()
+        timeout = min(
+            stall_timeout,
+            PROGRESS_UPDATE_THROTTLE_SEC,
+            max(0.0, next_force_at - now),
+        )
+        events = sel.select(timeout=timeout)
+        redraw = False
+
+        for _, mask in events:
+            if mask & selectors.EVENT_WRITE:
+                if sent < total:
+                    try:
+                        n = sock.send(view[sent:])
+                    except (BlockingIOError, InterruptedError):
+                        n = 0
+                    if n > 0:
+                        sent += n
+                        last_activity = time.perf_counter()
+                else:
+                    n = 0
+                now = time.perf_counter()
+                if (
+                    progress is not None
+                    and now - last_update >= PROGRESS_UPDATE_THROTTLE_SEC
+                    and _render_progress()
+                ):
+                    last_update = time.perf_counter()
+                    next_force_at = last_update + PROGRESS_TIMER_FORCE_SEC
+                    redraw = True
+
+            if mask & selectors.EVENT_READ:
+                try:
+                    peek = sock.recv(4096, socket.MSG_PEEK)
+                except (BlockingIOError, InterruptedError):
+                    peek = b""
+
+                if peek == b"":
+                    if acked_device < total:
+                        raise OTAError(
+                            f"Peer closed early (acked {acked_device} / {total})"
+                        )
+                    break
+
+                i = 0
+                for b in peek:
+                    if b == ack_val:
+                        i += 1
+                    else:
+                        break
+
+                if i > 0:
+                    sock.recv(i)
+                    acked_device = min(acked_device + i * ack_block_size, total)
+                    acked_segments = min(acked_segments + i, total_segments)
+                    last_activity = time.perf_counter()
+                    if progress is not None and _render_progress():
+                        last_update = time.perf_counter()
+                        next_force_at = last_update + PROGRESS_TIMER_FORCE_SEC
+                        redraw = True
+                elif acked_device < total:
+                    first = peek[0]
+                    raise OTAError(
+                        f"Unexpected byte 0x{first:02X} from device before upload completed"
+                    )
+
+        now = time.perf_counter()
+        if (
+            progress is not None
+            and not redraw
+            and use_sock_ack
+            and now >= next_force_at
+        ):
+            if _render_progress():
+                last_update = time.perf_counter()
+                next_force_at = last_update + PROGRESS_TIMER_FORCE_SEC
+                redraw = True
+            else:
+                next_force_at = now + PROGRESS_TIMER_FORCE_SEC
+
+        if time.perf_counter() - last_activity > stall_timeout:
+            raise OTAError(
+                f"Stall: no send progress/protocol ack received within {stall_timeout} seconds"
+            )

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -430,31 +430,36 @@ def perform_ota(
     """
 
     addresses = resolve_ip_address(remote_host, remote_port)
+    sock: socket.socket | None = None
     remote_ip = None
-    for af, _socktype, _proto, _canonname, sa in addresses:
-        if af == socket.AF_INET:
-            remote_ip = sa[0]
-            break
-    if remote_ip is None:
-        raise OTAError(f"Could not resolve IPv4 address for {remote_host}")
-    _LOGGER.info("Connecting to %s:%s...", remote_ip, remote_port)
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        sock.settimeout(OTA_CONNECT_TIMEOUT)
+    last_err: OSError | None = None
+    for af, socktype, _proto, _canonname, sa in addresses:
+        _LOGGER.info("Connecting to %s:%s...", sa[0], sa[1])
+        s = socket.socket(af, socktype)
+        s.settimeout(OTA_CONNECT_TIMEOUT)
         try:
             # Clamp TCP MSS so more packets fit into the device's small receive window.
             # Keeping more segments in flight makes fast retransmit more likely
             # and reduces the amount of RTO backoffs on loss.
-            sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, 536)
+            s.setsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG, 536)
         except (AttributeError, OSError) as err:
             _LOGGER.warning("Could not set TCP MSS: %s", err)
         try:
-            sock.connect((remote_ip, remote_port))
+            s.connect(sa)
         except OSError as err:
-            raise OTAError(
-                f"Error connecting to {remote_ip}:{remote_port}: {err}"
-            ) from err
-
+            last_err = err
+            s.close()
+            _LOGGER.error("Connecting to %s:%s failed: %s", sa[0], sa[1], err)
+            continue
+        sock = s
+        remote_ip = sa[0]
+        _LOGGER.info("Connected to %s", remote_ip)
+        break
+    if sock is None:
+        raise OTAError(
+            f"Error connecting to {remote_host}:{remote_port}: {last_err}"
+        )
+    try:
         sock.settimeout(OTA_IMAGE_TRANSFER_TIMEOUT)
 
         with open(filename, "rb") as file:


### PR DESCRIPTION
# What does this implement/fix?

* Nagle is a no-op on large transfers. It merges small writes, which we do not do, so disabling it slightly trims the tail delay.
* Remove the artificial send buffer limit (SO\_SNDBUF). No longer needed since we do not use a blocking socket.
* Send the image as one continuous stream so TCP can keep more data in flight and recover faster from packet loss. Avoid periodic pauses every 8 kByte.
* Clamp TCP MSS to 536 so more packets fit into the microcontroller's small receive window. This increases the chance of fast recovery on loss without changing the microcontroller RWND. Overhead impact is minimal.
* Use a non-blocking socket and process microcontroller responses asynchronously. Progress is now driven primarily by TCP ACKs observed via SIOCOUTQ on Linux; when this is not available, fall back to the microcontroller's 8 kByte CHUNK\_OK acknowledgements.
* Progress bar: starts at 0, shows percentages with 2 decimals. If TCP ACKs can be read, shows "Segments: a/b" to reflect the microcontroller ACK bytes. Updates are throttled and only forced if there are not enough socket events to keep output responsive.
* Extend and clarify setup logging. Status messages clarify what is happening before the firmware image transfer starts and indicate where it might hang.
* Improve error handling: detect stalls (no send progress or protocol ACKs within the transfer timeout), report early peer close, and flag unexpected bytes during upload.
* Increase transfer timeout to 600 s for lossy or spotty links.
* Increase connect timeout to 60 s. This does not mean we actually wait that long; it is a safeguard that gives TCP enough leeway to handle ACK resends and decide when to abort.

## Test results:


### Speed to an ESP32-S3 with good connectivity

TL;DR: New Updater and TCP SACK is faster than the old method without TCP SACK. The smaller packages don't have any impact on the performance.

#### With the old updater:

```
INFO Upload took 6.76 seconds, waiting for result...
```

#### With sack and the old method:

```
INFO Upload took 4.42 seconds, waiting for result...
```

#### With the new updater, without sack:

```
INFO Upload took 23.46 seconds, waiting for result...
```


#### With the new updater and sack:

```
INFO Upload took 4.58 seconds, waiting for result...
```


### Speed to an ESP32-C3 Supermini with bad connectivity:

TL;DR: The old method didn't work, if timeouts were massively increased, it would take 15 minutes for an update. New method with SACK is the fasted option and consistently up to ~13 times faster.

#### Before any change:

- Timeout at various stages, even when run every half hour for 5 days no luck doing an update

#### With the old updater but longer timeouts and smaller TCP packages:

```
INFO Upload took 898.68 seconds, waiting for result...
```

#### With the new updater, without sack - good example:

```
INFO Upload took 164.96 seconds, waiting for result...
```

#### With the new updater, without sack - bad example:

(Sometimes it would go *extreeeemly* slow, much slower than that example below. I never completed these runs.)
```
INFO Upload took 254.26 seconds, waiting for result...
```

#### With the new updater and sack:

Consistently good results:

```
INFO Upload took 82.81 seconds, waiting for result...
--- 
INFO Upload took 71.05 seconds, waiting for result...
---
INFO Upload took 112.56 seconds, waiting for result...
```

Note:

Sometimes it *will* still be slower in the worst case scenarios, but I had a deep look at the traffic, and I could not see a single stall. The sender tried to recover efficiently and did pick up as soon as the RF conditions improved again.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

The issue:

https://github.com/esphome/esphome/pull/10152#issuecomment-3173587115

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32 (ESP32-C3 Supermini)
- [x] ESP32 IDF (ESP32-S3 and ESP32-C3 Supermini - with and without TCP SACK)
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840




## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
