### PR TITLE
http_request: Fix timeout when Content-Length is not present

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -243,8 +243,11 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       return;
     }
 
+    size_t max_length = this->max_response_buffer_size_;
     size_t content_length = container->content_length;
-    size_t max_length = std::min(content_length, this->max_response_buffer_size_);
+    if (content_length > 0) {
+      max_length = std::min(max_length, content_length);
+    }
 
 #ifdef USE_HTTP_REQUEST_RESPONSE
     if (this->capture_response_.value(x...)) {
@@ -256,6 +259,9 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
         while (container->get_bytes_read() < max_length) {
           int read = container->read(buf + read_index, std::min<size_t>(max_length - read_index, 512));
           App.feed_wdt();
+          if (read <= 0) {
+            break;
+          }
           yield();
           read_index += read;
         }
@@ -299,7 +305,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       new Trigger<std::shared_ptr<HttpContainer>, Ts...>();
   Trigger<Ts...> *error_trigger_ = new Trigger<Ts...>();
 
-  size_t max_response_buffer_size_{SIZE_MAX};
+  size_t max_response_buffer_size_{SIZE_MAX};  // Initialized by set_max_response_buffer_size.
 };
 
 }  // namespace http_request

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -214,19 +214,13 @@ int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
   const uint32_t start = millis();
   watchdog::WatchdogManager wdm(this->parent_->get_watchdog_timeout());
 
-  int bufsize = std::min(max_len, this->content_length - this->bytes_read_);
-
-  if (bufsize == 0) {
-    this->duration_ms += (millis() - start);
-    return 0;
-  }
-
+  int read_len = esp_http_client_read_response(this->client_, (char *) buf, max_len);
   this->feed_wdt();
-  int read_len = esp_http_client_read(this->client_, (char *) buf, bufsize);
-  this->feed_wdt();
-  this->bytes_read_ += read_len;
 
   this->duration_ms += (millis() - start);
+  if (read_len >= 0) {
+    this->bytes_read_ += read_len;
+  }
 
   return read_len;
 }


### PR DESCRIPTION
# What does this implement/fix?

This fixes the http_request client timing out when the Content-Length header is not present.

I altered the implementation to not treat the Content-Length as a requirement, to just be a suggestion for buffer allocation. When not present, the client will read until EOF or until the `max_response_buffer_size` is reached.

I only fixed the ESP-IDF client. The same issue is likely present in the Arduino client, but I am currently unable to test it because it is broken due to something unrelated.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other
<!--
**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>
-->
## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

<!--
## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```
-->

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

<!--
If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
-->