### PR TITLE
[button] Convert LOG_BUTTON macro to function to reduce flash usage

### DIFF
--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -6,6 +6,19 @@ namespace button {
 
 static const char *const TAG = "button";
 
+// Function implementation of LOG_BUTTON macro to reduce code size
+void log_button(const char *tag, const char *prefix, const char *type, Button *obj) {
+  if (obj == nullptr) {
+    return;
+  }
+
+  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+
+  if (!obj->get_icon().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
+  }
+}
+
 void Button::press() {
   ESP_LOGD(TAG, "'%s' Pressed.", this->get_name().c_str());
   this->press_action();

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -7,6 +7,7 @@
 namespace esphome {
 namespace button {
 
+class Button;
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
 
 #define LOG_BUTTON(prefix, type, obj) log_button(TAG, prefix, LOG_STR_LITERAL(type), obj)

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -11,7 +11,6 @@ namespace button {
 class Button;
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
 
-// Macro that calls the function - kept for backward compatibility
 #define LOG_BUTTON(prefix, type, obj) log_button(TAG, prefix, LOG_STR_LITERAL(type), obj)
 
 #define SUB_BUTTON(name) \

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -7,13 +7,12 @@
 namespace esphome {
 namespace button {
 
-#define LOG_BUTTON(prefix, type, obj) \
-  if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
-    } \
-  }
+// Forward declaration
+class Button;
+void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
+
+// Macro that calls the function - kept for backward compatibility
+#define LOG_BUTTON(prefix, type, obj) log_button(TAG, prefix, LOG_STR_LITERAL(type), obj)
 
 #define SUB_BUTTON(name) \
  protected: \

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -7,7 +7,6 @@
 namespace esphome {
 namespace button {
 
-// Forward declaration
 class Button;
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
 

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -7,7 +7,6 @@
 namespace esphome {
 namespace button {
 
-class Button;
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
 
 #define LOG_BUTTON(prefix, type, obj) log_button(TAG, prefix, LOG_STR_LITERAL(type), obj)


### PR DESCRIPTION
# What does this implement/fix?

This PR converts the `LOG_BUTTON` macro to a function to reduce flash memory usage in configurations with button components. Following the same successful pattern already used by `LOG_SWITCH`, `LOG_SENSOR`, `LOG_NUMBER`, and `LOG_BINARY_SENSOR`, this optimization consolidates the logging code that was previously duplicated at every call site.

The macro was being expanded inline at 16+ call sites across the codebase, including common components like restart, factory reset, safe mode, and shutdown buttons, as well as device-specific buttons in LD2450, LD2420, and other components. By converting it to a function, the code is now centralized, with each call site only needing a small function call instead of the entire expanded macro.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts
- Follows the same pattern as `LOG_SWITCH`, `LOG_SENSOR`, `LOG_NUMBER`, and `LOG_BINARY_SENSOR` optimizations

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example showing a configuration that benefits from this optimization:

button:
  - platform: restart
    name: "Restart Device"
    
  - platform: factory_reset
    name: "Factory Reset"
    
  - platform: safe_mode
    name: "Safe Mode"
    
  - platform: ld2450
    ld2450_id: ld2450_radar
    factory_reset:
      name: "LD2450 Factory Reset"
    restart:
      name: "LD2450 Restart"
```

## Memory Savings

Testing shows consistent flash memory savings that scale with the number of button components:

| Configuration | Button Components | Flash Before | Flash After | Savings |
|--------------|-------------------|--------------|-------------|---------|
| neargaragedoor.yaml (ESP8266) | 4 | 515,565 B | 515,485 B | **+80 B** |
| test_ld2450.yaml | 2 | TBD | TBD | Expected ~40 B |

The optimization provides approximately **20 bytes of flash savings per button component** that uses `LOG_BUTTON`. This is particularly valuable on memory-constrained devices like ESP8266.

## Technical Details

### Changes Made:
1. Added `log_button()` function in `button.cpp` that implements the logging logic
2. Converted `LOG_BUTTON` macro to call the new function while preserving the macro interface for backward compatibility
3. The `LOG_STR_LITERAL(type)` expansion still happens at the macro level to maintain compile-time string handling

### Implementation Pattern:
This follows the exact same proven pattern already successfully used by:
- `LOG_SWITCH` in the switch component
- `LOG_SENSOR` in the sensor component  
- `LOG_NUMBER` in the number component
- `LOG_BINARY_SENSOR` in the binary_sensor component

### Key Considerations:
- The nullptr check from the original macro is preserved
- The macro interface remains unchanged, ensuring backward compatibility
- `TAG` and `LOG_STR_LITERAL(type)` are expanded at the call site as before
- The function is not inlined to ensure the size reduction
- The simple structure (only name and icon) results in modest but consistent per-component savings

### Components That Benefit (16+ files including):
- System buttons: Restart, Factory Reset, Safe Mode, Shutdown
- UART Button
- Wake on LAN
- Output Button
- Copy Button
- LD2450, LD2412, LD2410, LD2420 buttons
- Seeed MR60FDA2, MR24HPC1 buttons
- Micronova buttons
- And others

### Why This Matters:
Buttons are commonly used in ESPHome configurations for:
- Device management (restart, factory reset)
- Safety features (safe mode)
- Triggering actions (wake on LAN)
- Device-specific controls (sensor resets, mode changes)

Many configurations include multiple buttons, making the cumulative savings significant across the ESPHome ecosystem.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).