### PR TITLE
[i2c] Optimize memory usage with stack allocation for small buffers

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -44,7 +44,7 @@ ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, siz
 
   buffer[0] = a_register;
   std::copy(data, data + len, buffer + 1);
-  return bus_->write_readv(this->address_, buffer, len + 1, nullptr, 0);
+  return this->bus_->write_readv(this->address_, buffer, len + 1, nullptr, 0);
 }
 
 ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
@@ -54,7 +54,7 @@ ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, 
   buffer[0] = a_register >> 8;
   buffer[1] = a_register;
   std::copy(data, data + len, buffer + 2);
-  return bus_->write_readv(this->address_, buffer, len + 2, nullptr, 0);
+  return this->bus_->write_readv(this->address_, buffer, len + 2, nullptr, 0);
 }
 
 bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len) {

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -39,18 +39,22 @@ ErrorCode I2CDevice::read_register16(uint16_t a_register, uint8_t *data, size_t 
 }
 
 ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, size_t len) const {
-  std::vector<uint8_t> v{};
-  v.push_back(a_register);
-  v.insert(v.end(), data, data + len);
-  return bus_->write_readv(this->address_, v.data(), v.size(), nullptr, 0);
+  SmallBufferWithHeapFallback<17> buffer_alloc;  // Most I2C writes are <= 16 bytes
+  uint8_t *buffer = buffer_alloc.get(len + 1);
+
+  buffer[0] = a_register;
+  std::copy(data, data + len, buffer + 1);
+  return bus_->write_readv(this->address_, buffer, len + 1, nullptr, 0);
 }
 
 ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
-  std::vector<uint8_t> v(len + 2);
-  v[0] = a_register >> 8;
-  v[1] = a_register;
-  std::copy(data, data + len, v.begin() + 2);
-  return bus_->write_readv(this->address_, v.data(), v.size(), nullptr, 0);
+  SmallBufferWithHeapFallback<18> buffer_alloc;  // Most I2C writes are <= 16 bytes + 2 for register
+  uint8_t *buffer = buffer_alloc.get(len + 2);
+
+  buffer[0] = a_register >> 8;
+  buffer[1] = a_register;
+  std::copy(data, data + len, buffer + 2);
+  return bus_->write_readv(this->address_, buffer, len + 2, nullptr, 0);
 }
 
 bool I2CDevice::read_bytes_16(uint8_t a_register, uint16_t *data, uint8_t len) {

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -2,6 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -9,6 +10,22 @@
 
 namespace esphome {
 namespace i2c {
+
+/// @brief Helper class for efficient buffer allocation - uses stack for small sizes, heap for large
+template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
+ public:
+  uint8_t *get(size_t size) {
+    if (size <= STACK_SIZE) {
+      return stack_buffer_;
+    }
+    heap_buffer_ = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
+    return heap_buffer_.get();
+  }
+
+ private:
+  uint8_t stack_buffer_[STACK_SIZE];
+  std::unique_ptr<uint8_t[]> heap_buffer_;
+};
 
 /// @brief Error codes returned by I2CBus and I2CDevice methods
 enum ErrorCode {
@@ -74,14 +91,17 @@ class I2CBus {
     for (size_t i = 0; i != count; i++) {
       total_len += read_buffers[i].len;
     }
-    std::vector<uint8_t> buffer(total_len);
-    auto err = this->write_readv(address, nullptr, 0, buffer.data(), total_len);
+
+    SmallBufferWithHeapFallback<128> buffer_alloc;  // Most I2C reads are small
+    uint8_t *buffer = buffer_alloc.get(total_len);
+
+    auto err = this->write_readv(address, nullptr, 0, buffer, total_len);
     if (err != ERROR_OK)
       return err;
     size_t pos = 0;
     for (size_t i = 0; i != count; i++) {
       if (read_buffers[i].len != 0) {
-        std::memcpy(read_buffers[i].data, buffer.data() + pos, read_buffers[i].len);
+        std::memcpy(read_buffers[i].data, buffer + pos, read_buffers[i].len);
         pos += read_buffers[i].len;
       }
     }
@@ -91,11 +111,21 @@ class I2CBus {
   ESPDEPRECATED("This method is deprecated and will be removed in ESPHome 2026.3.0. Use write_readv() instead.",
                 "2025.9.0")
   ErrorCode writev(uint8_t address, const WriteBuffer *write_buffers, size_t count, bool stop = true) {
-    std::vector<uint8_t> buffer{};
+    size_t total_len = 0;
     for (size_t i = 0; i != count; i++) {
-      buffer.insert(buffer.end(), write_buffers[i].data, write_buffers[i].data + write_buffers[i].len);
+      total_len += write_buffers[i].len;
     }
-    return this->write_readv(address, buffer.data(), buffer.size(), nullptr, 0);
+
+    SmallBufferWithHeapFallback<128> buffer_alloc;  // Most I2C writes are small
+    uint8_t *buffer = buffer_alloc.get(total_len);
+
+    size_t pos = 0;
+    for (size_t i = 0; i != count; i++) {
+      std::memcpy(buffer + pos, write_buffers[i].data, write_buffers[i].len);
+      pos += write_buffers[i].len;
+    }
+
+    return this->write_readv(address, buffer, total_len, nullptr, 0);
   }
 
  protected:

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -16,10 +16,10 @@ template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
  public:
   uint8_t *get(size_t size) {
     if (size <= STACK_SIZE) {
-      return stack_buffer_;
+      return this->stack_buffer_;
     }
-    heap_buffer_ = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
-    return heap_buffer_.get();
+    this->heap_buffer_ = std::unique_ptr<uint8_t[]>(new uint8_t[size]);
+    return this->heap_buffer_.get();
   }
 
  private:


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage in the I2C component by replacing unnecessary heap allocations (`std::vector`) with stack allocations for small buffers. For larger buffers, it falls back to heap allocation using `std::unique_ptr`.

The changes introduce a `SmallBufferWithHeapFallback` template class that intelligently chooses between stack and heap allocation based on buffer size. This reduces heap fragmentation and improves performance, especially on memory-constrained devices like ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Memory optimization for ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
i2c:
  sda: 21
  scl: 22
  scan: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Performance Impact

- **Flash usage:** No change (verified: 479190 bytes before and after)
- **RAM usage:** Reduced heap allocations for I2C operations
- **Benefits:**
  - Most I2C operations (≤16-128 bytes) now use stack allocation
  - Reduced heap fragmentation on memory-constrained devices
  - Cleaner code with eliminated duplication via template helper class
