### PR TITLE
[pipsolar] set sensors unavailable on timeout, misc fixes

### DIFF
--- a/esphome/components/pipsolar/output/pipsolar_output.cpp
+++ b/esphome/components/pipsolar/output/pipsolar_output.cpp
@@ -13,7 +13,7 @@ void PipsolarOutput::write_state(float state) {
 
   if (std::find(this->possible_values_.begin(), this->possible_values_.end(), state) != this->possible_values_.end()) {
     ESP_LOGD(TAG, "Will write: %s out of value %f / %02.0f", tmp, state, state);
-    this->parent_->switch_command(std::string(tmp));
+    this->parent_->queue_command(std::string(tmp));
   } else {
     ESP_LOGD(TAG, "Will not write: %s as it is not in list of allowed values", tmp);
   }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -273,240 +273,139 @@ void Pipsolar::queue_command(const std::string &command) {
 }
 
 void Pipsolar::handle_qpiri_(const char* message) {
-  QPIRIValues values = QPIRIValues();
-
-  sscanf(message, "(%f %f %f %f %f %d %d %f %f %f %f %f %d %d %d %d %d %d %d %d %d %d %f %d %d",       // NOLINT
-          &values.grid_rating_voltage, &values.grid_rating_current, &values.ac_output_rating_voltage,  // NOLINT
-          &values.ac_output_rating_frequency, &values.ac_output_rating_current,                        // NOLINT
-          &values.ac_output_rating_apparent_power, &values.ac_output_rating_active_power,              // NOLINT
-          &values.battery_rating_voltage, &values.battery_recharge_voltage,                            // NOLINT
-          &values.battery_under_voltage, &values.battery_bulk_voltage, &values.battery_float_voltage,  // NOLINT
-          &values.battery_type, &values.current_max_ac_charging_current,                               // NOLINT
-          &values.current_max_charging_current, &values.input_voltage_range,                           // NOLINT
-          &values.output_source_priority, &values.charger_source_priority, &values.parallel_max_num,   // NOLINT
-          &values.machine_type, &values.topology, &values.output_mode,                                 // NOLINT
-          &values.battery_redischarge_voltage, &values.pv_ok_condition_for_parallel,                   // NOLINT
-          &values.pv_power_balance);                                                                   // NOLINT
   if (this->last_qpiri_) {
     this->last_qpiri_->publish_state(message);
   }
 
-  if (this->grid_rating_voltage_) {
-    this->grid_rating_voltage_->publish_state(values.grid_rating_voltage);
-  }
-  if (this->grid_rating_current_) {
-    this->grid_rating_current_->publish_state(values.grid_rating_current);
-  }
-  if (this->ac_output_rating_voltage_) {
-    this->ac_output_rating_voltage_->publish_state(values.ac_output_rating_voltage);
-  }
-  if (this->ac_output_rating_frequency_) {
-    this->ac_output_rating_frequency_->publish_state(values.ac_output_rating_frequency);
-  }
-  if (this->ac_output_rating_current_) {
-    this->ac_output_rating_current_->publish_state(values.ac_output_rating_current);
-  }
-  if (this->ac_output_rating_apparent_power_) {
-    this->ac_output_rating_apparent_power_->publish_state(values.ac_output_rating_apparent_power);
-  }
-  if (this->ac_output_rating_active_power_) {
-    this->ac_output_rating_active_power_->publish_state(values.ac_output_rating_active_power);
-  }
-  if (this->battery_rating_voltage_) {
-    this->battery_rating_voltage_->publish_state(values.battery_rating_voltage);
-  }
-  if (this->battery_recharge_voltage_) {
-    this->battery_recharge_voltage_->publish_state(values.battery_recharge_voltage);
-  }
-  if (this->battery_under_voltage_) {
-    this->battery_under_voltage_->publish_state(values.battery_under_voltage);
-  }
-  if (this->battery_bulk_voltage_) {
-    this->battery_bulk_voltage_->publish_state(values.battery_bulk_voltage);
-  }
-  if (this->battery_float_voltage_) {
-    this->battery_float_voltage_->publish_state(values.battery_float_voltage);
-  }
-  if (this->battery_type_) {
-    this->battery_type_->publish_state(values.battery_type);
-  }
-  if (this->current_max_ac_charging_current_) {
-    this->current_max_ac_charging_current_->publish_state(values.current_max_ac_charging_current);
-  }
-  if (this->current_max_charging_current_) {
-    this->current_max_charging_current_->publish_state(values.current_max_charging_current);
-  }
+  size_t pos = 0;
+  this->skip_start_(message, &pos);
+
+  this->read_float_sensor_(message, &pos, this->grid_rating_voltage_);
+  this->read_float_sensor_(message, &pos, this->grid_rating_current_);
+  this->read_float_sensor_(message, &pos, this->ac_output_rating_voltage_);
+  this->read_float_sensor_(message, &pos, this->ac_output_rating_frequency_);
+  this->read_float_sensor_(message, &pos, this->ac_output_rating_current_);
+
+  this->read_int_sensor_(message, &pos, this->ac_output_rating_apparent_power_);
+  this->read_int_sensor_(message, &pos, this->ac_output_rating_active_power_);
+
+  this->read_float_sensor_(message, &pos, this->battery_rating_voltage_);
+  this->read_float_sensor_(message, &pos, this->battery_recharge_voltage_);
+  this->read_float_sensor_(message, &pos, this->battery_under_voltage_);
+  this->read_float_sensor_(message, &pos, this->battery_bulk_voltage_);
+  this->read_float_sensor_(message, &pos, this->battery_float_voltage_);
+
+  this->read_int_sensor_(message, &pos, this->battery_type_);
+  this->read_int_sensor_(message, &pos, this->current_max_ac_charging_current_);
+  this->read_int_sensor_(message, &pos, this->current_max_charging_current_);
+
+  esphome::optional<int> input_voltage_range = parse_number<int32_t>(this->read_field_(message, &pos));
+  esphome::optional<int> output_source_priority = parse_number<int32_t>(this->read_field_(message, &pos));
+
+  this->read_int_sensor_(message, &pos, this->charger_source_priority_);
+  this->read_int_sensor_(message, &pos, this->parallel_max_num_);
+  this->read_int_sensor_(message, &pos, this->machine_type_);
+  this->read_int_sensor_(message, &pos, this->topology_);
+  this->read_int_sensor_(message, &pos, this->output_mode_);
+
+  this->read_float_sensor_(message, &pos, this->battery_redischarge_voltage_);
+
+  esphome::optional<int> pv_ok_condition_for_parallel = parse_number<int32_t>(this->read_field_(message, &pos));
+  esphome::optional<int> pv_power_balance = parse_number<int32_t>(this->read_field_(message, &pos));
+
   if (this->input_voltage_range_) {
-    this->input_voltage_range_->publish_state(values.input_voltage_range);
+    this->input_voltage_range_->publish_state(input_voltage_range.value_or(NAN));
   }
   // special for input voltage range switch
-  if (this->input_voltage_range_switch_) {
-    this->input_voltage_range_switch_->publish_state(values.input_voltage_range == 1);
+  if (this->input_voltage_range_switch_ && input_voltage_range.has_value()) {
+    this->input_voltage_range_switch_->publish_state(input_voltage_range.value() == 1);
   }
+
   if (this->output_source_priority_) {
-    this->output_source_priority_->publish_state(values.output_source_priority);
+    this->output_source_priority_->publish_state(output_source_priority.value_or(NAN));
   }
   // special for output source priority switches
-  if (this->output_source_priority_utility_switch_) {
-    this->output_source_priority_utility_switch_->publish_state(values.output_source_priority == 0);
+  if (this->output_source_priority_utility_switch_ && output_source_priority.has_value()) {
+    this->output_source_priority_utility_switch_->publish_state(output_source_priority.value() == 0);
   }
-  if (this->output_source_priority_solar_switch_) {
-    this->output_source_priority_solar_switch_->publish_state(values.output_source_priority == 1);
+  if (this->output_source_priority_solar_switch_ && output_source_priority.has_value()) {
+    this->output_source_priority_solar_switch_->publish_state(output_source_priority.value() == 1);
   }
-  if (this->output_source_priority_battery_switch_) {
-    this->output_source_priority_battery_switch_->publish_state(values.output_source_priority == 2);
+  if (this->output_source_priority_battery_switch_ && output_source_priority.has_value()) {
+    this->output_source_priority_battery_switch_->publish_state(output_source_priority.value() == 2);
   }
-  if (this->output_source_priority_hybrid_switch_) {
-    this->output_source_priority_hybrid_switch_->publish_state(values.output_source_priority == 3);
+  if (this->output_source_priority_hybrid_switch_ && output_source_priority.has_value()) {
+    this->output_source_priority_hybrid_switch_->publish_state(output_source_priority.value() == 3);
   }
-  if (this->charger_source_priority_) {
-    this->charger_source_priority_->publish_state(values.charger_source_priority);
-  }
-  if (this->parallel_max_num_) {
-    this->parallel_max_num_->publish_state(values.parallel_max_num);
-  }
-  if (this->machine_type_) {
-    this->machine_type_->publish_state(values.machine_type);
-  }
-  if (this->topology_) {
-    this->topology_->publish_state(values.topology);
-  }
-  if (this->output_mode_) {
-    this->output_mode_->publish_state(values.output_mode);
-  }
-  if (this->battery_redischarge_voltage_) {
-    this->battery_redischarge_voltage_->publish_state(values.battery_redischarge_voltage);
-  }
+
   if (this->pv_ok_condition_for_parallel_) {
-    this->pv_ok_condition_for_parallel_->publish_state(values.pv_ok_condition_for_parallel);
+    this->pv_ok_condition_for_parallel_->publish_state(pv_ok_condition_for_parallel.value_or(NAN));
   }
   // special for pv ok condition switch
-  if (this->pv_ok_condition_for_parallel_switch_) {
-    this->pv_ok_condition_for_parallel_switch_->publish_state(values.pv_ok_condition_for_parallel == 1);
+  if (this->pv_ok_condition_for_parallel_switch_ && pv_ok_condition_for_parallel.has_value()) {
+    this->pv_ok_condition_for_parallel_switch_->publish_state(pv_ok_condition_for_parallel.value() == 1);
   }
+
   if (this->pv_power_balance_) {
-    this->pv_power_balance_->publish_state(values.pv_power_balance == 1);
+    this->pv_power_balance_->publish_state(pv_power_balance.value_or(NAN));
   }
   // special for power balance switch
-  if (this->pv_power_balance_switch_) {
-    this->pv_power_balance_switch_->publish_state(values.pv_power_balance == 1);
+  if (this->pv_power_balance_switch_ && pv_power_balance.has_value()) {
+    this->pv_power_balance_switch_->publish_state(pv_power_balance.value() == 1);
   }
 }
 
 void Pipsolar::handle_qpigs_(const char* message) {
-  QPIGSValues values = QPIGSValues();
-
-  sscanf(                                                                                              // NOLINT
-      message,                                                                                         // NOLINT
-      "(%f %f %f %f %d %d %d %d %f %d %d %d %f %f %f %d %1d%1d%1d%1d%1d%1d%1d%1d %d %d %d %1d%1d%1d",  // NOLINT
-      &values.grid_voltage, &values.grid_frequency, &values.ac_output_voltage,                         // NOLINT
-      &values.ac_output_frequency,                                                                     // NOLINT
-      &values.ac_output_apparent_power, &values.ac_output_active_power, &values.output_load_percent,   // NOLINT
-      &values.bus_voltage, &values.battery_voltage, &values.battery_charging_current,                  // NOLINT
-      &values.battery_capacity_percent, &values.inverter_heat_sink_temperature,                        // NOLINT
-      &values.pv_input_current_for_battery, &values.pv_input_voltage, &values.battery_voltage_scc,     // NOLINT
-      &values.battery_discharge_current, &values.add_sbu_priority_version,                             // NOLINT
-      &values.configuration_status, &values.scc_firmware_version, &values.load_status,                 // NOLINT
-      &values.battery_voltage_to_steady_while_charging, &values.charging_status,                       // NOLINT
-      &values.scc_charging_status, &values.ac_charging_status,                                         // NOLINT
-      &values.battery_voltage_offset_for_fans_on, &values.eeprom_version, &values.pv_charging_power,   // NOLINT
-      &values.charging_to_floating_mode, &values.switch_on,                                            // NOLINT
-      &values.dustproof_installed);                                                                    // NOLINT
   if (this->last_qpigs_) {
     this->last_qpigs_->publish_state(message);
   }
 
-  if (this->grid_voltage_) {
-    this->grid_voltage_->publish_state(values.grid_voltage);
-  }
-  if (this->grid_frequency_) {
-    this->grid_frequency_->publish_state(values.grid_frequency);
-  }
-  if (this->ac_output_voltage_) {
-    this->ac_output_voltage_->publish_state(values.ac_output_voltage);
-  }
-  if (this->ac_output_frequency_) {
-    this->ac_output_frequency_->publish_state(values.ac_output_frequency);
-  }
-  if (this->ac_output_apparent_power_) {
-    this->ac_output_apparent_power_->publish_state(values.ac_output_apparent_power);
-  }
-  if (this->ac_output_active_power_) {
-    this->ac_output_active_power_->publish_state(values.ac_output_active_power);
-  }
-  if (this->output_load_percent_) {
-    this->output_load_percent_->publish_state(values.output_load_percent);
-  }
-  if (this->bus_voltage_) {
-    this->bus_voltage_->publish_state(values.bus_voltage);
-  }
-  if (this->battery_voltage_) {
-    this->battery_voltage_->publish_state(values.battery_voltage);
-  }
-  if (this->battery_charging_current_) {
-    this->battery_charging_current_->publish_state(values.battery_charging_current);
-  }
-  if (this->battery_capacity_percent_) {
-    this->battery_capacity_percent_->publish_state(values.battery_capacity_percent);
-  }
-  if (this->inverter_heat_sink_temperature_) {
-    this->inverter_heat_sink_temperature_->publish_state(values.inverter_heat_sink_temperature);
-  }
-  if (this->pv_input_current_for_battery_) {
-    this->pv_input_current_for_battery_->publish_state(values.pv_input_current_for_battery);
-  }
-  if (this->pv_input_voltage_) {
-    this->pv_input_voltage_->publish_state(values.pv_input_voltage);
-  }
-  if (this->battery_voltage_scc_) {
-    this->battery_voltage_scc_->publish_state(values.battery_voltage_scc);
-  }
-  if (this->battery_discharge_current_) {
-    this->battery_discharge_current_->publish_state(values.battery_discharge_current);
-  }
-  if (this->add_sbu_priority_version_) {
-    this->add_sbu_priority_version_->publish_state(values.add_sbu_priority_version);
-  }
-  if (this->configuration_status_) {
-    this->configuration_status_->publish_state(values.configuration_status);
-  }
-  if (this->scc_firmware_version_) {
-    this->scc_firmware_version_->publish_state(values.scc_firmware_version);
-  }
-  if (this->load_status_) {
-    this->load_status_->publish_state(values.load_status);
-  }
-  if (this->battery_voltage_to_steady_while_charging_) {
-    this->battery_voltage_to_steady_while_charging_->publish_state(
-        values.battery_voltage_to_steady_while_charging);
-  }
-  if (this->charging_status_) {
-    this->charging_status_->publish_state(values.charging_status);
-  }
-  if (this->scc_charging_status_) {
-    this->scc_charging_status_->publish_state(values.scc_charging_status);
-  }
-  if (this->ac_charging_status_) {
-    this->ac_charging_status_->publish_state(values.ac_charging_status);
-  }
+  size_t pos = 0;
+  this->skip_start_(message, &pos);
+
+  this->read_float_sensor_(message, &pos, this->grid_voltage_);
+  this->read_float_sensor_(message, &pos, this->grid_frequency_);
+  this->read_float_sensor_(message, &pos, this->ac_output_voltage_);
+  this->read_float_sensor_(message, &pos, this->ac_output_frequency_);
+
+  this->read_int_sensor_(message, &pos, this->ac_output_apparent_power_);
+  this->read_int_sensor_(message, &pos, this->ac_output_active_power_);
+  this->read_int_sensor_(message, &pos, this->output_load_percent_);
+  this->read_int_sensor_(message, &pos, this->bus_voltage_);
+
+  this->read_float_sensor_(message, &pos, this->battery_voltage_);
+
+  this->read_int_sensor_(message, &pos, this->battery_charging_current_);
+  this->read_int_sensor_(message, &pos, this->battery_capacity_percent_);
+  this->read_int_sensor_(message, &pos, this->inverter_heat_sink_temperature_);
+
+  this->read_float_sensor_(message, &pos, this->pv_input_current_for_battery_);
+  this->read_float_sensor_(message, &pos, this->pv_input_voltage_);
+  this->read_float_sensor_(message, &pos, this->battery_voltage_scc_);
+
+  this->read_int_sensor_(message, &pos, this->battery_discharge_current_);
+
+  std::string device_status_1 = this->read_field_(message, &pos);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 0), this->add_sbu_priority_version_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 1), this->configuration_status_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 2), this->scc_firmware_version_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 3), this->load_status_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 4), this->battery_voltage_to_steady_while_charging_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 5), this->charging_status_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 6), this->scc_charging_status_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_1, 7), this->ac_charging_status_);
+
+  esphome::optional<int> battery_voltage_offset_for_fans_on_ = parse_number<int32_t>(this->read_field_(message, &pos));
   if (this->battery_voltage_offset_for_fans_on_) {
-    this->battery_voltage_offset_for_fans_on_->publish_state(values.battery_voltage_offset_for_fans_on / 10.0f);
-  }  //.1 scale
-  if (this->eeprom_version_) {
-    this->eeprom_version_->publish_state(values.eeprom_version);
+    this->battery_voltage_offset_for_fans_on_->publish_state(battery_voltage_offset_for_fans_on_.value_or(NAN) / 10.0f);
   }
-  if (this->pv_charging_power_) {
-    this->pv_charging_power_->publish_state(values.pv_charging_power);
-  }
-  if (this->charging_to_floating_mode_) {
-    this->charging_to_floating_mode_->publish_state(values.charging_to_floating_mode);
-  }
-  if (this->switch_on_) {
-    this->switch_on_->publish_state(values.switch_on);
-  }
-  if (this->dustproof_installed_) {
-    this->dustproof_installed_->publish_state(values.dustproof_installed);
-  }
+  this->read_int_sensor_(message, &pos, this->eeprom_version_);
+  this->read_int_sensor_(message, &pos, this->pv_charging_power_);
+  
+  std::string device_status_2 = this->read_field_(message, &pos);
+  this->publish_binary_sensor_(this->get_bit_(device_status_2, 0), this->charging_to_floating_mode_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_2, 1), this->switch_on_);
+  this->publish_binary_sensor_(this->get_bit_(device_status_2, 2), this->dustproof_installed_);
 }
 
 void Pipsolar::handle_qmod_(const char* message) {
@@ -524,6 +423,10 @@ void Pipsolar::handle_qmod_(const char* message) {
 void Pipsolar::handle_qflag_(const char* message) {
   // result like:"(EbkuvxzDajy"
   // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
+  if (this->last_qflag_) {
+    this->last_qflag_->publish_state(message);
+  }
+
   QFLAGValues values = QFLAGValues();
   bool enabled = true;
   for (size_t i = 1; i < strlen(message); i++) {
@@ -563,302 +466,182 @@ void Pipsolar::handle_qflag_(const char* message) {
         break;
     }
   }
-  if (this->last_qflag_) {
-    this->last_qflag_->publish_state(message);
-  }
 
-  if (this->silence_buzzer_open_buzzer_) {
-    this->silence_buzzer_open_buzzer_->publish_state(values.silence_buzzer_open_buzzer);
-  }
-  if (this->overload_bypass_function_) {
-    this->overload_bypass_function_->publish_state(values.overload_bypass_function);
-  }
-  if (this->lcd_escape_to_default_) {
-    this->lcd_escape_to_default_->publish_state(values.lcd_escape_to_default);
-  }
-  if (this->overload_restart_function_) {
-    this->overload_restart_function_->publish_state(values.overload_restart_function);
-  }
-  if (this->over_temperature_restart_function_) {
-    this->over_temperature_restart_function_->publish_state(values.over_temperature_restart_function);
-  }
-  if (this->backlight_on_) {
-    this->backlight_on_->publish_state(values.backlight_on);
-  }
-  if (this->alarm_on_when_primary_source_interrupt_) {
-    this->alarm_on_when_primary_source_interrupt_->publish_state(values.alarm_on_when_primary_source_interrupt);
-  }
-  if (this->fault_code_record_) {
-    this->fault_code_record_->publish_state(values.fault_code_record);
-  }
-  if (this->power_saving_) {
-    this->power_saving_->publish_state(values.power_saving);
-  }
+  this->publish_binary_sensor_(values.silence_buzzer_open_buzzer, this->silence_buzzer_open_buzzer_);
+  this->publish_binary_sensor_(values.overload_bypass_function, this->overload_bypass_function_);
+  this->publish_binary_sensor_(values.lcd_escape_to_default, this->lcd_escape_to_default_);
+  this->publish_binary_sensor_(values.overload_restart_function, this->overload_restart_function_);
+  this->publish_binary_sensor_(values.over_temperature_restart_function, this->over_temperature_restart_function_);
+  this->publish_binary_sensor_(values.backlight_on, this->backlight_on_);
+  this->publish_binary_sensor_(values.alarm_on_when_primary_source_interrupt, this->alarm_on_when_primary_source_interrupt_);
+  this->publish_binary_sensor_(values.fault_code_record, this->fault_code_record_);
+  this->publish_binary_sensor_(values.power_saving, this->power_saving_);
 }
 
 void Pipsolar::handle_qpiws_(const char* message) {
   // '(00000000000000000000000000000000'
   // iterate over all available flag (as not all models have all flags, but at least in the same order)
-  QPIWSValues values = QPIWSValues();
-  bool enabled = true;
-  std::string fc;
-  bool value_warnings_present = false;
-  bool value_faults_present = false;
-
-  for (size_t i = 1; i < strlen(message); i++) {
-    enabled = message[i] == '1';
-    switch (i) {
-      case 1:
-        values.warning_power_loss = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 2:
-        values.fault_inverter_fault = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 3:
-        values.fault_bus_over = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 4:
-        values.fault_bus_under = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 5:
-        values.fault_bus_soft_fail = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 6:
-        values.warning_line_fail = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 7:
-        values.fault_opvshort = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 8:
-        values.fault_inverter_voltage_too_low = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 9:
-        values.fault_inverter_voltage_too_high = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 10:
-        values.warning_over_temperature = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 11:
-        values.warning_fan_lock = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 12:
-        values.warning_battery_voltage_high = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 13:
-        values.warning_battery_low_alarm = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 15:
-        values.warning_battery_under_shutdown = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 16:
-        values.warning_battery_derating = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 17:
-        values.warning_over_load = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 18:
-        values.warning_eeprom_failed = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 19:
-        values.fault_inverter_over_current = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 20:
-        values.fault_inverter_soft_failed = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 21:
-        values.fault_self_test_failed = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 22:
-        values.fault_op_dc_voltage_over = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 23:
-        values.fault_battery_open = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 24:
-        values.fault_current_sensor_failed = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 25:
-        values.fault_battery_short = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 26:
-        values.warning_power_limit = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 27:
-        values.warning_pv_voltage_high = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 28:
-        values.fault_mppt_overload = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 29:
-        values.warning_mppt_overload = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 30:
-        values.warning_battery_too_low_to_charge = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 31:
-        values.fault_dc_dc_over_current = enabled;
-        value_faults_present |= enabled;
-        break;
-      case 32:
-        fc = message[i];
-        fc += message[i + 1];
-        values.fault_code = parse_number<int>(fc).value_or(0);
-        break;
-      case 34:
-        values.warnung_low_pv_energy = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 35:
-        values.warning_high_ac_input_during_bus_soft_start = enabled;
-        value_warnings_present |= enabled;
-        break;
-      case 36:
-        values.warning_battery_equalization = enabled;
-        value_warnings_present |= enabled;
-        break;
-    }
-  }
   if (this->last_qpiws_) {
     this->last_qpiws_->publish_state(message);
   }
 
-  if (this->warnings_present_) {
-    this->warnings_present_->publish_state(value_warnings_present);
+  size_t pos = 0;
+  this->skip_start_(message, &pos);
+  std::string flags = this->read_field_(message, &pos);
+
+  esphome::optional<bool> enabled;
+  bool value_warnings_present = false;
+  bool value_faults_present = false;
+
+  for (size_t i = 0; i < 36; i++) {
+    if (i == 31 || i == 32) {
+      // special case for fault code
+      continue;
+    }
+    enabled = this->get_bit_(flags, i);
+    switch (i) {
+      case 0:
+        this->publish_binary_sensor_(enabled, this->warning_power_loss_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 1:
+        this->publish_binary_sensor_(enabled, this->fault_inverter_fault_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 2:
+        this->publish_binary_sensor_(enabled, this->fault_bus_over_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 3:
+        this->publish_binary_sensor_(enabled, this->fault_bus_under_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 4:
+        this->publish_binary_sensor_(enabled, this->fault_bus_soft_fail_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 5:
+        this->publish_binary_sensor_(enabled, this->warning_line_fail_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 6:
+        this->publish_binary_sensor_(enabled, this->fault_opvshort_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 7:
+        this->publish_binary_sensor_(enabled, this->fault_inverter_voltage_too_low_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 8:
+        this->publish_binary_sensor_(enabled, this->fault_inverter_voltage_too_high_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 9:
+        this->publish_binary_sensor_(enabled, this->warning_over_temperature_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 10:
+        this->publish_binary_sensor_(enabled, this->warning_fan_lock_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 11:
+        this->publish_binary_sensor_(enabled, this->warning_battery_voltage_high_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 12:
+        this->publish_binary_sensor_(enabled, this->warning_battery_low_alarm_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 14:
+        this->publish_binary_sensor_(enabled, this->warning_battery_under_shutdown_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 15:
+        this->publish_binary_sensor_(enabled, this->warning_battery_derating_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 16:
+        this->publish_binary_sensor_(enabled, this->warning_over_load_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 17:
+        this->publish_binary_sensor_(enabled, this->warning_eeprom_failed_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 18:
+        this->publish_binary_sensor_(enabled, this->fault_inverter_over_current_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 19:
+        this->publish_binary_sensor_(enabled, this->fault_inverter_soft_failed_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 20:
+        this->publish_binary_sensor_(enabled, this->fault_self_test_failed_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 21:
+        this->publish_binary_sensor_(enabled, this->fault_op_dc_voltage_over_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 22:
+        this->publish_binary_sensor_(enabled, this->fault_battery_open_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 23:
+        this->publish_binary_sensor_(enabled, this->fault_current_sensor_failed_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 24:
+        this->publish_binary_sensor_(enabled, this->fault_battery_short_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 25:
+        this->publish_binary_sensor_(enabled, this->warning_power_limit_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 26:
+        this->publish_binary_sensor_(enabled, this->warning_pv_voltage_high_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 27:
+        this->publish_binary_sensor_(enabled, this->fault_mppt_overload_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 28:
+        this->publish_binary_sensor_(enabled, this->warning_mppt_overload_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 29:
+        this->publish_binary_sensor_(enabled, this->warning_battery_too_low_to_charge_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 30:
+        this->publish_binary_sensor_(enabled, this->fault_dc_dc_over_current_);
+        value_faults_present |= enabled.value_or(false);
+        break;
+      case 33:
+        this->publish_binary_sensor_(enabled, this->warnung_low_pv_energy_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+      case 34:
+        this->publish_binary_sensor_(enabled, this->warning_high_ac_input_during_bus_soft_start_);
+        value_warnings_present |= enabled.value_or(false);
+        35;
+      case 36:
+        this->publish_binary_sensor_(enabled, this->warning_battery_equalization_);
+        value_warnings_present |= enabled.value_or(false);
+        break;
+    }
   }
-  if (this->faults_present_) {
-    this->faults_present_->publish_state(value_faults_present);
-  }
-  if (this->warning_power_loss_) {
-    this->warning_power_loss_->publish_state(values.warning_power_loss);
-  }
-  if (this->fault_inverter_fault_) {
-    this->fault_inverter_fault_->publish_state(values.fault_inverter_fault);
-  }
-  if (this->fault_bus_over_) {
-    this->fault_bus_over_->publish_state(values.fault_bus_over);
-  }
-  if (this->fault_bus_under_) {
-    this->fault_bus_under_->publish_state(values.fault_bus_under);
-  }
-  if (this->fault_bus_soft_fail_) {
-    this->fault_bus_soft_fail_->publish_state(values.fault_bus_soft_fail);
-  }
-  if (this->warning_line_fail_) {
-    this->warning_line_fail_->publish_state(values.warning_line_fail);
-  }
-  if (this->fault_opvshort_) {
-    this->fault_opvshort_->publish_state(values.fault_opvshort);
-  }
-  if (this->fault_inverter_voltage_too_low_) {
-    this->fault_inverter_voltage_too_low_->publish_state(values.fault_inverter_voltage_too_low);
-  }
-  if (this->fault_inverter_voltage_too_high_) {
-    this->fault_inverter_voltage_too_high_->publish_state(values.fault_inverter_voltage_too_high);
-  }
-  if (this->warning_over_temperature_) {
-    this->warning_over_temperature_->publish_state(values.warning_over_temperature);
-  }
-  if (this->warning_fan_lock_) {
-    this->warning_fan_lock_->publish_state(values.warning_fan_lock);
-  }
-  if (this->warning_battery_voltage_high_) {
-    this->warning_battery_voltage_high_->publish_state(values.warning_battery_voltage_high);
-  }
-  if (this->warning_battery_low_alarm_) {
-    this->warning_battery_low_alarm_->publish_state(values.warning_battery_low_alarm);
-  }
-  if (this->warning_battery_under_shutdown_) {
-    this->warning_battery_under_shutdown_->publish_state(values.warning_battery_under_shutdown);
-  }
-  if (this->warning_battery_derating_) {
-    this->warning_battery_derating_->publish_state(values.warning_battery_derating);
-  }
-  if (this->warning_over_load_) {
-    this->warning_over_load_->publish_state(values.warning_over_load);
-  }
-  if (this->warning_eeprom_failed_) {
-    this->warning_eeprom_failed_->publish_state(values.warning_eeprom_failed);
-  }
-  if (this->fault_inverter_over_current_) {
-    this->fault_inverter_over_current_->publish_state(values.fault_inverter_over_current);
-  }
-  if (this->fault_inverter_soft_failed_) {
-    this->fault_inverter_soft_failed_->publish_state(values.fault_inverter_soft_failed);
-  }
-  if (this->fault_self_test_failed_) {
-    this->fault_self_test_failed_->publish_state(values.fault_self_test_failed);
-  }
-  if (this->fault_op_dc_voltage_over_) {
-    this->fault_op_dc_voltage_over_->publish_state(values.fault_op_dc_voltage_over);
-  }
-  if (this->fault_battery_open_) {
-    this->fault_battery_open_->publish_state(values.fault_battery_open);
-  }
-  if (this->fault_current_sensor_failed_) {
-    this->fault_current_sensor_failed_->publish_state(values.fault_current_sensor_failed);
-  }
-  if (this->fault_battery_short_) {
-    this->fault_battery_short_->publish_state(values.fault_battery_short);
-  }
-  if (this->warning_power_limit_) {
-    this->warning_power_limit_->publish_state(values.warning_power_limit);
-  }
-  if (this->warning_pv_voltage_high_) {
-    this->warning_pv_voltage_high_->publish_state(values.warning_pv_voltage_high);
-  }
-  if (this->fault_mppt_overload_) {
-    this->fault_mppt_overload_->publish_state(values.fault_mppt_overload);
-  }
-  if (this->warning_mppt_overload_) {
-    this->warning_mppt_overload_->publish_state(values.warning_mppt_overload);
-  }
-  if (this->warning_battery_too_low_to_charge_) {
-    this->warning_battery_too_low_to_charge_->publish_state(values.warning_battery_too_low_to_charge);
-  }
-  if (this->fault_dc_dc_over_current_) {
-    this->fault_dc_dc_over_current_->publish_state(values.fault_dc_dc_over_current);
-  }
+
   if (this->fault_code_) {
-    this->fault_code_->publish_state(values.fault_code);
-  }
-  if (this->warnung_low_pv_energy_) {
-    this->warnung_low_pv_energy_->publish_state(values.warnung_low_pv_energy);
-  }
-  if (this->warning_high_ac_input_during_bus_soft_start_) {
-    this->warning_high_ac_input_during_bus_soft_start_->publish_state(
-        values.warning_high_ac_input_during_bus_soft_start);
-  }
-  if (this->warning_battery_equalization_) {
-    this->warning_battery_equalization_->publish_state(values.warning_battery_equalization);
+    if (flags.length() < 33) {
+      this->fault_code_->publish_state(NAN);
+    } else {
+      std::string fc(flags, 31, 2);
+      this->fault_code_->publish_state(parse_number<int>(fc).value_or(NAN));
+    }
   }
 }
 
@@ -872,6 +655,76 @@ void Pipsolar::handle_qmn_(const char *message) {
   if (this->last_qmn_) {
     this->last_qmn_->publish_state(message);
   }
+}
+
+void Pipsolar::skip_start_(const char* message, size_t *pos) {
+  if (message[*pos] == '(') {
+    (*pos++);
+  }
+}
+void Pipsolar::skip_field_(const char* message, size_t *pos) {
+  // find delimiter or end of string
+  while (message[*pos] != '\0' && message[*pos] != ' ') {
+    (*pos)++;
+  }
+  if (message[*pos] != '\0') {
+    // skip delimiter after this field if there is one
+    (*pos)++;
+  }
+}
+std::string Pipsolar::read_field_(const char* message, size_t *pos) {
+  size_t begin = *pos;
+  // find delimiter or end of string
+  while (message[*pos] != '\0' && message[*pos] != ' ') {
+    (*pos)++;
+  }
+  if (*pos == begin) {
+    return "";
+  }
+  
+  std::string field(message, begin, *pos - begin);
+
+  if (message[*pos] != '\0') {
+    // skip delimiter after this field if there is one
+    (*pos)++;
+  }
+
+  return field;
+}
+
+void Pipsolar::read_float_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor) {
+  if (sensor != nullptr) {
+    std::string field = this->read_field_(message, pos);
+    sensor->publish_state(parse_number<float>(field).value_or(NAN));
+  } else {
+    this->skip_field_(message, pos);
+  }
+}
+void Pipsolar::read_int_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor) {
+  if (sensor != nullptr) {
+    std::string field = this->read_field_(message, pos);
+    esphome::optional<int32_t> parsed = parse_number<int32_t>(field);
+    sensor->publish_state(parsed.has_value() ? parsed.value() : NAN);
+  } else {
+    this->skip_field_(message, pos);
+  }
+}
+
+void Pipsolar::publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor) {
+  if (sensor) {
+    if (b.has_value()) {
+      sensor->publish_state(b.value());
+    } else {
+      sensor->invalidate_state();
+    }
+  }
+}
+
+esphome::optional<bool> Pipsolar::get_bit_(std::string bits, uint8_t bit_pos) {
+  if (bit_pos >= bits.length()) {
+    return {};
+  }
+  return bits[bit_pos] == '1';
 }
 
 void Pipsolar::dump_config() {

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -66,46 +66,8 @@ void Pipsolar::loop() {
   }
 
   if (this->state_ == STATE_POLL_CHECKED) {
-    switch (this->enabled_polling_commands_[this->last_polling_command_].identifier) {
-      case POLLING_QPIRI:
-        ESP_LOGD(TAG, "Decode QPIRI");
-        handle_qpiri_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QPIGS:
-        ESP_LOGD(TAG, "Decode QPIGS");
-        handle_qpigs_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QMOD:
-        ESP_LOGD(TAG, "Decode QMOD");
-        handle_qmod_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QFLAG:
-        ESP_LOGD(TAG, "Decode QFLAG");
-        handle_qflag_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QPIWS:
-        ESP_LOGD(TAG, "Decode QPIWS");
-        handle_qpiws_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QT:
-        ESP_LOGD(TAG, "Decode QT");
-        handle_qt_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QMN:
-        ESP_LOGD(TAG, "Decode QMN");
-        handle_qmn_((const char*)this->read_buffer_);
-        this->state_ = STATE_IDLE;
-        break;
-      default:
-        this->state_ = STATE_IDLE;
-        break;
-    }
+    this->handle_poll_response_(this->enabled_polling_commands_[this->last_polling_command_].identifier, (const char*)this->read_buffer_);
+    this->state_ = STATE_IDLE;
     return;
   }
 
@@ -113,6 +75,8 @@ void Pipsolar::loop() {
     if (this->check_incoming_crc_()) {
       if (this->read_buffer_[0] == '(' && this->read_buffer_[1] == 'N' && this->read_buffer_[2] == 'A' &&
           this->read_buffer_[3] == 'K') {
+        ESP_LOGD(TAG, "poll %s NACK", this->enabled_polling_commands_[this->last_polling_command_].command);
+        this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
         this->state_ = STATE_IDLE;
         return;
       }
@@ -121,6 +85,8 @@ void Pipsolar::loop() {
       this->state_ = STATE_POLL_CHECKED;
       return;
     } else {
+      ESP_LOGD(TAG, "poll %s CRC error", this->enabled_polling_commands_[this->last_polling_command_].command);
+      this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
       this->state_ = STATE_IDLE;
     }
   }
@@ -166,7 +132,8 @@ void Pipsolar::loop() {
   if (this->state_ == STATE_POLL) {
     if (millis() - this->command_start_millis_ > esphome::pipsolar::Pipsolar::COMMAND_TIMEOUT) {
       // command timeout
-      ESP_LOGD(TAG, "timeout command to poll: %s", this->enabled_polling_commands_[this->last_polling_command_].command);
+      ESP_LOGD(TAG, "poll %s timeout", this->enabled_polling_commands_[this->last_polling_command_].command);
+      this->handle_poll_error_(this->enabled_polling_commands_[this->last_polling_command_].identifier);
       this->state_ = STATE_IDLE;
     } else {
     }
@@ -270,6 +237,69 @@ void Pipsolar::queue_command(const std::string &command) {
     }
   }
   ESP_LOGD(TAG, "Command queue full dropping command: %s", command);
+}
+
+void Pipsolar::handle_poll_response_(ENUMPollingCommand polling_command, const char *message) {
+  switch (polling_command) {
+    case POLLING_QPIRI:
+      ESP_LOGD(TAG, "Decode QPIRI");
+      handle_qpiri_(message);
+      break;
+    case POLLING_QPIGS:
+      ESP_LOGD(TAG, "Decode QPIGS");
+      handle_qpigs_(message);
+      break;
+    case POLLING_QMOD:
+      ESP_LOGD(TAG, "Decode QMOD");
+      handle_qmod_(message);
+      break;
+    case POLLING_QFLAG:
+      ESP_LOGD(TAG, "Decode QFLAG");
+      handle_qflag_(message);
+      break;
+    case POLLING_QPIWS:
+      ESP_LOGD(TAG, "Decode QPIWS");
+      handle_qpiws_(message);
+      break;
+    case POLLING_QT:
+      ESP_LOGD(TAG, "Decode QT");
+      handle_qt_(message);
+      break;
+    case POLLING_QMN:
+      ESP_LOGD(TAG, "Decode QMN");
+      handle_qmn_(message);
+      break;
+    default:
+      break;
+  }
+}
+void Pipsolar::handle_poll_error_(ENUMPollingCommand polling_command) {
+  // these handlers are designed in a way that an empty message sets all sensors to unknown
+  switch (polling_command) {
+    case POLLING_QPIRI:
+      handle_qpiri_("");
+      break;
+    case POLLING_QPIGS:
+      handle_qpigs_("");
+      break;
+    case POLLING_QMOD:
+      handle_qmod_("");
+      break;
+    case POLLING_QFLAG:
+      handle_qflag_("");
+      break;
+    case POLLING_QPIWS:
+      handle_qpiws_("");
+      break;
+    case POLLING_QT:
+      handle_qt_("");
+      break;
+    case POLLING_QMN:
+      handle_qmn_("");
+      break;
+    default:
+      break;
+  }
 }
 
 void Pipsolar::handle_qpiri_(const char* message) {

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -603,7 +603,7 @@ void Pipsolar::handle_qpiws_(const char* message) {
   bool enabled = true;
   std::string fc;
   bool value_warnings_present = false;
-  bool value_faults_present = true;
+  bool value_faults_present = false;
 
   for (size_t i = 1; i < strlen(message); i++) {
     enabled = message[i] == '1';

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -66,7 +66,8 @@ void Pipsolar::loop() {
   }
 
   if (this->state_ == STATE_POLL_CHECKED) {
-    this->handle_poll_response_(this->enabled_polling_commands_[this->last_polling_command_].identifier, (const char*)this->read_buffer_);
+    this->handle_poll_response_(this->enabled_polling_commands_[this->last_polling_command_].identifier,
+                                (const char *) this->read_buffer_);
     this->state_ = STATE_IDLE;
     return;
   }
@@ -200,7 +201,7 @@ bool Pipsolar::send_next_poll_() {
       // not enabled
       continue;
     }
-    if(!this->enabled_polling_commands_[this->last_polling_command_].needs_update) {
+    if (!this->enabled_polling_commands_[this->last_polling_command_].needs_update) {
       // no update requested
       continue;
     }
@@ -218,8 +219,8 @@ bool Pipsolar::send_next_poll_() {
     // end Byte
     this->write(0x0D);
     ESP_LOGD(TAG, "Sending polling command : %s with length %d",
-            this->enabled_polling_commands_[this->last_polling_command_].command,
-            this->enabled_polling_commands_[this->last_polling_command_].length);
+             this->enabled_polling_commands_[this->last_polling_command_].command,
+             this->enabled_polling_commands_[this->last_polling_command_].length);
     return true;
   }
   return false;
@@ -302,7 +303,7 @@ void Pipsolar::handle_poll_error_(ENUMPollingCommand polling_command) {
   }
 }
 
-void Pipsolar::handle_qpiri_(const char* message) {
+void Pipsolar::handle_qpiri_(const char *message) {
   if (this->last_qpiri_) {
     this->last_qpiri_->publish_state(message);
   }
@@ -385,7 +386,7 @@ void Pipsolar::handle_qpiri_(const char* message) {
   }
 }
 
-void Pipsolar::handle_qpigs_(const char* message) {
+void Pipsolar::handle_qpigs_(const char *message) {
   if (this->last_qpigs_) {
     this->last_qpigs_->publish_state(message);
   }
@@ -431,14 +432,14 @@ void Pipsolar::handle_qpigs_(const char* message) {
   }
   this->read_int_sensor_(message, &pos, this->eeprom_version_);
   this->read_int_sensor_(message, &pos, this->pv_charging_power_);
-  
+
   std::string device_status_2 = this->read_field_(message, &pos);
   this->publish_binary_sensor_(this->get_bit_(device_status_2, 0), this->charging_to_floating_mode_);
   this->publish_binary_sensor_(this->get_bit_(device_status_2, 1), this->switch_on_);
   this->publish_binary_sensor_(this->get_bit_(device_status_2, 2), this->dustproof_installed_);
 }
 
-void Pipsolar::handle_qmod_(const char* message) {
+void Pipsolar::handle_qmod_(const char *message) {
   std::string mode;
   char device_mode = char(message[1]);
   if (this->last_qmod_) {
@@ -450,7 +451,7 @@ void Pipsolar::handle_qmod_(const char* message) {
   }
 }
 
-void Pipsolar::handle_qflag_(const char* message) {
+void Pipsolar::handle_qflag_(const char *message) {
   // result like:"(EbkuvxzDajy"
   // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
   if (this->last_qflag_) {
@@ -503,12 +504,13 @@ void Pipsolar::handle_qflag_(const char* message) {
   this->publish_binary_sensor_(values.overload_restart_function, this->overload_restart_function_);
   this->publish_binary_sensor_(values.over_temperature_restart_function, this->over_temperature_restart_function_);
   this->publish_binary_sensor_(values.backlight_on, this->backlight_on_);
-  this->publish_binary_sensor_(values.alarm_on_when_primary_source_interrupt, this->alarm_on_when_primary_source_interrupt_);
+  this->publish_binary_sensor_(values.alarm_on_when_primary_source_interrupt,
+                               this->alarm_on_when_primary_source_interrupt_);
   this->publish_binary_sensor_(values.fault_code_record, this->fault_code_record_);
   this->publish_binary_sensor_(values.power_saving, this->power_saving_);
 }
 
-void Pipsolar::handle_qpiws_(const char* message) {
+void Pipsolar::handle_qpiws_(const char *message) {
   // '(00000000000000000000000000000000'
   // iterate over all available flag (as not all models have all flags, but at least in the same order)
   if (this->last_qpiws_) {
@@ -687,12 +689,12 @@ void Pipsolar::handle_qmn_(const char *message) {
   }
 }
 
-void Pipsolar::skip_start_(const char* message, size_t *pos) {
+void Pipsolar::skip_start_(const char *message, size_t *pos) {
   if (message[*pos] == '(') {
     (*pos++);
   }
 }
-void Pipsolar::skip_field_(const char* message, size_t *pos) {
+void Pipsolar::skip_field_(const char *message, size_t *pos) {
   // find delimiter or end of string
   while (message[*pos] != '\0' && message[*pos] != ' ') {
     (*pos)++;
@@ -702,7 +704,7 @@ void Pipsolar::skip_field_(const char* message, size_t *pos) {
     (*pos)++;
   }
 }
-std::string Pipsolar::read_field_(const char* message, size_t *pos) {
+std::string Pipsolar::read_field_(const char *message, size_t *pos) {
   size_t begin = *pos;
   // find delimiter or end of string
   while (message[*pos] != '\0' && message[*pos] != ' ') {
@@ -711,7 +713,7 @@ std::string Pipsolar::read_field_(const char* message, size_t *pos) {
   if (*pos == begin) {
     return "";
   }
-  
+
   std::string field(message, begin, *pos - begin);
 
   if (message[*pos] != '\0') {
@@ -722,7 +724,7 @@ std::string Pipsolar::read_field_(const char* message, size_t *pos) {
   return field;
 }
 
-void Pipsolar::read_float_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor) {
+void Pipsolar::read_float_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor) {
   if (sensor != nullptr) {
     std::string field = this->read_field_(message, pos);
     sensor->publish_state(parse_number<float>(field).value_or(NAN));
@@ -730,7 +732,7 @@ void Pipsolar::read_float_sensor_(const char* message, size_t *pos, sensor::Sens
     this->skip_field_(message, pos);
   }
 }
-void Pipsolar::read_int_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor) {
+void Pipsolar::read_int_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor) {
   if (sensor != nullptr) {
     std::string field = this->read_field_(message, pos);
     esphome::optional<int32_t> parsed = parse_number<int32_t>(field);

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -65,631 +65,42 @@ void Pipsolar::loop() {
     }
   }
 
-  if (this->state_ == STATE_POLL_DECODED) {
-    std::string mode;
-    switch (this->enabled_polling_commands_[this->last_polling_command_].identifier) {
-      case POLLING_QPIRI:
-        if (this->grid_rating_voltage_) {
-          this->grid_rating_voltage_->publish_state(value_grid_rating_voltage_);
-        }
-        if (this->grid_rating_current_) {
-          this->grid_rating_current_->publish_state(value_grid_rating_current_);
-        }
-        if (this->ac_output_rating_voltage_) {
-          this->ac_output_rating_voltage_->publish_state(value_ac_output_rating_voltage_);
-        }
-        if (this->ac_output_rating_frequency_) {
-          this->ac_output_rating_frequency_->publish_state(value_ac_output_rating_frequency_);
-        }
-        if (this->ac_output_rating_current_) {
-          this->ac_output_rating_current_->publish_state(value_ac_output_rating_current_);
-        }
-        if (this->ac_output_rating_apparent_power_) {
-          this->ac_output_rating_apparent_power_->publish_state(value_ac_output_rating_apparent_power_);
-        }
-        if (this->ac_output_rating_active_power_) {
-          this->ac_output_rating_active_power_->publish_state(value_ac_output_rating_active_power_);
-        }
-        if (this->battery_rating_voltage_) {
-          this->battery_rating_voltage_->publish_state(value_battery_rating_voltage_);
-        }
-        if (this->battery_recharge_voltage_) {
-          this->battery_recharge_voltage_->publish_state(value_battery_recharge_voltage_);
-        }
-        if (this->battery_under_voltage_) {
-          this->battery_under_voltage_->publish_state(value_battery_under_voltage_);
-        }
-        if (this->battery_bulk_voltage_) {
-          this->battery_bulk_voltage_->publish_state(value_battery_bulk_voltage_);
-        }
-        if (this->battery_float_voltage_) {
-          this->battery_float_voltage_->publish_state(value_battery_float_voltage_);
-        }
-        if (this->battery_type_) {
-          this->battery_type_->publish_state(value_battery_type_);
-        }
-        if (this->current_max_ac_charging_current_) {
-          this->current_max_ac_charging_current_->publish_state(value_current_max_ac_charging_current_);
-        }
-        if (this->current_max_charging_current_) {
-          this->current_max_charging_current_->publish_state(value_current_max_charging_current_);
-        }
-        if (this->input_voltage_range_) {
-          this->input_voltage_range_->publish_state(value_input_voltage_range_);
-        }
-        // special for input voltage range switch
-        if (this->input_voltage_range_switch_) {
-          this->input_voltage_range_switch_->publish_state(value_input_voltage_range_ == 1);
-        }
-        if (this->output_source_priority_) {
-          this->output_source_priority_->publish_state(value_output_source_priority_);
-        }
-        // special for output source priority switches
-        if (this->output_source_priority_utility_switch_) {
-          this->output_source_priority_utility_switch_->publish_state(value_output_source_priority_ == 0);
-        }
-        if (this->output_source_priority_solar_switch_) {
-          this->output_source_priority_solar_switch_->publish_state(value_output_source_priority_ == 1);
-        }
-        if (this->output_source_priority_battery_switch_) {
-          this->output_source_priority_battery_switch_->publish_state(value_output_source_priority_ == 2);
-        }
-        if (this->output_source_priority_hybrid_switch_) {
-          this->output_source_priority_hybrid_switch_->publish_state(value_output_source_priority_ == 3);
-        }
-        if (this->charger_source_priority_) {
-          this->charger_source_priority_->publish_state(value_charger_source_priority_);
-        }
-        if (this->parallel_max_num_) {
-          this->parallel_max_num_->publish_state(value_parallel_max_num_);
-        }
-        if (this->machine_type_) {
-          this->machine_type_->publish_state(value_machine_type_);
-        }
-        if (this->topology_) {
-          this->topology_->publish_state(value_topology_);
-        }
-        if (this->output_mode_) {
-          this->output_mode_->publish_state(value_output_mode_);
-        }
-        if (this->battery_redischarge_voltage_) {
-          this->battery_redischarge_voltage_->publish_state(value_battery_redischarge_voltage_);
-        }
-        if (this->pv_ok_condition_for_parallel_) {
-          this->pv_ok_condition_for_parallel_->publish_state(value_pv_ok_condition_for_parallel_);
-        }
-        // special for pv ok condition switch
-        if (this->pv_ok_condition_for_parallel_switch_) {
-          this->pv_ok_condition_for_parallel_switch_->publish_state(value_pv_ok_condition_for_parallel_ == 1);
-        }
-        if (this->pv_power_balance_) {
-          this->pv_power_balance_->publish_state(value_pv_power_balance_ == 1);
-        }
-        // special for power balance switch
-        if (this->pv_power_balance_switch_) {
-          this->pv_power_balance_switch_->publish_state(value_pv_power_balance_ == 1);
-        }
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QPIGS:
-        if (this->grid_voltage_) {
-          this->grid_voltage_->publish_state(value_grid_voltage_);
-        }
-        if (this->grid_frequency_) {
-          this->grid_frequency_->publish_state(value_grid_frequency_);
-        }
-        if (this->ac_output_voltage_) {
-          this->ac_output_voltage_->publish_state(value_ac_output_voltage_);
-        }
-        if (this->ac_output_frequency_) {
-          this->ac_output_frequency_->publish_state(value_ac_output_frequency_);
-        }
-        if (this->ac_output_apparent_power_) {
-          this->ac_output_apparent_power_->publish_state(value_ac_output_apparent_power_);
-        }
-        if (this->ac_output_active_power_) {
-          this->ac_output_active_power_->publish_state(value_ac_output_active_power_);
-        }
-        if (this->output_load_percent_) {
-          this->output_load_percent_->publish_state(value_output_load_percent_);
-        }
-        if (this->bus_voltage_) {
-          this->bus_voltage_->publish_state(value_bus_voltage_);
-        }
-        if (this->battery_voltage_) {
-          this->battery_voltage_->publish_state(value_battery_voltage_);
-        }
-        if (this->battery_charging_current_) {
-          this->battery_charging_current_->publish_state(value_battery_charging_current_);
-        }
-        if (this->battery_capacity_percent_) {
-          this->battery_capacity_percent_->publish_state(value_battery_capacity_percent_);
-        }
-        if (this->inverter_heat_sink_temperature_) {
-          this->inverter_heat_sink_temperature_->publish_state(value_inverter_heat_sink_temperature_);
-        }
-        if (this->pv_input_current_for_battery_) {
-          this->pv_input_current_for_battery_->publish_state(value_pv_input_current_for_battery_);
-        }
-        if (this->pv_input_voltage_) {
-          this->pv_input_voltage_->publish_state(value_pv_input_voltage_);
-        }
-        if (this->battery_voltage_scc_) {
-          this->battery_voltage_scc_->publish_state(value_battery_voltage_scc_);
-        }
-        if (this->battery_discharge_current_) {
-          this->battery_discharge_current_->publish_state(value_battery_discharge_current_);
-        }
-        if (this->add_sbu_priority_version_) {
-          this->add_sbu_priority_version_->publish_state(value_add_sbu_priority_version_);
-        }
-        if (this->configuration_status_) {
-          this->configuration_status_->publish_state(value_configuration_status_);
-        }
-        if (this->scc_firmware_version_) {
-          this->scc_firmware_version_->publish_state(value_scc_firmware_version_);
-        }
-        if (this->load_status_) {
-          this->load_status_->publish_state(value_load_status_);
-        }
-        if (this->battery_voltage_to_steady_while_charging_) {
-          this->battery_voltage_to_steady_while_charging_->publish_state(
-              value_battery_voltage_to_steady_while_charging_);
-        }
-        if (this->charging_status_) {
-          this->charging_status_->publish_state(value_charging_status_);
-        }
-        if (this->scc_charging_status_) {
-          this->scc_charging_status_->publish_state(value_scc_charging_status_);
-        }
-        if (this->ac_charging_status_) {
-          this->ac_charging_status_->publish_state(value_ac_charging_status_);
-        }
-        if (this->battery_voltage_offset_for_fans_on_) {
-          this->battery_voltage_offset_for_fans_on_->publish_state(value_battery_voltage_offset_for_fans_on_ / 10.0f);
-        }  //.1 scale
-        if (this->eeprom_version_) {
-          this->eeprom_version_->publish_state(value_eeprom_version_);
-        }
-        if (this->pv_charging_power_) {
-          this->pv_charging_power_->publish_state(value_pv_charging_power_);
-        }
-        if (this->charging_to_floating_mode_) {
-          this->charging_to_floating_mode_->publish_state(value_charging_to_floating_mode_);
-        }
-        if (this->switch_on_) {
-          this->switch_on_->publish_state(value_switch_on_);
-        }
-        if (this->dustproof_installed_) {
-          this->dustproof_installed_->publish_state(value_dustproof_installed_);
-        }
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QMOD:
-        if (this->device_mode_) {
-          mode = value_device_mode_;
-          this->device_mode_->publish_state(mode);
-        }
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QFLAG:
-        if (this->silence_buzzer_open_buzzer_) {
-          this->silence_buzzer_open_buzzer_->publish_state(value_silence_buzzer_open_buzzer_);
-        }
-        if (this->overload_bypass_function_) {
-          this->overload_bypass_function_->publish_state(value_overload_bypass_function_);
-        }
-        if (this->lcd_escape_to_default_) {
-          this->lcd_escape_to_default_->publish_state(value_lcd_escape_to_default_);
-        }
-        if (this->overload_restart_function_) {
-          this->overload_restart_function_->publish_state(value_overload_restart_function_);
-        }
-        if (this->over_temperature_restart_function_) {
-          this->over_temperature_restart_function_->publish_state(value_over_temperature_restart_function_);
-        }
-        if (this->backlight_on_) {
-          this->backlight_on_->publish_state(value_backlight_on_);
-        }
-        if (this->alarm_on_when_primary_source_interrupt_) {
-          this->alarm_on_when_primary_source_interrupt_->publish_state(value_alarm_on_when_primary_source_interrupt_);
-        }
-        if (this->fault_code_record_) {
-          this->fault_code_record_->publish_state(value_fault_code_record_);
-        }
-        if (this->power_saving_) {
-          this->power_saving_->publish_state(value_power_saving_);
-        }
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QPIWS:
-        if (this->warnings_present_) {
-          this->warnings_present_->publish_state(value_warnings_present_);
-        }
-        if (this->faults_present_) {
-          this->faults_present_->publish_state(value_faults_present_);
-        }
-        if (this->warning_power_loss_) {
-          this->warning_power_loss_->publish_state(value_warning_power_loss_);
-        }
-        if (this->fault_inverter_fault_) {
-          this->fault_inverter_fault_->publish_state(value_fault_inverter_fault_);
-        }
-        if (this->fault_bus_over_) {
-          this->fault_bus_over_->publish_state(value_fault_bus_over_);
-        }
-        if (this->fault_bus_under_) {
-          this->fault_bus_under_->publish_state(value_fault_bus_under_);
-        }
-        if (this->fault_bus_soft_fail_) {
-          this->fault_bus_soft_fail_->publish_state(value_fault_bus_soft_fail_);
-        }
-        if (this->warning_line_fail_) {
-          this->warning_line_fail_->publish_state(value_warning_line_fail_);
-        }
-        if (this->fault_opvshort_) {
-          this->fault_opvshort_->publish_state(value_fault_opvshort_);
-        }
-        if (this->fault_inverter_voltage_too_low_) {
-          this->fault_inverter_voltage_too_low_->publish_state(value_fault_inverter_voltage_too_low_);
-        }
-        if (this->fault_inverter_voltage_too_high_) {
-          this->fault_inverter_voltage_too_high_->publish_state(value_fault_inverter_voltage_too_high_);
-        }
-        if (this->warning_over_temperature_) {
-          this->warning_over_temperature_->publish_state(value_warning_over_temperature_);
-        }
-        if (this->warning_fan_lock_) {
-          this->warning_fan_lock_->publish_state(value_warning_fan_lock_);
-        }
-        if (this->warning_battery_voltage_high_) {
-          this->warning_battery_voltage_high_->publish_state(value_warning_battery_voltage_high_);
-        }
-        if (this->warning_battery_low_alarm_) {
-          this->warning_battery_low_alarm_->publish_state(value_warning_battery_low_alarm_);
-        }
-        if (this->warning_battery_under_shutdown_) {
-          this->warning_battery_under_shutdown_->publish_state(value_warning_battery_under_shutdown_);
-        }
-        if (this->warning_battery_derating_) {
-          this->warning_battery_derating_->publish_state(value_warning_battery_derating_);
-        }
-        if (this->warning_over_load_) {
-          this->warning_over_load_->publish_state(value_warning_over_load_);
-        }
-        if (this->warning_eeprom_failed_) {
-          this->warning_eeprom_failed_->publish_state(value_warning_eeprom_failed_);
-        }
-        if (this->fault_inverter_over_current_) {
-          this->fault_inverter_over_current_->publish_state(value_fault_inverter_over_current_);
-        }
-        if (this->fault_inverter_soft_failed_) {
-          this->fault_inverter_soft_failed_->publish_state(value_fault_inverter_soft_failed_);
-        }
-        if (this->fault_self_test_failed_) {
-          this->fault_self_test_failed_->publish_state(value_fault_self_test_failed_);
-        }
-        if (this->fault_op_dc_voltage_over_) {
-          this->fault_op_dc_voltage_over_->publish_state(value_fault_op_dc_voltage_over_);
-        }
-        if (this->fault_battery_open_) {
-          this->fault_battery_open_->publish_state(value_fault_battery_open_);
-        }
-        if (this->fault_current_sensor_failed_) {
-          this->fault_current_sensor_failed_->publish_state(value_fault_current_sensor_failed_);
-        }
-        if (this->fault_battery_short_) {
-          this->fault_battery_short_->publish_state(value_fault_battery_short_);
-        }
-        if (this->warning_power_limit_) {
-          this->warning_power_limit_->publish_state(value_warning_power_limit_);
-        }
-        if (this->warning_pv_voltage_high_) {
-          this->warning_pv_voltage_high_->publish_state(value_warning_pv_voltage_high_);
-        }
-        if (this->fault_mppt_overload_) {
-          this->fault_mppt_overload_->publish_state(value_fault_mppt_overload_);
-        }
-        if (this->warning_mppt_overload_) {
-          this->warning_mppt_overload_->publish_state(value_warning_mppt_overload_);
-        }
-        if (this->warning_battery_too_low_to_charge_) {
-          this->warning_battery_too_low_to_charge_->publish_state(value_warning_battery_too_low_to_charge_);
-        }
-        if (this->fault_dc_dc_over_current_) {
-          this->fault_dc_dc_over_current_->publish_state(value_fault_dc_dc_over_current_);
-        }
-        if (this->fault_code_) {
-          this->fault_code_->publish_state(value_fault_code_);
-        }
-        if (this->warnung_low_pv_energy_) {
-          this->warnung_low_pv_energy_->publish_state(value_warnung_low_pv_energy_);
-        }
-        if (this->warning_high_ac_input_during_bus_soft_start_) {
-          this->warning_high_ac_input_during_bus_soft_start_->publish_state(
-              value_warning_high_ac_input_during_bus_soft_start_);
-        }
-        if (this->warning_battery_equalization_) {
-          this->warning_battery_equalization_->publish_state(value_warning_battery_equalization_);
-        }
-        this->state_ = STATE_IDLE;
-        break;
-      case POLLING_QT:
-      case POLLING_QMN:
-        this->state_ = STATE_IDLE;
-        break;
-    }
-  }
-
   if (this->state_ == STATE_POLL_CHECKED) {
-    bool enabled = true;
-    std::string fc;
-    char tmp[PIPSOLAR_READ_BUFFER_LENGTH];
-    sprintf(tmp, "%s", this->read_buffer_);
     switch (this->enabled_polling_commands_[this->last_polling_command_].identifier) {
       case POLLING_QPIRI:
         ESP_LOGD(TAG, "Decode QPIRI");
-        sscanf(tmp, "(%f %f %f %f %f %d %d %f %f %f %f %f %d %d %d %d %d %d %d %d %d %d %f %d %d",          // NOLINT
-               &value_grid_rating_voltage_, &value_grid_rating_current_, &value_ac_output_rating_voltage_,  // NOLINT
-               &value_ac_output_rating_frequency_, &value_ac_output_rating_current_,                        // NOLINT
-               &value_ac_output_rating_apparent_power_, &value_ac_output_rating_active_power_,              // NOLINT
-               &value_battery_rating_voltage_, &value_battery_recharge_voltage_,                            // NOLINT
-               &value_battery_under_voltage_, &value_battery_bulk_voltage_, &value_battery_float_voltage_,  // NOLINT
-               &value_battery_type_, &value_current_max_ac_charging_current_,                               // NOLINT
-               &value_current_max_charging_current_, &value_input_voltage_range_,                           // NOLINT
-               &value_output_source_priority_, &value_charger_source_priority_, &value_parallel_max_num_,   // NOLINT
-               &value_machine_type_, &value_topology_, &value_output_mode_,                                 // NOLINT
-               &value_battery_redischarge_voltage_, &value_pv_ok_condition_for_parallel_,                   // NOLINT
-               &value_pv_power_balance_);                                                                   // NOLINT
-        if (this->last_qpiri_) {
-          this->last_qpiri_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qpiri_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QPIGS:
         ESP_LOGD(TAG, "Decode QPIGS");
-        sscanf(                                                                                              // NOLINT
-            tmp,                                                                                             // NOLINT
-            "(%f %f %f %f %d %d %d %d %f %d %d %d %f %f %f %d %1d%1d%1d%1d%1d%1d%1d%1d %d %d %d %1d%1d%1d",  // NOLINT
-            &value_grid_voltage_, &value_grid_frequency_, &value_ac_output_voltage_,                         // NOLINT
-            &value_ac_output_frequency_,                                                                     // NOLINT
-            &value_ac_output_apparent_power_, &value_ac_output_active_power_, &value_output_load_percent_,   // NOLINT
-            &value_bus_voltage_, &value_battery_voltage_, &value_battery_charging_current_,                  // NOLINT
-            &value_battery_capacity_percent_, &value_inverter_heat_sink_temperature_,                        // NOLINT
-            &value_pv_input_current_for_battery_, &value_pv_input_voltage_, &value_battery_voltage_scc_,     // NOLINT
-            &value_battery_discharge_current_, &value_add_sbu_priority_version_,                             // NOLINT
-            &value_configuration_status_, &value_scc_firmware_version_, &value_load_status_,                 // NOLINT
-            &value_battery_voltage_to_steady_while_charging_, &value_charging_status_,                       // NOLINT
-            &value_scc_charging_status_, &value_ac_charging_status_,                                         // NOLINT
-            &value_battery_voltage_offset_for_fans_on_, &value_eeprom_version_, &value_pv_charging_power_,   // NOLINT
-            &value_charging_to_floating_mode_, &value_switch_on_,                                            // NOLINT
-            &value_dustproof_installed_);                                                                    // NOLINT
-        if (this->last_qpigs_) {
-          this->last_qpigs_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qpigs_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QMOD:
         ESP_LOGD(TAG, "Decode QMOD");
-        this->value_device_mode_ = char(this->read_buffer_[1]);
-        if (this->last_qmod_) {
-          this->last_qmod_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qmod_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QFLAG:
         ESP_LOGD(TAG, "Decode QFLAG");
-        // result like:"(EbkuvxzDajy"
-        // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
-        for (size_t i = 1; i < strlen(tmp); i++) {
-          switch (tmp[i]) {
-            case 'E':
-              enabled = true;
-              break;
-            case 'D':
-              enabled = false;
-              break;
-            case 'a':
-              this->value_silence_buzzer_open_buzzer_ = enabled;
-              break;
-            case 'b':
-              this->value_overload_bypass_function_ = enabled;
-              break;
-            case 'k':
-              this->value_lcd_escape_to_default_ = enabled;
-              break;
-            case 'u':
-              this->value_overload_restart_function_ = enabled;
-              break;
-            case 'v':
-              this->value_over_temperature_restart_function_ = enabled;
-              break;
-            case 'x':
-              this->value_backlight_on_ = enabled;
-              break;
-            case 'y':
-              this->value_alarm_on_when_primary_source_interrupt_ = enabled;
-              break;
-            case 'z':
-              this->value_fault_code_record_ = enabled;
-              break;
-            case 'j':
-              this->value_power_saving_ = enabled;
-              break;
-          }
-        }
-        if (this->last_qflag_) {
-          this->last_qflag_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qflag_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QPIWS:
         ESP_LOGD(TAG, "Decode QPIWS");
-        // '(00000000000000000000000000000000'
-        // iterate over all available flag (as not all models have all flags, but at least in the same order)
-        this->value_warnings_present_ = false;
-        this->value_faults_present_ = true;
-
-        for (size_t i = 1; i < strlen(tmp); i++) {
-          enabled = tmp[i] == '1';
-          switch (i) {
-            case 1:
-              this->value_warning_power_loss_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 2:
-              this->value_fault_inverter_fault_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 3:
-              this->value_fault_bus_over_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 4:
-              this->value_fault_bus_under_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 5:
-              this->value_fault_bus_soft_fail_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 6:
-              this->value_warning_line_fail_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 7:
-              this->value_fault_opvshort_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 8:
-              this->value_fault_inverter_voltage_too_low_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 9:
-              this->value_fault_inverter_voltage_too_high_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 10:
-              this->value_warning_over_temperature_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 11:
-              this->value_warning_fan_lock_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 12:
-              this->value_warning_battery_voltage_high_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 13:
-              this->value_warning_battery_low_alarm_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 15:
-              this->value_warning_battery_under_shutdown_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 16:
-              this->value_warning_battery_derating_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 17:
-              this->value_warning_over_load_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 18:
-              this->value_warning_eeprom_failed_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 19:
-              this->value_fault_inverter_over_current_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 20:
-              this->value_fault_inverter_soft_failed_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 21:
-              this->value_fault_self_test_failed_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 22:
-              this->value_fault_op_dc_voltage_over_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 23:
-              this->value_fault_battery_open_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 24:
-              this->value_fault_current_sensor_failed_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 25:
-              this->value_fault_battery_short_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 26:
-              this->value_warning_power_limit_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 27:
-              this->value_warning_pv_voltage_high_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 28:
-              this->value_fault_mppt_overload_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 29:
-              this->value_warning_mppt_overload_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 30:
-              this->value_warning_battery_too_low_to_charge_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 31:
-              this->value_fault_dc_dc_over_current_ = enabled;
-              this->value_faults_present_ += enabled;
-              break;
-            case 32:
-              fc = tmp[i];
-              fc += tmp[i + 1];
-              this->value_fault_code_ = parse_number<int>(fc).value_or(0);
-              break;
-            case 34:
-              this->value_warnung_low_pv_energy_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 35:
-              this->value_warning_high_ac_input_during_bus_soft_start_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-            case 36:
-              this->value_warning_battery_equalization_ = enabled;
-              this->value_warnings_present_ += enabled;
-              break;
-          }
-        }
-        if (this->last_qpiws_) {
-          this->last_qpiws_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qpiws_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QT:
         ESP_LOGD(TAG, "Decode QT");
-        if (this->last_qt_) {
-          this->last_qt_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qt_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       case POLLING_QMN:
         ESP_LOGD(TAG, "Decode QMN");
-        if (this->last_qmn_) {
-          this->last_qmn_->publish_state(tmp);
-        }
-        this->state_ = STATE_POLL_DECODED;
+        handle_qmn_((const char*)this->read_buffer_);
+        this->state_ = STATE_IDLE;
         break;
       default:
         this->state_ = STATE_IDLE;
@@ -859,6 +270,602 @@ void Pipsolar::queue_command(const std::string &command) {
     }
   }
   ESP_LOGD(TAG, "Command queue full dropping command: %s", command);
+}
+
+void Pipsolar::handle_qpiri_(const char* message) {
+  sscanf(message, "(%f %f %f %f %f %d %d %f %f %f %f %f %d %d %d %d %d %d %d %d %d %d %f %d %d",       // NOLINT
+          &value_grid_rating_voltage_, &value_grid_rating_current_, &value_ac_output_rating_voltage_,  // NOLINT
+          &value_ac_output_rating_frequency_, &value_ac_output_rating_current_,                        // NOLINT
+          &value_ac_output_rating_apparent_power_, &value_ac_output_rating_active_power_,              // NOLINT
+          &value_battery_rating_voltage_, &value_battery_recharge_voltage_,                            // NOLINT
+          &value_battery_under_voltage_, &value_battery_bulk_voltage_, &value_battery_float_voltage_,  // NOLINT
+          &value_battery_type_, &value_current_max_ac_charging_current_,                               // NOLINT
+          &value_current_max_charging_current_, &value_input_voltage_range_,                           // NOLINT
+          &value_output_source_priority_, &value_charger_source_priority_, &value_parallel_max_num_,   // NOLINT
+          &value_machine_type_, &value_topology_, &value_output_mode_,                                 // NOLINT
+          &value_battery_redischarge_voltage_, &value_pv_ok_condition_for_parallel_,                   // NOLINT
+          &value_pv_power_balance_);                                                                   // NOLINT
+  if (this->last_qpiri_) {
+    this->last_qpiri_->publish_state(message);
+  }
+
+  if (this->grid_rating_voltage_) {
+    this->grid_rating_voltage_->publish_state(value_grid_rating_voltage_);
+  }
+  if (this->grid_rating_current_) {
+    this->grid_rating_current_->publish_state(value_grid_rating_current_);
+  }
+  if (this->ac_output_rating_voltage_) {
+    this->ac_output_rating_voltage_->publish_state(value_ac_output_rating_voltage_);
+  }
+  if (this->ac_output_rating_frequency_) {
+    this->ac_output_rating_frequency_->publish_state(value_ac_output_rating_frequency_);
+  }
+  if (this->ac_output_rating_current_) {
+    this->ac_output_rating_current_->publish_state(value_ac_output_rating_current_);
+  }
+  if (this->ac_output_rating_apparent_power_) {
+    this->ac_output_rating_apparent_power_->publish_state(value_ac_output_rating_apparent_power_);
+  }
+  if (this->ac_output_rating_active_power_) {
+    this->ac_output_rating_active_power_->publish_state(value_ac_output_rating_active_power_);
+  }
+  if (this->battery_rating_voltage_) {
+    this->battery_rating_voltage_->publish_state(value_battery_rating_voltage_);
+  }
+  if (this->battery_recharge_voltage_) {
+    this->battery_recharge_voltage_->publish_state(value_battery_recharge_voltage_);
+  }
+  if (this->battery_under_voltage_) {
+    this->battery_under_voltage_->publish_state(value_battery_under_voltage_);
+  }
+  if (this->battery_bulk_voltage_) {
+    this->battery_bulk_voltage_->publish_state(value_battery_bulk_voltage_);
+  }
+  if (this->battery_float_voltage_) {
+    this->battery_float_voltage_->publish_state(value_battery_float_voltage_);
+  }
+  if (this->battery_type_) {
+    this->battery_type_->publish_state(value_battery_type_);
+  }
+  if (this->current_max_ac_charging_current_) {
+    this->current_max_ac_charging_current_->publish_state(value_current_max_ac_charging_current_);
+  }
+  if (this->current_max_charging_current_) {
+    this->current_max_charging_current_->publish_state(value_current_max_charging_current_);
+  }
+  if (this->input_voltage_range_) {
+    this->input_voltage_range_->publish_state(value_input_voltage_range_);
+  }
+  // special for input voltage range switch
+  if (this->input_voltage_range_switch_) {
+    this->input_voltage_range_switch_->publish_state(value_input_voltage_range_ == 1);
+  }
+  if (this->output_source_priority_) {
+    this->output_source_priority_->publish_state(value_output_source_priority_);
+  }
+  // special for output source priority switches
+  if (this->output_source_priority_utility_switch_) {
+    this->output_source_priority_utility_switch_->publish_state(value_output_source_priority_ == 0);
+  }
+  if (this->output_source_priority_solar_switch_) {
+    this->output_source_priority_solar_switch_->publish_state(value_output_source_priority_ == 1);
+  }
+  if (this->output_source_priority_battery_switch_) {
+    this->output_source_priority_battery_switch_->publish_state(value_output_source_priority_ == 2);
+  }
+  if (this->output_source_priority_hybrid_switch_) {
+    this->output_source_priority_hybrid_switch_->publish_state(value_output_source_priority_ == 3);
+  }
+  if (this->charger_source_priority_) {
+    this->charger_source_priority_->publish_state(value_charger_source_priority_);
+  }
+  if (this->parallel_max_num_) {
+    this->parallel_max_num_->publish_state(value_parallel_max_num_);
+  }
+  if (this->machine_type_) {
+    this->machine_type_->publish_state(value_machine_type_);
+  }
+  if (this->topology_) {
+    this->topology_->publish_state(value_topology_);
+  }
+  if (this->output_mode_) {
+    this->output_mode_->publish_state(value_output_mode_);
+  }
+  if (this->battery_redischarge_voltage_) {
+    this->battery_redischarge_voltage_->publish_state(value_battery_redischarge_voltage_);
+  }
+  if (this->pv_ok_condition_for_parallel_) {
+    this->pv_ok_condition_for_parallel_->publish_state(value_pv_ok_condition_for_parallel_);
+  }
+  // special for pv ok condition switch
+  if (this->pv_ok_condition_for_parallel_switch_) {
+    this->pv_ok_condition_for_parallel_switch_->publish_state(value_pv_ok_condition_for_parallel_ == 1);
+  }
+  if (this->pv_power_balance_) {
+    this->pv_power_balance_->publish_state(value_pv_power_balance_ == 1);
+  }
+  // special for power balance switch
+  if (this->pv_power_balance_switch_) {
+    this->pv_power_balance_switch_->publish_state(value_pv_power_balance_ == 1);
+  }
+}
+
+void Pipsolar::handle_qpigs_(const char* message) {
+  sscanf(                                                                                              // NOLINT
+      message,                                                                                         // NOLINT
+      "(%f %f %f %f %d %d %d %d %f %d %d %d %f %f %f %d %1d%1d%1d%1d%1d%1d%1d%1d %d %d %d %1d%1d%1d",  // NOLINT
+      &value_grid_voltage_, &value_grid_frequency_, &value_ac_output_voltage_,                         // NOLINT
+      &value_ac_output_frequency_,                                                                     // NOLINT
+      &value_ac_output_apparent_power_, &value_ac_output_active_power_, &value_output_load_percent_,   // NOLINT
+      &value_bus_voltage_, &value_battery_voltage_, &value_battery_charging_current_,                  // NOLINT
+      &value_battery_capacity_percent_, &value_inverter_heat_sink_temperature_,                        // NOLINT
+      &value_pv_input_current_for_battery_, &value_pv_input_voltage_, &value_battery_voltage_scc_,     // NOLINT
+      &value_battery_discharge_current_, &value_add_sbu_priority_version_,                             // NOLINT
+      &value_configuration_status_, &value_scc_firmware_version_, &value_load_status_,                 // NOLINT
+      &value_battery_voltage_to_steady_while_charging_, &value_charging_status_,                       // NOLINT
+      &value_scc_charging_status_, &value_ac_charging_status_,                                         // NOLINT
+      &value_battery_voltage_offset_for_fans_on_, &value_eeprom_version_, &value_pv_charging_power_,   // NOLINT
+      &value_charging_to_floating_mode_, &value_switch_on_,                                            // NOLINT
+      &value_dustproof_installed_);                                                                    // NOLINT
+  if (this->last_qpigs_) {
+    this->last_qpigs_->publish_state(message);
+  }
+
+  if (this->grid_voltage_) {
+    this->grid_voltage_->publish_state(value_grid_voltage_);
+  }
+  if (this->grid_frequency_) {
+    this->grid_frequency_->publish_state(value_grid_frequency_);
+  }
+  if (this->ac_output_voltage_) {
+    this->ac_output_voltage_->publish_state(value_ac_output_voltage_);
+  }
+  if (this->ac_output_frequency_) {
+    this->ac_output_frequency_->publish_state(value_ac_output_frequency_);
+  }
+  if (this->ac_output_apparent_power_) {
+    this->ac_output_apparent_power_->publish_state(value_ac_output_apparent_power_);
+  }
+  if (this->ac_output_active_power_) {
+    this->ac_output_active_power_->publish_state(value_ac_output_active_power_);
+  }
+  if (this->output_load_percent_) {
+    this->output_load_percent_->publish_state(value_output_load_percent_);
+  }
+  if (this->bus_voltage_) {
+    this->bus_voltage_->publish_state(value_bus_voltage_);
+  }
+  if (this->battery_voltage_) {
+    this->battery_voltage_->publish_state(value_battery_voltage_);
+  }
+  if (this->battery_charging_current_) {
+    this->battery_charging_current_->publish_state(value_battery_charging_current_);
+  }
+  if (this->battery_capacity_percent_) {
+    this->battery_capacity_percent_->publish_state(value_battery_capacity_percent_);
+  }
+  if (this->inverter_heat_sink_temperature_) {
+    this->inverter_heat_sink_temperature_->publish_state(value_inverter_heat_sink_temperature_);
+  }
+  if (this->pv_input_current_for_battery_) {
+    this->pv_input_current_for_battery_->publish_state(value_pv_input_current_for_battery_);
+  }
+  if (this->pv_input_voltage_) {
+    this->pv_input_voltage_->publish_state(value_pv_input_voltage_);
+  }
+  if (this->battery_voltage_scc_) {
+    this->battery_voltage_scc_->publish_state(value_battery_voltage_scc_);
+  }
+  if (this->battery_discharge_current_) {
+    this->battery_discharge_current_->publish_state(value_battery_discharge_current_);
+  }
+  if (this->add_sbu_priority_version_) {
+    this->add_sbu_priority_version_->publish_state(value_add_sbu_priority_version_);
+  }
+  if (this->configuration_status_) {
+    this->configuration_status_->publish_state(value_configuration_status_);
+  }
+  if (this->scc_firmware_version_) {
+    this->scc_firmware_version_->publish_state(value_scc_firmware_version_);
+  }
+  if (this->load_status_) {
+    this->load_status_->publish_state(value_load_status_);
+  }
+  if (this->battery_voltage_to_steady_while_charging_) {
+    this->battery_voltage_to_steady_while_charging_->publish_state(
+        value_battery_voltage_to_steady_while_charging_);
+  }
+  if (this->charging_status_) {
+    this->charging_status_->publish_state(value_charging_status_);
+  }
+  if (this->scc_charging_status_) {
+    this->scc_charging_status_->publish_state(value_scc_charging_status_);
+  }
+  if (this->ac_charging_status_) {
+    this->ac_charging_status_->publish_state(value_ac_charging_status_);
+  }
+  if (this->battery_voltage_offset_for_fans_on_) {
+    this->battery_voltage_offset_for_fans_on_->publish_state(value_battery_voltage_offset_for_fans_on_ / 10.0f);
+  }  //.1 scale
+  if (this->eeprom_version_) {
+    this->eeprom_version_->publish_state(value_eeprom_version_);
+  }
+  if (this->pv_charging_power_) {
+    this->pv_charging_power_->publish_state(value_pv_charging_power_);
+  }
+  if (this->charging_to_floating_mode_) {
+    this->charging_to_floating_mode_->publish_state(value_charging_to_floating_mode_);
+  }
+  if (this->switch_on_) {
+    this->switch_on_->publish_state(value_switch_on_);
+  }
+  if (this->dustproof_installed_) {
+    this->dustproof_installed_->publish_state(value_dustproof_installed_);
+  }
+}
+
+void Pipsolar::handle_qmod_(const char* message) {
+  std::string mode;
+  this->value_device_mode_ = char(message[1]);
+  if (this->last_qmod_) {
+    this->last_qmod_->publish_state(message);
+  }
+  if (this->device_mode_) {
+    mode = value_device_mode_;
+    this->device_mode_->publish_state(mode);
+  }
+}
+
+void Pipsolar::handle_qflag_(const char* message) {
+  // result like:"(EbkuvxzDajy"
+  // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
+  bool enabled = true;
+  for (size_t i = 1; i < strlen(message); i++) {
+    switch (message[i]) {
+      case 'E':
+        enabled = true;
+        break;
+      case 'D':
+        enabled = false;
+        break;
+      case 'a':
+        this->value_silence_buzzer_open_buzzer_ = enabled;
+        break;
+      case 'b':
+        this->value_overload_bypass_function_ = enabled;
+        break;
+      case 'k':
+        this->value_lcd_escape_to_default_ = enabled;
+        break;
+      case 'u':
+        this->value_overload_restart_function_ = enabled;
+        break;
+      case 'v':
+        this->value_over_temperature_restart_function_ = enabled;
+        break;
+      case 'x':
+        this->value_backlight_on_ = enabled;
+        break;
+      case 'y':
+        this->value_alarm_on_when_primary_source_interrupt_ = enabled;
+        break;
+      case 'z':
+        this->value_fault_code_record_ = enabled;
+        break;
+      case 'j':
+        this->value_power_saving_ = enabled;
+        break;
+    }
+  }
+  if (this->last_qflag_) {
+    this->last_qflag_->publish_state(message);
+  }
+
+  if (this->silence_buzzer_open_buzzer_) {
+    this->silence_buzzer_open_buzzer_->publish_state(value_silence_buzzer_open_buzzer_);
+  }
+  if (this->overload_bypass_function_) {
+    this->overload_bypass_function_->publish_state(value_overload_bypass_function_);
+  }
+  if (this->lcd_escape_to_default_) {
+    this->lcd_escape_to_default_->publish_state(value_lcd_escape_to_default_);
+  }
+  if (this->overload_restart_function_) {
+    this->overload_restart_function_->publish_state(value_overload_restart_function_);
+  }
+  if (this->over_temperature_restart_function_) {
+    this->over_temperature_restart_function_->publish_state(value_over_temperature_restart_function_);
+  }
+  if (this->backlight_on_) {
+    this->backlight_on_->publish_state(value_backlight_on_);
+  }
+  if (this->alarm_on_when_primary_source_interrupt_) {
+    this->alarm_on_when_primary_source_interrupt_->publish_state(value_alarm_on_when_primary_source_interrupt_);
+  }
+  if (this->fault_code_record_) {
+    this->fault_code_record_->publish_state(value_fault_code_record_);
+  }
+  if (this->power_saving_) {
+    this->power_saving_->publish_state(value_power_saving_);
+  }
+}
+
+void Pipsolar::handle_qpiws_(const char* message) {
+  // '(00000000000000000000000000000000'
+  // iterate over all available flag (as not all models have all flags, but at least in the same order)
+  bool enabled = true;
+  std::string fc;
+  this->value_warnings_present_ = false;
+  this->value_faults_present_ = true;
+
+  for (size_t i = 1; i < strlen(message); i++) {
+    enabled = message[i] == '1';
+    switch (i) {
+      case 1:
+        this->value_warning_power_loss_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 2:
+        this->value_fault_inverter_fault_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 3:
+        this->value_fault_bus_over_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 4:
+        this->value_fault_bus_under_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 5:
+        this->value_fault_bus_soft_fail_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 6:
+        this->value_warning_line_fail_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 7:
+        this->value_fault_opvshort_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 8:
+        this->value_fault_inverter_voltage_too_low_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 9:
+        this->value_fault_inverter_voltage_too_high_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 10:
+        this->value_warning_over_temperature_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 11:
+        this->value_warning_fan_lock_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 12:
+        this->value_warning_battery_voltage_high_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 13:
+        this->value_warning_battery_low_alarm_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 15:
+        this->value_warning_battery_under_shutdown_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 16:
+        this->value_warning_battery_derating_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 17:
+        this->value_warning_over_load_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 18:
+        this->value_warning_eeprom_failed_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 19:
+        this->value_fault_inverter_over_current_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 20:
+        this->value_fault_inverter_soft_failed_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 21:
+        this->value_fault_self_test_failed_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 22:
+        this->value_fault_op_dc_voltage_over_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 23:
+        this->value_fault_battery_open_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 24:
+        this->value_fault_current_sensor_failed_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 25:
+        this->value_fault_battery_short_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 26:
+        this->value_warning_power_limit_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 27:
+        this->value_warning_pv_voltage_high_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 28:
+        this->value_fault_mppt_overload_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 29:
+        this->value_warning_mppt_overload_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 30:
+        this->value_warning_battery_too_low_to_charge_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 31:
+        this->value_fault_dc_dc_over_current_ = enabled;
+        this->value_faults_present_ += enabled;
+        break;
+      case 32:
+        fc = message[i];
+        fc += message[i + 1];
+        this->value_fault_code_ = parse_number<int>(fc).value_or(0);
+        break;
+      case 34:
+        this->value_warnung_low_pv_energy_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 35:
+        this->value_warning_high_ac_input_during_bus_soft_start_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+      case 36:
+        this->value_warning_battery_equalization_ = enabled;
+        this->value_warnings_present_ += enabled;
+        break;
+    }
+  }
+  if (this->last_qpiws_) {
+    this->last_qpiws_->publish_state(message);
+  }
+
+  if (this->warnings_present_) {
+    this->warnings_present_->publish_state(value_warnings_present_);
+  }
+  if (this->faults_present_) {
+    this->faults_present_->publish_state(value_faults_present_);
+  }
+  if (this->warning_power_loss_) {
+    this->warning_power_loss_->publish_state(value_warning_power_loss_);
+  }
+  if (this->fault_inverter_fault_) {
+    this->fault_inverter_fault_->publish_state(value_fault_inverter_fault_);
+  }
+  if (this->fault_bus_over_) {
+    this->fault_bus_over_->publish_state(value_fault_bus_over_);
+  }
+  if (this->fault_bus_under_) {
+    this->fault_bus_under_->publish_state(value_fault_bus_under_);
+  }
+  if (this->fault_bus_soft_fail_) {
+    this->fault_bus_soft_fail_->publish_state(value_fault_bus_soft_fail_);
+  }
+  if (this->warning_line_fail_) {
+    this->warning_line_fail_->publish_state(value_warning_line_fail_);
+  }
+  if (this->fault_opvshort_) {
+    this->fault_opvshort_->publish_state(value_fault_opvshort_);
+  }
+  if (this->fault_inverter_voltage_too_low_) {
+    this->fault_inverter_voltage_too_low_->publish_state(value_fault_inverter_voltage_too_low_);
+  }
+  if (this->fault_inverter_voltage_too_high_) {
+    this->fault_inverter_voltage_too_high_->publish_state(value_fault_inverter_voltage_too_high_);
+  }
+  if (this->warning_over_temperature_) {
+    this->warning_over_temperature_->publish_state(value_warning_over_temperature_);
+  }
+  if (this->warning_fan_lock_) {
+    this->warning_fan_lock_->publish_state(value_warning_fan_lock_);
+  }
+  if (this->warning_battery_voltage_high_) {
+    this->warning_battery_voltage_high_->publish_state(value_warning_battery_voltage_high_);
+  }
+  if (this->warning_battery_low_alarm_) {
+    this->warning_battery_low_alarm_->publish_state(value_warning_battery_low_alarm_);
+  }
+  if (this->warning_battery_under_shutdown_) {
+    this->warning_battery_under_shutdown_->publish_state(value_warning_battery_under_shutdown_);
+  }
+  if (this->warning_battery_derating_) {
+    this->warning_battery_derating_->publish_state(value_warning_battery_derating_);
+  }
+  if (this->warning_over_load_) {
+    this->warning_over_load_->publish_state(value_warning_over_load_);
+  }
+  if (this->warning_eeprom_failed_) {
+    this->warning_eeprom_failed_->publish_state(value_warning_eeprom_failed_);
+  }
+  if (this->fault_inverter_over_current_) {
+    this->fault_inverter_over_current_->publish_state(value_fault_inverter_over_current_);
+  }
+  if (this->fault_inverter_soft_failed_) {
+    this->fault_inverter_soft_failed_->publish_state(value_fault_inverter_soft_failed_);
+  }
+  if (this->fault_self_test_failed_) {
+    this->fault_self_test_failed_->publish_state(value_fault_self_test_failed_);
+  }
+  if (this->fault_op_dc_voltage_over_) {
+    this->fault_op_dc_voltage_over_->publish_state(value_fault_op_dc_voltage_over_);
+  }
+  if (this->fault_battery_open_) {
+    this->fault_battery_open_->publish_state(value_fault_battery_open_);
+  }
+  if (this->fault_current_sensor_failed_) {
+    this->fault_current_sensor_failed_->publish_state(value_fault_current_sensor_failed_);
+  }
+  if (this->fault_battery_short_) {
+    this->fault_battery_short_->publish_state(value_fault_battery_short_);
+  }
+  if (this->warning_power_limit_) {
+    this->warning_power_limit_->publish_state(value_warning_power_limit_);
+  }
+  if (this->warning_pv_voltage_high_) {
+    this->warning_pv_voltage_high_->publish_state(value_warning_pv_voltage_high_);
+  }
+  if (this->fault_mppt_overload_) {
+    this->fault_mppt_overload_->publish_state(value_fault_mppt_overload_);
+  }
+  if (this->warning_mppt_overload_) {
+    this->warning_mppt_overload_->publish_state(value_warning_mppt_overload_);
+  }
+  if (this->warning_battery_too_low_to_charge_) {
+    this->warning_battery_too_low_to_charge_->publish_state(value_warning_battery_too_low_to_charge_);
+  }
+  if (this->fault_dc_dc_over_current_) {
+    this->fault_dc_dc_over_current_->publish_state(value_fault_dc_dc_over_current_);
+  }
+  if (this->fault_code_) {
+    this->fault_code_->publish_state(value_fault_code_);
+  }
+  if (this->warnung_low_pv_energy_) {
+    this->warnung_low_pv_energy_->publish_state(value_warnung_low_pv_energy_);
+  }
+  if (this->warning_high_ac_input_during_bus_soft_start_) {
+    this->warning_high_ac_input_during_bus_soft_start_->publish_state(
+        value_warning_high_ac_input_during_bus_soft_start_);
+  }
+  if (this->warning_battery_equalization_) {
+    this->warning_battery_equalization_->publish_state(value_warning_battery_equalization_);
+  }
+}
+
+void Pipsolar::handle_qt_(const char *message) {
+  if (this->last_qt_) {
+    this->last_qt_->publish_state(message);
+  }
+}
+
+void Pipsolar::handle_qmn_(const char *message) {
+  if (this->last_qmn_) {
+    this->last_qmn_->publish_state(message);
+  }
 }
 
 void Pipsolar::dump_config() {

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -887,17 +887,15 @@ void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand poll
       }
     }
     if (enabled_polling_command.length == 0) {
-      size_t length = strlen(command) + 1;
-      const char *beg = command;
-      const char *end = command + length;
-      enabled_polling_command.command = new uint8_t[length];  // NOLINT(cppcoreguidelines-owning-memory)
-      size_t i = 0;
-      for (; beg != end; ++beg, ++i) {
-        enabled_polling_command.command[i] = (uint8_t) (*beg);
+      size_t length = strlen(command);
+
+      enabled_polling_command.command = new uint8_t[length + 1];  // NOLINT(cppcoreguidelines-owning-memory)
+      for (size_t i = 0; i < length + 1; i++) {
+        enabled_polling_command.command[i] = (uint8_t) command[i];
       }
       enabled_polling_command.errors = 0;
       enabled_polling_command.identifier = polling_command;
-      enabled_polling_command.length = length - 1;
+      enabled_polling_command.length = length;
       enabled_polling_command.needs_update = true;
       return;
     }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -23,20 +23,18 @@ void Pipsolar::loop() {
   // Read message
   if (this->state_ == STATE_IDLE) {
     this->empty_uart_buffer_();
-    switch (this->send_next_command_()) {
-      case 0:
-        // no command send (empty queue) time to poll
-        if (millis() - this->last_poll_ > this->update_interval_) {
-          this->send_next_poll_();
-          this->last_poll_ = millis();
-        }
-        return;
-        break;
-      case 1:
-        // command send
-        return;
-        break;
+
+    if (this->send_next_command_()) {
+      // command sent
+      return;
     }
+
+    if (this->send_next_poll_()) {
+      // poll sent
+      return;
+    }
+
+    return;
   }
   if (this->state_ == STATE_COMMAND_COMPLETE) {
     if (this->check_incoming_length_(4)) {
@@ -708,6 +706,7 @@ void Pipsolar::loop() {
         return;
       }
       // crc ok
+      this->enabled_polling_commands_[this->last_polling_command_].needs_update = false;
       this->state_ = STATE_POLL_CHECKED;
       return;
     } else {
@@ -814,32 +813,38 @@ bool Pipsolar::send_next_command_() {
   return false;
 }
 
-void Pipsolar::send_next_poll_() {
+bool Pipsolar::send_next_poll_() {
   uint16_t crc16;
-  this->last_polling_command_ = (this->last_polling_command_ + 1) % 15;
-  if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
-    this->last_polling_command_ = 0;
+
+  for (uint8_t i = 0; i < POLLING_COMMANDS_MAX; i++) {
+    this->last_polling_command_ = (this->last_polling_command_ + 1) % POLLING_COMMANDS_MAX;
+    if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
+      // not enabled
+      continue;
+    }
+    if(!this->enabled_polling_commands_[this->last_polling_command_].needs_update) {
+      // no update requested
+      continue;
+    }
+    this->state_ = STATE_POLL;
+    this->command_start_millis_ = millis();
+    this->empty_uart_buffer_();
+    this->read_pos_ = 0;
+    crc16 = this->pipsolar_crc_(this->enabled_polling_commands_[this->last_polling_command_].command,
+                                this->enabled_polling_commands_[this->last_polling_command_].length);
+    this->write_array(this->enabled_polling_commands_[this->last_polling_command_].command,
+                      this->enabled_polling_commands_[this->last_polling_command_].length);
+    // checksum
+    this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
+    this->write(((uint8_t) ((crc16) &0xff)));  // lowbyte
+    // end Byte
+    this->write(0x0D);
+    ESP_LOGD(TAG, "Sending polling command : %s with length %d",
+            this->enabled_polling_commands_[this->last_polling_command_].command,
+            this->enabled_polling_commands_[this->last_polling_command_].length);
+    return true;
   }
-  if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
-    // no command specified
-    return;
-  }
-  this->state_ = STATE_POLL;
-  this->command_start_millis_ = millis();
-  this->empty_uart_buffer_();
-  this->read_pos_ = 0;
-  crc16 = this->pipsolar_crc_(this->enabled_polling_commands_[this->last_polling_command_].command,
-                              this->enabled_polling_commands_[this->last_polling_command_].length);
-  this->write_array(this->enabled_polling_commands_[this->last_polling_command_].command,
-                    this->enabled_polling_commands_[this->last_polling_command_].length);
-  // checksum
-  this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
-  this->write(((uint8_t) ((crc16) &0xff)));  // lowbyte
-  // end Byte
-  this->write(0x0D);
-  ESP_LOGD(TAG, "Sending polling command : %s with length %d",
-           this->enabled_polling_commands_[this->last_polling_command_].command,
-           this->enabled_polling_commands_[this->last_polling_command_].length);
+  return false;
 }
 
 void Pipsolar::queue_command(const std::string &command) {
@@ -865,7 +870,13 @@ void Pipsolar::dump_config() {
     }
   }
 }
-void Pipsolar::update() {}
+void Pipsolar::update() {
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length != 0) {
+      enabled_polling_command.needs_update = true;
+    }
+  }
+}
 
 void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand polling_command) {
   for (auto &enabled_polling_command : this->enabled_polling_commands_) {
@@ -887,6 +898,7 @@ void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand poll
       enabled_polling_command.errors = 0;
       enabled_polling_command.identifier = polling_command;
       enabled_polling_command.length = length - 1;
+      enabled_polling_command.needs_update = true;
       return;
     }
   }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -842,7 +842,7 @@ void Pipsolar::send_next_poll_() {
            this->used_polling_commands_[this->last_polling_command_].length);
 }
 
-void Pipsolar::queue_command_(const char *command, uint8_t length) {
+void Pipsolar::queue_command(const std::string &command) {
   uint8_t next_position = command_queue_position_;
   for (uint8_t i = 0; i < COMMAND_QUEUE_LENGTH; i++) {
     uint8_t testposition = (next_position + i) % COMMAND_QUEUE_LENGTH;
@@ -856,10 +856,6 @@ void Pipsolar::queue_command_(const char *command, uint8_t length) {
   ESP_LOGD(TAG, "Command queue full dropping command: %s", command);
 }
 
-void Pipsolar::switch_command(const std::string &command) {
-  ESP_LOGD(TAG, "got command: %s", command.c_str());
-  queue_command_(command.c_str(), command.length());
-}
 void Pipsolar::dump_config() {
   ESP_LOGCONFIG(TAG, "Pipsolar:\n"
                      "used commands:");

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -69,7 +69,7 @@ void Pipsolar::loop() {
 
   if (this->state_ == STATE_POLL_DECODED) {
     std::string mode;
-    switch (this->used_polling_commands_[this->last_polling_command_].identifier) {
+    switch (this->enabled_polling_commands_[this->last_polling_command_].identifier) {
       case POLLING_QPIRI:
         if (this->grid_rating_voltage_) {
           this->grid_rating_voltage_->publish_state(value_grid_rating_voltage_);
@@ -428,7 +428,7 @@ void Pipsolar::loop() {
     std::string fc;
     char tmp[PIPSOLAR_READ_BUFFER_LENGTH];
     sprintf(tmp, "%s", this->read_buffer_);
-    switch (this->used_polling_commands_[this->last_polling_command_].identifier) {
+    switch (this->enabled_polling_commands_[this->last_polling_command_].identifier) {
       case POLLING_QPIRI:
         ESP_LOGD(TAG, "Decode QPIRI");
         sscanf(tmp, "(%f %f %f %f %f %d %d %f %f %f %f %f %d %d %d %d %d %d %d %d %d %d %f %d %d",          // NOLINT
@@ -756,7 +756,7 @@ void Pipsolar::loop() {
   if (this->state_ == STATE_POLL) {
     if (millis() - this->command_start_millis_ > esphome::pipsolar::Pipsolar::COMMAND_TIMEOUT) {
       // command timeout
-      ESP_LOGD(TAG, "timeout command to poll: %s", this->used_polling_commands_[this->last_polling_command_].command);
+      ESP_LOGD(TAG, "timeout command to poll: %s", this->enabled_polling_commands_[this->last_polling_command_].command);
       this->state_ = STATE_IDLE;
     } else {
     }
@@ -787,8 +787,8 @@ uint8_t Pipsolar::check_incoming_crc_() {
   return 0;
 }
 
-// send next command used
-uint8_t Pipsolar::send_next_command_() {
+// send next command from queue
+bool Pipsolar::send_next_command_() {
   uint16_t crc16;
   if (!this->command_queue_[this->command_queue_position_].empty()) {
     const char *command = this->command_queue_[this->command_queue_position_].c_str();
@@ -809,18 +809,18 @@ uint8_t Pipsolar::send_next_command_() {
     // end Byte
     this->write(0x0D);
     ESP_LOGD(TAG, "Sending command from queue: %s with length %d", command, length);
-    return 1;
+    return true;
   }
-  return 0;
+  return false;
 }
 
 void Pipsolar::send_next_poll_() {
   uint16_t crc16;
   this->last_polling_command_ = (this->last_polling_command_ + 1) % 15;
-  if (this->used_polling_commands_[this->last_polling_command_].length == 0) {
+  if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
     this->last_polling_command_ = 0;
   }
-  if (this->used_polling_commands_[this->last_polling_command_].length == 0) {
+  if (this->enabled_polling_commands_[this->last_polling_command_].length == 0) {
     // no command specified
     return;
   }
@@ -828,18 +828,18 @@ void Pipsolar::send_next_poll_() {
   this->command_start_millis_ = millis();
   this->empty_uart_buffer_();
   this->read_pos_ = 0;
-  crc16 = this->pipsolar_crc_(this->used_polling_commands_[this->last_polling_command_].command,
-                              this->used_polling_commands_[this->last_polling_command_].length);
-  this->write_array(this->used_polling_commands_[this->last_polling_command_].command,
-                    this->used_polling_commands_[this->last_polling_command_].length);
+  crc16 = this->pipsolar_crc_(this->enabled_polling_commands_[this->last_polling_command_].command,
+                              this->enabled_polling_commands_[this->last_polling_command_].length);
+  this->write_array(this->enabled_polling_commands_[this->last_polling_command_].command,
+                    this->enabled_polling_commands_[this->last_polling_command_].length);
   // checksum
   this->write(((uint8_t) ((crc16) >> 8)));   // highbyte
   this->write(((uint8_t) ((crc16) &0xff)));  // lowbyte
   // end Byte
   this->write(0x0D);
   ESP_LOGD(TAG, "Sending polling command : %s with length %d",
-           this->used_polling_commands_[this->last_polling_command_].command,
-           this->used_polling_commands_[this->last_polling_command_].length);
+           this->enabled_polling_commands_[this->last_polling_command_].command,
+           this->enabled_polling_commands_[this->last_polling_command_].length);
 }
 
 void Pipsolar::queue_command(const std::string &command) {
@@ -858,35 +858,35 @@ void Pipsolar::queue_command(const std::string &command) {
 
 void Pipsolar::dump_config() {
   ESP_LOGCONFIG(TAG, "Pipsolar:\n"
-                     "used commands:");
-  for (auto &used_polling_command : this->used_polling_commands_) {
-    if (used_polling_command.length != 0) {
-      ESP_LOGCONFIG(TAG, "%s", used_polling_command.command);
+                     "enabled polling commands:");
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length != 0) {
+      ESP_LOGCONFIG(TAG, "%s", enabled_polling_command.command);
     }
   }
 }
 void Pipsolar::update() {}
 
 void Pipsolar::add_polling_command_(const char *command, ENUMPollingCommand polling_command) {
-  for (auto &used_polling_command : this->used_polling_commands_) {
-    if (used_polling_command.length == strlen(command)) {
+  for (auto &enabled_polling_command : this->enabled_polling_commands_) {
+    if (enabled_polling_command.length == strlen(command)) {
       uint8_t len = strlen(command);
-      if (memcmp(used_polling_command.command, command, len) == 0) {
+      if (memcmp(enabled_polling_command.command, command, len) == 0) {
         return;
       }
     }
-    if (used_polling_command.length == 0) {
+    if (enabled_polling_command.length == 0) {
       size_t length = strlen(command) + 1;
       const char *beg = command;
       const char *end = command + length;
-      used_polling_command.command = new uint8_t[length];  // NOLINT(cppcoreguidelines-owning-memory)
+      enabled_polling_command.command = new uint8_t[length];  // NOLINT(cppcoreguidelines-owning-memory)
       size_t i = 0;
       for (; beg != end; ++beg, ++i) {
-        used_polling_command.command[i] = (uint8_t) (*beg);
+        enabled_polling_command.command[i] = (uint8_t) (*beg);
       }
-      used_polling_command.errors = 0;
-      used_polling_command.identifier = polling_command;
-      used_polling_command.length = length - 1;
+      enabled_polling_command.errors = 0;
+      enabled_polling_command.identifier = polling_command;
+      enabled_polling_command.length = length - 1;
       return;
     }
   }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -273,246 +273,250 @@ void Pipsolar::queue_command(const std::string &command) {
 }
 
 void Pipsolar::handle_qpiri_(const char* message) {
+  QPIRIValues values = QPIRIValues();
+
   sscanf(message, "(%f %f %f %f %f %d %d %f %f %f %f %f %d %d %d %d %d %d %d %d %d %d %f %d %d",       // NOLINT
-          &value_grid_rating_voltage_, &value_grid_rating_current_, &value_ac_output_rating_voltage_,  // NOLINT
-          &value_ac_output_rating_frequency_, &value_ac_output_rating_current_,                        // NOLINT
-          &value_ac_output_rating_apparent_power_, &value_ac_output_rating_active_power_,              // NOLINT
-          &value_battery_rating_voltage_, &value_battery_recharge_voltage_,                            // NOLINT
-          &value_battery_under_voltage_, &value_battery_bulk_voltage_, &value_battery_float_voltage_,  // NOLINT
-          &value_battery_type_, &value_current_max_ac_charging_current_,                               // NOLINT
-          &value_current_max_charging_current_, &value_input_voltage_range_,                           // NOLINT
-          &value_output_source_priority_, &value_charger_source_priority_, &value_parallel_max_num_,   // NOLINT
-          &value_machine_type_, &value_topology_, &value_output_mode_,                                 // NOLINT
-          &value_battery_redischarge_voltage_, &value_pv_ok_condition_for_parallel_,                   // NOLINT
-          &value_pv_power_balance_);                                                                   // NOLINT
+          &values.grid_rating_voltage, &values.grid_rating_current, &values.ac_output_rating_voltage,  // NOLINT
+          &values.ac_output_rating_frequency, &values.ac_output_rating_current,                        // NOLINT
+          &values.ac_output_rating_apparent_power, &values.ac_output_rating_active_power,              // NOLINT
+          &values.battery_rating_voltage, &values.battery_recharge_voltage,                            // NOLINT
+          &values.battery_under_voltage, &values.battery_bulk_voltage, &values.battery_float_voltage,  // NOLINT
+          &values.battery_type, &values.current_max_ac_charging_current,                               // NOLINT
+          &values.current_max_charging_current, &values.input_voltage_range,                           // NOLINT
+          &values.output_source_priority, &values.charger_source_priority, &values.parallel_max_num,   // NOLINT
+          &values.machine_type, &values.topology, &values.output_mode,                                 // NOLINT
+          &values.battery_redischarge_voltage, &values.pv_ok_condition_for_parallel,                   // NOLINT
+          &values.pv_power_balance);                                                                   // NOLINT
   if (this->last_qpiri_) {
     this->last_qpiri_->publish_state(message);
   }
 
   if (this->grid_rating_voltage_) {
-    this->grid_rating_voltage_->publish_state(value_grid_rating_voltage_);
+    this->grid_rating_voltage_->publish_state(values.grid_rating_voltage);
   }
   if (this->grid_rating_current_) {
-    this->grid_rating_current_->publish_state(value_grid_rating_current_);
+    this->grid_rating_current_->publish_state(values.grid_rating_current);
   }
   if (this->ac_output_rating_voltage_) {
-    this->ac_output_rating_voltage_->publish_state(value_ac_output_rating_voltage_);
+    this->ac_output_rating_voltage_->publish_state(values.ac_output_rating_voltage);
   }
   if (this->ac_output_rating_frequency_) {
-    this->ac_output_rating_frequency_->publish_state(value_ac_output_rating_frequency_);
+    this->ac_output_rating_frequency_->publish_state(values.ac_output_rating_frequency);
   }
   if (this->ac_output_rating_current_) {
-    this->ac_output_rating_current_->publish_state(value_ac_output_rating_current_);
+    this->ac_output_rating_current_->publish_state(values.ac_output_rating_current);
   }
   if (this->ac_output_rating_apparent_power_) {
-    this->ac_output_rating_apparent_power_->publish_state(value_ac_output_rating_apparent_power_);
+    this->ac_output_rating_apparent_power_->publish_state(values.ac_output_rating_apparent_power);
   }
   if (this->ac_output_rating_active_power_) {
-    this->ac_output_rating_active_power_->publish_state(value_ac_output_rating_active_power_);
+    this->ac_output_rating_active_power_->publish_state(values.ac_output_rating_active_power);
   }
   if (this->battery_rating_voltage_) {
-    this->battery_rating_voltage_->publish_state(value_battery_rating_voltage_);
+    this->battery_rating_voltage_->publish_state(values.battery_rating_voltage);
   }
   if (this->battery_recharge_voltage_) {
-    this->battery_recharge_voltage_->publish_state(value_battery_recharge_voltage_);
+    this->battery_recharge_voltage_->publish_state(values.battery_recharge_voltage);
   }
   if (this->battery_under_voltage_) {
-    this->battery_under_voltage_->publish_state(value_battery_under_voltage_);
+    this->battery_under_voltage_->publish_state(values.battery_under_voltage);
   }
   if (this->battery_bulk_voltage_) {
-    this->battery_bulk_voltage_->publish_state(value_battery_bulk_voltage_);
+    this->battery_bulk_voltage_->publish_state(values.battery_bulk_voltage);
   }
   if (this->battery_float_voltage_) {
-    this->battery_float_voltage_->publish_state(value_battery_float_voltage_);
+    this->battery_float_voltage_->publish_state(values.battery_float_voltage);
   }
   if (this->battery_type_) {
-    this->battery_type_->publish_state(value_battery_type_);
+    this->battery_type_->publish_state(values.battery_type);
   }
   if (this->current_max_ac_charging_current_) {
-    this->current_max_ac_charging_current_->publish_state(value_current_max_ac_charging_current_);
+    this->current_max_ac_charging_current_->publish_state(values.current_max_ac_charging_current);
   }
   if (this->current_max_charging_current_) {
-    this->current_max_charging_current_->publish_state(value_current_max_charging_current_);
+    this->current_max_charging_current_->publish_state(values.current_max_charging_current);
   }
   if (this->input_voltage_range_) {
-    this->input_voltage_range_->publish_state(value_input_voltage_range_);
+    this->input_voltage_range_->publish_state(values.input_voltage_range);
   }
   // special for input voltage range switch
   if (this->input_voltage_range_switch_) {
-    this->input_voltage_range_switch_->publish_state(value_input_voltage_range_ == 1);
+    this->input_voltage_range_switch_->publish_state(values.input_voltage_range == 1);
   }
   if (this->output_source_priority_) {
-    this->output_source_priority_->publish_state(value_output_source_priority_);
+    this->output_source_priority_->publish_state(values.output_source_priority);
   }
   // special for output source priority switches
   if (this->output_source_priority_utility_switch_) {
-    this->output_source_priority_utility_switch_->publish_state(value_output_source_priority_ == 0);
+    this->output_source_priority_utility_switch_->publish_state(values.output_source_priority == 0);
   }
   if (this->output_source_priority_solar_switch_) {
-    this->output_source_priority_solar_switch_->publish_state(value_output_source_priority_ == 1);
+    this->output_source_priority_solar_switch_->publish_state(values.output_source_priority == 1);
   }
   if (this->output_source_priority_battery_switch_) {
-    this->output_source_priority_battery_switch_->publish_state(value_output_source_priority_ == 2);
+    this->output_source_priority_battery_switch_->publish_state(values.output_source_priority == 2);
   }
   if (this->output_source_priority_hybrid_switch_) {
-    this->output_source_priority_hybrid_switch_->publish_state(value_output_source_priority_ == 3);
+    this->output_source_priority_hybrid_switch_->publish_state(values.output_source_priority == 3);
   }
   if (this->charger_source_priority_) {
-    this->charger_source_priority_->publish_state(value_charger_source_priority_);
+    this->charger_source_priority_->publish_state(values.charger_source_priority);
   }
   if (this->parallel_max_num_) {
-    this->parallel_max_num_->publish_state(value_parallel_max_num_);
+    this->parallel_max_num_->publish_state(values.parallel_max_num);
   }
   if (this->machine_type_) {
-    this->machine_type_->publish_state(value_machine_type_);
+    this->machine_type_->publish_state(values.machine_type);
   }
   if (this->topology_) {
-    this->topology_->publish_state(value_topology_);
+    this->topology_->publish_state(values.topology);
   }
   if (this->output_mode_) {
-    this->output_mode_->publish_state(value_output_mode_);
+    this->output_mode_->publish_state(values.output_mode);
   }
   if (this->battery_redischarge_voltage_) {
-    this->battery_redischarge_voltage_->publish_state(value_battery_redischarge_voltage_);
+    this->battery_redischarge_voltage_->publish_state(values.battery_redischarge_voltage);
   }
   if (this->pv_ok_condition_for_parallel_) {
-    this->pv_ok_condition_for_parallel_->publish_state(value_pv_ok_condition_for_parallel_);
+    this->pv_ok_condition_for_parallel_->publish_state(values.pv_ok_condition_for_parallel);
   }
   // special for pv ok condition switch
   if (this->pv_ok_condition_for_parallel_switch_) {
-    this->pv_ok_condition_for_parallel_switch_->publish_state(value_pv_ok_condition_for_parallel_ == 1);
+    this->pv_ok_condition_for_parallel_switch_->publish_state(values.pv_ok_condition_for_parallel == 1);
   }
   if (this->pv_power_balance_) {
-    this->pv_power_balance_->publish_state(value_pv_power_balance_ == 1);
+    this->pv_power_balance_->publish_state(values.pv_power_balance == 1);
   }
   // special for power balance switch
   if (this->pv_power_balance_switch_) {
-    this->pv_power_balance_switch_->publish_state(value_pv_power_balance_ == 1);
+    this->pv_power_balance_switch_->publish_state(values.pv_power_balance == 1);
   }
 }
 
 void Pipsolar::handle_qpigs_(const char* message) {
+  QPIGSValues values = QPIGSValues();
+
   sscanf(                                                                                              // NOLINT
       message,                                                                                         // NOLINT
       "(%f %f %f %f %d %d %d %d %f %d %d %d %f %f %f %d %1d%1d%1d%1d%1d%1d%1d%1d %d %d %d %1d%1d%1d",  // NOLINT
-      &value_grid_voltage_, &value_grid_frequency_, &value_ac_output_voltage_,                         // NOLINT
-      &value_ac_output_frequency_,                                                                     // NOLINT
-      &value_ac_output_apparent_power_, &value_ac_output_active_power_, &value_output_load_percent_,   // NOLINT
-      &value_bus_voltage_, &value_battery_voltage_, &value_battery_charging_current_,                  // NOLINT
-      &value_battery_capacity_percent_, &value_inverter_heat_sink_temperature_,                        // NOLINT
-      &value_pv_input_current_for_battery_, &value_pv_input_voltage_, &value_battery_voltage_scc_,     // NOLINT
-      &value_battery_discharge_current_, &value_add_sbu_priority_version_,                             // NOLINT
-      &value_configuration_status_, &value_scc_firmware_version_, &value_load_status_,                 // NOLINT
-      &value_battery_voltage_to_steady_while_charging_, &value_charging_status_,                       // NOLINT
-      &value_scc_charging_status_, &value_ac_charging_status_,                                         // NOLINT
-      &value_battery_voltage_offset_for_fans_on_, &value_eeprom_version_, &value_pv_charging_power_,   // NOLINT
-      &value_charging_to_floating_mode_, &value_switch_on_,                                            // NOLINT
-      &value_dustproof_installed_);                                                                    // NOLINT
+      &values.grid_voltage, &values.grid_frequency, &values.ac_output_voltage,                         // NOLINT
+      &values.ac_output_frequency,                                                                     // NOLINT
+      &values.ac_output_apparent_power, &values.ac_output_active_power, &values.output_load_percent,   // NOLINT
+      &values.bus_voltage, &values.battery_voltage, &values.battery_charging_current,                  // NOLINT
+      &values.battery_capacity_percent, &values.inverter_heat_sink_temperature,                        // NOLINT
+      &values.pv_input_current_for_battery, &values.pv_input_voltage, &values.battery_voltage_scc,     // NOLINT
+      &values.battery_discharge_current, &values.add_sbu_priority_version,                             // NOLINT
+      &values.configuration_status, &values.scc_firmware_version, &values.load_status,                 // NOLINT
+      &values.battery_voltage_to_steady_while_charging, &values.charging_status,                       // NOLINT
+      &values.scc_charging_status, &values.ac_charging_status,                                         // NOLINT
+      &values.battery_voltage_offset_for_fans_on, &values.eeprom_version, &values.pv_charging_power,   // NOLINT
+      &values.charging_to_floating_mode, &values.switch_on,                                            // NOLINT
+      &values.dustproof_installed);                                                                    // NOLINT
   if (this->last_qpigs_) {
     this->last_qpigs_->publish_state(message);
   }
 
   if (this->grid_voltage_) {
-    this->grid_voltage_->publish_state(value_grid_voltage_);
+    this->grid_voltage_->publish_state(values.grid_voltage);
   }
   if (this->grid_frequency_) {
-    this->grid_frequency_->publish_state(value_grid_frequency_);
+    this->grid_frequency_->publish_state(values.grid_frequency);
   }
   if (this->ac_output_voltage_) {
-    this->ac_output_voltage_->publish_state(value_ac_output_voltage_);
+    this->ac_output_voltage_->publish_state(values.ac_output_voltage);
   }
   if (this->ac_output_frequency_) {
-    this->ac_output_frequency_->publish_state(value_ac_output_frequency_);
+    this->ac_output_frequency_->publish_state(values.ac_output_frequency);
   }
   if (this->ac_output_apparent_power_) {
-    this->ac_output_apparent_power_->publish_state(value_ac_output_apparent_power_);
+    this->ac_output_apparent_power_->publish_state(values.ac_output_apparent_power);
   }
   if (this->ac_output_active_power_) {
-    this->ac_output_active_power_->publish_state(value_ac_output_active_power_);
+    this->ac_output_active_power_->publish_state(values.ac_output_active_power);
   }
   if (this->output_load_percent_) {
-    this->output_load_percent_->publish_state(value_output_load_percent_);
+    this->output_load_percent_->publish_state(values.output_load_percent);
   }
   if (this->bus_voltage_) {
-    this->bus_voltage_->publish_state(value_bus_voltage_);
+    this->bus_voltage_->publish_state(values.bus_voltage);
   }
   if (this->battery_voltage_) {
-    this->battery_voltage_->publish_state(value_battery_voltage_);
+    this->battery_voltage_->publish_state(values.battery_voltage);
   }
   if (this->battery_charging_current_) {
-    this->battery_charging_current_->publish_state(value_battery_charging_current_);
+    this->battery_charging_current_->publish_state(values.battery_charging_current);
   }
   if (this->battery_capacity_percent_) {
-    this->battery_capacity_percent_->publish_state(value_battery_capacity_percent_);
+    this->battery_capacity_percent_->publish_state(values.battery_capacity_percent);
   }
   if (this->inverter_heat_sink_temperature_) {
-    this->inverter_heat_sink_temperature_->publish_state(value_inverter_heat_sink_temperature_);
+    this->inverter_heat_sink_temperature_->publish_state(values.inverter_heat_sink_temperature);
   }
   if (this->pv_input_current_for_battery_) {
-    this->pv_input_current_for_battery_->publish_state(value_pv_input_current_for_battery_);
+    this->pv_input_current_for_battery_->publish_state(values.pv_input_current_for_battery);
   }
   if (this->pv_input_voltage_) {
-    this->pv_input_voltage_->publish_state(value_pv_input_voltage_);
+    this->pv_input_voltage_->publish_state(values.pv_input_voltage);
   }
   if (this->battery_voltage_scc_) {
-    this->battery_voltage_scc_->publish_state(value_battery_voltage_scc_);
+    this->battery_voltage_scc_->publish_state(values.battery_voltage_scc);
   }
   if (this->battery_discharge_current_) {
-    this->battery_discharge_current_->publish_state(value_battery_discharge_current_);
+    this->battery_discharge_current_->publish_state(values.battery_discharge_current);
   }
   if (this->add_sbu_priority_version_) {
-    this->add_sbu_priority_version_->publish_state(value_add_sbu_priority_version_);
+    this->add_sbu_priority_version_->publish_state(values.add_sbu_priority_version);
   }
   if (this->configuration_status_) {
-    this->configuration_status_->publish_state(value_configuration_status_);
+    this->configuration_status_->publish_state(values.configuration_status);
   }
   if (this->scc_firmware_version_) {
-    this->scc_firmware_version_->publish_state(value_scc_firmware_version_);
+    this->scc_firmware_version_->publish_state(values.scc_firmware_version);
   }
   if (this->load_status_) {
-    this->load_status_->publish_state(value_load_status_);
+    this->load_status_->publish_state(values.load_status);
   }
   if (this->battery_voltage_to_steady_while_charging_) {
     this->battery_voltage_to_steady_while_charging_->publish_state(
-        value_battery_voltage_to_steady_while_charging_);
+        values.battery_voltage_to_steady_while_charging);
   }
   if (this->charging_status_) {
-    this->charging_status_->publish_state(value_charging_status_);
+    this->charging_status_->publish_state(values.charging_status);
   }
   if (this->scc_charging_status_) {
-    this->scc_charging_status_->publish_state(value_scc_charging_status_);
+    this->scc_charging_status_->publish_state(values.scc_charging_status);
   }
   if (this->ac_charging_status_) {
-    this->ac_charging_status_->publish_state(value_ac_charging_status_);
+    this->ac_charging_status_->publish_state(values.ac_charging_status);
   }
   if (this->battery_voltage_offset_for_fans_on_) {
-    this->battery_voltage_offset_for_fans_on_->publish_state(value_battery_voltage_offset_for_fans_on_ / 10.0f);
+    this->battery_voltage_offset_for_fans_on_->publish_state(values.battery_voltage_offset_for_fans_on / 10.0f);
   }  //.1 scale
   if (this->eeprom_version_) {
-    this->eeprom_version_->publish_state(value_eeprom_version_);
+    this->eeprom_version_->publish_state(values.eeprom_version);
   }
   if (this->pv_charging_power_) {
-    this->pv_charging_power_->publish_state(value_pv_charging_power_);
+    this->pv_charging_power_->publish_state(values.pv_charging_power);
   }
   if (this->charging_to_floating_mode_) {
-    this->charging_to_floating_mode_->publish_state(value_charging_to_floating_mode_);
+    this->charging_to_floating_mode_->publish_state(values.charging_to_floating_mode);
   }
   if (this->switch_on_) {
-    this->switch_on_->publish_state(value_switch_on_);
+    this->switch_on_->publish_state(values.switch_on);
   }
   if (this->dustproof_installed_) {
-    this->dustproof_installed_->publish_state(value_dustproof_installed_);
+    this->dustproof_installed_->publish_state(values.dustproof_installed);
   }
 }
 
 void Pipsolar::handle_qmod_(const char* message) {
   std::string mode;
-  this->value_device_mode_ = char(message[1]);
+  char device_mode = char(message[1]);
   if (this->last_qmod_) {
     this->last_qmod_->publish_state(message);
   }
   if (this->device_mode_) {
-    mode = value_device_mode_;
+    mode = device_mode;
     this->device_mode_->publish_state(mode);
   }
 }
@@ -520,6 +524,7 @@ void Pipsolar::handle_qmod_(const char* message) {
 void Pipsolar::handle_qflag_(const char* message) {
   // result like:"(EbkuvxzDajy"
   // get through all char: ignore first "(" Enable flag on 'E', Disable on 'D') else set the corresponding value
+  QFLAGValues values = QFLAGValues();
   bool enabled = true;
   for (size_t i = 1; i < strlen(message); i++) {
     switch (message[i]) {
@@ -530,31 +535,31 @@ void Pipsolar::handle_qflag_(const char* message) {
         enabled = false;
         break;
       case 'a':
-        this->value_silence_buzzer_open_buzzer_ = enabled;
+        values.silence_buzzer_open_buzzer = enabled;
         break;
       case 'b':
-        this->value_overload_bypass_function_ = enabled;
+        values.overload_bypass_function = enabled;
         break;
       case 'k':
-        this->value_lcd_escape_to_default_ = enabled;
+        values.lcd_escape_to_default = enabled;
         break;
       case 'u':
-        this->value_overload_restart_function_ = enabled;
+        values.overload_restart_function = enabled;
         break;
       case 'v':
-        this->value_over_temperature_restart_function_ = enabled;
+        values.over_temperature_restart_function = enabled;
         break;
       case 'x':
-        this->value_backlight_on_ = enabled;
+        values.backlight_on = enabled;
         break;
       case 'y':
-        this->value_alarm_on_when_primary_source_interrupt_ = enabled;
+        values.alarm_on_when_primary_source_interrupt = enabled;
         break;
       case 'z':
-        this->value_fault_code_record_ = enabled;
+        values.fault_code_record = enabled;
         break;
       case 'j':
-        this->value_power_saving_ = enabled;
+        values.power_saving = enabled;
         break;
     }
   }
@@ -563,181 +568,182 @@ void Pipsolar::handle_qflag_(const char* message) {
   }
 
   if (this->silence_buzzer_open_buzzer_) {
-    this->silence_buzzer_open_buzzer_->publish_state(value_silence_buzzer_open_buzzer_);
+    this->silence_buzzer_open_buzzer_->publish_state(values.silence_buzzer_open_buzzer);
   }
   if (this->overload_bypass_function_) {
-    this->overload_bypass_function_->publish_state(value_overload_bypass_function_);
+    this->overload_bypass_function_->publish_state(values.overload_bypass_function);
   }
   if (this->lcd_escape_to_default_) {
-    this->lcd_escape_to_default_->publish_state(value_lcd_escape_to_default_);
+    this->lcd_escape_to_default_->publish_state(values.lcd_escape_to_default);
   }
   if (this->overload_restart_function_) {
-    this->overload_restart_function_->publish_state(value_overload_restart_function_);
+    this->overload_restart_function_->publish_state(values.overload_restart_function);
   }
   if (this->over_temperature_restart_function_) {
-    this->over_temperature_restart_function_->publish_state(value_over_temperature_restart_function_);
+    this->over_temperature_restart_function_->publish_state(values.over_temperature_restart_function);
   }
   if (this->backlight_on_) {
-    this->backlight_on_->publish_state(value_backlight_on_);
+    this->backlight_on_->publish_state(values.backlight_on);
   }
   if (this->alarm_on_when_primary_source_interrupt_) {
-    this->alarm_on_when_primary_source_interrupt_->publish_state(value_alarm_on_when_primary_source_interrupt_);
+    this->alarm_on_when_primary_source_interrupt_->publish_state(values.alarm_on_when_primary_source_interrupt);
   }
   if (this->fault_code_record_) {
-    this->fault_code_record_->publish_state(value_fault_code_record_);
+    this->fault_code_record_->publish_state(values.fault_code_record);
   }
   if (this->power_saving_) {
-    this->power_saving_->publish_state(value_power_saving_);
+    this->power_saving_->publish_state(values.power_saving);
   }
 }
 
 void Pipsolar::handle_qpiws_(const char* message) {
   // '(00000000000000000000000000000000'
   // iterate over all available flag (as not all models have all flags, but at least in the same order)
+  QPIWSValues values = QPIWSValues();
   bool enabled = true;
   std::string fc;
-  this->value_warnings_present_ = false;
-  this->value_faults_present_ = true;
+  bool value_warnings_present = false;
+  bool value_faults_present = true;
 
   for (size_t i = 1; i < strlen(message); i++) {
     enabled = message[i] == '1';
     switch (i) {
       case 1:
-        this->value_warning_power_loss_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_power_loss = enabled;
+        value_warnings_present |= enabled;
         break;
       case 2:
-        this->value_fault_inverter_fault_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_inverter_fault = enabled;
+        value_faults_present |= enabled;
         break;
       case 3:
-        this->value_fault_bus_over_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_bus_over = enabled;
+        value_faults_present |= enabled;
         break;
       case 4:
-        this->value_fault_bus_under_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_bus_under = enabled;
+        value_faults_present |= enabled;
         break;
       case 5:
-        this->value_fault_bus_soft_fail_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_bus_soft_fail = enabled;
+        value_faults_present |= enabled;
         break;
       case 6:
-        this->value_warning_line_fail_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_line_fail = enabled;
+        value_warnings_present |= enabled;
         break;
       case 7:
-        this->value_fault_opvshort_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_opvshort = enabled;
+        value_faults_present |= enabled;
         break;
       case 8:
-        this->value_fault_inverter_voltage_too_low_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_inverter_voltage_too_low = enabled;
+        value_faults_present |= enabled;
         break;
       case 9:
-        this->value_fault_inverter_voltage_too_high_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_inverter_voltage_too_high = enabled;
+        value_faults_present |= enabled;
         break;
       case 10:
-        this->value_warning_over_temperature_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_over_temperature = enabled;
+        value_warnings_present |= enabled;
         break;
       case 11:
-        this->value_warning_fan_lock_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_fan_lock = enabled;
+        value_warnings_present |= enabled;
         break;
       case 12:
-        this->value_warning_battery_voltage_high_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_voltage_high = enabled;
+        value_warnings_present |= enabled;
         break;
       case 13:
-        this->value_warning_battery_low_alarm_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_low_alarm = enabled;
+        value_warnings_present |= enabled;
         break;
       case 15:
-        this->value_warning_battery_under_shutdown_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_under_shutdown = enabled;
+        value_warnings_present |= enabled;
         break;
       case 16:
-        this->value_warning_battery_derating_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_derating = enabled;
+        value_warnings_present |= enabled;
         break;
       case 17:
-        this->value_warning_over_load_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_over_load = enabled;
+        value_warnings_present |= enabled;
         break;
       case 18:
-        this->value_warning_eeprom_failed_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_eeprom_failed = enabled;
+        value_warnings_present |= enabled;
         break;
       case 19:
-        this->value_fault_inverter_over_current_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_inverter_over_current = enabled;
+        value_faults_present |= enabled;
         break;
       case 20:
-        this->value_fault_inverter_soft_failed_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_inverter_soft_failed = enabled;
+        value_faults_present |= enabled;
         break;
       case 21:
-        this->value_fault_self_test_failed_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_self_test_failed = enabled;
+        value_faults_present |= enabled;
         break;
       case 22:
-        this->value_fault_op_dc_voltage_over_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_op_dc_voltage_over = enabled;
+        value_faults_present |= enabled;
         break;
       case 23:
-        this->value_fault_battery_open_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_battery_open = enabled;
+        value_faults_present |= enabled;
         break;
       case 24:
-        this->value_fault_current_sensor_failed_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_current_sensor_failed = enabled;
+        value_faults_present |= enabled;
         break;
       case 25:
-        this->value_fault_battery_short_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_battery_short = enabled;
+        value_faults_present |= enabled;
         break;
       case 26:
-        this->value_warning_power_limit_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_power_limit = enabled;
+        value_warnings_present |= enabled;
         break;
       case 27:
-        this->value_warning_pv_voltage_high_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_pv_voltage_high = enabled;
+        value_warnings_present |= enabled;
         break;
       case 28:
-        this->value_fault_mppt_overload_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_mppt_overload = enabled;
+        value_faults_present |= enabled;
         break;
       case 29:
-        this->value_warning_mppt_overload_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_mppt_overload = enabled;
+        value_warnings_present |= enabled;
         break;
       case 30:
-        this->value_warning_battery_too_low_to_charge_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_too_low_to_charge = enabled;
+        value_warnings_present |= enabled;
         break;
       case 31:
-        this->value_fault_dc_dc_over_current_ = enabled;
-        this->value_faults_present_ += enabled;
+        values.fault_dc_dc_over_current = enabled;
+        value_faults_present |= enabled;
         break;
       case 32:
         fc = message[i];
         fc += message[i + 1];
-        this->value_fault_code_ = parse_number<int>(fc).value_or(0);
+        values.fault_code = parse_number<int>(fc).value_or(0);
         break;
       case 34:
-        this->value_warnung_low_pv_energy_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warnung_low_pv_energy = enabled;
+        value_warnings_present |= enabled;
         break;
       case 35:
-        this->value_warning_high_ac_input_during_bus_soft_start_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_high_ac_input_during_bus_soft_start = enabled;
+        value_warnings_present |= enabled;
         break;
       case 36:
-        this->value_warning_battery_equalization_ = enabled;
-        this->value_warnings_present_ += enabled;
+        values.warning_battery_equalization = enabled;
+        value_warnings_present |= enabled;
         break;
     }
   }
@@ -746,113 +752,113 @@ void Pipsolar::handle_qpiws_(const char* message) {
   }
 
   if (this->warnings_present_) {
-    this->warnings_present_->publish_state(value_warnings_present_);
+    this->warnings_present_->publish_state(value_warnings_present);
   }
   if (this->faults_present_) {
-    this->faults_present_->publish_state(value_faults_present_);
+    this->faults_present_->publish_state(value_faults_present);
   }
   if (this->warning_power_loss_) {
-    this->warning_power_loss_->publish_state(value_warning_power_loss_);
+    this->warning_power_loss_->publish_state(values.warning_power_loss);
   }
   if (this->fault_inverter_fault_) {
-    this->fault_inverter_fault_->publish_state(value_fault_inverter_fault_);
+    this->fault_inverter_fault_->publish_state(values.fault_inverter_fault);
   }
   if (this->fault_bus_over_) {
-    this->fault_bus_over_->publish_state(value_fault_bus_over_);
+    this->fault_bus_over_->publish_state(values.fault_bus_over);
   }
   if (this->fault_bus_under_) {
-    this->fault_bus_under_->publish_state(value_fault_bus_under_);
+    this->fault_bus_under_->publish_state(values.fault_bus_under);
   }
   if (this->fault_bus_soft_fail_) {
-    this->fault_bus_soft_fail_->publish_state(value_fault_bus_soft_fail_);
+    this->fault_bus_soft_fail_->publish_state(values.fault_bus_soft_fail);
   }
   if (this->warning_line_fail_) {
-    this->warning_line_fail_->publish_state(value_warning_line_fail_);
+    this->warning_line_fail_->publish_state(values.warning_line_fail);
   }
   if (this->fault_opvshort_) {
-    this->fault_opvshort_->publish_state(value_fault_opvshort_);
+    this->fault_opvshort_->publish_state(values.fault_opvshort);
   }
   if (this->fault_inverter_voltage_too_low_) {
-    this->fault_inverter_voltage_too_low_->publish_state(value_fault_inverter_voltage_too_low_);
+    this->fault_inverter_voltage_too_low_->publish_state(values.fault_inverter_voltage_too_low);
   }
   if (this->fault_inverter_voltage_too_high_) {
-    this->fault_inverter_voltage_too_high_->publish_state(value_fault_inverter_voltage_too_high_);
+    this->fault_inverter_voltage_too_high_->publish_state(values.fault_inverter_voltage_too_high);
   }
   if (this->warning_over_temperature_) {
-    this->warning_over_temperature_->publish_state(value_warning_over_temperature_);
+    this->warning_over_temperature_->publish_state(values.warning_over_temperature);
   }
   if (this->warning_fan_lock_) {
-    this->warning_fan_lock_->publish_state(value_warning_fan_lock_);
+    this->warning_fan_lock_->publish_state(values.warning_fan_lock);
   }
   if (this->warning_battery_voltage_high_) {
-    this->warning_battery_voltage_high_->publish_state(value_warning_battery_voltage_high_);
+    this->warning_battery_voltage_high_->publish_state(values.warning_battery_voltage_high);
   }
   if (this->warning_battery_low_alarm_) {
-    this->warning_battery_low_alarm_->publish_state(value_warning_battery_low_alarm_);
+    this->warning_battery_low_alarm_->publish_state(values.warning_battery_low_alarm);
   }
   if (this->warning_battery_under_shutdown_) {
-    this->warning_battery_under_shutdown_->publish_state(value_warning_battery_under_shutdown_);
+    this->warning_battery_under_shutdown_->publish_state(values.warning_battery_under_shutdown);
   }
   if (this->warning_battery_derating_) {
-    this->warning_battery_derating_->publish_state(value_warning_battery_derating_);
+    this->warning_battery_derating_->publish_state(values.warning_battery_derating);
   }
   if (this->warning_over_load_) {
-    this->warning_over_load_->publish_state(value_warning_over_load_);
+    this->warning_over_load_->publish_state(values.warning_over_load);
   }
   if (this->warning_eeprom_failed_) {
-    this->warning_eeprom_failed_->publish_state(value_warning_eeprom_failed_);
+    this->warning_eeprom_failed_->publish_state(values.warning_eeprom_failed);
   }
   if (this->fault_inverter_over_current_) {
-    this->fault_inverter_over_current_->publish_state(value_fault_inverter_over_current_);
+    this->fault_inverter_over_current_->publish_state(values.fault_inverter_over_current);
   }
   if (this->fault_inverter_soft_failed_) {
-    this->fault_inverter_soft_failed_->publish_state(value_fault_inverter_soft_failed_);
+    this->fault_inverter_soft_failed_->publish_state(values.fault_inverter_soft_failed);
   }
   if (this->fault_self_test_failed_) {
-    this->fault_self_test_failed_->publish_state(value_fault_self_test_failed_);
+    this->fault_self_test_failed_->publish_state(values.fault_self_test_failed);
   }
   if (this->fault_op_dc_voltage_over_) {
-    this->fault_op_dc_voltage_over_->publish_state(value_fault_op_dc_voltage_over_);
+    this->fault_op_dc_voltage_over_->publish_state(values.fault_op_dc_voltage_over);
   }
   if (this->fault_battery_open_) {
-    this->fault_battery_open_->publish_state(value_fault_battery_open_);
+    this->fault_battery_open_->publish_state(values.fault_battery_open);
   }
   if (this->fault_current_sensor_failed_) {
-    this->fault_current_sensor_failed_->publish_state(value_fault_current_sensor_failed_);
+    this->fault_current_sensor_failed_->publish_state(values.fault_current_sensor_failed);
   }
   if (this->fault_battery_short_) {
-    this->fault_battery_short_->publish_state(value_fault_battery_short_);
+    this->fault_battery_short_->publish_state(values.fault_battery_short);
   }
   if (this->warning_power_limit_) {
-    this->warning_power_limit_->publish_state(value_warning_power_limit_);
+    this->warning_power_limit_->publish_state(values.warning_power_limit);
   }
   if (this->warning_pv_voltage_high_) {
-    this->warning_pv_voltage_high_->publish_state(value_warning_pv_voltage_high_);
+    this->warning_pv_voltage_high_->publish_state(values.warning_pv_voltage_high);
   }
   if (this->fault_mppt_overload_) {
-    this->fault_mppt_overload_->publish_state(value_fault_mppt_overload_);
+    this->fault_mppt_overload_->publish_state(values.fault_mppt_overload);
   }
   if (this->warning_mppt_overload_) {
-    this->warning_mppt_overload_->publish_state(value_warning_mppt_overload_);
+    this->warning_mppt_overload_->publish_state(values.warning_mppt_overload);
   }
   if (this->warning_battery_too_low_to_charge_) {
-    this->warning_battery_too_low_to_charge_->publish_state(value_warning_battery_too_low_to_charge_);
+    this->warning_battery_too_low_to_charge_->publish_state(values.warning_battery_too_low_to_charge);
   }
   if (this->fault_dc_dc_over_current_) {
-    this->fault_dc_dc_over_current_->publish_state(value_fault_dc_dc_over_current_);
+    this->fault_dc_dc_over_current_->publish_state(values.fault_dc_dc_over_current);
   }
   if (this->fault_code_) {
-    this->fault_code_->publish_state(value_fault_code_);
+    this->fault_code_->publish_state(values.fault_code);
   }
   if (this->warnung_low_pv_energy_) {
-    this->warnung_low_pv_energy_->publish_state(value_warnung_low_pv_energy_);
+    this->warnung_low_pv_energy_->publish_state(values.warnung_low_pv_energy);
   }
   if (this->warning_high_ac_input_during_bus_soft_start_) {
     this->warning_high_ac_input_during_bus_soft_start_->publish_state(
-        value_warning_high_ac_input_during_bus_soft_start_);
+        values.warning_high_ac_input_during_bus_soft_start);
   }
   if (this->warning_battery_equalization_) {
-    this->warning_battery_equalization_->publish_state(value_warning_battery_equalization_);
+    this->warning_battery_equalization_->publish_state(values.warning_battery_equalization);
   }
 }
 

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -25,6 +25,7 @@ struct PollingCommand {
   uint8_t length = 0;
   uint8_t errors;
   ENUMPollingCommand identifier;
+  bool needs_update;
 };
 
 #define PIPSOLAR_VALUED_ENTITY_(type, name, polling_command, value_type) \
@@ -189,14 +190,14 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   static const size_t PIPSOLAR_READ_BUFFER_LENGTH = 110;  // maximum supported answer length
   static const size_t COMMAND_QUEUE_LENGTH = 10;
   static const size_t COMMAND_TIMEOUT = 5000;
-  uint32_t last_poll_ = 0;
+  static const size_t POLLING_COMMANDS_MAX = 15;
   void add_polling_command_(const char *command, ENUMPollingCommand polling_command);
   void empty_uart_buffer_();
   uint8_t check_incoming_crc_();
   uint8_t check_incoming_length_(uint8_t length);
   uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
   bool send_next_command_();
-  void send_next_poll_();
+  bool send_next_poll_();
   std::string command_queue_[COMMAND_QUEUE_LENGTH];
   uint8_t command_queue_position_ = 0;
   uint8_t read_buffer_[PIPSOLAR_READ_BUFFER_LENGTH];
@@ -215,7 +216,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   };
 
   uint8_t last_polling_command_ = 0;
-  PollingCommand enabled_polling_commands_[15];
+  PollingCommand enabled_polling_commands_[POLLING_COMMANDS_MAX];
 };
 
 }  // namespace pipsolar

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -198,6 +198,15 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
   bool send_next_command_();
   bool send_next_poll_();
+
+  void handle_qpiri_(const char *message);
+  void handle_qpigs_(const char *message);
+  void handle_qmod_(const char *message);
+  void handle_qflag_(const char *message);
+  void handle_qpiws_(const char *message);
+  void handle_qt_(const char *message);
+  void handle_qmn_(const char *message);
+
   std::string command_queue_[COMMAND_QUEUE_LENGTH];
   uint8_t command_queue_position_ = 0;
   uint8_t read_buffer_[PIPSOLAR_READ_BUFFER_LENGTH];
@@ -212,7 +221,6 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
     STATE_POLL_COMPLETE = 3,
     STATE_COMMAND_COMPLETE = 4,
     STATE_POLL_CHECKED = 5,
-    STATE_POLL_DECODED = 6,
   };
 
   uint8_t last_polling_command_ = 0;

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -195,7 +195,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   uint8_t check_incoming_crc_();
   uint8_t check_incoming_length_(uint8_t length);
   uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
-  uint8_t send_next_command_();
+  bool send_next_command_();
   void send_next_poll_();
   std::string command_queue_[COMMAND_QUEUE_LENGTH];
   uint8_t command_queue_position_ = 0;
@@ -215,7 +215,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   };
 
   uint8_t last_polling_command_ = 0;
-  PollingCommand used_polling_commands_[15];
+  PollingCommand enabled_polling_commands_[15];
 };
 
 }  // namespace pipsolar

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -51,8 +51,7 @@ struct QFLAGValues {
     this->add_polling_command_(#polling_command, POLLING_##polling_command); \
   }
 
-#define PIPSOLAR_SENSOR(name, polling_command) \
-  PIPSOLAR_ENTITY_(sensor::Sensor, name, polling_command)
+#define PIPSOLAR_SENSOR(name, polling_command) PIPSOLAR_ENTITY_(sensor::Sensor, name, polling_command)
 #define PIPSOLAR_SWITCH(name, polling_command) PIPSOLAR_ENTITY_(switch_::Switch, name, polling_command)
 #define PIPSOLAR_BINARY_SENSOR(name, polling_command) \
   PIPSOLAR_ENTITY_(binary_sensor::BinarySensor, name, polling_command)
@@ -216,12 +215,12 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   void handle_qt_(const char *message);
   void handle_qmn_(const char *message);
 
-  void skip_start_(const char* message, size_t *pos);
-  void skip_field_(const char* message, size_t *pos);
-  std::string read_field_(const char* message, size_t *pos);
-  
-  void read_float_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor);
-  void read_int_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor);
+  void skip_start_(const char *message, size_t *pos);
+  void skip_field_(const char *message, size_t *pos);
+  std::string read_field_(const char *message, size_t *pos);
+
+  void read_float_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor);
+  void read_int_sensor_(const char *message, size_t *pos, sensor::Sensor *sensor);
 
   void publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor);
 

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -7,6 +7,7 @@
 #include "esphome/components/uart/uart.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace pipsolar {
@@ -28,115 +29,17 @@ struct PollingCommand {
   bool needs_update;
 };
 
-struct QPIRIValues {
-  float grid_rating_voltage;
-  float grid_rating_current;
-  float ac_output_rating_voltage;
-  float ac_output_rating_frequency;
-  float ac_output_rating_current;
-  int ac_output_rating_apparent_power;
-  int ac_output_rating_active_power;
-  float battery_rating_voltage;
-  float battery_recharge_voltage;
-  float battery_under_voltage;
-  float battery_bulk_voltage;
-  float battery_float_voltage;
-  int battery_type;
-  int current_max_ac_charging_current;
-  int current_max_charging_current;
-  int input_voltage_range;
-  int output_source_priority;
-  int charger_source_priority;
-  int parallel_max_num;
-  int machine_type;
-  int topology;
-  int output_mode;
-  float battery_redischarge_voltage;
-  int pv_ok_condition_for_parallel;
-  int pv_power_balance;
-};
-struct QPIGSValues {
-  float grid_voltage;
-  float grid_frequency;
-  float ac_output_voltage;
-  float ac_output_frequency;
-  int ac_output_apparent_power;
-  int ac_output_active_power;
-  int output_load_percent;
-  int bus_voltage;
-  float battery_voltage;
-  int battery_charging_current;
-  int battery_capacity_percent;
-  int inverter_heat_sink_temperature;
-  float pv_input_current_for_battery;
-  float pv_input_voltage;
-  float battery_voltage_scc;
-  int battery_discharge_current;
-  int add_sbu_priority_version;
-  int configuration_status;
-  int scc_firmware_version;
-  int load_status;
-  int battery_voltage_to_steady_while_charging;
-  int charging_status;
-  int scc_charging_status;
-  int ac_charging_status;
-  int battery_voltage_offset_for_fans_on;
-  int eeprom_version;
-  int pv_charging_power;
-  int charging_to_floating_mode;
-  int switch_on;
-  int dustproof_installed;
-};
 struct QFLAGValues {
-  int silence_buzzer_open_buzzer;
-  int overload_bypass_function;
-  int lcd_escape_to_default;
-  int overload_restart_function;
-  int over_temperature_restart_function;
-  int backlight_on;
-  int alarm_on_when_primary_source_interrupt;
-  int fault_code_record;
-  int power_saving;
+  esphome::optional<bool> silence_buzzer_open_buzzer;
+  esphome::optional<bool> overload_bypass_function;
+  esphome::optional<bool> lcd_escape_to_default;
+  esphome::optional<bool> overload_restart_function;
+  esphome::optional<bool> over_temperature_restart_function;
+  esphome::optional<bool> backlight_on;
+  esphome::optional<bool> alarm_on_when_primary_source_interrupt;
+  esphome::optional<bool> fault_code_record;
+  esphome::optional<bool> power_saving;
 };
-struct QPIWSValues {
-  bool warnings_present;
-  bool faults_present;
-  bool warning_power_loss;
-  bool fault_inverter_fault;
-  bool fault_bus_over;
-  bool fault_bus_under;
-  bool fault_bus_soft_fail;
-  bool warning_line_fail;
-  bool fault_opvshort;
-  bool fault_inverter_voltage_too_low;
-  bool fault_inverter_voltage_too_high;
-  bool warning_over_temperature;
-  bool warning_fan_lock;
-  bool warning_battery_voltage_high;
-  bool warning_battery_low_alarm;
-  bool warning_battery_under_shutdown;
-  bool warning_battery_derating;
-  bool warning_over_load;
-  bool warning_eeprom_failed;
-  bool fault_inverter_over_current;
-  bool fault_inverter_soft_failed;
-  bool fault_self_test_failed;
-  bool fault_op_dc_voltage_over;
-  bool fault_battery_open;
-  bool fault_current_sensor_failed;
-  bool fault_battery_short;
-  bool warning_power_limit;
-  bool warning_pv_voltage_high;
-  bool fault_mppt_overload;
-  bool warning_mppt_overload;
-  bool warning_battery_too_low_to_charge;
-  bool fault_dc_dc_over_current;
-  int fault_code;
-  bool warnung_low_pv_energy;
-  bool warning_high_ac_input_during_bus_soft_start;
-  bool warning_battery_equalization;
-};
-
 
 #define PIPSOLAR_ENTITY_(type, name, polling_command) \
  protected: \
@@ -309,6 +212,17 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   void handle_qpiws_(const char *message);
   void handle_qt_(const char *message);
   void handle_qmn_(const char *message);
+
+  void skip_start_(const char* message, size_t *pos);
+  void skip_field_(const char* message, size_t *pos);
+  std::string read_field_(const char* message, size_t *pos);
+  
+  void read_float_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor);
+  void read_int_sensor_(const char* message, size_t *pos, sensor::Sensor *sensor);
+
+  void publish_binary_sensor_(esphome::optional<bool> b, binary_sensor::BinarySensor *sensor);
+
+  esphome::optional<bool> get_bit_(std::string bits, uint8_t bit_pos);
 
   std::string command_queue_[COMMAND_QUEUE_LENGTH];
   uint8_t command_queue_position_ = 0;

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -205,6 +205,9 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   bool send_next_command_();
   bool send_next_poll_();
 
+  void handle_poll_response_(ENUMPollingCommand polling_command, const char *message);
+  void handle_poll_error_(ENUMPollingCommand polling_command);
+  // these handlers are designed in a way that an empty message sets all sensors to unknown
   void handle_qpiri_(const char *message);
   void handle_qpigs_(const char *message);
   void handle_qmod_(const char *message);

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -28,10 +28,115 @@ struct PollingCommand {
   bool needs_update;
 };
 
-#define PIPSOLAR_VALUED_ENTITY_(type, name, polling_command, value_type) \
- protected: \
-  value_type value_##name##_; \
-  PIPSOLAR_ENTITY_(type, name, polling_command)
+struct QPIRIValues {
+  float grid_rating_voltage;
+  float grid_rating_current;
+  float ac_output_rating_voltage;
+  float ac_output_rating_frequency;
+  float ac_output_rating_current;
+  int ac_output_rating_apparent_power;
+  int ac_output_rating_active_power;
+  float battery_rating_voltage;
+  float battery_recharge_voltage;
+  float battery_under_voltage;
+  float battery_bulk_voltage;
+  float battery_float_voltage;
+  int battery_type;
+  int current_max_ac_charging_current;
+  int current_max_charging_current;
+  int input_voltage_range;
+  int output_source_priority;
+  int charger_source_priority;
+  int parallel_max_num;
+  int machine_type;
+  int topology;
+  int output_mode;
+  float battery_redischarge_voltage;
+  int pv_ok_condition_for_parallel;
+  int pv_power_balance;
+};
+struct QPIGSValues {
+  float grid_voltage;
+  float grid_frequency;
+  float ac_output_voltage;
+  float ac_output_frequency;
+  int ac_output_apparent_power;
+  int ac_output_active_power;
+  int output_load_percent;
+  int bus_voltage;
+  float battery_voltage;
+  int battery_charging_current;
+  int battery_capacity_percent;
+  int inverter_heat_sink_temperature;
+  float pv_input_current_for_battery;
+  float pv_input_voltage;
+  float battery_voltage_scc;
+  int battery_discharge_current;
+  int add_sbu_priority_version;
+  int configuration_status;
+  int scc_firmware_version;
+  int load_status;
+  int battery_voltage_to_steady_while_charging;
+  int charging_status;
+  int scc_charging_status;
+  int ac_charging_status;
+  int battery_voltage_offset_for_fans_on;
+  int eeprom_version;
+  int pv_charging_power;
+  int charging_to_floating_mode;
+  int switch_on;
+  int dustproof_installed;
+};
+struct QFLAGValues {
+  int silence_buzzer_open_buzzer;
+  int overload_bypass_function;
+  int lcd_escape_to_default;
+  int overload_restart_function;
+  int over_temperature_restart_function;
+  int backlight_on;
+  int alarm_on_when_primary_source_interrupt;
+  int fault_code_record;
+  int power_saving;
+};
+struct QPIWSValues {
+  bool warnings_present;
+  bool faults_present;
+  bool warning_power_loss;
+  bool fault_inverter_fault;
+  bool fault_bus_over;
+  bool fault_bus_under;
+  bool fault_bus_soft_fail;
+  bool warning_line_fail;
+  bool fault_opvshort;
+  bool fault_inverter_voltage_too_low;
+  bool fault_inverter_voltage_too_high;
+  bool warning_over_temperature;
+  bool warning_fan_lock;
+  bool warning_battery_voltage_high;
+  bool warning_battery_low_alarm;
+  bool warning_battery_under_shutdown;
+  bool warning_battery_derating;
+  bool warning_over_load;
+  bool warning_eeprom_failed;
+  bool fault_inverter_over_current;
+  bool fault_inverter_soft_failed;
+  bool fault_self_test_failed;
+  bool fault_op_dc_voltage_over;
+  bool fault_battery_open;
+  bool fault_current_sensor_failed;
+  bool fault_battery_short;
+  bool warning_power_limit;
+  bool warning_pv_voltage_high;
+  bool fault_mppt_overload;
+  bool warning_mppt_overload;
+  bool warning_battery_too_low_to_charge;
+  bool fault_dc_dc_over_current;
+  int fault_code;
+  bool warnung_low_pv_energy;
+  bool warning_high_ac_input_during_bus_soft_start;
+  bool warning_battery_equalization;
+};
+
 
 #define PIPSOLAR_ENTITY_(type, name, polling_command) \
  protected: \
@@ -43,126 +148,124 @@ struct PollingCommand {
     this->add_polling_command_(#polling_command, POLLING_##polling_command); \
   }
 
-#define PIPSOLAR_SENSOR(name, polling_command, value_type) \
-  PIPSOLAR_VALUED_ENTITY_(sensor::Sensor, name, polling_command, value_type)
+#define PIPSOLAR_SENSOR(name, polling_command) \
+  PIPSOLAR_ENTITY_(sensor::Sensor, name, polling_command)
 #define PIPSOLAR_SWITCH(name, polling_command) PIPSOLAR_ENTITY_(switch_::Switch, name, polling_command)
-#define PIPSOLAR_BINARY_SENSOR(name, polling_command, value_type) \
-  PIPSOLAR_VALUED_ENTITY_(binary_sensor::BinarySensor, name, polling_command, value_type)
-#define PIPSOLAR_VALUED_TEXT_SENSOR(name, polling_command, value_type) \
-  PIPSOLAR_VALUED_ENTITY_(text_sensor::TextSensor, name, polling_command, value_type)
+#define PIPSOLAR_BINARY_SENSOR(name, polling_command) \
+  PIPSOLAR_ENTITY_(binary_sensor::BinarySensor, name, polling_command)
 #define PIPSOLAR_TEXT_SENSOR(name, polling_command) PIPSOLAR_ENTITY_(text_sensor::TextSensor, name, polling_command)
 
 class Pipsolar : public uart::UARTDevice, public PollingComponent {
   // QPIGS values
-  PIPSOLAR_SENSOR(grid_voltage, QPIGS, float)
-  PIPSOLAR_SENSOR(grid_frequency, QPIGS, float)
-  PIPSOLAR_SENSOR(ac_output_voltage, QPIGS, float)
-  PIPSOLAR_SENSOR(ac_output_frequency, QPIGS, float)
-  PIPSOLAR_SENSOR(ac_output_apparent_power, QPIGS, int)
-  PIPSOLAR_SENSOR(ac_output_active_power, QPIGS, int)
-  PIPSOLAR_SENSOR(output_load_percent, QPIGS, int)
-  PIPSOLAR_SENSOR(bus_voltage, QPIGS, int)
-  PIPSOLAR_SENSOR(battery_voltage, QPIGS, float)
-  PIPSOLAR_SENSOR(battery_charging_current, QPIGS, int)
-  PIPSOLAR_SENSOR(battery_capacity_percent, QPIGS, int)
-  PIPSOLAR_SENSOR(inverter_heat_sink_temperature, QPIGS, int)
-  PIPSOLAR_SENSOR(pv_input_current_for_battery, QPIGS, float)
-  PIPSOLAR_SENSOR(pv_input_voltage, QPIGS, float)
-  PIPSOLAR_SENSOR(battery_voltage_scc, QPIGS, float)
-  PIPSOLAR_SENSOR(battery_discharge_current, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(add_sbu_priority_version, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(configuration_status, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(scc_firmware_version, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(load_status, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(battery_voltage_to_steady_while_charging, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(charging_status, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(scc_charging_status, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(ac_charging_status, QPIGS, int)
-  PIPSOLAR_SENSOR(battery_voltage_offset_for_fans_on, QPIGS, int)  //.1 scale
-  PIPSOLAR_SENSOR(eeprom_version, QPIGS, int)
-  PIPSOLAR_SENSOR(pv_charging_power, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(charging_to_floating_mode, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(switch_on, QPIGS, int)
-  PIPSOLAR_BINARY_SENSOR(dustproof_installed, QPIGS, int)
+  PIPSOLAR_SENSOR(grid_voltage, QPIGS)
+  PIPSOLAR_SENSOR(grid_frequency, QPIGS)
+  PIPSOLAR_SENSOR(ac_output_voltage, QPIGS)
+  PIPSOLAR_SENSOR(ac_output_frequency, QPIGS)
+  PIPSOLAR_SENSOR(ac_output_apparent_power, QPIGS)
+  PIPSOLAR_SENSOR(ac_output_active_power, QPIGS)
+  PIPSOLAR_SENSOR(output_load_percent, QPIGS)
+  PIPSOLAR_SENSOR(bus_voltage, QPIGS)
+  PIPSOLAR_SENSOR(battery_voltage, QPIGS)
+  PIPSOLAR_SENSOR(battery_charging_current, QPIGS)
+  PIPSOLAR_SENSOR(battery_capacity_percent, QPIGS)
+  PIPSOLAR_SENSOR(inverter_heat_sink_temperature, QPIGS)
+  PIPSOLAR_SENSOR(pv_input_current_for_battery, QPIGS)
+  PIPSOLAR_SENSOR(pv_input_voltage, QPIGS)
+  PIPSOLAR_SENSOR(battery_voltage_scc, QPIGS)
+  PIPSOLAR_SENSOR(battery_discharge_current, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(add_sbu_priority_version, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(configuration_status, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(scc_firmware_version, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(load_status, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(battery_voltage_to_steady_while_charging, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(charging_status, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(scc_charging_status, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(ac_charging_status, QPIGS)
+  PIPSOLAR_SENSOR(battery_voltage_offset_for_fans_on, QPIGS)  //.1 scale
+  PIPSOLAR_SENSOR(eeprom_version, QPIGS)
+  PIPSOLAR_SENSOR(pv_charging_power, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(charging_to_floating_mode, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(switch_on, QPIGS)
+  PIPSOLAR_BINARY_SENSOR(dustproof_installed, QPIGS)
 
   // QPIRI values
-  PIPSOLAR_SENSOR(grid_rating_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(grid_rating_current, QPIRI, float)
-  PIPSOLAR_SENSOR(ac_output_rating_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(ac_output_rating_frequency, QPIRI, float)
-  PIPSOLAR_SENSOR(ac_output_rating_current, QPIRI, float)
-  PIPSOLAR_SENSOR(ac_output_rating_apparent_power, QPIRI, int)
-  PIPSOLAR_SENSOR(ac_output_rating_active_power, QPIRI, int)
-  PIPSOLAR_SENSOR(battery_rating_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(battery_recharge_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(battery_under_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(battery_bulk_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(battery_float_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(battery_type, QPIRI, int)
-  PIPSOLAR_SENSOR(current_max_ac_charging_current, QPIRI, int)
-  PIPSOLAR_SENSOR(current_max_charging_current, QPIRI, int)
-  PIPSOLAR_SENSOR(input_voltage_range, QPIRI, int)
-  PIPSOLAR_SENSOR(output_source_priority, QPIRI, int)
-  PIPSOLAR_SENSOR(charger_source_priority, QPIRI, int)
-  PIPSOLAR_SENSOR(parallel_max_num, QPIRI, int)
-  PIPSOLAR_SENSOR(machine_type, QPIRI, int)
-  PIPSOLAR_SENSOR(topology, QPIRI, int)
-  PIPSOLAR_SENSOR(output_mode, QPIRI, int)
-  PIPSOLAR_SENSOR(battery_redischarge_voltage, QPIRI, float)
-  PIPSOLAR_SENSOR(pv_ok_condition_for_parallel, QPIRI, int)
-  PIPSOLAR_SENSOR(pv_power_balance, QPIRI, int)
+  PIPSOLAR_SENSOR(grid_rating_voltage, QPIRI)
+  PIPSOLAR_SENSOR(grid_rating_current, QPIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_voltage, QPIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_frequency, QPIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_current, QPIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_apparent_power, QPIRI)
+  PIPSOLAR_SENSOR(ac_output_rating_active_power, QPIRI)
+  PIPSOLAR_SENSOR(battery_rating_voltage, QPIRI)
+  PIPSOLAR_SENSOR(battery_recharge_voltage, QPIRI)
+  PIPSOLAR_SENSOR(battery_under_voltage, QPIRI)
+  PIPSOLAR_SENSOR(battery_bulk_voltage, QPIRI)
+  PIPSOLAR_SENSOR(battery_float_voltage, QPIRI)
+  PIPSOLAR_SENSOR(battery_type, QPIRI)
+  PIPSOLAR_SENSOR(current_max_ac_charging_current, QPIRI)
+  PIPSOLAR_SENSOR(current_max_charging_current, QPIRI)
+  PIPSOLAR_SENSOR(input_voltage_range, QPIRI)
+  PIPSOLAR_SENSOR(output_source_priority, QPIRI)
+  PIPSOLAR_SENSOR(charger_source_priority, QPIRI)
+  PIPSOLAR_SENSOR(parallel_max_num, QPIRI)
+  PIPSOLAR_SENSOR(machine_type, QPIRI)
+  PIPSOLAR_SENSOR(topology, QPIRI)
+  PIPSOLAR_SENSOR(output_mode, QPIRI)
+  PIPSOLAR_SENSOR(battery_redischarge_voltage, QPIRI)
+  PIPSOLAR_SENSOR(pv_ok_condition_for_parallel, QPIRI)
+  PIPSOLAR_SENSOR(pv_power_balance, QPIRI)
 
   // QMOD values
-  PIPSOLAR_VALUED_TEXT_SENSOR(device_mode, QMOD, char)
+  PIPSOLAR_TEXT_SENSOR(device_mode, QMOD)
 
   // QFLAG values
-  PIPSOLAR_BINARY_SENSOR(silence_buzzer_open_buzzer, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(overload_bypass_function, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(lcd_escape_to_default, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(overload_restart_function, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(over_temperature_restart_function, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(backlight_on, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(alarm_on_when_primary_source_interrupt, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(fault_code_record, QFLAG, int)
-  PIPSOLAR_BINARY_SENSOR(power_saving, QFLAG, int)
+  PIPSOLAR_BINARY_SENSOR(silence_buzzer_open_buzzer, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(overload_bypass_function, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(lcd_escape_to_default, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(overload_restart_function, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(over_temperature_restart_function, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(backlight_on, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(alarm_on_when_primary_source_interrupt, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(fault_code_record, QFLAG)
+  PIPSOLAR_BINARY_SENSOR(power_saving, QFLAG)
 
   // QPIWS values
-  PIPSOLAR_BINARY_SENSOR(warnings_present, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(faults_present, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_power_loss, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_inverter_fault, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_bus_over, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_bus_under, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_bus_soft_fail, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_line_fail, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_opvshort, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_inverter_voltage_too_low, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_inverter_voltage_too_high, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_over_temperature, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_fan_lock, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_voltage_high, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_low_alarm, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_under_shutdown, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_derating, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_over_load, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_eeprom_failed, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_inverter_over_current, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_inverter_soft_failed, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_self_test_failed, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_op_dc_voltage_over, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_battery_open, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_current_sensor_failed, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_battery_short, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_power_limit, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_pv_voltage_high, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_mppt_overload, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_mppt_overload, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_too_low_to_charge, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_dc_dc_over_current, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(fault_code, QPIWS, int)
-  PIPSOLAR_BINARY_SENSOR(warnung_low_pv_energy, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_high_ac_input_during_bus_soft_start, QPIWS, bool)
-  PIPSOLAR_BINARY_SENSOR(warning_battery_equalization, QPIWS, bool)
+  PIPSOLAR_BINARY_SENSOR(warnings_present, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(faults_present, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_power_loss, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_inverter_fault, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_bus_over, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_bus_under, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_bus_soft_fail, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_line_fail, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_opvshort, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_inverter_voltage_too_low, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_inverter_voltage_too_high, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_over_temperature, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_fan_lock, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_voltage_high, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_low_alarm, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_under_shutdown, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_derating, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_over_load, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_eeprom_failed, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_inverter_over_current, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_inverter_soft_failed, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_self_test_failed, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_op_dc_voltage_over, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_battery_open, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_current_sensor_failed, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_battery_short, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_power_limit, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_pv_voltage_high, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_mppt_overload, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_mppt_overload, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_too_low_to_charge, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_dc_dc_over_current, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(fault_code, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warnung_low_pv_energy, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_high_ac_input_during_bus_soft_start, QPIWS)
+  PIPSOLAR_BINARY_SENSOR(warning_battery_equalization, QPIWS)
 
   PIPSOLAR_TEXT_SENSOR(last_qpigs, QPIGS)
   PIPSOLAR_TEXT_SENSOR(last_qpiri, QPIRI)

--- a/esphome/components/pipsolar/pipsolar.h
+++ b/esphome/components/pipsolar/pipsolar.h
@@ -179,7 +179,7 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   PIPSOLAR_SWITCH(pv_ok_condition_for_parallel_switch, QPIRI)
   PIPSOLAR_SWITCH(pv_power_balance_switch, QPIRI)
 
-  void switch_command(const std::string &command);
+  void queue_command(const std::string &command);
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -197,7 +197,6 @@ class Pipsolar : public uart::UARTDevice, public PollingComponent {
   uint16_t pipsolar_crc_(uint8_t *msg, uint8_t len);
   uint8_t send_next_command_();
   void send_next_poll_();
-  void queue_command_(const char *command, uint8_t length);
   std::string command_queue_[COMMAND_QUEUE_LENGTH];
   uint8_t command_queue_position_ = 0;
   uint8_t read_buffer_[PIPSOLAR_READ_BUFFER_LENGTH];

--- a/esphome/components/pipsolar/switch/pipsolar_switch.cpp
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.cpp
@@ -11,11 +11,11 @@ void PipsolarSwitch::dump_config() { LOG_SWITCH("", "Pipsolar Switch", this); }
 void PipsolarSwitch::write_state(bool state) {
   if (state) {
     if (!this->on_command_.empty()) {
-      this->parent_->switch_command(this->on_command_);
+      this->parent_->queue_command(this->on_command_);
     }
   } else {
     if (!this->off_command_.empty()) {
-      this->parent_->switch_command(this->off_command_);
+      this->parent_->queue_command(this->off_command_);
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This changes a few things in the pipsolar integration:
- fix `update_interval` when multiple poll requests are enabled (previously, at each update, only one request was being fired)
- fix `faults_present` binary sensor (was always true due to a bug)
- split huge loop() method into multiple methods
- set sensors unavailable if its value is missing or there is a response error (NACK, timeout, CRC error)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  - id: inverter_uart
    rx_pin: GPIO21
    tx_pin: GPIO22
    baud_rate: 2400
    data_bits: 8
    parity: NONE
    stop_bits: 1

pipsolar:
  - id: inverter0
    uart_id: inverter_uart
    update_interval: 10s

sensor:
  - platform: pipsolar
    pipsolar_id: inverter0
    ac_output_voltage:
      name: Inv AC Output Voltage
    ac_output_frequency:
      name: Inv AC Output Frequency
    ac_output_apparent_power:
      name: Inv AC Output Apparent Power
    ac_output_active_power:
      name: Inv AC Output Active Power
    output_load_percent:
      name: Inv AC Output Load
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
