### PR TITLE
[ezo] extract shared code to component root

### DIFF
--- a/esphome/components/ezo/__init__.py
+++ b/esphome/components/ezo/__init__.py
@@ -1,0 +1,44 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import i2c, sensor
+import esphome.config_validation as cv
+
+CODEOWNERS = ["@ssieb"]
+DEPENDENCIES = ["i2c"]
+
+CONF_ON_LED = "on_led"
+CONF_ON_DEVICE_INFORMATION = "on_device_information"
+CONF_ON_SLOPE = "on_slope"
+CONF_ON_CALIBRATION = "on_calibration"
+CONF_ON_T = "on_t"
+CONF_ON_CUSTOM = "on_custom"
+
+ezo_ns = cg.esphome_ns.namespace("ezo")
+
+EZOSensor = ezo_ns.class_(
+    "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
+)
+
+CustomTrigger = ezo_ns.class_(
+    "CustomTrigger", automation.Trigger.template(cg.std_string)
+)
+
+TTrigger = ezo_ns.class_("TTrigger", automation.Trigger.template(cg.std_string))
+
+SlopeTrigger = ezo_ns.class_("SlopeTrigger", automation.Trigger.template(cg.std_string))
+
+CalibrationTrigger = ezo_ns.class_(
+    "CalibrationTrigger", automation.Trigger.template(cg.std_string)
+)
+
+DeviceInformationTrigger = ezo_ns.class_(
+    "DeviceInformationTrigger", automation.Trigger.template(cg.std_string)
+)
+
+LedTrigger = ezo_ns.class_("LedTrigger", automation.Trigger.template(cg.bool_))
+
+CONFIG_SCHEMA = cv.Schema({}).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    cg.add_global(cg.RawStatement('#include "esphome/components/ezo/ezo.h"'))

--- a/esphome/components/ezo/sensor.py
+++ b/esphome/components/ezo/sensor.py
@@ -4,41 +4,24 @@ from esphome.components import i2c, sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
+from . import (
+    CONF_ON_CALIBRATION,
+    CONF_ON_CUSTOM,
+    CONF_ON_DEVICE_INFORMATION,
+    CONF_ON_LED,
+    CONF_ON_SLOPE,
+    CONF_ON_T,
+    CalibrationTrigger,
+    CustomTrigger,
+    DeviceInformationTrigger,
+    EZOSensor,
+    LedTrigger,
+    SlopeTrigger,
+    TTrigger,
+)
+
 CODEOWNERS = ["@ssieb"]
-
-DEPENDENCIES = ["i2c"]
-
-CONF_ON_LED = "on_led"
-CONF_ON_DEVICE_INFORMATION = "on_device_information"
-CONF_ON_SLOPE = "on_slope"
-CONF_ON_CALIBRATION = "on_calibration"
-CONF_ON_T = "on_t"
-CONF_ON_CUSTOM = "on_custom"
-
-ezo_ns = cg.esphome_ns.namespace("ezo")
-
-EZOSensor = ezo_ns.class_(
-    "EZOSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
-)
-
-CustomTrigger = ezo_ns.class_(
-    "CustomTrigger", automation.Trigger.template(cg.std_string)
-)
-
-
-TTrigger = ezo_ns.class_("TTrigger", automation.Trigger.template(cg.std_string))
-
-SlopeTrigger = ezo_ns.class_("SlopeTrigger", automation.Trigger.template(cg.std_string))
-
-CalibrationTrigger = ezo_ns.class_(
-    "CalibrationTrigger", automation.Trigger.template(cg.std_string)
-)
-
-DeviceInformationTrigger = ezo_ns.class_(
-    "DeviceInformationTrigger", automation.Trigger.template(cg.std_string)
-)
-
-LedTrigger = ezo_ns.class_("LedTrigger", automation.Trigger.template(cg.bool_))
+DEPENDENCIES = ["ezo"]
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(EZOSensor)


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the EZO component to extract shared code from `sensor.py` into the component root `__init__.py`. This change enables other components to extend the EZO functionality by making the common definitions and classes available at the component level.

Previously, all EZO-related classes (like `EZOSensor`, trigger classes, and configuration constants) were defined inside `sensor.py`, making them inaccessible to other components that wanted to build upon the EZO base functionality. This refactoring moves these shared definitions to `__init__.py` where they can be properly imported by components that depend on `ezo`.

The original EZO component supports only a common set of I2C functionality shared by all EZO circuits. Functionality that only exists for a particular type of circuit is generally not implemented. This PR is necessary foundational work to allow me to develop an extended [component that adds the type-specific functionality](https://github.com/terpasaurus-midwest/my-esp-comps) without disrupting the generic component.

This is my first change for ESPHome and I'm not a C++ programmer or super experienced with the Espressif framework, so don't hesitate to call out anything absurdly stupid I've done here.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A, I ran into the issue, and fixed it locally to unblock my own development. Now I'm trying to upstream my change so I don't need to maintain a trivial fork.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

No documentation change is required.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No changes to the config schema were made.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
