### PR TITLE
2025.8.0b3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.8.0b2
+PROJECT_NUMBER         = 2025.8.0b3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -476,7 +476,7 @@ def show_logs(config: ConfigType, args: ArgsProtocol, devices: list[str]) -> int
         from esphome.components.api.client import run_logs
 
         return run_logs(config, addresses_to_use)
-    if get_port_type(port) == "MQTT" and "mqtt" in config:
+    if get_port_type(port) in ("NETWORK", "MQTT") and "mqtt" in config:
         from esphome import mqtt
 
         return mqtt.show_logs(

--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -133,7 +133,7 @@ void BluetoothConnection::loop() {
 
   // Check if we should disable the loop
   // - For V3_WITH_CACHE: Services are never sent, disable after INIT state
-  // - For other connections: Disable only after service discovery is complete
+  // - For V3_WITHOUT_CACHE: Disable only after service discovery is complete
   //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
   if (this->state_ != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
                                                    this->send_service_ == DONE_SENDING_SERVICES)) {
@@ -160,10 +160,7 @@ void BluetoothConnection::send_service_for_discovery_() {
   if (this->send_service_ >= this->service_count_) {
     this->send_service_ = DONE_SENDING_SERVICES;
     this->proxy_->send_gatt_services_done(this->address_);
-    if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
-        this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-      this->release_services();
-    }
+    this->release_services();
     return;
   }
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -824,8 +824,9 @@ async def to_code(config):
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
-    cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{config[CONF_VARIANT]}")
-    cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[config[CONF_VARIANT]])
+    variant = config[CONF_VARIANT]
+    cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")
+    cg.add_define("ESPHOME_VARIANT", VARIANT_FRIENDLY[variant])
     cg.add_define(ThreadModel.MULTI_ATOMICS)
 
     cg.add_platformio_option("lib_ldf_mode", "off")
@@ -859,6 +860,7 @@ async def to_code(config):
         cg.add_platformio_option(
             "platform_packages", ["espressif/toolchain-esp32ulp@2.35.0-20220830"]
         )
+        add_idf_sdkconfig_option(f"CONFIG_IDF_TARGET_{variant}", True)
         add_idf_sdkconfig_option(
             f"CONFIG_ESPTOOLPY_FLASHSIZE_{config[CONF_FLASH_SIZE]}", True
         )

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -294,6 +294,7 @@ async def to_code(config):
 
     if config[CONF_ADVERTISING]:
         cg.add_define("USE_ESP32_BLE_ADVERTISING")
+        cg.add_define("USE_ESP32_BLE_UUID")
 
 
 @automation.register_condition("ble.enabled", BLEEnabledCondition, cv.Schema({}))

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -306,7 +306,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTS: {
         esp_gatts_cb_event_t event = ble_event->event_.gatts.gatts_event;
         esp_gatt_if_t gatts_if = ble_event->event_.gatts.gatts_if;
-        esp_ble_gatts_cb_param_t *param = ble_event->event_.gatts.gatts_param;
+        esp_ble_gatts_cb_param_t *param = &ble_event->event_.gatts.gatts_param;
         ESP_LOGV(TAG, "gatts_event [esp_gatt_if: %d] - %d", gatts_if, event);
         for (auto *gatts_handler : this->gatts_event_handlers_) {
           gatts_handler->gatts_event_handler(event, gatts_if, param);
@@ -316,7 +316,7 @@ void ESP32BLE::loop() {
       case BLEEvent::GATTC: {
         esp_gattc_cb_event_t event = ble_event->event_.gattc.gattc_event;
         esp_gatt_if_t gattc_if = ble_event->event_.gattc.gattc_if;
-        esp_ble_gattc_cb_param_t *param = ble_event->event_.gattc.gattc_param;
+        esp_ble_gattc_cb_param_t *param = &ble_event->event_.gattc.gattc_param;
         ESP_LOGV(TAG, "gattc_event [esp_gatt_if: %d] - %d", gattc_if, event);
         for (auto *gattc_handler : this->gattc_event_handlers_) {
           gattc_handler->gattc_event_handler(event, gattc_if, param);

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -764,7 +764,8 @@ void Nextion::process_nextion_commands_() {
         variable_name = to_process.substr(0, index);
         ++index;
 
-        text_value = to_process.substr(index);
+        // Get variable value without terminating NUL byte.  Length check above ensures substr len >= 0.
+        text_value = to_process.substr(index, to_process_length - index - 1);
 
         ESP_LOGN(TAG, "Text sensor: %s='%s'", variable_name.c_str(), text_value.c_str());
 

--- a/esphome/components/senseair/senseair.cpp
+++ b/esphome/components/senseair/senseair.cpp
@@ -53,10 +53,14 @@ void SenseAirComponent::update() {
 
   this->status_clear_warning();
   const uint8_t length = response[2];
-  const uint16_t status = (uint16_t(response[3]) << 8) | response[4];
-  const int16_t ppm = int16_t((response[length + 1] << 8) | response[length + 2]);
+  const uint16_t status = encode_uint16(response[3], response[4]);
+  const uint16_t ppm = encode_uint16(response[length + 1], response[length + 2]);
 
-  ESP_LOGD(TAG, "SenseAir Received CO₂=%dppm Status=0x%02X", ppm, status);
+  ESP_LOGD(TAG, "SenseAir Received CO₂=%uppm Status=0x%02X", ppm, status);
+  if (ppm == 0 && (status & SenseAirStatus::OUT_OF_RANGE_ERROR) != 0) {
+    ESP_LOGD(TAG, "Discarding 0 ppm reading with out-of-range status.");
+    return;
+  }
   if (this->co2_sensor_ != nullptr)
     this->co2_sensor_->publish_state(ppm);
 }

--- a/esphome/components/senseair/senseair.h
+++ b/esphome/components/senseair/senseair.h
@@ -8,6 +8,17 @@
 namespace esphome {
 namespace senseair {
 
+enum SenseAirStatus : uint8_t {
+  FATAL_ERROR = 1 << 0,
+  OFFSET_ERROR = 1 << 1,
+  ALGORITHM_ERROR = 1 << 2,
+  OUTPUT_ERROR = 1 << 3,
+  SELF_DIAGNOSTIC_ERROR = 1 << 4,
+  OUT_OF_RANGE_ERROR = 1 << 5,
+  MEMORY_ERROR = 1 << 6,
+  RESERVED = 1 << 7
+};
+
 class SenseAirComponent : public PollingComponent, public uart::UARTDevice {
  public:
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -813,7 +813,7 @@ std::string WebServer::cover_state_json_generator(WebServer *web_server, void *s
   return web_server->cover_json((cover::Cover *) (source), DETAIL_STATE);
 }
 std::string WebServer::cover_all_json_generator(WebServer *web_server, void *source) {
-  return web_server->cover_json((cover::Cover *) (source), DETAIL_STATE);
+  return web_server->cover_json((cover::Cover *) (source), DETAIL_ALL);
 }
 std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -375,11 +375,16 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
 
+    # Track if any network uses Enterprise authentication
+    has_eap = False
+
     def add_sta(ap, network):
         ip_config = network.get(CONF_MANUAL_IP, config.get(CONF_MANUAL_IP))
         cg.add(var.add_sta(wifi_network(network, ap, ip_config)))
 
     for network in config.get(CONF_NETWORKS, []):
+        if CONF_EAP in network:
+            has_eap = True
         cg.with_local_variable(network[CONF_ID], WiFiAP(), add_sta, network)
 
     if CONF_AP in config:
@@ -395,6 +400,10 @@ async def to_code(config):
     elif CORE.is_esp32 and CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
+
+    # Disable Enterprise WiFi support if no EAP is configured
+    if CORE.is_esp32 and CORE.using_esp_idf and not has_eap:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT", False)
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_power_save_mode(config[CONF_POWER_SAVE_MODE]))

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.8.0b2"
+__version__ = "2025.8.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -803,6 +803,10 @@ class EsphomeCore:
             raise TypeError(
                 f"Library {library} must be instance of Library, not {type(library)}"
             )
+
+        if not library.name:
+            raise ValueError(f"The library for {library.repository} must have a name")
+
         short_name = (
             library.name if "/" not in library.name else library.name.split("/")[-1]
         )

--- a/tests/integration/fixtures/scheduler_removed_item_race.yaml
+++ b/tests/integration/fixtures/scheduler_removed_item_race.yaml
@@ -1,0 +1,139 @@
+esphome:
+  name: scheduler-removed-item-race
+
+host:
+
+api:
+  services:
+    - service: run_test
+      then:
+        - script.execute: run_test_script
+
+logger:
+  level: DEBUG
+
+globals:
+  - id: test_passed
+    type: bool
+    initial_value: 'true'
+  - id: removed_item_executed
+    type: int
+    initial_value: '0'
+  - id: normal_item_executed
+    type: int
+    initial_value: '0'
+
+sensor:
+  - platform: template
+    id: test_sensor
+    name: "Test Sensor"
+    update_interval: never
+    lambda: return 0.0;
+
+script:
+  - id: run_test_script
+    then:
+      - logger.log: "=== Starting Removed Item Race Test ==="
+
+      # This test creates a scenario where:
+      # 1. First item in heap is NOT cancelled (cleanup stops immediately)
+      # 2. Items behind it ARE cancelled (remain in heap after cleanup)
+      # 3. All items execute at the same time, including cancelled ones
+
+      - lambda: |-
+          // The key to hitting the race:
+          // 1. Add items in a specific order to control heap structure
+          // 2. Cancel ONLY items that won't be at the front
+          // 3. Ensure the first item stays non-cancelled so cleanup_() stops immediately
+
+          // Schedule all items to execute at the SAME time (1ms from now)
+          // Using 1ms instead of 0 to avoid defer queue on multi-core platforms
+          // This ensures they'll all be ready together and go through the heap
+          const uint32_t exec_time = 1;
+
+          // CRITICAL: Add a non-cancellable item FIRST
+          // This will be at the front of the heap and block cleanup_()
+          App.scheduler.set_timeout(id(test_sensor), "blocker", exec_time, []() {
+            ESP_LOGD("test", "Blocker timeout executed (expected) - was at front of heap");
+            id(normal_item_executed)++;
+          });
+
+          // Now add items that we WILL cancel
+          // These will be behind the blocker in the heap
+          App.scheduler.set_timeout(id(test_sensor), "cancel_1", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 1 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "cancel_2", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 2 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "cancel_3", exec_time, []() {
+            ESP_LOGE("test", "RACE: Cancelled timeout 3 executed after being cancelled!");
+            id(removed_item_executed)++;
+            id(test_passed) = false;
+          });
+
+          // Add some more normal items
+          App.scheduler.set_timeout(id(test_sensor), "normal_1", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 1 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "normal_2", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 2 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          App.scheduler.set_timeout(id(test_sensor), "normal_3", exec_time, []() {
+            ESP_LOGD("test", "Normal timeout 3 executed (expected)");
+            id(normal_item_executed)++;
+          });
+
+          // Force items into the heap before cancelling
+          App.scheduler.process_to_add();
+
+          // NOW cancel the items - they're behind "blocker" in the heap
+          // When cleanup_() runs, it will see "blocker" (not removed) at the front
+          // and stop immediately, leaving cancel_1, cancel_2, cancel_3 in the heap
+          bool c1 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_1");
+          bool c2 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_2");
+          bool c3 = App.scheduler.cancel_timeout(id(test_sensor), "cancel_3");
+
+          ESP_LOGD("test", "Cancelled items (behind blocker): %s, %s, %s",
+                   c1 ? "true" : "false",
+                   c2 ? "true" : "false",
+                   c3 ? "true" : "false");
+
+          // The heap now has:
+          // - "blocker" at front (not cancelled)
+          // - cancelled items behind it (marked remove=true but still in heap)
+          // - When all execute at once, cleanup_() stops at "blocker"
+          // - The loop then executes ALL ready items including cancelled ones
+
+          ESP_LOGD("test", "Setup complete. Blocker at front prevents cleanup of cancelled items behind it");
+
+      # Wait for all timeouts to execute (or not)
+      - delay: 20ms
+
+      # Check results
+      - lambda: |-
+          ESP_LOGI("test", "=== Test Results ===");
+          ESP_LOGI("test", "Normal items executed: %d (expected 4)", id(normal_item_executed));
+          ESP_LOGI("test", "Removed items executed: %d (expected 0)", id(removed_item_executed));
+
+          if (id(removed_item_executed) > 0) {
+            ESP_LOGE("test", "TEST FAILED: %d cancelled items were executed!", id(removed_item_executed));
+            id(test_passed) = false;
+          } else if (id(normal_item_executed) != 4) {
+            ESP_LOGE("test", "TEST FAILED: Expected 4 normal items, got %d", id(normal_item_executed));
+            id(test_passed) = false;
+          } else {
+            ESP_LOGI("test", "TEST PASSED: No cancelled items were executed");
+          }
+
+          ESP_LOGI("test", "=== Test Complete ===");

--- a/tests/integration/test_scheduler_removed_item_race.py
+++ b/tests/integration/test_scheduler_removed_item_race.py
@@ -1,0 +1,102 @@
+"""Test for scheduler race condition where removed items still execute."""
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_removed_item_race(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that items marked for removal don't execute.
+
+    This test verifies the fix for a race condition where:
+    1. cleanup_() only removes items from the front of the heap
+    2. Items in the middle of the heap marked for removal still execute
+    3. This causes cancelled timeouts to run when they shouldn't
+    """
+
+    loop = asyncio.get_running_loop()
+    test_complete_future: asyncio.Future[bool] = loop.create_future()
+
+    # Track test results
+    test_passed = False
+    removed_executed = 0
+    normal_executed = 0
+
+    # Patterns to match
+    race_pattern = re.compile(r"RACE: .* executed after being cancelled!")
+    passed_pattern = re.compile(r"TEST PASSED")
+    failed_pattern = re.compile(r"TEST FAILED")
+    complete_pattern = re.compile(r"=== Test Complete ===")
+    normal_count_pattern = re.compile(r"Normal items executed: (\d+)")
+    removed_count_pattern = re.compile(r"Removed items executed: (\d+)")
+
+    def check_output(line: str) -> None:
+        """Check log output for test results."""
+        nonlocal test_passed, removed_executed, normal_executed
+
+        if race_pattern.search(line):
+            # Race condition detected - a cancelled item executed
+            test_passed = False
+
+        if passed_pattern.search(line):
+            test_passed = True
+        elif failed_pattern.search(line):
+            test_passed = False
+
+        normal_match = normal_count_pattern.search(line)
+        if normal_match:
+            normal_executed = int(normal_match.group(1))
+
+        removed_match = removed_count_pattern.search(line)
+        if removed_match:
+            removed_executed = int(removed_match.group(1))
+
+        if not test_complete_future.done() and complete_pattern.search(line):
+            test_complete_future.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Verify we can connect
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "scheduler-removed-item-race"
+
+        # List services
+        _, services = await asyncio.wait_for(
+            client.list_entities_services(), timeout=5.0
+        )
+
+        # Find run_test service
+        run_test_service = next((s for s in services if s.name == "run_test"), None)
+        assert run_test_service is not None, "run_test service not found"
+
+        # Execute the test
+        client.execute_service(run_test_service, {})
+
+        # Wait for test completion
+        try:
+            await asyncio.wait_for(test_complete_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Test did not complete within timeout")
+
+        # Verify results
+        assert test_passed, (
+            f"Test failed! Removed items executed: {removed_executed}, "
+            f"Normal items executed: {normal_executed}"
+        )
+        assert removed_executed == 0, (
+            f"Cancelled items should not execute, but {removed_executed} did"
+        )
+        assert normal_executed == 4, (
+            f"Expected 4 normal items to execute, got {normal_executed}"
+        )

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -1,0 +1,220 @@
+"""Test writer module functionality."""
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esphome.storage_json import StorageJSON
+from esphome.writer import storage_should_clean, update_storage_json
+
+
+@pytest.fixture
+def create_storage() -> Callable[..., StorageJSON]:
+    """Factory fixture to create StorageJSON instances."""
+
+    def _create(
+        loaded_integrations: list[str] | None = None, **kwargs: Any
+    ) -> StorageJSON:
+        return StorageJSON(
+            storage_version=kwargs.get("storage_version", 1),
+            name=kwargs.get("name", "test"),
+            friendly_name=kwargs.get("friendly_name", "Test Device"),
+            comment=kwargs.get("comment"),
+            esphome_version=kwargs.get("esphome_version", "2025.1.0"),
+            src_version=kwargs.get("src_version", 1),
+            address=kwargs.get("address", "test.local"),
+            web_port=kwargs.get("web_port", 80),
+            target_platform=kwargs.get("target_platform", "ESP32"),
+            build_path=kwargs.get("build_path", "/build"),
+            firmware_bin_path=kwargs.get("firmware_bin_path", "/firmware.bin"),
+            loaded_integrations=set(loaded_integrations or []),
+            loaded_platforms=kwargs.get("loaded_platforms", set()),
+            no_mdns=kwargs.get("no_mdns", False),
+            framework=kwargs.get("framework", "arduino"),
+            core_platform=kwargs.get("core_platform", "esp32"),
+        )
+
+    return _create
+
+
+def test_storage_should_clean_when_old_is_none(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when old storage is None."""
+    new = create_storage(loaded_integrations=["api", "wifi"])
+    assert storage_should_clean(None, new) is True
+
+
+def test_storage_should_clean_when_src_version_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when src_version changes."""
+    old = create_storage(loaded_integrations=["api", "wifi"], src_version=1)
+    new = create_storage(loaded_integrations=["api", "wifi"], src_version=2)
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_build_path_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when build_path changes."""
+    old = create_storage(loaded_integrations=["api", "wifi"], build_path="/build1")
+    new = create_storage(loaded_integrations=["api", "wifi"], build_path="/build2")
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_component_removed(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when a component is removed."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi", "bluetooth_proxy", "esp32_ble_tracker"]
+    )
+    new = create_storage(loaded_integrations=["api", "wifi", "esp32_ble_tracker"])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_clean_when_multiple_components_removed(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is triggered when multiple components are removed."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi", "ota", "web_server", "logger"]
+    )
+    new = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_should_not_clean_when_nothing_changes(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when nothing changes."""
+    old = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    new = create_storage(loaded_integrations=["api", "wifi", "logger"])
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_should_not_clean_when_component_added(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when a component is only added."""
+    old = create_storage(loaded_integrations=["api", "wifi"])
+    new = create_storage(loaded_integrations=["api", "wifi", "ota"])
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_should_not_clean_when_other_fields_change(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test that clean is not triggered when non-relevant fields change."""
+    old = create_storage(
+        loaded_integrations=["api", "wifi"],
+        friendly_name="Old Name",
+        esphome_version="2024.12.0",
+    )
+    new = create_storage(
+        loaded_integrations=["api", "wifi"],
+        friendly_name="New Name",
+        esphome_version="2025.1.0",
+    )
+    assert storage_should_clean(old, new) is False
+
+
+def test_storage_edge_case_empty_integrations(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test edge case when old has integrations but new has none."""
+    old = create_storage(loaded_integrations=["api", "wifi"])
+    new = create_storage(loaded_integrations=[])
+    assert storage_should_clean(old, new) is True
+
+
+def test_storage_edge_case_from_empty_integrations(
+    create_storage: Callable[..., StorageJSON],
+) -> None:
+    """Test edge case when old has no integrations but new has some."""
+    old = create_storage(loaded_integrations=[])
+    new = create_storage(loaded_integrations=["api", "wifi"])
+    assert storage_should_clean(old, new) is False
+
+
+@patch("esphome.writer.clean_build")
+@patch("esphome.writer.StorageJSON")
+@patch("esphome.writer.storage_path")
+@patch("esphome.writer.CORE")
+def test_update_storage_json_logging_when_old_is_none(
+    mock_core: MagicMock,
+    mock_storage_path: MagicMock,
+    mock_storage_json_class: MagicMock,
+    mock_clean_build: MagicMock,
+    create_storage: Callable[..., StorageJSON],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that update_storage_json doesn't crash when old storage is None.
+
+    This is a regression test for the AttributeError that occurred when
+    old was None and we tried to access old.loaded_integrations.
+    """
+    # Setup mocks
+    mock_storage_path.return_value = "/test/path"
+    mock_storage_json_class.load.return_value = None  # Old storage is None
+
+    new_storage = create_storage(loaded_integrations=["api", "wifi"])
+    new_storage.save = MagicMock()  # Mock the save method
+    mock_storage_json_class.from_esphome_core.return_value = new_storage
+
+    # Call the function - should not raise AttributeError
+    with caplog.at_level("INFO"):
+        update_storage_json()
+
+    # Verify clean_build was called
+    mock_clean_build.assert_called_once()
+
+    # Verify the correct log message was used (not the component removal message)
+    assert "Core config or version changed, cleaning build files..." in caplog.text
+    assert "Components removed" not in caplog.text
+
+    # Verify save was called
+    new_storage.save.assert_called_once_with("/test/path")
+
+
+@patch("esphome.writer.clean_build")
+@patch("esphome.writer.StorageJSON")
+@patch("esphome.writer.storage_path")
+@patch("esphome.writer.CORE")
+def test_update_storage_json_logging_components_removed(
+    mock_core: MagicMock,
+    mock_storage_path: MagicMock,
+    mock_storage_json_class: MagicMock,
+    mock_clean_build: MagicMock,
+    create_storage: Callable[..., StorageJSON],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that update_storage_json logs removed components correctly."""
+    # Setup mocks
+    mock_storage_path.return_value = "/test/path"
+
+    old_storage = create_storage(loaded_integrations=["api", "wifi", "bluetooth_proxy"])
+    new_storage = create_storage(loaded_integrations=["api", "wifi"])
+    new_storage.save = MagicMock()  # Mock the save method
+
+    mock_storage_json_class.load.return_value = old_storage
+    mock_storage_json_class.from_esphome_core.return_value = new_storage
+
+    # Call the function
+    with caplog.at_level("INFO"):
+        update_storage_json()
+
+    # Verify clean_build was called
+    mock_clean_build.assert_called_once()
+
+    # Verify the correct log message was used with component names
+    assert (
+        "Components removed (bluetooth_proxy), cleaning build files..." in caplog.text
+    )
+    assert "Core config or version changed" not in caplog.text
+
+    # Verify save was called
+    new_storage.save.assert_called_once_with("/test/path")


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
## Full list of changes

### All changes

<details>
<summary>Show</summary>

- [esp32_ble] Add ``USE_ESP32_BLE_UUID`` when advertising is desired [esphome#10230](https://github.com/esphome/esphome/pull/10230)
- Improve error reporting for add_library [esphome#10226](https://github.com/esphome/esphome/pull/10226)
- [wifi] Automatically disable Enterprise WiFi support when EAP is not configured [esphome#10242](https://github.com/esphome/esphome/pull/10242)
- [core] Trigger clean build when components are removed from configuration [esphome#10235](https://github.com/esphome/esphome/pull/10235)
- [bluetooth_proxy] Remove redundant connection type check after V1 removal [esphome#10208](https://github.com/esphome/esphome/pull/10208)
- [esp32_ble] Optimize BLE event memory usage by eliminating std::vector overhead [esphome#10247](https://github.com/esphome/esphome/pull/10247)
- [web_server] fix cover_all_json_generator wrong detail [esphome#10252](https://github.com/esphome/esphome/pull/10252)
- [esp32_ble] Store GATTC/GATTS param and small data inline to nearly eliminate heap allocations [esphome#10249](https://github.com/esphome/esphome/pull/10249)
- [senseair] Discard 0 ppm readings with "Out Of Range" bit set. [esphome#10275](https://github.com/esphome/esphome/pull/10275)
- [core] Fix post-OTA logs display when using esphome run and MQTT [esphome#10274](https://github.com/esphome/esphome/pull/10274)
- [core] Fix scheduler race condition where cancelled items still execute [esphome#10268](https://github.com/esphome/esphome/pull/10268)
- [esp32] Write variant to sdkconfig file [esphome#10267](https://github.com/esphome/esphome/pull/10267)
- [nextion] Don't include terminating NUL in nextion text_sensor states [esphome#10273](https://github.com/esphome/esphome/pull/10273)
</details>

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
