### PR TITLE
[core] Fix post-OTA logs display when using esphome run and MQTT

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -476,7 +476,7 @@ def show_logs(config: ConfigType, args: ArgsProtocol, devices: list[str]) -> int
         from esphome.components.api.client import run_logs
 
         return run_logs(config, addresses_to_use)
-    if get_port_type(port) == "MQTT" and "mqtt" in config:
+    if get_port_type(port) in ("NETWORK", "MQTT") and "mqtt" in config:
         from esphome import mqtt
 
         return mqtt.show_logs(


### PR DESCRIPTION
# What does this implement/fix?

When transitioning to showing logs after an OTA, get_port_type() is called with the device's hostname which returns "NETWORK" instead of "MQTT".  This causes esphome to incorrectly claim no remote logging is configured at the end of an OTA of an MQTT-only device, even though running `esphome logs` afterwards works.

This change tweaks the logging logic to use MQTT logging in either case when mqtt is available but native logs aren't, because `esphome logs` still ends up passing in "MQTT" instead of the hostname to show_logs().

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
mqtt:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
