### PR TITLE
[esp32_ble_client] Add missing ESP_GATTC_UNREG_FOR_NOTIFY_EVT logging

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -484,6 +484,13 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       break;
     }
 
+    case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
+      if (this->conn_id_ != param->unreg_for_notify.conn_id)
+        return false;
+      this->log_gattc_event_("UNREG_FOR_NOTIFY");
+      break;
+    }
+
     default:
       // ideally would check all other events for matching conn_id
       ESP_LOGD(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_.c_str(), event);

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -485,8 +485,6 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     }
 
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
-      if (this->conn_id_ != param->unreg_for_notify.conn_id)
-        return false;
       this->log_gattc_event_("UNREG_FOR_NOTIFY");
       break;
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR adds proper logging for the `ESP_GATTC_UNREG_FOR_NOTIFY_EVT` event (event 39) in the ESP32 BLE client. Previously, this event was only logged as "Event 39" in the default case, making it difficult to understand what was happening during BLE disconnections.

The `ESP_GATTC_UNREG_FOR_NOTIFY_EVT` event is triggered when a notification is unregistered from a GATT characteristic, which commonly occurs during disconnection sequences. Having proper logging for this event helps with debugging BLE connection issues.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #(issue number if applicable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is an internal logging improvement

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal logging improvement
# Example BLE client configuration remains unchanged:

esp32_ble_tracker:

ble_client:
  - mac_address: 78:9C:85:0A:94:40
    id: my_ble_client
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

Before this change, when `ESP_GATTC_UNREG_FOR_NOTIFY_EVT` occurred, it would be logged as:
```
[20:01:25.967][D][esp32_ble_client:499]: [0] [78:9C:85:0A:94:40] Event 39
```

After this change, it will be properly logged as:
```
[20:01:25.967][D][esp32_ble_client:217]: [0] [78:9C:85:0A:94:40] ESP_GATTC_UNREG_FOR_NOTIFY_EVT
```

This makes it consistent with how other GATT client events are logged and improves debugging capabilities.