### PR TITLE
[absolute_humidity] Fix typo

### DIFF
--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -61,11 +61,10 @@ void AbsoluteHumidityComponent::loop() {
       ESP_LOGW(TAG, "No valid state from temperature sensor!");
     }
     if (no_humidity) {
-      ESP_LOGW(TAG, "No valid state from temperature sensor!");
+      ESP_LOGW(TAG, "No valid state from humidity sensor!");
     }
-    ESP_LOGW(TAG, "Unable to calculate absolute humidity.");
     this->publish_state(NAN);
-    this->status_set_warning();
+    this->status_set_warning("Unable to calculate absolute humidity.");
     return;
   }
 
@@ -87,9 +86,8 @@ void AbsoluteHumidityComponent::loop() {
       es = es_wobus(temperature_c);
       break;
     default:
-      ESP_LOGE(TAG, "Invalid saturation vapor pressure equation selection!");
       this->publish_state(NAN);
-      this->status_set_error();
+      this->status_set_error("Invalid saturation vapor pressure equation selection!");
       return;
   }
   ESP_LOGD(TAG, "Saturation vapor pressure %f kPa", es);


### PR DESCRIPTION
# What does this implement/fix?

Fix a copy/paste error, use new code style when setting error/warning status

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp8266:
  board: d1_mini

i2c:

sensor:
  # BME280 Environment Sensor
  - platform: bme280_i2c
    temperature:
      name: Air Temperature
      id: air_temperature
    pressure:
      name: Air Pressure
      accuracy_decimals: 2
    humidity:
      name: Relative Humidity
      id: relative_humidity
    address: 0x76
    update_interval: 30s

  # Absolute Humidity
  - platform: absolute_humidity
    name: Absolute Humidity
    temperature: air_temperature
    humidity: relative_humidity
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
