### PR TITLE
[web_server] Reduce flash usage by consolidating defer calls in switch and lock handlers

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -507,14 +507,37 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
       auto detail = get_request_detail(request);
       std::string data = this->switch_json(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
-    } else if (match.method_equals("toggle")) {
-      this->defer([obj]() { obj->toggle(); });
-      request->send(200);
+      return;
+    }
+
+    // Handle action methods with single defer and response
+    enum SwitchAction { NONE, TOGGLE, TURN_ON, TURN_OFF };
+    SwitchAction action = NONE;
+
+    if (match.method_equals("toggle")) {
+      action = TOGGLE;
     } else if (match.method_equals("turn_on")) {
-      this->defer([obj]() { obj->turn_on(); });
-      request->send(200);
+      action = TURN_ON;
     } else if (match.method_equals("turn_off")) {
-      this->defer([obj]() { obj->turn_off(); });
+      action = TURN_OFF;
+    }
+
+    if (action != NONE) {
+      this->defer([obj, action]() {
+        switch (action) {
+          case TOGGLE:
+            obj->toggle();
+            break;
+          case TURN_ON:
+            obj->turn_on();
+            break;
+          case TURN_OFF:
+            obj->turn_off();
+            break;
+          default:
+            break;
+        }
+      });
       request->send(200);
     } else {
       request->send(404);
@@ -1332,14 +1355,37 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
       auto detail = get_request_detail(request);
       std::string data = this->lock_json(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
-    } else if (match.method_equals("lock")) {
-      this->defer([obj]() { obj->lock(); });
-      request->send(200);
+      return;
+    }
+
+    // Handle action methods with single defer and response
+    enum LockAction { NONE, LOCK, UNLOCK, OPEN };
+    LockAction action = NONE;
+
+    if (match.method_equals("lock")) {
+      action = LOCK;
     } else if (match.method_equals("unlock")) {
-      this->defer([obj]() { obj->unlock(); });
-      request->send(200);
+      action = UNLOCK;
     } else if (match.method_equals("open")) {
-      this->defer([obj]() { obj->open(); });
+      action = OPEN;
+    }
+
+    if (action != NONE) {
+      this->defer([obj, action]() {
+        switch (action) {
+          case LOCK:
+            obj->lock();
+            break;
+          case UNLOCK:
+            obj->unlock();
+            break;
+          case OPEN:
+            obj->open();
+            break;
+          default:
+            break;
+        }
+      });
       request->send(200);
     } else {
       request->send(404);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -534,8 +534,6 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
           case TURN_OFF:
             obj->turn_off();
             break;
-          default:
-            break;
         }
       });
       request->send(200);
@@ -1381,8 +1379,6 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
             break;
           case OPEN:
             obj->open();
-            break;
-          default:
             break;
         }
       });

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -534,6 +534,8 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
           case TURN_OFF:
             obj->turn_off();
             break;
+          default:
+            break;
         }
       });
       request->send(200);
@@ -1379,6 +1381,8 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
             break;
           case OPEN:
             obj->open();
+            break;
+          default:
             break;
         }
       });


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the web server component's request handlers for `switch` and `lock` entities by consolidating multiple defer calls into single defer calls with switch statements. This reduces flash usage by eliminating duplicate lambda code generation.

The optimization consolidates the three separate lambdas for `toggle`, `turn_on`/`lock`, and `turn_off`/`unlock`/`open` operations into a single lambda with an enum-based switch statement. This results in a flash savings of 176 bytes on ESP8266 (96 bytes for switch handler, 80 bytes for lock handler).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces flash usage for web server component

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
web_server:
  port: 80

switch:
  - platform: gpio
    pin: GPIO5
    name: "Test Switch"
    id: test_switch

lock:
  - platform: template
    name: "Test Lock"
    id: test_lock
    lambda: |-
      return LOCK_STATE_LOCKED;
    lock_action:
      - logger.log: "Lock locked"
    unlock_action:
      - logger.log: "Lock unlocked"
    open_action:
      - logger.log: "Lock opened"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing Results

Tested on ESP8266 with the following flash usage measurements:

**Before optimization:**
- Flash: 514,769 bytes

**After optimization:**  
- Flash: 514,593 bytes
- **Savings: 176 bytes**

The handlers continue to work identically - all three operations (toggle/turn_on/turn_off for switch and lock/unlock/open for lock) function correctly through the web interface.