### PR TITLE
[bluetooth_proxy] Expose configured scanning mode in API responses

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1712,6 +1712,7 @@ message BluetoothScannerStateResponse {
 
   BluetoothScannerState state = 1;
   BluetoothScannerMode mode = 2;
+  BluetoothScannerMode configured_mode = 3;
 }
 
 message BluetoothScannerSetModeRequest {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2153,10 +2153,12 @@ void BluetoothDeviceClearCacheResponse::calculate_size(ProtoSize &size) const {
 void BluetoothScannerStateResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->state));
   buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
+  buffer.encode_uint32(3, static_cast<uint32_t>(this->configured_mode));
 }
 void BluetoothScannerStateResponse::calculate_size(ProtoSize &size) const {
   size.add_uint32(1, static_cast<uint32_t>(this->state));
   size.add_uint32(1, static_cast<uint32_t>(this->mode));
+  size.add_uint32(1, static_cast<uint32_t>(this->configured_mode));
 }
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
   switch (field_id) {

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2214,12 +2214,13 @@ class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
 class BluetoothScannerStateResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 126;
-  static constexpr uint8_t ESTIMATED_SIZE = 4;
+  static constexpr uint8_t ESTIMATED_SIZE = 6;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "bluetooth_scanner_state_response"; }
 #endif
   enums::BluetoothScannerState state{};
   enums::BluetoothScannerMode mode{};
+  enums::BluetoothScannerMode configured_mode{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1704,6 +1704,7 @@ void BluetoothScannerStateResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerStateResponse");
   dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
+  dump_field(out, "configured_mode", static_cast<enums::BluetoothScannerMode>(this->configured_mode));
 }
 void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerSetModeRequest");

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -24,6 +24,9 @@ void BluetoothProxy::setup() {
   this->connections_free_response_.limit = BLUETOOTH_PROXY_MAX_CONNECTIONS;
   this->connections_free_response_.free = BLUETOOTH_PROXY_MAX_CONNECTIONS;
 
+  // Capture the configured scan mode from YAML before any API changes
+  this->configured_scan_active_ = this->parent_->get_scan_active();
+
   this->parent_->add_scanner_state_callback([this](esp32_ble_tracker::ScannerState state) {
     if (this->api_connection_ != nullptr) {
       this->send_bluetooth_scanner_state_(state);
@@ -36,6 +39,9 @@ void BluetoothProxy::send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerSta
   resp.state = static_cast<api::enums::BluetoothScannerState>(state);
   resp.mode = this->parent_->get_scan_active() ? api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_ACTIVE
                                                : api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_PASSIVE;
+  resp.configured_mode = this->configured_scan_active_
+                             ? api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_ACTIVE
+                             : api::enums::BluetoothScannerMode::BLUETOOTH_SCANNER_MODE_PASSIVE;
   this->api_connection_->send_message(resp, api::BluetoothScannerStateResponse::MESSAGE_TYPE);
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -161,7 +161,8 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
   // Group 4: 1-byte types grouped together
   bool active_;
   uint8_t connection_count_{0};
-  // 2 bytes used, 2 bytes padding
+  bool configured_scan_active_{false};  // Configured scan mode from YAML
+  // 3 bytes used, 1 byte padding
 };
 
 extern BluetoothProxy *global_bluetooth_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the ability for API clients to determine the originally configured (YAML) BLE scanning mode, allowing them to restore the default scanning mode after temporarily changing it.

**Problem:**
When an API client uses `bluetooth_scanner_set_mode` to temporarily change the BLE scanning mode (e.g., switching to active scanning for better device discovery), there's no way to know what the original configured mode was to restore it afterwards. The API only reports the current scanning mode, not the default configured in YAML.

Critically, if the API client (like Home Assistant) restarts after changing the scanning mode, it has no way to determine whether the current mode is the configured default or a temporary change that should be reverted. This can leave the device in an unintended scanning mode permanently.

**Solution:**
- Added a `configured_mode` field to `BluetoothScannerStateResponse` protobuf message
- Store the configured scanning mode from YAML during `BluetoothProxy` setup (before any API modifications)
- Report both the current mode and configured mode in scanner state responses

**Design Rationale:**
The `configured_mode` field was added directly to `BluetoothScannerStateResponse` rather than creating a separate message or adding it to `DeviceInfoResponse` because:
- **Stateless recovery**: API clients can always determine the configured mode even after restarts, preventing permanent unintended mode changes
- **Minimal overhead**: The extra enum field is negligible compared to message framing overhead
- **No new protobuf message ID**: Reuses the existing scanner state response message
- **Always available**: API clients always have both current and configured modes without needing separate queries
- **Logical placement**: The configured mode is scanner-related information that belongs with scanner state
- **Preserves DeviceInfo field numbers**: Avoids consuming limited field number space in the DeviceInfo message
- **Efficient**: Avoids the much higher cost of separate message exchanges

This allows API clients to:
1. Query the current scanner state and see both active and configured modes
2. Temporarily change the scanning mode for specific operations
3. Restore the original configured mode when done

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves Bluetooth proxy API control capabilities

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required (API-only change, backwards compatible)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an API enhancement
esp32_ble_tracker:
  scan_parameters:
    active: false  # This configured value is now exposed via API

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).