### PR TITLE
2025.8.2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.8.1
+PROJECT_NUMBER         = 2025.8.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -132,14 +132,17 @@ def choose_upload_log_host(
                 ]
                 resolved.append(choose_prompt(options, purpose=purpose))
             elif device == "OTA":
-                if (show_ota and "ota" in CORE.config) or (
-                    show_api and "api" in CORE.config
+                if CORE.address and (
+                    (show_ota and "ota" in CORE.config)
+                    or (show_api and "api" in CORE.config)
                 ):
                     resolved.append(CORE.address)
                 elif show_mqtt and has_mqtt_logging():
                     resolved.append("MQTT")
             else:
                 resolved.append(device)
+        if not resolved:
+            _LOGGER.error("All specified devices: %s could not be resolved.", defaults)
         return resolved
 
     # No devices specified, show interactive chooser

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -41,7 +41,7 @@ void AXS15231Touchscreen::update_touches() {
   i2c::ErrorCode err;
   uint8_t data[8]{};
 
-  err = this->write(AXS_READ_TOUCHPAD, sizeof(AXS_READ_TOUCHPAD), false);
+  err = this->write(AXS_READ_TOUCHPAD, sizeof(AXS_READ_TOUCHPAD));
   ERROR_CHECK(err);
   err = this->read(data, sizeof(data));
   ERROR_CHECK(err);

--- a/esphome/components/bmi160/bmi160.cpp
+++ b/esphome/components/bmi160/bmi160.cpp
@@ -203,7 +203,7 @@ void BMI160Component::dump_config() {
 i2c::ErrorCode BMI160Component::read_le_int16_(uint8_t reg, int16_t *value, uint8_t len) {
   uint8_t raw_data[len * 2];
   // read using read_register because we have little-endian data, and read_bytes_16 will swap it
-  i2c::ErrorCode err = this->read_register(reg, raw_data, len * 2, true);
+  i2c::ErrorCode err = this->read_register(reg, raw_data, len * 2);
   if (err != i2c::ERROR_OK) {
     return err;
   }

--- a/esphome/components/bmp280_base/bmp280_base.h
+++ b/esphome/components/bmp280_base/bmp280_base.h
@@ -67,12 +67,12 @@ class BMP280Component : public PollingComponent {
   float get_setup_priority() const override;
   void update() override;
 
-  virtual bool read_byte(uint8_t a_register, uint8_t *data) = 0;
-  virtual bool write_byte(uint8_t a_register, uint8_t data) = 0;
-  virtual bool read_bytes(uint8_t a_register, uint8_t *data, size_t len) = 0;
-  virtual bool read_byte_16(uint8_t a_register, uint16_t *data) = 0;
-
  protected:
+  virtual bool bmp_read_byte(uint8_t a_register, uint8_t *data) = 0;
+  virtual bool bmp_write_byte(uint8_t a_register, uint8_t data) = 0;
+  virtual bool bmp_read_bytes(uint8_t a_register, uint8_t *data, size_t len) = 0;
+  virtual bool bmp_read_byte_16(uint8_t a_register, uint16_t *data) = 0;
+
   /// Read the temperature value and store the calculated ambient temperature in t_fine.
   float read_temperature_(int32_t *t_fine);
   /// Read the pressure value in hPa using the provided t_fine value.

--- a/esphome/components/bmp280_i2c/bmp280_i2c.cpp
+++ b/esphome/components/bmp280_i2c/bmp280_i2c.cpp
@@ -5,19 +5,6 @@
 namespace esphome {
 namespace bmp280_i2c {
 
-bool BMP280I2CComponent::read_byte(uint8_t a_register, uint8_t *data) {
-  return I2CDevice::read_byte(a_register, data);
-};
-bool BMP280I2CComponent::write_byte(uint8_t a_register, uint8_t data) {
-  return I2CDevice::write_byte(a_register, data);
-};
-bool BMP280I2CComponent::read_bytes(uint8_t a_register, uint8_t *data, size_t len) {
-  return I2CDevice::read_bytes(a_register, data, len);
-};
-bool BMP280I2CComponent::read_byte_16(uint8_t a_register, uint16_t *data) {
-  return I2CDevice::read_byte_16(a_register, data);
-};
-
 void BMP280I2CComponent::dump_config() {
   LOG_I2C_DEVICE(this);
   BMP280Component::dump_config();

--- a/esphome/components/bmp280_i2c/bmp280_i2c.h
+++ b/esphome/components/bmp280_i2c/bmp280_i2c.h
@@ -11,10 +11,12 @@ static const char *const TAG = "bmp280_i2c.sensor";
 /// This class implements support for the BMP280 Temperature+Pressure i2c sensor.
 class BMP280I2CComponent : public esphome::bmp280_base::BMP280Component, public i2c::I2CDevice {
  public:
-  bool read_byte(uint8_t a_register, uint8_t *data) override;
-  bool write_byte(uint8_t a_register, uint8_t data) override;
-  bool read_bytes(uint8_t a_register, uint8_t *data, size_t len) override;
-  bool read_byte_16(uint8_t a_register, uint16_t *data) override;
+  bool bmp_read_byte(uint8_t a_register, uint8_t *data) override { return read_byte(a_register, data); }
+  bool bmp_write_byte(uint8_t a_register, uint8_t data) override { return write_byte(a_register, data); }
+  bool bmp_read_bytes(uint8_t a_register, uint8_t *data, size_t len) override {
+    return read_bytes(a_register, data, len);
+  }
+  bool bmp_read_byte_16(uint8_t a_register, uint16_t *data) override { return read_byte_16(a_register, data); }
   void dump_config() override;
 };
 

--- a/esphome/components/bmp280_spi/bmp280_spi.cpp
+++ b/esphome/components/bmp280_spi/bmp280_spi.cpp
@@ -28,7 +28,7 @@ void BMP280SPIComponent::setup() {
 // 0x77 is transferred, for read access, the byte 0xF7 is transferred.
 // https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmp280-ds001.pdf
 
-bool BMP280SPIComponent::read_byte(uint8_t a_register, uint8_t *data) {
+bool BMP280SPIComponent::bmp_read_byte(uint8_t a_register, uint8_t *data) {
   this->enable();
   this->transfer_byte(set_bit(a_register, 7));
   *data = this->transfer_byte(0);
@@ -36,7 +36,7 @@ bool BMP280SPIComponent::read_byte(uint8_t a_register, uint8_t *data) {
   return true;
 }
 
-bool BMP280SPIComponent::write_byte(uint8_t a_register, uint8_t data) {
+bool BMP280SPIComponent::bmp_write_byte(uint8_t a_register, uint8_t data) {
   this->enable();
   this->transfer_byte(clear_bit(a_register, 7));
   this->transfer_byte(data);
@@ -44,7 +44,7 @@ bool BMP280SPIComponent::write_byte(uint8_t a_register, uint8_t data) {
   return true;
 }
 
-bool BMP280SPIComponent::read_bytes(uint8_t a_register, uint8_t *data, size_t len) {
+bool BMP280SPIComponent::bmp_read_bytes(uint8_t a_register, uint8_t *data, size_t len) {
   this->enable();
   this->transfer_byte(set_bit(a_register, 7));
   this->read_array(data, len);
@@ -52,7 +52,7 @@ bool BMP280SPIComponent::read_bytes(uint8_t a_register, uint8_t *data, size_t le
   return true;
 }
 
-bool BMP280SPIComponent::read_byte_16(uint8_t a_register, uint16_t *data) {
+bool BMP280SPIComponent::bmp_read_byte_16(uint8_t a_register, uint16_t *data) {
   this->enable();
   this->transfer_byte(set_bit(a_register, 7));
   ((uint8_t *) data)[1] = this->transfer_byte(0);

--- a/esphome/components/bmp280_spi/bmp280_spi.h
+++ b/esphome/components/bmp280_spi/bmp280_spi.h
@@ -10,10 +10,10 @@ class BMP280SPIComponent : public esphome::bmp280_base::BMP280Component,
                            public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                  spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_200KHZ> {
   void setup() override;
-  bool read_byte(uint8_t a_register, uint8_t *data) override;
-  bool write_byte(uint8_t a_register, uint8_t data) override;
-  bool read_bytes(uint8_t a_register, uint8_t *data, size_t len) override;
-  bool read_byte_16(uint8_t a_register, uint16_t *data) override;
+  bool bmp_read_byte(uint8_t a_register, uint8_t *data) override;
+  bool bmp_write_byte(uint8_t a_register, uint8_t data) override;
+  bool bmp_read_bytes(uint8_t a_register, uint8_t *data, size_t len) override;
+  bool bmp_read_byte_16(uint8_t a_register, uint16_t *data) override;
 };
 
 }  // namespace bmp280_spi

--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -91,7 +91,7 @@ bool CH422GComponent::read_inputs_() {
 
 // Write a register. Can't use the standard write_byte() method because there is no single pre-configured i2c address.
 bool CH422GComponent::write_reg_(uint8_t reg, uint8_t value) {
-  auto err = this->bus_->write(reg, &value, 1);
+  auto err = this->bus_->write_readv(reg, &value, 1, nullptr, 0);
   if (err != i2c::ERROR_OK) {
     this->status_set_warning(str_sprintf("write failed for register 0x%X, error %d", reg, err).c_str());
     return false;
@@ -102,7 +102,7 @@ bool CH422GComponent::write_reg_(uint8_t reg, uint8_t value) {
 
 uint8_t CH422GComponent::read_reg_(uint8_t reg) {
   uint8_t value;
-  auto err = this->bus_->read(reg, &value, 1);
+  auto err = this->bus_->write_readv(reg, nullptr, 0, &value, 1);
   if (err != i2c::ERROR_OK) {
     this->status_set_warning(str_sprintf("read failed for register 0x%X, error %d", reg, err).c_str());
     return 0;

--- a/esphome/components/ee895/ee895.cpp
+++ b/esphome/components/ee895/ee895.cpp
@@ -83,7 +83,7 @@ void EE895Component::write_command_(uint16_t addr, uint16_t reg_cnt) {
   crc16 = calc_crc16_(address, 6);
   address[5] = crc16 & 0xFF;
   address[6] = (crc16 >> 8) & 0xFF;
-  this->write(address, 7, true);
+  this->write(address, 7);
 }
 
 float EE895Component::read_float_() {

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -100,8 +100,8 @@ void ESPHomeOTAComponent::handle_handshake_() {
   /// Handle the initial OTA handshake.
   ///
   /// This method is non-blocking and will return immediately if no data is available.
-  /// It waits for the first magic byte (0x6C) before proceeding to handle_data_().
-  /// A 10-second timeout is enforced from initial connection.
+  /// It reads all 5 magic bytes (0x6C, 0x26, 0xF7, 0x5C, 0x45) non-blocking
+  /// before proceeding to handle_data_(). A 10-second timeout is enforced from initial connection.
 
   if (this->client_ == nullptr) {
     // We already checked server_->ready() in loop(), so we can accept directly
@@ -126,6 +126,7 @@ void ESPHomeOTAComponent::handle_handshake_() {
     }
     this->log_start_("handshake");
     this->client_connect_time_ = App.get_loop_component_start_time();
+    this->magic_buf_pos_ = 0;  // Reset magic buffer position
   }
 
   // Check for handshake timeout
@@ -136,34 +137,47 @@ void ESPHomeOTAComponent::handle_handshake_() {
     return;
   }
 
-  // Try to read first byte of magic bytes
-  uint8_t first_byte;
-  ssize_t read = this->client_->read(&first_byte, 1);
+  // Try to read remaining magic bytes
+  if (this->magic_buf_pos_ < 5) {
+    // Read as many bytes as available
+    uint8_t bytes_to_read = 5 - this->magic_buf_pos_;
+    ssize_t read = this->client_->read(this->magic_buf_ + this->magic_buf_pos_, bytes_to_read);
 
-  if (read == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-    return;  // No data yet, try again next loop
-  }
-
-  if (read <= 0) {
-    // Error or connection closed
-    if (read == -1) {
-      this->log_socket_error_("reading first byte");
-    } else {
-      ESP_LOGW(TAG, "Remote closed during handshake");
+    if (read == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+      return;  // No data yet, try again next loop
     }
-    this->cleanup_connection_();
-    return;
+
+    if (read <= 0) {
+      // Error or connection closed
+      if (read == -1) {
+        this->log_socket_error_("reading magic bytes");
+      } else {
+        ESP_LOGW(TAG, "Remote closed during handshake");
+      }
+      this->cleanup_connection_();
+      return;
+    }
+
+    this->magic_buf_pos_ += read;
   }
 
-  // Got first byte, check if it's the magic byte
-  if (first_byte != 0x6C) {
-    ESP_LOGW(TAG, "Invalid initial byte: 0x%02X", first_byte);
-    this->cleanup_connection_();
-    return;
-  }
+  // Check if we have all 5 magic bytes
+  if (this->magic_buf_pos_ == 5) {
+    // Validate magic bytes
+    static const uint8_t MAGIC_BYTES[5] = {0x6C, 0x26, 0xF7, 0x5C, 0x45};
+    if (memcmp(this->magic_buf_, MAGIC_BYTES, 5) != 0) {
+      ESP_LOGW(TAG, "Magic bytes mismatch! 0x%02X-0x%02X-0x%02X-0x%02X-0x%02X", this->magic_buf_[0],
+               this->magic_buf_[1], this->magic_buf_[2], this->magic_buf_[3], this->magic_buf_[4]);
+      // Send error response (non-blocking, best effort)
+      uint8_t error = static_cast<uint8_t>(ota::OTA_RESPONSE_ERROR_MAGIC);
+      this->client_->write(&error, 1);
+      this->cleanup_connection_();
+      return;
+    }
 
-  // First byte is valid, continue with data handling
-  this->handle_data_();
+    // All 5 magic bytes are valid, continue with data handling
+    this->handle_data_();
+  }
 }
 
 void ESPHomeOTAComponent::handle_data_() {
@@ -185,18 +199,6 @@ void ESPHomeOTAComponent::handle_data_() {
 #if USE_OTA_VERSION == 2
   size_t size_acknowledged = 0;
 #endif
-
-  // Read remaining 4 bytes of magic (we already read the first byte 0x6C in handle_handshake_)
-  if (!this->readall_(buf, 4)) {
-    this->log_read_error_("magic bytes");
-    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
-  }
-  // Check remaining magic bytes: 0x26, 0xF7, 0x5C, 0x45
-  if (buf[0] != 0x26 || buf[1] != 0xF7 || buf[2] != 0x5C || buf[3] != 0x45) {
-    ESP_LOGW(TAG, "Magic bytes mismatch! 0x6C-0x%02X-0x%02X-0x%02X-0x%02X", buf[0], buf[1], buf[2], buf[3]);
-    error_code = ota::OTA_RESPONSE_ERROR_MAGIC;
-    goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
-  }
 
   // Send OK and version - 2 bytes
   buf[0] = ota::OTA_RESPONSE_OK;
@@ -487,6 +489,7 @@ void ESPHomeOTAComponent::cleanup_connection_() {
   this->client_->close();
   this->client_ = nullptr;
   this->client_connect_time_ = 0;
+  this->magic_buf_pos_ = 0;
 }
 
 void ESPHomeOTAComponent::yield_and_feed_watchdog_() {

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -41,11 +41,13 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   std::string password_;
 #endif  // USE_OTA_PASSWORD
 
-  uint16_t port_;
-  uint32_t client_connect_time_{0};
-
   std::unique_ptr<socket::Socket> server_;
   std::unique_ptr<socket::Socket> client_;
+
+  uint32_t client_connect_time_{0};
+  uint16_t port_;
+  uint8_t magic_buf_[5];
+  uint8_t magic_buf_pos_{0};
 };
 
 }  // namespace esphome

--- a/esphome/components/hte501/hte501.cpp
+++ b/esphome/components/hte501/hte501.cpp
@@ -9,9 +9,8 @@ static const char *const TAG = "hte501";
 
 void HTE501Component::setup() {
   uint8_t address[] = {0x70, 0x29};
-  this->write(address, 2, false);
   uint8_t identification[9];
-  this->read(identification, 9);
+  this->write_read(address, sizeof address, identification, sizeof identification);
   if (identification[8] != calc_crc8_(identification, 0, 7)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->mark_failed();
@@ -42,7 +41,7 @@ void HTE501Component::dump_config() {
 float HTE501Component::get_setup_priority() const { return setup_priority::DATA; }
 void HTE501Component::update() {
   uint8_t address_1[] = {0x2C, 0x1B};
-  this->write(address_1, 2, true);
+  this->write(address_1, 2);
   this->set_timeout(50, [this]() {
     uint8_t i2c_response[6];
     this->read(i2c_response, 6);

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -2,7 +2,6 @@ import logging
 
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components import esp32
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
@@ -14,8 +13,6 @@ from esphome.const import (
     CONF_SCL,
     CONF_SDA,
     CONF_TIMEOUT,
-    KEY_CORE,
-    KEY_FRAMEWORK_VERSION,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RP2040,
@@ -48,28 +45,8 @@ def _bus_declare_type(value):
 
 
 def validate_config(config):
-    if (
-        config[CONF_SCAN]
-        and CORE.is_esp32
-        and CORE.using_esp_idf
-        and esp32.get_esp32_variant()
-        in [
-            esp32.const.VARIANT_ESP32C5,
-            esp32.const.VARIANT_ESP32C6,
-            esp32.const.VARIANT_ESP32P4,
-        ]
-    ):
-        version: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
-        if version.major == 5 and (
-            (version.minor == 3 and version.patch <= 3)
-            or (version.minor == 4 and version.patch <= 1)
-        ):
-            LOGGER.warning(
-                "There is a bug in esp-idf version %s that breaks I2C scan, I2C scan "
-                "has been disabled, see https://github.com/esphome/issues/issues/7128",
-                str(version),
-            )
-            config[CONF_SCAN] = False
+    if CORE.using_esp_idf:
+        return cv.require_framework_version(esp_idf=cv.Version(5, 4, 2))(config)
     return config
 
 

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -1,4 +1,6 @@
 #include "i2c.h"
+
+#include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 #include <memory>
 
@@ -7,38 +9,48 @@ namespace i2c {
 
 static const char *const TAG = "i2c";
 
-ErrorCode I2CDevice::read_register(uint8_t a_register, uint8_t *data, size_t len, bool stop) {
-  ErrorCode err = this->write(&a_register, 1, stop);
-  if (err != ERROR_OK)
-    return err;
-  return bus_->read(address_, data, len);
+void I2CBus::i2c_scan_() {
+  // suppress logs from the IDF I2C library during the scan
+#if defined(USE_ESP32) && defined(USE_LOGGER)
+  auto previous = esp_log_level_get("*");
+  esp_log_level_set("*", ESP_LOG_NONE);
+#endif
+
+  for (uint8_t address = 8; address != 120; address++) {
+    auto err = write_readv(address, nullptr, 0, nullptr, 0);
+    if (err == ERROR_OK) {
+      scan_results_.emplace_back(address, true);
+    } else if (err == ERROR_UNKNOWN) {
+      scan_results_.emplace_back(address, false);
+    }
+  }
+#if defined(USE_ESP32) && defined(USE_LOGGER)
+  esp_log_level_set("*", previous);
+#endif
 }
 
-ErrorCode I2CDevice::read_register16(uint16_t a_register, uint8_t *data, size_t len, bool stop) {
+ErrorCode I2CDevice::read_register(uint8_t a_register, uint8_t *data, size_t len) {
+  return bus_->write_readv(this->address_, &a_register, 1, data, len);
+}
+
+ErrorCode I2CDevice::read_register16(uint16_t a_register, uint8_t *data, size_t len) {
   a_register = convert_big_endian(a_register);
-  ErrorCode const err = this->write(reinterpret_cast<const uint8_t *>(&a_register), 2, stop);
-  if (err != ERROR_OK)
-    return err;
-  return bus_->read(address_, data, len);
+  return bus_->write_readv(this->address_, reinterpret_cast<const uint8_t *>(&a_register), 2, data, len);
 }
 
-ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, size_t len, bool stop) {
-  WriteBuffer buffers[2];
-  buffers[0].data = &a_register;
-  buffers[0].len = 1;
-  buffers[1].data = data;
-  buffers[1].len = len;
-  return bus_->writev(address_, buffers, 2, stop);
+ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, size_t len) const {
+  std::vector<uint8_t> v{};
+  v.push_back(a_register);
+  v.insert(v.end(), data, data + len);
+  return bus_->write_readv(this->address_, v.data(), v.size(), nullptr, 0);
 }
 
-ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len, bool stop) {
-  a_register = convert_big_endian(a_register);
-  WriteBuffer buffers[2];
-  buffers[0].data = reinterpret_cast<const uint8_t *>(&a_register);
-  buffers[0].len = 2;
-  buffers[1].data = data;
-  buffers[1].len = len;
-  return bus_->writev(address_, buffers, 2, stop);
+ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
+  std::vector<uint8_t> v(len + 2);
+  v.push_back(a_register >> 8);
+  v.push_back(a_register);
+  v.insert(v.end(), data, data + len);
+  return bus_->write_readv(this->address_, v.data(), v.size(), nullptr, 0);
 }
 
 bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len) {
@@ -49,7 +61,7 @@ bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len) {
   return true;
 }
 
-bool I2CDevice::write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len) {
+bool I2CDevice::write_bytes_16(uint8_t a_register, const uint16_t *data, uint8_t len) const {
   // we have to copy in order to be able to change byte order
   std::unique_ptr<uint16_t[]> temp{new uint16_t[len]};
   for (size_t i = 0; i < len; i++)

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -19,8 +19,8 @@ class ArduinoI2CBus : public InternalI2CBus, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
+  ErrorCode write_readv(uint8_t address, const uint8_t *write_buffer, size_t write_count, uint8_t *read_buffer,
+                        size_t read_count) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
   void set_scan(bool scan) { scan_ = scan; }

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -2,14 +2,9 @@
 
 #ifdef USE_ESP_IDF
 
-#include "esp_idf_version.h"
 #include "esphome/core/component.h"
 #include "i2c_bus.h"
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
 #include <driver/i2c_master.h>
-#else
-#include <driver/i2c.h>
-#endif
 
 namespace esphome {
 namespace i2c {
@@ -24,36 +19,33 @@ class IDFI2CBus : public InternalI2CBus, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  ErrorCode readv(uint8_t address, ReadBuffer *buffers, size_t cnt) override;
-  ErrorCode writev(uint8_t address, WriteBuffer *buffers, size_t cnt, bool stop) override;
+  ErrorCode write_readv(uint8_t address, const uint8_t *write_buffer, size_t write_count, uint8_t *read_buffer,
+                        size_t read_count) override;
   float get_setup_priority() const override { return setup_priority::BUS; }
 
-  void set_scan(bool scan) { scan_ = scan; }
-  void set_sda_pin(uint8_t sda_pin) { sda_pin_ = sda_pin; }
-  void set_sda_pullup_enabled(bool sda_pullup_enabled) { sda_pullup_enabled_ = sda_pullup_enabled; }
-  void set_scl_pin(uint8_t scl_pin) { scl_pin_ = scl_pin; }
-  void set_scl_pullup_enabled(bool scl_pullup_enabled) { scl_pullup_enabled_ = scl_pullup_enabled; }
-  void set_frequency(uint32_t frequency) { frequency_ = frequency; }
-  void set_timeout(uint32_t timeout) { timeout_ = timeout; }
+  void set_scan(bool scan) { this->scan_ = scan; }
+  void set_sda_pin(uint8_t sda_pin) { this->sda_pin_ = sda_pin; }
+  void set_sda_pullup_enabled(bool sda_pullup_enabled) { this->sda_pullup_enabled_ = sda_pullup_enabled; }
+  void set_scl_pin(uint8_t scl_pin) { this->scl_pin_ = scl_pin; }
+  void set_scl_pullup_enabled(bool scl_pullup_enabled) { this->scl_pullup_enabled_ = scl_pullup_enabled; }
+  void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
+  void set_timeout(uint32_t timeout) { this->timeout_ = timeout; }
 
-  int get_port() const override { return static_cast<int>(this->port_); }
+  int get_port() const override { return this->port_; }
 
  private:
   void recover_();
-  RecoveryCode recovery_result_;
+  RecoveryCode recovery_result_{};
 
  protected:
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 2)
-  i2c_master_dev_handle_t dev_;
-  i2c_master_bus_handle_t bus_;
-  void i2c_scan() override;
-#endif
-  i2c_port_t port_;
-  uint8_t sda_pin_;
-  bool sda_pullup_enabled_;
-  uint8_t scl_pin_;
-  bool scl_pullup_enabled_;
-  uint32_t frequency_;
+  i2c_master_dev_handle_t dev_{};
+  i2c_master_bus_handle_t bus_{};
+  i2c_port_t port_{};
+  uint8_t sda_pin_{};
+  bool sda_pullup_enabled_{};
+  uint8_t scl_pin_{};
+  bool scl_pullup_enabled_{};
+  uint32_t frequency_{};
   uint32_t timeout_ = 0;
   bool initialized_ = false;
 };

--- a/esphome/components/iaqcore/iaqcore.cpp
+++ b/esphome/components/iaqcore/iaqcore.cpp
@@ -35,7 +35,7 @@ void IAQCore::setup() {
 void IAQCore::update() {
   uint8_t buffer[sizeof(SensorData)];
 
-  if (this->read_register(0xB5, buffer, sizeof(buffer), false) != i2c::ERROR_OK) {
+  if (this->read_register(0xB5, buffer, sizeof(buffer)) != i2c::ERROR_OK) {
     ESP_LOGD(TAG, "Read failed");
     this->status_set_warning();
     this->publish_nans_();

--- a/esphome/components/ina2xx_i2c/ina2xx_i2c.cpp
+++ b/esphome/components/ina2xx_i2c/ina2xx_i2c.cpp
@@ -21,7 +21,7 @@ void INA2XXI2C::dump_config() {
 }
 
 bool INA2XXI2C::read_ina_register(uint8_t reg, uint8_t *data, size_t len) {
-  auto ret = this->read_register(reg, data, len, false);
+  auto ret = this->read_register(reg, data, len);
   if (ret != i2c::ERROR_OK) {
     ESP_LOGE(TAG, "read_ina_register_ failed. Reg=0x%02X Err=%d", reg, ret);
   }

--- a/esphome/components/kmeteriso/kmeteriso.cpp
+++ b/esphome/components/kmeteriso/kmeteriso.cpp
@@ -22,7 +22,7 @@ void KMeterISOComponent::setup() {
     this->reset_to_construction_state();
   }
 
-  auto err = this->bus_->writev(this->address_, nullptr, 0);
+  auto err = this->bus_->write_readv(this->address_, nullptr, 0, nullptr, 0);
   if (err == esphome::i2c::ERROR_OK) {
     ESP_LOGCONFIG(TAG, "Could write to the address %d.", this->address_);
   } else {
@@ -33,7 +33,7 @@ void KMeterISOComponent::setup() {
   }
 
   uint8_t read_buf[4] = {1};
-  if (!this->read_bytes(KMETER_ERROR_STATUS_REG, read_buf, 1)) {
+  if (!this->read_register(KMETER_ERROR_STATUS_REG, read_buf, 1)) {
     ESP_LOGCONFIG(TAG, "Could not read from the device.");
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -184,7 +184,7 @@ uint8_t Lc709203f::get_register_(uint8_t register_to_read, uint16_t *register_va
     //  function will send a stop between the read and the write portion of the I2C
     //  transaction. This is bad in this case and will result in reading nothing but 0xFFFF
     //  from the registers.
-    return_code = this->read_register(register_to_read, &read_buffer[3], 3, false);
+    return_code = this->read_register(register_to_read, &read_buffer[3], 3);
     if (return_code != i2c::NO_ERROR) {
       // Error on the i2c bus
       this->status_set_warning(
@@ -225,7 +225,7 @@ uint8_t Lc709203f::set_register_(uint8_t register_to_set, uint16_t value_to_set)
   for (uint8_t i = 0; i <= LC709203F_I2C_RETRY_COUNT; i++) {
     // Note: we don't write the first byte of the write buffer to the device.
     //  This is done automatically by the write() function.
-    return_code = this->write(&write_buffer[1], 4, true);
+    return_code = this->write(&write_buffer[1], 4);
     if (return_code == i2c::NO_ERROR) {
       return return_code;
     } else {

--- a/esphome/components/mcp4461/mcp4461.cpp
+++ b/esphome/components/mcp4461/mcp4461.cpp
@@ -328,7 +328,7 @@ bool Mcp4461Component::increase_wiper_(Mcp4461WiperIdx wiper) {
   ESP_LOGV(TAG, "Increasing wiper %u", wiper_idx);
   uint8_t addr = this->get_wiper_address_(wiper_idx);
   uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::INCREMENT);
-  auto err = this->write(&this->address_, reg, sizeof(reg));
+  auto err = this->write(&this->address_, reg);
   if (err != i2c::ERROR_OK) {
     this->error_code_ = MCP4461_STATUS_I2C_ERROR;
     this->status_set_warning();
@@ -359,7 +359,7 @@ bool Mcp4461Component::decrease_wiper_(Mcp4461WiperIdx wiper) {
   ESP_LOGV(TAG, "Decreasing wiper %u", wiper_idx);
   uint8_t addr = this->get_wiper_address_(wiper_idx);
   uint8_t reg = addr | static_cast<uint8_t>(Mcp4461Commands::DECREMENT);
-  auto err = this->write(&this->address_, reg, sizeof(reg));
+  auto err = this->write(&this->address_, reg);
   if (err != i2c::ERROR_OK) {
     this->error_code_ = MCP4461_STATUS_I2C_ERROR;
     this->status_set_warning();

--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -309,8 +309,12 @@ class DriverChip:
                 CONF_NATIVE_HEIGHT, height + offset_height * 2
             )
             offset_height = native_height - height - offset_height
-        # Swap default dimensions if swap_xy is set
-        if transform[CONF_SWAP_XY] is True:
+        # Swap default dimensions if swap_xy is set, or if rotation is 90/270 and we are not using a buffer
+        rotated = not requires_buffer(config) and config.get(CONF_ROTATION, 0) in (
+            90,
+            270,
+        )
+        if transform[CONF_SWAP_XY] is True or rotated:
             width, height = height, width
             offset_height, offset_width = offset_width, offset_height
         return width, height, offset_width, offset_height

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -90,18 +90,18 @@ float MLX90614Component::get_setup_priority() const { return setup_priority::DAT
 
 void MLX90614Component::update() {
   uint8_t emissivity[3];
-  if (this->read_register(MLX90614_EMISSIVITY, emissivity, 3, false) != i2c::ERROR_OK) {
+  if (this->read_register(MLX90614_EMISSIVITY, emissivity, 3) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
   uint8_t raw_object[3];
-  if (this->read_register(MLX90614_TEMPERATURE_OBJECT_1, raw_object, 3, false) != i2c::ERROR_OK) {
+  if (this->read_register(MLX90614_TEMPERATURE_OBJECT_1, raw_object, 3) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
 
   uint8_t raw_ambient[3];
-  if (this->read_register(MLX90614_TEMPERATURE_AMBIENT, raw_ambient, 3, false) != i2c::ERROR_OK) {
+  if (this->read_register(MLX90614_TEMPERATURE_AMBIENT, raw_ambient, 3) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }

--- a/esphome/components/mpl3115a2/mpl3115a2.cpp
+++ b/esphome/components/mpl3115a2/mpl3115a2.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "mpl3115a2";
 
 void MPL3115A2Component::setup() {
   uint8_t whoami = 0xFF;
-  if (!this->read_byte(MPL3115A2_WHOAMI, &whoami, false)) {
+  if (!this->read_byte(MPL3115A2_WHOAMI, &whoami)) {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;
@@ -54,24 +54,24 @@ void MPL3115A2Component::dump_config() {
 
 void MPL3115A2Component::update() {
   uint8_t mode = MPL3115A2_CTRL_REG1_OS128;
-  this->write_byte(MPL3115A2_CTRL_REG1, mode, true);
+  this->write_byte(MPL3115A2_CTRL_REG1, mode);
   // Trigger a new reading
   mode |= MPL3115A2_CTRL_REG1_OST;
   if (this->altitude_ != nullptr)
     mode |= MPL3115A2_CTRL_REG1_ALT;
-  this->write_byte(MPL3115A2_CTRL_REG1, mode, true);
+  this->write_byte(MPL3115A2_CTRL_REG1, mode);
 
   // Wait until status shows reading available
   uint8_t status = 0;
-  if (!this->read_byte(MPL3115A2_REGISTER_STATUS, &status, false) || (status & MPL3115A2_REGISTER_STATUS_PDR) == 0) {
+  if (!this->read_byte(MPL3115A2_REGISTER_STATUS, &status) || (status & MPL3115A2_REGISTER_STATUS_PDR) == 0) {
     delay(10);
-    if (!this->read_byte(MPL3115A2_REGISTER_STATUS, &status, false) || (status & MPL3115A2_REGISTER_STATUS_PDR) == 0) {
+    if (!this->read_byte(MPL3115A2_REGISTER_STATUS, &status) || (status & MPL3115A2_REGISTER_STATUS_PDR) == 0) {
       return;
     }
   }
 
   uint8_t buffer[5] = {0, 0, 0, 0, 0};
-  this->read_register(MPL3115A2_REGISTER_PRESSURE_MSB, buffer, 5, false);
+  this->read_register(MPL3115A2_REGISTER_PRESSURE_MSB, buffer, 5);
 
   float altitude = 0, pressure = 0;
   if (this->altitude_ != nullptr) {

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -33,7 +33,7 @@ float NPI19Component::get_setup_priority() const { return setup_priority::DATA; 
 
 i2c::ErrorCode NPI19Component::read_(uint16_t &raw_temperature, uint16_t &raw_pressure) {
   // initiate data read from device
-  i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND), true);
+  i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND));
   if (w_err != i2c::ERROR_OK) {
     return w_err;
   }

--- a/esphome/components/opt3001/opt3001.cpp
+++ b/esphome/components/opt3001/opt3001.cpp
@@ -72,7 +72,7 @@ void OPT3001Sensor::read_lx_(const std::function<void(float)> &f) {
   }
 
   this->set_timeout("read", OPT3001_CONVERSION_TIME_800, [this, f]() {
-    if (this->write(&OPT3001_REG_CONFIGURATION, 1, true) != i2c::ERROR_OK) {
+    if (this->write(&OPT3001_REG_CONFIGURATION, 1) != i2c::ERROR_OK) {
       ESP_LOGW(TAG, "Starting configuration register read failed");
       f(NAN);
       return;

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -33,7 +33,7 @@ void PCA6416AComponent::setup() {
   }
 
   // Test to see if the device supports pull-up resistors
-  if (this->read_register(PCAL6416A_PULL_EN0, &value, 1, true) == i2c::ERROR_OK) {
+  if (this->read_register(PCAL6416A_PULL_EN0, &value, 1) == i2c::ERROR_OK) {
     this->has_pullup_ = true;
   }
 
@@ -105,7 +105,7 @@ bool PCA6416AComponent::read_register_(uint8_t reg, uint8_t *value) {
     return false;
   }
 
-  this->last_error_ = this->read_register(reg, value, 1, true);
+  this->last_error_ = this->read_register(reg, value, 1);
   if (this->last_error_ != i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
@@ -122,7 +122,7 @@ bool PCA6416AComponent::write_register_(uint8_t reg, uint8_t value) {
     return false;
   }
 
-  this->last_error_ = this->write_register(reg, &value, 1, true);
+  this->last_error_ = this->write_register(reg, &value, 1);
   if (this->last_error_ != i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error_);

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -96,7 +96,7 @@ bool PCA9554Component::read_inputs_() {
     return false;
   }
 
-  this->last_error_ = this->read_register(INPUT_REG * this->reg_width_, inputs, this->reg_width_, true);
+  this->last_error_ = this->read_register(INPUT_REG * this->reg_width_, inputs, this->reg_width_);
   if (this->last_error_ != i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "read_register_(): I2C I/O error: %d", (int) this->last_error_);
@@ -114,7 +114,7 @@ bool PCA9554Component::write_register_(uint8_t reg, uint16_t value) {
   uint8_t outputs[2];
   outputs[0] = (uint8_t) value;
   outputs[1] = (uint8_t) (value >> 8);
-  this->last_error_ = this->write_register(reg * this->reg_width_, outputs, this->reg_width_, true);
+  this->last_error_ = this->write_register(reg * this->reg_width_, outputs, this->reg_width_);
   if (this->last_error_ != i2c::ERROR_OK) {
     this->status_set_warning();
     ESP_LOGE(TAG, "write_register_(): I2C I/O error: %d", (int) this->last_error_);

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -60,35 +60,60 @@ class Rtttl : public Component {
     }
     return ret;
   }
+  /**
+   * @brief Finalizes the playback of the RTTTL string.
+   *
+   * This method is called internally when the end of the RTTTL string is reached
+   * or when a parsing error occurs. It stops the output, sets the component state,
+   * and triggers the on_finished_playback_callback_.
+   */
   void finish_();
   void set_state_(State state);
 
+  /// The RTTTL string to play.
   std::string rtttl_{""};
+  /// The current position in the RTTTL string.
   size_t position_{0};
+  /// The duration of a whole note in milliseconds.
   uint16_t wholenote_;
+  /// The default duration of a note (e.g. 4 for a quarter note).
   uint16_t default_duration_;
+  /// The default octave for a note.
   uint16_t default_octave_;
+  /// The time the last note was started.
   uint32_t last_note_;
+  /// The duration of the current note in milliseconds.
   uint16_t note_duration_;
 
+  /// The frequency of the current note in Hz.
   uint32_t output_freq_;
+  /// The gain of the output.
   float gain_{0.6f};
+  /// The current state of the RTTTL player.
   State state_{State::STATE_STOPPED};
 
 #ifdef USE_OUTPUT
+  /// The output to write the sound to.
   output::FloatOutput *output_;
 #endif
 
 #ifdef USE_SPEAKER
+  /// The speaker to write the sound to.
   speaker::Speaker *speaker_{nullptr};
+  /// The sample rate of the speaker.
   int sample_rate_{16000};
+  /// The number of samples for one full cycle of a note's waveform, in Q10 fixed-point format.
   int samples_per_wave_{0};
+  /// The number of samples sent.
   int samples_sent_{0};
+  /// The total number of samples to send.
   int samples_count_{0};
+  /// The number of samples for the gap between notes.
   int samples_gap_{0};
 
 #endif
 
+  /// The callback to call when playback is finished.
   CallbackManager<void()> on_finished_playback_callback_;
 };
 

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -51,8 +51,7 @@ void HOT I2CST7567::write_display_data() {
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           this->get_width_internal() - x > BLOCK_SIZE ? BLOCK_SIZE : this->get_width_internal() - x,
-                           true);
+                           this->get_width_internal() - x > BLOCK_SIZE ? BLOCK_SIZE : this->get_width_internal() - x);
     }
   }
 }

--- a/esphome/components/tca9548a/tca9548a.cpp
+++ b/esphome/components/tca9548a/tca9548a.cpp
@@ -6,23 +6,15 @@ namespace tca9548a {
 
 static const char *const TAG = "tca9548a";
 
-i2c::ErrorCode TCA9548AChannel::readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) {
+i2c::ErrorCode TCA9548AChannel::write_readv(uint8_t address, const uint8_t *write_buffer, size_t write_count,
+                                            uint8_t *read_buffer, size_t read_count) {
   auto err = this->parent_->switch_to_channel(channel_);
   if (err != i2c::ERROR_OK)
     return err;
-  err = this->parent_->bus_->readv(address, buffers, cnt);
+  err = this->parent_->bus_->write_readv(address, write_buffer, write_count, read_buffer, read_count);
   this->parent_->disable_all_channels();
   return err;
 }
-i2c::ErrorCode TCA9548AChannel::writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) {
-  auto err = this->parent_->switch_to_channel(channel_);
-  if (err != i2c::ERROR_OK)
-    return err;
-  err = this->parent_->bus_->writev(address, buffers, cnt, stop);
-  this->parent_->disable_all_channels();
-  return err;
-}
-
 void TCA9548AComponent::setup() {
   uint8_t status = 0;
   if (this->read(&status, 1) != i2c::ERROR_OK) {

--- a/esphome/components/tca9548a/tca9548a.h
+++ b/esphome/components/tca9548a/tca9548a.h
@@ -14,8 +14,8 @@ class TCA9548AChannel : public i2c::I2CBus {
   void set_channel(uint8_t channel) { channel_ = channel; }
   void set_parent(TCA9548AComponent *parent) { parent_ = parent; }
 
-  i2c::ErrorCode readv(uint8_t address, i2c::ReadBuffer *buffers, size_t cnt) override;
-  i2c::ErrorCode writev(uint8_t address, i2c::WriteBuffer *buffers, size_t cnt, bool stop) override;
+  i2c::ErrorCode write_readv(uint8_t address, const uint8_t *write_buffer, size_t write_count, uint8_t *read_buffer,
+                             size_t read_count) override;
 
  protected:
   uint8_t channel_;

--- a/esphome/components/tee501/tee501.cpp
+++ b/esphome/components/tee501/tee501.cpp
@@ -9,9 +9,9 @@ static const char *const TAG = "tee501";
 
 void TEE501Component::setup() {
   uint8_t address[] = {0x70, 0x29};
-  this->write(address, 2, false);
   uint8_t identification[9];
   this->read(identification, 9);
+  this->write_read(address, sizeof address, identification, sizeof identification);
   if (identification[8] != calc_crc8_(identification, 0, 7)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->mark_failed();
@@ -41,7 +41,7 @@ void TEE501Component::dump_config() {
 float TEE501Component::get_setup_priority() const { return setup_priority::DATA; }
 void TEE501Component::update() {
   uint8_t address_1[] = {0x2C, 0x1B};
-  this->write(address_1, 2, true);
+  this->write(address_1, 2);
   this->set_timeout(50, [this]() {
     uint8_t i2c_response[3];
     this->read(i2c_response, 3);

--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -74,7 +74,8 @@ void TLC59208FOutput::setup() {
   ESP_LOGV(TAG, "  Resetting all devices on the bus");
 
   // Reset all devices on the bus
-  if (this->bus_->write(TLC59208F_SWRST_ADDR >> 1, TLC59208F_SWRST_SEQ, 2) != i2c::ERROR_OK) {
+  if (this->bus_->write_readv(TLC59208F_SWRST_ADDR >> 1, TLC59208F_SWRST_SEQ, sizeof TLC59208F_SWRST_SEQ, nullptr, 0) !=
+      i2c::ERROR_OK) {
     ESP_LOGE(TAG, "RESET failed");
     this->mark_failed();
     return;

--- a/esphome/components/veml3235/veml3235.cpp
+++ b/esphome/components/veml3235/veml3235.cpp
@@ -14,14 +14,12 @@ void VEML3235Sensor::setup() {
     this->mark_failed();
     return;
   }
-  if ((this->write(&ID_REG, 1, false) != i2c::ERROR_OK) || !this->read_bytes_raw(device_id, 2)) {
+  if ((this->read_register(ID_REG, device_id, sizeof device_id) != i2c::ERROR_OK)) {
     ESP_LOGE(TAG, "Unable to read ID");
     this->mark_failed();
-    return;
   } else if (device_id[0] != DEVICE_ID) {
     ESP_LOGE(TAG, "Incorrect device ID - expected 0x%.2x, read 0x%.2x", DEVICE_ID, device_id[0]);
     this->mark_failed();
-    return;
   }
 }
 
@@ -49,7 +47,7 @@ float VEML3235Sensor::read_lx_() {
   }
 
   uint8_t als_regs[] = {0, 0};
-  if ((this->write(&ALS_REG, 1, false) != i2c::ERROR_OK) || !this->read_bytes_raw(als_regs, 2)) {
+  if ((this->read_register(ALS_REG, als_regs, sizeof als_regs) != i2c::ERROR_OK)) {
     this->status_set_warning();
     return NAN;
   }

--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -279,20 +279,18 @@ ErrorCode VEML7700Component::reconfigure_time_and_gain_(IntegrationTime time, Ga
 }
 
 ErrorCode VEML7700Component::read_sensor_output_(Readings &data) {
-  auto als_err =
-      this->read_register((uint8_t) CommandRegisters::ALS, (uint8_t *) &data.als_counts, VEML_REG_SIZE, false);
+  auto als_err = this->read_register((uint8_t) CommandRegisters::ALS, (uint8_t *) &data.als_counts, VEML_REG_SIZE);
   if (als_err != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "Error reading ALS register, err = %d", als_err);
   }
   auto white_err =
-      this->read_register((uint8_t) CommandRegisters::WHITE, (uint8_t *) &data.white_counts, VEML_REG_SIZE, false);
+      this->read_register((uint8_t) CommandRegisters::WHITE, (uint8_t *) &data.white_counts, VEML_REG_SIZE);
   if (white_err != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "Error reading WHITE register, err = %d", white_err);
   }
 
   ConfigurationRegister conf{0};
-  auto err =
-      this->read_register((uint8_t) CommandRegisters::ALS_CONF_0, (uint8_t *) conf.raw_bytes, VEML_REG_SIZE, false);
+  auto err = this->read_register((uint8_t) CommandRegisters::ALS_CONF_0, (uint8_t *) conf.raw_bytes, VEML_REG_SIZE);
   if (err != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "Error reading ALS_CONF_0 register, err = %d", white_err);
   }

--- a/esphome/components/veml7700/veml7700.h
+++ b/esphome/components/veml7700/veml7700.h
@@ -3,7 +3,6 @@
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
-#include "esphome/core/optional.h"
 
 namespace esphome {
 namespace veml7700 {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -151,6 +151,8 @@ void WiFiComponent::loop() {
         this->status_set_warning("waiting to reconnect");
         if (millis() - this->action_started_ > 5000) {
           if (this->fast_connect_ || this->retry_hidden_) {
+            if (!this->selected_ap_.get_bssid().has_value())
+              this->selected_ap_ = this->sta_[0];
             this->start_connecting(this->selected_ap_, false);
           } else {
             this->start_scanning();
@@ -670,10 +672,12 @@ void WiFiComponent::check_connecting_finished() {
       return;
     }
 
+    ESP_LOGI(TAG, "Connected");
     // We won't retry hidden networks unless a reconnect fails more than three times again
+    if (this->retry_hidden_ && !this->selected_ap_.get_hidden())
+      ESP_LOGW(TAG, "Network '%s' should be marked as hidden", this->selected_ap_.get_ssid().c_str());
     this->retry_hidden_ = false;
 
-    ESP_LOGI(TAG, "Connected");
     this->print_connect_params_();
 
     if (this->has_ap()) {

--- a/esphome/components/wifi/wifi_component_esp32_arduino.cpp
+++ b/esphome/components/wifi/wifi_component_esp32_arduino.cpp
@@ -547,8 +547,6 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     }
     case ESPHOME_EVENT_ID_WIFI_STA_STOP: {
       ESP_LOGV(TAG, "STA stop");
-      // Clear the STA interface handle to prevent use-after-free
-      s_sta_netif = nullptr;
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {
@@ -638,10 +636,6 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STOP: {
       ESP_LOGV(TAG, "AP stop");
-#ifdef USE_WIFI_AP
-      // Clear the AP interface handle to prevent use-after-free
-      s_ap_netif = nullptr;
-#endif
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_AP_STACONNECTED: {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -697,8 +697,6 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_STOP) {
     ESP_LOGV(TAG, "STA stop");
     s_sta_started = false;
-    // Clear the STA interface handle to prevent use-after-free
-    s_sta_netif = nullptr;
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_AUTHMODE_CHANGE) {
     const auto &it = data->data.sta_authmode_change;
@@ -797,10 +795,6 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_STOP) {
     ESP_LOGV(TAG, "AP stop");
     s_ap_started = false;
-#ifdef USE_WIFI_AP
-    // Clear the AP interface handle to prevent use-after-free
-    s_ap_netif = nullptr;
-#endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_PROBEREQRECVED) {
     const auto &it = data->data.ap_probe_req_rx;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.8.1"
+__version__ = "2025.8.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [wifi] Fix reconnection failures after adapter restart by not clearing netif pointers [esphome#10458](https://github.com/esphome/esphome/pull/10458)
- [mipi_spi] Fix dimensions [esphome#10443](https://github.com/esphome/esphome/pull/10443)
- [i2c] Perform register reads as single transactions [esphome#10389](https://github.com/esphome/esphome/pull/10389)
- [wifi] Fix retry with hidden networks. [esphome#10445](https://github.com/esphome/esphome/pull/10445)
- Fix AttributeError when uploading OTA to offline OpenThread devices [esphome#10459](https://github.com/esphome/esphome/pull/10459)
- [rtttl] Fix RTTTL for speakers [esphome#10381](https://github.com/esphome/esphome/pull/10381)
- [esphome] Fix OTA watchdog resets by validating all magic bytes before blocking [esphome#10401](https://github.com/esphome/esphome/pull/10401)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
