### PR TITLE
[uart] Add clock source selection for ESP32 Arduino to improve baud rate precision

### DIFF
--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -138,6 +138,7 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
     invert = true;
   if (rx_pin_ != nullptr && rx_pin_->is_inverted())
     invert = true;
+  this->hw_serial_->setClockSource(UART_CLK_SRC_APB);
   this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
   this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx, invert);
   if (dump_config) {

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -155,11 +155,18 @@ void ESP32ArduinoUARTComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
   ESP_LOGCONFIG(TAG,
-                "  Baud Rate: %u baud\n"
+                "  Baud Rate: %u bps\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
                 "  Stop bits: %u",
                 this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+
+#if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE)
+  if (this->hw_serial_ != nullptr) {
+    ESP_LOGV(TAG, "  Actual baud rate: %u bps", static_cast<uint32_t>(this->hw_serial_->baudRate()));
+  }
+#endif
+
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -121,12 +121,13 @@ void ESP8266UartComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);  // NOLINT
   }
   ESP_LOGCONFIG(TAG,
-                "  Baud Rate: %u baud\n"
+                "  Baud Rate: %u bps\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
                 "  Stop bits: %u",
                 this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
   if (this->hw_serial_ != nullptr) {
+    ESP_LOGV(TAG, "  Actual baud rate: %u bps", this->hw_serial_->baudRate());
     ESP_LOGCONFIG(TAG, "  Using hardware serial interface.");
   } else {
     ESP_LOGCONFIG(TAG, "  Using software serial");

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -157,11 +157,19 @@ void IDFUARTComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  RX Buffer Size: %u", this->rx_buffer_size_);
   }
   ESP_LOGCONFIG(TAG,
-                "  Baud Rate: %" PRIu32 " baud\n"
+                "  Baud Rate: %" PRIu32 " bps\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
                 "  Stop bits: %u",
                 this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+
+#if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE)
+  uint32_t actual = 0; 
+  if (uart_get_baudrate(this->uart_num_, &actual) == ESP_OK && actual != 0) { 
+    ESP_LOGV(TAG, "  Actual baud rate: %" PRIu32 " bps", actual); 
+  }
+#endif
+
   this->check_logger_conflict();
 }
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -164,9 +164,9 @@ void IDFUARTComponent::dump_config() {
                 this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
 
 #if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE)
-  uint32_t actual = 0; 
-  if (uart_get_baudrate(this->uart_num_, &actual) == ESP_OK && actual != 0) { 
-    ESP_LOGV(TAG, "  Actual baud rate: %" PRIu32 " bps", actual); 
+  uint32_t actual = 0;
+  if (uart_get_baudrate(this->uart_num_, &actual) == ESP_OK && actual != 0) {
+    ESP_LOGV(TAG, "  Actual baud rate: %" PRIu32 " bps", actual);
   }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for configuring the UART clock source on ESP32 when using the Arduino framework, addressing significant baud rate precision issues.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #10087 
- #10202

Outside this repo:
- espressif/arduino-esp32#11721
- Blackymas/NSPanel_HA_Blueprint#2630
- Blackymas/NSPanel_HA_Blueprint#2646

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:
```yaml
uart:
  id: high_precision_uart
  baud_rate: 921600
  tx_pin: GPIO17
  rx_pin: GPIO16
  clock_source: APB  # Use APB clock for accurate baud rates
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
