### PR TITLE
[ld2450] Replace ``throttle`` with native filters

### DIFF
--- a/esphome/components/ld2450/__init__.py
+++ b/esphome/components/ld2450/__init__.py
@@ -17,9 +17,8 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LD2450Component),
-            cv.Optional(CONF_THROTTLE, default="1000ms"): cv.All(
-                cv.positive_time_period_milliseconds,
-                cv.Range(min=cv.TimePeriod(milliseconds=1)),
+            cv.Optional(CONF_THROTTLE): cv.invalid(
+                f"{CONF_THROTTLE} has been removed; use per-sensor filters, instead"
             ),
         }
     )
@@ -46,4 +45,3 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    cg.add(var.set_throttle(config[CONF_THROTTLE]))

--- a/esphome/components/ld2450/binary_sensor.py
+++ b/esphome/components/ld2450/binary_sensor.py
@@ -21,14 +21,17 @@ CONFIG_SCHEMA = {
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,
+        filters=[{"settle": cv.TimePeriod(milliseconds=1000)}],
         icon=ICON_SHIELD_ACCOUNT,
     ),
     cv.Optional(CONF_HAS_MOVING_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_MOTION,
+        filters=[{"settle": cv.TimePeriod(milliseconds=1000)}],
         icon=ICON_TARGET_ACCOUNT,
     ),
     cv.Optional(CONF_HAS_STILL_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,
+        filters=[{"settle": cv.TimePeriod(milliseconds=1000)}],
         icon=ICON_MEDITATION,
     ),
 }

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -110,7 +110,6 @@ class LD2450Component : public Component, public uart::UARTDevice {
   void dump_config() override;
   void loop() override;
   void set_presence_timeout();
-  void set_throttle(uint16_t value) { this->throttle_ = value; }
   void read_all_info();
   void query_zone_info();
   void restart_and_read_all_info();
@@ -161,11 +160,9 @@ class LD2450Component : public Component, public uart::UARTDevice {
   bool get_timeout_status_(uint32_t check_millis);
   uint8_t count_targets_in_zone_(const Zone &zone, bool is_moving);
 
-  uint32_t last_periodic_millis_ = 0;
   uint32_t presence_millis_ = 0;
   uint32_t still_presence_millis_ = 0;
   uint32_t moving_presence_millis_ = 0;
-  uint16_t throttle_ = 0;
   uint16_t timeout_ = 5;
   uint8_t buffer_data_[MAX_LINE_LENGTH];
   uint8_t mac_address_[6] = {0, 0, 0, 0, 0, 0};

--- a/esphome/components/ld2450/sensor.py
+++ b/esphome/components/ld2450/sensor.py
@@ -42,16 +42,43 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
-            icon=ICON_ACCOUNT_GROUP,
             accuracy_decimals=0,
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
+            icon=ICON_ACCOUNT_GROUP,
         ),
         cv.Optional(CONF_STILL_TARGET_COUNT): sensor.sensor_schema(
-            icon=ICON_HUMAN_GREETING_PROXIMITY,
             accuracy_decimals=0,
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
+            icon=ICON_HUMAN_GREETING_PROXIMITY,
         ),
         cv.Optional(CONF_MOVING_TARGET_COUNT): sensor.sensor_schema(
-            icon=ICON_ACCOUNT_SWITCH,
             accuracy_decimals=0,
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
+            icon=ICON_ACCOUNT_SWITCH,
         ),
     }
 )
@@ -62,32 +89,86 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
             {
                 cv.Optional(CONF_X): sensor.sensor_schema(
                     device_class=DEVICE_CLASS_DISTANCE,
-                    unit_of_measurement=UNIT_MILLIMETER,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_ALPHA_X_BOX_OUTLINE,
+                    unit_of_measurement=UNIT_MILLIMETER,
                 ),
                 cv.Optional(CONF_Y): sensor.sensor_schema(
                     device_class=DEVICE_CLASS_DISTANCE,
-                    unit_of_measurement=UNIT_MILLIMETER,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_ALPHA_Y_BOX_OUTLINE,
+                    unit_of_measurement=UNIT_MILLIMETER,
                 ),
                 cv.Optional(CONF_SPEED): sensor.sensor_schema(
                     device_class=DEVICE_CLASS_SPEED,
-                    unit_of_measurement=UNIT_MILLIMETER_PER_SECOND,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_SPEEDOMETER_SLOW,
+                    unit_of_measurement=UNIT_MILLIMETER_PER_SECOND,
                 ),
                 cv.Optional(CONF_ANGLE): sensor.sensor_schema(
-                    unit_of_measurement=UNIT_DEGREES,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_FORMAT_TEXT_ROTATION_ANGLE_UP,
+                    unit_of_measurement=UNIT_DEGREES,
                 ),
                 cv.Optional(CONF_DISTANCE): sensor.sensor_schema(
                     device_class=DEVICE_CLASS_DISTANCE,
-                    unit_of_measurement=UNIT_MILLIMETER,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_MAP_MARKER_DISTANCE,
+                    unit_of_measurement=UNIT_MILLIMETER,
                 ),
                 cv.Optional(CONF_RESOLUTION): sensor.sensor_schema(
                     device_class=DEVICE_CLASS_DISTANCE,
-                    unit_of_measurement=UNIT_MILLIMETER,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
                     icon=ICON_RELATION_ZERO_OR_ONE_TO_ZERO_OR_ONE,
+                    unit_of_measurement=UNIT_MILLIMETER,
                 ),
             }
         )
@@ -97,16 +178,43 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
         cv.Optional(f"zone_{n + 1}"): cv.Schema(
             {
                 cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
-                    icon=ICON_MAP_MARKER_ACCOUNT,
                     accuracy_decimals=0,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
+                    icon=ICON_MAP_MARKER_ACCOUNT,
                 ),
                 cv.Optional(CONF_STILL_TARGET_COUNT): sensor.sensor_schema(
-                    icon=ICON_MAP_MARKER_ACCOUNT,
                     accuracy_decimals=0,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
+                    icon=ICON_MAP_MARKER_ACCOUNT,
                 ),
                 cv.Optional(CONF_MOVING_TARGET_COUNT): sensor.sensor_schema(
-                    icon=ICON_MAP_MARKER_ACCOUNT,
                     accuracy_decimals=0,
+                    filters=[
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+                    ],
+                    icon=ICON_MAP_MARKER_ACCOUNT,
                 ),
             }
         )

--- a/tests/components/ld2450/common.yaml
+++ b/tests/components/ld2450/common.yaml
@@ -9,7 +9,6 @@ uart:
 ld2450:
   - id: ld2450_radar
     uart_id: ld2450_uart
-    throttle: 1000ms
 
 button:
   - platform: ld2450


### PR DESCRIPTION
# What does this implement/fix?

To bring this component to parity with other ESPHome components/platforms, this PR removes the throttle configuration variable and replaces it with default filters leveraging ESPHome's built-in data throttling mechanisms.

Continues work done in #10019 for consistency across platforms.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5226

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
