### PR TITLE
[wifi] Automatically disable Enterprise WiFi support when EAP is not configured

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -375,11 +375,16 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
 
+    # Track if any network uses Enterprise authentication
+    has_eap = False
+
     def add_sta(ap, network):
         ip_config = network.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
         cg.add(var.add_sta(wifi_network(network, ap, ip_config)))
 
     for network in config.get(CONF_NETWORKS, []):
+        if CONF_EAP in network:
+            has_eap = True
         cg.with_local_variable(network[CONF_ID], WiFiAP(), add_sta, network)
 
     if CONF_AP in config:
@@ -395,6 +400,10 @@ async def to_code(config):
     elif CORE.is_esp32 and CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
+
+    # Disable Enterprise WiFi support if no EAP is configured
+    if CORE.is_esp32 and CORE.using_esp_idf and not has_eap:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT", False)
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_power_save_mode(config[CONF_POWER_SAVE_MODE]))


### PR DESCRIPTION
# What does this implement/fix?

This PR automatically disables ESP-IDF's Enterprise WiFi support (`CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT`) when no EAP authentication is configured in the YAML. This provides automatic flash memory savings for ESP32 users running ESP-IDF who don't need Enterprise WiFi functionality.

**Flash savings:** Testing shows this saves 556 bytes of flash when Enterprise WiFi is not needed (1,163,358 → 1,162,802 bytes). While this is a modest saving, every byte counts on memory-constrained devices, and this optimization is completely transparent to users.

**Note:** This optimization only applies to ESP32 devices using the ESP-IDF framework. Arduino framework and other platforms are not affected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Helps with flash memory optimization for ESP32 devices
- Related to overall memory reduction efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- No documentation changes needed (automatic optimization)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard WiFi configuration (Enterprise support automatically disabled)
wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

# With Enterprise authentication (Enterprise support automatically enabled)
wifi:
  ssid: "Corporate"
  eap:
    identity: "user@company.com"
    username: "user"
    password: "password"
```

## Implementation Details

The change tracks whether any configured WiFi network uses EAP authentication during code generation. If no EAP is found and the platform is ESP32 with ESP-IDF framework, it automatically adds `CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT: False` to the sdkconfig options.

This optimization is only implemented for ESP-IDF because:
- Arduino framework uses pre-compiled libraries where sdkconfig flags have no effect
- The sdkconfig mechanism is specific to ESP-IDF builds where libraries are compiled from source
- Only ESP-IDF builds can benefit from compile-time configuration changes

### Testing performed:

1. **Without EAP configuration:**
   - Verified `CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT` is set to `n` in sdkconfig
   - Confirmed successful compilation
   - Measured flash savings

2. **With EAP configuration:**
   - Verified `CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT` remains `y` in sdkconfig
   - Confirmed Enterprise authentication code compiles correctly
   - Verified no regression in functionality

3. **Multi-network configurations:**
   - Tested with multiple networks where at least one has EAP
   - Confirmed Enterprise support correctly stays enabled

## Benefits

- **Automatic optimization:** Users get flash savings without any manual configuration
- **Transparent:** Works based on actual YAML configuration needs
- **Safe:** Only disables Enterprise support when it's genuinely not needed
- **Future-proof:** As ESP-IDF adds more Enterprise features, the savings may increase

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-facing changes