### PR TITLE
[senseair] Discard 0 ppm readings with "Out Of Range" bit set.

### DIFF
--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -53,10 +53,14 @@ void SenseAirComponent::update() {
 
   this->status_clear_warning();
   const uint8_t length = response[2];
-  const uint16_t status = (uint16_t(response[3]) << 8) | response[4];
-  const int16_t ppm = int16_t((response[length + 1] << 8) | response[length + 2]);
+  const uint16_t status = encode_uint16(response[3], response[4]);
+  const uint16_t ppm = encode_uint16(response[length + 1], response[length + 2]);
 
-  ESP_LOGD(TAG, "SenseAir Received CO₂=%dppm Status=0x%02X", ppm, status);
+  ESP_LOGD(TAG, "SenseAir Received CO₂=%uppm Status=0x%02X", ppm, status);
+  if (ppm == 0 && (status & SenseAirStatus::OUT_OF_RANGE_ERROR) != 0) {
+    ESP_LOGD(TAG, "Discarding 0 ppm reading with out-of-range status.");
+    return;
+  }
   if (this->co2_sensor_ != nullptr)
     this->co2_sensor_->publish_state(ppm);
 }

--- a/esphome/components/senseair/senseair.h
+++ b/esphome/components/senseair/senseair.h
@@ -8,6 +8,17 @@
 namespace esphome {
 namespace senseair {
 
+enum SenseAirStatus : uint8_t {
+  FATAL_ERROR = 1 << 0,
+  OFFSET_ERROR = 1 << 1,
+  ALGORITHM_ERROR = 1 << 2,
+  OUTPUT_ERROR = 1 << 3,
+  SELF_DIAGNOSTIC_ERROR = 1 << 4,
+  OUT_OF_RANGE_ERROR = 1 << 5,
+  MEMORY_ERROR = 1 << 6,
+  RESERVED = 1 << 7
+};
+
 class SenseAirComponent : public PollingComponent, public uart::UARTDevice {
  public:
   float get_setup_priority() const override { return setup_priority::DATA; }


### PR DESCRIPTION
# What does this implement/fix?

If you attempt to read from the SenseAir S8 before it has acquired its first measurement (which can happen after a power cycle if the MCU boots quickly enough), the reading will return 0 PPM and the "Out Of Range" bit will be set in the MeterStatus register.

This change discards such readings instead of sending incorrect data                                                                                           
and cleans up some manual byte combining to use encode_uint16().

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: senseair
    co2:
      name: "CO2 Concentration"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
