### PR TITLE
[esp32_ble_client] Reduce log level for harmless BLE timeout race conditions

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -159,7 +159,8 @@ void BLEClientBase::disconnect() {
     return;
   }
   if (this->state_ == espbt::ClientState::CONNECTING || this->conn_id_ == UNSET_CONN_ID) {
-    this->log_warning_("Disconnect before connected, disconnect scheduled.");
+    ESP_LOGD(TAG, "[%d] [%s] Disconnect before connected, disconnect scheduled", this->connection_index_,
+             this->address_str_.c_str());
     this->want_disconnect_ = true;
     return;
   }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -300,7 +300,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         // This should not happen but lets log it in case it does
         // because it means we have a bad assumption about how the
         // ESP BT stack works.
-        ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT in %s state (status=%d)", this->connection_index_,
+        ESP_LOGE(TAG, "[%d] [%s] ESP_GATTC_OPEN_EVT in %s state (status=%d)", this->connection_index_,
                  this->address_str_.c_str(), espbt::client_state_to_string(this->state_), param->open.status);
       }
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -285,11 +285,22 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->log_gattc_event_("OPEN");
       // conn_id was already set in ESP_GATTC_CONNECT_EVT
       this->service_count_ = 0;
+
+      // ESP-IDF's BLE stack may send ESP_GATTC_OPEN_EVT after esp_ble_gattc_open() returns an
+      // error, if the error occurred at the BTA/GATT layer. This can result in the event
+      // arriving after we've already transitioned to IDLE state.
+      if (this->state_ == espbt::ClientState::IDLE) {
+        ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_OPEN_EVT in IDLE state (status=%d), ignoring", this->connection_index_,
+                 this->address_str_.c_str(), param->open.status);
+        break;
+      }
+
       if (this->state_ != espbt::ClientState::CONNECTING) {
         // This should not happen but lets log it in case it does
         // because it means we have a bad assumption about how the
         // ESP BT stack works.
-        this->log_error_("ESP_GATTC_OPEN_EVT wrong state status", param->open.status);
+        ESP_LOGE(TAG, "[%d] [%s] Got ESP_GATTC_OPEN_EVT in %s state (status=%d)", this->connection_index_,
+                 this->address_str_.c_str(), espbt::client_state_to_string(this->state_), param->open.status);
       }
       if (param->open.status != ESP_GATT_OK && param->open.status != ESP_GATT_ALREADY_OPEN) {
         this->log_gattc_warning_("Connection open", param->open.status);


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes unnecessary error log spam caused by a harmless race condition in the ESP32 BLE client when connection attempts timeout.

## The Issue

When BLE connection attempts fail (device unreachable, interference, etc.), users see alarming error messages:
```
Bluetooth proxy Aanbouw: [E][esp32_ble_client:284]: [0] [49:22:05:13:0A:90] Got ESP_GATTC_OPEN_EVT while in IDLE state, status=133
Bluetooth proxy Aanbouw: [E][esp32_ble_client:284]: [1] [49:22:05:13:0A:90] Got ESP_GATTC_OPEN_EVT while in IDLE state, status=133
```

OR when ESP-IDF timeout wins the race:

```
[19:14:24.716][I][esp32_ble_client:110]: [1] [49:22:08:15:00:BB] 0x00 Connecting
[19:14:43.939][D][esp32_ble_client:344]: [1] [49:22:08:15:00:BB] ESP_GATTC_DISCONNECT_EVT, reason 0x100
[19:14:43.945][D][esp32_ble_client:218]: [1] [49:22:08:15:00:BB] ESP_GATTC_OPEN_EVT
[19:14:43.947][E][esp32_ble_client:239]: [1] [49:22:08:15:00:BB] ESP_GATTC_OPEN_EVT wrong state status=133
```

OR when both timeouts fire simultaneously:

```
[20:01:42.451][W][esp32_ble_client:242]: [1] [49:22:08:15:00:BB] Disconnect before connected, disconnect scheduled.
[20:01:42.489][D][esp32_ble_client:354]: [1] [49:22:08:15:00:BB] ESP_GATTC_DISCONNECT_EVT, reason 0x100
[20:01:42.495][D][esp32_ble_client:217]: [1] [49:22:08:15:00:BB] ESP_GATTC_OPEN_EVT
[20:01:42.498][D][esp32_ble_client:292]: [1] [49:22:08:15:00:BB] ESP_GATTC_OPEN_EVT in IDLE state (status=133), ignoring
```

This is actually a **harmless transient condition** that doesn't affect functionality - the connection attempt already failed/timed out, both events agree on that. The client is ready for the next attempt.

## Root Cause

After #10013 aligned ESP-IDF and client timeouts to 20 seconds, a race condition occurs where:
1. Connection attempt fails/hangs
2. ESP-IDF timeout fires first → sends `ESP_GATTC_DISCONNECT_EVT` 
3. Client processes disconnect → transitions to IDLE state
4. ESP-IDF then sends `ESP_GATTC_OPEN_EVT` (status 133)
5. Client receives OPEN_EVT in IDLE state → logs ERROR

This is expected ESP-IDF behavior - it always sends OPEN_EVT after connection attempts, even if already disconnected.

## The Fix

Change the log level from ERROR/WARNING to DEBUG for timeout-related race conditions:

1. **"ESP_GATTC_OPEN_EVT in IDLE state"** - When ESP-IDF timeout fires first and sends OPEN_EVT after DISCONNECT_EVT
2. **"Disconnect before connected, disconnect scheduled"** - When client timeout fires during connection attempt

Both messages now logged at debug level since they represent normal timeout behavior when both ESP-IDF and client timeouts fire around 20 seconds.

This:
- Eliminates scary error/warning messages that alarm users
- Preserves the information for debugging if needed  
- Still logs real errors for truly unexpected states
- Acknowledges these are normal transient behaviors, not problems

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10337

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation fix, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
# Example bluetooth_proxy configuration that benefits from this fix:

esp32_ble_tracker:
  scan_parameters:
    active: true

bluetooth_proxy:
  active: true

esp32_ble_client:
  - mac_address: XX:XX:XX:XX:XX:XX
    id: my_ble_device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).