### PR TITLE
[esp32] Write variant to sdkconfig file

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -824,8 +824,9 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
-    cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
-    cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[config[CONF_VARIANT]])
+    variant = config[CONF_VARIANT]
+    cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")
+    cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[variant])
     cg.add_define(ThreadModel.MULTI_ATOMICS)
 
     cg.add_platformio_option("lib_ldf_mode", "off")
@@ -859,6 +860,7 @@ async def to_code(config):
         cg.add_platformio_option(
             "platform_packages", ["espressif/toolchain-esp32ulp@2.35.0-20220830"]
         )
+        add_idf_sdkconfig_option(f"CONFIG_IDF_TARGET_{variant}", True)
         add_idf_sdkconfig_option(
             f"CONFIG_ESPTOOLPY_FLASHSIZE_{config[CONF_FLASH_SIZE]}", True
         )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This fixes an issue where the sdkconfig files (both internal and generated) are not re-written with a variant change in yaml causing the following error:

```
INFO ESPHome 2025.7.5
INFO Reading configuration /config/esphome/sump-alert.yaml...
INFO Generating C++ source...
INFO Compiling app...
Processing sump-alert (board: esp32-c6-devkitc-1; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip)
--------------------------------------------------------------------------------
HARDWARE: ESP32C6 160MHz, 320KB RAM, 8MB Flash
 - framework-espidf @ 3.50302.0 (5.3.2) 
 - tool-cmake @ 3.30.2 
 - tool-esptoolpy @ 4.8.6 
 - tool-mklittlefs @ 3.2.0 
 - tool-ninja @ 1.10.2 
 - tool-riscv32-esp-elf-gdb @ 14.2.0+20240403 
 - tool-xtensa-esp-elf-gdb @ 14.2.0+20240403 
 - toolchain-esp32ulp @ 2.35.0-20220830 
 - toolchain-riscv32-esp @ 13.2.0+20240530
Reading CMake configuration...
-- Configuring incomplete, errors occurred!

CMake Error at /data/cache/platformio/packages/framework-espidf/tools/cmake/targets.cmake:108 (message):
   Target 'esp32c3' in sdkconfig '/data/build/sump-alert/sdkconfig.sump-alert' does not match currently selected IDF_TARGET 'esp32c6'. To change the target, clear the build directory and sdkconfig file, and build the project again.
Call Stack (most recent call first):
  /data/cache/platformio/packages/framework-espidf/tools/cmake/project.cmake:24 (__target_init)
  CMakeLists.txt:2 (include)



========================== [FAILED] Took 3.96 seconds ==========================
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
