### PR TITLE
[sensor] Change state_class_to_string() to return const char* to avoid allocations

### DIFF
--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -17,8 +17,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 "%s  State Class: '%s'\n"
                 "%s  Unit of Measurement: '%s'\n"
                 "%s  Accuracy Decimals: %d",
-                prefix, type, obj->get_name().c_str(), prefix, state_class_to_string(obj->get_state_class()).c_str(),
-                prefix, obj->get_unit_of_measurement().c_str(), prefix, obj->get_accuracy_decimals());
+                prefix, type, obj->get_name().c_str(), prefix, state_class_to_string(obj->get_state_class()), prefix,
+                obj->get_unit_of_measurement().c_str(), prefix, obj->get_accuracy_decimals());
 
   if (!obj->get_device_class().empty()) {
     ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class().c_str());
@@ -33,7 +33,7 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
   }
 }
 
-std::string state_class_to_string(StateClass state_class) {
+const char *state_class_to_string(StateClass state_class) {
   switch (state_class) {
     case STATE_CLASS_MEASUREMENT:
       return "measurement";

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -33,7 +33,7 @@ enum StateClass : uint8_t {
   STATE_CLASS_TOTAL = 3,
 };
 
-std::string state_class_to_string(StateClass state_class);
+const char *state_class_to_string(StateClass state_class);
 
 /** Base-class for all sensors.
  *


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `state_class_to_string()` function to return `const char*` instead of `std::string`, eliminating unnecessary heap allocations when logging sensor state classes or sending MQTT discovery messages.

### Changes:
Changed `state_class_to_string()` to return `const char*` instead of `std::string`. Since this function only returns string literals (`"measurement"`, `"total_increasing"`, `"total"`, or `""`), there's no need to allocate a `std::string` object.

### Performance Impact:
- **Eliminates string allocation** every time a sensor logs its state class
- **Reduces heap churn** when API clients connect and dump_config runs
- **Zero-copy optimization** for ArduinoJson - the `const char*` is used directly without copying
- No functional changes - the same string values are returned

### Compatibility:
- ArduinoJson v7 handles `const char*` efficiently with its `JsonString` zero-copy design
- The historical issue in PR #2331 was specifically with `LogString*`, not `const char*`

### Files Modified:
- `components/sensor/sensor.h` - Changed function signature
- `components/sensor/sensor.cpp` - Changed implementation and removed `.c_str()` call in logging

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Performance optimization, no specific issue
- Related historical context: PR #2331 (fixed `LogString*` issue, not `const char*`)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All sensors with state_class automatically benefit

sensor:
  - platform: energy_meter
    name: "Power Usage"
    state_class: total_increasing  # State class logging now more efficient
    
  - platform: temperature
    name: "Temperature"
    state_class: measurement       # State class logging now more efficient
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Breaking Change Notice

**This is technically a breaking change** for external components that call `state_class_to_string()` and expect a `std::string`. However:

1. **Very low risk** - This function is primarily for internal use (logging and MQTT discovery)
2. **Easy fix** - External components can wrap the result: `std::string(state_class_to_string(...))`
3. **Unlikely to affect anyone** - External components rarely need to convert state class enums to strings

The performance benefit (eliminating allocations for every sensor log) outweighs the minimal compatibility risk.

## Additional Context

The function only returns string literals, making `std::string` allocation unnecessary:
```cpp
// Before - allocates std::string
std::string state_class_to_string(StateClass state_class) {
  switch (state_class) {
    case STATE_CLASS_MEASUREMENT:
      return "measurement";  // Creates temporary std::string
    // ...
  }
}

// After - returns pointer to string literal
const char *state_class_to_string(StateClass state_class) {
  switch (state_class) {
    case STATE_CLASS_MEASUREMENT:
      return "measurement";  // Returns pointer to static string
    // ...
  }
}
```

This optimization is particularly beneficial when combined with ArduinoJson v7's zero-copy `JsonString` design, eliminating allocations in both logging and MQTT paths.