### PR TITLE
[pvvx_mithermometer] Fix race condition with BLE authentication

### DIFF
--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -47,14 +47,11 @@ void PVVXDisplay::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
       this->connection_established_ = true;
       this->char_handle_ = chr->handle;
 
-      // Check if already paired - if not, writes will be deferred to next update cycle
-      if (this->parent_->is_paired()) {
-        ESP_LOGD(TAG, "[%s] Device is paired, writing immediately.", this->parent_->address_str().c_str());
-        this->sync_time_and_display_();
-      } else {
-        ESP_LOGD(TAG, "[%s] Device not paired yet, deferring writes until authentication completes.",
-                 this->parent_->address_str().c_str());
-      }
+      // Attempt to write immediately
+      // For devices without security, this will work
+      // For devices with security that are already paired, this will work
+      // For devices that need pairing, the write will be retried after auth completes
+      this->sync_time_and_display_();
       break;
     }
     default:
@@ -106,11 +103,6 @@ void PVVXDisplay::display() {
              this->parent_->address_str().c_str());
     return;
   }
-  // Check if authentication is required and not complete
-  if (!this->parent_->is_paired()) {
-    ESP_LOGD(TAG, "[%s] Waiting for pairing to complete before writing.", this->parent_->address_str().c_str());
-    return;
-  }
   ESP_LOGD(TAG, "[%s] Send to display: bignum %d, smallnum: %d, cfg: 0x%02x, validity period: %u.",
            this->parent_->address_str().c_str(), this->bignum_, this->smallnum_, this->cfg_, this->validity_period_);
   uint8_t blk[8] = {};
@@ -137,10 +129,6 @@ void PVVXDisplay::setcfgbit_(uint8_t bit, bool value) {
 void PVVXDisplay::send_to_setup_char_(uint8_t *blk, size_t size) {
   if (!this->connection_established_) {
     ESP_LOGW(TAG, "[%s] Not connected to BLE client.", this->parent_->address_str().c_str());
-    return;
-  }
-  if (!this->parent_->is_paired()) {
-    ESP_LOGW(TAG, "[%s] Cannot write - authentication not complete.", this->parent_->address_str().c_str());
     return;
   }
   auto status =

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -46,10 +46,35 @@ void PVVXDisplay::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t 
       }
       this->connection_established_ = true;
       this->char_handle_ = chr->handle;
-#ifdef USE_TIME
-      this->sync_time_();
-#endif
-      this->display();
+
+      // Check if already paired - if not, writes will be deferred to next update cycle
+      if (this->parent_->is_paired()) {
+        ESP_LOGD(TAG, "[%s] Device is paired, writing immediately.", this->parent_->address_str().c_str());
+        this->sync_time_and_display_();
+      } else {
+        ESP_LOGD(TAG, "[%s] Device not paired yet, deferring writes until authentication completes.",
+                 this->parent_->address_str().c_str());
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void PVVXDisplay::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
+  switch (event) {
+    case ESP_GAP_BLE_AUTH_CMPL_EVT: {
+      if (!this->parent_->check_addr(param->ble_security.auth_cmpl.bd_addr))
+        return;
+
+      if (param->ble_security.auth_cmpl.success) {
+        ESP_LOGD(TAG, "[%s] Authentication successful, performing writes.", this->parent_->address_str().c_str());
+        // Now that pairing is complete, perform the pending writes
+        this->sync_time_and_display_();
+      } else {
+        ESP_LOGW(TAG, "[%s] Authentication failed.", this->parent_->address_str().c_str());
+      }
       break;
     }
     default:
@@ -81,6 +106,11 @@ void PVVXDisplay::display() {
              this->parent_->address_str().c_str());
     return;
   }
+  // Check if authentication is required and not complete
+  if (!this->parent_->is_paired()) {
+    ESP_LOGD(TAG, "[%s] Waiting for pairing to complete before writing.", this->parent_->address_str().c_str());
+    return;
+  }
   ESP_LOGD(TAG, "[%s] Send to display: bignum %d, smallnum: %d, cfg: 0x%02x, validity period: %u.",
            this->parent_->address_str().c_str(), this->bignum_, this->smallnum_, this->cfg_, this->validity_period_);
   uint8_t blk[8] = {};
@@ -109,6 +139,10 @@ void PVVXDisplay::send_to_setup_char_(uint8_t *blk, size_t size) {
     ESP_LOGW(TAG, "[%s] Not connected to BLE client.", this->parent_->address_str().c_str());
     return;
   }
+  if (!this->parent_->is_paired()) {
+    ESP_LOGW(TAG, "[%s] Cannot write - authentication not complete.", this->parent_->address_str().c_str());
+    return;
+  }
   auto status =
       esp_ble_gattc_write_char(this->parent_->get_gattc_if(), this->parent_->get_conn_id(), this->char_handle_, size,
                                blk, ESP_GATT_WRITE_TYPE_NO_RSP, ESP_GATT_AUTH_REQ_NONE);
@@ -125,6 +159,13 @@ void PVVXDisplay::delayed_disconnect_() {
     return;
   this->cancel_timeout("disconnect");
   this->set_timeout("disconnect", this->disconnect_delay_ms_, [this]() { this->parent_->set_enabled(false); });
+}
+
+void PVVXDisplay::sync_time_and_display_() {
+#ifdef USE_TIME
+  this->sync_time_();
+#endif
+  this->display();
 }
 
 #ifdef USE_TIME

--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -43,6 +43,7 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
 
   void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                            esp_ble_gattc_cb_param_t *param) override;
+  void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) override;
 
   /// Set validity period of the display information in seconds (1..65535)
   void set_validity_period(uint16_t validity_period) { this->validity_period_ = validity_period; }
@@ -112,6 +113,7 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
   void setcfgbit_(uint8_t bit, bool value);
   void send_to_setup_char_(uint8_t *blk, size_t size);
   void delayed_disconnect_();
+  void sync_time_and_display_();
 #ifdef USE_TIME
   void sync_time_();
   time::RealTimeClock *time_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

This fixes a race condition in the `pvvx_mithermometer` display component where it attempts to write characteristics before BLE authentication/pairing completes. The component was writing immediately after service discovery (ESP_GATTC_SEARCH_CMPL_EVT) without checking if the device requires authentication.

This race condition has likely existed for a long time, with the component inadvertently relying on overhead/delays in the BLE stack to provide time for authentication to complete. Recent refactoring that improved efficiency eliminated this overhead, exposing the underlying race condition. Devices with PIN/passkey authentication would fail to update because writes were attempted before authentication completed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10317

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config for pvvx_mithermometer with PIN authentication
esp32_ble_tracker:

ble_client:
  - mac_address: "A4:C1:38:XX:XX:XX"
    id: pvvx_ble_display
    on_passkey_request:
      then:
        - logger.log: "Authenticating with passkey"
        - ble_client.passkey_reply:
            id: pvvx_ble_display
            passkey: 123456

display:
  - platform: pvvx_mithermometer
    ble_client_id: pvvx_ble_display
    update_interval: 24h
    time_id: homeassistant_time
    validity_period: 300
    disconnect_delay: 30s
    auto_clear: true
    lambda: |-
      it.print_bignum(25.5);
      it.print_smallnum(50);
      it.print_percent(true);

time:
  - platform: homeassistant
    id: homeassistant_time
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

The fix ensures writes happen at the appropriate time:
1. On service discovery (ESP_GATTC_SEARCH_CMPL_EVT), always attempt to write
   - For devices without security requirements: writes succeed immediately
   - For already-paired devices: writes succeed immediately
   - For devices requiring authentication: writes are silently ignored by the device
2. Handle the ESP_GAP_BLE_AUTH_CMPL_EVT to retry writes after successful authentication
3. Add helper method `sync_time_and_display_()` to avoid code duplication

This ensures the component works correctly with:
- Devices that don't require authentication (no change in behavior)
- Already-paired devices (no change in behavior)  
- Devices that require PIN/passkey authentication (fixed - now waits for auth to complete)