### PR TITLE
[esp32_ble_tracker] Fix on_scan_end trigger compilation without USE_ESP32_BLE_DEVICE

### DIFF
--- a/esphome/components/esp32_ble_tracker/automation.h
+++ b/esphome/components/esp32_ble_tracker/automation.h
@@ -80,14 +80,17 @@ class BLEManufacturerDataAdvertiseTrigger : public Trigger<const adv_data_t &>, 
   ESPBTUUID uuid_;
 };
 
+#endif  // USE_ESP32_BLE_DEVICE
+
 class BLEEndOfScanTrigger : public Trigger<>, public ESPBTDeviceListener {
  public:
   explicit BLEEndOfScanTrigger(ESP32BLETracker *parent) { parent->register_listener(this); }
 
+#ifdef USE_ESP32_BLE_DEVICE
   bool parse_device(const ESPBTDevice &device) override { return false; }
+#endif
   void on_scan_end() override { this->trigger(); }
 };
-#endif  // USE_ESP32_BLE_DEVICE
 
 template<typename... Ts> class ESP32BLEStartScanAction : public Action<Ts...> {
  public:

--- a/tests/components/esp32_ble_tracker/test-on-scan-end.esp32-idf.yaml
+++ b/tests/components/esp32_ble_tracker/test-on-scan-end.esp32-idf.yaml
@@ -1,0 +1,3 @@
+esp32_ble_tracker:
+  on_scan_end:
+    - logger.log: "Scan ended!"


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a compilation error when using the `on_scan_end` trigger for `esp32_ble_tracker` without any other BLE triggers that would enable the `USE_ESP32_BLE_DEVICE` define.

The `BLEEndOfScanTrigger` class was incorrectly placed inside an `#ifdef USE_ESP32_BLE_DEVICE` block, but this trigger doesn't actually need `ESPBTDevice` functionality - it only needs to be notified when a scan ends. This fix moves the class outside the conditional compilation block and only conditionally compiles the `parse_device` method override that references `ESPBTDevice`.

This regression was introduced in PR #9489 which added stricter conditional compilation to reduce binary size, but inadvertently made `on_scan_end` dependent on `USE_ESP32_BLE_DEVICE` being defined.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10386

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Minimal configuration that previously failed to compile
esp32_ble_tracker:
  on_scan_end:
    - logger.log: "Scan ended!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

