### PR TITLE
[api] Mark protobuf message classes as final to enable compiler optimizations

### DIFF
--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -321,7 +321,7 @@ class CommandProtoMessage : public ProtoDecodableMessage {
 
  protected:
 };
-class HelloRequest : public ProtoDecodableMessage {
+class HelloRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 1;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -339,7 +339,7 @@ class HelloRequest : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class HelloResponse : public ProtoMessage {
+class HelloResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 2;
   static constexpr uint8_t ESTIMATED_SIZE = 26;
@@ -360,7 +360,7 @@ class HelloResponse : public ProtoMessage {
 
  protected:
 };
-class ConnectRequest : public ProtoDecodableMessage {
+class ConnectRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 3;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
@@ -375,7 +375,7 @@ class ConnectRequest : public ProtoDecodableMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class ConnectResponse : public ProtoMessage {
+class ConnectResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 4;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
@@ -391,7 +391,7 @@ class ConnectResponse : public ProtoMessage {
 
  protected:
 };
-class DisconnectRequest : public ProtoMessage {
+class DisconnectRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 5;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -404,7 +404,7 @@ class DisconnectRequest : public ProtoMessage {
 
  protected:
 };
-class DisconnectResponse : public ProtoMessage {
+class DisconnectResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 6;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -417,7 +417,7 @@ class DisconnectResponse : public ProtoMessage {
 
  protected:
 };
-class PingRequest : public ProtoMessage {
+class PingRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 7;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -430,7 +430,7 @@ class PingRequest : public ProtoMessage {
 
  protected:
 };
-class PingResponse : public ProtoMessage {
+class PingResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 8;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -443,7 +443,7 @@ class PingResponse : public ProtoMessage {
 
  protected:
 };
-class DeviceInfoRequest : public ProtoMessage {
+class DeviceInfoRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 9;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -457,7 +457,7 @@ class DeviceInfoRequest : public ProtoMessage {
  protected:
 };
 #ifdef USE_AREAS
-class AreaInfo : public ProtoMessage {
+class AreaInfo final : public ProtoMessage {
  public:
   uint32_t area_id{0};
   StringRef name_ref_{};
@@ -472,7 +472,7 @@ class AreaInfo : public ProtoMessage {
 };
 #endif
 #ifdef USE_DEVICES
-class DeviceInfo : public ProtoMessage {
+class DeviceInfo final : public ProtoMessage {
  public:
   uint32_t device_id{0};
   StringRef name_ref_{};
@@ -487,7 +487,7 @@ class DeviceInfo : public ProtoMessage {
  protected:
 };
 #endif
-class DeviceInfoResponse : public ProtoMessage {
+class DeviceInfoResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 10;
   static constexpr uint8_t ESTIMATED_SIZE = 247;
@@ -559,7 +559,7 @@ class DeviceInfoResponse : public ProtoMessage {
 
  protected:
 };
-class ListEntitiesRequest : public ProtoMessage {
+class ListEntitiesRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 11;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -572,7 +572,7 @@ class ListEntitiesRequest : public ProtoMessage {
 
  protected:
 };
-class ListEntitiesDoneResponse : public ProtoMessage {
+class ListEntitiesDoneResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 19;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -585,7 +585,7 @@ class ListEntitiesDoneResponse : public ProtoMessage {
 
  protected:
 };
-class SubscribeStatesRequest : public ProtoMessage {
+class SubscribeStatesRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 20;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -599,7 +599,7 @@ class SubscribeStatesRequest : public ProtoMessage {
  protected:
 };
 #ifdef USE_BINARY_SENSOR
-class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
+class ListEntitiesBinarySensorResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 12;
   static constexpr uint8_t ESTIMATED_SIZE = 51;
@@ -617,7 +617,7 @@ class ListEntitiesBinarySensorResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class BinarySensorStateResponse : public StateResponseProtoMessage {
+class BinarySensorStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 21;
   static constexpr uint8_t ESTIMATED_SIZE = 13;
@@ -636,7 +636,7 @@ class BinarySensorStateResponse : public StateResponseProtoMessage {
 };
 #endif
 #ifdef USE_COVER
-class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
+class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 13;
   static constexpr uint8_t ESTIMATED_SIZE = 57;
@@ -657,7 +657,7 @@ class ListEntitiesCoverResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class CoverStateResponse : public StateResponseProtoMessage {
+class CoverStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 22;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
@@ -675,7 +675,7 @@ class CoverStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class CoverCommandRequest : public CommandProtoMessage {
+class CoverCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 30;
   static constexpr uint8_t ESTIMATED_SIZE = 25;
@@ -697,7 +697,7 @@ class CoverCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_FAN
-class ListEntitiesFanResponse : public InfoResponseProtoMessage {
+class ListEntitiesFanResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 14;
   static constexpr uint8_t ESTIMATED_SIZE = 68;
@@ -717,7 +717,7 @@ class ListEntitiesFanResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class FanStateResponse : public StateResponseProtoMessage {
+class FanStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 23;
   static constexpr uint8_t ESTIMATED_SIZE = 28;
@@ -738,7 +738,7 @@ class FanStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class FanCommandRequest : public CommandProtoMessage {
+class FanCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 31;
   static constexpr uint8_t ESTIMATED_SIZE = 38;
@@ -766,7 +766,7 @@ class FanCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_LIGHT
-class ListEntitiesLightResponse : public InfoResponseProtoMessage {
+class ListEntitiesLightResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 15;
   static constexpr uint8_t ESTIMATED_SIZE = 73;
@@ -785,7 +785,7 @@ class ListEntitiesLightResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class LightStateResponse : public StateResponseProtoMessage {
+class LightStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 24;
   static constexpr uint8_t ESTIMATED_SIZE = 67;
@@ -813,7 +813,7 @@ class LightStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class LightCommandRequest : public CommandProtoMessage {
+class LightCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 32;
   static constexpr uint8_t ESTIMATED_SIZE = 112;
@@ -857,7 +857,7 @@ class LightCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_SENSOR
-class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
+class ListEntitiesSensorResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 16;
   static constexpr uint8_t ESTIMATED_SIZE = 66;
@@ -879,7 +879,7 @@ class ListEntitiesSensorResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class SensorStateResponse : public StateResponseProtoMessage {
+class SensorStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 25;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
@@ -898,7 +898,7 @@ class SensorStateResponse : public StateResponseProtoMessage {
 };
 #endif
 #ifdef USE_SWITCH
-class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
+class ListEntitiesSwitchResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 17;
   static constexpr uint8_t ESTIMATED_SIZE = 51;
@@ -916,7 +916,7 @@ class ListEntitiesSwitchResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class SwitchStateResponse : public StateResponseProtoMessage {
+class SwitchStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 26;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -932,7 +932,7 @@ class SwitchStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class SwitchCommandRequest : public CommandProtoMessage {
+class SwitchCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 33;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -950,7 +950,7 @@ class SwitchCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_TEXT_SENSOR
-class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
+class ListEntitiesTextSensorResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 18;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
@@ -967,7 +967,7 @@ class ListEntitiesTextSensorResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class TextSensorStateResponse : public StateResponseProtoMessage {
+class TextSensorStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 27;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -986,7 +986,7 @@ class TextSensorStateResponse : public StateResponseProtoMessage {
  protected:
 };
 #endif
-class SubscribeLogsRequest : public ProtoDecodableMessage {
+class SubscribeLogsRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 28;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1002,7 +1002,7 @@ class SubscribeLogsRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class SubscribeLogsResponse : public ProtoMessage {
+class SubscribeLogsResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 29;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -1025,7 +1025,7 @@ class SubscribeLogsResponse : public ProtoMessage {
  protected:
 };
 #ifdef USE_API_NOISE
-class NoiseEncryptionSetKeyRequest : public ProtoDecodableMessage {
+class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 124;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
@@ -1040,7 +1040,7 @@ class NoiseEncryptionSetKeyRequest : public ProtoDecodableMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class NoiseEncryptionSetKeyResponse : public ProtoMessage {
+class NoiseEncryptionSetKeyResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 125;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
@@ -1058,7 +1058,7 @@ class NoiseEncryptionSetKeyResponse : public ProtoMessage {
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-class SubscribeHomeassistantServicesRequest : public ProtoMessage {
+class SubscribeHomeassistantServicesRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 34;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1071,7 +1071,7 @@ class SubscribeHomeassistantServicesRequest : public ProtoMessage {
 
  protected:
 };
-class HomeassistantServiceMap : public ProtoMessage {
+class HomeassistantServiceMap final : public ProtoMessage {
  public:
   StringRef key_ref_{};
   void set_key(const StringRef &ref) { this->key_ref_ = ref; }
@@ -1084,7 +1084,7 @@ class HomeassistantServiceMap : public ProtoMessage {
 
  protected:
 };
-class HomeassistantServiceResponse : public ProtoMessage {
+class HomeassistantServiceResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 35;
   static constexpr uint8_t ESTIMATED_SIZE = 113;
@@ -1107,7 +1107,7 @@ class HomeassistantServiceResponse : public ProtoMessage {
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
-class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
+class SubscribeHomeAssistantStatesRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 38;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1120,7 +1120,7 @@ class SubscribeHomeAssistantStatesRequest : public ProtoMessage {
 
  protected:
 };
-class SubscribeHomeAssistantStateResponse : public ProtoMessage {
+class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 39;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -1140,7 +1140,7 @@ class SubscribeHomeAssistantStateResponse : public ProtoMessage {
 
  protected:
 };
-class HomeAssistantStateResponse : public ProtoDecodableMessage {
+class HomeAssistantStateResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 40;
   static constexpr uint8_t ESTIMATED_SIZE = 27;
@@ -1158,7 +1158,7 @@ class HomeAssistantStateResponse : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 #endif
-class GetTimeRequest : public ProtoMessage {
+class GetTimeRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 36;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -1171,7 +1171,7 @@ class GetTimeRequest : public ProtoMessage {
 
  protected:
 };
-class GetTimeResponse : public ProtoDecodableMessage {
+class GetTimeResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 37;
   static constexpr uint8_t ESTIMATED_SIZE = 5;
@@ -1189,7 +1189,7 @@ class GetTimeResponse : public ProtoDecodableMessage {
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
 };
 #ifdef USE_API_SERVICES
-class ListEntitiesServicesArgument : public ProtoMessage {
+class ListEntitiesServicesArgument final : public ProtoMessage {
  public:
   StringRef name_ref_{};
   void set_name(const StringRef &ref) { this->name_ref_ = ref; }
@@ -1202,7 +1202,7 @@ class ListEntitiesServicesArgument : public ProtoMessage {
 
  protected:
 };
-class ListEntitiesServicesResponse : public ProtoMessage {
+class ListEntitiesServicesResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 41;
   static constexpr uint8_t ESTIMATED_SIZE = 48;
@@ -1221,7 +1221,7 @@ class ListEntitiesServicesResponse : public ProtoMessage {
 
  protected:
 };
-class ExecuteServiceArgument : public ProtoDecodableMessage {
+class ExecuteServiceArgument final : public ProtoDecodableMessage {
  public:
   bool bool_{false};
   int32_t legacy_int{0};
@@ -1241,7 +1241,7 @@ class ExecuteServiceArgument : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class ExecuteServiceRequest : public ProtoDecodableMessage {
+class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 42;
   static constexpr uint8_t ESTIMATED_SIZE = 39;
@@ -1260,7 +1260,7 @@ class ExecuteServiceRequest : public ProtoDecodableMessage {
 };
 #endif
 #ifdef USE_CAMERA
-class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
+class ListEntitiesCameraResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 43;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
@@ -1275,7 +1275,7 @@ class ListEntitiesCameraResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class CameraImageResponse : public StateResponseProtoMessage {
+class CameraImageResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 44;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -1297,7 +1297,7 @@ class CameraImageResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class CameraImageRequest : public ProtoDecodableMessage {
+class CameraImageRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 45;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1315,7 +1315,7 @@ class CameraImageRequest : public ProtoDecodableMessage {
 };
 #endif
 #ifdef USE_CLIMATE
-class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
+class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 46;
   static constexpr uint8_t ESTIMATED_SIZE = 145;
@@ -1347,7 +1347,7 @@ class ListEntitiesClimateResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class ClimateStateResponse : public StateResponseProtoMessage {
+class ClimateStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 47;
   static constexpr uint8_t ESTIMATED_SIZE = 68;
@@ -1377,7 +1377,7 @@ class ClimateStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class ClimateCommandRequest : public CommandProtoMessage {
+class ClimateCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 48;
   static constexpr uint8_t ESTIMATED_SIZE = 84;
@@ -1415,7 +1415,7 @@ class ClimateCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_NUMBER
-class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
+class ListEntitiesNumberResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 49;
   static constexpr uint8_t ESTIMATED_SIZE = 75;
@@ -1438,7 +1438,7 @@ class ListEntitiesNumberResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class NumberStateResponse : public StateResponseProtoMessage {
+class NumberStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 50;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
@@ -1455,7 +1455,7 @@ class NumberStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class NumberCommandRequest : public CommandProtoMessage {
+class NumberCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 51;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
@@ -1473,7 +1473,7 @@ class NumberCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_SELECT
-class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
+class ListEntitiesSelectResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 52;
   static constexpr uint8_t ESTIMATED_SIZE = 58;
@@ -1489,7 +1489,7 @@ class ListEntitiesSelectResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class SelectStateResponse : public StateResponseProtoMessage {
+class SelectStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 53;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -1507,7 +1507,7 @@ class SelectStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class SelectCommandRequest : public CommandProtoMessage {
+class SelectCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 54;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -1526,7 +1526,7 @@ class SelectCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_SIREN
-class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
+class ListEntitiesSirenResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 55;
   static constexpr uint8_t ESTIMATED_SIZE = 62;
@@ -1544,7 +1544,7 @@ class ListEntitiesSirenResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class SirenStateResponse : public StateResponseProtoMessage {
+class SirenStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 56;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -1560,7 +1560,7 @@ class SirenStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class SirenCommandRequest : public CommandProtoMessage {
+class SirenCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 57;
   static constexpr uint8_t ESTIMATED_SIZE = 37;
@@ -1586,7 +1586,7 @@ class SirenCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_LOCK
-class ListEntitiesLockResponse : public InfoResponseProtoMessage {
+class ListEntitiesLockResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 58;
   static constexpr uint8_t ESTIMATED_SIZE = 55;
@@ -1606,7 +1606,7 @@ class ListEntitiesLockResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class LockStateResponse : public StateResponseProtoMessage {
+class LockStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 59;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -1622,7 +1622,7 @@ class LockStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class LockCommandRequest : public CommandProtoMessage {
+class LockCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 60;
   static constexpr uint8_t ESTIMATED_SIZE = 22;
@@ -1643,7 +1643,7 @@ class LockCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_BUTTON
-class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
+class ListEntitiesButtonResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 61;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
@@ -1660,7 +1660,7 @@ class ListEntitiesButtonResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class ButtonCommandRequest : public CommandProtoMessage {
+class ButtonCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 62;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
@@ -1677,7 +1677,7 @@ class ButtonCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
-class MediaPlayerSupportedFormat : public ProtoMessage {
+class MediaPlayerSupportedFormat final : public ProtoMessage {
  public:
   StringRef format_ref_{};
   void set_format(const StringRef &ref) { this->format_ref_ = ref; }
@@ -1693,7 +1693,7 @@ class MediaPlayerSupportedFormat : public ProtoMessage {
 
  protected:
 };
-class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
+class ListEntitiesMediaPlayerResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 63;
   static constexpr uint8_t ESTIMATED_SIZE = 80;
@@ -1711,7 +1711,7 @@ class ListEntitiesMediaPlayerResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class MediaPlayerStateResponse : public StateResponseProtoMessage {
+class MediaPlayerStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 64;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -1729,7 +1729,7 @@ class MediaPlayerStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class MediaPlayerCommandRequest : public CommandProtoMessage {
+class MediaPlayerCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 65;
   static constexpr uint8_t ESTIMATED_SIZE = 35;
@@ -1755,7 +1755,7 @@ class MediaPlayerCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-class SubscribeBluetoothLEAdvertisementsRequest : public ProtoDecodableMessage {
+class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 66;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1770,7 +1770,7 @@ class SubscribeBluetoothLEAdvertisementsRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothLERawAdvertisement : public ProtoMessage {
+class BluetoothLERawAdvertisement final : public ProtoMessage {
  public:
   uint64_t address{0};
   int32_t rssi{0};
@@ -1785,7 +1785,7 @@ class BluetoothLERawAdvertisement : public ProtoMessage {
 
  protected:
 };
-class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
+class BluetoothLERawAdvertisementsResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 93;
   static constexpr uint8_t ESTIMATED_SIZE = 136;
@@ -1802,7 +1802,7 @@ class BluetoothLERawAdvertisementsResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothDeviceRequest : public ProtoDecodableMessage {
+class BluetoothDeviceRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 68;
   static constexpr uint8_t ESTIMATED_SIZE = 12;
@@ -1820,7 +1820,7 @@ class BluetoothDeviceRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothDeviceConnectionResponse : public ProtoMessage {
+class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 69;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
@@ -1839,7 +1839,7 @@ class BluetoothDeviceConnectionResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTGetServicesRequest : public ProtoDecodableMessage {
+class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 70;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1854,7 +1854,7 @@ class BluetoothGATTGetServicesRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTDescriptor : public ProtoMessage {
+class BluetoothGATTDescriptor final : public ProtoMessage {
  public:
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
@@ -1867,7 +1867,7 @@ class BluetoothGATTDescriptor : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTCharacteristic : public ProtoMessage {
+class BluetoothGATTCharacteristic final : public ProtoMessage {
  public:
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
@@ -1882,7 +1882,7 @@ class BluetoothGATTCharacteristic : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTService : public ProtoMessage {
+class BluetoothGATTService final : public ProtoMessage {
  public:
   std::array<uint64_t, 2> uuid{};
   uint32_t handle{0};
@@ -1896,7 +1896,7 @@ class BluetoothGATTService : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTGetServicesResponse : public ProtoMessage {
+class BluetoothGATTGetServicesResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 71;
   static constexpr uint8_t ESTIMATED_SIZE = 38;
@@ -1913,7 +1913,7 @@ class BluetoothGATTGetServicesResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
+class BluetoothGATTGetServicesDoneResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 72;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -1929,7 +1929,7 @@ class BluetoothGATTGetServicesDoneResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTReadRequest : public ProtoDecodableMessage {
+class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 73;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -1945,7 +1945,7 @@ class BluetoothGATTReadRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTReadResponse : public ProtoMessage {
+class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 74;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -1968,7 +1968,7 @@ class BluetoothGATTReadResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTWriteRequest : public ProtoDecodableMessage {
+class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 75;
   static constexpr uint8_t ESTIMATED_SIZE = 19;
@@ -1987,7 +1987,7 @@ class BluetoothGATTWriteRequest : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTReadDescriptorRequest : public ProtoDecodableMessage {
+class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 76;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -2003,7 +2003,7 @@ class BluetoothGATTReadDescriptorRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTWriteDescriptorRequest : public ProtoDecodableMessage {
+class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 77;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -2021,7 +2021,7 @@ class BluetoothGATTWriteDescriptorRequest : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTNotifyRequest : public ProtoDecodableMessage {
+class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 78;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
@@ -2038,7 +2038,7 @@ class BluetoothGATTNotifyRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class BluetoothGATTNotifyDataResponse : public ProtoMessage {
+class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 79;
   static constexpr uint8_t ESTIMATED_SIZE = 17;
@@ -2061,7 +2061,7 @@ class BluetoothGATTNotifyDataResponse : public ProtoMessage {
 
  protected:
 };
-class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
+class SubscribeBluetoothConnectionsFreeRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 80;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2074,7 +2074,7 @@ class SubscribeBluetoothConnectionsFreeRequest : public ProtoMessage {
 
  protected:
 };
-class BluetoothConnectionsFreeResponse : public ProtoMessage {
+class BluetoothConnectionsFreeResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 81;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -2092,7 +2092,7 @@ class BluetoothConnectionsFreeResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTErrorResponse : public ProtoMessage {
+class BluetoothGATTErrorResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 82;
   static constexpr uint8_t ESTIMATED_SIZE = 12;
@@ -2110,7 +2110,7 @@ class BluetoothGATTErrorResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTWriteResponse : public ProtoMessage {
+class BluetoothGATTWriteResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 83;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -2127,7 +2127,7 @@ class BluetoothGATTWriteResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothGATTNotifyResponse : public ProtoMessage {
+class BluetoothGATTNotifyResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 84;
   static constexpr uint8_t ESTIMATED_SIZE = 8;
@@ -2144,7 +2144,7 @@ class BluetoothGATTNotifyResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothDevicePairingResponse : public ProtoMessage {
+class BluetoothDevicePairingResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 85;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
@@ -2162,7 +2162,7 @@ class BluetoothDevicePairingResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothDeviceUnpairingResponse : public ProtoMessage {
+class BluetoothDeviceUnpairingResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 86;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
@@ -2180,7 +2180,7 @@ class BluetoothDeviceUnpairingResponse : public ProtoMessage {
 
  protected:
 };
-class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
+class UnsubscribeBluetoothLEAdvertisementsRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 87;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2193,7 +2193,7 @@ class UnsubscribeBluetoothLEAdvertisementsRequest : public ProtoMessage {
 
  protected:
 };
-class BluetoothDeviceClearCacheResponse : public ProtoMessage {
+class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 88;
   static constexpr uint8_t ESTIMATED_SIZE = 10;
@@ -2211,7 +2211,7 @@ class BluetoothDeviceClearCacheResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothScannerStateResponse : public ProtoMessage {
+class BluetoothScannerStateResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 126;
   static constexpr uint8_t ESTIMATED_SIZE = 4;
@@ -2228,7 +2228,7 @@ class BluetoothScannerStateResponse : public ProtoMessage {
 
  protected:
 };
-class BluetoothScannerSetModeRequest : public ProtoDecodableMessage {
+class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 127;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
@@ -2245,7 +2245,7 @@ class BluetoothScannerSetModeRequest : public ProtoDecodableMessage {
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
-class SubscribeVoiceAssistantRequest : public ProtoDecodableMessage {
+class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 89;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
@@ -2261,7 +2261,7 @@ class SubscribeVoiceAssistantRequest : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAudioSettings : public ProtoMessage {
+class VoiceAssistantAudioSettings final : public ProtoMessage {
  public:
   uint32_t noise_suppression_level{0};
   uint32_t auto_gain{0};
@@ -2274,7 +2274,7 @@ class VoiceAssistantAudioSettings : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantRequest : public ProtoMessage {
+class VoiceAssistantRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 90;
   static constexpr uint8_t ESTIMATED_SIZE = 41;
@@ -2296,7 +2296,7 @@ class VoiceAssistantRequest : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantResponse : public ProtoDecodableMessage {
+class VoiceAssistantResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 91;
   static constexpr uint8_t ESTIMATED_SIZE = 6;
@@ -2312,7 +2312,7 @@ class VoiceAssistantResponse : public ProtoDecodableMessage {
  protected:
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantEventData : public ProtoDecodableMessage {
+class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
   std::string name{};
   std::string value{};
@@ -2323,7 +2323,7 @@ class VoiceAssistantEventData : public ProtoDecodableMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class VoiceAssistantEventResponse : public ProtoDecodableMessage {
+class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 92;
   static constexpr uint8_t ESTIMATED_SIZE = 36;
@@ -2340,7 +2340,7 @@ class VoiceAssistantEventResponse : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAudio : public ProtoDecodableMessage {
+class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 106;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -2365,7 +2365,7 @@ class VoiceAssistantAudio : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantTimerEventResponse : public ProtoDecodableMessage {
+class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 115;
   static constexpr uint8_t ESTIMATED_SIZE = 30;
@@ -2386,7 +2386,7 @@ class VoiceAssistantTimerEventResponse : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAnnounceRequest : public ProtoDecodableMessage {
+class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 119;
   static constexpr uint8_t ESTIMATED_SIZE = 29;
@@ -2405,7 +2405,7 @@ class VoiceAssistantAnnounceRequest : public ProtoDecodableMessage {
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
   bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
-class VoiceAssistantAnnounceFinished : public ProtoMessage {
+class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 120;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
@@ -2421,7 +2421,7 @@ class VoiceAssistantAnnounceFinished : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantWakeWord : public ProtoMessage {
+class VoiceAssistantWakeWord final : public ProtoMessage {
  public:
   StringRef id_ref_{};
   void set_id(const StringRef &ref) { this->id_ref_ = ref; }
@@ -2436,7 +2436,7 @@ class VoiceAssistantWakeWord : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantConfigurationRequest : public ProtoMessage {
+class VoiceAssistantConfigurationRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 121;
   static constexpr uint8_t ESTIMATED_SIZE = 0;
@@ -2449,7 +2449,7 @@ class VoiceAssistantConfigurationRequest : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantConfigurationResponse : public ProtoMessage {
+class VoiceAssistantConfigurationResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 122;
   static constexpr uint8_t ESTIMATED_SIZE = 56;
@@ -2467,7 +2467,7 @@ class VoiceAssistantConfigurationResponse : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantSetConfiguration : public ProtoDecodableMessage {
+class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 123;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -2484,7 +2484,7 @@ class VoiceAssistantSetConfiguration : public ProtoDecodableMessage {
 };
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
+class ListEntitiesAlarmControlPanelResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 94;
   static constexpr uint8_t ESTIMATED_SIZE = 48;
@@ -2502,7 +2502,7 @@ class ListEntitiesAlarmControlPanelResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
+class AlarmControlPanelStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 95;
   static constexpr uint8_t ESTIMATED_SIZE = 11;
@@ -2518,7 +2518,7 @@ class AlarmControlPanelStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class AlarmControlPanelCommandRequest : public CommandProtoMessage {
+class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 96;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -2538,7 +2538,7 @@ class AlarmControlPanelCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_TEXT
-class ListEntitiesTextResponse : public InfoResponseProtoMessage {
+class ListEntitiesTextResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 97;
   static constexpr uint8_t ESTIMATED_SIZE = 59;
@@ -2558,7 +2558,7 @@ class ListEntitiesTextResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class TextStateResponse : public StateResponseProtoMessage {
+class TextStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 98;
   static constexpr uint8_t ESTIMATED_SIZE = 20;
@@ -2576,7 +2576,7 @@ class TextStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class TextCommandRequest : public CommandProtoMessage {
+class TextCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 99;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -2595,7 +2595,7 @@ class TextCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_DATETIME_DATE
-class ListEntitiesDateResponse : public InfoResponseProtoMessage {
+class ListEntitiesDateResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 100;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
@@ -2610,7 +2610,7 @@ class ListEntitiesDateResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class DateStateResponse : public StateResponseProtoMessage {
+class DateStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 101;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
@@ -2629,7 +2629,7 @@ class DateStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class DateCommandRequest : public CommandProtoMessage {
+class DateCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 102;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
@@ -2649,7 +2649,7 @@ class DateCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_DATETIME_TIME
-class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
+class ListEntitiesTimeResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 103;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
@@ -2664,7 +2664,7 @@ class ListEntitiesTimeResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class TimeStateResponse : public StateResponseProtoMessage {
+class TimeStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 104;
   static constexpr uint8_t ESTIMATED_SIZE = 23;
@@ -2683,7 +2683,7 @@ class TimeStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class TimeCommandRequest : public CommandProtoMessage {
+class TimeCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 105;
   static constexpr uint8_t ESTIMATED_SIZE = 21;
@@ -2703,7 +2703,7 @@ class TimeCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_EVENT
-class ListEntitiesEventResponse : public InfoResponseProtoMessage {
+class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 107;
   static constexpr uint8_t ESTIMATED_SIZE = 67;
@@ -2721,7 +2721,7 @@ class ListEntitiesEventResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class EventResponse : public StateResponseProtoMessage {
+class EventResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 108;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -2740,7 +2740,7 @@ class EventResponse : public StateResponseProtoMessage {
 };
 #endif
 #ifdef USE_VALVE
-class ListEntitiesValveResponse : public InfoResponseProtoMessage {
+class ListEntitiesValveResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 109;
   static constexpr uint8_t ESTIMATED_SIZE = 55;
@@ -2760,7 +2760,7 @@ class ListEntitiesValveResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class ValveStateResponse : public StateResponseProtoMessage {
+class ValveStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 110;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
@@ -2777,7 +2777,7 @@ class ValveStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class ValveCommandRequest : public CommandProtoMessage {
+class ValveCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 111;
   static constexpr uint8_t ESTIMATED_SIZE = 18;
@@ -2797,7 +2797,7 @@ class ValveCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_DATETIME_DATETIME
-class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
+class ListEntitiesDateTimeResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 112;
   static constexpr uint8_t ESTIMATED_SIZE = 40;
@@ -2812,7 +2812,7 @@ class ListEntitiesDateTimeResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class DateTimeStateResponse : public StateResponseProtoMessage {
+class DateTimeStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 113;
   static constexpr uint8_t ESTIMATED_SIZE = 16;
@@ -2829,7 +2829,7 @@ class DateTimeStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class DateTimeCommandRequest : public CommandProtoMessage {
+class DateTimeCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 114;
   static constexpr uint8_t ESTIMATED_SIZE = 14;
@@ -2847,7 +2847,7 @@ class DateTimeCommandRequest : public CommandProtoMessage {
 };
 #endif
 #ifdef USE_UPDATE
-class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
+class ListEntitiesUpdateResponse final : public InfoResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 116;
   static constexpr uint8_t ESTIMATED_SIZE = 49;
@@ -2864,7 +2864,7 @@ class ListEntitiesUpdateResponse : public InfoResponseProtoMessage {
 
  protected:
 };
-class UpdateStateResponse : public StateResponseProtoMessage {
+class UpdateStateResponse final : public StateResponseProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 117;
   static constexpr uint8_t ESTIMATED_SIZE = 65;
@@ -2893,7 +2893,7 @@ class UpdateStateResponse : public StateResponseProtoMessage {
 
  protected:
 };
-class UpdateCommandRequest : public CommandProtoMessage {
+class UpdateCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 118;
   static constexpr uint8_t ESTIMATED_SIZE = 11;

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1952,7 +1952,7 @@ def build_message_type(
     dump_impl += "}\n"
 
     if base_class:
-        out = f"class {desc.name} : public {base_class} {{\n"
+        out = f"class {desc.name} final : public {base_class} {{\n"
     else:
         # Check if message has any non-deprecated fields
         has_fields = any(not field.options.deprecated for field in desc.field)
@@ -1961,7 +1961,7 @@ def build_message_type(
             base_class = "ProtoDecodableMessage"
         else:
             base_class = "ProtoMessage"
-        out = f"class {desc.name} : public {base_class} {{\n"
+        out = f"class {desc.name} final : public {base_class} {{\n"
     out += " public:\n"
     out += indent("\n".join(public_content)) + "\n"
     out += "\n"


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the `final` keyword to all protobuf message classes in the API component to enable compiler devirtualization optimizations. This is a performance and flash memory optimization that allows the compiler to convert virtual function calls to direct calls when it can prove that no derived classes exist.

## Technical Details

The change modifies the Python code generator (`script/api_protobuf/api_protobuf.py`) to add the `final` keyword to all generated protobuf message classes. When a class is marked as `final`, the compiler knows that no class can inherit from it, which enables several optimizations:

1. **Devirtualization**: Virtual function calls can be converted to direct calls, eliminating vtable lookups
2. **Inlining**: The compiler can inline virtual functions that would otherwise require indirect calls
3. **Reduced vtable size**: In some cases, the compiler can optimize the vtable structure

### Performance Impact
- **Flash memory savings**: 104 bytes (898,426 → 898,322 bytes) on ESP32 with Ethernet and Bluetooth proxy
- **Runtime performance**: ~12.9% improvement in message decoding with `-Os` optimization
- **Assembly analysis**: 10 fewer indirect calls (`callx8` instructions) in the compiled code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing API memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-exposed changes

## Additional Notes

This optimization is safe because:
1. The generated protobuf message classes are never intended to be inherited from
2. The `final` keyword only affects the generated classes, not the base `ProtoMessage` class
3. All existing functionality remains unchanged - this is purely a performance optimization
4. The change is backward compatible and requires no configuration changes