### PR TITLE
[mqtt] use `subscribe_qos` to subscribe to command topic

### DIFF
--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -133,9 +133,12 @@ class MQTTComponent : public Component {
    *
    * @param topic The topic. Wildcards are currently not supported.
    * @param callback The callback that will be called when a message with matching topic is received.
-   * @param qos The MQTT quality of service. Defaults to 0.
+   * @param qos The MQTT quality of service. Defaults to `subscribe_qos`.
    */
-  void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
+  void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos);
+  void subscribe(const std::string &topic, mqtt_callback_t callback) {
+    this->subscribe(topic, callback, this->subscribe_qos_);
+  }
 
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *
@@ -144,9 +147,12 @@ class MQTTComponent : public Component {
    * @param topic The topic. Wildcards are currently not supported.
    * @param callback The callback with a parsed JsonObject that will be called when a message with matching topic is
    * received.
-   * @param qos The MQTT quality of service. Defaults to 0.
+   * @param qos The MQTT quality of service. Defaults to `subscribe_qos`.
    */
-  void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos = 0);
+  void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos);
+  void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback) {
+    this->subscribe_json(topic, callback, this->subscribe_qos_);
+  }
 
  protected:
   /// Helper method to get the discovery topic for this component.

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -151,7 +151,7 @@ class MQTTComponent : public Component {
    */
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos);
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback) {
-    this->subscribe_json(topic, std::move(callback), this->subscribe_qos_);
+    this->subscribe_json(topic, callback, this->subscribe_qos_);
   }
 
  protected:

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -137,7 +137,7 @@ class MQTTComponent : public Component {
    */
   void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos);
   void subscribe(const std::string &topic, mqtt_callback_t callback) {
-    this->subscribe(topic, callback, this->subscribe_qos_);
+    this->subscribe(topic, std::move(callback), this->subscribe_qos_);
   }
 
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
@@ -151,7 +151,7 @@ class MQTTComponent : public Component {
    */
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos);
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback) {
-    this->subscribe_json(topic, callback, this->subscribe_qos_);
+    this->subscribe_json(topic, std::move(callback), this->subscribe_qos_);
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Currently all components use qos `0` when subscribing to command topics. Which seems counterintuitive, as  `subscribe_qos` is published in discovery messages, and HomeAssistant use it to publish commands. There is the `clean_session` option, which defaults to `false`, but no way of actually using this session to receive missed commands, as subscriptions are always using qos `0`.

This PR changes the default qos for subscriptions in `MQTTComponent` from `0` to `subscribe_qos`, which is used in all subscriptions to command topics.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

-

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
cover:
  - platform: time_based
    name: Cover
    manual_control: true
    open_action:
      - ...
    open_duration: 30s
    close_action:
      - ...
    close_duration: 30s
    stop_action:
      - ...
    availability:
    qos: 1
    subscribe_qos: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
