### PR TITLE
[core] Improve entity duplicate validation error messages

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -627,13 +627,15 @@ class SchemaValidationStep(ConfigValidationStep):
     def __init__(
         self, domain: str, path: ConfigPath, conf: ConfigType, comp: ComponentManifest
     ):
+        self.domain = domain
         self.path = path
         self.conf = conf
         self.comp = comp
 
     def run(self, result: Config) -> None:
         token = path_context.set(self.path)
-        with result.catch_error(self.path):
+        # The domain already contains the full component path (e.g., "sensor.template", "sensor.uptime")
+        with CORE.component_context(self.domain), result.catch_error(self.path):
             if self.comp.is_platform:
                 # Remove 'platform' key for validation
                 input_conf = OrderedDict(self.conf)

--- a/esphome/types.py
+++ b/esphome/types.py
@@ -1,5 +1,7 @@
 """This helper module tracks commonly used types in the esphome python codebase."""
 
+from typing import TypedDict
+
 from esphome.core import ID, EsphomeCore, Lambda
 
 ConfigFragmentType = (
@@ -16,3 +18,13 @@ ConfigFragmentType = (
 ConfigType = dict[str, ConfigFragmentType]
 CoreType = EsphomeCore
 ConfigPathType = str | int
+
+
+class EntityMetadata(TypedDict):
+    """Metadata stored for each entity to help with duplicate detection."""
+
+    name: str
+    device_id: str
+    platform: str
+    entity_id: str
+    component: str

--- a/tests/unit_tests/fixtures/core/entity_helpers/entity_conflict_components.yaml
+++ b/tests/unit_tests/fixtures/core/entity_helpers/entity_conflict_components.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: test-device
+
+esp32:
+  board: esp32dev
+
+# Uptime sensor
+sensor:
+  - platform: uptime
+    name: "Battery"
+    id: uptime_battery
+
+# Template sensor also named "Battery" - this should conflict
+  - platform: template
+    name: "Battery"
+    id: template_battery
+    lambda: |-
+      return 95.0;
+    unit_of_measurement: "%"
+    update_interval: 60s


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the error messages when duplicate entity names are detected during configuration validation. The enhanced error messages now provide specific details about which component created the conflicting entity, making it much easier for users to identify and resolve naming conflicts.

### Changes:
- Modified entity duplicate validation to store and display metadata about conflicting entities
- Added tracking of which component/platform created each entity
- Enhanced error messages to show the entity ID and originating component of conflicts
- Used a context manager to cleanly track the current component during validation

### Example improvements:

**Example 1 - Basic conflict:**

Before:
```
Duplicate sensor entity with name 'Battery' found. Each entity on a device must have a unique name within its platform.
```

After:
```
Duplicate sensor entity with name 'Battery' found. Conflicts with entity 'Battery' (id: uptime_battery) from component 'sensor.uptime'. Each entity on a device must have a unique name within its platform.
```

**Example 2 - Conflict with devices:**

Before:
```
Duplicate sensor entity with name 'Temperature' found. Each entity on a device must have a unique name within its platform.
```

After:
```
Duplicate sensor entity with name 'Temperature' found on device 'living_room'. Conflicts with entity 'Temperature' on device 'living_room' (id: living_temp) from component 'sensor.template'. Each entity on a device must have a unique name within its platform.
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to esphome/esphome#10159

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example configuration that would trigger the improved error message
esphome:
  name: my-device

esp32:
  board: esp32dev

# First sensor named "Battery" from the uptime component
sensor:
  - platform: uptime
    name: "Battery"
    id: uptime_battery

  # Second sensor also named "Battery" from the template component
  # This will now produce a more helpful error message
  - platform: template
    name: "Battery"
    id: template_battery
    lambda: |-
      return 95.0;
    unit_of_measurement: "%"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Added `test_entity_duplicate_validator_error_message` to verify enhanced error messages
    - Added `test_entity_conflict_between_components_yaml` to test YAML config conflicts
    - Updated existing tests to work with the new dict-based validation tracking

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).