### PR TITLE
[api] Optimize single vector writes to use write() instead of writev()

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -156,7 +156,9 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   }
 
   // Try to send directly if no buffered data
-  ssize_t sent = this->socket_->writev(iov, iovcnt);
+  // Optimize for single iovec case (common for plaintext API)
+  ssize_t sent =
+      (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
   if (sent == -1) {
     APIError err = this->handle_socket_write_error_();


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API frame helper to use `write()` instead of `writev()` when sending a single I/O vector, avoiding unnecessary overhead in the lwIP networking stack.

When analyzing the ESPHome API send path for Bluetooth proxy performance, I found that plaintext API connections always use a single iovec, but still call `writev()`. The lwIP implementation has no fast path for single vectors - it always goes through full vector processing via `lwip_sendmsg()`. This change detects single-vector writes and calls `write()` directly, reducing CPU overhead for every API message.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).