### PR TITLE
[esp32_ble] Increase GATT connection retry count to use full timeout window

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -280,14 +280,10 @@ async def to_code(config):
             add_idf_sdkconfig_option(
                 "CONFIG_BT_BLE_ESTAB_LINK_CONN_TOUT", timeout_seconds
             )
-        else:
-            # Default to 20 seconds if not specified
-            add_idf_sdkconfig_option("CONFIG_BT_BLE_ESTAB_LINK_CONN_TOUT", 20)
-
-        # Increase GATT client connection retry count for problematic devices
-        # Default in ESP-IDF is 3, we increase to 10 for better reliability with
-        # low-power/timing-sensitive devices
-        add_idf_sdkconfig_option("CONFIG_BT_GATTC_CONNECT_RETRY_COUNT", 10)
+            # Increase GATT client connection retry count for problematic devices
+            # Default in ESP-IDF is 3, we increase to 10 for better reliability with
+            # low-power/timing-sensitive devices
+            add_idf_sdkconfig_option("CONFIG_BT_GATTC_CONNECT_RETRY_COUNT", 10)
 
         # Set the maximum number of notification registrations
         # This controls how many BLE characteristics can have notifications enabled

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -280,6 +280,14 @@ async def to_code(config):
             add_idf_sdkconfig_option(
                 "CONFIG_BT_BLE_ESTAB_LINK_CONN_TOUT", timeout_seconds
             )
+        else:
+            # Default to 20 seconds if not specified
+            add_idf_sdkconfig_option("CONFIG_BT_BLE_ESTAB_LINK_CONN_TOUT", 20)
+
+        # Increase GATT client connection retry count for problematic devices
+        # Default in ESP-IDF is 3, we increase to 10 for better reliability with
+        # low-power/timing-sensitive devices
+        add_idf_sdkconfig_option("CONFIG_BT_GATTC_CONNECT_RETRY_COUNT", 10)
 
         # Set the maximum number of notification registrations
         # This controls how many BLE characteristics can have notifications enabled


### PR DESCRIPTION
# What does this implement/fix?

This PR increases the BLE GATT client connection retry count from the ESP-IDF default of 3 to 10, ensuring that connection attempts continue throughout the full 20-second timeout window rather than giving up early.

## Problem

The ESP-IDF default `CONFIG_BT_GATTC_CONNECT_RETRY_COUNT` is set to 3, which means BLE connection attempts often fail after only 3 retries (typically 5-10 seconds), even though the connection timeout is set to 20 seconds. This leaves 10-15 seconds of potential retry time unused.

This particularly affects:
- Low-power BLE sensors with strict timing requirements (e.g., Inkbird thermometers, battery-powered sensors)
- Devices at the edge of reception range
- Environments with intermittent 2.4GHz interference
- ESP32 boards with marginal RF performance

## Solution

Set `CONFIG_BT_GATTC_CONNECT_RETRY_COUNT` to 10 retries, allowing the ESP32 to continue attempting connections throughout the full timeout window. This significantly improves the success rate for marginal connections without changing the overall timeout behavior.

## Testing Results

Before (3 retries):
```
[08:39:18][D][esp-idf:000][BTU_TASK]: W (37628) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:39:19][D][esp-idf:000][BTU_TASK]: W (38880) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:39:23][D][esp-idf:000][BTU_TASK]: W (42008) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:39:26][D][esp32_ble_client:355]: ESP_GATTC_DISCONNECT_EVT, reason 0x100  # Timeout after only 3 attempts
```

After (10 retries):
```
[08:42:02][I][esp32_ble_client:111]: [1] [49:22:03:25:01:46] 0x00 Connecting
[08:42:02][D][esp-idf:000][BTU_TASK]: W (201450) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:05][D][esp-idf:000][BTU_TASK]: W (203970) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:06][D][esp-idf:000][BTU_TASK]: W (205230) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:07][D][esp-idf:000][BTU_TASK]: W (206483) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:08][D][esp-idf:000][BTU_TASK]: W (207743) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:10][D][esp-idf:000][BTU_TASK]: W (209047) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:13][D][esp-idf:000][BTU_TASK]: W (212828) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:17][D][esp-idf:000][BTU_TASK]: W (216600) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:19][D][esp-idf:000][BTU_TASK]: W (218497) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:20][D][esp-idf:000][BTU_TASK]: W (219758) BT_HCI: hcif disc complete: hdl 0x1, rsn 0x3e dev_find 1
[08:42:21][D][esp32_ble_client:355]: ESP_GATTC_DISCONNECT_EVT, reason 0x100  # Full 20 seconds utilized with 10 attempts
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves connectivity with low-power BLE sensors
- Helps with issues reported with Inkbird thermometers and similar battery-powered devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal implementation change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Standard BLE configuration continues to work as before:

esp32_ble_tracker:

bluetooth_proxy:
  active: true

# Benefits all BLE client connections automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

This change is particularly beneficial for:
1. **ESP32 boards with marginal RF performance** - Gives more chances for successful connection
2. **Low-power BLE sensors** - Multiple retry attempts increase the probability of catching the device during its connection window
3. **Environments with RF interference** - Transient interference may clear during the retry period
4. **Devices at edge of range** - More attempts increase the chance of a successful connection when signal is marginal

The retry attempts are spaced variably (0.5-3.5 seconds apart), which helps avoid systematic interference patterns and increases the chance of success under varying RF conditions.