### PR TITLE
[core] Dont copy platform source files if there are no entities of that type

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+from collections import defaultdict
 from contextlib import contextmanager
 import contextvars
 import functools
@@ -37,11 +38,13 @@ from esphome.yaml_util import ESPForceValue, ESPHomeDataBase, is_secret
 _LOGGER = logging.getLogger(__name__)
 
 
-def iter_components(config):
+def iter_components(config: ConfigType, platform_counts: defaultdict[str, int]):
     for domain, conf in config.items():
         component = get_component(domain)
         yield domain, component
         if component.is_platform_component:
+            if not platform_counts.get(domain):
+                continue
             for p_config in conf:
                 p_name = f"{domain}.{p_config[CONF_PLATFORM]}"
                 platform = get_platform(domain, p_config[CONF_PLATFORM])

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -43,7 +43,7 @@ def iter_components(config: ConfigType, platform_counts: defaultdict[str, int]):
         component = get_component(domain)
         yield domain, component
         if component.is_platform_component:
-            if not platform_counts.get(domain):
+            if not platform_counts[domain]:
                 continue
             for p_config in conf:
                 p_name = f"{domain}.{p_config[CONF_PLATFORM]}"

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -181,7 +181,7 @@ the custom_components folder or the external_components feature.
 
 def copy_src_tree():
     source_files: list[loader.FileResource] = []
-    for _, component in iter_components(CORE.config):
+    for _, component in iter_components(CORE.config, CORE.platform_counts):
         source_files += component.resources
     source_files_map = {
         Path(x.package.replace(".", "/") + "/" + x.resource): x for x in source_files


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Optimizations in #10023 meant that the entity defines eg `USE_NUMBER` are now only defined if there is actually an entity to be added. This meant that the platform files for components were being copied to the project, but parts were pre-processed out. 

Rather than put `#ifdef USE_NUMBER` inside platform files, we can simply not copy the source files if there is no chance they are going to be used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10433

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
