### PR TITLE
[core] Add memory pool to scheduler to reduce heap fragmentation

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1135,7 +1135,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   dump_field(out, "string_", this->string_);
   dump_field(out, "int_", this->int_);
   for (const auto it : this->bool_array) {
-    dump_field(out, "bool_array", it, 4);
+    dump_field(out, "bool_array", static_cast<bool>(it), 4);
   }
   for (const auto &it : this->int_array) {
     dump_field(out, "int_array", it, 4);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -104,37 +104,42 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // Take lock early to protect scheduler_item_pool_ access
   LockGuard guard{this->lock_};
 
-  // Optimization: if we're updating a defer that hasn't executed yet, just update its callback
+  // Optimization: if we're updating a timeout that hasn't been added to heap yet, just update it in-place
   // This avoids allocating a new item and cancelling/re-adding
-  if (delay == 0 && type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr) {
-#ifdef ESPHOME_THREAD_SINGLE
-    // Single-threaded: check to_add_ for defers that haven't been moved to heap yet
-    if (this->try_update_defer_in_container_(this->to_add_, component, name_cstr, std::move(func))) {
-      return;
-    }
-#else
-    // Multi-threaded: check defer_queue_
-    if (this->try_update_defer_in_container_(this->defer_queue_, component, name_cstr, std::move(func))) {
+  if (type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr) {
+#ifndef ESPHOME_THREAD_SINGLE
+    // Multi-threaded: defers go to defer_queue_
+    if (delay == 0 && this->try_update_defer_in_container_(this->defer_queue_, component, name_cstr, std::move(func))) {
       return;
     }
 #endif
-  }
 
-  // Optimization: if we're updating a timeout that's still in to_add_, just update it in-place
-  // This is common when timers are rapidly rescheduled (like api_reboot on connect/disconnect)
-  if (delay != 0 && type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr && !this->to_add_.empty()) {
-    auto &last_item = this->to_add_.back();
-    // Check if last item in to_add_ matches and can be updated
-    if (last_item->component == component && last_item->type == SchedulerItem::TIMEOUT &&
-        !is_item_removed_(last_item.get()) && this->names_match_(last_item->get_name(), name_cstr)) {
-      // Same timeout at the end of to_add_ - update it instead of creating new
-      last_item->callback = std::move(func);
-      last_item->next_execution_ = now + delay;
+    // Check if we can update an existing timeout in to_add_
+    if (!this->to_add_.empty()) {
+      auto &last_item = this->to_add_.back();
+      // Check if last item in to_add_ matches and can be updated
+      if (last_item->component == component && last_item->type == SchedulerItem::TIMEOUT &&
+          !is_item_removed_(last_item.get()) && this->names_match_(last_item->get_name(), name_cstr)) {
+        // For defers (delay==0), only update callback
+        if (delay == 0 && last_item->interval == 0) {
+          last_item->callback = std::move(func);
 #ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Updated existing timeout in to_add_ for '%s/%s'", component->get_component_source(),
-               name_cstr ? name_cstr : "(null)");
+          ESP_LOGD(TAG, "Updated existing defer in to_add_ for '%s/%s'", component->get_component_source(),
+                   name_cstr ? name_cstr : "(null)");
 #endif
-      return;
+          return;
+        }
+        // For regular timeouts, update callback and execution time
+        if (delay != 0) {
+          last_item->callback = std::move(func);
+          last_item->next_execution_ = now + delay;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+          ESP_LOGD(TAG, "Updated existing timeout in to_add_ for '%s/%s'", component->get_component_source(),
+                   name_cstr ? name_cstr : "(null)");
+#endif
+          return;
+        }
+      }
     }
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -127,13 +127,13 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     item = std::move(this->scheduler_item_pool_.back());
     this->scheduler_item_pool_.pop_back();
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGVV(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
 #endif
   } else {
     // Allocate new if pool is empty
     item = make_unique<SchedulerItem>();
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGVV(TAG, "Allocated new item (pool empty)");
+    ESP_LOGD(TAG, "Allocated new item (pool empty)");
 #endif
   }
   item->component = component;
@@ -819,11 +819,11 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
     item->clear_dynamic_name();
     this->scheduler_item_pool_.push_back(std::move(item));
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGVV(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+    ESP_LOGD(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_.size());
 #endif
   } else {
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGVV(TAG, "Pool full (size: %zu), deleting item", this->scheduler_item_pool_.size());
+    ESP_LOGD(TAG, "Pool full (size: %zu), deleting item", this->scheduler_item_pool_.size());
 #endif
   }
   // else: unique_ptr will delete the item when it goes out of scope

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -120,6 +120,24 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
 #endif
   }
 
+  // Optimization: if we're updating a timeout that's still in to_add_, just update it in-place
+  // This is common when timers are rapidly rescheduled (like api_reboot on connect/disconnect)
+  if (delay != 0 && type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr && !this->to_add_.empty()) {
+    auto &last_item = this->to_add_.back();
+    // Check if last item in to_add_ matches and can be updated
+    if (last_item->component == component && last_item->type == SchedulerItem::TIMEOUT &&
+        !is_item_removed_(last_item.get()) && this->names_match_(last_item->get_name(), name_cstr)) {
+      // Same timeout at the end of to_add_ - update it instead of creating new
+      last_item->callback = std::move(func);
+      last_item->next_execution_ = now + delay;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+      ESP_LOGD(TAG, "Updated existing timeout in to_add_ for '%s/%s'", component->get_component_source(),
+               name_cstr ? name_cstr : "(null)");
+#endif
+      return;
+    }
+  }
+
   // Create and populate the scheduler item
   std::unique_ptr<SchedulerItem> item;
   if (!this->scheduler_item_pool_.empty()) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -399,10 +399,12 @@ void HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // Check if we should perform cleanup based on number of cancelled items
-  // Cleanup when we have accumulated MAX_LOGICALLY_DELETED_ITEMS cancelled items
-  // This simple threshold ensures we don't waste memory on cancelled items
-  // regardless of how many intervals are running
+  // Cleanup removed items before processing
+  // First try to clean items from the top of the heap (fast path)
+  this->cleanup_();
+
+  // If we still have too many cancelled items, do a full cleanup
+  // This only happens if cancelled items are stuck in the middle/bottom of the heap
   if (this->to_remove_ >= MAX_LOGICALLY_DELETED_ITEMS) {
     // We hold the lock for the entire cleanup operation because:
     // 1. We're rebuilding the entire items_ list, so we need exclusive access throughout
@@ -429,9 +431,6 @@ void HOT Scheduler::call(uint32_t now) {
     std::make_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
     this->to_remove_ = 0;
   }
-
-  // Cleanup removed items before processing
-  this->cleanup_();
   while (!this->items_.empty()) {
     // use scoping to indicate visibility of `item` variable
     {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -656,12 +656,23 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 
-  // Cancel items in the main heap (can't recycle immediately due to heap structure)
-  for (auto &item : this->items_) {
-    if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
-      this->mark_item_removed_(item.get());
+  // Cancel items in the main heap
+  // Special case: if the last item in the heap matches, we can remove it immediately
+  // (removing the last element doesn't break heap structure)
+  if (!this->items_.empty()) {
+    auto &last_item = this->items_.back();
+    if (this->matches_item_(last_item, component, name_cstr, type, match_retry)) {
+      this->recycle_item_(std::move(this->items_.back()));
+      this->items_.pop_back();
       total_cancelled++;
-      this->to_remove_++;  // Track removals for heap items
+    }
+    // For other items in heap, we can only mark for removal (can't remove from middle of heap)
+    for (auto &item : this->items_) {
+      if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
+        this->mark_item_removed_(item.get());
+        total_cancelled++;
+        this->to_remove_++;  // Track removals for heap items
+      }
     }
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -91,9 +91,15 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     // Reuse from pool
     item = std::move(this->scheduler_item_pool_.back());
     this->scheduler_item_pool_.pop_back();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGVV(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+#endif
   } else {
     // Allocate new if pool is empty
     item = make_unique<SchedulerItem>();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGVV(TAG, "Allocated new item (pool empty)");
+#endif
   }
   item->component = component;
   item->set_name(name_cstr, !is_static_string);
@@ -771,6 +777,13 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
     // Clear dynamic name if any
     item->clear_dynamic_name();
     this->scheduler_item_pool_.push_back(std::move(item));
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGVV(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+#endif
+  } else {
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGVV(TAG, "Pool full (size: %zu), deleting item", this->scheduler_item_pool_.size());
+#endif
   }
   // else: unique_ptr will delete the item when it goes out of scope
 }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -101,6 +101,22 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // Take lock early to protect scheduler_item_pool_ access
   LockGuard guard{this->lock_};
 
+  // Optimization: if we're updating a defer that hasn't executed yet, just update its callback
+  // This avoids allocating a new item and cancelling/re-adding
+  if (delay == 0 && type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr) {
+#ifdef ESPHOME_THREAD_SINGLE
+    // Single-threaded: check to_add_ for defers that haven't been moved to heap yet
+    if (this->try_update_defer_in_container_(this->to_add_, component, name_cstr, std::move(func))) {
+      return;
+    }
+#else
+    // Multi-threaded: check defer_queue_
+    if (this->try_update_defer_in_container_(this->defer_queue_, component, name_cstr, std::move(func))) {
+      return;
+    }
+#endif
+  }
+
   // Create and populate the scheduler item
   std::unique_ptr<SchedulerItem> item;
   if (!this->scheduler_item_pool_.empty()) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -349,6 +349,8 @@ void HOT Scheduler::call(uint32_t now) {
     if (!this->should_skip_item_(item.get())) {
       this->execute_item_(item.get(), now);
     }
+    // Recycle the defer item after execution
+    this->recycle_item_(std::move(item));
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -26,6 +26,11 @@ static constexpr size_t MAX_POOL_SIZE = 10;
 // recycled to the pool in a timely manner to maintain pool efficiency.
 static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 6;
 
+// Ensure MAX_LOGICALLY_DELETED_ITEMS is at least 4 smaller than MAX_POOL_SIZE
+// This guarantees we have room in the pool for recycled items when cleanup occurs
+static_assert(MAX_LOGICALLY_DELETED_ITEMS + 4 <= MAX_POOL_SIZE,
+              "MAX_LOGICALLY_DELETED_ITEMS must be at least 4 smaller than MAX_POOL_SIZE");
+
 // Half the 32-bit range - used to detect rollovers vs normal time progression
 static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
 // max delay to start an interval sequence

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -517,7 +517,9 @@ void HOT Scheduler::call(uint32_t now) {
 void HOT Scheduler::process_to_add() {
   LockGuard guard{this->lock_};
   for (auto &it : this->to_add_) {
-    if (it->remove) {
+    if (is_item_removed_(it.get())) {
+      // Recycle cancelled items
+      this->recycle_item_(std::move(it));
       continue;
     }
 
@@ -595,10 +597,14 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 
   // Check all containers for matching items
 #ifndef ESPHOME_THREAD_SINGLE
-  // Cancel and immediately recycle items in defer queue
+  // Mark items in defer queue as cancelled (they'll be skipped when processed)
   if (type == SchedulerItem::TIMEOUT) {
-    total_cancelled +=
-        this->cancel_and_recycle_from_container_(this->defer_queue_, component, name_cstr, type, match_retry);
+    for (auto &item : this->defer_queue_) {
+      if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
+        this->mark_item_removed_(item.get());
+        total_cancelled++;
+      }
+    }
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 
@@ -622,8 +628,14 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
     }
   }
 
-  // Cancel and immediately recycle items in to_add_ since they're not in heap yet
-  total_cancelled += this->cancel_and_recycle_from_container_(this->to_add_, component, name_cstr, type, match_retry);
+  // Cancel items in to_add_
+  for (auto &item : this->to_add_) {
+    if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
+      this->mark_item_removed_(item.get());
+      total_cancelled++;
+      // Don't track removals for to_add_ items
+    }
+  }
 
   return total_cancelled > 0;
 }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -759,7 +759,7 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
   if (!item)
     return;
 
-  static constexpr size_t MAX_POOL_SIZE = 16;
+  static constexpr size_t MAX_POOL_SIZE = 8;
   if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
     // Clear callback to release captured resources
     item->callback = nullptr;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -759,6 +759,11 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
   if (!item)
     return;
 
+  // Pool size of 8 is a balance between memory usage and performance:
+  // - Small enough to not waste memory on simple configs (1-2 timers)
+  // - Large enough to handle complex setups with multiple sensors/components
+  // - Prevents system-wide stalls from heap allocation/deallocation that can
+  //   disrupt task synchronization and cause dropped events
   static constexpr size_t MAX_POOL_SIZE = 8;
   if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
     // Clear callback to release captured resources

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -120,7 +120,8 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
       // Check if last item in to_add_ matches and can be updated
       if (last_item->component == component && last_item->type == SchedulerItem::TIMEOUT &&
           !is_item_removed_(last_item.get()) && this->names_match_(last_item->get_name(), name_cstr)) {
-        // For defers (delay==0), only update callback
+#ifdef ESPHOME_THREAD_SINGLE
+        // Single-threaded: defers can be in to_add_, only update callback
         if (delay == 0 && last_item->interval == 0) {
           last_item->callback = std::move(func);
 #ifdef ESPHOME_DEBUG_SCHEDULER
@@ -129,6 +130,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
 #endif
           return;
         }
+#endif
         // For regular timeouts, update callback and execution time
         if (delay != 0) {
           last_item->callback = std::move(func);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -23,16 +23,10 @@ static const char *const TAG = "scheduler";
 // See https://github.com/esphome/backlog/issues/52
 static constexpr size_t MAX_POOL_SIZE = 5;
 
-// Cleanup is performed when cancelled items exceed this percentage of total items.
-// Using integer math: cleanup when (cancelled * 100 / total) > 50
-// This balances cleanup frequency with performance - we avoid O(n) cleanup
-// on every cancellation but don't let cancelled items accumulate excessively.
-static constexpr uint32_t CLEANUP_PERCENTAGE = 50;
-
-// Minimum number of cancelled items before considering cleanup.
-// Even if the fraction is exceeded, we need at least this many cancelled items
-// to make the O(n) cleanup operation worthwhile.
-static constexpr uint32_t MIN_CANCELLED_ITEMS_FOR_CLEANUP = 3;
+// Maximum number of logically deleted (cancelled) items before forcing cleanup.
+// Set to 5 to match the pool size - when we have as many cancelled items as our
+// pool can hold, it's time to clean up and recycle them.
+static constexpr uint32_t MAX_LOGICALLY_DELETED_ITEMS = 5;
 
 // Half the 32-bit range - used to detect rollovers vs normal time progression
 static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
@@ -446,18 +440,11 @@ void HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // Check if we should perform cleanup based on percentage of cancelled items
-  // Cleanup when: cancelled items >= MIN_CANCELLED_ITEMS_FOR_CLEANUP AND
-  //               cancelled percentage > CLEANUP_PERCENTAGE
-  size_t total_items = this->items_.size();
-  bool should_cleanup = false;
-
-  if (this->to_remove_ >= MIN_CANCELLED_ITEMS_FOR_CLEANUP && total_items > 0) {
-    // Use integer math to avoid floating point: (cancelled * 100 / total) > CLEANUP_PERCENTAGE
-    should_cleanup = (this->to_remove_ * 100) > (total_items * CLEANUP_PERCENTAGE);
-  }
-
-  if (should_cleanup) {
+  // Check if we should perform cleanup based on number of cancelled items
+  // Cleanup when we have accumulated MAX_LOGICALLY_DELETED_ITEMS cancelled items
+  // This simple threshold ensures we don't waste memory on cancelled items
+  // regardless of how many intervals are running
+  if (this->to_remove_ >= MAX_LOGICALLY_DELETED_ITEMS) {
     // We hold the lock for the entire cleanup operation because:
     // 1. We're rebuilding the entire items_ list, so we need exclusive access throughout
     // 2. Other threads must see either the old state or the new state, not intermediate states

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -14,7 +14,7 @@ namespace esphome {
 
 static const char *const TAG = "scheduler";
 
-static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 10;
+static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 6;
 // Half the 32-bit range - used to detect rollovers vs normal time progression
 static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
 // max delay to start an interval sequence
@@ -765,12 +765,12 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
   if (!item)
     return;
 
-  // Pool size of 8 is a balance between memory usage and performance:
+  // Pool size of 10 is a balance between memory usage and performance:
   // - Small enough to not waste memory on simple configs (1-2 timers)
   // - Large enough to handle complex setups with multiple sensors/components
   // - Prevents system-wide stalls from heap allocation/deallocation that can
   //   disrupt task synchronization and cause dropped events
-  static constexpr size_t MAX_POOL_SIZE = 8;
+  static constexpr size_t MAX_POOL_SIZE = 10;
   if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
     // Clear callback to release captured resources
     item->callback = nullptr;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -14,7 +14,18 @@ namespace esphome {
 
 static const char *const TAG = "scheduler";
 
+// Memory pool configuration constants
+// Pool size of 10 is a balance between memory usage and performance:
+// - Small enough to not waste memory on simple configs (1-2 timers)
+// - Large enough to handle complex setups with multiple sensors/components
+// - Prevents system-wide stalls from heap allocation/deallocation that can
+//   disrupt task synchronization and cause dropped events
+static constexpr size_t MAX_POOL_SIZE = 10;
+// Maximum number of cancelled items to keep in the heap before forcing a cleanup.
+// Set to 6 to trigger cleanup relatively frequently, ensuring cancelled items are
+// recycled to the pool in a timely manner to maintain pool efficiency.
 static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 6;
+
 // Half the 32-bit range - used to detect rollovers vs normal time progression
 static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
 // max delay to start an interval sequence
@@ -765,12 +776,6 @@ void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
   if (!item)
     return;
 
-  // Pool size of 10 is a balance between memory usage and performance:
-  // - Small enough to not waste memory on simple configs (1-2 timers)
-  // - Large enough to handle complex setups with multiple sensors/components
-  // - Prevents system-wide stalls from heap allocation/deallocation that can
-  //   disrupt task synchronization and cause dropped events
-  static constexpr size_t MAX_POOL_SIZE = 10;
   if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
     // Clear callback to release captured resources
     item->callback = nullptr;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -403,9 +403,10 @@ void HOT Scheduler::call(uint32_t now) {
       }
 
       const char *name = item->get_name();
-      ESP_LOGD(TAG, "  %s '%s/%s' interval=%" PRIu32 " next_execution in %" PRIu64 "ms at %" PRIu64,
+      bool is_cancelled = is_item_removed_(item.get());
+      ESP_LOGD(TAG, "  %s '%s/%s' interval=%" PRIu32 " next_execution in %" PRIu64 "ms at %" PRIu64 "%s",
                item->get_type_str(), item->get_source(), name ? name : "(null)", item->interval,
-               item->next_execution_ - now_64, item->next_execution_);
+               item->next_execution_ - now_64, item->next_execution_, is_cancelled ? " [CANCELLED]" : "");
 
       old_items.push_back(std::move(item));
     }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -79,8 +79,22 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     return;
   }
 
+  // Get fresh timestamp BEFORE taking lock - millis_64_ may need to acquire lock itself
+  const uint64_t now = this->millis_64_(millis());
+
+  // Take lock early to protect scheduler_item_pool_ access
+  LockGuard guard{this->lock_};
+
   // Create and populate the scheduler item
-  auto item = make_unique<SchedulerItem>();
+  std::unique_ptr<SchedulerItem> item;
+  if (!this->scheduler_item_pool_.empty()) {
+    // Reuse from pool
+    item = std::move(this->scheduler_item_pool_.back());
+    this->scheduler_item_pool_.pop_back();
+  } else {
+    // Allocate new if pool is empty
+    item = make_unique<SchedulerItem>();
+  }
   item->component = component;
   item->set_name(name_cstr, !is_static_string);
   item->type = type;
@@ -99,7 +113,6 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // Single-core platforms don't need thread-safe defer handling
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
     // Put in defer queue for guaranteed FIFO execution
-    LockGuard guard{this->lock_};
     if (!skip_cancel) {
       this->cancel_item_locked_(component, name_cstr, type);
     }
@@ -107,9 +120,6 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     return;
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
-
-  // Get fresh timestamp for new timer/interval - ensures accurate scheduling
-  const auto now = this->millis_64_(millis());  // Fresh millis() call
 
   // Type-specific setup
   if (type == SchedulerItem::INTERVAL) {
@@ -141,8 +151,6 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
              name_cstr ? name_cstr : "(null)", type_str, delay, static_cast<uint32_t>(item->next_execution_ - now));
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
-
-  LockGuard guard{this->lock_};
 
   // For retries, check if there's a cancelled timeout first
   if (is_retry && name_cstr != nullptr && type == SchedulerItem::TIMEOUT &&
@@ -335,11 +343,11 @@ void HOT Scheduler::call(uint32_t now) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     const auto last_dbg = this->last_millis_.load(std::memory_order_relaxed);
     const auto major_dbg = this->millis_major_.load(std::memory_order_relaxed);
-    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
-             major_dbg, last_dbg);
+    ESP_LOGD(TAG, "Items: count=%zu, pool=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(),
+             this->scheduler_item_pool_.size(), now_64, major_dbg, last_dbg);
 #else  /* not ESPHOME_THREAD_MULTI_ATOMICS */
-    ESP_LOGD(TAG, "Items: count=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(), now_64,
-             this->millis_major_, this->last_millis_);
+    ESP_LOGD(TAG, "Items: count=%zu, pool=%zu, now=%" PRIu64 " (%" PRIu16 ", %" PRIu32 ")", this->items_.size(),
+             this->scheduler_item_pool_.size(), now_64, this->millis_major_, this->last_millis_);
 #endif /* else ESPHOME_THREAD_MULTI_ATOMICS */
     // Cleanup before debug output
     this->cleanup_();
@@ -380,10 +388,13 @@ void HOT Scheduler::call(uint32_t now) {
 
     std::vector<std::unique_ptr<SchedulerItem>> valid_items;
 
-    // Move all non-removed items to valid_items
+    // Move all non-removed items to valid_items, recycle removed ones
     for (auto &item : this->items_) {
-      if (!item->remove) {
+      if (!is_item_removed_(item.get())) {
         valid_items.push_back(std::move(item));
+      } else {
+        // Recycle removed items
+        this->recycle_item_(std::move(item));
       }
     }
 
@@ -469,6 +480,9 @@ void HOT Scheduler::call(uint32_t now) {
         // Add new item directly to to_add_
         // since we have the lock held
         this->to_add_.push_back(std::move(item));
+      } else {
+        // Timeout completed - recycle it
+        this->recycle_item_(std::move(item));
       }
     }
   }
@@ -518,6 +532,10 @@ size_t HOT Scheduler::cleanup_() {
 }
 void HOT Scheduler::pop_raw_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
+
+  // Instead of destroying, recycle the item
+  this->recycle_item_(std::move(this->items_.back()));
+
   this->items_.pop_back();
 }
 
@@ -552,18 +570,14 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
 
   // Check all containers for matching items
 #ifndef ESPHOME_THREAD_SINGLE
-  // Only check defer queue for timeouts (intervals never go there)
+  // Cancel and immediately recycle items in defer queue
   if (type == SchedulerItem::TIMEOUT) {
-    for (auto &item : this->defer_queue_) {
-      if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
-        this->mark_item_removed_(item.get());
-        total_cancelled++;
-      }
-    }
+    total_cancelled +=
+        this->cancel_and_recycle_from_container_(this->defer_queue_, component, name_cstr, type, match_retry);
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 
-  // Cancel items in the main heap
+  // Cancel items in the main heap (can't recycle immediately due to heap structure)
   for (auto &item : this->items_) {
     if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
       this->mark_item_removed_(item.get());
@@ -572,14 +586,8 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
     }
   }
 
-  // Cancel items in to_add_
-  for (auto &item : this->to_add_) {
-    if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
-      this->mark_item_removed_(item.get());
-      total_cancelled++;
-      // Don't track removals for to_add_ items
-    }
-  }
+  // Cancel and immediately recycle items in to_add_ since they're not in heap yet
+  total_cancelled += this->cancel_and_recycle_from_container_(this->to_add_, component, name_cstr, type, match_retry);
 
   return total_cancelled > 0;
 }
@@ -745,6 +753,21 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,
                                        const std::unique_ptr<SchedulerItem> &b) {
   return a->next_execution_ > b->next_execution_;
+}
+
+void Scheduler::recycle_item_(std::unique_ptr<SchedulerItem> item) {
+  if (!item)
+    return;
+
+  static constexpr size_t MAX_POOL_SIZE = 16;
+  if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
+    // Clear callback to release captured resources
+    item->callback = nullptr;
+    // Clear dynamic name if any
+    item->clear_dynamic_name();
+    this->scheduler_item_pool_.push_back(std::move(item));
+  }
+  // else: unique_ptr will delete the item when it goes out of scope
 }
 
 }  // namespace esphome

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -98,47 +98,6 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // Take lock early to protect scheduler_item_pool_ access
   LockGuard guard{this->lock_};
 
-  // Optimization: if we're updating a timeout that hasn't been added to heap yet, just update it in-place
-  // This avoids allocating a new item and cancelling/re-adding
-  if (type == SchedulerItem::TIMEOUT && !skip_cancel && name_cstr != nullptr) {
-#ifndef ESPHOME_THREAD_SINGLE
-    // Multi-threaded: defers go to defer_queue_
-    if (delay == 0 && this->try_update_defer_in_container_(this->defer_queue_, component, name_cstr, std::move(func))) {
-      return;
-    }
-#endif
-
-    // Check if we can update an existing timeout in to_add_
-    if (!this->to_add_.empty()) {
-      auto &last_item = this->to_add_.back();
-      // Check if last item in to_add_ matches and can be updated
-      if (last_item->component == component && last_item->type == SchedulerItem::TIMEOUT &&
-          !is_item_removed_(last_item.get()) && this->names_match_(last_item->get_name(), name_cstr)) {
-#ifdef ESPHOME_THREAD_SINGLE
-        // Single-threaded: defers can be in to_add_, only update callback
-        if (delay == 0 && last_item->interval == 0) {
-          last_item->callback = std::move(func);
-#ifdef ESPHOME_DEBUG_SCHEDULER
-          ESP_LOGD(TAG, "Updated existing defer in to_add_ for '%s/%s'", component->get_component_source(),
-                   name_cstr ? name_cstr : "(null)");
-#endif
-          return;
-        }
-#endif
-        // For regular timeouts, update callback and execution time
-        if (delay != 0) {
-          last_item->callback = std::move(func);
-          last_item->next_execution_ = now + delay;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-          ESP_LOGD(TAG, "Updated existing timeout in to_add_ for '%s/%s'", component->get_component_source(),
-                   name_cstr ? name_cstr : "(null)");
-#endif
-          return;
-        }
-      }
-    }
-  }
-
   // Create and populate the scheduler item
   std::unique_ptr<SchedulerItem> item;
   if (!this->scheduler_item_pool_.empty()) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -15,21 +15,24 @@ namespace esphome {
 static const char *const TAG = "scheduler";
 
 // Memory pool configuration constants
-// Pool size of 10 is a balance between memory usage and performance:
-// - Small enough to not waste memory on simple configs (1-2 timers)
-// - Large enough to handle complex setups with multiple sensors/components
-// - Prevents system-wide stalls from heap allocation/deallocation that can
-//   disrupt task synchronization and cause dropped events
-static constexpr size_t MAX_POOL_SIZE = 10;
-// Maximum number of cancelled items to keep in the heap before forcing a cleanup.
-// Set to 6 to trigger cleanup relatively frequently, ensuring cancelled items are
-// recycled to the pool in a timely manner to maintain pool efficiency.
-static const uint32_t MAX_LOGICALLY_DELETED_ITEMS = 6;
+// Pool size of 5 matches typical usage patterns (2-4 active timers)
+// - Minimal memory overhead (~250 bytes on ESP32)
+// - Sufficient for most configs with a couple sensors/components
+// - Still prevents heap fragmentation and allocation stalls
+// - Complex setups with many timers will just allocate beyond the pool
+// See https://github.com/esphome/backlog/issues/52
+static constexpr size_t MAX_POOL_SIZE = 5;
 
-// Ensure MAX_LOGICALLY_DELETED_ITEMS is at least 4 smaller than MAX_POOL_SIZE
-// This guarantees we have room in the pool for recycled items when cleanup occurs
-static_assert(MAX_LOGICALLY_DELETED_ITEMS + 4 <= MAX_POOL_SIZE,
-              "MAX_LOGICALLY_DELETED_ITEMS must be at least 4 smaller than MAX_POOL_SIZE");
+// Cleanup is performed when cancelled items exceed this percentage of total items.
+// Using integer math: cleanup when (cancelled * 100 / total) > 50
+// This balances cleanup frequency with performance - we avoid O(n) cleanup
+// on every cancellation but don't let cancelled items accumulate excessively.
+static constexpr uint32_t CLEANUP_PERCENTAGE = 50;
+
+// Minimum number of cancelled items before considering cleanup.
+// Even if the fraction is exceeded, we need at least this many cancelled items
+// to make the O(n) cleanup operation worthwhile.
+static constexpr uint32_t MIN_CANCELLED_ITEMS_FOR_CLEANUP = 3;
 
 // Half the 32-bit range - used to detect rollovers vs normal time progression
 static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
@@ -417,8 +420,18 @@ void HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // If we have too many items to remove
-  if (this->to_remove_ > MAX_LOGICALLY_DELETED_ITEMS) {
+  // Check if we should perform cleanup based on percentage of cancelled items
+  // Cleanup when: cancelled items >= MIN_CANCELLED_ITEMS_FOR_CLEANUP AND
+  //               cancelled percentage > CLEANUP_PERCENTAGE
+  size_t total_items = this->items_.size();
+  bool should_cleanup = false;
+
+  if (this->to_remove_ >= MIN_CANCELLED_ITEMS_FOR_CLEANUP && total_items > 0) {
+    // Use integer math to avoid floating point: (cancelled * 100 / total) > CLEANUP_PERCENTAGE
+    should_cleanup = (this->to_remove_ * 100) > (total_items * CLEANUP_PERCENTAGE);
+  }
+
+  if (should_cleanup) {
     // We hold the lock for the entire cleanup operation because:
     // 1. We're rebuilding the entire items_ list, so we need exclusive access throughout
     // 2. Other threads must see either the old state or the new state, not intermediate states

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -217,6 +217,15 @@ class Scheduler {
   // Common implementation for cancel operations
   bool cancel_item_(Component *component, bool is_static_string, const void *name_ptr, SchedulerItem::Type type);
 
+  // Helper to check if two scheduler item names match
+  inline bool HOT names_match_(const char *name1, const char *name2) const {
+    // Check pointer equality first (common for static strings), then string contents
+    // The core ESPHome codebase uses static strings (const char*) for component names,
+    // making pointer comparison effective. The std::string overloads exist only for
+    // compatibility with external components but are rarely used in practice.
+    return (name1 != nullptr && name2 != nullptr) && ((name1 == name2) || (strcmp(name1, name2) == 0));
+  }
+
   // Helper function to check if item matches criteria for cancellation
   inline bool HOT matches_item_(const std::unique_ptr<SchedulerItem> &item, Component *component, const char *name_cstr,
                                 SchedulerItem::Type type, bool match_retry, bool skip_removed = true) const {
@@ -224,19 +233,7 @@ class Scheduler {
         (match_retry && !item->is_retry)) {
       return false;
     }
-    const char *item_name = item->get_name();
-    if (item_name == nullptr) {
-      return false;
-    }
-    // Fast path: if pointers are equal
-    // This is effective because the core ESPHome codebase uses static strings (const char*)
-    // for component names. The std::string overloads exist only for compatibility with
-    // external components, but are rarely used in practice.
-    if (item_name == name_cstr) {
-      return true;
-    }
-    // Slow path: compare string contents
-    return strcmp(name_cstr, item_name) == 0;
+    return this->names_match_(item->get_name(), name_cstr);
   }
 
   // Helper to execute a scheduler item
@@ -311,6 +308,28 @@ class Scheduler {
       }
     }
     return cancelled;
+  }
+
+  // Template helper to try updating a defer in a container instead of allocating a new one
+  // Returns true if the defer was updated, false if not found
+  template<typename Container>
+  bool try_update_defer_in_container_(Container &container, Component *component, const char *name_cstr,
+                                      std::function<void()> &&func) {
+    if (container.empty()) {
+      return false;
+    }
+
+    auto &last_item = container.back();
+
+    // Check if last item is a matching defer (timeout with 0 delay) and names match
+    if (last_item->component != component || last_item->type != SchedulerItem::TIMEOUT || last_item->interval != 0 ||
+        is_item_removed_(last_item.get()) || !this->names_match_(last_item->get_name(), name_cstr)) {
+      return false;
+    }
+
+    // Same defer at the end - just update the callback, no allocation needed
+    last_item->callback = std::move(func);
+    return true;
   }
 
   Mutex lock_;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -309,28 +309,6 @@ class Scheduler {
     return cancelled;
   }
 
-  // Template helper to try updating a defer in a container instead of allocating a new one
-  // Returns true if the defer was updated, false if not found
-  template<typename Container>
-  bool try_update_defer_in_container_(Container &container, Component *component, const char *name_cstr,
-                                      std::function<void()> &&func) {
-    if (container.empty()) {
-      return false;
-    }
-
-    auto &last_item = container.back();
-
-    // Check if last item is a matching defer (timeout with 0 delay) and names match
-    if (last_item->component != component || last_item->type != SchedulerItem::TIMEOUT || last_item->interval != 0 ||
-        is_item_removed_(last_item.get()) || !this->names_match_(last_item->get_name(), name_cstr)) {
-      return false;
-    }
-
-    // Same defer at the end - just update the callback, no allocation needed
-    last_item->callback = std::move(func);
-    return true;
-  }
-
   Mutex lock_;
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -291,24 +291,6 @@ class Scheduler {
     return false;
   }
 
-  // Template helper to cancel and recycle items from a container
-  template<typename Container>
-  size_t cancel_and_recycle_from_container_(Container &container, Component *component, const char *name_cstr,
-                                            SchedulerItem::Type type, bool match_retry) {
-    size_t cancelled = 0;
-    for (auto it = container.begin(); it != container.end();) {
-      if (this->matches_item_(*it, component, name_cstr, type, match_retry)) {
-        // Recycle the cancelled item immediately
-        this->recycle_item_(std::move(*it));
-        it = container.erase(it);
-        cancelled++;
-      } else {
-        ++it;
-      }
-    }
-    return cancelled;
-  }
-
   Mutex lock_;
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -344,8 +344,8 @@ class Scheduler {
   // Memory pool for recycling SchedulerItem objects to reduce heap churn.
   // Design decisions:
   // - std::vector is used instead of a fixed array because many systems only need 1-2 scheduler items
-  // - The vector grows dynamically up to MAX_POOL_SIZE (10) only when needed, saving memory on simple setups
-  // - This approach balances memory efficiency for simple configs with performance for complex ones
+  // - The vector grows dynamically up to MAX_POOL_SIZE (5) only when needed, saving memory on simple setups
+  // - Pool size of 5 matches typical usage (2-4 timers) while keeping memory overhead low (~250 bytes on ESP32)
   // - The pool significantly reduces heap fragmentation which is critical because heap allocation/deallocation
   //   can stall the entire system, causing timing issues and dropped events for any components that need
   //   to synchronize between tasks (see https://github.com/esphome/backlog/issues/52)

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -322,7 +322,14 @@ class Scheduler {
 #endif                                                      /* ESPHOME_THREAD_SINGLE */
   uint32_t to_remove_{0};
 
-  // Memory pool for recycling SchedulerItem objects
+  // Memory pool for recycling SchedulerItem objects to reduce heap churn.
+  // Design decisions:
+  // - std::vector is used instead of a fixed array because many systems only need 1-2 scheduler items
+  // - The vector grows dynamically up to MAX_POOL_SIZE (8) only when needed, saving memory on simple setups
+  // - This approach balances memory efficiency for simple configs with performance for complex ones
+  // - The pool significantly reduces heap fragmentation which is critical because heap allocation/deallocation
+  //   can stall the entire system, causing timing issues and dropped events for any components that need
+  //   to synchronize between tasks (see https://github.com/esphome/backlog/issues/52)
   std::vector<std::unique_ptr<SchedulerItem>> scheduler_item_pool_;
 
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <cstring>
 #include <deque>
-#include <array>
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
 #include <atomic>
 #endif

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -325,7 +325,7 @@ class Scheduler {
   // Memory pool for recycling SchedulerItem objects to reduce heap churn.
   // Design decisions:
   // - std::vector is used instead of a fixed array because many systems only need 1-2 scheduler items
-  // - The vector grows dynamically up to MAX_POOL_SIZE (8) only when needed, saving memory on simple setups
+  // - The vector grows dynamically up to MAX_POOL_SIZE (10) only when needed, saving memory on simple setups
   // - This approach balances memory efficiency for simple configs with performance for complex ones
   // - The pool significantly reduces heap fragmentation which is critical because heap allocation/deallocation
   //   can stall the entire system, causing timing issues and dropped events for any components that need

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <cstring>
 #include <deque>
+#include <array>
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
 #include <atomic>
 #endif
@@ -142,11 +143,7 @@ class Scheduler {
     }
 
     // Destructor to clean up dynamic names
-    ~SchedulerItem() {
-      if (name_is_dynamic) {
-        delete[] name_.dynamic_name;
-      }
-    }
+    ~SchedulerItem() { clear_dynamic_name(); }
 
     // Delete copy operations to prevent accidental copies
     SchedulerItem(const SchedulerItem &) = delete;
@@ -159,13 +156,19 @@ class Scheduler {
     // Helper to get the name regardless of storage type
     const char *get_name() const { return name_is_dynamic ? name_.dynamic_name : name_.static_name; }
 
+    // Helper to clear dynamic name if allocated
+    void clear_dynamic_name() {
+      if (name_is_dynamic && name_.dynamic_name) {
+        delete[] name_.dynamic_name;
+        name_.dynamic_name = nullptr;
+        name_is_dynamic = false;
+      }
+    }
+
     // Helper to set name with proper ownership
     void set_name(const char *name, bool make_copy = false) {
       // Clean up old dynamic name if any
-      if (name_is_dynamic && name_.dynamic_name) {
-        delete[] name_.dynamic_name;
-        name_is_dynamic = false;
-      }
+      clear_dynamic_name();
 
       if (!name) {
         // nullptr case - no name provided
@@ -240,9 +243,12 @@ class Scheduler {
   void execute_item_(SchedulerItem *item, uint32_t now);
 
   // Helper to check if item should be skipped
-  bool should_skip_item_(const SchedulerItem *item) const {
-    return item->remove || (item->component != nullptr && item->component->is_failed());
+  bool should_skip_item_(SchedulerItem *item) const {
+    return is_item_removed_(item) || (item->component != nullptr && item->component->is_failed());
   }
+
+  // Helper to recycle a SchedulerItem
+  void recycle_item_(std::unique_ptr<SchedulerItem> item);
 
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization
@@ -280,12 +286,31 @@ class Scheduler {
   bool has_cancelled_timeout_in_container_(const Container &container, Component *component, const char *name_cstr,
                                            bool match_retry) const {
     for (const auto &item : container) {
-      if (item->remove && this->matches_item_(item, component, name_cstr, SchedulerItem::TIMEOUT, match_retry,
-                                              /* skip_removed= */ false)) {
+      if (is_item_removed_(item.get()) &&
+          this->matches_item_(item, component, name_cstr, SchedulerItem::TIMEOUT, match_retry,
+                              /* skip_removed= */ false)) {
         return true;
       }
     }
     return false;
+  }
+
+  // Template helper to cancel and recycle items from a container
+  template<typename Container>
+  size_t cancel_and_recycle_from_container_(Container &container, Component *component, const char *name_cstr,
+                                            SchedulerItem::Type type, bool match_retry) {
+    size_t cancelled = 0;
+    for (auto it = container.begin(); it != container.end();) {
+      if (this->matches_item_(*it, component, name_cstr, type, match_retry)) {
+        // Recycle the cancelled item immediately
+        this->recycle_item_(std::move(*it));
+        it = container.erase(it);
+        cancelled++;
+      } else {
+        ++it;
+      }
+    }
+    return cancelled;
   }
 
   Mutex lock_;
@@ -296,6 +321,9 @@ class Scheduler {
   std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
 #endif                                                      /* ESPHOME_THREAD_SINGLE */
   uint32_t to_remove_{0};
+
+  // Memory pool for recycling SchedulerItem objects
+  std::vector<std::unique_ptr<SchedulerItem>> scheduler_item_pool_;
 
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   /*

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -144,33 +144,39 @@ script:
     then:
       - lambda: |-
           // Simulate defer patterns (state changes, async operations)
-          ESP_LOGI("test", "Phase 4: Simulating defer patterns");
+          ESP_LOGI("test", "Phase 4: Simulating heavy defer patterns like ratgdo");
 
-          class TestComponent : public Component {
-          public:
-            void simulate_state_changes() {
-              // Defer state changes (common in switches, lights, etc)
-              this->defer("state_change_1", []() {
-                ESP_LOGD("test", "State change 1 applied");
-                id(create_count)++;
-              });
+          auto *component = id(test_sensor);
 
-              // Another state change
-              this->defer("state_change_2", []() {
-                ESP_LOGD("test", "State change 2 applied");
-                id(create_count)++;
-              });
+          // Simulate a burst of defer operations like ratgdo does with state updates
+          // These should execute immediately and recycle quickly to the pool
+          for (int i = 0; i < 10; i++) {
+            std::string defer_name = "defer_" + std::to_string(i);
+            App.scheduler.set_timeout(component, defer_name, 0, [i]() {
+              ESP_LOGD("test", "Defer %d executed", i);
+              // Force a small delay between defer executions to see recycling
+              if (i == 5) {
+                ESP_LOGI("test", "Half of defers executed, checking pool status");
+              }
+            });
+          }
 
-              // Cleanup operation
-              this->defer("cleanup", []() {
-                ESP_LOGD("test", "Cleanup executed");
-                id(create_count)++;
-              });
-            }
-          };
+          id(create_count) += 10;
+          ESP_LOGD("test", "Created 10 defer operations (0ms timeouts)");
 
-          static TestComponent test_comp;
-          test_comp.simulate_state_changes();
+          // Also create some named defers that might get replaced
+          App.scheduler.set_timeout(component, "state_update", 0, []() {
+            ESP_LOGD("test", "State update 1");
+          });
+
+          // Replace the same named defer (should cancel previous)
+          App.scheduler.set_timeout(component, "state_update", 0, []() {
+            ESP_LOGD("test", "State update 2 (replaced)");
+          });
+
+          id(create_count) += 2;
+          id(cancel_count) += 1; // One cancelled due to replacement
+
           ESP_LOGI("test", "Phase 4 complete");
 
   - id: test_pool_reuse_verification

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -175,22 +175,26 @@ script:
       - lambda: |-
           ESP_LOGI("test", "Phase 5: Verifying pool reuse after everything settles");
 
-          // First, ensure any remaining intervals are cancelled to recycle to pool
+          // Cancel any remaining intervals
           auto *component = id(test_sensor);
           App.scheduler.cancel_interval(component, "temp_sensor");
           App.scheduler.cancel_interval(component, "humidity_sensor");
           App.scheduler.cancel_interval(component, "heartbeat");
 
-          // Give a moment for items to be recycled
-          ESP_LOGD("test", "Cancelled any remaining intervals to build up pool");
+          ESP_LOGD("test", "Cancelled any remaining intervals");
 
-          // Now create 6 new timeouts - they should all reuse from pool
-          int reuse_test_count = 6;
-          int initial_pool_reused = 0;
+          // The pool should have items from completed timeouts in earlier phases.
+          // Phase 1 had 3 timeouts that completed and were recycled.
+          // Phase 3 had 1 timeout that completed and was recycled.
+          // Phase 4 had 3 defers that completed and were recycled.
+          // So we should have a decent pool size already from naturally completed items.
+
+          // Now create 8 new timeouts - they should reuse from pool when available
+          int reuse_test_count = 8;
 
           for (int i = 0; i < reuse_test_count; i++) {
             std::string name = "reuse_test_" + std::to_string(i);
-            App.scheduler.set_timeout(component, name, 100 + i * 50, [i]() {
+            App.scheduler.set_timeout(component, name, 50 + i * 10, [i]() {
               ESP_LOGD("test", "Reuse test %d completed", i);
             });
           }

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -24,6 +24,9 @@ api:
     - service: run_phase_5
       then:
         - script.execute: test_pool_reuse_verification
+    - service: run_phase_6
+      then:
+        - script.execute: test_full_pool_reuse
     - service: run_complete
       then:
         - script.execute: complete_test
@@ -202,6 +205,29 @@ script:
           ESP_LOGI("test", "Created %d items for reuse verification", reuse_test_count);
           id(create_count) += reuse_test_count;
           ESP_LOGI("test", "Phase 5 complete");
+
+  - id: test_full_pool_reuse
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "Phase 6: Testing full pool reuse after Phase 5 items complete");
+
+          // At this point, all Phase 5 timeouts should have completed and been recycled.
+          // The pool should be at or near its maximum size (10).
+          // Creating 10 new items should reuse all from the pool.
+
+          auto *component = id(test_sensor);
+          int full_reuse_count = 10;
+
+          for (int i = 0; i < full_reuse_count; i++) {
+            std::string name = "full_reuse_" + std::to_string(i);
+            App.scheduler.set_timeout(component, name, 50 + i * 10, [i]() {
+              ESP_LOGD("test", "Full reuse test %d completed", i);
+            });
+          }
+
+          ESP_LOGI("test", "Created %d items for full pool reuse verification", full_reuse_count);
+          id(create_count) += full_reuse_count;
+          ESP_LOGI("test", "Phase 6 complete");
 
   - id: complete_test
     then:

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -1,0 +1,215 @@
+esphome:
+  name: scheduler-pool-test
+  on_boot:
+    priority: -100
+    then:
+      - logger.log: "Starting scheduler pool tests"
+  debug_scheduler: true  # Enable scheduler debug logging
+
+host:
+api:
+  services:
+    - service: run_phase_1
+      then:
+        - script.execute: test_pool_recycling
+    - service: run_phase_2
+      then:
+        - script.execute: test_sensor_polling
+    - service: run_phase_3
+      then:
+        - script.execute: test_communication_patterns
+    - service: run_phase_4
+      then:
+        - script.execute: test_defer_patterns
+    - service: run_phase_5
+      then:
+        - script.execute: test_pool_reuse_verification
+    - service: run_complete
+      then:
+        - script.execute: complete_test
+logger:
+  level: VERY_VERBOSE  # Need VERY_VERBOSE to see pool debug messages
+
+globals:
+  - id: create_count
+    type: int
+    initial_value: '0'
+  - id: cancel_count
+    type: int
+    initial_value: '0'
+  - id: interval_counter
+    type: int
+    initial_value: '0'
+  - id: pool_test_done
+    type: bool
+    initial_value: 'false'
+
+script:
+  - id: test_pool_recycling
+    then:
+      - logger.log: "Testing scheduler pool recycling with realistic usage patterns"
+      - lambda: |-
+          auto *component = id(test_sensor);
+
+          // Simulate realistic component behavior with timeouts that complete naturally
+          ESP_LOGI("test", "Phase 1: Simulating normal component lifecycle");
+
+          // Sensor update timeouts (common pattern)
+          App.scheduler.set_timeout(component, "sensor_init", 100, []() {
+            ESP_LOGD("test", "Sensor initialized");
+            id(create_count)++;
+          });
+
+          // Retry timeout (gets cancelled if successful)
+          App.scheduler.set_timeout(component, "retry_timeout", 500, []() {
+            ESP_LOGD("test", "Retry timeout executed");
+            id(create_count)++;
+          });
+
+          // Simulate successful operation - cancel retry
+          App.scheduler.set_timeout(component, "success_sim", 200, []() {
+            ESP_LOGD("test", "Operation succeeded, cancelling retry");
+            App.scheduler.cancel_timeout(id(test_sensor), "retry_timeout");
+            id(cancel_count)++;
+          });
+
+          id(create_count) += 3;
+          ESP_LOGI("test", "Phase 1 complete");
+
+  - id: test_sensor_polling
+    then:
+      - lambda: |-
+          // Simulate sensor polling pattern
+          ESP_LOGI("test", "Phase 2: Simulating sensor polling patterns");
+          auto *component = id(test_sensor);
+
+          // Multiple sensors with different update intervals
+          App.scheduler.set_interval(component, "temp_sensor", 1000, []() {
+            ESP_LOGD("test", "Temperature sensor update");
+            id(interval_counter)++;
+            if (id(interval_counter) >= 3) {
+              App.scheduler.cancel_interval(id(test_sensor), "temp_sensor");
+              ESP_LOGD("test", "Temperature sensor stopped");
+            }
+          });
+
+          App.scheduler.set_interval(component, "humidity_sensor", 1500, []() {
+            ESP_LOGD("test", "Humidity sensor update");
+            id(interval_counter)++;
+            if (id(interval_counter) >= 5) {
+              App.scheduler.cancel_interval(id(test_sensor), "humidity_sensor");
+              ESP_LOGD("test", "Humidity sensor stopped");
+            }
+          });
+
+          id(create_count) += 2;
+          ESP_LOGI("test", "Phase 2 complete");
+
+  - id: test_communication_patterns
+    then:
+      - lambda: |-
+          // Simulate communication patterns (WiFi/API reconnects, etc)
+          ESP_LOGI("test", "Phase 3: Simulating communication patterns");
+          auto *component = id(test_sensor);
+
+          // Connection timeout pattern
+          App.scheduler.set_timeout(component, "connect_timeout", 2000, []() {
+            ESP_LOGD("test", "Connection timeout - would retry");
+            id(create_count)++;
+
+            // Schedule retry
+            App.scheduler.set_timeout(id(test_sensor), "connect_retry", 1000, []() {
+              ESP_LOGD("test", "Retrying connection");
+              id(create_count)++;
+            });
+          });
+
+          // Heartbeat pattern
+          App.scheduler.set_interval(component, "heartbeat", 500, []() {
+            ESP_LOGD("test", "Heartbeat");
+            id(interval_counter)++;
+            if (id(interval_counter) >= 10) {
+              App.scheduler.cancel_interval(id(test_sensor), "heartbeat");
+              ESP_LOGD("test", "Heartbeat stopped");
+            }
+          });
+
+          id(create_count) += 2;
+          ESP_LOGI("test", "Phase 3 complete");
+
+  - id: test_defer_patterns
+    then:
+      - lambda: |-
+          // Simulate defer patterns (state changes, async operations)
+          ESP_LOGI("test", "Phase 4: Simulating defer patterns");
+
+          class TestComponent : public Component {
+          public:
+            void simulate_state_changes() {
+              // Defer state changes (common in switches, lights, etc)
+              this->defer("state_change_1", []() {
+                ESP_LOGD("test", "State change 1 applied");
+                id(create_count)++;
+              });
+
+              // Another state change
+              this->defer("state_change_2", []() {
+                ESP_LOGD("test", "State change 2 applied");
+                id(create_count)++;
+              });
+
+              // Cleanup operation
+              this->defer("cleanup", []() {
+                ESP_LOGD("test", "Cleanup executed");
+                id(create_count)++;
+              });
+            }
+          };
+
+          static TestComponent test_comp;
+          test_comp.simulate_state_changes();
+          ESP_LOGI("test", "Phase 4 complete");
+
+  - id: test_pool_reuse_verification
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "Phase 5: Verifying pool reuse after everything settles");
+
+          // First, ensure any remaining intervals are cancelled to recycle to pool
+          auto *component = id(test_sensor);
+          App.scheduler.cancel_interval(component, "temp_sensor");
+          App.scheduler.cancel_interval(component, "humidity_sensor");
+          App.scheduler.cancel_interval(component, "heartbeat");
+
+          // Give a moment for items to be recycled
+          ESP_LOGD("test", "Cancelled any remaining intervals to build up pool");
+
+          // Now create 6 new timeouts - they should all reuse from pool
+          int reuse_test_count = 6;
+          int initial_pool_reused = 0;
+
+          for (int i = 0; i < reuse_test_count; i++) {
+            std::string name = "reuse_test_" + std::to_string(i);
+            App.scheduler.set_timeout(component, name, 100 + i * 50, [i]() {
+              ESP_LOGD("test", "Reuse test %d completed", i);
+            });
+          }
+
+          ESP_LOGI("test", "Created %d items for reuse verification", reuse_test_count);
+          id(create_count) += reuse_test_count;
+          ESP_LOGI("test", "Phase 5 complete");
+
+  - id: complete_test
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "Pool recycling test complete - created %d items, cancelled %d, intervals %d",
+                   id(create_count), id(cancel_count), id(interval_counter));
+
+sensor:
+  - platform: template
+    name: Test Sensor
+    id: test_sensor
+    lambda: return 1.0;
+    update_interval: never
+
+# No interval - tests will be triggered from Python via API services

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -27,6 +27,9 @@ api:
     - service: run_phase_6
       then:
         - script.execute: test_full_pool_reuse
+    - service: run_phase_7
+      then:
+        - script.execute: test_same_defer_optimization
     - service: run_complete
       then:
         - script.execute: complete_test
@@ -87,7 +90,8 @@ script:
           auto *component = id(test_sensor);
 
           // Multiple sensors with different update intervals
-          App.scheduler.set_interval(component, "temp_sensor", 100, []() {
+          // These should only allocate once and reuse the same item for each interval execution
+          App.scheduler.set_interval(component, "temp_sensor", 10, []() {
             ESP_LOGD("test", "Temperature sensor update");
             id(interval_counter)++;
             if (id(interval_counter) >= 3) {
@@ -96,7 +100,7 @@ script:
             }
           });
 
-          App.scheduler.set_interval(component, "humidity_sensor", 150, []() {
+          App.scheduler.set_interval(component, "humidity_sensor", 15, []() {
             ESP_LOGD("test", "Humidity sensor update");
             id(interval_counter)++;
             if (id(interval_counter) >= 5) {
@@ -105,7 +109,9 @@ script:
             }
           });
 
+          // Only 2 allocations for the intervals, no matter how many times they execute
           id(create_count) += 2;
+          ESP_LOGD("test", "Created 2 intervals - they will reuse same items for each execution");
           ESP_LOGI("test", "Phase 2 complete");
 
   - id: test_communication_patterns
@@ -215,11 +221,14 @@ script:
   - id: test_full_pool_reuse
     then:
       - lambda: |-
-          ESP_LOGI("test", "Phase 6: Testing full pool reuse after Phase 5 items complete");
+          ESP_LOGI("test", "Phase 6: Testing pool size limits after Phase 5 items complete");
 
           // At this point, all Phase 5 timeouts should have completed and been recycled.
-          // The pool should be at or near its maximum size (10).
-          // Creating 10 new items should reuse all from the pool.
+          // The pool should be at its maximum size (5).
+          // Creating 10 new items tests that:
+          // - First 5 items reuse from the pool
+          // - Remaining 5 items allocate new (pool empty)
+          // - Pool doesn't grow beyond MAX_POOL_SIZE of 5
 
           auto *component = id(test_sensor);
           int full_reuse_count = 10;
@@ -234,6 +243,28 @@ script:
           ESP_LOGI("test", "Created %d items for full pool reuse verification", full_reuse_count);
           id(create_count) += full_reuse_count;
           ESP_LOGI("test", "Phase 6 complete");
+
+  - id: test_same_defer_optimization
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "Phase 7: Testing same-named defer optimization");
+
+          auto *component = id(test_sensor);
+
+          // Create 10 defers with the same name - should optimize to update callback in-place
+          // This pattern is common in components like ratgdo that repeatedly defer state updates
+          for (int i = 0; i < 10; i++) {
+            App.scheduler.set_timeout(component, "repeated_defer", 0, [i]() {
+              ESP_LOGD("test", "Repeated defer executed with value: %d", i);
+            });
+          }
+
+          // Only the first should allocate, the rest should update in-place
+          // We expect only 1 allocation for all 10 operations
+          id(create_count) += 1;  // Only count 1 since others should be optimized
+
+          ESP_LOGD("test", "Created 10 same-named defers (should only allocate once)");
+          ESP_LOGI("test", "Phase 7 complete");
 
   - id: complete_test
     then:

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -58,19 +58,19 @@ script:
           ESP_LOGI("test", "Phase 1: Simulating normal component lifecycle");
 
           // Sensor update timeouts (common pattern)
-          App.scheduler.set_timeout(component, "sensor_init", 100, []() {
+          App.scheduler.set_timeout(component, "sensor_init", 10, []() {
             ESP_LOGD("test", "Sensor initialized");
             id(create_count)++;
           });
 
           // Retry timeout (gets cancelled if successful)
-          App.scheduler.set_timeout(component, "retry_timeout", 500, []() {
+          App.scheduler.set_timeout(component, "retry_timeout", 50, []() {
             ESP_LOGD("test", "Retry timeout executed");
             id(create_count)++;
           });
 
           // Simulate successful operation - cancel retry
-          App.scheduler.set_timeout(component, "success_sim", 200, []() {
+          App.scheduler.set_timeout(component, "success_sim", 20, []() {
             ESP_LOGD("test", "Operation succeeded, cancelling retry");
             App.scheduler.cancel_timeout(id(test_sensor), "retry_timeout");
             id(cancel_count)++;
@@ -87,7 +87,7 @@ script:
           auto *component = id(test_sensor);
 
           // Multiple sensors with different update intervals
-          App.scheduler.set_interval(component, "temp_sensor", 1000, []() {
+          App.scheduler.set_interval(component, "temp_sensor", 100, []() {
             ESP_LOGD("test", "Temperature sensor update");
             id(interval_counter)++;
             if (id(interval_counter) >= 3) {
@@ -96,7 +96,7 @@ script:
             }
           });
 
-          App.scheduler.set_interval(component, "humidity_sensor", 1500, []() {
+          App.scheduler.set_interval(component, "humidity_sensor", 150, []() {
             ESP_LOGD("test", "Humidity sensor update");
             id(interval_counter)++;
             if (id(interval_counter) >= 5) {
@@ -116,19 +116,19 @@ script:
           auto *component = id(test_sensor);
 
           // Connection timeout pattern
-          App.scheduler.set_timeout(component, "connect_timeout", 2000, []() {
+          App.scheduler.set_timeout(component, "connect_timeout", 200, []() {
             ESP_LOGD("test", "Connection timeout - would retry");
             id(create_count)++;
 
             // Schedule retry
-            App.scheduler.set_timeout(id(test_sensor), "connect_retry", 1000, []() {
+            App.scheduler.set_timeout(id(test_sensor), "connect_retry", 100, []() {
               ESP_LOGD("test", "Retrying connection");
               id(create_count)++;
             });
           });
 
           // Heartbeat pattern
-          App.scheduler.set_interval(component, "heartbeat", 500, []() {
+          App.scheduler.set_interval(component, "heartbeat", 50, []() {
             ESP_LOGD("test", "Heartbeat");
             id(interval_counter)++;
             if (id(interval_counter) >= 10) {
@@ -203,7 +203,7 @@ script:
 
           for (int i = 0; i < reuse_test_count; i++) {
             std::string name = "reuse_test_" + std::to_string(i);
-            App.scheduler.set_timeout(component, name, 50 + i * 10, [i]() {
+            App.scheduler.set_timeout(component, name, 10 + i * 5, [i]() {
               ESP_LOGD("test", "Reuse test %d completed", i);
             });
           }
@@ -226,7 +226,7 @@ script:
 
           for (int i = 0; i < full_reuse_count; i++) {
             std::string name = "full_reuse_" + std::to_string(i);
-            App.scheduler.set_timeout(component, name, 50 + i * 10, [i]() {
+            App.scheduler.set_timeout(component, name, 10 + i * 5, [i]() {
               ESP_LOGD("test", "Full reuse test %d completed", i);
             });
           }

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -148,7 +148,7 @@ async def test_scheduler_pool(
 
             # Complete test
             client.execute_service(complete_service, {})
-            await asyncio.wait_for(test_complete_future, timeout=2.0)
+            await asyncio.wait_for(test_complete_future, timeout=0.5)
 
         except TimeoutError as e:
             # Print debug info if test times out

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -1,0 +1,194 @@
+"""Integration test for scheduler memory pool functionality."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_pool(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that the scheduler memory pool is working correctly with realistic usage.
+
+    This test simulates real-world scheduler usage patterns and verifies that:
+    1. Items are recycled to the pool when timeouts complete naturally
+    2. Items are recycled when intervals/timeouts are cancelled
+    3. Items are reused from the pool for new scheduler operations
+    4. The pool grows gradually based on actual usage patterns
+    5. Pool operations are logged correctly with debug scheduler enabled
+    """
+    # Track log messages to verify pool behavior
+    log_lines: list[str] = []
+    pool_reuse_count = 0
+    pool_recycle_count = 0
+    pool_full_count = 0
+    new_alloc_count = 0
+
+    # Patterns to match pool operations
+    reuse_pattern = re.compile(r"Reused item from pool \(pool size now: (\d+)\)")
+    recycle_pattern = re.compile(r"Recycled item to pool \(pool size now: (\d+)\)")
+    pool_full_pattern = re.compile(r"Pool full \(size: (\d+)\), deleting item")
+    new_alloc_pattern = re.compile(r"Allocated new item \(pool empty\)")
+
+    # Futures to track when test phases complete
+    loop = asyncio.get_running_loop()
+    test_complete_future: asyncio.Future[bool] = loop.create_future()
+    phase_futures = {
+        1: loop.create_future(),
+        2: loop.create_future(),
+        3: loop.create_future(),
+        4: loop.create_future(),
+        5: loop.create_future(),
+    }
+
+    def check_output(line: str) -> None:
+        """Check log output for pool operations and phase completion."""
+        nonlocal pool_reuse_count, pool_recycle_count, pool_full_count, new_alloc_count
+        log_lines.append(line)
+
+        # Track pool operations
+        if reuse_pattern.search(line):
+            pool_reuse_count += 1
+
+        elif recycle_pattern.search(line):
+            pool_recycle_count += 1
+
+        elif pool_full_pattern.search(line):
+            pool_full_count += 1
+
+        elif new_alloc_pattern.search(line):
+            new_alloc_count += 1
+
+        # Track phase completion
+        for phase_num in range(1, 6):
+            if (
+                f"Phase {phase_num} complete" in line
+                and not phase_futures[phase_num].done()
+            ):
+                phase_futures[phase_num].set_result(True)
+
+        # Check for test completion
+        if "Pool recycling test complete" in line and not test_complete_future.done():
+            test_complete_future.set_result(True)
+
+    # Run the test with log monitoring
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Verify device is running
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "scheduler-pool-test"
+
+        # Get list of services
+        entities, services = await client.list_entities_services()
+        service_names = {s.name for s in services}
+
+        # Verify all test services are available
+        expected_services = {
+            "run_phase_1",
+            "run_phase_2",
+            "run_phase_3",
+            "run_phase_4",
+            "run_phase_5",
+            "run_complete",
+        }
+        assert expected_services.issubset(service_names), (
+            f"Missing services: {expected_services - service_names}"
+        )
+
+        # Get service objects
+        phase_services = {
+            num: next(s for s in services if s.name == f"run_phase_{num}")
+            for num in range(1, 6)
+        }
+        complete_service = next(s for s in services if s.name == "run_complete")
+
+        try:
+            # Phase 1: Component lifecycle
+            client.execute_service(phase_services[1], {})
+            await asyncio.wait_for(phase_futures[1], timeout=3.0)
+            await asyncio.sleep(0.5)  # Let timeouts complete
+
+            # Phase 2: Sensor polling
+            client.execute_service(phase_services[2], {})
+            await asyncio.wait_for(phase_futures[2], timeout=3.0)
+            await asyncio.sleep(1.0)  # Let intervals run a bit
+
+            # Phase 3: Communication patterns
+            client.execute_service(phase_services[3], {})
+            await asyncio.wait_for(phase_futures[3], timeout=3.0)
+            await asyncio.sleep(1.0)  # Let heartbeat run
+
+            # Phase 4: Defer patterns
+            client.execute_service(phase_services[4], {})
+            await asyncio.wait_for(phase_futures[4], timeout=3.0)
+            await asyncio.sleep(2.0)  # Let everything settle and recycle
+
+            # Phase 5: Pool reuse verification
+            client.execute_service(phase_services[5], {})
+            await asyncio.wait_for(phase_futures[5], timeout=3.0)
+            await asyncio.sleep(0.5)  # Let reuse tests complete
+
+            # Complete test
+            client.execute_service(complete_service, {})
+            await asyncio.wait_for(test_complete_future, timeout=2.0)
+
+        except TimeoutError as e:
+            # Print debug info if test times out
+            recent_logs = "\n".join(log_lines[-30:])
+            phases_completed = [num for num, fut in phase_futures.items() if fut.done()]
+            pytest.fail(
+                f"Test timed out waiting for phase/completion. Error: {e}\n"
+                f"  Phases completed: {phases_completed}\n"
+                f"  Pool stats:\n"
+                f"    Reuse count: {pool_reuse_count}\n"
+                f"    Recycle count: {pool_recycle_count}\n"
+                f"    Pool full count: {pool_full_count}\n"
+                f"    New alloc count: {new_alloc_count}\n"
+                f"Recent logs:\n{recent_logs}"
+            )
+
+    # Verify all test phases ran
+    for phase_num in range(1, 6):
+        assert phase_futures[phase_num].done(), f"Phase {phase_num} did not complete"
+
+    # Verify pool behavior
+    assert pool_recycle_count > 0, "Should have recycled items to pool"
+
+    # Check pool metrics
+    if pool_recycle_count > 0:
+        max_pool_size = 0
+        for line in log_lines:
+            if match := recycle_pattern.search(line):
+                size = int(match.group(1))
+                max_pool_size = max(max_pool_size, size)
+
+        # Pool can grow up to its maximum of 8
+        assert max_pool_size <= 8, f"Pool grew beyond maximum ({max_pool_size})"
+
+    # Log summary for debugging
+    print("\nScheduler Pool Test Summary (Python Orchestrated):")
+    print(f"  Items recycled to pool: {pool_recycle_count}")
+    print(f"  Items reused from pool: {pool_reuse_count}")
+    print(f"  Pool full events: {pool_full_count}")
+    print(f"  New allocations: {new_alloc_count}")
+    print("  All phases completed successfully")
+
+    # Verify reuse happened
+    if pool_reuse_count == 0 and pool_recycle_count > 3:
+        pytest.fail("Pool had items recycled but none were reused")
+
+    # Success - pool is working
+    assert pool_recycle_count > 0 or new_alloc_count < 15, (
+        "Pool should either recycle items or limit new allocations"
+    )

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -48,6 +48,7 @@ async def test_scheduler_pool(
         4: loop.create_future(),
         5: loop.create_future(),
         6: loop.create_future(),
+        7: loop.create_future(),
     }
 
     def check_output(line: str) -> None:
@@ -69,9 +70,10 @@ async def test_scheduler_pool(
             new_alloc_count += 1
 
         # Track phase completion
-        for phase_num in range(1, 7):
+        for phase_num in range(1, 8):
             if (
                 f"Phase {phase_num} complete" in line
+                and phase_num in phase_futures
                 and not phase_futures[phase_num].done()
             ):
                 phase_futures[phase_num].set_result(True)
@@ -102,6 +104,7 @@ async def test_scheduler_pool(
             "run_phase_4",
             "run_phase_5",
             "run_phase_6",
+            "run_phase_7",
             "run_complete",
         }
         assert expected_services.issubset(service_names), (
@@ -111,7 +114,7 @@ async def test_scheduler_pool(
         # Get service objects
         phase_services = {
             num: next(s for s in services if s.name == f"run_phase_{num}")
-            for num in range(1, 7)
+            for num in range(1, 8)
         }
         complete_service = next(s for s in services if s.name == "run_complete")
 
@@ -146,6 +149,11 @@ async def test_scheduler_pool(
             await asyncio.wait_for(phase_futures[6], timeout=1.0)
             await asyncio.sleep(0.1)  # Let Phase 6 timeouts complete
 
+            # Phase 7: Same-named defer optimization
+            client.execute_service(phase_services[7], {})
+            await asyncio.wait_for(phase_futures[7], timeout=1.0)
+            await asyncio.sleep(0.05)  # Let the single defer execute
+
             # Complete test
             client.execute_service(complete_service, {})
             await asyncio.wait_for(test_complete_future, timeout=0.5)
@@ -166,7 +174,7 @@ async def test_scheduler_pool(
             )
 
     # Verify all test phases ran
-    for phase_num in range(1, 7):
+    for phase_num in range(1, 8):
         assert phase_futures[phase_num].done(), f"Phase {phase_num} did not complete"
 
     # Verify pool behavior
@@ -180,8 +188,8 @@ async def test_scheduler_pool(
                 size = int(match.group(1))
                 max_pool_size = max(max_pool_size, size)
 
-        # Pool can grow up to its maximum of 10
-        assert max_pool_size <= 10, f"Pool grew beyond maximum ({max_pool_size})"
+        # Pool can grow up to its maximum of 5
+        assert max_pool_size <= 5, f"Pool grew beyond maximum ({max_pool_size})"
 
     # Log summary for debugging
     print("\nScheduler Pool Test Summary (Python Orchestrated):")

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -118,33 +118,33 @@ async def test_scheduler_pool(
         try:
             # Phase 1: Component lifecycle
             client.execute_service(phase_services[1], {})
-            await asyncio.wait_for(phase_futures[1], timeout=3.0)
-            await asyncio.sleep(0.5)  # Let timeouts complete
+            await asyncio.wait_for(phase_futures[1], timeout=1.0)
+            await asyncio.sleep(0.05)  # Let timeouts complete
 
             # Phase 2: Sensor polling
             client.execute_service(phase_services[2], {})
-            await asyncio.wait_for(phase_futures[2], timeout=3.0)
-            await asyncio.sleep(1.0)  # Let intervals run a bit
+            await asyncio.wait_for(phase_futures[2], timeout=1.0)
+            await asyncio.sleep(0.1)  # Let intervals run a bit
 
             # Phase 3: Communication patterns
             client.execute_service(phase_services[3], {})
-            await asyncio.wait_for(phase_futures[3], timeout=3.0)
-            await asyncio.sleep(1.0)  # Let heartbeat run
+            await asyncio.wait_for(phase_futures[3], timeout=1.0)
+            await asyncio.sleep(0.1)  # Let heartbeat run
 
             # Phase 4: Defer patterns
             client.execute_service(phase_services[4], {})
-            await asyncio.wait_for(phase_futures[4], timeout=3.0)
-            await asyncio.sleep(2.0)  # Let everything settle and recycle
+            await asyncio.wait_for(phase_futures[4], timeout=1.0)
+            await asyncio.sleep(0.2)  # Let everything settle and recycle
 
             # Phase 5: Pool reuse verification
             client.execute_service(phase_services[5], {})
-            await asyncio.wait_for(phase_futures[5], timeout=3.0)
-            await asyncio.sleep(1.0)  # Let Phase 5 timeouts complete and recycle
+            await asyncio.wait_for(phase_futures[5], timeout=1.0)
+            await asyncio.sleep(0.1)  # Let Phase 5 timeouts complete and recycle
 
             # Phase 6: Full pool reuse verification
             client.execute_service(phase_services[6], {})
-            await asyncio.wait_for(phase_futures[6], timeout=3.0)
-            await asyncio.sleep(1.0)  # Let Phase 6 timeouts complete
+            await asyncio.wait_for(phase_futures[6], timeout=1.0)
+            await asyncio.sleep(0.1)  # Let Phase 6 timeouts complete
 
             # Complete test
             client.execute_service(complete_service, {})

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -47,6 +47,7 @@ async def test_scheduler_pool(
         3: loop.create_future(),
         4: loop.create_future(),
         5: loop.create_future(),
+        6: loop.create_future(),
     }
 
     def check_output(line: str) -> None:
@@ -68,7 +69,7 @@ async def test_scheduler_pool(
             new_alloc_count += 1
 
         # Track phase completion
-        for phase_num in range(1, 6):
+        for phase_num in range(1, 7):
             if (
                 f"Phase {phase_num} complete" in line
                 and not phase_futures[phase_num].done()
@@ -100,6 +101,7 @@ async def test_scheduler_pool(
             "run_phase_3",
             "run_phase_4",
             "run_phase_5",
+            "run_phase_6",
             "run_complete",
         }
         assert expected_services.issubset(service_names), (
@@ -109,7 +111,7 @@ async def test_scheduler_pool(
         # Get service objects
         phase_services = {
             num: next(s for s in services if s.name == f"run_phase_{num}")
-            for num in range(1, 6)
+            for num in range(1, 7)
         }
         complete_service = next(s for s in services if s.name == "run_complete")
 
@@ -137,7 +139,12 @@ async def test_scheduler_pool(
             # Phase 5: Pool reuse verification
             client.execute_service(phase_services[5], {})
             await asyncio.wait_for(phase_futures[5], timeout=3.0)
-            await asyncio.sleep(0.5)  # Let reuse tests complete
+            await asyncio.sleep(1.0)  # Let Phase 5 timeouts complete and recycle
+
+            # Phase 6: Full pool reuse verification
+            client.execute_service(phase_services[6], {})
+            await asyncio.wait_for(phase_futures[6], timeout=3.0)
+            await asyncio.sleep(1.0)  # Let Phase 6 timeouts complete
 
             # Complete test
             client.execute_service(complete_service, {})
@@ -159,7 +166,7 @@ async def test_scheduler_pool(
             )
 
     # Verify all test phases ran
-    for phase_num in range(1, 6):
+    for phase_num in range(1, 7):
         assert phase_futures[phase_num].done(), f"Phase {phase_num} did not complete"
 
     # Verify pool behavior

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -173,8 +173,8 @@ async def test_scheduler_pool(
                 size = int(match.group(1))
                 max_pool_size = max(max_pool_size, size)
 
-        # Pool can grow up to its maximum of 8
-        assert max_pool_size <= 8, f"Pool grew beyond maximum ({max_pool_size})"
+        # Pool can grow up to its maximum of 10
+        assert max_pool_size <= 10, f"Pool grew beyond maximum ({max_pool_size})"
 
     # Log summary for debugging
     print("\nScheduler Pool Test Summary (Python Orchestrated):")


### PR DESCRIPTION
needs https://github.com/esphome/esphome/pull/10553

# What does this implement/fix?

This PR implements a memory pool for `SchedulerItem` objects in the scheduler to significantly reduce heap fragmentation and prevent system-wide stalls during memory allocation/deallocation.

## Problem
The scheduler previously created and destroyed `SchedulerItem` objects for every timer operation, causing continuous heap churn. During heavy heap allocation/deallocation, the entire system can stall, leading to:
- Dropped events in components that synchronize between tasks
- Timing issues in multi-threaded scenarios  
- Degraded performance on memory-constrained devices
- Delayed cleanup of cancelled items wasting memory

## Solution
Implements an object pool that recycles up to 5 `SchedulerItem` objects:
- Items are recycled instead of deleted when timers complete or are cancelled
- New timer requests try to get items from the pool before allocating new ones
- Pool grows dynamically only when needed (many simple configs only use 1-2 timers)
- Uses `std::vector` to avoid wasting memory on simple configurations
- Includes optimizations for cancelling items in different scheduler containers

## Key Changes

### Memory Pool Implementation
- **Pool size of 5**: Matches typical usage patterns (2-4 active timers) based on real-world testing
- **Dynamic growth**: Vector starts empty and grows only as needed (~250 bytes on ESP32 when full)
- **Proper cleanup**: Clears callbacks and dynamic names when recycling to prevent resource leaks
- **Thread-safe**: Lock is acquired early before any pool access

### Key Optimizations
- **Item recycling**: All completed/cancelled items are now recycled to the pool instead of being destroyed
- **Last heap item optimization**: If the last item in the heap is cancelled, it's immediately removed and recycled (removing last element doesn't break heap structure)
- **Deferred queue recycling**: Items processed from defer queue are recycled after execution
- **Two-stage cleanup**: First tries fast cleanup from heap top, only does expensive O(n) rebuild if needed
- **Cleanup recycling**: During periodic cleanup, removed items are recycled instead of destroyed

## Real-World Testing
Tested with actual hardware (garage door controller, gate controller) showing:
- Pool successfully handles normal operation with 4 intervals
- Efficiently manages bursts of activity (light toggling, gate operations)
- Pool size oscillates between 0-4 items, never exhausts
- No heap allocations during steady-state operation

## Flash Impact
The memory pool implementation adds approximately 448 bytes of flash (387125 vs 386677 baseline) - a small trade-off for the significant stability improvements and reduced heap fragmentation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/backlog/issues/52

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] Host (native platform for integration tests)

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# that benefits all ESPHome configurations automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal optimization with no user-exposed changes