### PR TITLE
[remote_transmitter] Fix libretiny inconsistent wait time between repeats

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_libretiny.cpp
@@ -83,8 +83,8 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->target_time_ = 0;
   this->transmit_trigger_->trigger();
+  InterruptLock lock;
   for (uint32_t i = 0; i < send_times; i++) {
-    InterruptLock lock;
     for (int32_t item : this->temp_.get_data()) {
       if (item > 0) {
         const auto length = uint32_t(item);


### PR DESCRIPTION
# What does this implement/fix?

This fixes inconsistent wait times between repeats in LibreTiny's `remote_transmitter`.

Here is my oscilloscope capture before the fix:
<img width="1024" height="600" alt="RigolDS0" src="https://github.com/user-attachments/assets/40eba200-e64e-4680-a6fd-0fd39e384398" />

And after the fix (with identical YAML):
<img width="1024" height="600" alt="RigolDS1" src="https://github.com/user-attachments/assets/bbd2fcef-775a-4d2d-8086-58d3e2aca079" />

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6177

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
