### PR TITLE
[core] Trigger clean build when components are removed from configuration

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -80,7 +80,7 @@ def replace_file_content(text, pattern, repl):
     return content_new, count
 
 
-def storage_should_clean(old: StorageJSON, new: StorageJSON) -> bool:
+def storage_should_clean(old: StorageJSON | None, new: StorageJSON) -> bool:
     if old is None:
         return True
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -103,7 +103,7 @@ def storage_should_update_cmake_cache(old: StorageJSON, new: StorageJSON) -> boo
     return False
 
 
-def update_storage_json():
+def update_storage_json() -> None:
     path = storage_path()
     old = StorageJSON.load(path)
     new = StorageJSON.from_esphome_core(CORE, old)
@@ -111,7 +111,7 @@ def update_storage_json():
         return
 
     if storage_should_clean(old, new):
-        if old.loaded_integrations - new.loaded_integrations:
+        if old is not None and old.loaded_integrations - new.loaded_integrations:
             removed = old.loaded_integrations - new.loaded_integrations
             _LOGGER.info(
                 "Components removed (%s), cleaning build files...",

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -111,7 +111,7 @@ def update_storage_json():
         return
 
     if storage_should_clean(old, new):
-        if old and old.loaded_integrations - new.loaded_integrations:
+        if old.loaded_integrations - new.loaded_integrations:
             removed = old.loaded_integrations - new.loaded_integrations
             _LOGGER.info(
                 "Components removed (%s), cleaning build files...",

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -86,7 +86,10 @@ def storage_should_clean(old: StorageJSON, new: StorageJSON) -> bool:
 
     if old.src_version != new.src_version:
         return True
-    return old.build_path != new.build_path
+    if old.build_path != new.build_path:
+        return True
+    # Check if any components have been removed
+    return bool(old.loaded_integrations - new.loaded_integrations)
 
 
 def storage_should_update_cmake_cache(old: StorageJSON, new: StorageJSON) -> bool:
@@ -108,7 +111,14 @@ def update_storage_json():
         return
 
     if storage_should_clean(old, new):
-        _LOGGER.info("Core config, version changed, cleaning build files...")
+        if old and old.loaded_integrations - new.loaded_integrations:
+            removed = old.loaded_integrations - new.loaded_integrations
+            _LOGGER.info(
+                "Components removed (%s), cleaning build files...",
+                ", ".join(sorted(removed)),
+            )
+        else:
+            _LOGGER.info("Core config or version changed, cleaning build files...")
         clean_build()
     elif storage_should_update_cmake_cache(old, new):
         _LOGGER.info("Integrations changed, cleaning cmake cache...")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -2,11 +2,12 @@
 
 from collections.abc import Callable
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from esphome.storage_json import StorageJSON
-from esphome.writer import storage_should_clean
+from esphome.writer import storage_should_clean, update_storage_json
 
 
 @pytest.fixture
@@ -137,3 +138,83 @@ def test_storage_edge_case_from_empty_integrations(
     old = create_storage(loaded_integrations=[])
     new = create_storage(loaded_integrations=["api", "wifi"])
     assert storage_should_clean(old, new) is False
+
+
+@patch("esphome.writer.clean_build")
+@patch("esphome.writer.StorageJSON")
+@patch("esphome.writer.storage_path")
+@patch("esphome.writer.CORE")
+@patch("esphome.writer._LOGGER")
+def test_update_storage_json_logging_when_old_is_none(
+    mock_logger: MagicMock,
+    mock_core: MagicMock,
+    mock_storage_path: MagicMock,
+    mock_storage_json_class: MagicMock,
+    mock_clean_build: MagicMock,
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that update_storage_json doesn't crash when old storage is None.
+
+    This is a regression test for the AttributeError that occurred when
+    old was None and we tried to access old.loaded_integrations.
+    """
+    # Setup mocks
+    mock_storage_path.return_value = "/test/path"
+    mock_storage_json_class.load.return_value = None  # Old storage is None
+
+    new_storage = create_storage(loaded_integrations=["api", "wifi"])
+    new_storage.save = MagicMock()  # Mock the save method
+    mock_storage_json_class.from_esphome_core.return_value = new_storage
+
+    # Call the function - should not raise AttributeError
+    update_storage_json()
+
+    # Verify clean_build was called
+    mock_clean_build.assert_called_once()
+
+    # Verify the correct log message was used (not the component removal message)
+    mock_logger.info.assert_called_with(
+        "Core config or version changed, cleaning build files..."
+    )
+
+    # Verify save was called
+    new_storage.save.assert_called_once_with("/test/path")
+
+
+@patch("esphome.writer.clean_build")
+@patch("esphome.writer.StorageJSON")
+@patch("esphome.writer.storage_path")
+@patch("esphome.writer.CORE")
+@patch("esphome.writer._LOGGER")
+def test_update_storage_json_logging_components_removed(
+    mock_logger: MagicMock,
+    mock_core: MagicMock,
+    mock_storage_path: MagicMock,
+    mock_storage_json_class: MagicMock,
+    mock_clean_build: MagicMock,
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that update_storage_json logs removed components correctly."""
+    # Setup mocks
+    mock_storage_path.return_value = "/test/path"
+
+    old_storage = create_storage(loaded_integrations=["api", "wifi", "bluetooth_proxy"])
+    new_storage = create_storage(loaded_integrations=["api", "wifi"])
+    new_storage.save = MagicMock()  # Mock the save method
+
+    mock_storage_json_class.load.return_value = old_storage
+    mock_storage_json_class.from_esphome_core.return_value = new_storage
+
+    # Call the function
+    update_storage_json()
+
+    # Verify clean_build was called
+    mock_clean_build.assert_called_once()
+
+    # Verify the correct log message was used with component names
+    mock_logger.info.assert_called_with(
+        "Components removed (%s), cleaning build files...", "bluetooth_proxy"
+    )
+
+    # Verify save was called
+    new_storage.save.assert_called_once_with("/test/path")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -144,14 +144,13 @@ def test_storage_edge_case_from_empty_integrations(
 @patch("esphome.writer.StorageJSON")
 @patch("esphome.writer.storage_path")
 @patch("esphome.writer.CORE")
-@patch("esphome.writer._LOGGER")
 def test_update_storage_json_logging_when_old_is_none(
-    mock_logger: MagicMock,
     mock_core: MagicMock,
     mock_storage_path: MagicMock,
     mock_storage_json_class: MagicMock,
     mock_clean_build: MagicMock,
     create_storage: Callable[..., StorageJSON],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update_storage_json doesn't crash when old storage is None.
 
@@ -167,15 +166,15 @@ def test_update_storage_json_logging_when_old_is_none(
     mock_storage_json_class.from_esphome_core.return_value = new_storage
 
     # Call the function - should not raise AttributeError
-    update_storage_json()
+    with caplog.at_level("INFO"):
+        update_storage_json()
 
     # Verify clean_build was called
     mock_clean_build.assert_called_once()
 
     # Verify the correct log message was used (not the component removal message)
-    mock_logger.info.assert_called_with(
-        "Core config or version changed, cleaning build files..."
-    )
+    assert "Core config or version changed, cleaning build files..." in caplog.text
+    assert "Components removed" not in caplog.text
 
     # Verify save was called
     new_storage.save.assert_called_once_with("/test/path")
@@ -185,14 +184,13 @@ def test_update_storage_json_logging_when_old_is_none(
 @patch("esphome.writer.StorageJSON")
 @patch("esphome.writer.storage_path")
 @patch("esphome.writer.CORE")
-@patch("esphome.writer._LOGGER")
 def test_update_storage_json_logging_components_removed(
-    mock_logger: MagicMock,
     mock_core: MagicMock,
     mock_storage_path: MagicMock,
     mock_storage_json_class: MagicMock,
     mock_clean_build: MagicMock,
     create_storage: Callable[..., StorageJSON],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that update_storage_json logs removed components correctly."""
     # Setup mocks
@@ -206,15 +204,17 @@ def test_update_storage_json_logging_components_removed(
     mock_storage_json_class.from_esphome_core.return_value = new_storage
 
     # Call the function
-    update_storage_json()
+    with caplog.at_level("INFO"):
+        update_storage_json()
 
     # Verify clean_build was called
     mock_clean_build.assert_called_once()
 
     # Verify the correct log message was used with component names
-    mock_logger.info.assert_called_with(
-        "Components removed (%s), cleaning build files...", "bluetooth_proxy"
+    assert (
+        "Components removed (bluetooth_proxy), cleaning build files..." in caplog.text
     )
+    assert "Core config or version changed" not in caplog.text
 
     # Verify save was called
     new_storage.save.assert_called_once_with("/test/path")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -1,0 +1,139 @@
+"""Test writer module functionality."""
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from esphome.storage_json import StorageJSON
+from esphome.writer import storage_should_clean
+
+
+@pytest.fixture
+def create_storage() -> Callable[..., StorageJSON]:
+    """Factory fixture to create StorageJSON instances."""
+
+    def _create(
+        loaded_integrations: list[str] | None = None, **kwargs: Any
+    ) -> StorageJSON:
+        return StorageJSON(
+            storage_version=kwargs.get("storage_version", 1),
+            name=kwargs.get("name", "test"),
+            friendly_name=kwargs.get("friendly_name", "Test Device"),
+            comment=kwargs.get("comment"),
+            esphome_version=kwargs.get("esphome_version", "2025.1.0"),
+            src_version=kwargs.get("src_version", 1),
+            address=kwargs.get("address", "test.local"),
+            web_port=kwargs.get("web_port", 80),
+            target_platform=kwargs.get("target_platform", "ESP32"),
+            build_path=kwargs.get("build_path", "/build"),
+            firmware_bin_path=kwargs.get("firmware_bin_path", "/firmware.bin"),
+            loaded_integrations=set(loaded_integrations or []),
+            loaded_platforms=kwargs.get("loaded_platforms", set()),
+            no_mdns=kwargs.get("no_mdns", False),
+            framework=kwargs.get("framework", "arduino"),
+            core_platform=kwargs.get("core_platform", "esp32"),
+        )
+
+    return _create
+
+
+def test_storage_should_clean_when_old_is_none(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when old storage is None."""
+    new = create_storage(loaded_integrations=["api", "wifi"])
+    assert storage_should_clean(None, new) is True
+
+
+def test_storage_should_clean_when_src_version_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when src_version changes."""
+    old = create_storage(loaded_integrations=["api", "wifi"], src_version=1)
+    new = create_storage(loaded_integrations=["api", "wifi"], src_version=2)
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_build_path_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when build_path changes."""
+    old = create_storage(loaded_integrations=["api", "wifi"], build_path="/build1")
+    new = create_storage(loaded_integrations=["api", "wifi"], build_path="/build2")
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_component_removed(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when a component is removed."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi", "bluetooth_proxy", "esp32_ble_tracker"]
+    )
+    new = create_storage(loaded_integrations=["api", "wifi", "esp32_ble_tracker"])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_multiple_components_removed(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when multiple components are removed."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi", "ota", "web_server", "logger"]
+    )
+    new = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_not_clean_when_nothing_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when nothing changes."""
+    old = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    new = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_should_not_clean_when_component_added(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when a component is only added."""
+    old = create_storage(loaded_integrations=["api", "wifi"])
+    new = create_storage(loaded_integrations=["api", "wifi", "ota"])
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_should_not_clean_when_other_fields_change(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when non-relevant fields change."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi"],
+        friendly_name="Old Name",
+        esphome_version="2024.12.0",
+    )
+    new = create_storage(
+        loaded_integrations=["api", "wifi"],
+        friendly_name="New Name",
+        esphome_version="2025.1.0",
+    )
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_edge_case_empty_integrations(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test edge case when old has integrations but new has none."""
+    old = create_storage(loaded_integrations=["api", "wifi"])
+    new = create_storage(loaded_integrations=[])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_edge_case_from_empty_integrations(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test edge case when old has no integrations but new has some."""
+    old = create_storage(loaded_integrations=[])
+    new = create_storage(loaded_integrations=["api", "wifi"])
+    assert storage_should_clean(old, new) is False


### PR DESCRIPTION
# What does this implement/fix?

**We currently have to tell users to clean build files nearly every day** when they encounter mysterious build failures or runtime issues. This PR addresses one of the most common root causes.

This PR fixes an issue where removing components from the ESPHome configuration doesn't trigger a clean build, leaving stale build artifacts that create hard-to-diagnose problems including:
- Ethernet connectivity issues when WiFi components are removed but artifacts remain
- Memory allocation conflicts
- Undefined reference linker errors
- Conflicting symbol definitions
- Runtime crashes from leftover component code
- "Component not found" errors that persist after removal
- Mysterious compilation failures that "just work" after cleaning
- **Devices becoming completely inaccessible** - In testing issue #10170, various combinations of adding/removing WiFi, Ethernet, and Bluetooth components without clean builds resulted in a device that required physical access and serial flashing to recover (had to dig it out of the wall!). **This issue could no longer be reproduced after implementing this fix.**

The fix detects when components have been removed from the configuration and automatically triggers a clean build to ensure all related artifacts are properly removed. While this doesn't solve all cases where users need to clean build files, it addresses a significant portion of the daily support burden.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10170 (Ethernet issues when WiFi removed but no clean build triggered)
- Addresses the **daily occurrence** of having to tell users to "try a clean build"
- Will prevent countless hard-to-diagnose issues that waste both user and maintainer time

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal build system improvement, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example showing component removal that will now trigger clean build
# Before: Remove bluetooth_proxy, build artifacts remain
# After: Remove bluetooth_proxy, clean build triggered automatically

esphome:
  name: test-device

esp32:
  board: esp32dev

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

api:

# Removing this component will now trigger a clean build
# bluetooth_proxy:
#   active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Changes Made:
1. Modified `storage_should_clean()` in `writer.py` to detect when components are removed by comparing old and new `loaded_integrations` sets
2. Enhanced logging to show which specific components were removed (e.g., "Components removed (ethernet, bluetooth_proxy), cleaning build files...")
3. Added comprehensive unit tests in `tests/unit_tests/test_writer.py` covering various scenarios

### Impact:
**This change will dramatically reduce the daily support burden** where the answer is "try cleaning your build files". This is one of the most frequent support responses we have to give, and this PR eliminates a major category of these issues.

Users will no longer need to manually clean build files when:
- Switching between WiFi and Ethernet
- Removing Bluetooth/BLE components  
- Removing web_server or api components
- Removing any component with platform-specific code
- Changing their device configuration and removing features

The enhanced logging provides clear feedback about what's happening, helping users understand why a clean build is triggered rather than experiencing mysterious failures that require support intervention.

### Tradeoff:
The downside is that builds will take longer when a component is removed since a full clean build is required. However, the impact should be minimal because:
- **Adding components is far more common than removing them** - most users are building up their configurations, not tearing them down
- Component removal typically happens during initial setup/experimentation or when fixing issues
- When users do remove components, they're often already experiencing problems that would require a manual clean anyway
- The alternative - mysterious build failures and hours of debugging - is far more time-consuming

This change only affects the relatively rare case of component removal, while the common case of adding components or adjusting configuration remains fast.

**Note for users who frequently remove components:** If you have a workflow that involves regularly removing components (e.g., testing different configurations), you will experience longer build times. However, this ensures your builds are correct rather than potentially broken with stale artifacts.