### PR TITLE
[core] Remove unnecessary FD_SETSIZE check on ESP32 and improve logging

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -475,11 +475,16 @@ bool Application::register_socket_fd(int fd) {
   if (fd < 0)
     return false;
 
+#ifndef USE_ESP32
+  // Only check on non-ESP32 platforms
+  // On ESP32 (both Arduino and ESP-IDF), CONFIG_LWIP_MAX_SOCKETS is always <= FD_SETSIZE by design
+  // (LWIP_SOCKET_OFFSET = FD_SETSIZE - CONFIG_LWIP_MAX_SOCKETS per lwipopts.h)
+  // Other platforms may not have this guarantee
   if (fd >= FD_SETSIZE) {
-    ESP_LOGE(TAG, "Cannot monitor socket fd %d: exceeds FD_SETSIZE (%d)", fd, FD_SETSIZE);
-    ESP_LOGE(TAG, "Socket will not be monitored for data - may cause performance issues!");
+    ESP_LOGE(TAG, "fd %d exceeds FD_SETSIZE %d", fd, FD_SETSIZE);
     return false;
   }
+#endif
 
   this->socket_fds_.push_back(fd);
   this->socket_fds_changed_ = true;


### PR DESCRIPTION
# What does this implement/fix?

This PR removes unnecessary FD_SETSIZE checking and excessive logging on ESP32 platforms, and improves logging to meet ESPHome standards.

The check for `fd >= FD_SETSIZE` is unnecessary on ESP32 because:
- ESP32's LWIP configuration guarantees `CONFIG_LWIP_MAX_SOCKETS <= FD_SETSIZE` by design
- The socket offset is calculated as `LWIP_SOCKET_OFFSET = FD_SETSIZE - CONFIG_LWIP_MAX_SOCKETS`
- LWIP won't create a socket if the max socket count is reached, so we can never receive an invalid fd

Changes:
1. Removed redundant double logging that violated ESPHome logging standards
2. Made remaining log message concise (removed unnecessary words)
3. Added `#ifndef USE_ESP32` to skip the check entirely on ESP32 platforms where it's guaranteed safe
4. Kept the check for other platforms that use socket select support (LibreTiny chips like BK72xx/RTL87xx/LN882x, and host builds)
   - Note: ESP8266 and RP2040 don't use this code path as they use LWIP TCP implementation without socket select

**Performance Impact:**
- Flash usage reduced by 180 bytes (from 1162546 to 1162366 bytes)
- RAM usage unchanged
- Removes dead code that would never execute on ESP32

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
