### PR TITLE
improve const imports of `esphome.const`

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -5,9 +5,14 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
 import esphome.config_validation as cv
-from esphome.const import CONF_ENABLE_ON_BOOT, CONF_ESPHOME, CONF_ID, CONF_NAME
+from esphome.const import (
+    CONF_ENABLE_ON_BOOT,
+    CONF_ESPHOME,
+    CONF_ID,
+    CONF_NAME,
+    CONF_NAME_ADD_MAC_SUFFIX,
+)
 from esphome.core import CORE, TimePeriod
-from esphome.core.config import CONF_NAME_ADD_MAC_SUFFIX
 import esphome.final_validate as fv
 
 DEPENDENCIES = ["esp32"]

--- a/esphome/components/sdm_meter/sensor.py
+++ b/esphome/components/sdm_meter/sensor.py
@@ -1,6 +1,5 @@
 import esphome.codegen as cg
 from esphome.components import modbus, sensor
-from esphome.components.atm90e32.sensor import CONF_PHASE_A, CONF_PHASE_B, CONF_PHASE_C
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ACTIVE_POWER,
@@ -12,7 +11,10 @@ from esphome.const import (
     CONF_ID,
     CONF_IMPORT_ACTIVE_ENERGY,
     CONF_IMPORT_REACTIVE_ENERGY,
+    CONF_PHASE_A,
     CONF_PHASE_ANGLE,
+    CONF_PHASE_B,
+    CONF_PHASE_C,
     CONF_POWER_FACTOR,
     CONF_REACTIVE_POWER,
     CONF_TOTAL_POWER,


### PR DESCRIPTION
# What does this implement/fix?

improve const imports of `esphome.const`
-> moving them to the correct import path

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
