### PR TITLE
[bluetooth_proxy] Change default for active connections to true

### DIFF
--- a/esphome/components/bluetooth_proxy/__init__.py
+++ b/esphome/components/bluetooth_proxy/__init__.py
@@ -80,7 +80,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Schema(
             {
                 cv.GenerateID(): cv.declare_id(BluetoothProxy),
-                cv.Optional(CONF_ACTIVE, default=False): cv.boolean,
+                cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
                 cv.SplitDefault(CONF_CACHE_SERVICES, esp32_idf=True): cv.All(
                     cv.only_with_esp_idf, cv.boolean
                 ),


### PR DESCRIPTION
# What does this implement/fix?

This PR changes the default value for `active` connections in the Bluetooth proxy component from `false` to `true`. This is a breaking change that improves the user experience by enabling active connections by default, which is what most users expect when setting up a Bluetooth proxy.

Currently, users often build their own Bluetooth proxies and forget to enable active connections, then open issues when their devices don't work because they expect the proxy to be able to make connections. While passive-only proxies (for listening to broadcasts) are still useful, there's little harm in enabling active connections by default since users who want passive-only functionality can explicitly disable it. This change makes the component work as expected for the majority use case.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses common user confusion about non-functional Bluetooth proxies

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5324

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Bluetooth proxy with active connections enabled by default (new behavior)
bluetooth_proxy:
  # active: true is now the default

# To restore previous behavior (passive proxy only)
bluetooth_proxy:
  active: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).