### PR TITLE
[esp32] Clear IDF environment variables

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -840,11 +840,8 @@ async def to_code(config):
     if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_CUSTOM_MAC]:
         cg.add_define("USE_ESP32_IGNORE_EFUSE_CUSTOM_MAC")
 
-    if "IDF_PATH" in os.environ:
-        del os.environ["IDF_PATH"]
-
-    if "IDF_TOOLS_PATH" in os.environ:
-        del os.environ["IDF_TOOLS_PATH"]
+    for clean_var in ("IDF_PATH", "IDF_TOOLS_PATH"):
+        os.environ.pop(clean_var, None)
 
     add_extra_script(
         "post",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -843,6 +843,9 @@ async def to_code(config):
     if "IDF_PATH" in os.environ:
         del os.environ["IDF_PATH"]
 
+    if "IDF_TOOLS_PATH" in os.environ:
+        del os.environ["IDF_TOOLS_PATH"]
+
     add_extra_script(
         "post",
         "post_build.py",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -840,6 +840,9 @@ async def to_code(config):
     if conf[CONF_ADVANCED][CONF_IGNORE_EFUSE_CUSTOM_MAC]:
         cg.add_define("USE_ESP32_IGNORE_EFUSE_CUSTOM_MAC")
 
+    if "IDF_PATH" in os.environ:
+        del os.environ["IDF_PATH"]
+
     add_extra_script(
         "post",
         "post_build.py",


### PR DESCRIPTION
# What does this implement/fix?

Clear IDF environment variables which can be set if the user previously installed the Arduino IDE (or some other tools). If these variables are set they can interfere with the platform install. 

The latest pioarduino rerelease was supposed to fixed this but someone was claiming they still had to manually unset them.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
