### PR TITLE
[binary_sensor] Convert LOG_BINARY_SENSOR macro to function to reduce flash usage

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -7,6 +7,19 @@ namespace binary_sensor {
 
 static const char *const TAG = "binary_sensor";
 
+// Function implementation of LOG_BINARY_SENSOR macro to reduce code size
+void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj) {
+  if (obj == nullptr) {
+    return;
+  }
+
+  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+
+  if (!obj->get_device_class().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
+  }
+}
+
 void BinarySensor::publish_state(bool new_state) {
   if (this->filter_list_ == nullptr) {
     this->send_state_internal(new_state);

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -10,7 +10,6 @@ namespace esphome {
 
 namespace binary_sensor {
 
-// Forward declaration
 class BinarySensor;
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj);
 

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -10,13 +10,12 @@ namespace esphome {
 
 namespace binary_sensor {
 
-#define LOG_BINARY_SENSOR(prefix, type, obj) \
-  if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_device_class().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
-    } \
-  }
+// Forward declaration
+class BinarySensor;
+void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj);
+
+// Macro that calls the function - kept for backward compatibility
+#define LOG_BINARY_SENSOR(prefix, type, obj) log_binary_sensor(TAG, prefix, LOG_STR_LITERAL(type), obj)
 
 #define SUB_BINARY_SENSOR(name) \
  protected: \

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -14,7 +14,6 @@ namespace binary_sensor {
 class BinarySensor;
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj);
 
-// Macro that calls the function - kept for backward compatibility
 #define LOG_BINARY_SENSOR(prefix, type, obj) log_binary_sensor(TAG, prefix, LOG_STR_LITERAL(type), obj)
 
 #define SUB_BINARY_SENSOR(name) \


### PR DESCRIPTION
# What does this implement/fix?

This PR converts the `LOG_BINARY_SENSOR` macro to a function to reduce flash memory usage in configurations with binary sensors. Following the same successful pattern already used by `LOG_SWITCH`, `LOG_SENSOR`, and `LOG_NUMBER`, this optimization consolidates the logging code that was previously duplicated at every call site.

The macro was being expanded inline at 53+ call sites across the codebase, making it one of the most widely used logging macros. By converting it to a function, the code is now centralized, with each call site only needing a small function call instead of the entire expanded macro.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts
- Follows the same pattern as `LOG_SWITCH`, `LOG_SENSOR`, and `LOG_NUMBER` optimizations

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example showing a configuration that benefits from this optimization:

binary_sensor:
  - platform: gpio
    pin: GPIO5
    name: "Motion Sensor"
    device_class: motion
    
  - platform: ld2450
    ld2450_id: ld2450_radar
    has_target:
      name: "Presence"
    has_moving_target:
      name: "Moving Target"
    has_still_target:
      name: "Still Target"
      
  - platform: status
    name: "System Status"
```

## Memory Savings

Testing shows consistent flash memory savings that scale with the number of binary sensors:

| Configuration | Binary Sensors | Flash Before | Flash After | Savings |
|--------------|----------------|--------------|-------------|---------|
| test_ld2450.yaml | 3 | 354,598 B | 354,490 B | **+108 B** |
| ol.yaml | 2 | 1,346,626 B | 1,346,546 B | **+80 B** |

The optimization provides approximately **36-40 bytes of flash savings per binary sensor** that uses `LOG_BINARY_SENSOR`. While the per-component savings are smaller than `LOG_SENSOR` or `LOG_NUMBER` (due to the simpler logging structure), the impact is significant because:

- **53+ files** use `LOG_BINARY_SENSOR` across the codebase (vs. 15 for `LOG_NUMBER`)
- Binary sensors are one of the most common component types in ESPHome
- Many real-world configurations have numerous binary sensors

## Technical Details

### Changes Made:
1. Added `log_binary_sensor()` function in `binary_sensor.cpp` that implements the logging logic
2. Converted `LOG_BINARY_SENSOR` macro to call the new function while preserving the macro interface for backward compatibility
3. The `LOG_STR_LITERAL(type)` expansion still happens at the macro level to maintain compile-time string handling

### Implementation Pattern:
This follows the exact same proven pattern already successfully used by:
- `LOG_SWITCH` in the switch component
- `LOG_SENSOR` in the sensor component
- `LOG_NUMBER` in the number component

### Key Considerations:
- The nullptr check from the original macro is preserved
- The macro interface remains unchanged, ensuring backward compatibility
- `TAG` and `LOG_STR_LITERAL(type)` are expanded at the call site as before
- The function is not inlined to ensure the size reduction
- The simpler structure (only name and device_class) results in smaller per-component savings but wider impact

### Components That Benefit (53+ files including):
- GPIO Binary Sensor
- LD2450, LD2412, LD2410, LD2420
- ESP32 Touch
- Remote Base
- RC522, PN532 (NFC/RFID)
- Status Binary Sensor
- Template Binary Sensor
- HomeAssistant Binary Sensor
- BLE Presence
- Xiaomi sensors (MJYD02YLA, CGPR1, MUE4094RT, WX08ZM, RTCGQ02LM)
- Modbus Controller
- And many others

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).