### PR TITLE
[esp32_ble] Store GATTC/GATTS param and small data inline to nearly eliminate heap allocations

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -306,7 +306,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTS: {
         esp_gatts_cb_event_t event = ble_event->event_.gatts.gatts_event;
         esp_gatt_if_t gatts_if = ble_event->event_.gatts.gatts_if;
-        esp_ble_gatts_cb_param_t *param = ble_event->event_.gatts.gatts_param;
+        esp_ble_gatts_cb_param_t *param = &ble_event->event_.gatts.gatts_param;  // Take address of inline struct
         ESP_LOGV(TAG, "gatts_event [esp_gatt_if: %d] - %d", gatts_if, event);
         for (auto *gatts_handler : this->gatts_event_handlers_) {
           gatts_handler->gatts_event_handler(event, gatts_if, param);
@@ -316,7 +316,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTC: {
         esp_gattc_cb_event_t event = ble_event->event_.gattc.gattc_event;
         esp_gatt_if_t gattc_if = ble_event->event_.gattc.gattc_if;
-        esp_ble_gattc_cb_param_t *param = ble_event->event_.gattc.gattc_param;
+        esp_ble_gattc_cb_param_t *param = &ble_event->event_.gattc.gattc_param;  // Take address of inline struct
         ESP_LOGV(TAG, "gattc_event [esp_gatt_if: %d] - %d", gattc_if, event);
         for (auto *gattc_handler : this->gattc_event_handlers_) {
           gattc_handler->gattc_event_handler(event, gattc_if, param);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -306,7 +306,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTS: {
         esp_gatts_cb_event_t event = ble_event->event_.gatts.gatts_event;
         esp_gatt_if_t gatts_if = ble_event->event_.gatts.gatts_if;
-        esp_ble_gatts_cb_param_t *param = &ble_event->event_.gatts.gatts_param;  // Take address of inline struct
+        esp_ble_gatts_cb_param_t *param = &ble_event->event_.gatts.gatts_param;
         ESP_LOGV(TAG, "gatts_event [esp_gatt_if: %d] - %d", gatts_if, event);
         for (auto *gatts_handler : this->gatts_event_handlers_) {
           gatts_handler->gatts_event_handler(event, gatts_if, param);
@@ -316,7 +316,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTC: {
         esp_gattc_cb_event_t event = ble_event->event_.gattc.gattc_event;
         esp_gatt_if_t gattc_if = ble_event->event_.gattc.gattc_if;
-        esp_ble_gattc_cb_param_t *param = &ble_event->event_.gattc.gattc_param;  // Take address of inline struct
+        esp_ble_gattc_cb_param_t *param = &ble_event->event_.gattc.gattc_param;
         ESP_LOGV(TAG, "gattc_event [esp_gatt_if: %d] - %d", gattc_if, event);
         for (auto *gattc_handler : this->gattc_event_handlers_) {
           gattc_handler->gattc_event_handler(event, gattc_if, param);

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -4,7 +4,6 @@
 
 #include <cstddef>  // for offsetof
 #include <cstring>  // for memcpy
-#include <vector>
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
@@ -64,7 +63,7 @@ static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.remote_addr) == si
 
 // Received GAP, GATTC and GATTS events are only queued, and get processed in the main loop().
 // This class stores each event with minimal memory usage.
-// GAP events (99% of traffic) don't have the vector overhead.
+// GAP events (99% of traffic) don't have the heap allocation overhead.
 // GATTC/GATTS events use heap allocation for their param and data.
 //
 // Event flow:

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -139,7 +139,7 @@ class BLEEvent {
   ~BLEEvent() { this->release(); }
 
   // Default constructor for pre-allocation in pool
-  BLEEvent() : type_(GAP), event_{} {}
+  BLEEvent() : event_{}, type_(GAP) {}
 
   // Invoked on return to EventPool - clean up any heap-allocated data
   void release() {

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -61,9 +61,19 @@ static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.rssi) == sizeof(es
 static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.remote_addr) == sizeof(esp_bt_status_t) + sizeof(int8_t),
               "remote_addr must follow rssi in read_rssi_cmpl");
 
-// Maximum size for inline storage of GATTC/GATTS data
-// This value is chosen to fit within the 80-byte union while maximizing inline storage
-static constexpr size_t INLINE_DATA_SIZE = 68;
+// Param struct sizes on ESP32
+static constexpr size_t GATTC_PARAM_SIZE = 28;
+static constexpr size_t GATTS_PARAM_SIZE = 32;
+
+// Maximum size for inline storage of data
+// GATTC: 80 - 28 (param) - 8 (other fields) = 44 bytes for data
+// GATTS: 80 - 32 (param) - 8 (other fields) = 40 bytes for data
+static constexpr size_t GATTC_INLINE_DATA_SIZE = 44;
+static constexpr size_t GATTS_INLINE_DATA_SIZE = 40;
+
+// Verify param struct sizes
+static_assert(sizeof(esp_ble_gattc_cb_param_t) == GATTC_PARAM_SIZE, "GATTC param size unexpected");
+static_assert(sizeof(esp_ble_gatts_cb_param_t) == GATTS_PARAM_SIZE, "GATTS param size unexpected");
 
 // Received GAP, GATTC and GATTS events are only queued, and get processed in the main loop().
 // This class stores each event with minimal memory usage.
@@ -115,21 +125,21 @@ class BLEEvent {
     this->init_gap_data_(e, p);
   }
 
-  // Constructor for GATTC events - uses heap allocation
-  // IMPORTANT: The heap allocation is REQUIRED and must not be removed as an optimization.
-  // The param pointer from ESP-IDF is only valid during the callback execution.
-  // Since BLE events are processed asynchronously in the main loop, we must create
-  // our own copy to ensure the data remains valid until the event is processed.
+  // Constructor for GATTC events - param stored inline, data may use heap
+  // IMPORTANT: We MUST copy the param struct because the pointer from ESP-IDF
+  // is only valid during the callback execution. Since BLE events are processed
+  // asynchronously in the main loop, we store our own copy inline to ensure
+  // the data remains valid until the event is processed.
   BLEEvent(esp_gattc_cb_event_t e, esp_gatt_if_t i, esp_ble_gattc_cb_param_t *p) {
     this->type_ = GATTC;
     this->init_gattc_data_(e, i, p);
   }
 
-  // Constructor for GATTS events - uses heap allocation
-  // IMPORTANT: The heap allocation is REQUIRED and must not be removed as an optimization.
-  // The param pointer from ESP-IDF is only valid during the callback execution.
-  // Since BLE events are processed asynchronously in the main loop, we must create
-  // our own copy to ensure the data remains valid until the event is processed.
+  // Constructor for GATTS events - param stored inline, data may use heap
+  // IMPORTANT: We MUST copy the param struct because the pointer from ESP-IDF
+  // is only valid during the callback execution. Since BLE events are processed
+  // asynchronously in the main loop, we store our own copy inline to ensure
+  // the data remains valid until the event is processed.
   BLEEvent(esp_gatts_cb_event_t e, esp_gatt_if_t i, esp_ble_gatts_cb_param_t *p) {
     this->type_ = GATTS;
     this->init_gatts_data_(e, i, p);
@@ -148,24 +158,20 @@ class BLEEvent {
         // GAP events don't have heap allocations
         break;
       case GATTC:
-        delete this->event_.gattc.gattc_param;
-        // Only delete heap data if it was heap-allocated
+        // Param is now stored inline, only delete heap data if it was heap-allocated
         if (!this->event_.gattc.is_inline && this->event_.gattc.data.heap_data != nullptr) {
           delete[] this->event_.gattc.data.heap_data;
         }
         // Clear critical fields to prevent issues if type changes
-        this->event_.gattc.gattc_param = nullptr;
         this->event_.gattc.is_inline = false;
         this->event_.gattc.data.heap_data = nullptr;
         break;
       case GATTS:
-        delete this->event_.gatts.gatts_param;
-        // Only delete heap data if it was heap-allocated
+        // Param is now stored inline, only delete heap data if it was heap-allocated
         if (!this->event_.gatts.is_inline && this->event_.gatts.data.heap_data != nullptr) {
           delete[] this->event_.gatts.data.heap_data;
         }
         // Clear critical fields to prevent issues if type changes
-        this->event_.gatts.gatts_param = nullptr;
         this->event_.gatts.is_inline = false;
         this->event_.gatts.data.heap_data = nullptr;
         break;
@@ -220,30 +226,30 @@ class BLEEvent {
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     struct gattc_event {
-      esp_ble_gattc_cb_param_t *gattc_param;  // Heap-allocated (4 bytes)
-      esp_gattc_cb_event_t gattc_event;       // 4 bytes
+      esp_ble_gattc_cb_param_t gattc_param;  // Stored inline (28 bytes)
+      esp_gattc_cb_event_t gattc_event;      // 4 bytes
       union {
-        uint8_t *heap_data;                     // 4 bytes when heap-allocated
-        uint8_t inline_data[INLINE_DATA_SIZE];  // INLINE_DATA_SIZE bytes when stored inline
-      } data;                                   // INLINE_DATA_SIZE bytes total
-      uint16_t data_len;                        // 2 bytes
-      esp_gatt_if_t gattc_if;                   // 1 byte
-      bool is_inline;                           // 1 byte - true when data is stored inline
-    } gattc;                                    // Total: 80 bytes
+        uint8_t *heap_data;                           // 4 bytes when heap-allocated
+        uint8_t inline_data[GATTC_INLINE_DATA_SIZE];  // 44 bytes when stored inline
+      } data;                                         // 44 bytes total
+      uint16_t data_len;                              // 2 bytes
+      esp_gatt_if_t gattc_if;                         // 1 byte
+      bool is_inline;                                 // 1 byte - true when data is stored inline
+    } gattc;                                          // Total: 80 bytes
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     struct gatts_event {
-      esp_ble_gatts_cb_param_t *gatts_param;  // Heap-allocated (4 bytes)
-      esp_gatts_cb_event_t gatts_event;       // 4 bytes
+      esp_ble_gatts_cb_param_t gatts_param;  // Stored inline (32 bytes)
+      esp_gatts_cb_event_t gatts_event;      // 4 bytes
       union {
-        uint8_t *heap_data;                     // 4 bytes when heap-allocated
-        uint8_t inline_data[INLINE_DATA_SIZE];  // INLINE_DATA_SIZE bytes when stored inline
-      } data;                                   // INLINE_DATA_SIZE bytes total
-      uint16_t data_len;                        // 2 bytes
-      esp_gatt_if_t gatts_if;                   // 1 byte
-      bool is_inline;                           // 1 byte - true when data is stored inline
-    } gatts;                                    // Total: 80 bytes
-  } event_;                                     // 80 bytes
+        uint8_t *heap_data;                           // 4 bytes when heap-allocated
+        uint8_t inline_data[GATTS_INLINE_DATA_SIZE];  // 40 bytes when stored inline
+      } data;                                         // 40 bytes total
+      uint16_t data_len;                              // 2 bytes
+      esp_gatt_if_t gatts_if;                         // 1 byte
+      bool is_inline;                                 // 1 byte - true when data is stored inline
+    } gatts;                                          // Total: 80 bytes
+  } event_;                                           // 80 bytes
 
   ble_event_t type_;
 
@@ -258,12 +264,12 @@ class BLEEvent {
 
  private:
   // Helper to copy data with inline storage optimization
-  template<typename EventStruct>
+  template<typename EventStruct, size_t InlineSize>
   void copy_data_with_inline_storage_(EventStruct &event, const uint8_t *src_data, uint16_t len,
                                       uint8_t **param_value_ptr) {
     event.data_len = len;
     if (len > 0) {
-      if (len <= INLINE_DATA_SIZE) {
+      if (len <= InlineSize) {
         event.is_inline = true;
         memcpy(event.data.inline_data, src_data, len);
         *param_value_ptr = event.data.inline_data;
@@ -364,34 +370,33 @@ class BLEEvent {
     this->event_.gattc.gattc_if = i;
 
     if (p == nullptr) {
-      this->event_.gattc.gattc_param = nullptr;
+      // Zero out the param struct when null
+      memset(&this->event_.gattc.gattc_param, 0, sizeof(this->event_.gattc.gattc_param));
       this->event_.gattc.is_inline = false;
       this->event_.gattc.data.heap_data = nullptr;
       this->event_.gattc.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
-    // Heap-allocate param
-    // Heap allocation is used because GATTC/GATTS events are rare (<1% of events)
-    // while GAP events (99%) are stored inline to minimize memory usage
-    // IMPORTANT: This heap allocation provides clear ownership semantics:
-    // - The BLEEvent owns the allocated memory for its lifetime
-    // - The data remains valid from the BLE callback context until processed in the main loop
-    // - Without this copy, we'd have use-after-free bugs as ESP-IDF reuses the callback memory
-    this->event_.gattc.gattc_param = new esp_ble_gattc_cb_param_t(*p);
+    // Copy param struct inline (no heap allocation!)
+    // GATTC/GATTS events are rare (<1% of events) but we can still store them inline
+    // along with small data payloads, eliminating all heap allocations for typical BLE operations
+    // CRITICAL: This copy is REQUIRED for memory safety - the ESP-IDF param pointer
+    // is only valid during the callback and will be reused/freed after we return
+    this->event_.gattc.gattc_param = *p;
 
     // Copy data for events that need it
     // The param struct contains pointers (e.g., notify.value) that point to temporary buffers.
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTC_NOTIFY_EVT:
-        copy_data_with_inline_storage_(this->event_.gattc, p->notify.value, p->notify.value_len,
-                                       &this->event_.gattc.gattc_param->notify.value);
+        copy_data_with_inline_storage_<decltype(this->event_.gattc), GATTC_INLINE_DATA_SIZE>(
+            this->event_.gattc, p->notify.value, p->notify.value_len, &this->event_.gattc.gattc_param.notify.value);
         break;
       case ESP_GATTC_READ_CHAR_EVT:
       case ESP_GATTC_READ_DESCR_EVT:
-        copy_data_with_inline_storage_(this->event_.gattc, p->read.value, p->read.value_len,
-                                       &this->event_.gattc.gattc_param->read.value);
+        copy_data_with_inline_storage_<decltype(this->event_.gattc), GATTC_INLINE_DATA_SIZE>(
+            this->event_.gattc, p->read.value, p->read.value_len, &this->event_.gattc.gattc_param.read.value);
         break;
       default:
         this->event_.gattc.is_inline = false;
@@ -407,29 +412,28 @@ class BLEEvent {
     this->event_.gatts.gatts_if = i;
 
     if (p == nullptr) {
-      this->event_.gatts.gatts_param = nullptr;
+      // Zero out the param struct when null
+      memset(&this->event_.gatts.gatts_param, 0, sizeof(this->event_.gatts.gatts_param));
       this->event_.gatts.is_inline = false;
       this->event_.gatts.data.heap_data = nullptr;
       this->event_.gatts.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
-    // Heap-allocate param
-    // Heap allocation is used because GATTC/GATTS events are rare (<1% of events)
-    // while GAP events (99%) are stored inline to minimize memory usage
-    // IMPORTANT: This heap allocation provides clear ownership semantics:
-    // - The BLEEvent owns the allocated memory for its lifetime
-    // - The data remains valid from the BLE callback context until processed in the main loop
-    // - Without this copy, we'd have use-after-free bugs as ESP-IDF reuses the callback memory
-    this->event_.gatts.gatts_param = new esp_ble_gatts_cb_param_t(*p);
+    // Copy param struct inline (no heap allocation!)
+    // GATTC/GATTS events are rare (<1% of events) but we can still store them inline
+    // along with small data payloads, eliminating all heap allocations for typical BLE operations
+    // CRITICAL: This copy is REQUIRED for memory safety - the ESP-IDF param pointer
+    // is only valid during the callback and will be reused/freed after we return
+    this->event_.gatts.gatts_param = *p;
 
     // Copy data for events that need it
     // The param struct contains pointers (e.g., write.value) that point to temporary buffers.
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTS_WRITE_EVT:
-        copy_data_with_inline_storage_(this->event_.gatts, p->write.value, p->write.len,
-                                       &this->event_.gatts.gatts_param->write.value);
+        copy_data_with_inline_storage_<decltype(this->event_.gatts), GATTS_INLINE_DATA_SIZE>(
+            this->event_.gatts, p->write.value, p->write.len, &this->event_.gatts.gatts_param.write.value);
         break;
       default:
         this->event_.gatts.is_inline = false;

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -6,7 +6,6 @@
 #include <cstring>  // for memcpy
 #include <vector>
 #include <memory>  // for std::unique_ptr
-
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -3,7 +3,9 @@
 #ifdef USE_ESP32
 
 #include <cstddef>  // for offsetof
+#include <cstring>  // for memcpy
 #include <vector>
+#include <memory>  // for std::unique_ptr
 
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
@@ -145,16 +147,14 @@ class BLEEvent {
     }
     if (this->type_ == GATTC) {
       delete this->event_.gattc.gattc_param;
-      delete this->event_.gattc.data;
       this->event_.gattc.gattc_param = nullptr;
-      this->event_.gattc.data = nullptr;
+      this->reset_gattc_data_();
       return;
     }
     if (this->type_ == GATTS) {
       delete this->event_.gatts.gatts_param;
-      delete this->event_.gatts.data;
       this->event_.gatts.gatts_param = nullptr;
-      this->event_.gatts.data = nullptr;
+      this->reset_gatts_data_();
     }
   }
 
@@ -209,17 +209,19 @@ class BLEEvent {
       esp_gattc_cb_event_t gattc_event;
       esp_gatt_if_t gattc_if;
       esp_ble_gattc_cb_param_t *gattc_param;  // Heap-allocated
-      std::vector<uint8_t> *data;             // Heap-allocated
-    } gattc;                                  // 16 bytes (pointers only)
+      uint8_t *data;                          // Heap-allocated raw buffer (manually managed)
+      uint16_t data_len;                      // Track size separately
+    } gattc;
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     struct gatts_event {
       esp_gatts_cb_event_t gatts_event;
       esp_gatt_if_t gatts_if;
       esp_ble_gatts_cb_param_t *gatts_param;  // Heap-allocated
-      std::vector<uint8_t> *data;             // Heap-allocated
-    } gatts;                                  // 16 bytes (pointers only)
-  } event_;                                   // 80 bytes
+      uint8_t *data;                          // Heap-allocated raw buffer (manually managed)
+      uint16_t data_len;                      // Track size separately
+    } gatts;
+  } event_;  // 80 bytes
 
   ble_event_t type_;
 
@@ -233,6 +235,20 @@ class BLEEvent {
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:
+  // Helper to reset GATTC data
+  void reset_gattc_data_() {
+    delete[] this->event_.gattc.data;
+    this->event_.gattc.data = nullptr;
+    this->event_.gattc.data_len = 0;
+  }
+
+  // Helper to reset GATTS data
+  void reset_gatts_data_() {
+    delete[] this->event_.gatts.data;
+    this->event_.gatts.data = nullptr;
+    this->event_.gatts.data_len = 0;
+  }
+
   // Initialize GAP event data
   void init_gap_data_(esp_gap_ble_cb_event_t e, esp_ble_gap_cb_param_t *p) {
     this->event_.gap.gap_event = e;
@@ -318,7 +334,7 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gattc.gattc_param = nullptr;
-      this->event_.gattc.data = nullptr;
+      this->reset_gattc_data_();
       return;  // Invalid event, but we can't log in header file
     }
 
@@ -336,16 +352,20 @@ class BLEEvent {
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTC_NOTIFY_EVT:
-        this->event_.gattc.data = new std::vector<uint8_t>(p->notify.value, p->notify.value + p->notify.value_len);
-        this->event_.gattc.gattc_param->notify.value = this->event_.gattc.data->data();
+        this->event_.gattc.data_len = p->notify.value_len;
+        this->event_.gattc.data = new uint8_t[p->notify.value_len];
+        memcpy(this->event_.gattc.data, p->notify.value, p->notify.value_len);
+        this->event_.gattc.gattc_param->notify.value = this->event_.gattc.data;
         break;
       case ESP_GATTC_READ_CHAR_EVT:
       case ESP_GATTC_READ_DESCR_EVT:
-        this->event_.gattc.data = new std::vector<uint8_t>(p->read.value, p->read.value + p->read.value_len);
-        this->event_.gattc.gattc_param->read.value = this->event_.gattc.data->data();
+        this->event_.gattc.data_len = p->read.value_len;
+        this->event_.gattc.data = new uint8_t[p->read.value_len];
+        memcpy(this->event_.gattc.data, p->read.value, p->read.value_len);
+        this->event_.gattc.gattc_param->read.value = this->event_.gattc.data;
         break;
       default:
-        this->event_.gattc.data = nullptr;
+        this->reset_gattc_data_();
         break;
     }
   }
@@ -357,7 +377,7 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gatts.gatts_param = nullptr;
-      this->event_.gatts.data = nullptr;
+      this->reset_gatts_data_();
       return;  // Invalid event, but we can't log in header file
     }
 
@@ -375,11 +395,13 @@ class BLEEvent {
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTS_WRITE_EVT:
-        this->event_.gatts.data = new std::vector<uint8_t>(p->write.value, p->write.value + p->write.len);
-        this->event_.gatts.gatts_param->write.value = this->event_.gatts.data->data();
+        this->event_.gatts.data_len = p->write.len;
+        this->event_.gatts.data = new uint8_t[p->write.len];
+        memcpy(this->event_.gatts.data, p->write.value, p->write.len);
+        this->event_.gatts.gatts_param->write.value = this->event_.gatts.data;
         break;
       default:
-        this->event_.gatts.data = nullptr;
+        this->reset_gatts_data_();
         break;
     }
   }

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -5,7 +5,6 @@
 #include <cstddef>  // for offsetof
 #include <cstring>  // for memcpy
 #include <vector>
-#include <memory>  // for std::unique_ptr
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -344,15 +344,23 @@ class BLEEvent {
     switch (e) {
       case ESP_GATTC_NOTIFY_EVT:
         this->event_.gattc.data_len = p->notify.value_len;
-        this->event_.gattc.data = new uint8_t[p->notify.value_len];
-        memcpy(this->event_.gattc.data, p->notify.value, p->notify.value_len);
+        if (p->notify.value_len > 0) {
+          this->event_.gattc.data = new uint8_t[p->notify.value_len];
+          memcpy(this->event_.gattc.data, p->notify.value, p->notify.value_len);
+        } else {
+          this->event_.gattc.data = nullptr;
+        }
         this->event_.gattc.gattc_param->notify.value = this->event_.gattc.data;
         break;
       case ESP_GATTC_READ_CHAR_EVT:
       case ESP_GATTC_READ_DESCR_EVT:
         this->event_.gattc.data_len = p->read.value_len;
-        this->event_.gattc.data = new uint8_t[p->read.value_len];
-        memcpy(this->event_.gattc.data, p->read.value, p->read.value_len);
+        if (p->read.value_len > 0) {
+          this->event_.gattc.data = new uint8_t[p->read.value_len];
+          memcpy(this->event_.gattc.data, p->read.value, p->read.value_len);
+        } else {
+          this->event_.gattc.data = nullptr;
+        }
         this->event_.gattc.gattc_param->read.value = this->event_.gattc.data;
         break;
       default:
@@ -389,8 +397,12 @@ class BLEEvent {
     switch (e) {
       case ESP_GATTS_WRITE_EVT:
         this->event_.gatts.data_len = p->write.len;
-        this->event_.gatts.data = new uint8_t[p->write.len];
-        memcpy(this->event_.gatts.data, p->write.value, p->write.len);
+        if (p->write.len > 0) {
+          this->event_.gatts.data = new uint8_t[p->write.len];
+          memcpy(this->event_.gatts.data, p->write.value, p->write.len);
+        } else {
+          this->event_.gatts.data = nullptr;
+        }
         this->event_.gatts.gatts_param->write.value = this->event_.gatts.data;
         break;
       default:

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -61,10 +61,14 @@ static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.rssi) == sizeof(es
 static_assert(offsetof(esp_ble_gap_cb_param_t, read_rssi_cmpl.remote_addr) == sizeof(esp_bt_status_t) + sizeof(int8_t),
               "remote_addr must follow rssi in read_rssi_cmpl");
 
+// Maximum size for inline storage of GATTC/GATTS data
+// This value is chosen to fit within the 80-byte union while maximizing inline storage
+static constexpr size_t INLINE_DATA_SIZE = 68;
+
 // Received GAP, GATTC and GATTS events are only queued, and get processed in the main loop().
 // This class stores each event with minimal memory usage.
 // GAP events (99% of traffic) don't have the heap allocation overhead.
-// GATTC/GATTS events use heap allocation for their param and data.
+// GATTC/GATTS events use heap allocation for their param and inline storage for small data.
 //
 // Event flow:
 // 1. ESP-IDF BLE stack calls our static handlers in the BLE task context
@@ -135,27 +139,36 @@ class BLEEvent {
   ~BLEEvent() { this->release(); }
 
   // Default constructor for pre-allocation in pool
-  BLEEvent() : type_(GAP) {}
+  BLEEvent() : type_(GAP), event_{} {}
 
   // Invoked on return to EventPool - clean up any heap-allocated data
   void release() {
-    if (this->type_ == GAP) {
-      return;
-    }
-    if (this->type_ == GATTC) {
-      delete this->event_.gattc.gattc_param;
-      delete[] this->event_.gattc.data;
-      this->event_.gattc.gattc_param = nullptr;
-      this->event_.gattc.data = nullptr;
-      this->event_.gattc.data_len = 0;
-      return;
-    }
-    if (this->type_ == GATTS) {
-      delete this->event_.gatts.gatts_param;
-      delete[] this->event_.gatts.data;
-      this->event_.gatts.gatts_param = nullptr;
-      this->event_.gatts.data = nullptr;
-      this->event_.gatts.data_len = 0;
+    switch (this->type_) {
+      case GAP:
+        // GAP events don't have heap allocations
+        break;
+      case GATTC:
+        delete this->event_.gattc.gattc_param;
+        // Only delete heap data if it was heap-allocated
+        if (!this->event_.gattc.is_inline && this->event_.gattc.data.heap_data != nullptr) {
+          delete[] this->event_.gattc.data.heap_data;
+        }
+        // Clear critical fields to prevent issues if type changes
+        this->event_.gattc.gattc_param = nullptr;
+        this->event_.gattc.is_inline = false;
+        this->event_.gattc.data.heap_data = nullptr;
+        break;
+      case GATTS:
+        delete this->event_.gatts.gatts_param;
+        // Only delete heap data if it was heap-allocated
+        if (!this->event_.gatts.is_inline && this->event_.gatts.data.heap_data != nullptr) {
+          delete[] this->event_.gatts.data.heap_data;
+        }
+        // Clear critical fields to prevent issues if type changes
+        this->event_.gatts.gatts_param = nullptr;
+        this->event_.gatts.is_inline = false;
+        this->event_.gatts.data.heap_data = nullptr;
+        break;
     }
   }
 
@@ -207,22 +220,30 @@ class BLEEvent {
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     struct gattc_event {
-      esp_gattc_cb_event_t gattc_event;
-      esp_gatt_if_t gattc_if;
-      esp_ble_gattc_cb_param_t *gattc_param;  // Heap-allocated
-      uint8_t *data;                          // Heap-allocated raw buffer (manually managed)
-      uint16_t data_len;                      // Track size separately
-    } gattc;
+      esp_ble_gattc_cb_param_t *gattc_param;  // Heap-allocated (4 bytes)
+      esp_gattc_cb_event_t gattc_event;       // 4 bytes
+      union {
+        uint8_t *heap_data;                     // 4 bytes when heap-allocated
+        uint8_t inline_data[INLINE_DATA_SIZE];  // INLINE_DATA_SIZE bytes when stored inline
+      } data;                                   // INLINE_DATA_SIZE bytes total
+      uint16_t data_len;                        // 2 bytes
+      esp_gatt_if_t gattc_if;                   // 1 byte
+      bool is_inline;                           // 1 byte - true when data is stored inline
+    } gattc;                                    // Total: 80 bytes
 
     // NOLINTNEXTLINE(readability-identifier-naming)
     struct gatts_event {
-      esp_gatts_cb_event_t gatts_event;
-      esp_gatt_if_t gatts_if;
-      esp_ble_gatts_cb_param_t *gatts_param;  // Heap-allocated
-      uint8_t *data;                          // Heap-allocated raw buffer (manually managed)
-      uint16_t data_len;                      // Track size separately
-    } gatts;
-  } event_;  // 80 bytes
+      esp_ble_gatts_cb_param_t *gatts_param;  // Heap-allocated (4 bytes)
+      esp_gatts_cb_event_t gatts_event;       // 4 bytes
+      union {
+        uint8_t *heap_data;                     // 4 bytes when heap-allocated
+        uint8_t inline_data[INLINE_DATA_SIZE];  // INLINE_DATA_SIZE bytes when stored inline
+      } data;                                   // INLINE_DATA_SIZE bytes total
+      uint16_t data_len;                        // 2 bytes
+      esp_gatt_if_t gatts_if;                   // 1 byte
+      bool is_inline;                           // 1 byte - true when data is stored inline
+    } gatts;                                    // Total: 80 bytes
+  } event_;                                     // 80 bytes
 
   ble_event_t type_;
 
@@ -236,6 +257,29 @@ class BLEEvent {
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:
+  // Helper to copy data with inline storage optimization
+  template<typename EventStruct>
+  void copy_data_with_inline_storage_(EventStruct &event, const uint8_t *src_data, uint16_t len,
+                                      uint8_t **param_value_ptr) {
+    event.data_len = len;
+    if (len > 0) {
+      if (len <= INLINE_DATA_SIZE) {
+        event.is_inline = true;
+        memcpy(event.data.inline_data, src_data, len);
+        *param_value_ptr = event.data.inline_data;
+      } else {
+        event.is_inline = false;
+        event.data.heap_data = new uint8_t[len];
+        memcpy(event.data.heap_data, src_data, len);
+        *param_value_ptr = event.data.heap_data;
+      }
+    } else {
+      event.is_inline = false;
+      event.data.heap_data = nullptr;
+      *param_value_ptr = nullptr;
+    }
+  }
+
   // Initialize GAP event data
   void init_gap_data_(esp_gap_ble_cb_event_t e, esp_ble_gap_cb_param_t *p) {
     this->event_.gap.gap_event = e;
@@ -321,12 +365,13 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gattc.gattc_param = nullptr;
-      this->event_.gattc.data = nullptr;
+      this->event_.gattc.is_inline = false;
+      this->event_.gattc.data.heap_data = nullptr;
       this->event_.gattc.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
-    // Heap-allocate param and data
+    // Heap-allocate param
     // Heap allocation is used because GATTC/GATTS events are rare (<1% of events)
     // while GAP events (99%) are stored inline to minimize memory usage
     // IMPORTANT: This heap allocation provides clear ownership semantics:
@@ -340,28 +385,17 @@ class BLEEvent {
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTC_NOTIFY_EVT:
-        this->event_.gattc.data_len = p->notify.value_len;
-        if (p->notify.value_len > 0) {
-          this->event_.gattc.data = new uint8_t[p->notify.value_len];
-          memcpy(this->event_.gattc.data, p->notify.value, p->notify.value_len);
-        } else {
-          this->event_.gattc.data = nullptr;
-        }
-        this->event_.gattc.gattc_param->notify.value = this->event_.gattc.data;
+        copy_data_with_inline_storage_(this->event_.gattc, p->notify.value, p->notify.value_len,
+                                       &this->event_.gattc.gattc_param->notify.value);
         break;
       case ESP_GATTC_READ_CHAR_EVT:
       case ESP_GATTC_READ_DESCR_EVT:
-        this->event_.gattc.data_len = p->read.value_len;
-        if (p->read.value_len > 0) {
-          this->event_.gattc.data = new uint8_t[p->read.value_len];
-          memcpy(this->event_.gattc.data, p->read.value, p->read.value_len);
-        } else {
-          this->event_.gattc.data = nullptr;
-        }
-        this->event_.gattc.gattc_param->read.value = this->event_.gattc.data;
+        copy_data_with_inline_storage_(this->event_.gattc, p->read.value, p->read.value_len,
+                                       &this->event_.gattc.gattc_param->read.value);
         break;
       default:
-        this->event_.gattc.data = nullptr;
+        this->event_.gattc.is_inline = false;
+        this->event_.gattc.data.heap_data = nullptr;
         this->event_.gattc.data_len = 0;
         break;
     }
@@ -374,12 +408,13 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gatts.gatts_param = nullptr;
-      this->event_.gatts.data = nullptr;
+      this->event_.gatts.is_inline = false;
+      this->event_.gatts.data.heap_data = nullptr;
       this->event_.gatts.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
-    // Heap-allocate param and data
+    // Heap-allocate param
     // Heap allocation is used because GATTC/GATTS events are rare (<1% of events)
     // while GAP events (99%) are stored inline to minimize memory usage
     // IMPORTANT: This heap allocation provides clear ownership semantics:
@@ -393,17 +428,12 @@ class BLEEvent {
     // We must copy this data to ensure it remains valid when the event is processed later.
     switch (e) {
       case ESP_GATTS_WRITE_EVT:
-        this->event_.gatts.data_len = p->write.len;
-        if (p->write.len > 0) {
-          this->event_.gatts.data = new uint8_t[p->write.len];
-          memcpy(this->event_.gatts.data, p->write.value, p->write.len);
-        } else {
-          this->event_.gatts.data = nullptr;
-        }
-        this->event_.gatts.gatts_param->write.value = this->event_.gatts.data;
+        copy_data_with_inline_storage_(this->event_.gatts, p->write.value, p->write.len,
+                                       &this->event_.gatts.gatts_param->write.value);
         break;
       default:
-        this->event_.gatts.data = nullptr;
+        this->event_.gatts.is_inline = false;
+        this->event_.gatts.data.heap_data = nullptr;
         this->event_.gatts.data_len = 0;
         break;
     }
@@ -413,6 +443,15 @@ class BLEEvent {
 // Verify the gap_event struct hasn't grown beyond expected size
 // The gap member in the union should be 80 bytes (including the gap_event enum)
 static_assert(sizeof(decltype(((BLEEvent *) nullptr)->event_.gap)) <= 80, "gap_event struct has grown beyond 80 bytes");
+
+// Verify GATTC and GATTS structs don't exceed GAP struct size
+// This ensures the union size is determined by GAP (the most common event type)
+static_assert(sizeof(decltype(((BLEEvent *) nullptr)->event_.gattc)) <=
+                  sizeof(decltype(((BLEEvent *) nullptr)->event_.gap)),
+              "gattc_event struct exceeds gap_event size - union size would increase");
+static_assert(sizeof(decltype(((BLEEvent *) nullptr)->event_.gatts)) <=
+                  sizeof(decltype(((BLEEvent *) nullptr)->event_.gap)),
+              "gatts_event struct exceeds gap_event size - union size would increase");
 
 // Verify esp_ble_sec_t fits within our union
 static_assert(sizeof(esp_ble_sec_t) <= 73, "esp_ble_sec_t is larger than BLEScanResult");

--- a/esphome/components/esp32_ble/ble_event.h
+++ b/esphome/components/esp32_ble/ble_event.h
@@ -147,14 +147,18 @@ class BLEEvent {
     }
     if (this->type_ == GATTC) {
       delete this->event_.gattc.gattc_param;
+      delete[] this->event_.gattc.data;
       this->event_.gattc.gattc_param = nullptr;
-      this->reset_gattc_data_();
+      this->event_.gattc.data = nullptr;
+      this->event_.gattc.data_len = 0;
       return;
     }
     if (this->type_ == GATTS) {
       delete this->event_.gatts.gatts_param;
+      delete[] this->event_.gatts.data;
       this->event_.gatts.gatts_param = nullptr;
-      this->reset_gatts_data_();
+      this->event_.gatts.data = nullptr;
+      this->event_.gatts.data_len = 0;
     }
   }
 
@@ -235,20 +239,6 @@ class BLEEvent {
   const esp_ble_sec_t &security() const { return event_.gap.security; }
 
  private:
-  // Helper to reset GATTC data
-  void reset_gattc_data_() {
-    delete[] this->event_.gattc.data;
-    this->event_.gattc.data = nullptr;
-    this->event_.gattc.data_len = 0;
-  }
-
-  // Helper to reset GATTS data
-  void reset_gatts_data_() {
-    delete[] this->event_.gatts.data;
-    this->event_.gatts.data = nullptr;
-    this->event_.gatts.data_len = 0;
-  }
-
   // Initialize GAP event data
   void init_gap_data_(esp_gap_ble_cb_event_t e, esp_ble_gap_cb_param_t *p) {
     this->event_.gap.gap_event = e;
@@ -334,7 +324,8 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gattc.gattc_param = nullptr;
-      this->reset_gattc_data_();
+      this->event_.gattc.data = nullptr;
+      this->event_.gattc.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
@@ -365,7 +356,8 @@ class BLEEvent {
         this->event_.gattc.gattc_param->read.value = this->event_.gattc.data;
         break;
       default:
-        this->reset_gattc_data_();
+        this->event_.gattc.data = nullptr;
+        this->event_.gattc.data_len = 0;
         break;
     }
   }
@@ -377,7 +369,8 @@ class BLEEvent {
 
     if (p == nullptr) {
       this->event_.gatts.gatts_param = nullptr;
-      this->reset_gatts_data_();
+      this->event_.gatts.data = nullptr;
+      this->event_.gatts.data_len = 0;
       return;  // Invalid event, but we can't log in header file
     }
 
@@ -401,7 +394,8 @@ class BLEEvent {
         this->event_.gatts.gatts_param->write.value = this->event_.gatts.data;
         break;
       default:
-        this->reset_gatts_data_();
+        this->event_.gatts.data = nullptr;
+        this->event_.gatts.data_len = 0;
         break;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

This PR delivers a **massive reduction in heap allocations** for ESP32 BLE operations by storing both param structs and data inline, achieving **ZERO heap allocations** for virtually all real-world BLE device communications.

This is a follow-up to #10247 which eliminated std::vector overhead. The union must be 80 bytes to accommodate GAP advertising data (the largest and most common event type at 99% of traffic). GATTC events only used ~16 bytes and GATTS only ~20 bytes of the union, leaving 60+ bytes sitting unused. This PR transforms that wasted memory into useful inline storage.

**Key improvements:**
- **Zero heap allocations** for 95%+ of BLE operations - from 2 allocations per event to 0
- **Massive impact for always-connected devices** like Inkbird thermometers, LED-BLE controllers, and other devices that send continuous small notifications
- **60+ bytes of wasted memory** now actively used for inline storage
- **Dramatic reduction in heap fragmentation** - critical for long-running bluetooth_proxy devices
- **Better performance** - no malloc/free overhead, better cache locality, faster event processing

**Why this matters:**
Always-connected BLE devices like Inkbird temperature sensors send thousands of small notifications per day (typically 2-8 bytes). Previously, each notification required 2 heap allocations. With bluetooth_proxy handling multiple such devices, this could mean 100,000+ heap allocations per day. This PR eliminates those allocations entirely, dramatically improving stability and reducing heap fragmentation for ESP32 BLE components.

**Technical details:**
- GATTC: 28-byte param stored inline + up to 44 bytes data inline
- GATTS: 32-byte param stored inline + up to 40 bytes data inline  
- Measurements show GATTC param is exactly 28 bytes, GATTS param is 32 bytes on ESP32
- Small payloads (≤44/40 bytes) are copied directly into the inline buffer
- Large payloads (>44/40 bytes) continue to use heap allocation for data only
- Added compile-time checks to ensure struct sizes and prevent union growth

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #10247
- Improves memory efficiency for `bluetooth_proxy`, `esp32_ble_client`, and `esp32_ble_server` components

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Benefits all configurations using BLE components:

bluetooth_proxy:
  active: true

# Or with BLE client:
esp32_ble_client:
  - mac_address: XX:XX:XX:XX:XX:XX
    id: my_ble_device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal optimization only, no user-exposed changes

## Testing performed

Tested with production bluetooth_proxy device:
- Successfully connects to BLE devices
- Handles GATTC notifications correctly
- No memory leaks or crashes
- Flash increase: +84 bytes (minimal)
- RAM usage: Unchanged (union remains 80 bytes)

Added logging to verify param struct sizes:
- GATTC param: 28 bytes (confirmed)
- GATTS param: 32 bytes (confirmed via static_assert)

## Memory impact analysis

For typical BLE operations:
- **Before**: 2 heap allocations (param + data)
- **After**: 0 heap allocations (both stored inline)
- **Reduction**: 100% heap allocation elimination

Common device examples:
| Device | Data Size | Heap Allocations Before | After | Improvement |
|--------|-----------|-------------------------|-------|-------------|
| SwitchBot | ≤23 bytes | 2 | 0 | 100% elimination |
| Temperature sensor | 2-8 bytes | 2 | 0 | 100% elimination |
| Battery level | 1 byte | 2 | 0 | 100% elimination |
| NOTIFY events | 2-8 bytes | 2 | 0 | 100% elimination |
| READ_CHAR | 8 bytes | 2 | 0 | 100% elimination |
| READ_DESCR | 2 bytes | 2 | 0 | 100% elimination |
| HomeKit (after handshake) | ≤40 bytes | 2 | 0 | 100% elimination |
| HomeKit (initial handshake) | 418 bytes | 2 | 1 | 50% reduction |