### PR TITLE
[api] Fix VERY_VERBOSE logging compilation error with bool arrays

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1135,7 +1135,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   dump_field(out, "string_", this->string_);
   dump_field(out, "int_", this->int_);
   for (const auto it : this->bool_array) {
-    dump_field(out, "bool_array", it, 4);
+    dump_field(out, "bool_array", static_cast<bool>(it), 4);
   }
   for (const auto &it : this->int_array) {
     dump_field(out, "int_array", it, 4);

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1059,7 +1059,9 @@ def _generate_array_dump_content(
     # Check if underlying type can use dump_field
     if ti.can_use_dump_field():
         # For types that have dump_field overloads, use them with extra indent
-        o += f'  dump_field(out, "{name}", {ti.dump_field_value("it")}, 4);\n'
+        # std::vector<bool> iterators return proxy objects, need explicit cast
+        value_expr = "static_cast<bool>(it)" if is_bool else ti.dump_field_value("it")
+        o += f'  dump_field(out, "{name}", {value_expr}, 4);\n'
     else:
         # For complex types (messages, bytes), use the old pattern
         o += f'  out.append("  {name}: ");\n'

--- a/tests/integration/fixtures/parallel_script_delays.yaml
+++ b/tests/integration/fixtures/parallel_script_delays.yaml
@@ -4,7 +4,7 @@ esphome:
 host:
 
 logger:
-  level: DEBUG
+  level: VERY_VERBOSE
 
 api:
   actions:


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a compilation error that occurs when compiling with VERY_VERBOSE logging enabled and using custom API services with boolean array parameters. 

## Compilation Error
```
ld: Undefined symbols:
  char const* esphome::api::proto_enum_to_string<std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool>>>>(std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool>>>), referenced from:
      void esphome::api::dump_field<std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool>>>>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, char const*, std::__1::__bit_const_reference<std::__1::vector<bool, std::__1::allocator<bool>>>, int) in api_pb2_dump.o
```

The issue is caused by `std::vector<bool>` using proxy objects (bit references) instead of actual bool values when iterating, which causes template instantiation errors in the dump functions.

The fix adds an explicit `static_cast<bool>()` only for boolean arrays in the protobuf code generator, ensuring the proxy objects are properly converted to bool values before being passed to `dump_field()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes compilation errors when using VERY_VERBOSE logging with boolean arrays in custom API services

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal fix only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example that previously failed to compile with VERY_VERBOSE logging
logger:
  level: VERY_VERBOSE

api:
  services:
    - service: test_bool_array
      variables:
        bool_array: bool[]
      then:
        - logger.log: "Service called"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

