### PR TITLE
[atm90e32] Only read 1 register per SPI transaction per datasheet.

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -140,7 +140,6 @@ class ATM90E32Component : public PollingComponent,
   number::Number *ref_currents_[3]{nullptr, nullptr, nullptr};
 #endif
   uint16_t read16_(uint16_t a_register);
-  uint16_t read16_transaction_(uint16_t a_register);
   int read32_(uint16_t addr_h, uint16_t addr_l);
   void write16_(uint16_t a_register, uint16_t val, bool validate = true);
   float get_local_phase_voltage_(uint8_t phase);


### PR DESCRIPTION
# What does this implement/fix?

This reverts the addition of read16_transaction_ from #10143, folds it back into read16_, and switches read32_ back to making 2 transactions.

According to the datasheet (section 4.2.2 / page 31), we're only allowed to read a single register per SPI transaction: "The SPI read/write transaction is CS-low defined. Each transaction can only access one register."

This corrects incorrect power register readings for me (which use read32_).

@CircuitSetup FYI

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
