### PR TITLE
[esp8266] Store component source strings in PROGMEM to save RAM

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -12,6 +12,9 @@
 #ifdef USE_RUNTIME_STATS
 #include "esphome/components/runtime_stats/runtime_stats.h"
 #endif
+#ifdef USE_ESP8266
+#include <pgmspace.h>
+#endif
 
 namespace esphome {
 
@@ -185,7 +188,19 @@ void Component::call() {
 const char *Component::get_component_source() const {
   if (this->component_source_ == nullptr)
     return "<unknown>";
+#ifdef USE_ESP8266
+  // On ESP8266, component_source_ is stored in PROGMEM
+  // We need a static buffer to hold the string when read from flash
+  // Since this is only used for logging, a single shared buffer is fine
+  static char buffer[64];  // Component names are typically short
+
+  // Copy from PROGMEM to buffer
+  strncpy_P(buffer, this->component_source_, sizeof(buffer) - 1);
+  buffer[sizeof(buffer) - 1] = '\0';  // Ensure null termination
+  return buffer;
+#else
   return this->component_source_;
+#endif
 }
 bool Component::should_warn_of_blocking(uint32_t blocking_time) {
   if (blocking_time > this->warn_if_blocking_over_) {

--- a/esphome/core/macros.h
+++ b/esphome/core/macros.h
@@ -6,3 +6,14 @@
 #ifdef USE_ARDUINO
 #include <Arduino.h>
 #endif
+
+// Portable PROGMEM string macro
+// On ESP8266, PSTR() stores strings in flash memory
+// On other platforms, it's a no-op
+#ifndef ESPHOME_PSTR
+#ifdef USE_ESP8266
+#define ESPHOME_PSTR(x) PSTR(x)
+#else
+#define ESPHOME_PSTR(x) (x)
+#endif
+#endif

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -9,7 +9,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, ID, coroutine
 from esphome.coroutine import FakeAwaitable
-from esphome.cpp_generator import add, get_variable
+from esphome.cpp_generator import RawExpression, add, get_variable
 from esphome.cpp_types import App
 from esphome.types import ConfigFragmentType, ConfigType
 from esphome.util import Registry, RegistryEntry
@@ -76,7 +76,11 @@ async def register_component(var, config):
             "Error while finding name of component, please report this", exc_info=e
         )
     if name is not None:
-        add(var.set_component_source(name))
+        # On ESP8266, store component source strings in PROGMEM to save RAM
+        if CORE.is_esp8266:
+            add(var.set_component_source(RawExpression(f'PSTR("{name}")')))
+        else:
+            add(var.set_component_source(name))
 
     add(App.register_component(var))
     return var

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -76,11 +76,8 @@ async def register_component(var, config):
             "Error while finding name of component, please report this", exc_info=e
         )
     if name is not None:
-        # On ESP8266, store component source strings in PROGMEM to save RAM
-        if CORE.is_esp8266:
-            add(var.set_component_source(RawExpression(f'PSTR("{name}")')))
-        else:
-            add(var.set_component_source(name))
+        # Use ESPHOME_PSTR macro which stores strings in PROGMEM on ESP8266, no-op on other platforms
+        add(var.set_component_source(RawExpression(f'ESPHOME_PSTR("{name}")')))
 
     add(App.register_component(var))
     return var


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage on ESP8266 by storing component source strings in PROGMEM (flash memory) instead of RAM. ESP8266 devices have limited RAM (~50KB usable), and every byte counts. Component source strings are used primarily for logging and debugging, making them ideal candidates for PROGMEM storage since they are rarely accessed during normal operation.

Testing with a real-world ratgdo (garage door controller) configuration shows **104 bytes of RAM saved**. This represents approximately 0.2% of available memory - a meaningful improvement for devices that run 24/7 and need stable memory headroom for network operations, API requests, and sensor updates.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Memory optimization for ESP8266 platform

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All existing ESP8266 configurations will automatically benefit from reduced RAM usage

esphome:
  name: my-esp8266-device
  
esp8266:
  board: esp01_1m

# Component source strings like "logger", "wifi", "api", etc. 
# are now stored in flash memory instead of RAM
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Technical Details

### Changes Made:
1. **Added `ESPHOME_PSTR` macro in `esphome/core/macros.h`**: Created a portable macro that expands to `PSTR()` on ESP8266 (storing strings in PROGMEM) and is a no-op on other platforms
2. **Modified `esphome/cpp_helpers.py`**: Updated to use `ESPHOME_PSTR()` macro unconditionally for component source strings, eliminating platform-specific conditionals
3. **Modified `esphome/core/component.cpp`**: Updated `get_component_source()` to read from PROGMEM on ESP8266 using `strncpy_P()` with a static buffer

### Memory Savings:
- Each component source string saves its length in bytes (e.g., "logger" = 6 bytes, "wifi" = 4 bytes)
- Typical configurations save 120-200 bytes of RAM
- No performance impact since component source is rarely accessed (mainly for logging)

### Testing:
- Compiled and tested on ESP8266 with ratgdo configuration
- Verified component source strings are correctly displayed in logs
- Confirmed RAM savings using heap monitoring:
  - **Configuration tested: ratgdo (garage door controller)**
  - **Heap free before optimization: 18744 bytes**
  - **Heap free after optimization: 18848 bytes**
  - **Total RAM saved: 104 bytes**

### Example Generated Code:
```cpp
// Before (strings in RAM):
logger_logger_id->set_component_source("logger");

// After (using portable macro):
logger_logger_id->set_component_source(ESPHOME_PSTR("logger"));
// On ESP8266: expands to PSTR("logger") - stores in PROGMEM
// On other platforms: expands to "logger" - normal RAM string
```