### PR TITLE
[esp32] Rebuild when idf_component.yml changes

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1081,9 +1081,9 @@ def _write_idf_component_yml():
     else:
         contents = ""
     if write_file_if_changed(yml_path, contents):
-        lock_path = CORE.relative_build_path("dependencies.lock")
-        if os.path.isfile(lock_path):
-            os.remove(lock_path)
+        dependencies_lock = CORE.relative_build_path("dependencies.lock")
+        if os.path.isfile(dependencies_lock):
+            os.remove(dependencies_lock)
         clean_cmake_cache()
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -40,6 +40,7 @@ from esphome.cpp_generator import RawExpression
 import esphome.final_validate as fv
 from esphome.helpers import copy_file_if_changed, mkdir_p, write_file_if_changed
 from esphome.types import ConfigType
+from esphome.writer import clean_cmake_cache
 
 from .boards import BOARDS, STANDARD_BOARDS
 from .const import (  # noqa
@@ -1079,7 +1080,11 @@ def _write_idf_component_yml():
         contents = yaml_util.dump({"dependencies": dependencies})
     else:
         contents = ""
-    write_file_if_changed(yml_path, contents)
+    if write_file_if_changed(yml_path, contents):
+        lock_path = CORE.relative_build_path("dependencies.lock")
+        if os.path.isfile(lock_path):
+            os.remove(lock_path)
+        clean_cmake_cache()
 
 
 # Called by writer.py

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -310,6 +310,10 @@ def clean_build():
     if os.path.isdir(piolibdeps):
         _LOGGER.info("Deleting %s", piolibdeps)
         shutil.rmtree(piolibdeps)
+    dependencies_lock = CORE.relative_build_path("dependencies.lock")
+    if os.path.isfile(dependencies_lock):
+        _LOGGER.info("Deleting %s", dependencies_lock)
+        os.remove(dependencies_lock)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome


### PR DESCRIPTION
# What does this implement/fix?

Clean cmake cache and remove dependencies.lock to force IDF to reevaluate component versions. Without this IDF component versions will not get updated if they are changed (see the attached issue). 

Should also remove dependencies.lock in clean. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10524

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
