### PR TITLE
[esp32_rmt_led_strip] add SK6112

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -53,6 +53,7 @@ class LEDStripTimings:
 CHIPSETS = {
     "WS2811": LEDStripTimings(300, 1090, 1090, 320, 0, 300000),
     "WS2812": LEDStripTimings(400, 1000, 1000, 400, 0, 0),
+    "SK6112": LEDStripTimings(300, 900, 900, 300, 0, 250000),
     "SK6812": LEDStripTimings(300, 900, 600, 600, 0, 0),
     "APA106": LEDStripTimings(350, 1360, 1360, 350, 0, 0),
     "SM16703": LEDStripTimings(300, 900, 900, 300, 0, 0),


### PR DESCRIPTION
# What does this implement/fix?

Draft while waiting on test by user with these LEDs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

https://discord.com/channels/429907082951524364/429907082955718657/1410019000188141709

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: esp32_rmt_led_strip
    chipset: SK6112
    rgb_order: GRB
    pin: GPIOXX
    num_leds: 30
    name: "My Light"

external_components:
  - source: github://pr#10463
    components: [esp32_rmt_led_strip]
    refresh: 1h
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
