### PR TITLE
enable tcp sack for BK72xx

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -27,6 +27,7 @@ from esphome.core import CORE
 
 from . import gpio  # noqa
 from .const import (
+    COMPONENT_BK72XX,
     CONF_GPIO_RECOVER,
     CONF_LOGLEVEL,
     CONF_SDK_SILENT,
@@ -262,6 +263,8 @@ async def component_to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", FAMILY_FRIENDLY[config[CONF_FAMILY]])
     cg.add_define(ThreadModel.MULTI_NO_ATOMICS)
+    if config[CONF_COMPONENT_ID] == COMPONENT_BK72XX:
+        cg.add_define("LWIP_TCP_SACK_OUT", 1)
 
     # force using arduino framework
     cg.add_platformio_option("framework", "arduino")


### PR DESCRIPTION
# What does this implement/fix?

enable tcp sack for BK72xx

TODO: Testing, validation that it's working

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

https://github.com/esphome/esphome/pull/10182

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
