### PR TITLE
Fix incorrect entity count due to undefined execution order with globals

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -423,7 +423,7 @@ async def _add_automations(config):
 DATETIME_SUBTYPES = {"date", "time", "datetime"}
 
 
-@coroutine_with_priority(-100.0)
+@coroutine_with_priority(-1000.0)
 async def _add_platform_defines() -> None:
     # Generate compile-time defines for platforms that have actual entities
     # Only add USE_* and count defines when there are entities


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes multiple issues where entities (sensors, binary sensors, etc.) from external components (like DHT22) could be missing or have incorrect counts when lambdas are present in the configuration.

The root cause was that `_add_platform_defines()` was running at priority -100.0, which is the same priority as the `globals` component. When multiple coroutines have the same priority, their execution order is undefined (in practice they run in the order defined in the configuration YAML, but this is not guaranteed, which made the issue hard to discover and reproduce). This could cause `_add_platform_defines()` to run before all entities were registered, resulting in incorrect `ESPHOME_ENTITY_*_COUNT` defines (e.g., `ESPHOME_ENTITY_SENSOR_COUNT`, `ESPHOME_ENTITY_BINARY_SENSOR_COUNT`, etc.).

**This undefined behavior has existed since the creation of `_add_platform_defines()`** but became a critical issue when the same `_add_platform_defines()` function was re-purposed for entity counts in ESPHome 2025.8.0. It was very difficult to discover because prior to 2025.8.0, everything still "worked" - `std::vector` could grow dynamically if more entities were added than initially counted. While this resulted in excess memory reallocations to grow the vector (which was inefficient), the entities would still function correctly, making the problem nearly invisible. However, 2025.8.0 started using these same counts with `StaticVector`, which has a fixed size determined at compile time. With static vectors, an incorrect count means entities simply won't fit and will be missing entirely.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10431
- fixes #10411
- fixes #10388
- fixes #10495

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration would previously cause issues with entity counts
# The problem occurs when globals is defined AFTER sensors that use them in lambdas

sensor:
  - platform: dht
    pin: GPIO4
    model: dht22
    humidity:
      name: "Humidity"
      on_value:
        then:
          - lambda: |-
              id(humidity_value) = x;
    temperature:
      name: "Temperature"

# When globals appears after sensors, it could cause _add_platform_defines
# to run before sensor registration completed
globals:
  - id: humidity_value
    type: float
    restore_value: no
    initial_value: "0.0"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Changes Made

1. **Changed priority of `_add_platform_defines()`** from -100.0 to -1000.0 in `esphome/core/config.py`
   - Ensures it runs after all components (including globals at -100.0) have registered their entities
   - Guarantees correct entity counts for static vector allocation

2. **Added unit test** in `tests/unit_tests/core/test_config.py`
   - `test_add_platform_defines_priority()` ensures the priority remains lower than globals
   - Prevents regression of this issue

## Technical Details

The issue occurs because:
- `globals` component runs at priority -100.0
- `_add_platform_defines()` was also at priority -100.0
- When priorities are equal, execution order is undefined
- If `_add_platform_defines()` runs before entity registration completes, counts are wrong
- Static vectors (2025.8.0+) can't grow, so wrong counts cause missing entities

The fix ensures `_add_platform_defines()` always runs after all component registration by using priority -1000.0.