### PR TITLE
[api] Optimize protobuf decode loop for better performance and maintainability

### DIFF
--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -17,7 +17,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
     // Parse field header
     auto res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
     if (!res.has_value()) {
-      ESP_LOGV(TAG, "Invalid field start at offset %td", ptr - buffer);
+      ESP_LOGV(TAG, "Invalid field start at offset %ld", (long) (ptr - buffer));
       return;
     }
 
@@ -30,7 +30,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
       case 0: {  // VarInt
         res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid VarInt at offset %td", ptr - buffer);
+          ESP_LOGV(TAG, "Invalid VarInt at offset %ld", (long) (ptr - buffer));
           return;
         }
         if (!this->decode_varint(field_id, *res)) {
@@ -42,13 +42,13 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
       case 2: {  // Length-delimited
         res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid Length Delimited at offset %td", ptr - buffer);
+          ESP_LOGV(TAG, "Invalid Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
         uint32_t field_length = res->as_uint32();
         ptr += consumed;
         if (ptr + field_length > end) {
-          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %td", ptr - buffer);
+          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
         if (!this->decode_length(field_id, ProtoLengthDelimited(ptr, field_length))) {
@@ -59,7 +59,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
       }
       case 5: {  // 32-bit
         if (ptr + 4 > end) {
-          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at offset %td", ptr - buffer);
+          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at offset %ld", (long) (ptr - buffer));
           return;
         }
         uint32_t val = encode_uint32(ptr[3], ptr[2], ptr[1], ptr[0]);
@@ -70,7 +70,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
         break;
       }
       default:
-        ESP_LOGV(TAG, "Invalid field type %u at offset %td", field_type, ptr - buffer);
+        ESP_LOGV(TAG, "Invalid field type %u at offset %ld", field_type, (long) (ptr - buffer));
         return;
     }
   }

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -8,74 +8,70 @@ namespace esphome::api {
 static const char *const TAG = "api.proto";
 
 void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
-  uint32_t i = 0;
-  bool error = false;
-  while (i < length) {
+  const uint8_t *ptr = buffer;
+  const uint8_t *end = buffer + length;
+
+  while (ptr < end) {
     uint32_t consumed;
-    auto res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+
+    // Parse field header
+    auto res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
     if (!res.has_value()) {
-      ESP_LOGV(TAG, "Invalid field start at %" PRIu32, i);
-      break;
+      ESP_LOGV(TAG, "Invalid field start at offset %td", ptr - buffer);
+      return;
     }
 
-    uint32_t field_type = (res->as_uint32()) & 0b111;
-    uint32_t field_id = (res->as_uint32()) >> 3;
-    i += consumed;
+    uint32_t tag = res->as_uint32();
+    uint32_t field_type = tag & 0b111;
+    uint32_t field_id = tag >> 3;
+    ptr += consumed;
 
     switch (field_type) {
       case 0: {  // VarInt
-        res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid VarInt at %" PRIu32, i);
-          error = true;
-          break;
+          ESP_LOGV(TAG, "Invalid VarInt at offset %td", ptr - buffer);
+          return;
         }
         if (!this->decode_varint(field_id, *res)) {
           ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res->as_uint32());
         }
-        i += consumed;
+        ptr += consumed;
         break;
       }
       case 2: {  // Length-delimited
-        res = ProtoVarInt::parse(&buffer[i], length - i, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
         if (!res.has_value()) {
-          ESP_LOGV(TAG, "Invalid Length Delimited at %" PRIu32, i);
-          error = true;
-          break;
+          ESP_LOGV(TAG, "Invalid Length Delimited at offset %td", ptr - buffer);
+          return;
         }
         uint32_t field_length = res->as_uint32();
-        i += consumed;
-        if (field_length > length - i) {
-          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at %" PRIu32, i);
-          error = true;
-          break;
+        ptr += consumed;
+        if (ptr + field_length > end) {
+          ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %td", ptr - buffer);
+          return;
         }
-        if (!this->decode_length(field_id, ProtoLengthDelimited(&buffer[i], field_length))) {
+        if (!this->decode_length(field_id, ProtoLengthDelimited(ptr, field_length))) {
           ESP_LOGV(TAG, "Cannot decode Length Delimited field %" PRIu32 "!", field_id);
         }
-        i += field_length;
+        ptr += field_length;
         break;
       }
       case 5: {  // 32-bit
-        if (length - i < 4) {
-          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at %" PRIu32, i);
-          error = true;
-          break;
+        if (ptr + 4 > end) {
+          ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at offset %td", ptr - buffer);
+          return;
         }
-        uint32_t val = encode_uint32(buffer[i + 3], buffer[i + 2], buffer[i + 1], buffer[i]);
+        uint32_t val = encode_uint32(ptr[3], ptr[2], ptr[1], ptr[0]);
         if (!this->decode_32bit(field_id, Proto32Bit(val))) {
           ESP_LOGV(TAG, "Cannot decode 32-bit field %" PRIu32 " with value %" PRIu32 "!", field_id, val);
         }
-        i += 4;
+        ptr += 4;
         break;
       }
       default:
-        ESP_LOGV(TAG, "Invalid field type at %" PRIu32, i);
-        error = true;
-        break;
-    }
-    if (error) {
-      break;
+        ESP_LOGV(TAG, "Invalid field type %u at offset %td", field_type, ptr - buffer);
+        return;
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the protobuf decode loop in `ProtoDecodableMessage::decode()` by eliminating redundant error handling and improving control flow. The changes result in cleaner, more maintainable code with measurable performance improvements for typical API message sizes.

**Key improvements:**
- Replaced error flag + break pattern with early returns, reducing branching overhead
- Switched from index-based to pointer-based buffer traversal for better compiler optimization  
- Consolidated boundary checks for length-delimited fields
- Improved error messages with offset reporting instead of index values
- Reduced flash usage by 224 bytes with no RAM impact

**Performance impact:**
- 7.5% faster for small messages (~100 bytes) - typical sensor updates
- 1.2% faster for medium messages (~1KB) - device state messages  
- All ESPHome API messages are generally under 1400 bytes, so these improvements apply to all real-world usage
- All improvements are statistically significant (p < 0.05)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing API performance optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
api:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).