### PR TITLE
[nextion] Don't include terminating NUL in nextion text_sensor states

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -764,7 +764,8 @@ void Nextion::process_nextion_commands_() {
         variable_name = to_process.substr(0, index);
         ++index;
 
-        text_value = to_process.substr(index);
+        // Get variable value without terminating NUL byte.  Length check above ensures substr len >= 0.
+        text_value = to_process.substr(index, to_process.length() - index - 1);
 
         ESP_LOGN(TAG, "Text sensor: %s='%s'", variable_name.c_str(), text_value.c_str());
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -765,7 +765,7 @@ void Nextion::process_nextion_commands_() {
         ++index;
 
         // Get variable value without terminating NUL byte.  Length check above ensures substr len >= 0.
-        text_value = to_process.substr(index, to_process.length() - index - 1);
+        text_value = to_process.substr(index, to_process_length - index - 1);
 
         ESP_LOGN(TAG, "Text sensor: %s='%s'", variable_name.c_str(), text_value.c_str());
 


### PR DESCRIPTION
# What does this implement/fix?

Trim off the trailing NUL of the serial response when setting text_sensor states.  NULs aren't allowed in sensor states and will upset the hass recorder with some database backends.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: nextion

text_sensor:
  - id: version_tft
    name: Version TFT
    platform: nextion
    component_name: boot.version
    entity_category: diagnostic

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
