### PR TITLE
[core] Improve error reporting for entity name conflicts with non-ASCII characters

### DIFF
--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -236,10 +236,20 @@ def entity_duplicate_validator(platform: str) -> Callable[[ConfigType], ConfigTy
             if existing_component != "unknown":
                 conflict_msg += f" from component '{existing_component}'"
 
+            # Show both original names and their ASCII-only versions if they differ
+            sanitized_msg = ""
+            if entity_name != name_key or existing_name != name_key:
+                sanitized_msg = (
+                    f"\n  Original names: '{entity_name}' and '{existing_name}'"
+                    f"\n  Both convert to ASCII ID: '{name_key}'"
+                    f"\n  To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B') to distinguish them"
+                )
+
             raise cv.Invalid(
                 f"Duplicate {platform} entity with name '{entity_name}' found{device_prefix}. "
                 f"{conflict_msg}. "
                 f"Each entity on a device must have a unique name within its platform."
+                f"{sanitized_msg}"
             )
 
         # Store metadata about this entity

--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -242,13 +242,14 @@ def entity_duplicate_validator(platform: str) -> Callable[[ConfigType], ConfigTy
                 sanitized_msg = (
                     f"\n  Original names: '{entity_name}' and '{existing_name}'"
                     f"\n  Both convert to ASCII ID: '{name_key}'"
-                    f"\n  To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B') to distinguish them"
+                    "\n  To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B')"
+                    "\n           to distinguish them"
                 )
 
             raise cv.Invalid(
                 f"Duplicate {platform} entity with name '{entity_name}' found{device_prefix}. "
                 f"{conflict_msg}. "
-                f"Each entity on a device must have a unique name within its platform."
+                "Each entity on a device must have a unique name within its platform."
                 f"{sanitized_msg}"
             )
 

--- a/esphome/core/entity_helpers.py
+++ b/esphome/core/entity_helpers.py
@@ -238,12 +238,12 @@ def entity_duplicate_validator(platform: str) -> Callable[[ConfigType], ConfigTy
 
             # Show both original names and their ASCII-only versions if they differ
             sanitized_msg = ""
-            if entity_name != name_key or existing_name != name_key:
+            if entity_name != existing_name:
                 sanitized_msg = (
                     f"\n  Original names: '{entity_name}' and '{existing_name}'"
                     f"\n  Both convert to ASCII ID: '{name_key}'"
                     "\n  To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B')"
-                    "\n           to distinguish them"
+                    "\n          to distinguish them"
                 )
 
             raise cv.Invalid(

--- a/tests/unit_tests/core/test_entity_helpers.py
+++ b/tests/unit_tests/core/test_entity_helpers.py
@@ -705,3 +705,28 @@ def test_empty_or_null_device_id_on_entity() -> None:
     config2 = {CONF_NAME: "Temperature", CONF_DEVICE_ID: None}
     validated2 = validator(config2)
     assert validated2 == config2
+
+
+def test_entity_duplicate_validator_non_ascii_names() -> None:
+    """Test that non-ASCII names show helpful error messages."""
+    # Create validator for binary_sensor platform
+    validator = entity_duplicate_validator("binary_sensor")
+
+    # First Russian sensor should pass
+    config1 = {CONF_NAME: "Датчик открытия основного крана"}
+    validated1 = validator(config1)
+    assert validated1 == config1
+
+    # Second Russian sensor with different text but same ASCII conversion should fail
+    config2 = {CONF_NAME: "Датчик закрытия основного крана"}
+    with pytest.raises(
+        Invalid,
+        match=re.compile(
+            r"Duplicate binary_sensor entity with name 'Датчик закрытия основного крана' found.*"
+            r"Original names: 'Датчик закрытия основного крана' and 'Датчик открытия основного крана'.*"
+            r"Both convert to ASCII ID: '_______________________________'.*"
+            r"To fix: Add unique ASCII characters \(e\.g\., '1', '2', or 'A', 'B'\)",
+            re.DOTALL,
+        ),
+    ):
+        validator(config2)

--- a/tests/unit_tests/core/test_entity_helpers.py
+++ b/tests/unit_tests/core/test_entity_helpers.py
@@ -730,3 +730,23 @@ def test_entity_duplicate_validator_non_ascii_names() -> None:
         ),
     ):
         validator(config2)
+
+
+def test_entity_duplicate_validator_same_name_no_enhanced_message() -> None:
+    """Test that identical names don't show the enhanced message."""
+    # Create validator for sensor platform
+    validator = entity_duplicate_validator("sensor")
+
+    # First entity should pass
+    config1 = {CONF_NAME: "Temperature"}
+    validated1 = validator(config1)
+    assert validated1 == config1
+
+    # Second entity with exact same name should fail without enhanced message
+    config2 = {CONF_NAME: "Temperature"}
+    with pytest.raises(
+        Invalid,
+        match=r"Duplicate sensor entity with name 'Temperature' found.*"
+        r"Each entity on a device must have a unique name within its platform\.$",
+    ):
+        validator(config2)


### PR DESCRIPTION
# What does this implement/fix?

This PR improves the error reporting when entity names conflict due to non-ASCII characters being converted to ASCII. The enhanced error messages now clearly show both the original names and their ASCII conversions, making it easier for users to understand why conflicts occur and how to fix them.

This addresses the confusion reported in #10283 where Russian entity names were creating conflicts that weren't immediately obvious to users.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10283

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (error message improvement only)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This example shows entity names that would conflict
binary_sensor:
  - platform: gpio
    pin: GPIO23
    name: "Датчик открытия основного крана"  # Russian: Main valve open sensor
    
  - platform: gpio
    pin: GPIO19
    name: "Датчик закрытия основного крана"  # Russian: Main valve closed sensor
    
# The improved error message now shows:
#   Original names: 'Датчик закрытия основного крана' and 'Датчик открытия основного крана'
#   Both convert to ASCII ID: '_______________________________'
#   To fix: Add unique ASCII characters (e.g., '1', '2', or 'A', 'B') to distinguish them

# Fixed version:
binary_sensor:
  - platform: gpio
    pin: GPIO23
    name: "Датчик открытия основного крана 1"  # Added '1' for uniqueness
    
  - platform: gpio
    pin: GPIO19
    name: "Датчик закрытия основного крана 2"  # Added '2' for uniqueness
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

