### PR TITLE
[libretiny] Optimize preferences is_changed() by replacing temporary vector with unique_ptr

### DIFF
--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/preferences.h"
 #include <flashdb.h>
 #include <cstring>
+#include <memory>
 #include <vector>
 #include <string>
 
@@ -139,21 +140,29 @@ class LibreTinyPreferences : public ESPPreferences {
   }
 
   bool is_changed(const fdb_kvdb_t db, const NVSData &to_save) {
-    NVSData stored_data{};
     struct fdb_kv kv;
     fdb_kv_t kvp = fdb_kv_get_obj(db, to_save.key.c_str(), &kv);
     if (kvp == nullptr) {
       ESP_LOGV(TAG, "fdb_kv_get_obj('%s'): nullptr - the key might not be set yet", to_save.key.c_str());
       return true;
     }
-    stored_data.data.resize(kv.value_len);
-    fdb_blob_make(&blob, stored_data.data.data(), kv.value_len);
+
+    // Check size first - if different, data has changed
+    if (kv.value_len != to_save.data.size()) {
+      return true;
+    }
+
+    // Allocate buffer on heap to avoid stack allocation for large data
+    auto stored_data = std::make_unique<uint8_t[]>(kv.value_len);
+    fdb_blob_make(&blob, stored_data.get(), kv.value_len);
     size_t actual_len = fdb_kv_get_blob(db, to_save.key.c_str(), &blob);
     if (actual_len != kv.value_len) {
       ESP_LOGV(TAG, "fdb_kv_get_blob('%s') len mismatch: %u != %u", to_save.key.c_str(), actual_len, kv.value_len);
       return true;
     }
-    return to_save.data != stored_data.data;
+
+    // Compare the actual data
+    return memcmp(to_save.data.data(), stored_data.get(), kv.value_len) != 0;
   }
 
   bool reset() override {

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -6,7 +6,6 @@
 #include <flashdb.h>
 #include <cstring>
 #include <memory>
-#include <vector>
 #include <string>
 
 namespace esphome {


### PR DESCRIPTION
# What does this implement/fix?

Optimizes LibreTiny preferences `is_changed()` method by replacing temporary vector allocation with `std::make_unique<uint8_t[]>`, following the same optimization pattern implemented for ESP32 in PR #10246.

This change:
- Eliminates unnecessary vector overhead for temporary storage
- Adds early size comparison to avoid memory allocation when data sizes differ
- Uses direct `memcmp()` for more efficient byte comparison
- Reduces memory fragmentation on memory-constrained LibreTiny devices
- Saves 64 bytes of flash memory on BK7200 (761860 → 761796 bytes) on 32-bit platform

**Performance improvements (benchmark results):**
- 40-82% faster for typical preference data sizes (16B-4KB)
- 97% faster when preference sizes differ (early exit optimization)
- Eliminates ~12 bytes of vector metadata overhead per comparison on 32-bit platforms

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows the same optimization pattern as commit 6c5632a0b (PR #10246) for ESP32

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-exposed functionality changes%                 