### PR TITLE
[esp32_ble_client] Add log helper functions to reduce flash usage by 120 bytes

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -137,6 +137,10 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void log_gattc_warning_(const char *operation, esp_gatt_status_t status);
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);
+  // Compact error logging helpers to reduce flash usage
+  void log_error_(const char *message);
+  void log_error_(const char *message, int code);
+  void log_warning_(const char *message);
 };
 
 }  // namespace esphome::esp32_ble_client


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash memory usage in the `esp32_ble_client` component by adding log helper functions that consolidate repetitive format strings and shortening log messages.

The ESP32 BLE client component had many log statements with identical format strings `"[%d] [%s] %s"` duplicated throughout the code. By consolidating these into helper functions, we store the format string once instead of multiple times, saving 120 bytes of flash memory.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Testing with Bluetooth Proxy configuration
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

esp32_ble_tracker:

bluetooth_proxy:
  active: true

# Optional: BLE client for testing
esp32_ble_client:
  - mac_address: FF:FF:FF:FF:FF:FF
    id: test_ble_client
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Changes made:
1. Added `log_error_()` helper functions for error logging with format `"[%d] [%s] %s"` and `"[%d] [%s] %s=%d"`
2. Added `log_warning_()` helper function for warning logging
3. Refactored 5 ESP_LOGE calls to use the error helpers
4. Refactored 2 ESP_LOGW calls to use the warning helper
5. Used existing `log_event_()` helper for 1 ESP_LOGD call
6. Shortened messages while maintaining clarity (e.g., "Remote closed during discovery")

### Flash memory savings:
- **Before**: 1162810 bytes
- **After**: 1162690 bytes
- **Savings**: 120 bytes

### Benefits:
- Reduces flash memory usage by consolidating format strings
- Improves code maintainability - log format can be changed in one place
- Cleaner code at call sites
- Establishes a pattern that can be extended to other components

This is part of ongoing efforts to optimize flash usage in ESPHome components, particularly important for devices like Bluetooth Proxies that have many features enabled.

