### PR TITLE
[nextion] Increase delay before reboot to prevent TFT upload interruption

### DIFF
--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "nextion.upload";
 bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Upload successful");
-    for (uint8_t i; i<=5; i++) {
+    for (uint8_t i=0; i<=5; i++) {
       delay(1000);  // NOLINT
       App.feed_wdt();  // Feed the watchdog timer.
     }

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -11,7 +11,10 @@ static const char *const TAG = "nextion.upload";
 bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Upload successful");
-    delay(1500);  // NOLINT
+    for (uint8_t i; i<=5; i++) {
+      delay(1000);  // NOLINT
+      App.feed_wdt();  // Feed the watchdog timer.
+    }
     App.safe_reboot();
   } else {
     ESP_LOGE(TAG, "Upload failed");

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -11,8 +11,8 @@ static const char *const TAG = "nextion.upload";
 bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Upload successful");
-    for (uint8_t i=0; i<=5; i++) {
-      delay(1000);  // NOLINT
+    for (uint8_t i = 0; i <= 5; i++) {
+      delay(1000);     // NOLINT
       App.feed_wdt();  // Feed the watchdog timer.
     }
     App.safe_reboot();

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -11,8 +11,8 @@ static const char *const TAG = "nextion.upload";
 bool Nextion::upload_end_(bool successful) {
   if (successful) {
     ESP_LOGD(TAG, "Upload successful");
-    for (uint8_t i; i<=5; i++) {
-      delay(1000);  // NOLINT
+    for (uint8_t i; i <= 5; i++) {
+      delay(1000);     // NOLINT
       App.feed_wdt();  // Feed the watchdog timer.
     }
     App.safe_reboot();


### PR DESCRIPTION
# What does this implement/fix?

Fix TFT upload failures caused by premature ESP reboot interrupting display processing.

**Problem:**
When the Nextion display is powered through an ESP-controlled switch, the current 1.5s delay before reboot may be insufficient for the display to complete TFT processing. This can cause power interruption during processing, resulting in "System Data ERROR!" and failed uploads.

**Solution:**
Increase delay from 1500ms to 5000ms before calling `App.safe_reboot()` to ensure the Nextion display has adequate time to complete TFT file processing before power interruption.

**Changes:**
- `delay(1500)` → `delay(5000)` in nextion_upload.cpp

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
