### PR TITLE
[dashboard] Add error reporting around name lookups

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -140,6 +140,12 @@ def choose_upload_log_host(
                     resolved.append("MQTT")
             else:
                 resolved.append(device)
+
+        resolved = [i for i in resolved if i]
+
+        if not resolved:
+            raise EsphomeError("No valid address for the device found. Is it online?")
+
         return resolved
 
     # No devices specified, show interactive chooser


### PR DESCRIPTION
# What does this implement/fix?

1. Adds an exception if an OTA was asked but the device does not have a `entry.address` AKA `use_address`

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10398

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

Try flashing any offline openthread device.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).