### PR TITLE
[core] Use get_unit_of_measurement_ref() in entity logging to avoid string allocations

### DIFF
--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -18,8 +18,8 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
     ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon().c_str());
   }
 
-  if (!obj->traits.get_unit_of_measurement().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement().c_str());
+  if (!obj->traits.get_unit_of_measurement_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
   }
 
   if (!obj->traits.get_device_class().empty()) {

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -18,7 +18,7 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 "%s  Unit of Measurement: '%s'\n"
                 "%s  Accuracy Decimals: %d",
                 prefix, type, obj->get_name().c_str(), prefix, state_class_to_string(obj->get_state_class()).c_str(),
-                prefix, obj->get_unit_of_measurement().c_str(), prefix, obj->get_accuracy_decimals());
+                prefix, obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
   if (!obj->get_device_class().empty()) {
     ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
@@ -128,7 +128,7 @@ void Sensor::internal_send_state_to_frontend(float state) {
   this->set_has_state(true);
   this->state = state;
   ESP_LOGD(TAG, "'%s': Sending state %.5f %s with %d decimals of accuracy", this->get_name().c_str(), state,
-           this->get_unit_of_measurement().c_str(), this->get_accuracy_decimals());
+           this->get_unit_of_measurement_ref().c_str(), this->get_accuracy_decimals());
   this->callback_.call(state);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes entity logging by using `get_unit_of_measurement_ref()` instead of `get_unit_of_measurement()` to avoid unnecessary heap allocations when logging unit of measurement information.

### Changes:
Replaced `get_unit_of_measurement()` calls with `get_unit_of_measurement_ref()` in logging functions for sensor and number components. The `get_unit_of_measurement_ref()` method returns a `StringRef` which avoids creating temporary `std::string` objects when the underlying unit of measurement is already stored as `const char*`.

### Performance Impact:
- **Eliminates string allocations** during entity logging operations
- **Reduces heap fragmentation** when API clients connect and dump_config runs
- **Reduces allocations during runtime** when sensors log state updates
- Units of measurement are always static strings, so 100% of cases benefit from this optimization
- No functional changes - purely a performance optimization

### Files Modified:
- `components/sensor/sensor.cpp` - Updated log_sensor function and internal_send_state_to_frontend
- `components/number/number.cpp` - Updated log_number function (traits.get_unit_of_measurement)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Performance optimization, no specific issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All entities with units automatically benefit from reduced memory allocations

sensor:
  - platform: dht
    pin: GPIO22
    temperature:
      name: "Temperature"
      unit_of_measurement: "°C"  # Unit logging now more efficient
    humidity:
      name: "Humidity"
      unit_of_measurement: "%"   # Unit logging now more efficient

  - platform: adc
    pin: GPIO34
    name: "Battery Voltage"
    unit_of_measurement: "V"     # Unit logging now more efficient
    
number:
  - platform: template
    name: "Thermostat Setpoint"
    unit_of_measurement: "°C"     # Unit logging now more efficient
    min_value: 10
    max_value: 30
    step: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

This optimization is part of a series of improvements to reduce unnecessary heap allocations in ESPHome. By using `StringRef` instead of `std::string` for read-only operations like logging, we avoid creating temporary string objects that immediately get destroyed.

The pattern changed is:
```cpp
// Before - creates temporary std::string
ESP_LOGD(TAG, "State: %.5f %s", state, this->get_unit_of_measurement().c_str());

// After - uses StringRef, no allocation
ESP_LOGD(TAG, "State: %.5f %s", state, this->get_unit_of_measurement_ref().c_str());
```

This optimization benefits both:
1. **Connection-time logging**: When API clients connect and dump_config runs at the start of the logging session
2. **Runtime logging**: When sensors publish state updates and log their values with units

This reduces heap churn on memory-constrained devices throughout the device's operation.