### PR TITLE
Fix AttributeError when uploading OTA to offline OpenThread devices

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -132,14 +132,17 @@ def choose_upload_log_host(
                 ]
                 resolved.append(choose_prompt(options, purpose=purpose))
             elif device == "OTA":
-                if (show_ota and "ota" in CORE.config) or (
-                    show_api and "api" in CORE.config
+                if CORE.address and (
+                    (show_ota and "ota" in CORE.config)
+                    or (show_api and "api" in CORE.config)
                 ):
                     resolved.append(CORE.address)
                 elif show_mqtt and has_mqtt_logging():
                     resolved.append("MQTT")
             else:
                 resolved.append(device)
+        if not resolved:
+            _LOGGER.error("All specified devices: %s could not be resolved.", defaults)
         return resolved
 
     # No devices specified, show interactive chooser


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an `AttributeError` that occurs when trying to upload via OTA to offline devices (particularly reported with OpenThread devices). When a device is offline and cannot be resolved via mDNS, `CORE.address` becomes `None` if no `use_address` is configured.

The fix prevents `None` from being added to the device list in `choose_upload_log_host()`, which was causing `get_port_type()` to crash when trying to call `startswith()` on `None`.

This is a short-term fix to prevent the crash and provide better error handling. A longer-term solution is being discussed in #10423 (comment: https://github.com/esphome/esphome/pull/10423#issuecomment-3225403889).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10398

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

See example in linked issue

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

