### PR TITLE
[core] Use get_device_class_ref() in entity platform logging to avoid string allocations

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -15,8 +15,8 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
 
-  if (!obj->get_device_class().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
+  if (!obj->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
   }
 }
 

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -19,8 +19,8 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    if (!(obj)->get_device_class_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -16,8 +16,8 @@ namespace event {
     if (!(obj)->get_icon().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \
     } \
-    if (!(obj)->get_device_class().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    if (!(obj)->get_device_class_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
     } \
   }
 

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -22,8 +22,8 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
     ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement().c_str());
   }
 
-  if (!obj->traits.get_device_class().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->traits.get_device_class().c_str());
+  if (!obj->traits.get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->traits.get_device_class_ref().c_str());
   }
 }
 

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -20,8 +20,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 prefix, type, obj->get_name().c_str(), prefix, state_class_to_string(obj->get_state_class()).c_str(),
                 prefix, obj->get_unit_of_measurement().c_str(), prefix, obj->get_accuracy_decimals());
 
-  if (!obj->get_device_class().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
+  if (!obj->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
   }
 
   if (!obj->get_icon().empty()) {

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -100,8 +100,8 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    if (!obj->get_device_class().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
+    if (!obj->get_device_class_ref().empty()) {
+      ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
     }
   }
 }

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -14,8 +14,8 @@ namespace text_sensor {
 #define LOG_TEXT_SENSOR(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_device_class().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    if (!(obj)->get_device_class_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
     } \
     if (!(obj)->get_icon().empty()) { \
       ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon().c_str()); \

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -19,8 +19,8 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class().c_str()); \
+    if (!(obj)->get_device_class_ref().empty()) { \
+      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
     } \
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes entity platform logging by using `get_device_class_ref()` instead of `get_device_class()` to avoid unnecessary heap allocations when logging device class information.

### Changes:
Replaced `get_device_class()` calls with `get_device_class_ref()` in logging macros and functions across entity platforms that support device classes. The `get_device_class_ref()` method returns a `StringRef` which avoids creating temporary `std::string` objects when the underlying device class is already stored as `const char*`.

### Performance Impact:
- **Eliminates string allocations** during entity logging/dump_config operations
- **Reduces heap fragmentation** when API clients connect and dump_config runs
- Device classes are always static strings, so 100% of cases benefit from this optimization
- No functional changes - purely a performance optimization

### Files Modified:
- `components/binary_sensor/binary_sensor.cpp` - Updated log_binary_sensor function
- `components/cover/cover.h` - Updated LOG_COVER macro
- `components/event/event.h` - Updated LOG_EVENT macro
- `components/number/number.cpp` - Updated log_number function (traits.get_device_class)
- `components/sensor/sensor.cpp` - Updated log_sensor function
- `components/switch/switch.cpp` - Updated log_switch function
- `components/text_sensor/text_sensor.h` - Updated LOG_TEXT_SENSOR macro
- `components/valve/valve.h` - Updated LOG_VALVE macro

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Performance optimization, no specific issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All entity platforms automatically benefit from reduced memory allocations

binary_sensor:
  - platform: gpio
    pin: GPIO23
    name: "Motion Sensor"
    device_class: motion  # Device class logging now more efficient

sensor:
  - platform: dht
    pin: GPIO22
    temperature:
      name: "Temperature"
      device_class: temperature  # Device class logging now more efficient
    humidity:
      name: "Humidity"
      device_class: humidity  # Device class logging now more efficient

switch:
  - platform: gpio
    pin: GPIO25
    name: "Outlet"
    device_class: outlet  # Device class logging now more efficient
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

This optimization is part of a series of improvements to reduce unnecessary heap allocations in ESPHome. By using `StringRef` instead of `std::string` for read-only operations like logging, we avoid creating temporary string objects that immediately get destroyed.

The pattern changed is:
```cpp
// Before - creates temporary std::string
if (!obj->get_device_class().empty()) {
  ESP_LOGCONFIG(TAG, "Device Class: '%s'", obj->get_device_class().c_str());
}

// After - uses StringRef, no allocation
if (!obj->get_device_class_ref().empty()) {
  ESP_LOGCONFIG(TAG, "Device Class: '%s'", obj->get_device_class_ref().c_str());
}
```

This is particularly beneficial when API clients connect, as dump_config runs at the start of the logging session and all entities log their configuration. This reduces heap churn on memory-constrained devices during each client connection.