### PR TITLE
[api] Add zero-copy StringRef methods for compilation_time and effect_name

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -465,9 +465,7 @@ uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *
   resp.cold_white = values.get_cold_white();
   resp.warm_white = values.get_warm_white();
   if (light->supports_effects()) {
-    // get_effect_name() returns temporary std::string - must store it
-    std::string effect_name = light->get_effect_name();
-    resp.set_effect(StringRef(effect_name));
+    resp.set_effect(light->get_effect_name_ref());
   }
   return fill_and_encode_entity_state(light, resp, LightStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }
@@ -1425,9 +1423,7 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
   resp.set_esphome_version(ESPHOME_VERSION_REF);
 
-  // get_compilation_time() returns temporary std::string - must store it
-  std::string compilation_time = App.get_compilation_time();
-  resp.set_compilation_time(StringRef(compilation_time));
+  resp.set_compilation_time(App.get_compilation_time_ref());
 
   // Compile-time StringRef constants for manufacturers
 #if defined(USE_ESP8266) || defined(USE_ESP32)

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -140,12 +140,22 @@ float LightState::get_setup_priority() const { return setup_priority::HARDWARE -
 void LightState::publish_state() { this->remote_values_callback_.call(); }
 
 LightOutput *LightState::get_output() const { return this->output_; }
+
+static constexpr const char *EFFECT_NONE = "None";
+static constexpr auto EFFECT_NONE_REF = StringRef::from_lit("None");
+
 std::string LightState::get_effect_name() {
   if (this->active_effect_index_ > 0) {
     return this->effects_[this->active_effect_index_ - 1]->get_name();
-  } else {
-    return "None";
   }
+  return EFFECT_NONE;
+}
+
+StringRef LightState::get_effect_name_ref() {
+  if (this->active_effect_index_ > 0) {
+    return StringRef(this->effects_[this->active_effect_index_ - 1]->get_name());
+  }
+  return EFFECT_NONE_REF;
 }
 
 void LightState::add_new_remote_values_callback(std::function<void()> &&send_callback) {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -4,6 +4,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/optional.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/string_ref.h"
 #include "light_call.h"
 #include "light_color_values.h"
 #include "light_effect.h"
@@ -116,6 +117,8 @@ class LightState : public EntityBase, public Component {
 
   /// Return the name of the current effect, or if no effect is active "None".
   std::string get_effect_name();
+  /// Return the name of the current effect as StringRef (for API usage)
+  StringRef get_effect_name_ref();
 
   /**
    * This lets front-end components subscribe to light change events. This callback is called once

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -10,6 +10,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/scheduler.h"
+#include "esphome/core/string_ref.h"
 
 #ifdef USE_DEVICES
 #include "esphome/core/device.h"
@@ -248,6 +249,8 @@ class Application {
   bool is_name_add_mac_suffix_enabled() const { return this->name_add_mac_suffix_; }
 
   std::string get_compilation_time() const { return this->compilation_time_; }
+  /// Get the compilation time as StringRef (for API usage)
+  StringRef get_compilation_time_ref() const { return StringRef(this->compilation_time_); }
 
   /// Get the cached time in milliseconds from when the current component started its loop execution
   inline uint32_t IRAM_ATTR HOT get_loop_component_start_time() const { return this->loop_component_start_time_; }


### PR DESCRIPTION
# What does this implement/fix?

This PR extends the zero-copy string optimization introduced in #9790 to additional API methods that were missed in the initial implementation. It adds StringRef getter methods for `compilation_time` and light `effect_name` to eliminate temporary string allocations during API message encoding.

This also fixes a rare string lifetime issue with `effect_name`. Verified fixed in #10377

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows up on #9790 (zero-copy string optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- fixes #10377

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
api:

light:
  - platform: rgb
    name: "Test Light"
    effects:
      - random:
      - strobe:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Changes Made:

1. **Added `get_compilation_time_ref()` to Application class**
   - Returns `StringRef` directly from the `const char*` pointer
   - Eliminates temporary string creation when sending device info via API

2. **Added `get_effect_name_ref()` to LightState class**
   - Returns `StringRef` for current effect name
   - Uses pre-computed `EFFECT_NONE_REF` constant for "None" 
   - Shares string literal between `get_effect_name()` and `get_effect_name_ref()`

3. **Updated API connection to use new methods**
   - Replaced `App.get_compilation_time()` with `App.get_compilation_time_ref()` in device info response
   - Replaced `light->get_effect_name()` with `light->get_effect_name_ref()` in light state response

### Performance Impact:

- Eliminates 2 temporary string allocations per API message containing these fields
- Reduces heap fragmentation from frequent API updates
- Small flash size reduction (12 bytes) from string deduplication
- Follows the established pattern from #9790 for consistency

### Safety Considerations:

Both StringRef usages are lifetime-safe:
- `compilation_time_` points to a compile-time string literal with static storage duration
- Effect names are either static literals ("None") or persistent `std::string` members of long-lived `LightEffect` objects
- StringRefs are only used during synchronous message encoding, well within the lifetime of referenced strings