### PR TITLE
Improve error reporting for add_library

### DIFF
--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -804,7 +804,7 @@ class EsphomeCore:
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
 
-        if library.name is None or library.name == "":
+        if not library.name:
             raise ValueError(f"The library for {library.repository} must have a name")
 
         short_name = (

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -803,6 +803,10 @@ class EsphomeCore:
             raise TypeError(
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
+
+        if library.name is None or library.name == "":
+            raise ValueError(f"The library for {library.repository} must have a name")
+
         short_name = (
             library.name if "/" not in library.name else library.name.split("/")[-1]
         )


### PR DESCRIPTION
# What does this implement/fix?

Check that a library has a valid name before splitting. In the case where libraries were added without a valid 'name' field, the error reported would be an IndexError at the split, rather than giving any true information about the cause of the error.

The documentation at esphome-docs also needs to be updated to reflect this, since it still refers to lib_deps (which allows for anonymous libraries), whereas now names are required.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
