### PR TITLE
[wifi] Fix reconnection failures after adapter restart by not clearing netif pointers

### DIFF
--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -547,8 +547,6 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     }
     case ESPHOME_EVENT_ID_WIFI_STA_STOP: {
       ESP_LOGV(TAG, "STA stop");
-      // Clear the STA interface handle to prevent use-after-free
-      s_sta_netif = nullptr;
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {
@@ -638,10 +636,6 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STOP: {
       ESP_LOGV(TAG, "AP stop");
-#ifdef USE_WIFI_AP
-      // Clear the AP interface handle to prevent use-after-free
-      s_ap_netif = nullptr;
-#endif
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STACONNECTED: {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -697,8 +697,6 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_STOP) {
     ESP_LOGV(TAG, "STA stop");
     s_sta_started = false;
-    // Clear the STA interface handle to prevent use-after-free
-    s_sta_netif = nullptr;
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_AUTHMODE_CHANGE) {
     const auto &it = data->data.sta_authmode_change;
@@ -797,10 +795,6 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_STOP) {
     ESP_LOGV(TAG, "AP stop");
     s_ap_started = false;
-#ifdef USE_WIFI_AP
-    // Clear the AP interface handle to prevent use-after-free
-    s_ap_netif = nullptr;
-#endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_PROBEREQRECVED) {
     const auto &it = data->data.ap_probe_req_rx;


### PR DESCRIPTION
# What does this implement/fix?

This partially reverts PR #9989 to fix WiFi reconnection failures after adapter restarts.

PR #9989 correctly added null checks to prevent crashes when `s_sta_netif`/`s_ap_netif` were accessed before being initialized during WiFi mode transitions. However, it also unnecessarily started clearing these pointers on `WIFI_EVENT_STA_STOP`/`WIFI_EVENT_AP_STOP` events.

**This bug was largely hidden because:** After WiFi fails to reconnect for long enough, ESPHome will reboot the device, and on fresh boot the netif pointers are properly initialized, allowing successful connection. This masked the issue in most cases - users would see their devices eventually connect after a reboot, not realizing the reconnection logic itself was broken.

**I only discovered this issue because my access point was in a bad state**, causing frequent connection failures that triggered the adapter restart logic repeatedly, exposing that reconnections would never succeed without a full reboot.

The problem:
- When `restart_adapter()` is called (due to connection issues), it sets WiFi mode to NULL
- This triggers stop events that clear the netif pointers  
- When WiFi tries to reconnect, the netif pointers are null
- The null checks prevent crashes but the connection always fails
- Device can only reconnect after a full reboot (when netif is freshly initialized)

The netif handles remain valid even when WiFi is stopped - they're managed internally by ESP-IDF/Arduino. We should keep the null checks for safety but not actively clear valid pointers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Partially reverts #9989
- Related to #9965

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fixes WiFi reconnection issues with poor signal quality
wifi:
  ssid: "YourSSID"
  password: "YourPassword"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).