### PR TITLE
[esp8266] Store GPIO initialization arrays in PROGMEM to save RAM

### DIFF
--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -58,8 +58,8 @@ extern "C" void resetPins() {  // NOLINT
 
 #ifdef USE_ESP8266_EARLY_PIN_INIT
   for (int i = 0; i < 16; i++) {
-    uint8_t mode = ESPHOME_ESP8266_GPIO_INITIAL_MODE[i];
-    uint8_t level = ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[i];
+    uint8_t mode = pgm_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_MODE[i]);
+    uint8_t level = pgm_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[i]);
     if (mode != 255)
       pinMode(i, mode);  // NOLINT
     if (level != 255)

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -58,8 +58,8 @@ extern "C" void resetPins() {  // NOLINT
 
 #ifdef USE_ESP8266_EARLY_PIN_INIT
   for (int i = 0; i < 16; i++) {
-    uint8_t mode = pgm_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_MODE[i]);
-    uint8_t level = pgm_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[i]);
+    uint8_t mode = progmem_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_MODE[i]);
+    uint8_t level = progmem_read_byte(&ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[i]);
     if (mode != 255)
       pinMode(i, mode);  // NOLINT
     if (level != 255)

--- a/esphome/components/esp8266/core.h
+++ b/esphome/components/esp8266/core.h
@@ -3,9 +3,10 @@
 #ifdef USE_ESP8266
 
 #include <cstdint>
+#include <pgmspace.h>
 
-extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16];
-extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16];
+extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] PROGMEM;
+extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] PROGMEM;
 
 namespace esphome {
 namespace esp8266 {}  // namespace esp8266

--- a/esphome/components/esp8266/core.h
+++ b/esphome/components/esp8266/core.h
@@ -5,8 +5,8 @@
 #include <cstdint>
 #include "esphome/core/hal.h"
 
-extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] PROGMEM;
-extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] PROGMEM;
+extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16];
+extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16];
 
 namespace esphome {
 namespace esp8266 {}  // namespace esp8266

--- a/esphome/components/esp8266/core.h
+++ b/esphome/components/esp8266/core.h
@@ -3,7 +3,6 @@
 #ifdef USE_ESP8266
 
 #include <cstdint>
-#include "esphome/core/hal.h"
 
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16];
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16];

--- a/esphome/components/esp8266/core.h
+++ b/esphome/components/esp8266/core.h
@@ -3,7 +3,6 @@
 #ifdef USE_ESP8266
 
 #include <cstdint>
-#include <pgmspace.h>
 
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] PROGMEM;
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] PROGMEM;

--- a/esphome/components/esp8266/core.h
+++ b/esphome/components/esp8266/core.h
@@ -3,6 +3,7 @@
 #ifdef USE_ESP8266
 
 #include <cstdint>
+#include "esphome/core/hal.h"
 
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] PROGMEM;
 extern const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] PROGMEM;

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -199,11 +199,11 @@ async def add_pin_initial_states_array():
 
     cg.add_global(
         cg.RawExpression(
-            f"const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] = {{{initial_modes_s}}}"
+            f"const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_MODE[16] PROGMEM = {{{initial_modes_s}}}"
         )
     )
     cg.add_global(
         cg.RawExpression(
-            f"const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] = {{{initial_levels_s}}}"
+            f"const uint8_t ESPHOME_ESP8266_GPIO_INITIAL_LEVEL[16] PROGMEM = {{{initial_levels_s}}}"
         )
     )


### PR DESCRIPTION
# What does this implement/fix?

Moves ESP8266 GPIO initialization arrays to PROGMEM to save 32 bytes of RAM. These arrays are only accessed once during the `resetPins()` function at startup, making them ideal candidates for flash storage.

The optimization converts `ESPHOME_ESP8266_GPIO_INITIAL_MODE` and `ESPHOME_ESP8266_GPIO_INITIAL_LEVEL` arrays (16 bytes each) from RAM to PROGMEM, using `pgm_read_byte()` to access the values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Memory optimization for ESP8266 platform

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
esp8266:
  board: d1_mini
  early_pin_init: true  # Arrays are used when this is enabled
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-facing changes

## Measurements

Tested on ESP8266 (esp01_1m board):

**Before:**
- RAM: 31692 bytes (38.7%)
- Flash: 364959 bytes (35.6%)

**After:**
- RAM: 31660 bytes (38.6%) - **32 bytes saved**
- Flash: 365007 bytes (35.6%) - 48 bytes increase

The 32 bytes of RAM saved is valuable on memory-constrained ESP8266 devices, while the small flash increase (48 bytes) is negligible given the available flash space.

