### PR TITLE
improve `esphome.components.esp32.const` imports

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -1,6 +1,6 @@
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components.esp32 import VARIANT_ESP32P4, get_esp32_variant
+from esphome.components.esp32 import get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32C2,
@@ -8,6 +8,7 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
+    VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import esp32, i2c
+from esphome.components.esp32.const import VARIANT_ESP32
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET, Framework
 
@@ -69,7 +70,7 @@ CONFIG_SCHEMA = cv.All(
         cv.only_on_esp8266,
         cv.All(
             cv.only_on_esp32,
-            esp32.only_on_variant(supported=[esp32.const.VARIANT_ESP32]),
+            esp32.only_on_variant(supported=[VARIANT_ESP32]),
         ),
     ),
 )

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -3,7 +3,8 @@ import re
 
 from esphome import automation
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
+from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32S2
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_ON_BOOT, CONF_ESPHOME, CONF_ID, CONF_NAME
 from esphome.core import CORE, TimePeriod
@@ -122,7 +123,7 @@ CONF_DISABLE_BT_LOGS = "disable_bt_logs"
 CONF_CONNECTION_TIMEOUT = "connection_timeout"
 CONF_MAX_NOTIFICATIONS = "max_notifications"
 
-NO_BLUETOOTH_VARIANTS = [const.VARIANT_ESP32S2]
+NO_BLUETOOTH_VARIANTS = [VARIANT_ESP32S2]
 
 esp32_ble_ns = cg.esphome_ns.namespace("esp32_ble")
 ESP32BLE = esp32_ble_ns.class_("ESP32BLE", cg.Component)

--- a/esphome/components/esp32_rmt/__init__.py
+++ b/esphome/components/esp32_rmt/__init__.py
@@ -1,4 +1,5 @@
 from esphome.components import esp32
+from esphome.components.esp32.const import VARIANT_ESP32H2
 import esphome.config_validation as cv
 
 CODEOWNERS = ["@jesserockz"]
@@ -9,7 +10,7 @@ def validate_clock_resolution():
         cv.only_on_esp32(value)
         value = cv.int_(value)
         variant = esp32.get_esp32_variant()
-        if variant == esp32.const.VARIANT_ESP32H2 and value > 32000000:
+        if variant == VARIANT_ESP32H2 and value > 32000000:
             raise cv.Invalid(
                 f"ESP32 variant {variant} has a max clock_resolution of 32000000."
             )

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -5,6 +5,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, light
 from esphome.components.const import CONF_USE_PSRAM
+from esphome.components.esp32.const import VARIANT_ESP32P4, VARIANT_ESP32S3
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHIPSET,
@@ -90,9 +91,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,
             cv.Optional(CONF_IS_WRGB, default=False): cv.boolean,
             cv.Optional(CONF_USE_DMA): cv.All(
-                esp32.only_on_variant(
-                    supported=[esp32.const.VARIANT_ESP32S3, esp32.const.VARIANT_ESP32P4]
-                ),
+                esp32.only_on_variant(supported=[VARIANT_ESP32P4, VARIANT_ESP32S3]),
                 cv.boolean,
             ),
             cv.Optional(CONF_USE_PSRAM, default=True): cv.boolean,

--- a/esphome/components/esp32_touch/__init__.py
+++ b/esphome/components/esp32_touch/__init__.py
@@ -255,9 +255,9 @@ CONFIG_SCHEMA = cv.All(
     cv.has_none_or_all_keys(CONF_WATERPROOF_GUARD_RING, CONF_WATERPROOF_SHIELD_DRIVER),
     esp32.only_on_variant(
         supported=[
-            esp32.const.VARIANT_ESP32,
-            esp32.const.VARIANT_ESP32S2,
-            esp32.const.VARIANT_ESP32S3,
+            VARIANT_ESP32,
+            VARIANT_ESP32S2,
+            VARIANT_ESP32S3,
         ]
     ),
     validate_variant_vars,

--- a/esphome/components/esp_ldo/__init__.py
+++ b/esphome/components/esp_ldo/__init__.py
@@ -1,6 +1,7 @@
 from esphome.automation import Action, register_action
 import esphome.codegen as cg
-from esphome.components.esp32 import VARIANT_ESP32P4, only_on_variant
+from esphome.components.esp32 import only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32P4
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL, CONF_ID, CONF_VOLTAGE
 from esphome.final_validate import full_config

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -3,6 +3,11 @@ import logging
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32
+from esphome.components.esp32.const import (
+    VARIANT_ESP32C5,
+    VARIANT_ESP32C6,
+    VARIANT_ESP32P4,
+)
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -54,9 +59,9 @@ def validate_config(config):
         and CORE.using_esp_idf
         and esp32.get_esp32_variant()
         in [
-            esp32.const.VARIANT_ESP32C5,
-            esp32.const.VARIANT_ESP32C6,
-            esp32.const.VARIANT_ESP32P4,
+            VARIANT_ESP32C5,
+            VARIANT_ESP32C6,
+            VARIANT_ESP32P4,
         ]
     ):
         version: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -1,6 +1,7 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, media_player
+from esphome.components.esp32.const import VARIANT_ESP32S2
 import esphome.config_validation as cv
 from esphome.const import CONF_MODE
 
@@ -40,7 +41,7 @@ INTERNAL_DAC_OPTIONS = {
 
 EXTERNAL_DAC_OPTIONS = [CONF_MONO, CONF_STEREO]
 
-NO_INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32S2]
+NO_INTERNAL_DAC_VARIANTS = [VARIANT_ESP32S2]
 
 I2C_COMM_FMT_OPTIONS = ["lsb", "msb"]
 

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -2,6 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import audio, esp32, microphone
 from esphome.components.adc import ESP32_VARIANT_ADC1_PIN_TO_CHANNEL, validate_adc_pin
+from esphome.components.esp32.const import VARIANT_ESP32, VARIANT_ESP32S3
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BITS_PER_SAMPLE,
@@ -37,8 +38,8 @@ I2SAudioMicrophone = i2s_audio_ns.class_(
     "I2SAudioMicrophone", I2SAudioIn, microphone.Microphone, cg.Component
 )
 
-INTERNAL_ADC_VARIANTS = [esp32.const.VARIANT_ESP32]
-PDM_VARIANTS = [esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S3]
+INTERNAL_ADC_VARIANTS = [VARIANT_ESP32]
+PDM_VARIANTS = [VARIANT_ESP32, VARIANT_ESP32S3]
 
 
 def _validate_esp32_variant(config):

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -1,6 +1,7 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import audio, esp32, speaker
+from esphome.components.esp32.const import VARIANT_ESP32
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BITS_PER_SAMPLE,
@@ -62,7 +63,7 @@ I2C_COMM_FMT_OPTIONS = {
     "pcm_long": i2s_comm_format_t.I2S_COMM_FORMAT_PCM_LONG,
 }
 
-INTERNAL_DAC_VARIANTS = [esp32.const.VARIANT_ESP32]
+INTERNAL_DAC_VARIANTS = [VARIANT_ESP32]
 
 
 def _set_num_channels_from_config(config):

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -12,7 +12,8 @@ from esphome.components.const import (
     CONF_DRAW_ROUNDING,
 )
 from esphome.components.display import CONF_SHOW_TEST_CARD
-from esphome.components.esp32 import const, only_on_variant
+from esphome.components.esp32 import only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32P4
 from esphome.components.mipi import (
     COLOR_ORDERS,
     CONF_COLOR_DEPTH,
@@ -165,7 +166,7 @@ def model_schema(config):
     )
     return cv.All(
         schema,
-        only_on_variant(supported=[const.VARIANT_ESP32P4]),
+        only_on_variant(supported=[VARIANT_ESP32P4]),
         cv.only_with_esp_idf,
     )
 

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -1,10 +1,6 @@
 import esphome.codegen as cg
-from esphome.components.esp32 import (
-    VARIANT_ESP32C6,
-    VARIANT_ESP32H2,
-    add_idf_sdkconfig_option,
-    only_on_variant,
-)
+from esphome.components.esp32 import add_idf_sdkconfig_option, only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32C6, VARIANT_ESP32H2
 from esphome.components.mdns import MDNSComponent
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL, CONF_ENABLE_IPV6, CONF_ID

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -4,11 +4,11 @@ import esphome.codegen as cg
 from esphome.components.esp32 import (
     CONF_CPU_FREQUENCY,
     CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES,
-    VARIANT_ESP32,
     add_idf_sdkconfig_option,
     get_esp32_variant,
 )
 from esphome.components.esp32.const import (
+    VARIANT_ESP32,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -1,6 +1,12 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
+from esphome.components.esp32.const import (
+    VARIANT_ESP32,
+    VARIANT_ESP32P4,
+    VARIANT_ESP32S2,
+    VARIANT_ESP32S3,
+)
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -63,10 +69,7 @@ RemoteReceiverComponent = remote_receiver_ns.class_(
 def validate_config(config):
     if CORE.is_esp32:
         variant = esp32.get_esp32_variant()
-        if variant in (esp32.const.VARIANT_ESP32, esp32.const.VARIANT_ESP32S2):
-            max_idle = 65535
-        else:
-            max_idle = 32767
+        max_idle = 65535 if variant in (VARIANT_ESP32, VARIANT_ESP32S2) else 32767
         if CONF_CLOCK_RESOLUTION in config:
             max_idle = int(max_idle * 1000000 / config[CONF_CLOCK_RESOLUTION])
         if config[CONF_IDLE].total_microseconds > max_idle:
@@ -144,9 +147,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
                 esp32=192,
             ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
             cv.Optional(CONF_USE_DMA): cv.All(
-                esp32.only_on_variant(
-                    supported=[esp32.const.VARIANT_ESP32S3, esp32.const.VARIANT_ESP32P4]
-                ),
+                esp32.only_on_variant(supported=[VARIANT_ESP32P4, VARIANT_ESP32S3]),
                 cv.boolean,
             ),
         }

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -1,6 +1,7 @@
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
+from esphome.components.esp32.const import VARIANT_ESP32P4, VARIANT_ESP32S3
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -49,9 +50,7 @@ CONFIG_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_EOT_LEVEL): cv.All(cv.only_on_esp32, cv.boolean),
         cv.Optional(CONF_USE_DMA): cv.All(
-            esp32.only_on_variant(
-                supported=[esp32.const.VARIANT_ESP32S3, esp32.const.VARIANT_ESP32P4]
-            ),
+            esp32.only_on_variant(supported=[VARIANT_ESP32P4, VARIANT_ESP32S3]),
             cv.boolean,
         ),
         cv.SplitDefault(

--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -1,7 +1,8 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import display
-from esphome.components.esp32 import const, only_on_variant
+from esphome.components.esp32 import only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.components.mipi import (
     CONF_DE_PIN,
     CONF_HSYNC_BACK_PORCH,
@@ -121,7 +122,7 @@ CONFIG_SCHEMA = cv.All(
             }
         )
     ),
-    only_on_variant(supported=[const.VARIANT_ESP32S3]),
+    only_on_variant(supported=[VARIANT_ESP32S3]),
     cv.only_with_esp_idf,
 )
 

--- a/esphome/components/st7701s/display.py
+++ b/esphome/components/st7701s/display.py
@@ -1,7 +1,8 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import display, spi
-from esphome.components.esp32 import const, only_on_variant
+from esphome.components.esp32 import only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32S3
 from esphome.components.mipi import (
     CONF_DE_PIN,
     CONF_HSYNC_BACK_PORCH,
@@ -161,7 +162,7 @@ CONFIG_SCHEMA = cv.All(
             }
         ).extend(spi.spi_device_schema(cs_pin_required=False, default_data_rate=1e6))
     ),
-    only_on_variant(supported=[const.VARIANT_ESP32S3]),
+    only_on_variant(supported=[VARIANT_ESP32S3]),
     cv.only_with_esp_idf,
 )
 

--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -1,10 +1,6 @@
 import esphome.codegen as cg
-from esphome.components.esp32 import (
-    VARIANT_ESP32S2,
-    VARIANT_ESP32S3,
-    add_idf_sdkconfig_option,
-    only_on_variant,
-)
+from esphome.components.esp32 import add_idf_sdkconfig_option, only_on_variant
+from esphome.components.esp32.const import VARIANT_ESP32S2, VARIANT_ESP32S3
 import esphome.config_validation as cv
 from esphome.const import CONF_DEVICES, CONF_ID
 from esphome.cpp_types import Component

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -2,7 +2,8 @@ from esphome import automation
 from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
-from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
+from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32H2
 from esphome.components.network import IPAddress
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
@@ -51,7 +52,7 @@ from . import wpa2_eap
 
 AUTO_LOAD = ["network"]
 
-NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2]
+NO_WIFI_VARIANTS = [VARIANT_ESP32H2]
 CONF_SAVE = "save"
 
 wifi_ns = cg.esphome_ns.namespace("wifi")

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from esphome import config_validation as cv
-from esphome.components.esp32 import KEY_BOARD, VARIANT_ESP32P4
+from esphome.components.esp32.const import KEY_BOARD, VARIANT_ESP32P4
 from esphome.const import (
     CONF_DIMENSIONS,
     CONF_HEIGHT,

--- a/tests/component_tests/mipi_spi/conftest.py
+++ b/tests/component_tests/mipi_spi/conftest.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Generator
 import pytest
 
 from esphome import config_validation as cv
-from esphome.components.esp32 import KEY_ESP32, KEY_VARIANT, VARIANTS
+from esphome.components.esp32.const import KEY_ESP32, KEY_VARIANT, VARIANTS
 from esphome.components.esp32.gpio import validate_gpio_pin
 from esphome.const import CONF_INPUT, CONF_OUTPUT
 from esphome.core import CORE

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from esphome import config_validation as cv
-from esphome.components.esp32 import (
+from esphome.components.esp32.const import (
     KEY_BOARD,
     KEY_VARIANT,
     VARIANT_ESP32,


### PR DESCRIPTION
# What does this implement/fix?

improve `esphome.components.esp32.const` imports that they got directly imported from the file where they are defined

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
