### PR TITLE
[safe_mode] Reduce flash usage by 184 bytes through code optimization

### DIFF
--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -79,7 +79,7 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   bool is_manual = rtc_val == SafeModeComponent::ENTER_SAFE_MODE_MAGIC;
 
   if (is_manual) {
-    ESP_LOGI(TAG, "Manual safe mode");
+    ESP_LOGI(TAG, "Manual mode");
   } else {
     ESP_LOGCONFIG(TAG, "Unsuccessful boot attempts: %" PRIu32, rtc_val);
   }

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -27,7 +27,7 @@ void SafeModeComponent::dump_config() {
   if (this->safe_mode_rtc_value_ > 1 && this->safe_mode_rtc_value_ != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
     auto remaining_restarts = this->safe_mode_num_attempts_ - this->safe_mode_rtc_value_;
     if (remaining_restarts) {
-      ESP_LOGW(TAG, "Last reset too quick; safe mode in %" PRIu32 " restarts", remaining_restarts);
+      ESP_LOGW(TAG, "Last reset too quick; invoke in %" PRIu32 " restarts", remaining_restarts);
     } else {
       ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
     }

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -98,7 +98,7 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
 
   this->status_set_error();
   this->set_timeout(enable_time, []() {
-    ESP_LOGW(TAG, "Safe mode timeout - restarting");
+    ESP_LOGW(TAG, "Timeout, restarting");
     App.reboot();
   });
 

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -18,7 +18,7 @@ void SafeModeComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Safe Mode:\n"
                 "  Successful after: %" PRIu32 "s\n"
-                "  Attempts: %u\n"
+                "  Invoke after: %u attempts\n"
                 "  Duration: %" PRIu32 "s",
                 this->safe_mode_boot_is_good_after_ / 1000,  // because milliseconds
                 this->safe_mode_num_attempts_,

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -15,11 +15,11 @@ namespace safe_mode {
 static const char *const TAG = "safe_mode";
 
 void SafeModeComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Safe Mode:");
   ESP_LOGCONFIG(TAG,
-                "  Boot considered successful after %" PRIu32 " seconds\n"
-                "  Invoke after %u boot attempts\n"
-                "  Remain for %" PRIu32 " seconds",
+                "Safe Mode:\n"
+                "  Successful after: %" PRIu32 "s\n"
+                "  Attempts: %u\n"
+                "  Duration: %" PRIu32 "s",
                 this->safe_mode_boot_is_good_after_ / 1000,  // because milliseconds
                 this->safe_mode_num_attempts_,
                 this->safe_mode_enable_time_ / 1000);  // because milliseconds
@@ -27,7 +27,7 @@ void SafeModeComponent::dump_config() {
   if (this->safe_mode_rtc_value_ > 1 && this->safe_mode_rtc_value_ != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
     auto remaining_restarts = this->safe_mode_num_attempts_ - this->safe_mode_rtc_value_;
     if (remaining_restarts) {
-      ESP_LOGW(TAG, "Last reset occurred too quickly; will be invoked in %" PRIu32 " restarts", remaining_restarts);
+      ESP_LOGW(TAG, "Last reset too quick; safe mode in %" PRIu32 " restarts", remaining_restarts);
     } else {
       ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
     }
@@ -72,43 +72,45 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   this->safe_mode_boot_is_good_after_ = boot_is_good_after;
   this->safe_mode_num_attempts_ = num_attempts;
   this->rtc_ = global_preferences->make_preference<uint32_t>(233825507UL, false);
-  this->safe_mode_rtc_value_ = this->read_rtc_();
 
-  bool is_manual_safe_mode = this->safe_mode_rtc_value_ == SafeModeComponent::ENTER_SAFE_MODE_MAGIC;
+  uint32_t rtc_val = this->read_rtc_();
+  this->safe_mode_rtc_value_ = rtc_val;
 
-  if (is_manual_safe_mode) {
-    ESP_LOGI(TAG, "Safe mode invoked manually");
+  bool is_manual = rtc_val == SafeModeComponent::ENTER_SAFE_MODE_MAGIC;
+
+  if (is_manual) {
+    ESP_LOGI(TAG, "Manual safe mode");
   } else {
-    ESP_LOGCONFIG(TAG, "There have been %" PRIu32 " suspected unsuccessful boot attempts", this->safe_mode_rtc_value_);
+    ESP_LOGCONFIG(TAG, "Unsuccessful boot attempts: %" PRIu32, rtc_val);
   }
 
-  if (this->safe_mode_rtc_value_ >= num_attempts || is_manual_safe_mode) {
-    this->clean_rtc();
-
-    if (!is_manual_safe_mode) {
-      ESP_LOGE(TAG, "Boot loop detected. Proceeding");
-    }
-
-    this->status_set_error();
-    this->set_timeout(enable_time, []() {
-      ESP_LOGW(TAG, "Safe mode enable time has elapsed -- restarting");
-      App.reboot();
-    });
-
-    // Delay here to allow power to stabilize before Wi-Fi/Ethernet is initialised
-    delay(300);  // NOLINT
-    App.setup();
-
-    ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
-
-    this->safe_mode_callback_.call();
-
-    return true;
-  } else {
+  if (rtc_val < num_attempts && !is_manual) {
     // increment counter
-    this->write_rtc_(this->safe_mode_rtc_value_ + 1);
+    this->write_rtc_(rtc_val + 1);
     return false;
   }
+
+  this->clean_rtc();
+
+  if (!is_manual) {
+    ESP_LOGE(TAG, "Boot loop detected");
+  }
+
+  this->status_set_error();
+  this->set_timeout(enable_time, []() {
+    ESP_LOGW(TAG, "Safe mode timeout - restarting");
+    App.reboot();
+  });
+
+  // Delay here to allow power to stabilize before Wi-Fi/Ethernet is initialised
+  delay(300);  // NOLINT
+  App.setup();
+
+  ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
+
+  this->safe_mode_callback_.call();
+
+  return true;
 }
 
 void SafeModeComponent::write_rtc_(uint32_t val) {


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the safe_mode component to reduce flash usage by 184 bytes through more efficient code structure and concise logging messages while maintaining identical functionality.

The main optimizations include:
- Restructured `should_enter_safe_mode()` control flow for early exit, reducing code paths
- Combined multiple log calls into single calls where possible
- Used more concise log messages while preserving all diagnostic information
- Cached RTC read result to avoid redundant member variable access

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
safe_mode:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-facing changes

## Additional notes

Flash usage reduction verified on ESP8266:
- Before: Flash [====      ] 39.9% (used 408393 bytes from 1023984 bytes)
- After:  Flash [====      ] 39.9% (used 408209 bytes from 1023984 bytes)
- **Savings: 184 bytes**

The optimized function behaves identically to the original, maintaining:
- All error detection and reporting functionality
- Same log levels and diagnostic information
- "SAFE MODE IS ACTIVE" message unchanged as per ESPHome conventions
- Proper handling of manual safe mode, boot loops, and normal operation