### PR TITLE
Move enabling of ipv6

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -282,6 +282,12 @@ void EthernetComponent::loop() {
       } else if (this->connected_) {
         // connection established
         ESP_LOGI(TAG, "Connected");
+#if USE_NETWORK_IPV6
+        auto err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+        if (err != ESP_OK) {
+          ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
+        }
+#endif /* USE_NETWORK_IPV6 */
         this->state_ = EthernetComponentState::CONNECTED;
 
         this->dump_connect_params_();
@@ -544,12 +550,6 @@ void EthernetComponent::start_connect_() {
       ESPHL_ERROR_CHECK(err, "DHCPC start error");
     }
   }
-#if USE_NETWORK_IPV6
-  err = esp_netif_create_ip6_linklocal(this->eth_netif_);
-  if (err != ESP_OK) {
-    ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
-  }
-#endif /* USE_NETWORK_IPV6 */
 
   this->connect_begin_ = millis();
   this->status_set_warning();


### PR DESCRIPTION
# What does this implement/fix?

Ethernet doesn't handle disconnectes well when IPv6 is used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10281

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
