### PR TITLE
[api] Fix string lifetime issue in fill_and_encode_entity_info for dynamic object_id

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -303,11 +303,13 @@ class APIConnection final : public APIServerConnection {
     msg.key = entity->get_object_id_hash();
     // Try to use static reference first to avoid allocation
     StringRef static_ref = entity->get_object_id_ref_for_api_();
+    // Store dynamic string outside the if-else to maintain lifetime
+    std::string object_id;
     if (!static_ref.empty()) {
       msg.set_object_id(static_ref);
     } else {
       // Dynamic case - need to allocate
-      std::string object_id = entity->get_object_id();
+      object_id = entity->get_object_id();
       msg.set_object_id(StringRef(object_id));
     }
 


### PR DESCRIPTION
No backport needed, only affects dev

# What does this implement/fix?

This PR fixes a string lifetime issue introduced in #10260 (commit 5a1533bea9c7b65862f191ef9b68cb81fe8ed801). 

The issue occurs in `fill_and_encode_entity_info()` when handling dynamic object IDs (when MAC suffix is enabled). The temporary `std::string object_id` was declared inside the else block, causing it to be destroyed when the block ended. However, the `StringRef` stored in the message continued to point to the now-freed memory, leading to use-after-free when `encode_message_to_buffer()` is called.

The fix moves the `std::string object_id` declaration outside the if-else block to ensure it remains in scope until after `encode_message_to_buffer()` completes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes regression from #10260

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API fix, no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This fix applies to all entities when MAC suffix is enabled
esphome:
  name_add_mac_suffix: true
  name: test-device

wifi:
  ssid: "test"
  password: "test123456"

api:

sensor:
  - platform: template
    name: "Test Sensor"
    lambda: return 42.0;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal API bugfix