### PR TITLE
RingBuffer: Make partial writing optional

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -78,9 +78,13 @@ size_t RingBuffer::write(const void *data, size_t len) {
   return this->write_without_replacement(data, len, 0);
 }
 
-size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait) {
+size_t RingBuffer::write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait,
+                                             bool write_partial) {
   if (!xRingbufferSend(this->handle_, data, len, ticks_to_wait)) {
-    // Couldn't fit all the data, so only write what will fit
+    if (!write_partial) {
+      return 0;  // Not enough space available and not allowed to write partial data
+    }
+    // Couldn't fit all the data, write what will fit
     size_t free = std::min(this->free(), len);
     if (xRingbufferSend(this->handle_, data, free, 0)) {
       return free;

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -50,7 +50,8 @@ class RingBuffer {
    * @param ticks_to_wait Maximum number of FreeRTOS ticks to wait (default: 0)
    * @return Number of bytes written
    */
-  size_t write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait = 0);
+  size_t write_without_replacement(const void *data, size_t len, TickType_t ticks_to_wait = 0,
+                                   bool write_partial = true);
 
   /**
    * @brief Returns the number of available bytes in the ring buffer.


### PR DESCRIPTION
# What does this implement/fix?

In chunk based streaming applications it is often required to write to the ring-buffer only if the entire chunk fits completely.
This PR makes partial writing to the ring-buffer optional. It adds a `write_partial` argument to the `write_without_replacement` method.
The default behavior keeps unchanged, i.e. partial writing is enabled. 


<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
