### PR TITLE
[api] Avoid object_id string allocations for all entity info messages

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -301,9 +301,15 @@ class APIConnection : public APIServerConnection {
                                               APIConnection *conn, uint32_t remaining_size, bool is_single) {
     // Set common fields that are shared by all entity types
     msg.key = entity->get_object_id_hash();
-    // IMPORTANT: get_object_id() may return a temporary std::string
-    std::string object_id = entity->get_object_id();
-    msg.set_object_id(StringRef(object_id));
+    // Try to use static reference first to avoid allocation
+    StringRef static_ref = entity->get_object_id_ref_for_api_();
+    if (!static_ref.empty()) {
+      msg.set_object_id(static_ref);
+    } else {
+      // Dynamic case - need to allocate
+      std::string object_id = entity->get_object_id();
+      msg.set_object_id(StringRef(object_id));
+    }
 
     if (entity->has_own_name()) {
       msg.set_name(entity->get_name());

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -1,6 +1,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
 
 namespace esphome {
 
@@ -57,6 +58,15 @@ std::string EntityBase::get_object_id() const {
     }
     return this->object_id_c_str_;
   }
+}
+StringRef EntityBase::get_object_id_ref_for_api_() const {
+  static constexpr auto EMPTY_STRING_REF = StringRef::from_lit("");
+  // Return empty for dynamic case (MAC suffix)
+  if (!this->flags_.has_own_name && App.is_name_add_mac_suffix_enabled()) {
+    return EMPTY_STRING_REF;
+  }
+  // For static case, return the string or empty if null
+  return this->object_id_c_str_ == nullptr ? EMPTY_STRING_REF : StringRef(this->object_id_c_str_);
 }
 void EntityBase::set_object_id(const char *object_id) {
   this->object_id_c_str_ = object_id;

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -51,22 +51,18 @@ std::string EntityBase::get_object_id() const {
   if (!this->flags_.has_own_name && App.is_name_add_mac_suffix_enabled()) {
     // `App.get_friendly_name()` is dynamic.
     return str_sanitize(str_snake_case(App.get_friendly_name()));
-  } else {
-    // `App.get_friendly_name()` is constant.
-    if (this->object_id_c_str_ == nullptr) {
-      return "";
-    }
-    return this->object_id_c_str_;
   }
+  // `App.get_friendly_name()` is constant.
+  return this->object_id_c_str_ == nullptr ? "" : this->object_id_c_str_;
 }
 StringRef EntityBase::get_object_id_ref_for_api_() const {
-  static constexpr auto EMPTY_STRING_REF = StringRef::from_lit("");
+  static constexpr auto EMPTY_STRING = StringRef::from_lit("");
   // Return empty for dynamic case (MAC suffix)
   if (!this->flags_.has_own_name && App.is_name_add_mac_suffix_enabled()) {
-    return EMPTY_STRING_REF;
+    return EMPTY_STRING;
   }
   // For static case, return the string or empty if null
-  return this->object_id_c_str_ == nullptr ? EMPTY_STRING_REF : StringRef(this->object_id_c_str_);
+  return this->object_id_c_str_ == nullptr ? EMPTY_STRING : StringRef(this->object_id_c_str_);
 }
 void EntityBase::set_object_id(const char *object_id) {
   this->object_id_c_str_ = object_id;

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -12,6 +12,11 @@
 
 namespace esphome {
 
+// Forward declaration for friend access
+namespace api {
+class APIConnection;
+}  // namespace api
+
 enum EntityCategory : uint8_t {
   ENTITY_CATEGORY_NONE = 0,
   ENTITY_CATEGORY_CONFIG = 1,
@@ -81,6 +86,12 @@ class EntityBase {
   void set_has_state(bool state) { this->flags_.has_state = state; }
 
  protected:
+  friend class api::APIConnection;
+
+  // Get object_id as StringRef when it's static (for API usage)
+  // Returns empty StringRef if object_id is dynamic (needs allocation)
+  StringRef get_object_id_ref_for_api_() const;
+
   /// The hash_base() function has been deprecated. It is kept in this
   /// class for now, to prevent external components from not compiling.
   virtual uint32_t hash_base() { return 0L; }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API to avoid allocating temporary strings for object_id when sending entity information. Since object_id is sent for every entity on each Home Assistant reconnect (which can be 10s-100s of entities), eliminating these allocations is worth the 80 bytes of flash overhead.

The optimization adds a `get_object_id_ref_for_api_()` method that returns a StringRef for static object_ids (the common case), only falling back to allocation for dynamic object_ids (when MAC suffix is enabled without own name).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal optimization only

## Additional Context:

### Performance Impact:
- **Flash**: +80 bytes (1205702 → 1205782 bytes)
- **RAM**: Saves one temporary string allocation per entity on every API connection
- **Benefit**: For a typical setup with 50-100 entities, this eliminates 50-100 temporary allocations on each Home Assistant reconnect

### Why This Trade-off Makes Sense:
Trading 80 bytes of flash for avoiding 10s-100s of heap allocations per Home Assistant reconnect is a clear win because:
- Flash is a one-time cost paid at compile time
- Heap allocations happen repeatedly at runtime on every reconnect
- Reducing heap fragmentation improves long-term stability
- Less allocation overhead means faster API connection establishment
- The flash cost is minimal compared to the runtime benefit

### Implementation:
- Added protected `get_object_id_ref_for_api_()` method to EntityBase
- Returns StringRef for static object_ids (most entities)
- Returns empty StringRef for dynamic cases (MAC suffix without own name)
- API connection uses this to avoid allocation when possible
- Follows established `_for_api_()` pattern used elsewhere in the codebase
- Method is protected with friend access to allow future changes without breaking external components