### PR TITLE
[uart] Add clock source selection for ESP32 Arduino framework

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -164,15 +164,15 @@ def validate_esp32_clock_source_compatibility(config):
     # Validate clock source compatibility with specific ESP32 variant
     if not (CORE.is_esp32 and CORE.using_arduino and CONF_CLOCK_SOURCE in config):
         return config
-    
+
     clock_source = config[CONF_CLOCK_SOURCE]
     if clock_source == "DEFAULT":
         return config
-    
+
     # Define supported clock sources per ESP32 variant
     SUPPORTED_CLOCK_SOURCES = {
         "esp32": ["APB", "REF_TICK"],
-        "esp32s2": ["APB", "REF_TICK"], 
+        "esp32s2": ["APB", "REF_TICK"],
         "esp32s3": ["APB", "XTAL", "RTC"],
         "esp32c2": ["XTAL", "RTC", "PLL_F40M"],
         "esp32c3": ["APB", "XTAL", "RTC"],
@@ -181,12 +181,12 @@ def validate_esp32_clock_source_compatibility(config):
         "esp32h2": ["XTAL", "RTC", "PLL_F48M"],
         "esp32p4": ["XTAL", "RTC", "PLL_F80M"],
     }
-    
+
     # Get the current board's variant
     board_variant = None
-    if hasattr(CORE, 'board') and CORE.board:
+    if hasattr(CORE, "board") and CORE.board:
         board_name = CORE.board.lower()
-        
+
         # Map board names to variants
         if any(x in board_name for x in ["esp32s3", "s3"]):
             board_variant = "esp32s3"
@@ -206,7 +206,7 @@ def validate_esp32_clock_source_compatibility(config):
             board_variant = "esp32p4"
         elif "esp32" in board_name:
             board_variant = "esp32"
-    
+
     # Check compatibility
     if board_variant and board_variant in SUPPORTED_CLOCK_SOURCES:
         supported = SUPPORTED_CLOCK_SOURCES[board_variant]
@@ -220,9 +220,9 @@ def validate_esp32_clock_source_compatibility(config):
         cv.warn_once(
             "clock_source_variant",
             f"Could not determine ESP32 variant for clock source validation. "
-            f"Please ensure '{clock_source}' is supported by your specific ESP32 chip."
+            f"Please ensure '{clock_source}' is supported by your specific ESP32 chip.",
         )
-    
+
     return config
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -272,7 +272,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PARITY, default="NONE"): cv.enum(
                 UART_PARITY_OPTIONS, upper=True
             ),
-            cv.Optional(CONF_CLOCK_SOURCE, default="DEFAULT"): cv.enum(
+            cv.Optional(CONF_CLOCK_SOURCE): cv.enum(
                 ESP32_UART_CLOCK_SOURCES, upper=True
             ),
             cv.Optional(CONF_INVERT): cv.invalid(

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -164,11 +164,11 @@ def validate_esp32_clock_source_compatibility(config):
     # Validate clock source compatibility with specific ESP32 variant
     if not (CORE.is_esp32 and CORE.using_arduino and CONF_CLOCK_SOURCE in config):
         return config
-    
+
     clock_source = config[CONF_CLOCK_SOURCE]
     if clock_source == "DEFAULT":
         return config
-    
+
     # Define supported clock sources per ESP32 variant
     SUPPORTED_CLOCK_SOURCES = {
         "esp32": ["APB", "REF_TICK"],
@@ -181,12 +181,12 @@ def validate_esp32_clock_source_compatibility(config):
         "esp32h2": ["XTAL", "RTC", "PLL_F48M"],
         "esp32p4": ["XTAL", "RTC", "PLL_F80M"],
     }
-    
-    # Get the current board's variant
+
+    # Get the current board's variant using CORE.board_id
     board_variant = None
-    if hasattr(CORE, 'board') and CORE.board:
-        board_name = CORE.board.lower()
-        
+    if hasattr(CORE, 'board_id') and CORE.board_id:
+        board_name = CORE.board_id.lower()
+
         # Map board names to variants
         if any(x in board_name for x in ["esp32s3", "s3"]):
             board_variant = "esp32s3"
@@ -206,7 +206,7 @@ def validate_esp32_clock_source_compatibility(config):
             board_variant = "esp32p4"
         elif "esp32" in board_name:
             board_variant = "esp32"
-    
+
     # Check compatibility
     if board_variant and board_variant in SUPPORTED_CLOCK_SOURCES:
         supported = SUPPORTED_CLOCK_SOURCES[board_variant]
@@ -215,14 +215,8 @@ def validate_esp32_clock_source_compatibility(config):
                 f"Clock source '{clock_source}' is not supported on {board_variant.upper()}. "
                 f"Supported options: {', '.join(supported)}"
             )
-    else:
-        # If we can't determine the variant, issue a warning
-        cv.warn_once(
-            "clock_source_variant",
-            f"Could not determine ESP32 variant for clock source validation. "
-            f"Please ensure '{clock_source}' is supported by your specific ESP32 chip."
-        )
-    
+    # If we can't determine the variant, silently continue (no warning needed)
+
     return config
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -99,6 +99,19 @@ UARTDummyReceiver = uart_ns.class_("UARTDummyReceiver", cg.Component)
 MULTI_CONF = True
 MULTI_CONF_NO_DEFAULT = True
 
+# ESP32 Arduino UART Clock Source options
+ESP32UARTClockSource = uart_ns.enum("ESP32UARTClockSource")
+ESP32_UART_CLOCK_SOURCES = {
+    "DEFAULT": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_DEFAULT,
+    "REF_TICK": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_REF_TICK,
+    "APB": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_APB,
+    "XTAL": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_XTAL,
+    "RTC": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_RTC,
+    "PLL_F40M": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_PLL_F40M,
+    "PLL_F48M": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_PLL_F48M,
+    "PLL_F80M": ESP32UARTClockSource.ESP32_UART_CLOCK_SOURCE_PLL_F80M,
+}
+
 
 def validate_raw_data(value):
     if isinstance(value, str):
@@ -147,6 +160,16 @@ def validate_host_config(config):
     return config
 
 
+def validate_esp32_clock_source(config):
+    """Validate ESP32 clock source configuration"""
+    if not (CORE.is_esp32 and CORE.using_arduino):
+        if CONF_CLOCK_SOURCE in config:
+            raise cv.Invalid(
+                "clock_source is only supported on ESP32 with Arduino framework"
+            )
+    return config
+
+
 def _uart_declare_type(value):
     if CORE.is_esp8266:
         return cv.declare_id(ESP8266UartComponent)(value)
@@ -174,6 +197,7 @@ UART_PARITY_OPTIONS = {
 CONF_STOP_BITS = "stop_bits"
 CONF_DATA_BITS = "data_bits"
 CONF_PARITY = "parity"
+CONF_CLOCK_SOURCE = "clock_source"
 
 UARTDirection = uart_ns.enum("UARTDirection")
 UART_DIRECTIONS = {
@@ -248,6 +272,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PARITY, default="NONE"): cv.enum(
                 UART_PARITY_OPTIONS, upper=True
             ),
+            cv.Optional(CONF_CLOCK_SOURCE, default="DEFAULT"): cv.enum(
+                ESP32_UART_CLOCK_SOURCES, upper=True
+            ),
             cv.Optional(CONF_INVERT): cv.invalid(
                 "This option has been removed. Please instead use invert in the tx/rx pin schemas."
             ),
@@ -257,6 +284,7 @@ CONFIG_SCHEMA = cv.All(
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN, CONF_PORT),
     validate_invert_esp32,
     validate_host_config,
+    validate_esp32_clock_source,
 )
 
 
@@ -304,6 +332,10 @@ async def to_code(config):
     cg.add(var.set_stop_bits(config[CONF_STOP_BITS]))
     cg.add(var.set_data_bits(config[CONF_DATA_BITS]))
     cg.add(var.set_parity(config[CONF_PARITY]))
+
+    # Set clock source for ESP32 Arduino framework
+    if CORE.is_esp32 and CORE.using_arduino and CONF_CLOCK_SOURCE in config:
+        cg.add(var.set_clock_source(config[CONF_CLOCK_SOURCE]))
 
     if CONF_DEBUG in config:
         await debug_to_code(config[CONF_DEBUG], var)

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -160,13 +160,69 @@ def validate_host_config(config):
     return config
 
 
-def validate_esp32_clock_source(config):
-    """Validate ESP32 clock source configuration"""
-    if not (CORE.is_esp32 and CORE.using_arduino):
-        if CONF_CLOCK_SOURCE in config:
+def validate_esp32_clock_source_compatibility(config):
+    # Validate clock source compatibility with specific ESP32 variant
+    if not (CORE.is_esp32 and CORE.using_arduino and CONF_CLOCK_SOURCE in config):
+        return config
+    
+    clock_source = config[CONF_CLOCK_SOURCE]
+    if clock_source == "DEFAULT":
+        return config
+    
+    # Define supported clock sources per ESP32 variant
+    SUPPORTED_CLOCK_SOURCES = {
+        "esp32": ["APB", "REF_TICK"],
+        "esp32s2": ["APB", "REF_TICK"], 
+        "esp32s3": ["APB", "XTAL", "RTC"],
+        "esp32c2": ["XTAL", "RTC", "PLL_F40M"],
+        "esp32c3": ["APB", "XTAL", "RTC"],
+        "esp32c5": ["XTAL", "RTC", "PLL_F80M"],
+        "esp32c6": ["XTAL", "RTC", "PLL_F80M"],
+        "esp32h2": ["XTAL", "RTC", "PLL_F48M"],
+        "esp32p4": ["XTAL", "RTC", "PLL_F80M"],
+    }
+    
+    # Get the current board's variant
+    board_variant = None
+    if hasattr(CORE, 'board') and CORE.board:
+        board_name = CORE.board.lower()
+        
+        # Map board names to variants
+        if any(x in board_name for x in ["esp32s3", "s3"]):
+            board_variant = "esp32s3"
+        elif any(x in board_name for x in ["esp32s2", "s2"]):
+            board_variant = "esp32s2"
+        elif any(x in board_name for x in ["esp32c2", "c2"]):
+            board_variant = "esp32c2"
+        elif any(x in board_name for x in ["esp32c3", "c3"]):
+            board_variant = "esp32c3"
+        elif any(x in board_name for x in ["esp32c5", "c5"]):
+            board_variant = "esp32c5"
+        elif any(x in board_name for x in ["esp32c6", "c6"]):
+            board_variant = "esp32c6"
+        elif any(x in board_name for x in ["esp32h2", "h2"]):
+            board_variant = "esp32h2"
+        elif any(x in board_name for x in ["esp32p4", "p4"]):
+            board_variant = "esp32p4"
+        elif "esp32" in board_name:
+            board_variant = "esp32"
+    
+    # Check compatibility
+    if board_variant and board_variant in SUPPORTED_CLOCK_SOURCES:
+        supported = SUPPORTED_CLOCK_SOURCES[board_variant]
+        if clock_source not in supported:
             raise cv.Invalid(
-                "clock_source is only supported on ESP32 with Arduino framework"
+                f"Clock source '{clock_source}' is not supported on {board_variant.upper()}. "
+                f"Supported options: {', '.join(supported)}"
             )
+    else:
+        # If we can't determine the variant, issue a warning
+        cv.warn_once(
+            "clock_source_variant",
+            f"Could not determine ESP32 variant for clock source validation. "
+            f"Please ensure '{clock_source}' is supported by your specific ESP32 chip."
+        )
+    
     return config
 
 
@@ -284,7 +340,7 @@ CONFIG_SCHEMA = cv.All(
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN, CONF_PORT),
     validate_invert_esp32,
     validate_host_config,
-    validate_esp32_clock_source,
+    validate_esp32_clock_source_compatibility,
 )
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -184,7 +184,7 @@ def validate_esp32_clock_source_compatibility(config):
 
     # Get the current board's variant using CORE.board_id
     board_variant = None
-    if hasattr(CORE, 'board_id') and CORE.board_id:
+    if hasattr(CORE, "board_id") and CORE.board_id:
         board_name = CORE.board_id.lower()
 
         # Map board names to variants

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -160,67 +160,11 @@ def validate_host_config(config):
     return config
 
 
-def validate_esp32_clock_source_compatibility(config):
-    # Validate clock source compatibility with specific ESP32 variant
-    if not (CORE.is_esp32 and CORE.using_arduino and CONF_CLOCK_SOURCE in config):
-        return config
-
-    clock_source = config[CONF_CLOCK_SOURCE]
-    if clock_source == "DEFAULT":
-        return config
-
-    # Define supported clock sources per ESP32 variant
-    SUPPORTED_CLOCK_SOURCES = {
-        "esp32": ["APB", "REF_TICK"],
-        "esp32s2": ["APB", "REF_TICK"],
-        "esp32s3": ["APB", "XTAL", "RTC"],
-        "esp32c2": ["XTAL", "RTC", "PLL_F40M"],
-        "esp32c3": ["APB", "XTAL", "RTC"],
-        "esp32c5": ["XTAL", "RTC", "PLL_F80M"],
-        "esp32c6": ["XTAL", "RTC", "PLL_F80M"],
-        "esp32h2": ["XTAL", "RTC", "PLL_F48M"],
-        "esp32p4": ["XTAL", "RTC", "PLL_F80M"],
-    }
-
-    # Get the current board's variant using CORE.board_id
-    board_variant = None
-    if hasattr(CORE, "board_id") and CORE.board_id:
-        board_name = CORE.board_id.lower()
-
-        # Map board names to variants
-        if any(x in board_name for x in ["esp32s3", "s3"]):
-            board_variant = "esp32s3"
-        elif any(x in board_name for x in ["esp32s2", "s2"]):
-            board_variant = "esp32s2"
-        elif any(x in board_name for x in ["esp32c2", "c2"]):
-            board_variant = "esp32c2"
-        elif any(x in board_name for x in ["esp32c3", "c3"]):
-            board_variant = "esp32c3"
-        elif any(x in board_name for x in ["esp32c5", "c5"]):
-            board_variant = "esp32c5"
-        elif any(x in board_name for x in ["esp32c6", "c6"]):
-            board_variant = "esp32c6"
-        elif any(x in board_name for x in ["esp32h2", "h2"]):
-            board_variant = "esp32h2"
-        elif any(x in board_name for x in ["esp32p4", "p4"]):
-            board_variant = "esp32p4"
-        elif "esp32" in board_name:
-            board_variant = "esp32"
-
-    # Check compatibility
-    if board_variant and board_variant in SUPPORTED_CLOCK_SOURCES:
-        supported = SUPPORTED_CLOCK_SOURCES[board_variant]
-        if clock_source not in supported:
-            raise cv.Invalid(
-                f"Clock source '{clock_source}' is not supported on {board_variant.upper()}. "
-                f"Supported options: {', '.join(supported)}"
-            )
-    else:
-        # If we can't determine the variant, issue a warning
-        cv.warn_once(
-            "clock_source_variant",
-            f"Could not determine ESP32 variant for clock source validation. "
-            f"Please ensure '{clock_source}' is supported by your specific ESP32 chip.",
+def validate_esp32_clock_source(config):
+    # Validate ESP32 clock source configuration
+    if CONF_CLOCK_SOURCE in config and not (CORE.is_esp32 and CORE.using_arduino):
+        raise cv.Invalid(
+            "clock_source is only supported on ESP32 with Arduino framework"
         )
 
     return config
@@ -340,7 +284,7 @@ CONFIG_SCHEMA = cv.All(
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN, CONF_PORT),
     validate_invert_esp32,
     validate_host_config,
-    validate_esp32_clock_source_compatibility,
+    validate_esp32_clock_source,
 )
 
 

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -213,7 +213,7 @@ void ESP32ArduinoUARTComponent::dump_config() {
       "PLL_F48M",  // ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6
       "PLL_F80M",  // ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7
   };
-  
+
   const char *clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];
 #endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -7,7 +7,7 @@
 
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
-#endif
+#endif  // USE_LOGGER
 
 namespace esphome {
 namespace uart {
@@ -84,14 +84,14 @@ void ESP32ArduinoUARTComponent::setup() {
 #else
   is_default_tx = tx_pin_ == nullptr || tx_pin_->get_pin() == 1;
   is_default_rx = rx_pin_ == nullptr || rx_pin_->get_pin() == 3;
-#endif
+#endif  // CONFIG_IDF_TARGET_ESP32C3
   static uint8_t next_uart_num = 0;
   if (is_default_tx && is_default_rx && next_uart_num == 0) {
 #if ARDUINO_USB_CDC_ON_BOOT
     this->hw_serial_ = &Serial0;
 #else
     this->hw_serial_ = &Serial;
-#endif
+#endif  // ARDUINO_USB_CDC_ON_BOOT
     next_uart_num++;
   } else {
 #ifdef USE_LOGGER
@@ -138,8 +138,46 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
     invert = true;
   if (rx_pin_ != nullptr && rx_pin_->is_inverted())
     invert = true;
+
+  // Set clock source before beginning UART communication
+  // This must be done before calling begin() to be effective
+  if (this->hw_serial_ != nullptr) {
+    // End current UART session if it's already running to allow clock source change
+    this->hw_serial_->end();
+    
+    // Set the desired clock source
+    switch (this->clock_source_) {
+      case ESP32_UART_CLOCK_SOURCE_APB:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_APB);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_XTAL:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_XTAL);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_RTC:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_RTC);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_REF_TICK:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_REF_TICK);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_PLL_F40M:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F40M);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_PLL_F48M:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F48M);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_PLL_F80M:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F80M);
+        break;
+      case ESP32_UART_CLOCK_SOURCE_DEFAULT:
+      default:
+        this->hw_serial_->setClockSource(UART_CLK_SRC_DEFAULT);
+        break;
+    }
+  }
+
   this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
   this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx, invert);
+  
   if (dump_config) {
     ESP_LOGCONFIG(TAG, "UART %u was reloaded.", this->number_);
     this->dump_config();
@@ -147,6 +185,23 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
 }
 
 void ESP32ArduinoUARTComponent::dump_config() {
+  // Flash-efficient lookup table for clock source names
+  static const char* const CLOCK_SOURCE_NAMES[] = {
+    "DEFAULT",   // ESP32_UART_CLOCK_SOURCE_DEFAULT = 0
+    "REF_TICK",  // ESP32_UART_CLOCK_SOURCE_REF_TICK = 1
+    "APB",       // ESP32_UART_CLOCK_SOURCE_APB = 2
+    "XTAL",      // ESP32_UART_CLOCK_SOURCE_XTAL = 3
+    "RTC",       // ESP32_UART_CLOCK_SOURCE_RTC = 4
+    "PLL_F40M",  // ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5
+    "PLL_F48M",  // ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6
+    "PLL_F80M",  // ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7
+  };
+  
+  const char *clock_source_str = "UNKNOWN";
+  if (this->clock_source_ < (sizeof(CLOCK_SOURCE_NAMES) / sizeof(CLOCK_SOURCE_NAMES[0]))) {
+    clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];
+  }
+
   ESP_LOGCONFIG(TAG, "UART Bus %d:", this->number_);
   LOG_PIN("  TX Pin: ", tx_pin_);
   LOG_PIN("  RX Pin: ", rx_pin_);
@@ -157,8 +212,11 @@ void ESP32ArduinoUARTComponent::dump_config() {
                 "  Baud Rate: %u baud\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
-                "  Stop bits: %u",
-                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+                "  Stop bits: %u\n"
+                "  Clock Source: %s",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_,
+                clock_source_str);
+
   this->check_logger_conflict();
 }
 
@@ -168,7 +226,7 @@ void ESP32ArduinoUARTComponent::write_array(const uint8_t *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
   }
-#endif
+#endif  // USE_UART_DEBUGGER
 }
 
 bool ESP32ArduinoUARTComponent::peek_byte(uint8_t *data) {
@@ -186,11 +244,12 @@ bool ESP32ArduinoUARTComponent::read_array(uint8_t *data, size_t len) {
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
   }
-#endif
+#endif  // USE_UART_DEBUGGER
   return true;
 }
 
 int ESP32ArduinoUARTComponent::available() { return this->hw_serial_->available(); }
+
 void ESP32ArduinoUARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   this->hw_serial_->flush();
@@ -206,7 +265,7 @@ void ESP32ArduinoUARTComponent::check_logger_conflict() {
     ESP_LOGW(TAG, "  You're using the same serial port for logging and the UART component. Please "
                   "disable logging over the serial port by setting logger->baud_rate to 0.");
   }
-#endif
+#endif  // USE_LOGGER
 }
 
 }  // namespace uart

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -213,11 +213,8 @@ void ESP32ArduinoUARTComponent::dump_config() {
       "PLL_F48M",  // ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6
       "PLL_F80M",  // ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7
   };
-
-  const char *clock_source_str = "UNKNOWN";
-  if (this->clock_source_ < (sizeof(CLOCK_SOURCE_NAMES) / sizeof(CLOCK_SOURCE_NAMES[0]))) {
-    clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];
-  }
+  
+  const char *clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];
 #endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
   ESP_LOGCONFIG(TAG, "UART Bus %d:", this->number_);

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -145,35 +145,51 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
     // End current UART session if it's already running to allow clock source change
     this->hw_serial_->end();
 
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
     // Set the desired clock source
     switch (this->clock_source_) {
+#ifdef UART_CLK_SRC_APB
       case ESP32_UART_CLOCK_SOURCE_APB:
         this->hw_serial_->setClockSource(UART_CLK_SRC_APB);
         break;
+#endif  // UART_CLK_SRC_APB
+#ifdef UART_CLK_SRC_XTAL
       case ESP32_UART_CLOCK_SOURCE_XTAL:
         this->hw_serial_->setClockSource(UART_CLK_SRC_XTAL);
         break;
+#endif  // UART_CLK_SRC_XTAL
+#ifdef UART_CLK_SRC_RTC
       case ESP32_UART_CLOCK_SOURCE_RTC:
         this->hw_serial_->setClockSource(UART_CLK_SRC_RTC);
         break;
+#endif  // UART_CLK_SRC_RTC
+#ifdef UART_CLK_SRC_REF_TICK
       case ESP32_UART_CLOCK_SOURCE_REF_TICK:
         this->hw_serial_->setClockSource(UART_CLK_SRC_REF_TICK);
         break;
+#endif  // UART_CLK_SRC_REF_TICK
+#ifdef UART_CLK_SRC_PLL_F40M
       case ESP32_UART_CLOCK_SOURCE_PLL_F40M:
         this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F40M);
         break;
+#endif  // UART_CLK_SRC_PLL_F40M
+#ifdef UART_CLK_SRC_PLL_F48M
       case ESP32_UART_CLOCK_SOURCE_PLL_F48M:
         this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F48M);
         break;
+#endif  // UART_CLK_SRC_PLL_F48M
+#ifdef UART_CLK_SRC_PLL_F80M
       case ESP32_UART_CLOCK_SOURCE_PLL_F80M:
         this->hw_serial_->setClockSource(UART_CLK_SRC_PLL_F80M);
         break;
+#endif  // UART_CLK_SRC_PLL_F80M
       case ESP32_UART_CLOCK_SOURCE_DEFAULT:
       default:
         this->hw_serial_->setClockSource(UART_CLK_SRC_DEFAULT);
         break;
     }
   }
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
   this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
   this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx, invert);
@@ -185,6 +201,7 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
 }
 
 void ESP32ArduinoUARTComponent::dump_config() {
+#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   // Flash-efficient lookup table for clock source names
   static const char *const CLOCK_SOURCE_NAMES[] = {
       "DEFAULT",   // ESP32_UART_CLOCK_SOURCE_DEFAULT = 0
@@ -201,6 +218,7 @@ void ESP32ArduinoUARTComponent::dump_config() {
   if (this->clock_source_ < (sizeof(CLOCK_SOURCE_NAMES) / sizeof(CLOCK_SOURCE_NAMES[0]))) {
     clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];
   }
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
   ESP_LOGCONFIG(TAG, "UART Bus %d:", this->number_);
   LOG_PIN("  TX Pin: ", tx_pin_);
@@ -212,10 +230,11 @@ void ESP32ArduinoUARTComponent::dump_config() {
                 "  Baud Rate: %u baud\n"
                 "  Data Bits: %u\n"
                 "  Parity: %s\n"
-                "  Stop bits: %u\n"
-                "  Clock Source: %s",
-                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_,
-                clock_source_str);
+                "  Stop bits: %u",
+                this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
+#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+  ESP_LOGCONFIG(TAG, "  Clock Source: %s", clock_source_str);
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
   this->check_logger_conflict();
 }

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -144,7 +144,7 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
   if (this->hw_serial_ != nullptr) {
     // End current UART session if it's already running to allow clock source change
     this->hw_serial_->end();
-    
+
     // Set the desired clock source
     switch (this->clock_source_) {
       case ESP32_UART_CLOCK_SOURCE_APB:
@@ -177,7 +177,7 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
 
   this->hw_serial_->setRxBufferSize(this->rx_buffer_size_);
   this->hw_serial_->begin(this->baud_rate_, get_config(), rx, tx, invert);
-  
+
   if (dump_config) {
     ESP_LOGCONFIG(TAG, "UART %u was reloaded.", this->number_);
     this->dump_config();
@@ -186,17 +186,17 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
 
 void ESP32ArduinoUARTComponent::dump_config() {
   // Flash-efficient lookup table for clock source names
-  static const char* const CLOCK_SOURCE_NAMES[] = {
-    "DEFAULT",   // ESP32_UART_CLOCK_SOURCE_DEFAULT = 0
-    "REF_TICK",  // ESP32_UART_CLOCK_SOURCE_REF_TICK = 1
-    "APB",       // ESP32_UART_CLOCK_SOURCE_APB = 2
-    "XTAL",      // ESP32_UART_CLOCK_SOURCE_XTAL = 3
-    "RTC",       // ESP32_UART_CLOCK_SOURCE_RTC = 4
-    "PLL_F40M",  // ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5
-    "PLL_F48M",  // ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6
-    "PLL_F80M",  // ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7
+  static const char *const CLOCK_SOURCE_NAMES[] = {
+      "DEFAULT",   // ESP32_UART_CLOCK_SOURCE_DEFAULT = 0
+      "REF_TICK",  // ESP32_UART_CLOCK_SOURCE_REF_TICK = 1
+      "APB",       // ESP32_UART_CLOCK_SOURCE_APB = 2
+      "XTAL",      // ESP32_UART_CLOCK_SOURCE_XTAL = 3
+      "RTC",       // ESP32_UART_CLOCK_SOURCE_RTC = 4
+      "PLL_F40M",  // ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5
+      "PLL_F48M",  // ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6
+      "PLL_F80M",  // ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7
   };
-  
+
   const char *clock_source_str = "UNKNOWN";
   if (this->clock_source_ < (sizeof(CLOCK_SOURCE_NAMES) / sizeof(CLOCK_SOURCE_NAMES[0]))) {
     clock_source_str = CLOCK_SOURCE_NAMES[this->clock_source_];

--- a/esphome/components/uart/uart_component_esp32_arduino.cpp
+++ b/esphome/components/uart/uart_component_esp32_arduino.cpp
@@ -201,7 +201,7 @@ void ESP32ArduinoUARTComponent::load_settings(bool dump_config) {
 }
 
 void ESP32ArduinoUARTComponent::dump_config() {
-#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   // Flash-efficient lookup table for clock source names
   static const char *const CLOCK_SOURCE_NAMES[] = {
       "DEFAULT",   // ESP32_UART_CLOCK_SOURCE_DEFAULT = 0
@@ -232,7 +232,7 @@ void ESP32ArduinoUARTComponent::dump_config() {
                 "  Parity: %s\n"
                 "  Stop bits: %u",
                 this->baud_rate_, this->data_bits_, LOG_STR_ARG(parity_to_str(this->parity_)), this->stop_bits_);
-#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   ESP_LOGCONFIG(TAG, "  Clock Source: %s", clock_source_str);
 #endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -15,14 +15,16 @@ namespace uart {
 
 /// Clock source options for ESP32 UART - comprehensive support for all ESP32 variants
 enum ESP32UARTClockSource {
-  ESP32_UART_CLOCK_SOURCE_DEFAULT = 0,    ///< Default clock source (varies by chip)
-  ESP32_UART_CLOCK_SOURCE_REF_TICK = 1,   ///< REF_TICK clock source (1MHz) - ESP32, ESP32-S2
-  ESP32_UART_CLOCK_SOURCE_APB = 2,        ///< APB clock source (80MHz) - ESP32, ESP32-S2, ESP32-C3, ESP32-S3
-  ESP32_UART_CLOCK_SOURCE_XTAL = 3,       ///< XTAL clock source (40MHz) - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3, ESP32-P4
-  ESP32_UART_CLOCK_SOURCE_RTC = 4,        ///< RTC clock source - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3, ESP32-P4
-  ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5,   ///< PLL F40M clock source (40MHz) - ESP32-C2
-  ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6,   ///< PLL F48M clock source (48MHz) - ESP32-H2
-  ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7,   ///< PLL F80M clock source (80MHz) - ESP32-C5, ESP32-C6, ESP32-C61, ESP32-P4
+  ESP32_UART_CLOCK_SOURCE_DEFAULT = 0,   ///< Default clock source (varies by chip)
+  ESP32_UART_CLOCK_SOURCE_REF_TICK = 1,  ///< REF_TICK clock source (1MHz) - ESP32, ESP32-S2
+  ESP32_UART_CLOCK_SOURCE_APB = 2,       ///< APB clock source (80MHz) - ESP32, ESP32-S2, ESP32-C3, ESP32-S3
+  ESP32_UART_CLOCK_SOURCE_XTAL = 3,  ///< XTAL clock source (40MHz) - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61,
+                                     ///< ESP32-H2, ESP32-S3, ESP32-P4
+  ESP32_UART_CLOCK_SOURCE_RTC =
+      4,  ///< RTC clock source - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3, ESP32-P4
+  ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5,  ///< PLL F40M clock source (40MHz) - ESP32-C2
+  ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6,  ///< PLL F48M clock source (48MHz) - ESP32-H2
+  ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7,  ///< PLL F80M clock source (80MHz) - ESP32-C5, ESP32-C6, ESP32-C61, ESP32-P4
 };
 
 class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
@@ -72,7 +74,8 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
 
   HardwareSerial *hw_serial_{nullptr};
   uint8_t number_{0};
-  ESP32UARTClockSource clock_source_{ESP32_UART_CLOCK_SOURCE_DEFAULT};  ///< Default to DEFAULT for backward compatibility
+  ESP32UARTClockSource clock_source_{
+      ESP32_UART_CLOCK_SOURCE_DEFAULT};  ///< Default to DEFAULT for backward compatibility
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -13,6 +13,18 @@
 namespace esphome {
 namespace uart {
 
+/// Clock source options for ESP32 UART - comprehensive support for all ESP32 variants
+enum ESP32UARTClockSource {
+  ESP32_UART_CLOCK_SOURCE_DEFAULT = 0,    ///< Default clock source (varies by chip)
+  ESP32_UART_CLOCK_SOURCE_REF_TICK = 1,   ///< REF_TICK clock source (1MHz) - ESP32, ESP32-S2
+  ESP32_UART_CLOCK_SOURCE_APB = 2,        ///< APB clock source (80MHz) - ESP32, ESP32-S2, ESP32-C3, ESP32-S3
+  ESP32_UART_CLOCK_SOURCE_XTAL = 3,       ///< XTAL clock source (40MHz) - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3, ESP32-P4
+  ESP32_UART_CLOCK_SOURCE_RTC = 4,        ///< RTC clock source - ESP32-C2, ESP32-C3, ESP32-C5, ESP32-C6, ESP32-C61, ESP32-H2, ESP32-S3, ESP32-P4
+  ESP32_UART_CLOCK_SOURCE_PLL_F40M = 5,   ///< PLL F40M clock source (40MHz) - ESP32-C2
+  ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6,   ///< PLL F48M clock source (48MHz) - ESP32-H2
+  ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7,   ///< PLL F80M clock source (80MHz) - ESP32-C5, ESP32-C6, ESP32-C61, ESP32-P4
+};
+
 class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
  public:
   void setup() override;
@@ -32,10 +44,18 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   HardwareSerial *get_hw_serial() { return this->hw_serial_; }
   uint8_t get_hw_serial_number() { return this->number_; }
 
+  /// Set the clock source for the UART peripheral
+  /// @param clock_source The clock source to use (REF_TICK or APB)
+  void set_clock_source(ESP32UARTClockSource clock_source) { this->clock_source_ = clock_source; }
+
+  /// Get the currently configured clock source
+  /// @return The configured clock source
+  ESP32UARTClockSource get_clock_source() const { return this->clock_source_; }
+
   /**
    * Load the UART with the current settings.
    * @param dump_config (Optional, default `true`): True for displaying new settings or
-   * false to change it quitely
+   * false to change it quietly
    *
    * Example:
    * ```cpp
@@ -52,6 +72,7 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
 
   HardwareSerial *hw_serial_{nullptr};
   uint8_t number_{0};
+  ESP32UARTClockSource clock_source_{ESP32_UART_CLOCK_SOURCE_DEFAULT};  ///< Default to DEFAULT for backward compatibility
 };
 
 }  // namespace uart

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -13,7 +13,7 @@
 namespace esphome {
 namespace uart {
 
-#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 /// Clock source options for ESP32 UART - comprehensive support for all ESP32 variants
 enum ESP32UARTClockSource {
   ESP32_UART_CLOCK_SOURCE_DEFAULT = 0,   ///< Default clock source (varies by chip)
@@ -63,7 +63,7 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   void load_settings() override { this->load_settings(true); }
 
-#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   /// Set the clock source for the UART peripheral
   /// @param clock_source The clock source to use (REF_TICK or APB)
   void set_clock_source(ESP32UARTClockSource clock_source) { this->clock_source_ = clock_source; }
@@ -79,7 +79,7 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   HardwareSerial *hw_serial_{nullptr};
   uint8_t number_{0};
 
-#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+#if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   ESP32UARTClockSource clock_source_{
       ESP32_UART_CLOCK_SOURCE_DEFAULT};  ///< Default to DEFAULT for backward compatibility
 };

--- a/esphome/components/uart/uart_component_esp32_arduino.h
+++ b/esphome/components/uart/uart_component_esp32_arduino.h
@@ -13,6 +13,7 @@
 namespace esphome {
 namespace uart {
 
+#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 /// Clock source options for ESP32 UART - comprehensive support for all ESP32 variants
 enum ESP32UARTClockSource {
   ESP32_UART_CLOCK_SOURCE_DEFAULT = 0,   ///< Default clock source (varies by chip)
@@ -26,6 +27,7 @@ enum ESP32UARTClockSource {
   ESP32_UART_CLOCK_SOURCE_PLL_F48M = 6,  ///< PLL F48M clock source (48MHz) - ESP32-H2
   ESP32_UART_CLOCK_SOURCE_PLL_F80M = 7,  ///< PLL F80M clock source (80MHz) - ESP32-C5, ESP32-C6, ESP32-C61, ESP32-P4
 };
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
 class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
  public:
@@ -46,14 +48,6 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   HardwareSerial *get_hw_serial() { return this->hw_serial_; }
   uint8_t get_hw_serial_number() { return this->number_; }
 
-  /// Set the clock source for the UART peripheral
-  /// @param clock_source The clock source to use (REF_TICK or APB)
-  void set_clock_source(ESP32UARTClockSource clock_source) { this->clock_source_ = clock_source; }
-
-  /// Get the currently configured clock source
-  /// @return The configured clock source
-  ESP32UARTClockSource get_clock_source() const { return this->clock_source_; }
-
   /**
    * Load the UART with the current settings.
    * @param dump_config (Optional, default `true`): True for displaying new settings or
@@ -69,14 +63,27 @@ class ESP32ArduinoUARTComponent : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   void load_settings() override { this->load_settings(true); }
 
+#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+  /// Set the clock source for the UART peripheral
+  /// @param clock_source The clock source to use (REF_TICK or APB)
+  void set_clock_source(ESP32UARTClockSource clock_source) { this->clock_source_ = clock_source; }
+
+  /// Get the currently configured clock source
+  /// @return The configured clock source
+  ESP32UARTClockSource get_clock_source() const { return this->clock_source_; }
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
+
  protected:
   void check_logger_conflict() override;
 
   HardwareSerial *hw_serial_{nullptr};
   uint8_t number_{0};
+
+#ifdef USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
   ESP32UARTClockSource clock_source_{
       ESP32_UART_CLOCK_SOURCE_DEFAULT};  ///< Default to DEFAULT for backward compatibility
 };
+#endif  // USE_ARDUINO_VERSION_CODE >= VERSION_CODE(3, 2, 1)
 
 }  // namespace uart
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Adds support for configuring UART clock source on ESP32 variants when using the Arduino framework, addressing baud rate precision issues at higher speeds.

**Problem**: ESP32 Arduino framework defaults vary by chip and can cause significant baud rate deviations, particularly at speeds ≥115200 baud, breaking communication with connected devices.

**Solution**: Implement a `clock_source` configuration option supporting all ESP32 variants:
- ESP32/S2: `APB`, `REF_TICK`
- ESP32-S3: `APB`, `XTAL`, `RTC`
- ESP32-C2: `XTAL`, `RTC`, `PLL_F40M`
- ESP32-C3: `APB`, `XTAL`, `RTC`
- ESP32-C5/C6/P4: `XTAL`, `RTC`, `PLL_F80M`
- ESP32-H2: `XTAL`, `RTC`, `PLL_F48M`
- All variants: `DEFAULT` (framework default)

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5245

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
 id: high_precision_uart
 baud_rate: 921600
 tx_pin: GPIO17
 rx_pin: GPIO16
 clock_source: APB
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
