### PR TITLE
[homeassistant] Add compilation test for homeassistant.tag_scanned action

### DIFF
--- a/tests/components/homeassistant/test-tag-scanned.esp32-idf.yaml
+++ b/tests/components/homeassistant/test-tag-scanned.esp32-idf.yaml
@@ -1,0 +1,14 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+api:
+
+esphome:
+  on_boot:
+    then:
+      - homeassistant.tag_scanned: 'test_tag_123'
+      - homeassistant.tag_scanned:
+          tag: 'another_tag'
+      - homeassistant.tag_scanned:
+          tag: !lambda 'return "dynamic_tag";'


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a compilation test for the `homeassistant.tag_scanned` action to ensure it compiles correctly. This is a follow-up to #10316 which fixed the compilation issue by adding the missing `USE_API_HOMEASSISTANT_SERVICES` define.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10263 (original issue reporting compilation error)
- Follow-up to #10316 (PR that fixed the compilation issue)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test only)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example usage of homeassistant.tag_scanned action
wifi:
  ssid: MySSID
  password: password1

api:

esphome:
  on_boot:
    then:
      - homeassistant.tag_scanned: 'test_tag_123'
      - homeassistant.tag_scanned:
          tag: 'another_tag'
      - homeassistant.tag_scanned:
          tag: !lambda 'return "dynamic_tag";'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

