### PR TITLE
[esp32_ble_client] Optimize BLE connection parameters for different connection types

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -4,7 +4,6 @@ import re
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
-from esphome.components.esp32.const import VARIANT_ESP32C3, VARIANT_ESP32S3
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_ON_BOOT, CONF_ESPHOME, CONF_ID, CONF_NAME
 from esphome.core import CORE, TimePeriod
@@ -260,12 +259,6 @@ async def to_code(config):
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
-        # Enable BLE 5.0 features on ESP32-S3/C3
-        # Note: Despite ESP-IDF docs stating BLE 4.2 and 5.0 can't be used simultaneously,
-        # both were already enabled by default and this configuration works in practice.
-        # We're making it explicit here for clarity and to ensure both APIs are available.
-        if get_esp32_variant() in (VARIANT_ESP32S3, VARIANT_ESP32C3):
-            add_idf_sdkconfig_option("CONFIG_BT_BLE_50_FEATURES_SUPPORTED", True)
 
         # Register the core BLE loggers that are always needed
         register_bt_logger(BTLoggers.GAP, BTLoggers.BTM, BTLoggers.HCI)

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -4,6 +4,7 @@ import re
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32C3, VARIANT_ESP32S3
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_ON_BOOT, CONF_ESPHOME, CONF_ID, CONF_NAME
 from esphome.core import CORE, TimePeriod
@@ -259,6 +260,12 @@ async def to_code(config):
     if CORE.using_esp_idf:
         add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
         add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
+        # Enable BLE 5.0 features on ESP32-S3/C3
+        # Note: Despite ESP-IDF docs stating BLE 4.2 and 5.0 can't be used simultaneously,
+        # both were already enabled by default and this configuration works in practice.
+        # We're making it explicit here for clarity and to ensure both APIs are available.
+        if get_esp32_variant() in (VARIANT_ESP32S3, VARIANT_ESP32C3):
+            add_idf_sdkconfig_option("CONFIG_BT_BLE_50_FEATURES_SUPPORTED", True)
 
         # Register the core BLE loggers that are always needed
         register_bt_logger(BTLoggers.GAP, BTLoggers.BTM, BTLoggers.HCI)

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -12,6 +12,12 @@ namespace esphome::esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
 
+// Default connection parameters matching ESP-IDF's BTM_BLE_CONN_INT_*_DEF
+// These are conservative values that work well with most devices
+static const uint16_t DEFAULT_MIN_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
+static const uint16_t DEFAULT_MAX_CONN_INTERVAL = 0x0C;  // 12 * 1.25ms = 15ms
+static const uint16_t DEFAULT_CONN_TIMEOUT = 600;        // 600 * 10ms = 6s
+
 // Intermediate connection parameters for standard operation
 // ESP-IDF defaults (12.5-15ms) are too slow for stable connections through WiFi-based BLE proxies,
 // causing disconnections. These medium parameters balance responsiveness with bandwidth usage.
@@ -111,8 +117,12 @@ void BLEClientBase::connect() {
            this->remote_addr_type_);
   this->paired_ = false;
 
-  // Open the connection without setting connection parameters
-  // Parameters will be set after connection is established if needed
+  // Set default connection parameters before connecting
+  // This ensures we use conservative parameters that work well with weak signal devices
+  // rather than potentially aggressive parameters from a previous connection
+  this->set_default_conn_params_();
+
+  // Open the connection with default parameters
   auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
   if (ret) {
     this->log_gattc_warning_("esp_ble_gattc_open", ret);
@@ -215,8 +225,8 @@ void BLEClientBase::log_warning_(const char *message) {
   ESP_LOGW(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_.c_str(), message);
 }
 
-void BLEClientBase::set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
-                                     const char *param_type) {
+void BLEClientBase::update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency,
+                                        uint16_t timeout, const char *param_type) {
   esp_ble_conn_update_params_t conn_params = {{0}};
   memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
   conn_params.min_int = min_interval;
@@ -230,16 +240,33 @@ void BLEClientBase::set_conn_params_(uint16_t min_interval, uint16_t max_interva
   }
 }
 
+void BLEClientBase::set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
+                                     const char *param_type) {
+  // Set preferred connection parameters before connecting
+  // These will be used when establishing the connection
+  this->log_connection_params_(param_type);
+  esp_err_t err = esp_ble_gap_set_prefer_conn_params(this->remote_bda_, min_interval, max_interval, latency, timeout);
+  if (err != ESP_OK) {
+    this->log_gattc_warning_("esp_ble_gap_set_prefer_conn_params", err);
+  }
+}
+
 void BLEClientBase::set_fast_conn_params_() {
   // Switch to fast connection parameters for service discovery
   // This improves discovery speed for devices with short timeouts
-  this->set_conn_params_(FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL, 0, FAST_CONN_TIMEOUT, "fast");
+  this->update_conn_params_(FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL, 0, FAST_CONN_TIMEOUT, "fast");
 }
 
 void BLEClientBase::set_medium_conn_params_() {
   // Set medium connection parameters for balanced performance
   // This balances performance with bandwidth usage for normal operation
-  this->set_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
+  this->update_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
+}
+
+void BLEClientBase::set_default_conn_params_() {
+  // Set default connection parameters before connecting
+  // These conservative values work well with most devices including weak signal ones
+  this->set_conn_params_(DEFAULT_MIN_CONN_INTERVAL, DEFAULT_MAX_CONN_INTERVAL, 0, DEFAULT_CONN_TIMEOUT, "default");
 }
 
 bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -303,7 +303,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       // Service discovery period is critical - we typically have only 10s to complete
       // discovery before the device disconnects us. Fast connection parameters are
       // essential to finish service resolution in time and avoid retry loops.
-      if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+      else if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         this->set_fast_conn_params_();
       }
       this->log_event_("Searching for services");

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -215,30 +215,31 @@ void BLEClientBase::log_warning_(const char *message) {
   ESP_LOGW(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_.c_str(), message);
 }
 
+void BLEClientBase::set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
+                                     const char *param_type) {
+  esp_ble_conn_update_params_t conn_params = {{0}};
+  memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
+  conn_params.min_int = min_interval;
+  conn_params.max_int = max_interval;
+  conn_params.latency = latency;
+  conn_params.timeout = timeout;
+  this->log_connection_params_(param_type);
+  esp_err_t err = esp_ble_gap_update_conn_params(&conn_params);
+  if (err != ESP_OK) {
+    this->log_gattc_warning_("esp_ble_gap_update_conn_params", err);
+  }
+}
+
 void BLEClientBase::set_fast_conn_params_() {
   // Switch to fast connection parameters for service discovery
   // This improves discovery speed for devices with short timeouts
-  esp_ble_conn_update_params_t conn_params = {{0}};
-  memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
-  conn_params.min_int = FAST_MIN_CONN_INTERVAL;
-  conn_params.max_int = FAST_MAX_CONN_INTERVAL;
-  conn_params.latency = 0;
-  conn_params.timeout = FAST_CONN_TIMEOUT;
-  this->log_connection_params_("fast");
-  esp_ble_gap_update_conn_params(&conn_params);
+  this->set_conn_params_(FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL, 0, FAST_CONN_TIMEOUT, "fast");
 }
 
 void BLEClientBase::set_medium_conn_params_() {
   // Set medium connection parameters for balanced performance
   // This balances performance with bandwidth usage for normal operation
-  esp_ble_conn_update_params_t conn_params = {{0}};
-  memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
-  conn_params.min_int = MEDIUM_MIN_CONN_INTERVAL;
-  conn_params.max_int = MEDIUM_MAX_CONN_INTERVAL;
-  conn_params.latency = 0;
-  conn_params.timeout = MEDIUM_CONN_TIMEOUT;
-  this->log_connection_params_("medium");
-  esp_ble_gap_update_conn_params(&conn_params);
+  this->set_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
 }
 
 bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -111,36 +111,8 @@ void BLEClientBase::connect() {
            this->remote_addr_type_);
   this->paired_ = false;
 
-  // Set preferred connection parameters before connecting
-  // Use FAST for all V3 connections (better latency and reliability)
-  // Use MEDIUM for V1/legacy connections (balanced performance)
-  uint16_t min_interval, max_interval, timeout;
-  const char *param_type;
-
-  if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE ||
-      this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-    min_interval = FAST_MIN_CONN_INTERVAL;
-    max_interval = FAST_MAX_CONN_INTERVAL;
-    timeout = FAST_CONN_TIMEOUT;
-    param_type = "fast";
-  } else {
-    min_interval = MEDIUM_MIN_CONN_INTERVAL;
-    max_interval = MEDIUM_MAX_CONN_INTERVAL;
-    timeout = MEDIUM_CONN_TIMEOUT;
-    param_type = "medium";
-  }
-
-  auto param_ret = esp_ble_gap_set_prefer_conn_params(this->remote_bda_, min_interval, max_interval,
-                                                      0,  // latency: 0
-                                                      timeout);
-  if (param_ret != ESP_OK) {
-    ESP_LOGW(TAG, "[%d] [%s] esp_ble_gap_set_prefer_conn_params failed: %d", this->connection_index_,
-             this->address_str_.c_str(), param_ret);
-  } else {
-    this->log_connection_params_(param_type);
-  }
-
-  // Now open the connection
+  // Open the connection without setting connection parameters
+  // Parameters will be set after connection is established if needed
   auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
   if (ret) {
     this->log_gattc_warning_("esp_ble_gattc_open", ret);
@@ -243,8 +215,21 @@ void BLEClientBase::log_warning_(const char *message) {
   ESP_LOGW(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_.c_str(), message);
 }
 
-void BLEClientBase::restore_medium_conn_params_() {
-  // Restore to medium connection parameters after initial connection phase
+void BLEClientBase::set_fast_conn_params_() {
+  // Switch to fast connection parameters for service discovery
+  // This improves discovery speed for devices with short timeouts
+  esp_ble_conn_update_params_t conn_params = {{0}};
+  memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
+  conn_params.min_int = FAST_MIN_CONN_INTERVAL;
+  conn_params.max_int = FAST_MAX_CONN_INTERVAL;
+  conn_params.latency = 0;
+  conn_params.timeout = FAST_CONN_TIMEOUT;
+  this->log_connection_params_("fast");
+  esp_ble_gap_update_conn_params(&conn_params);
+}
+
+void BLEClientBase::set_medium_conn_params_() {
+  // Set medium connection parameters for balanced performance
   // This balances performance with bandwidth usage for normal operation
   esp_ble_conn_update_params_t conn_params = {{0}};
   memcpy(conn_params.bda, this->remote_bda_, sizeof(esp_bd_addr_t));
@@ -308,11 +293,18 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->set_state(espbt::ClientState::CONNECTED);
       ESP_LOGI(TAG, "[%d] [%s] Connection open", this->connection_index_, this->address_str_.c_str());
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        // Restore to medium connection parameters for cached connections too
-        this->restore_medium_conn_params_();
+        // Cached connections use medium connection parameters
+        this->set_medium_conn_params_();
         // only set our state, subclients might have more stuff to do yet.
         this->state_ = espbt::ClientState::ESTABLISHED;
         break;
+      }
+      // For V3_WITHOUT_CACHE, switch to fast params for service discovery
+      // Service discovery period is critical - we typically have only 10s to complete
+      // discovery before the device disconnects us. Fast connection parameters are
+      // essential to finish service resolution in time and avoid retry loops.
+      if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+        this->set_fast_conn_params_();
       }
       this->log_event_("Searching for services");
       esp_ble_gattc_search_service(esp_gattc_if, param->cfg_mtu.conn_id, nullptr);
@@ -395,12 +387,11 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       if (this->conn_id_ != param->search_cmpl.conn_id)
         return false;
       this->log_gattc_event_("SEARCH_CMPL");
-      // For V3 connections, restore to medium connection parameters after service discovery
+      // For V3_WITHOUT_CACHE, switch back to medium connection parameters after service discovery
       // This balances performance with bandwidth usage after the critical discovery phase
-      if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE ||
-          this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        this->restore_medium_conn_params_();
-      } else {
+      if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+        this->set_medium_conn_params_();
+      } else if (this->connection_type_ != espbt::ConnectionType::V3_WITH_CACHE) {
 #ifdef USE_ESP32_BLE_DEVICE
         for (auto &svc : this->services_) {
           ESP_LOGV(TAG, "[%d] [%s] Service UUID: %s", this->connection_index_, this->address_str_.c_str(),

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -7,16 +7,11 @@
 
 #include <esp_gap_ble_api.h>
 #include <esp_gatt_defs.h>
+#include <esp_gattc_api.h>
 
 namespace esphome::esp32_ble_client {
 
 static const char *const TAG = "esp32_ble_client";
-
-// Default connection parameters matching ESP-IDF's BTM_BLE_CONN_INT_*_DEF
-// These are conservative values that work well with most devices
-static const uint16_t DEFAULT_MIN_CONN_INTERVAL = 0x0A;  // 10 * 1.25ms = 12.5ms
-static const uint16_t DEFAULT_MAX_CONN_INTERVAL = 0x0C;  // 12 * 1.25ms = 15ms
-static const uint16_t DEFAULT_CONN_TIMEOUT = 600;        // 600 * 10ms = 6s
 
 // Intermediate connection parameters for standard operation
 // ESP-IDF defaults (12.5-15ms) are too slow for stable connections through WiFi-based BLE proxies,
@@ -117,19 +112,19 @@ void BLEClientBase::connect() {
            this->remote_addr_type_);
   this->paired_ = false;
 
-  // Set default connection parameters before connecting
-  // This ensures we use conservative parameters that work well with weak signal devices
-  // rather than potentially aggressive parameters from a previous connection
-  this->set_default_conn_params_();
-
-  // Open the connection with default parameters
-  auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
-  if (ret) {
-    this->log_gattc_warning_("esp_ble_gattc_open", ret);
-    this->set_state(espbt::ClientState::IDLE);
-  } else {
-    this->set_state(espbt::ClientState::CONNECTING);
+  // Determine connection parameters based on connection type
+  if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
+    // V3 without cache needs fast params for service discovery
+    this->set_conn_params_(FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL, 0, FAST_CONN_TIMEOUT, "fast");
+  } else if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
+    // V3 with cache can use medium params
+    this->set_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
   }
+  // For V1/Legacy, don't set params - use ESP-IDF defaults
+
+  // Open the connection
+  auto ret = esp_ble_gattc_open(this->gattc_if_, this->remote_bda_, this->remote_addr_type_, true);
+  this->handle_connection_result_(ret);
 }
 
 esp_err_t BLEClientBase::pair() { return esp_ble_set_encryption(this->remote_bda_, ESP_BLE_SEC_ENCRYPT); }
@@ -213,6 +208,15 @@ void BLEClientBase::log_connection_params_(const char *param_type) {
   ESP_LOGD(TAG, "[%d] [%s] %s conn params", this->connection_index_, this->address_str_.c_str(), param_type);
 }
 
+void BLEClientBase::handle_connection_result_(esp_err_t ret) {
+  if (ret) {
+    this->log_gattc_warning_("esp_ble_gattc_open", ret);
+    this->set_state(espbt::ClientState::IDLE);
+  } else {
+    this->set_state(espbt::ClientState::CONNECTING);
+  }
+}
+
 void BLEClientBase::log_error_(const char *message) {
   ESP_LOGE(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_.c_str(), message);
 }
@@ -249,24 +253,6 @@ void BLEClientBase::set_conn_params_(uint16_t min_interval, uint16_t max_interva
   if (err != ESP_OK) {
     this->log_gattc_warning_("esp_ble_gap_set_prefer_conn_params", err);
   }
-}
-
-void BLEClientBase::set_fast_conn_params_() {
-  // Switch to fast connection parameters for service discovery
-  // This improves discovery speed for devices with short timeouts
-  this->update_conn_params_(FAST_MIN_CONN_INTERVAL, FAST_MAX_CONN_INTERVAL, 0, FAST_CONN_TIMEOUT, "fast");
-}
-
-void BLEClientBase::set_medium_conn_params_() {
-  // Set medium connection parameters for balanced performance
-  // This balances performance with bandwidth usage for normal operation
-  this->update_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
-}
-
-void BLEClientBase::set_default_conn_params_() {
-  // Set default connection parameters before connecting
-  // These conservative values work well with most devices including weak signal ones
-  this->set_conn_params_(DEFAULT_MIN_CONN_INTERVAL, DEFAULT_MAX_CONN_INTERVAL, 0, DEFAULT_CONN_TIMEOUT, "default");
 }
 
 bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t esp_gattc_if,
@@ -321,19 +307,13 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       this->set_state(espbt::ClientState::CONNECTED);
       ESP_LOGI(TAG, "[%d] [%s] Connection open", this->connection_index_, this->address_str_.c_str());
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE) {
-        // Cached connections use medium connection parameters
-        this->set_medium_conn_params_();
+        // Cached connections already connected with medium parameters, no update needed
         // only set our state, subclients might have more stuff to do yet.
         this->state_ = espbt::ClientState::ESTABLISHED;
         break;
       }
-      // For V3_WITHOUT_CACHE, switch to fast params for service discovery
-      // Service discovery period is critical - we typically have only 10s to complete
-      // discovery before the device disconnects us. Fast connection parameters are
-      // essential to finish service resolution in time and avoid retry loops.
-      else if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-        this->set_fast_conn_params_();
-      }
+      // For V3_WITHOUT_CACHE, we already set fast params before connecting
+      // No need to update them again here
       this->log_event_("Searching for services");
       esp_ble_gattc_search_service(esp_gattc_if, param->cfg_mtu.conn_id, nullptr);
       break;
@@ -418,7 +398,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       // For V3_WITHOUT_CACHE, switch back to medium connection parameters after service discovery
       // This balances performance with bandwidth usage after the critical discovery phase
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
-        this->set_medium_conn_params_();
+        this->update_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
       } else if (this->connection_type_ != espbt::ConnectionType::V3_WITH_CACHE) {
 #ifdef USE_ESP32_BLE_DEVICE
         for (auto &svc : this->services_) {

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -133,7 +133,8 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
 
   void log_event_(const char *name);
   void log_gattc_event_(const char *name);
-  void restore_medium_conn_params_();
+  void set_fast_conn_params_();
+  void set_medium_conn_params_();
   void log_gattc_warning_(const char *operation, esp_gatt_status_t status);
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -137,12 +137,10 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
                            const char *param_type);
   void set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                         const char *param_type);
-  void set_fast_conn_params_();
-  void set_medium_conn_params_();
-  void set_default_conn_params_();
   void log_gattc_warning_(const char *operation, esp_gatt_status_t status);
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);
+  void handle_connection_result_(esp_err_t ret);
   // Compact error logging helpers to reduce flash usage
   void log_error_(const char *message);
   void log_error_(const char *message, int code);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -133,10 +133,13 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
 
   void log_event_(const char *name);
   void log_gattc_event_(const char *name);
+  void update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
+                           const char *param_type);
   void set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                         const char *param_type);
   void set_fast_conn_params_();
   void set_medium_conn_params_();
+  void set_default_conn_params_();
   void log_gattc_warning_(const char *operation, esp_gatt_status_t status);
   void log_gattc_warning_(const char *operation, esp_err_t err);
   void log_connection_params_(const char *param_type);

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -133,6 +133,8 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
 
   void log_event_(const char *name);
   void log_gattc_event_(const char *name);
+  void set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
+                        const char *param_type);
   void set_fast_conn_params_();
   void set_medium_conn_params_();
   void log_gattc_warning_(const char *operation, esp_gatt_status_t status);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes BLE connection parameters based on the connection type (V3_WITHOUT_CACHE, V3_WITH_CACHE, or V1/Legacy), ensuring appropriate parameters are set before connecting.

## Problem

The previous implementation treated all V3 connections the same:
1. Both V3_WITH_CACHE and V3_WITHOUT_CACHE used fast parameters initially
2. Both types would update to medium parameters after service discovery
3. This was inefficient for V3_WITH_CACHE connections which don't need service discovery

## Key Changes

1. **Refactored connection parameter functions**:
   - Split the original `set_conn_params_()` into two distinct functions:
     - `set_conn_params_()`: Uses `esp_ble_gap_set_prefer_conn_params()` to set preferred parameters before connecting
     - `update_conn_params_()`: Uses `esp_ble_gap_update_conn_params()` to update parameters on active connections
   - Added `handle_connection_result_()` helper to reduce code duplication

2. **Optimized parameter setting by connection type**:
   - **V3_WITHOUT_CACHE**: Sets fast parameters (7.5ms) before connecting for service discovery, then updates to medium after
   - **V3_WITH_CACHE**: Sets medium parameters (8.75-11.25ms) before connecting (no update needed since no service discovery)
   - **V1/Legacy**: No longer sets parameters, uses ESP-IDF defaults instead

3. **Clean parameter management**:
   - Parameters are now set appropriately before connection based on connection type
   - Only V3_WITHOUT_CACHE performs a parameter update (after service discovery)
   - V3_WITH_CACHE no longer has unnecessary parameter update after connection
   - Uses the correct ESP-IDF API for each scenario (set_prefer vs update)

## Why This Matters

Different connection types have different requirements:
- **V3_WITHOUT_CACHE** needs fast parameters during service discovery to prevent timeouts
- **V3_WITH_CACHE** can use medium parameters throughout since services are already known
- **V1/Legacy** connections work best with ESP-IDF defaults

This optimization ensures:
- Faster and more reliable service discovery for V3_WITHOUT_CACHE connections
- Reduced power consumption for V3_WITH_CACHE connections
- Cleaner code with no redundant parameter updates

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses connection issues reported in #10327 (pvvx_mithermometer authentication failures)
- Maintains fix for service discovery timeouts from 2025.8.x

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal implementation change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example usage with BLE client components:

esp32_ble_tracker:

ble_client:
  - mac_address: "AA:BB:CC:DD:EE:FF"
    id: my_ble_client

# Components that benefit from this fix:
sensor:
  - platform: pvvx_mithermometer
    mac_address: "A4:C1:38:XX:XX:XX"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

The connection parameter timeline with this change:

1. **Before Connection (`connect()` method)**:
   - V3_WITHOUT_CACHE → Set fast params (7.5ms interval, 10s timeout)
   - V3_WITH_CACHE → Set medium params (8.75-11.25ms interval, 8s timeout)
   - V1/Legacy → No params set, use ESP-IDF defaults

2. **After Connection Open (ESP_GATTC_OPEN_EVT)**:
   - All types → No parameter changes (removed redundant updates)

3. **After Service Discovery (ESP_GATTC_SEARCH_CMPL_EVT)**:
   - V3_WITHOUT_CACHE → Update to medium params for normal operation
   - Others → No changes

This approach:
- Sets appropriate parameters once before connecting
- Avoids redundant parameter updates that can cause warnings
- Optimizes for each connection type's specific requirements

## Testing Notes

Tested with various BLE devices including:
- pvvx_mithermometer sensors
- Inkbird IBS-TH2 thermometers (49:22:XX:XX:XX:XX)
- Various ESP32 variants (ESP32 classic, ESP32-S3)

Note: During testing, discovered that some ESP32-S3 boards with W5500 ethernet may have hardware limitations affecting BLE connectivity with certain devices. This is unrelated to the connection parameter optimization and appears to be a hardware-specific issue with RF performance or power distribution.