### PR TITLE
[esphome] Fix OTA watchdog resets by validating all magic bytes before blocking

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -100,8 +100,8 @@ void ESPHomeOTAComponent::handle_handshake_() {
   /// Handle the initial OTA handshake.
   ///
   /// This method is non-blocking and will return immediately if no data is available.
-  /// It waits for the first magic byte (0x6C) before proceeding to handle_data_().
-  /// A 10-second timeout is enforced from initial connection.
+  /// It reads all 5 magic bytes (0x6C, 0x26, 0xF7, 0x5C, 0x45) non-blocking
+  /// before proceeding to handle_data_(). A 10-second timeout is enforced from initial connection.
 
   if (this->client_ == nullptr) {
     // We already checked server_->ready() in loop(), so we can accept directly
@@ -126,6 +126,7 @@ void ESPHomeOTAComponent::handle_handshake_() {
     }
     this->log_start_("handshake");
     this->client_connect_time_ = App.get_loop_component_start_time();
+    this->magic_buf_pos_ = 0;  // Reset magic buffer position
   }
 
   // Check for handshake timeout
@@ -136,34 +137,47 @@ void ESPHomeOTAComponent::handle_handshake_() {
     return;
   }
 
-  // Try to read first byte of magic bytes
-  uint8_t first_byte;
-  ssize_t read = this->client_->read(&first_byte, 1);
+  // Try to read remaining magic bytes
+  if (this->magic_buf_pos_ < 5) {
+    // Read as many bytes as available
+    uint8_t bytes_to_read = 5 - this->magic_buf_pos_;
+    ssize_t read = this->client_->read(this->magic_buf_ + this->magic_buf_pos_, bytes_to_read);
 
-  if (read == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-    return;  // No data yet, try again next loop
-  }
-
-  if (read <= 0) {
-    // Error or connection closed
-    if (read == -1) {
-      this->log_socket_error_("reading first byte");
-    } else {
-      ESP_LOGW(TAG, "Remote closed during handshake");
+    if (read == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      return;  // No data yet, try again next loop
     }
-    this->cleanup_connection_();
-    return;
+
+    if (read <= 0) {
+      // Error or connection closed
+      if (read == -1) {
+        this->log_socket_error_("reading magic bytes");
+      } else {
+        ESP_LOGW(TAG, "Remote closed during handshake");
+      }
+      this->cleanup_connection_();
+      return;
+    }
+
+    this->magic_buf_pos_ += read;
   }
 
-  // Got first byte, check if it's the magic byte
-  if (first_byte != 0x6C) {
-    ESP_LOGW(TAG, "Invalid initial byte: 0x%02X", first_byte);
-    this->cleanup_connection_();
-    return;
-  }
+  // Check if we have all 5 magic bytes
+  if (this->magic_buf_pos_ == 5) {
+    // Validate magic bytes
+    static const uint8_t MAGIC_BYTES[5] = {0x6C, 0x26, 0xF7, 0x5C, 0x45};
+    if (memcmp(this->magic_buf_, MAGIC_BYTES, 5) != 0) {
+      ESP_LOGW(TAG, "Magic bytes mismatch! 0x%02X-0x%02X-0x%02X-0x%02X-0x%02X", this->magic_buf_[0],
+               this->magic_buf_[1], this->magic_buf_[2], this->magic_buf_[3], this->magic_buf_[4]);
+      // Send error response (non-blocking, best effort)
+      uint8_t error = static_cast<uint8_t>(ota::OTA_RESPONSE_ERROR_MAGIC);
+      this->client_->write(&error, 1);
+      this->cleanup_connection_();
+      return;
+    }
 
-  // First byte is valid, continue with data handling
-  this->handle_data_();
+    // All 5 magic bytes are valid, continue with data handling
+    this->handle_data_();
+  }
 }
 
 void ESPHomeOTAComponent::handle_data_() {
@@ -185,18 +199,6 @@ void ESPHomeOTAComponent::handle_data_() {
 #if USE_OTA_VERSION == 2
   size_t size_acknowledged = 0;
 #endif
-
-  // Read remaining 4 bytes of magic (we already read the first byte 0x6C in handle_handshake_)
-  if (!this->readall_(buf, 4)) {
-    this->log_read_error_("magic bytes");
-    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
-  }
-  // Check remaining magic bytes: 0x26, 0xF7, 0x5C, 0x45
-  if (buf[0] != 0x26 || buf[1] != 0xF7 || buf[2] != 0x5C || buf[3] != 0x45) {
-    ESP_LOGW(TAG, "Magic bytes mismatch! 0x6C-0x%02X-0x%02X-0x%02X-0x%02X", buf[0], buf[1], buf[2], buf[3]);
-    error_code = ota::OTA_RESPONSE_ERROR_MAGIC;
-    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
-  }
 
   // Send OK and version - 2 bytes
   buf[0] = ota::OTA_RESPONSE_OK;
@@ -487,6 +489,7 @@ void ESPHomeOTAComponent::cleanup_connection_() {
   this->client_->close();
   this->client_ = nullptr;
   this->client_connect_time_ = 0;
+  this->magic_buf_pos_ = 0;
 }
 
 void ESPHomeOTAComponent::yield_and_feed_watchdog_() {

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -41,11 +41,13 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   std::string password_;
 #endif  // USE_OTA_PASSWORD
 
-  uint16_t port_;
-  uint32_t client_connect_time_{0};
-
   std::unique_ptr<socket::Socket> server_;
   std::unique_ptr<socket::Socket> client_;
+
+  uint32_t client_connect_time_{0};
+  uint16_t port_;
+  uint8_t magic_buf_[5];
+  uint8_t magic_buf_pos_{0};
 };
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a bug where OTA updates could trigger watchdog resets when port scanners or other network traffic accidentally sent data starting with 0x6C (ASCII 'l'). 

The previous fix in #10152 attempted to avoid using 6 bytes of RAM by only checking the first magic byte before entering blocking mode. However, this proved insufficient - if a port scanner happened to send 0x6C as its first probe byte, the OTA handler would immediately enter the blocking `handle_data_()` phase expecting the remaining magic bytes. When it received different data (e.g., 0x00 bytes), it would block waiting for the correct sequence, eventually triggering a watchdog reset.

This fix ensures all 5 magic bytes (0x6C, 0x26, 0xF7, 0x5C, 0x45) are read and validated in non-blocking mode before transitioning to the blocking data transfer phase. The 6 bytes of RAM (5-byte buffer + 1-byte position counter) is a worthwhile tradeoff for preventing these accidental resets from port scanners and other benign network traffic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves upon #10152 which partially addressed the issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** Not yet tested on real devices (traveling) - will test when back

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# OTA configuration remains the same:
ota:
  - platform: esphome
    password: "your_ota_password"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation only

## Additional Context

The key changes in this fix:
1. Added `magic_buf_[5]` and `magic_buf_pos_` to track partial reads of magic bytes
2. Modified `handle_handshake_()` to read all 5 magic bytes in non-blocking mode
3. Only transitions to blocking `handle_data_()` after all 5 magic bytes are validated
4. Sends proper `OTA_RESPONSE_ERROR_MAGIC` error code when magic validation fails
5. Optimized memory layout by grouping pointers together for better alignment

This ensures that random network traffic or port scanning cannot accidentally trigger the blocking OTA update mode, preventing watchdog resets while maintaining full backward compatibility.