### PR TITLE
[core] Fix scheduler race condition where cancelled items still execute

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -409,6 +409,8 @@ void HOT Scheduler::call(uint32_t now) {
       // This handles two cases:
       // 1. Item was marked for removal after cleanup_() but before we got here
       // 2. Item is marked for removal but wasn't at the front of the heap during cleanup_()
+      // TEMPORARILY DISABLED TO VERIFY TEST CATCHES THE BUG
+      /*
 #ifdef ESPHOME_THREAD_MULTI_NO_ATOMICS
       // Multi-threaded platforms without atomics: must take lock to safely read remove flag
       {
@@ -428,6 +430,7 @@ void HOT Scheduler::call(uint32_t now) {
         continue;
       }
 #endif
+      */
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
       const char *item_name = item->get_name();

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -409,8 +409,6 @@ void HOT Scheduler::call(uint32_t now) {
       // This handles two cases:
       // 1. Item was marked for removal after cleanup_() but before we got here
       // 2. Item is marked for removal but wasn't at the front of the heap during cleanup_()
-      // TEMPORARILY DISABLED TO VERIFY TEST CATCHES THE BUG
-      /*
 #ifdef ESPHOME_THREAD_MULTI_NO_ATOMICS
       // Multi-threaded platforms without atomics: must take lock to safely read remove flag
       {
@@ -430,7 +428,6 @@ void HOT Scheduler::call(uint32_t now) {
         continue;
       }
 #endif
-      */
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
       const char *item_name = item->get_name();

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -97,22 +97,42 @@ class Scheduler {
 
     std::function<void()> callback;
 
-    // Bit-packed fields to minimize padding
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+    // Multi-threaded with atomics: use atomic for lock-free access
+    // Place atomic<bool> separately since it can't be packed with bit fields
+    std::atomic<bool> remove{false};
+
+    // Bit-packed fields (3 bits used, 5 bits padding in 1 byte)
+    enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
+    bool name_is_dynamic : 1;  // True if name was dynamically allocated (needs delete[])
+    bool is_retry : 1;         // True if this is a retry timeout
+                               // 5 bits padding
+#else
+    // Single-threaded or multi-threaded without atomics: can pack all fields together
+    // Bit-packed fields (4 bits used, 4 bits padding in 1 byte)
     enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
     bool remove : 1;
     bool name_is_dynamic : 1;  // True if name was dynamically allocated (needs delete[])
     bool is_retry : 1;         // True if this is a retry timeout
-    // 4 bits padding
+                               // 4 bits padding
+#endif
 
     // Constructor
     SchedulerItem()
         : component(nullptr),
           interval(0),
           next_execution_(0),
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+          // remove is initialized in the member declaration as std::atomic<bool>{false}
+          type(TIMEOUT),
+          name_is_dynamic(false),
+          is_retry(false) {
+#else
           type(TIMEOUT),
           remove(false),
           name_is_dynamic(false),
           is_retry(false) {
+#endif
       name_.static_name = nullptr;
     }
 
@@ -217,6 +237,35 @@ class Scheduler {
   // Helper to check if item should be skipped
   bool should_skip_item_(const SchedulerItem *item) const {
     return item->remove || (item->component != nullptr && item->component->is_failed());
+  }
+
+  // Helper to check if item is marked for removal (platform-specific)
+  // Returns true if item should be skipped, handles platform-specific synchronization
+  // NOTE: For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller must hold lock!
+  bool is_item_removed_(SchedulerItem *item) const {
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+    // Multi-threaded with atomics: use atomic load for lock-free access
+    return item->remove.load(std::memory_order_acquire);
+#else
+    // Single-threaded (ESPHOME_THREAD_SINGLE) or
+    // multi-threaded without atomics (ESPHOME_THREAD_MULTI_NO_ATOMICS): direct read
+    // For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller MUST hold lock!
+    return item->remove;
+#endif
+  }
+
+  // Helper to mark item for removal (platform-specific)
+  // NOTE: For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller must hold lock!
+  void mark_item_removed_(SchedulerItem *item) {
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+    // Multi-threaded with atomics: use atomic store
+    item->remove.store(true, std::memory_order_release);
+#else
+    // Single-threaded (ESPHOME_THREAD_SINGLE) or
+    // multi-threaded without atomics (ESPHOME_THREAD_MULTI_NO_ATOMICS): direct write
+    // For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller MUST hold lock!
+    item->remove = true;
+#endif
   }
 
   // Template helper to check if any item in a container matches our criteria

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -241,10 +241,7 @@ class Scheduler {
 
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization
-  /**
-   * Returns true if the item is marked for removal.
-   * For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
-   */
+  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
   bool is_item_removed_(SchedulerItem *item) const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic load for lock-free access
@@ -258,10 +255,7 @@ class Scheduler {
   }
 
   // Helper to mark item for removal (platform-specific)
-  /**
-   * Marks the item for removal.
-   * For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
-   */
+  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
   void mark_item_removed_(SchedulerItem *item) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic store

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -241,7 +241,8 @@ class Scheduler {
 
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization
-  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
+  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this
+  // function.
   bool is_item_removed_(SchedulerItem *item) const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic load for lock-free access
@@ -255,7 +256,8 @@ class Scheduler {
   }
 
   // Helper to mark item for removal (platform-specific)
-  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
+  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this
+  // function.
   void mark_item_removed_(SchedulerItem *item) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic store

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -241,7 +241,10 @@ class Scheduler {
 
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization
-  // NOTE: For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller must hold lock!
+  /**
+   * Returns true if the item is marked for removal.
+   * For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
+   */
   bool is_item_removed_(SchedulerItem *item) const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic load for lock-free access

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -258,7 +258,10 @@ class Scheduler {
   }
 
   // Helper to mark item for removal (platform-specific)
-  // NOTE: For ESPHOME_THREAD_MULTI_NO_ATOMICS, caller must hold lock!
+  /**
+   * Marks the item for removal.
+   * For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this function.
+   */
   void mark_item_removed_(SchedulerItem *item) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     // Multi-threaded with atomics: use atomic store

--- a/tests/integration/fixtures/scheduler_removed_item_race.yaml
+++ b/tests/integration/fixtures/scheduler_removed_item_race.yaml
@@ -36,80 +36,101 @@ script:
       - logger.log: "=== Starting Removed Item Race Test ==="
 
       # This test creates a scenario where:
-      # 1. Multiple timeouts are scheduled to execute at nearly the same time
-      # 2. One timeout in the middle of the heap gets cancelled
-      # 3. Without the fix, the cancelled timeout would still execute
+      # 1. First item in heap is NOT cancelled (cleanup stops immediately)
+      # 2. Items behind it ARE cancelled (remain in heap after cleanup)
+      # 3. All items execute at the same time, including cancelled ones
 
       - lambda: |-
-          // Schedule multiple timeouts that will all be ready at the same time
-          // This ensures they're all in the heap together
+          // The key to hitting the race:
+          // 1. Add items in a specific order to control heap structure
+          // 2. Cancel ONLY items that won't be at the front
+          // 3. Ensure the first item stays non-cancelled so cleanup_() stops immediately
 
-          // First timeout - executes at 10ms
-          App.scheduler.set_timeout(id(test_sensor), "timeout1", 10, []() {
-            ESP_LOGD("test", "Timeout 1 executed (expected)");
+          // Schedule all items to execute at the SAME time (1ms from now)
+          // Using 1ms instead of 0 to avoid defer queue on multi-core platforms
+          // This ensures they'll all be ready together and go through the heap
+          const uint32_t exec_time = 1;
+
+          // CRITICAL: Add a non-cancellable item FIRST
+          // This will be at the front of the heap and block cleanup_()
+          App.scheduler.set_timeout(id(test_sensor), "blocker", exec_time, []() {
+            ESP_LOGD("test", "Blocker timeout executed (expected) - was at front of heap");
             id(normal_item_executed)++;
           });
 
-          // Second timeout - executes at 10ms (will be cancelled)
-          App.scheduler.set_timeout(id(test_sensor), "timeout2", 10, []() {
-            ESP_LOGE("test", "RACE: Timeout 2 executed after being cancelled!");
+          // Now add items that we WILL cancel
+          // These will be behind the blocker in the heap
+          App.scheduler.set_timeout(id(test_sensor), "cancel_1", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 1 executed after being cancelled!");
             id(removed_item_executed)++;
             id(test_passed) = false;
           });
 
-          // Third timeout - executes at 10ms
-          App.scheduler.set_timeout(id(test_sensor), "timeout3", 10, []() {
-            ESP_LOGD("test", "Timeout 3 executed (expected)");
-            id(normal_item_executed)++;
-          });
-
-          // Fourth timeout - executes at 10ms
-          App.scheduler.set_timeout(id(test_sensor), "timeout4", 10, []() {
-            ESP_LOGD("test", "Timeout 4 executed (expected)");
-            id(normal_item_executed)++;
-          });
-
-          // Now cancel timeout2
-          // Since all timeouts have the same execution time, they're all in the heap
-          // timeout2 might not be at the front, so cleanup_() won't remove it
-          bool cancelled = App.scheduler.cancel_timeout(id(test_sensor), "timeout2");
-          ESP_LOGD("test", "Cancelled timeout2: %s", cancelled ? "true" : "false");
-
-          // Also test with items at slightly different times
-          App.scheduler.set_timeout(id(test_sensor), "timeout5", 11, []() {
-            ESP_LOGD("test", "Timeout 5 executed (expected)");
-            id(normal_item_executed)++;
-          });
-
-          App.scheduler.set_timeout(id(test_sensor), "timeout6", 12, []() {
-            ESP_LOGE("test", "RACE: Timeout 6 executed after being cancelled!");
+          App.scheduler.set_timeout(id(test_sensor), "cancel_2", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 2 executed after being cancelled!");
             id(removed_item_executed)++;
             id(test_passed) = false;
           });
 
-          App.scheduler.set_timeout(id(test_sensor), "timeout7", 13, []() {
-            ESP_LOGD("test", "Timeout 7 executed (expected)");
+          App.scheduler.set_timeout(id(test_sensor), "cancel_3", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 3 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          // Add some more normal items
+          App.scheduler.set_timeout(id(test_sensor), "normal_1", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 1 executed (expected)");
             id(normal_item_executed)++;
           });
 
-          // Cancel timeout6
-          cancelled = App.scheduler.cancel_timeout(id(test_sensor), "timeout6");
-          ESP_LOGD("test", "Cancelled timeout6: %s", cancelled ? "true" : "false");
+          App.scheduler.set_timeout(id(test_sensor), "normal_2", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 2 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "normal_3", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 3 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Force items into the heap before cancelling
+          App.scheduler.process_to_add();
+
+          // NOW cancel the items - they're behind "blocker" in the heap
+          // When cleanup_() runs, it will see "blocker" (not removed) at the front
+          // and stop immediately, leaving cancel_1, cancel_2, cancel_3 in the heap
+          bool c1 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_1");
+          bool c2 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_2");
+          bool c3 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_3");
+
+          ESP_LOGD("test", "Cancelled items (behind blocker): %s, %s, %s",
+                   c1 ? "true" : "false",
+                   c2 ? "true" : "false",
+                   c3 ? "true" : "false");
+
+          // The heap now has:
+          // - "blocker" at front (not cancelled)
+          // - cancelled items behind it (marked remove=true but still in heap)
+          // - When all execute at once, cleanup_() stops at "blocker"
+          // - The loop then executes ALL ready items including cancelled ones
+
+          ESP_LOGD("test", "Setup complete. Blocker at front prevents cleanup of cancelled items behind it");
 
       # Wait for all timeouts to execute (or not)
-      - delay: 50ms
+      - delay: 20ms
 
       # Check results
       - lambda: |-
           ESP_LOGI("test", "=== Test Results ===");
-          ESP_LOGI("test", "Normal items executed: %d (expected 5)", id(normal_item_executed));
+          ESP_LOGI("test", "Normal items executed: %d (expected 4)", id(normal_item_executed));
           ESP_LOGI("test", "Removed items executed: %d (expected 0)", id(removed_item_executed));
 
           if (id(removed_item_executed) > 0) {
             ESP_LOGE("test", "TEST FAILED: %d cancelled items were executed!", id(removed_item_executed));
             id(test_passed) = false;
-          } else if (id(normal_item_executed) != 5) {
-            ESP_LOGE("test", "TEST FAILED: Expected 5 normal items, got %d", id(normal_item_executed));
+          } else if (id(normal_item_executed) != 4) {
+            ESP_LOGE("test", "TEST FAILED: Expected 4 normal items, got %d", id(normal_item_executed));
             id(test_passed) = false;
           } else {
             ESP_LOGI("test", "TEST PASSED: No cancelled items were executed");

--- a/tests/integration/fixtures/scheduler_removed_item_race.yaml
+++ b/tests/integration/fixtures/scheduler_removed_item_race.yaml
@@ -1,0 +1,118 @@
+esphome:
+  name: scheduler-removed-item-race
+
+host:
+
+api:
+  services:
+    - service: run_test
+      then:
+        - script.execute: run_test_script
+
+logger:
+  level: DEBUG
+
+globals:
+  - id: test_passed
+    type: bool
+    initial_value: 'true'
+  - id: removed_item_executed
+    type: int
+    initial_value: '0'
+  - id: normal_item_executed
+    type: int
+    initial_value: '0'
+
+sensor:
+  - platform: template
+    id: test_sensor
+    name: "Test Sensor"
+    update_interval: never
+    lambda: return 0.0;
+
+script:
+  - id: run_test_script
+    then:
+      - logger.log: "=== Starting Removed Item Race Test ==="
+
+      # This test creates a scenario where:
+      # 1. Multiple timeouts are scheduled to execute at nearly the same time
+      # 2. One timeout in the middle of the heap gets cancelled
+      # 3. Without the fix, the cancelled timeout would still execute
+
+      - lambda: |-
+          // Schedule multiple timeouts that will all be ready at the same time
+          // This ensures they're all in the heap together
+
+          // First timeout - executes at 10ms
+          App.scheduler.set_timeout(id(test_sensor), "timeout1", 10, []() {
+            ESP_LOGD("test", "Timeout 1 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Second timeout - executes at 10ms (will be cancelled)
+          App.scheduler.set_timeout(id(test_sensor), "timeout2", 10, []() {
+            ESP_LOGE("test", "RACE: Timeout 2 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          // Third timeout - executes at 10ms
+          App.scheduler.set_timeout(id(test_sensor), "timeout3", 10, []() {
+            ESP_LOGD("test", "Timeout 3 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Fourth timeout - executes at 10ms
+          App.scheduler.set_timeout(id(test_sensor), "timeout4", 10, []() {
+            ESP_LOGD("test", "Timeout 4 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Now cancel timeout2
+          // Since all timeouts have the same execution time, they're all in the heap
+          // timeout2 might not be at the front, so cleanup_() won't remove it
+          bool cancelled = App.scheduler.cancel_timeout(id(test_sensor), "timeout2");
+          ESP_LOGD("test", "Cancelled timeout2: %s", cancelled ? "true" : "false");
+
+          // Also test with items at slightly different times
+          App.scheduler.set_timeout(id(test_sensor), "timeout5", 11, []() {
+            ESP_LOGD("test", "Timeout 5 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "timeout6", 12, []() {
+            ESP_LOGE("test", "RACE: Timeout 6 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "timeout7", 13, []() {
+            ESP_LOGD("test", "Timeout 7 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Cancel timeout6
+          cancelled = App.scheduler.cancel_timeout(id(test_sensor), "timeout6");
+          ESP_LOGD("test", "Cancelled timeout6: %s", cancelled ? "true" : "false");
+
+      # Wait for all timeouts to execute (or not)
+      - delay: 50ms
+
+      # Check results
+      - lambda: |-
+          ESP_LOGI("test", "=== Test Results ===");
+          ESP_LOGI("test", "Normal items executed: %d (expected 5)", id(normal_item_executed));
+          ESP_LOGI("test", "Removed items executed: %d (expected 0)", id(removed_item_executed));
+
+          if (id(removed_item_executed) > 0) {
+            ESP_LOGE("test", "TEST FAILED: %d cancelled items were executed!", id(removed_item_executed));
+            id(test_passed) = false;
+          } else if (id(normal_item_executed) != 5) {
+            ESP_LOGE("test", "TEST FAILED: Expected 5 normal items, got %d", id(normal_item_executed));
+            id(test_passed) = false;
+          } else {
+            ESP_LOGI("test", "TEST PASSED: No cancelled items were executed");
+          }
+
+          ESP_LOGI("test", "=== Test Complete ===");

--- a/tests/integration/test_scheduler_removed_item_race.py
+++ b/tests/integration/test_scheduler_removed_item_race.py
@@ -97,6 +97,6 @@ async def test_scheduler_removed_item_race(
         assert removed_executed == 0, (
             f"Cancelled items should not execute, but {removed_executed} did"
         )
-        assert normal_executed == 5, (
-            f"Expected 5 normal items to execute, got {normal_executed}"
+        assert normal_executed == 4, (
+            f"Expected 4 normal items to execute, got {normal_executed}"
         )

--- a/tests/integration/test_scheduler_removed_item_race.py
+++ b/tests/integration/test_scheduler_removed_item_race.py
@@ -1,0 +1,102 @@
+"""Test for scheduler race condition where removed items still execute."""
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_removed_item_race(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that items marked for removal don't execute.
+
+    This test verifies the fix for a race condition where:
+    1. cleanup_() only removes items from the front of the heap
+    2. Items in the middle of the heap marked for removal still execute
+    3. This causes cancelled timeouts to run when they shouldn't
+    """
+
+    loop = asyncio.get_running_loop()
+    test_complete_future: asyncio.Future[bool] = loop.create_future()
+
+    # Track test results
+    test_passed = False
+    removed_executed = 0
+    normal_executed = 0
+
+    # Patterns to match
+    race_pattern = re.compile(r"RACE: .* executed after being cancelled!")
+    passed_pattern = re.compile(r"TEST PASSED")
+    failed_pattern = re.compile(r"TEST FAILED")
+    complete_pattern = re.compile(r"=== Test Complete ===")
+    normal_count_pattern = re.compile(r"Normal items executed: (\d+)")
+    removed_count_pattern = re.compile(r"Removed items executed: (\d+)")
+
+    def check_output(line: str) -> None:
+        """Check log output for test results."""
+        nonlocal test_passed, removed_executed, normal_executed
+
+        if race_pattern.search(line):
+            # Race condition detected - a cancelled item executed
+            test_passed = False
+
+        if passed_pattern.search(line):
+            test_passed = True
+        elif failed_pattern.search(line):
+            test_passed = False
+
+        normal_match = normal_count_pattern.search(line)
+        if normal_match:
+            normal_executed = int(normal_match.group(1))
+
+        removed_match = removed_count_pattern.search(line)
+        if removed_match:
+            removed_executed = int(removed_match.group(1))
+
+        if not test_complete_future.done() and complete_pattern.search(line):
+            test_complete_future.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Verify we can connect
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "scheduler-removed-item-race"
+
+        # List services
+        _, services = await asyncio.wait_for(
+            client.list_entities_services(), timeout=5.0
+        )
+
+        # Find run_test service
+        run_test_service = next((s for s in services if s.name == "run_test"), None)
+        assert run_test_service is not None, "run_test service not found"
+
+        # Execute the test
+        client.execute_service(run_test_service, {})
+
+        # Wait for test completion
+        try:
+            await asyncio.wait_for(test_complete_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Test did not complete within timeout")
+
+        # Verify results
+        assert test_passed, (
+            f"Test failed! Removed items executed: {removed_executed}, "
+            f"Normal items executed: {normal_executed}"
+        )
+        assert removed_executed == 0, (
+            f"Cancelled items should not execute, but {removed_executed} did"
+        )
+        assert normal_executed == 5, (
+            f"Expected 5 normal items to execute, got {normal_executed}"
+        )


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a race condition in the scheduler where cancelled items could still execute when they were not at the front of the heap during cleanup.

The issue occurs because `cleanup_()` only removes items from the front of the heap until it encounters a non-removed item, then stops. Items marked for removal that are deeper in the heap remain and can still execute when their time comes. This caused cancelled timeouts to run unexpectedly, leading to issues like spurious NaN values in sensor readings when timeout filters were used.

**Note:** While this bug has always existed in the scheduler, PR #9743 (commit ecd310d) made it more apparent by refactoring `empty_()` to explicit `cleanup_()` calls, making the cleanup timing more predictable and thus more likely to expose this race condition.

The fix adds a check for the `remove` flag before executing any scheduler item, ensuring cancelled items are properly skipped even if `cleanup_()` couldn't remove them from the heap.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if reported)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** Integration test has been run on HOST platform. Hardware testing on actual devices is pending.

## Example entry for `config.yaml`:

```yaml
# This fix applies to all scheduler operations.
# Example configuration that could trigger the race:
sensor:
  - platform: dallas_temp
    address: 0x1234567890abcdef
    filters:
      - timeout: 10s
        # Without this fix, cancelled timeout could still execute
        # and inject NaN into sensor readings
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Details

### Root Cause
The scheduler's `cleanup_()` function only removes items from the front of the heap:
```cpp
while (!this->items_.empty()) {
  auto &item = this->items_[0];
  if (!item->remove)
    break;  // Stops at first non-removed item
  // ...
}
```

When multiple items are ready to execute simultaneously and some are cancelled, the cancelled items behind the first non-removed item remain in the heap and execute.

### Solution
Added a check before execution to skip removed items:
- For platforms with atomics (ESP32, HOST): Use atomic operations for lock-free checking
- For platforms without atomics (LibreTiny): Take lock to safely read the remove flag  
- For single-threaded platforms (ESP8266, RP2040): Direct check without synchronization

### Testing
Created integration test `test_scheduler_removed_item_race.py` that:
1. Schedules multiple timeouts with identical execution times
2. Ensures a non-cancelled item blocks `cleanup_()` at the front of the heap
3. Cancels items behind it (which remain in heap)
4. Verifies cancelled items don't execute

Test results on HOST platform:
- Without fix: Test fails - cancelled items execute (race condition detected)
- With fix: Test passes - cancelled items are properly skipped

The integration test runs on the HOST platform and successfully reproduces and verifies the fix for the race condition. Hardware testing on actual microcontrollers is still needed to confirm the fix works correctly on all platforms.

### Thread Safety
The fix properly handles all three threading models in ESPHome:
- `ESPHOME_THREAD_SINGLE`: Direct access (ESP8266, RP2040)
- `ESPHOME_THREAD_MULTI_ATOMICS`: Atomic operations (ESP32, HOST)
- `ESPHOME_THREAD_MULTI_NO_ATOMICS`: Lock-based access (LibreTiny)

