### PR TITLE
[core] Use get_icon_ref() in entity platform logging to avoid string allocations

### DIFF
--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -14,8 +14,8 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
 
-  if (!obj->get_icon().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
+  if (!obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
   }
 }
 

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -16,8 +16,8 @@ namespace datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -16,8 +16,8 @@ namespace datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -16,8 +16,8 @@ namespace datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -13,8 +13,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
     if (!(obj)->get_device_class().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -15,8 +15,8 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -14,8 +14,8 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
 
-  if (!obj->get_icon().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
+  if (!obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
   }
 
   if (!obj->traits.get_unit_of_measurement().empty()) {

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,8 +12,8 @@ namespace select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -24,8 +24,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
     ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
   }
 
-  if (!obj->get_icon().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
+  if (!obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
   }
 
   if (obj->get_force_update()) {

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -91,8 +91,8 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    if (!obj->get_icon().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
+    if (!obj->get_icon_ref().empty()) {
+      ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
     }
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,8 +12,8 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -17,8 +17,8 @@ namespace text_sensor {
     if (!(obj)->get_device_class().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
     } \
-    if (!(obj)->get_icon().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
+    if (!(obj)->get_icon_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
     } \
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes entity platform logging by using `get_icon_ref()` instead of `get_icon()` to avoid unnecessary heap allocations when logging icon information.

### Changes:
Replaced `get_icon()` calls with `get_icon_ref()` in logging macros and functions across all entity platforms. The `get_icon_ref()` method returns a `StringRef` which avoids creating temporary `std::string` objects when the underlying icon is already stored as `const char*`.

### Performance Impact:
- **Eliminates string allocations** during entity logging/dump_config operations
- **Reduces heap fragmentation** during startup when all entities log their configuration
- Icons are typically static strings, so 99%+ of cases benefit from this optimization
- No functional changes - purely a performance optimization

### Files Modified:
- `components/number/number.cpp` - Updated log_number function
- `components/select/select.h` - Updated LOG_SELECT macro
- `components/sensor/sensor.cpp` - Updated log_sensor function  
- `components/switch/switch.cpp` - Updated log_switch function
- `components/text/text.h` - Updated LOG_TEXT macro
- `components/text_sensor/text_sensor.h` - Updated LOG_TEXT_SENSOR macro
- `components/button/button.cpp` - Updated log_button function
- `components/datetime/date_entity.h` - Updated LOG_DATETIME_DATE macro
- `components/datetime/datetime_entity.h` - Updated LOG_DATETIME_DATETIME macro
- `components/datetime/time_entity.h` - Updated LOG_DATETIME_TIME macro
- `components/event/event.h` - Updated LOG_EVENT macro
- `components/lock/lock.h` - Updated LOG_LOCK macro

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Performance optimization, no specific issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All entity platforms automatically benefit from reduced memory allocations

sensor:
  - platform: dht
    pin: GPIO23
    temperature:
      name: "Living Room Temperature"
      icon: "mdi:thermometer"  # Icon logging now more efficient
    humidity:
      name: "Living Room Humidity"  
      icon: "mdi:water-percent"  # Icon logging now more efficient

switch:
  - platform: gpio
    pin: GPIO25
    name: "Living Room Light"
    icon: "mdi:lightbulb"  # Icon logging now more efficient
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

This optimization is part of a series of improvements to reduce unnecessary heap allocations in ESPHome. By using `StringRef` instead of `std::string` for read-only operations like logging, we avoid creating temporary string objects that immediately get destroyed.

The pattern changed is:
```cpp
// Before - creates temporary std::string
if (!obj->get_icon().empty()) {
  ESP_LOGCONFIG(TAG, "Icon: '%s'", obj->get_icon().c_str());
}

// After - uses StringRef, no allocation
if (!obj->get_icon_ref().empty()) {
  ESP_LOGCONFIG(TAG, "Icon: '%s'", obj->get_icon_ref().c_str());
}
```

This is particularly beneficial when API clients connect, as dump_config runs at the start of the logging session and all entities log their configuration. This reduces heap churn on memory-constrained devices during each client connection.