### PR TITLE
[bme280_base, bmp280_base] add reasons to the fails, clean up logging

### DIFF
--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -8,8 +8,6 @@
 #include <esphome/core/component.h>
 
 #define BME280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
-#define BME280_ERROR_READING_STATUS_REG "Error reading status register"
-#define BME280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 namespace esphome {
 namespace bme280_base {
@@ -122,14 +120,12 @@ void BME280Component::setup() {
   do {  // NOLINT
     delay(2);
     if (!this->read_byte(BME280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, BME280_ERROR_READING_STATUS_REG);
-      this->mark_failed(BME280_ERROR_READING_STATUS_REG);
+      this->mark_failed("Error reading status register");
       return;
     }
   } while ((status & BME280_STATUS_IM_UPDATE) && (--retry));
   if (status & BME280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, BME280_ERROR_TIMEOUT_LOADING_NVM);
-    this->mark_failed(BME280_ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed("Timeout loading NVM");
     return;
   }
 

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -7,6 +7,10 @@
 #include <esphome/components/sensor/sensor.h>
 #include <esphome/core/component.h>
 
+#define BME280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
+#define BME280_ERROR_READING_STATUS_REG "Error reading status register"
+#define BME280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
+
 namespace esphome {
 namespace bme280_base {
 
@@ -48,10 +52,6 @@ static const uint8_t BME280_REGISTER_HUMIDDATA = 0xFD;
 static const uint8_t BME280_MODE_FORCED = 0b01;
 static const uint8_t BME280_SOFT_RESET = 0xB6;
 static const uint8_t BME280_STATUS_IM_UPDATE = 0b01;
-
-#define BME280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
-#define BME280_ERROR_READING_STATUS_REG "Error reading status register"
-#define BME280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -49,6 +49,10 @@ static const uint8_t BME280_MODE_FORCED = 0b01;
 static const uint8_t BME280_SOFT_RESET = 0xB6;
 static const uint8_t BME280_STATUS_IM_UPDATE = 0b01;
 
+static const char *const ERROR_WRONG_CHIP_ID = "Wrong chip ID";
+static const char *const ERROR_READING_STATUS_REG = "Error reading status register";
+static const char *const ERROR_TIMEOUT_LOADING_NVM = "Timeout loading NVM";
+
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
 const char *iir_filter_to_str(BME280IIRFilter filter) {  // NOLINT
@@ -98,18 +102,18 @@ void BME280Component::setup() {
 
   if (!this->read_byte(BME280_REGISTER_CHIPID, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed("can't communicate");
+    this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
     return;
   }
   if (chip_id != 0x60) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed("wrong chip id");
+    this->mark_failed(ERROR_WRONG_CHIP_ID);
     return;
   }
 
   // Send a soft reset.
   if (!this->write_byte(BME280_REGISTER_RESET, BME280_SOFT_RESET)) {
-    this->mark_failed("reset failed");
+    this->mark_failed("Reset failed");
     return;
   }
   // Wait until the NVM data has finished loading.
@@ -118,14 +122,14 @@ void BME280Component::setup() {
   do {  // NOLINT
     delay(2);
     if (!this->read_byte(BME280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, "Error reading status register.");
-      this->mark_failed("read status");
+      ESP_LOGW(TAG, ERROR_READING_STATUS_REG);
+      this->mark_failed(ERROR_READING_STATUS_REG);
       return;
     }
   } while ((status & BME280_STATUS_IM_UPDATE) && (--retry));
   if (status & BME280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, "Timeout loading NVM.");
-    this->mark_failed("timeout loading NVM");
+    ESP_LOGW(TAG, ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed(ERROR_TIMEOUT_LOADING_NVM);
     return;
   }
 
@@ -153,26 +157,26 @@ void BME280Component::setup() {
 
   uint8_t humid_control_val = 0;
   if (!this->read_byte(BME280_REGISTER_CONTROLHUMID, &humid_control_val)) {
-    this->mark_failed("read humidity control");
+    this->mark_failed("Read humidity control");
     return;
   }
   humid_control_val &= ~0b00000111;
   humid_control_val |= this->humidity_oversampling_ & 0b111;
   if (!this->write_byte(BME280_REGISTER_CONTROLHUMID, humid_control_val)) {
-    this->mark_failed("write humidity control");
+    this->mark_failed("Write humidity control");
     return;
   }
 
   uint8_t config_register = 0;
   if (!this->read_byte(BME280_REGISTER_CONFIG, &config_register)) {
-    this->mark_failed("read config");
+    this->mark_failed("Read config");
     return;
   }
   config_register &= ~0b11111100;
   config_register |= 0b101 << 5;  // 1000 ms standby time
   config_register |= (this->iir_filter_ & 0b111) << 2;
   if (!this->write_byte(BME280_REGISTER_CONFIG, config_register)) {
-    this->mark_failed("write config");
+    this->mark_failed("Write config");
     return;
   }
 }
@@ -183,7 +187,7 @@ void BME280Component::dump_config() {
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       break;
     case WRONG_CHIP_ID:
-      ESP_LOGE(TAG, "BME280 has wrong chip ID! Is it a BME280?");
+      ESP_LOGE(TAG, ERROR_WRONG_CHIP_ID);
       break;
     case NONE:
     default:
@@ -223,21 +227,21 @@ void BME280Component::update() {
   this->set_timeout("data", uint32_t(ceilf(meas_time)), [this]() {
     uint8_t data[8];
     if (!this->read_bytes(BME280_REGISTER_MEASUREMENTS, data, 8)) {
-      ESP_LOGW(TAG, "Error reading registers.");
+      ESP_LOGW(TAG, "Error reading registers");
       this->status_set_warning();
       return;
     }
     int32_t t_fine = 0;
     float const temperature = this->read_temperature_(data, &t_fine);
     if (std::isnan(temperature)) {
-      ESP_LOGW(TAG, "Invalid temperature, cannot read pressure & humidity values.");
+      ESP_LOGW(TAG, "Invalid temperature");
       this->status_set_warning();
       return;
     }
     float const pressure = this->read_pressure_(data, t_fine);
     float const humidity = this->read_humidity_(data, t_fine);
 
-    ESP_LOGV(TAG, "Got temperature=%.1f°C pressure=%.1fhPa humidity=%.1f%%", temperature, pressure, humidity);
+    ESP_LOGV(TAG, "Temperature=%.1f°C Pressure=%.1fhPa Humidity=%.1f%%", temperature, pressure, humidity);
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
     if (this->pressure_sensor_ != nullptr)

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -49,9 +49,9 @@ static const uint8_t BME280_MODE_FORCED = 0b01;
 static const uint8_t BME280_SOFT_RESET = 0xB6;
 static const uint8_t BME280_STATUS_IM_UPDATE = 0b01;
 
-static const char *const ERROR_WRONG_CHIP_ID = "Wrong chip ID";
-static const char *const ERROR_READING_STATUS_REG = "Error reading status register";
-static const char *const ERROR_TIMEOUT_LOADING_NVM = "Timeout loading NVM";
+#define BME280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
+#define BME280_ERROR_READING_STATUS_REG "Error reading status register"
+#define BME280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
@@ -107,7 +107,7 @@ void BME280Component::setup() {
   }
   if (chip_id != 0x60) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed(ERROR_WRONG_CHIP_ID);
+    this->mark_failed(BME280_ERROR_WRONG_CHIP_ID);
     return;
   }
 
@@ -122,14 +122,14 @@ void BME280Component::setup() {
   do {  // NOLINT
     delay(2);
     if (!this->read_byte(BME280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, ERROR_READING_STATUS_REG);
-      this->mark_failed(ERROR_READING_STATUS_REG);
+      ESP_LOGW(TAG, BME280_ERROR_READING_STATUS_REG);
+      this->mark_failed(BME280_ERROR_READING_STATUS_REG);
       return;
     }
   } while ((status & BME280_STATUS_IM_UPDATE) && (--retry));
   if (status & BME280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, ERROR_TIMEOUT_LOADING_NVM);
-    this->mark_failed(ERROR_TIMEOUT_LOADING_NVM);
+    ESP_LOGW(TAG, BME280_ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed(BME280_ERROR_TIMEOUT_LOADING_NVM);
     return;
   }
 
@@ -187,7 +187,7 @@ void BME280Component::dump_config() {
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       break;
     case WRONG_CHIP_ID:
-      ESP_LOGE(TAG, ERROR_WRONG_CHIP_ID);
+      ESP_LOGE(TAG, BME280_ERROR_WRONG_CHIP_ID);
       break;
     case NONE:
     default:

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -98,18 +98,18 @@ void BME280Component::setup() {
 
   if (!this->read_byte(BME280_REGISTER_CHIPID, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed();
+    this->mark_failed("can't communicate");
     return;
   }
   if (chip_id != 0x60) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed();
+    this->mark_failed("wrong chip id");
     return;
   }
 
   // Send a soft reset.
   if (!this->write_byte(BME280_REGISTER_RESET, BME280_SOFT_RESET)) {
-    this->mark_failed();
+    this->mark_failed("reset failed");
     return;
   }
   // Wait until the NVM data has finished loading.
@@ -119,13 +119,13 @@ void BME280Component::setup() {
     delay(2);
     if (!this->read_byte(BME280_REGISTER_STATUS, &status)) {
       ESP_LOGW(TAG, "Error reading status register.");
-      this->mark_failed();
+      this->mark_failed("read status");
       return;
     }
   } while ((status & BME280_STATUS_IM_UPDATE) && (--retry));
   if (status & BME280_STATUS_IM_UPDATE) {
     ESP_LOGW(TAG, "Timeout loading NVM.");
-    this->mark_failed();
+    this->mark_failed("timeout loading NVM");
     return;
   }
 
@@ -153,26 +153,26 @@ void BME280Component::setup() {
 
   uint8_t humid_control_val = 0;
   if (!this->read_byte(BME280_REGISTER_CONTROLHUMID, &humid_control_val)) {
-    this->mark_failed();
+    this->mark_failed("read humidity control");
     return;
   }
   humid_control_val &= ~0b00000111;
   humid_control_val |= this->humidity_oversampling_ & 0b111;
   if (!this->write_byte(BME280_REGISTER_CONTROLHUMID, humid_control_val)) {
-    this->mark_failed();
+    this->mark_failed("write humidity control");
     return;
   }
 
   uint8_t config_register = 0;
   if (!this->read_byte(BME280_REGISTER_CONFIG, &config_register)) {
-    this->mark_failed();
+    this->mark_failed("read config");
     return;
   }
   config_register &= ~0b11111100;
   config_register |= 0b101 << 5;  // 1000 ms standby time
   config_register |= (this->iir_filter_ & 0b111) << 2;
   if (!this->write_byte(BME280_REGISTER_CONFIG, config_register)) {
-    this->mark_failed();
+    this->mark_failed("write config");
     return;
   }
 }

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -18,6 +18,10 @@ static const uint8_t BMP280_MODE_FORCED = 0b01;
 static const uint8_t BMP280_SOFT_RESET = 0xB6;
 static const uint8_t BMP280_STATUS_IM_UPDATE = 0b01;
 
+static const char *const ERROR_WRONG_CHIP_ID = "Wrong chip ID";
+static const char *const ERROR_READING_STATUS_REG = "Error reading status register";
+static const char *const ERROR_TIMEOUT_LOADING_NVM = "Timeout loading NVM";
+
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
 static const char *oversampling_to_str(BMP280Oversampling oversampling) {
@@ -63,23 +67,23 @@ void BMP280Component::setup() {
   // https://community.st.com/t5/stm32-mcus-products/issue-with-reading-bmp280-chip-id-using-spi/td-p/691855
   if (!this->read_byte(0xD0, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed("communication failed");
+    this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
     return;
   }
   if (!this->read_byte(0xD0, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed("communication failed");
+    this->mark_failed(ESP_LOG_MSG_COMM_FAIL);
     return;
   }
   if (chip_id != 0x58) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed("wrong chip id");
+    this->mark_failed(ERROR_WRONG_CHIP_ID);
     return;
   }
 
   // Send a soft reset.
   if (!this->write_byte(BMP280_REGISTER_RESET, BMP280_SOFT_RESET)) {
-    this->mark_failed("reset failed");
+    this->mark_failed("Reset failed");
     return;
   }
   // Wait until the NVM data has finished loading.
@@ -88,14 +92,14 @@ void BMP280Component::setup() {
   do {
     delay(2);
     if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, "Error reading status register.");
-      this->mark_failed("read status");
+      ESP_LOGW(TAG, ERROR_READING_STATUS_REG);
+      this->mark_failed(ERROR_READING_STATUS_REG);
       return;
     }
   } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
   if (status & BMP280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, "Timeout loading NVM.");
-    this->mark_failed("timeout loading NVM");
+    ESP_LOGW(TAG, ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed(ERROR_TIMEOUT_LOADING_NVM);
     return;
   }
 
@@ -116,14 +120,14 @@ void BMP280Component::setup() {
 
   uint8_t config_register = 0;
   if (!this->read_byte(BMP280_REGISTER_CONFIG, &config_register)) {
-    this->mark_failed("read config");
+    this->mark_failed("Read config");
     return;
   }
   config_register &= ~0b11111100;
   config_register |= 0b000 << 5;  // 0.5 ms standby time
   config_register |= (this->iir_filter_ & 0b111) << 2;
   if (!this->write_byte(BMP280_REGISTER_CONFIG, config_register)) {
-    this->mark_failed("write config");
+    this->mark_failed("Write config");
     return;
   }
 }
@@ -134,7 +138,7 @@ void BMP280Component::dump_config() {
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       break;
     case WRONG_CHIP_ID:
-      ESP_LOGE(TAG, "BMP280 has wrong chip ID! Is it a BME280?");
+      ESP_LOGE(TAG, ERROR_WRONG_CHIP_ID);
       break;
     case NONE:
     default:
@@ -172,13 +176,13 @@ void BMP280Component::update() {
     int32_t t_fine = 0;
     float temperature = this->read_temperature_(&t_fine);
     if (std::isnan(temperature)) {
-      ESP_LOGW(TAG, "Invalid temperature, cannot read pressure values.");
+      ESP_LOGW(TAG, "Invalid temperature");
       this->status_set_warning();
       return;
     }
     float pressure = this->read_pressure_(t_fine);
 
-    ESP_LOGD(TAG, "Got temperature=%.1f°C pressure=%.1fhPa", temperature, pressure);
+    ESP_LOGV(TAG, "Temperature=%.1f°C Pressure=%.1fhPa", temperature, pressure);
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
     if (this->pressure_sensor_ != nullptr)

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -3,8 +3,6 @@
 #include "esphome/core/log.h"
 
 #define BMP280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
-#define BMP280_ERROR_READING_STATUS_REG "Error reading status register"
-#define BMP280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 namespace esphome {
 namespace bmp280_base {
@@ -92,14 +90,12 @@ void BMP280Component::setup() {
   do {
     delay(2);
     if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, BMP280_ERROR_READING_STATUS_REG);
-      this->mark_failed(BMP280_ERROR_READING_STATUS_REG);
+      this->mark_failed("Error reading status register");
       return;
     }
   } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
   if (status & BMP280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, BMP280_ERROR_TIMEOUT_LOADING_NVM);
-    this->mark_failed(BMP280_ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed("Timeout loading NVM");
     return;
   }
 

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -63,23 +63,23 @@ void BMP280Component::setup() {
   // https://community.st.com/t5/stm32-mcus-products/issue-with-reading-bmp280-chip-id-using-spi/td-p/691855
   if (!this->read_byte(0xD0, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed();
+    this->mark_failed("communication failed");
     return;
   }
   if (!this->read_byte(0xD0, &chip_id)) {
     this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed();
+    this->mark_failed("communication failed");
     return;
   }
   if (chip_id != 0x58) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed();
+    this->mark_failed("wrong chip id");
     return;
   }
 
   // Send a soft reset.
   if (!this->write_byte(BMP280_REGISTER_RESET, BMP280_SOFT_RESET)) {
-    this->mark_failed();
+    this->mark_failed("reset failed");
     return;
   }
   // Wait until the NVM data has finished loading.
@@ -89,13 +89,13 @@ void BMP280Component::setup() {
     delay(2);
     if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
       ESP_LOGW(TAG, "Error reading status register.");
-      this->mark_failed();
+      this->mark_failed("read status");
       return;
     }
   } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
   if (status & BMP280_STATUS_IM_UPDATE) {
     ESP_LOGW(TAG, "Timeout loading NVM.");
-    this->mark_failed();
+    this->mark_failed("timeout loading NVM");
     return;
   }
 
@@ -116,14 +116,14 @@ void BMP280Component::setup() {
 
   uint8_t config_register = 0;
   if (!this->read_byte(BMP280_REGISTER_CONFIG, &config_register)) {
-    this->mark_failed();
+    this->mark_failed("read config");
     return;
   }
   config_register &= ~0b11111100;
   config_register |= 0b000 << 5;  // 0.5 ms standby time
   config_register |= (this->iir_filter_ & 0b111) << 2;
   if (!this->write_byte(BMP280_REGISTER_CONFIG, config_register)) {
-    this->mark_failed();
+    this->mark_failed("write config");
     return;
   }
 }

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -2,6 +2,10 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
+#define BMP280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
+#define BMP280_ERROR_READING_STATUS_REG "Error reading status register"
+#define BMP280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
+
 namespace esphome {
 namespace bmp280_base {
 
@@ -17,10 +21,6 @@ static const uint8_t BMP280_REGISTER_RESET = 0xE0;
 static const uint8_t BMP280_MODE_FORCED = 0b01;
 static const uint8_t BMP280_SOFT_RESET = 0xB6;
 static const uint8_t BMP280_STATUS_IM_UPDATE = 0b01;
-
-#define BMP280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
-#define BMP280_ERROR_READING_STATUS_REG "Error reading status register"
-#define BMP280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -18,9 +18,9 @@ static const uint8_t BMP280_MODE_FORCED = 0b01;
 static const uint8_t BMP280_SOFT_RESET = 0xB6;
 static const uint8_t BMP280_STATUS_IM_UPDATE = 0b01;
 
-static const char *const ERROR_WRONG_CHIP_ID = "Wrong chip ID";
-static const char *const ERROR_READING_STATUS_REG = "Error reading status register";
-static const char *const ERROR_TIMEOUT_LOADING_NVM = "Timeout loading NVM";
+#define BMP280_ERROR_WRONG_CHIP_ID "Wrong chip ID"
+#define BMP280_ERROR_READING_STATUS_REG "Error reading status register"
+#define BMP280_ERROR_TIMEOUT_LOADING_NVM "Timeout loading NVM"
 
 inline uint16_t combine_bytes(uint8_t msb, uint8_t lsb) { return ((msb & 0xFF) << 8) | (lsb & 0xFF); }
 
@@ -77,7 +77,7 @@ void BMP280Component::setup() {
   }
   if (chip_id != 0x58) {
     this->error_code_ = WRONG_CHIP_ID;
-    this->mark_failed(ERROR_WRONG_CHIP_ID);
+    this->mark_failed(BMP280_ERROR_WRONG_CHIP_ID);
     return;
   }
 
@@ -92,14 +92,14 @@ void BMP280Component::setup() {
   do {
     delay(2);
     if (!this->read_byte(BMP280_REGISTER_STATUS, &status)) {
-      ESP_LOGW(TAG, ERROR_READING_STATUS_REG);
-      this->mark_failed(ERROR_READING_STATUS_REG);
+      ESP_LOGW(TAG, BMP280_ERROR_READING_STATUS_REG);
+      this->mark_failed(BMP280_ERROR_READING_STATUS_REG);
       return;
     }
   } while ((status & BMP280_STATUS_IM_UPDATE) && (--retry));
   if (status & BMP280_STATUS_IM_UPDATE) {
-    ESP_LOGW(TAG, ERROR_TIMEOUT_LOADING_NVM);
-    this->mark_failed(ERROR_TIMEOUT_LOADING_NVM);
+    ESP_LOGW(TAG, BMP280_ERROR_TIMEOUT_LOADING_NVM);
+    this->mark_failed(BMP280_ERROR_TIMEOUT_LOADING_NVM);
     return;
   }
 
@@ -138,7 +138,7 @@ void BMP280Component::dump_config() {
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
       break;
     case WRONG_CHIP_ID:
-      ESP_LOGE(TAG, ERROR_WRONG_CHIP_ID);
+      ESP_LOGE(TAG, BMP280_ERROR_WRONG_CHIP_ID);
       break;
     case NONE:
     default:


### PR DESCRIPTION
# What does this implement/fix?

Add reasons when failing the component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
