### PR TITLE
[lvgl] Fix meter rotation

### DIFF
--- a/esphome/components/lvgl/widgets/canvas.py
+++ b/esphome/components/lvgl/widgets/canvas.py
@@ -24,7 +24,7 @@ from ..defines import (
     literal,
 )
 from ..lv_validation import (
-    lv_angle,
+    lv_angle_degrees,
     lv_bool,
     lv_color,
     lv_image,
@@ -395,15 +395,15 @@ ARC_PROPS = {
     DRAW_OPA_SCHEMA.extend(
         {
             cv.Required(CONF_RADIUS): pixels,
-            cv.Required(CONF_START_ANGLE): lv_angle,
-            cv.Required(CONF_END_ANGLE): lv_angle,
+            cv.Required(CONF_START_ANGLE): lv_angle_degrees,
+            cv.Required(CONF_END_ANGLE): lv_angle_degrees,
         }
     ).extend({cv.Optional(prop): validator for prop, validator in ARC_PROPS.items()}),
 )
 async def canvas_draw_arc(config, action_id, template_arg, args):
     radius = await size.process(config[CONF_RADIUS])
-    start_angle = await lv_angle.process(config[CONF_START_ANGLE])
-    end_angle = await lv_angle.process(config[CONF_END_ANGLE])
+    start_angle = await lv_angle_degrees.process(config[CONF_START_ANGLE])
+    end_angle = await lv_angle_degrees.process(config[CONF_END_ANGLE])
 
     async def do_draw_arc(w: Widget, x, y, dsc_addr):
         lv.canvas_draw_arc(w.obj, x, y, radius, start_angle, end_angle, dsc_addr)

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -14,7 +14,6 @@ from esphome.const import (
     CONF_VALUE,
     CONF_WIDTH,
 )
-from esphome.cpp_generator import IntLiteral
 
 from ..automation import action_to_code
 from ..defines import (
@@ -32,7 +31,7 @@ from ..helpers import add_lv_use, lvgl_components_required
 from ..lv_validation import (
     get_end_value,
     get_start_value,
-    lv_angle,
+    lv_angle_degrees,
     lv_bool,
     lv_color,
     lv_float,
@@ -163,7 +162,7 @@ SCALE_SCHEMA = cv.Schema(
         cv.Optional(CONF_RANGE_FROM, default=0.0): cv.float_,
         cv.Optional(CONF_RANGE_TO, default=100.0): cv.float_,
         cv.Optional(CONF_ANGLE_RANGE, default=270): cv.int_range(0, 360),
-        cv.Optional(CONF_ROTATION): lv_angle,
+        cv.Optional(CONF_ROTATION): lv_angle_degrees,
         cv.Optional(CONF_INDICATORS): cv.ensure_list(INDICATOR_SCHEMA),
     }
 )
@@ -188,9 +187,7 @@ class MeterType(WidgetType):
         for scale_conf in config.get(CONF_SCALES, ()):
             rotation = 90 + (360 - scale_conf[CONF_ANGLE_RANGE]) / 2
             if CONF_ROTATION in scale_conf:
-                rotation = await lv_angle.process(scale_conf[CONF_ROTATION])
-                if isinstance(rotation, IntLiteral):
-                    rotation = int(str(rotation)) // 10
+                rotation = await lv_angle_degrees.process(scale_conf[CONF_ROTATION])
             with LocalVariable(
                 "meter_var", "lv_meter_scale_t", lv_expr.meter_add_scale(var)
             ) as meter_var:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Refactor of lvgl validator for angle into separate validators for degrees and for 1/10ths of degrees, was not applied to meter widget, resulting in rotation being incorrect. Same for arcs in `canvas:`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10322

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
