### PR TITLE
[esp32_ble_tracker] Remove duplicate client promotion logic

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -292,12 +292,7 @@ class ESP32BLETracker : public Component,
   /// Common cleanup logic when transitioning scanner to IDLE state
   void cleanup_scan_state_(bool is_stop_complete);
   /// Process a single scan result immediately
-  /// Returns true if a discovered client needs promotion to READY_TO_CONNECT
   void process_scan_result_(const BLEScanResult &scan_result);
-#ifdef USE_ESP32_BLE_DEVICE
-  /// Check if any clients are in connecting or ready to connect state
-  bool has_connecting_clients_() const;
-#endif
   /// Handle scanner failure states
   void handle_scanner_failure_();
   /// Try to promote discovered clients to ready to connect

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -293,7 +293,7 @@ class ESP32BLETracker : public Component,
   void cleanup_scan_state_(bool is_stop_complete);
   /// Process a single scan result immediately
   /// Returns true if a discovered client needs promotion to READY_TO_CONNECT
-  bool process_scan_result_(const BLEScanResult &scan_result);
+  void process_scan_result_(const BLEScanResult &scan_result);
 #ifdef USE_ESP32_BLE_DEVICE
   /// Check if any clients are in connecting or ready to connect state
   bool has_connecting_clients_() const;


### PR DESCRIPTION
# What does this implement/fix?

This PR removes duplicate scan stopping logic in the ESP32 BLE Tracker that was unnecessarily checking for discovered clients in two different places.

The scan stopping for client promotion was happening in:
1. `gap_scan_event_handler()` when processing scan results (removed by this PR)
2. `loop()` via `try_promote_discovered_clients_()` (kept as the single source of truth)

This consolidates all client promotion and scan stopping logic into the `loop()` method's state management, making the code cleaner and easier to maintain. The functionality remains the same - discovered clients are still promoted to connecting state when appropriate, but now through a single, well-defined path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/10317 (found while investigating)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Standard ESP32 BLE Tracker configuration
esp32_ble_tracker:
  scan_parameters:
    active: true

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation change only