### PR TITLE
[bluetooth_proxy] Remove redundant connection type check after V1 removal

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -119,7 +119,7 @@ void BluetoothConnection::loop() {
 
   // Check if we should disable the loop
   // - For V3_WITH_CACHE: Services are never sent, disable after INIT state
-  // - For other connections: Disable only after service discovery is complete
+  // - For V3_WITHOUT_CACHE: Disable only after service discovery is complete
   //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
   if (this->state_ != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
                                                    this->send_service_ == DONE_SENDING_SERVICES)) {
@@ -146,10 +146,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   if (this->send_service_ >= this->service_count_) {
     this->send_service_ = DONE_SENDING_SERVICES;
     this->proxy_->send_gatt_services_done(this->address_);
-    if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
-        this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-      this->release_services();
-    }
+    this->release_services();
     return;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR removes a redundant connection type check in the bluetooth_proxy component that became unnecessary after V1 connection support was removed in #10107.

Since V1 connections are no longer supported in bluetooth_proxy, the only possible connection types are now `V3_WITH_CACHE` and `V3_WITHOUT_CACHE`. This makes the check `if (connection_type_ == V3_WITH_CACHE || connection_type_ == V3_WITHOUT_CACHE)` always evaluate to true, so it can be simplified by removing the condition entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #10107

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal code cleanup
bluetooth_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

