### PR TITLE
[mcp4461] Fix reading level

### DIFF
--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -198,7 +198,7 @@ uint16_t Mcp4461Component::get_wiper_level_(Mcp4461WiperIdx wiper) {
 
 uint16_t Mcp4461Component::read_wiper_level_(uint8_t wiper_idx) {
   uint8_t addr = this->get_wiper_address_(wiper_idx);
-  uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::INCREMENT);
+  uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::READ);
   if (wiper_idx > 3) {
     if (!this->is_eeprom_ready_for_writing_(true)) {
       return 0;


### PR DESCRIPTION
Fix line 215 - change MCP4461Commands::INCREMENT to MCP4461Commands::READ

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>
Fix read wiper level. Minimal self explaining fix to use correct command (READ instead of INCREMENT)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
