### PR TITLE
[deep_sleep] Fix ESP32-C6 compilation error with gpio_deep_sleep_hold_en()

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -83,7 +83,11 @@ void DeepSleepComponent::deep_sleep_() {
     }
     gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
     gpio_hold_en(gpio_pin);
+#if !defined(USE_ESP32_VARIANT_ESP32C6)
+    // ESP32-C6 doesn't have gpio_deep_sleep_hold_en() since it has SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
+    // For C6, gpio_hold_en() is sufficient to hold the pin state during deep sleep
     gpio_deep_sleep_hold_en();
+#endif
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;
@@ -120,7 +124,11 @@ void DeepSleepComponent::deep_sleep_() {
     }
     gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
     gpio_hold_en(gpio_pin);
+#if !defined(USE_ESP32_VARIANT_ESP32C6)
+    // ESP32-C6 doesn't have gpio_deep_sleep_hold_en() since it has SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
+    // For C6, gpio_hold_en() is sufficient to hold the pin state during deep sleep
     gpio_deep_sleep_hold_en();
+#endif
     bool level = !this->wakeup_pin_->is_inverted();
     if (this->wakeup_pin_mode_ == WAKEUP_PIN_MODE_INVERT_WAKEUP && this->wakeup_pin_->digital_read()) {
       level = !level;

--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -1,4 +1,5 @@
 #ifdef USE_ESP32
+#include "soc/soc_caps.h"
 #include "driver/gpio.h"
 #include "deep_sleep_component.h"
 #include "esphome/core/log.h"
@@ -83,9 +84,9 @@ void DeepSleepComponent::deep_sleep_() {
     }
     gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
     gpio_hold_en(gpio_pin);
-#if !defined(USE_ESP32_VARIANT_ESP32C6)
-    // ESP32-C6 doesn't have gpio_deep_sleep_hold_en() since it has SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
-    // For C6, gpio_hold_en() is sufficient to hold the pin state during deep sleep
+#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
+    // Some ESP32 variants support holding a single GPIO during deep sleep without this function
+    // For those variants, gpio_hold_en() is sufficient to hold the pin state during deep sleep
     gpio_deep_sleep_hold_en();
 #endif
     bool level = !this->wakeup_pin_->is_inverted();
@@ -124,9 +125,9 @@ void DeepSleepComponent::deep_sleep_() {
     }
     gpio_sleep_set_direction(gpio_pin, GPIO_MODE_INPUT);
     gpio_hold_en(gpio_pin);
-#if !defined(USE_ESP32_VARIANT_ESP32C6)
-    // ESP32-C6 doesn't have gpio_deep_sleep_hold_en() since it has SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
-    // For C6, gpio_hold_en() is sufficient to hold the pin state during deep sleep
+#if !SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP
+    // Some ESP32 variants support holding a single GPIO during deep sleep without this function
+    // For those variants, gpio_hold_en() is sufficient to hold the pin state during deep sleep
     gpio_deep_sleep_hold_en();
 #endif
     bool level = !this->wakeup_pin_->is_inverted();

--- a/tests/components/deep_sleep/test.esp32-c6-idf.yaml
+++ b/tests/components/deep_sleep/test.esp32-c6-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wakeup_pin: GPIO4
+
+<<: !include common.yaml
+<<: !include common-esp32.yaml

--- a/tests/components/deep_sleep/test.esp32-s2-idf.yaml
+++ b/tests/components/deep_sleep/test.esp32-s2-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wakeup_pin: GPIO4
+
+<<: !include common.yaml
+<<: !include common-esp32.yaml

--- a/tests/components/deep_sleep/test.esp32-s3-idf.yaml
+++ b/tests/components/deep_sleep/test.esp32-s3-idf.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wakeup_pin: GPIO4
+
+<<: !include common.yaml
+<<: !include common-esp32.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a compilation error for the deep sleep component on ESP32-C6 devices. The error occurs because ESP32-C6 doesn't have the `gpio_deep_sleep_hold_en()` function available due to its SOC capabilities.

The fix uses the `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP` capability flag to determine whether `gpio_deep_sleep_hold_en()` should be called. This is a portable approach that automatically handles all ESP32 variants with this capability (C5, C6, H2) both now and in the future. Variants with this capability can hold individual GPIO pins during deep sleep directly with `gpio_hold_en()`, without needing the separate `gpio_deep_sleep_hold_en()` function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10234

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** I don't have access to an ESP32-C6 device for testing (currently traveling). This fix is based on ESP-IDF source code analysis and review feedback. Testing on actual ESP32-C6 hardware would be appreciated.

## Example entry for `config.yaml`:

```yaml
# Example configuration that was failing to compile on ESP32-C6
esphome:
  name: esp32-c6-deep-sleep
  friendly_name: ESP32-C6 Deep Sleep Test

esp32:
  board: esp32-c6-devkitm-1
  framework:
    type: esp-idf

deep_sleep:
  id: deep_sleep_component
  run_duration: 30s
  sleep_duration: 5min
  wakeup_pin:
    number: GPIO5
    mode: INPUT_PULLUP
    inverted: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

The ESP-IDF conditionally compiles `gpio_deep_sleep_hold_en()` based on SOC capabilities. The function is only available when:
- `SOC_GPIO_SUPPORT_HOLD_IO_IN_DSLP` is defined (chip supports holding IO in deep sleep)
- AND `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP` is NOT defined (chip doesn't support single IO hold)

ESP32 variants fall into two categories:
1. **Variants that need `gpio_deep_sleep_hold_en()`**: ESP32, ESP32-S2, ESP32-S3, ESP32-C3 (they don't have `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP`)
2. **Variants that don't need it**: ESP32-C5, ESP32-C6, ESP32-H2 (they have `SOC_GPIO_SUPPORT_HOLD_SINGLE_IO_IN_DSLP = 1`)

For the second category, `gpio_hold_en()` alone is sufficient to hold the pin state during deep sleep, making `gpio_deep_sleep_hold_en()` unnecessary and unavailable.