### PR TITLE
Revert "[core] Dont copy platform source files if there are no entities of that type"

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from collections import defaultdict
 from contextlib import contextmanager
 import contextvars
 import functools
@@ -38,13 +37,11 @@ from esphome.yaml_util import ESPForceValue, ESPHomeDataBase, is_secret
 _LOGGER = logging.getLogger(__name__)
 
 
-def iter_components(config: ConfigType, platform_counts: defaultdict[str, int]):
+def iter_components(config):
     for domain, conf in config.items():
         component = get_component(domain)
         yield domain, component
         if component.is_platform_component:
-            if not platform_counts[domain]:
-                continue
             for p_config in conf:
                 p_name = f"{domain}.{p_config[CONF_PLATFORM]}"
                 platform = get_platform(domain, p_config[CONF_PLATFORM])

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -181,7 +181,7 @@ the custom_components folder or the external_components feature.
 
 def copy_src_tree():
     source_files: list[loader.FileResource] = []
-    for _, component in iter_components(CORE.config, CORE.platform_counts):
+    for _, component in iter_components(CORE.config):
         source_files += component.resources
     source_files_map = {
         Path(x.package.replace(".", "/") + "/" + x.resource): x for x in source_files


### PR DESCRIPTION
Reverts esphome/esphome#10436

Had lots of knock-on effects; The problem is that there are lots of platform components that don't define entities, so now they are being excluded because     CORE.register_platform_component(DOMAIN, var) isn't being called. 
