### PR TITLE
[i2c] Fix bug in write_register16

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -46,7 +46,7 @@ ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, siz
 }
 
 ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
-  std::vector<uint8_t> v(len + 2);
+  std::vector<uint8_t> v{};
   v.push_back(a_register >> 8);
   v.push_back(a_register);
   v.insert(v.end(), data, data + len);

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -46,10 +46,10 @@ ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, siz
 }
 
 ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
-  std::vector<uint8_t> v{};
-  v.push_back(a_register >> 8);
-  v.push_back(a_register);
-  v.insert(v.end(), data, data + len);
+  std::vector<uint8_t> v(len + 2);
+  v[0] = a_register >> 8;
+  v[1] = a_register;
+  std::copy(data, data + len, v.begin() + 2);
   return bus_->write_readv(this->address_, v.data(), v.size(), nullptr, 0);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This is a fix for https://github.com/esphome/esphome/pull/10389.
Fixing write buffer which is always has more bytes than needed, so incorrect data is getting sent to the bus.

The bug occurs because `std::vector<uint8_t> v(len + 2)` creates `len + 2` elements (initialized to 0), but then push_back() adds more elements instead of replacing them. And then `insert()` adds even more.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes  https://github.com/esphome/esphome/issues/10498

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
