### PR TITLE
[http_request] Fix for host after ArduinoJson library bump

### DIFF
--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -1,6 +1,9 @@
-#include "http_request_host.h"
-
 #ifdef USE_HOST
+
+#define USE_HTTP_REQUEST_HOST_H
+#define CPPHTTPLIB_NO_EXCEPTIONS
+#include "httplib.h"
+#include "http_request_host.h"
 
 #include <regex>
 #include "esphome/components/network/util.h"

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -1,11 +1,7 @@
 #pragma once
 
-#include "http_request.h"
-
 #ifdef USE_HOST
-
-#define CPPHTTPLIB_NO_EXCEPTIONS
-#include "httplib.h"
+#include "http_request.h"
 namespace esphome {
 namespace http_request {
 

--- a/esphome/components/http_request/httplib.h
+++ b/esphome/components/http_request/httplib.h
@@ -3,11 +3,9 @@
 /**
  * NOTE: This is a copy of httplib.h from https://github.com/yhirose/cpp-httplib
  *
- * It has been modified only to add ifdefs for USE_HOST. While it contains many functions unused in ESPHome,
+ * It has been modified to add ifdefs for USE_HOST. While it contains many functions unused in ESPHome,
  * it was considered preferable to use it with as few changes as possible, to facilitate future updates.
  */
-
-#include "esphome/core/defines.h"
 
 //
 //  httplib.h
@@ -17,6 +15,11 @@
 //
 
 #ifdef USE_HOST
+// Prevent this code being included in main.cpp
+#ifdef USE_HTTP_REQUEST_HOST_H
+
+#include "esphome/core/defines.h"
+
 #ifndef CPPHTTPLIB_HTTPLIB_H
 #define CPPHTTPLIB_HTTPLIB_H
 
@@ -9687,5 +9690,6 @@ inline SSL_CTX *Client::ssl_context() const {
 #endif
 
 #endif  // CPPHTTPLIB_HTTPLIB_H
+#endif  // USE_HTTP_REQUEST_HOST_H
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

https://github.com/esphome/esphome/pull/8857 broke http_request on host, as the new ArduinoJson library defines a globally scoped type that conflicts with MacOs headers.

The CI tests did not pick this up since they are not run on MacOs.

Add some #ifdefs to work-around this.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10241 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
