### PR TITLE
[esp8266][logger] Store LOG_LEVELS strings in PROGMEM to reduce RAM usage

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -266,8 +266,7 @@ static const LogString *const LOG_LEVELS[] = {
     reinterpret_cast<const LogString *>(LOG_LEVEL_VERBOSE), reinterpret_cast<const LogString *>(LOG_LEVEL_VERY_VERBOSE),
 };
 #else
-static const LogString *const LOG_LEVELS[] = {"NONE",   "ERROR", "WARN",    "INFO",
-                                              "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
+static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
 #endif
 
 void Logger::dump_config() {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -246,14 +246,16 @@ void Logger::add_on_log_callback(std::function<void(uint8_t, const char *, const
   this->log_callback_.add(std::move(callback));
 }
 float Logger::get_setup_priority() const { return setup_priority::BUS + 500.0f; }
-static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
+static const LogString *const LOG_LEVELS[] = {LOG_STR("NONE"),    LOG_STR("ERROR"),       LOG_STR("WARN"),
+                                              LOG_STR("INFO"),    LOG_STR("CONFIG"),      LOG_STR("DEBUG"),
+                                              LOG_STR("VERBOSE"), LOG_STR("VERY_VERBOSE")};
 
 void Logger::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Logger:\n"
                 "  Max Level: %s\n"
                 "  Initial Level: %s",
-                LOG_LEVELS[ESPHOME_LOG_LEVEL], LOG_LEVELS[this->current_level_]);
+                LOG_STR_ARG(LOG_LEVELS[ESPHOME_LOG_LEVEL]), LOG_STR_ARG(LOG_LEVELS[this->current_level_]));
 #ifndef USE_HOST
   ESP_LOGCONFIG(TAG,
                 "  Log Baud Rate: %" PRIu32 "\n"
@@ -267,14 +269,14 @@ void Logger::dump_config() {
 #endif
 
   for (auto &it : this->log_levels_) {
-    ESP_LOGCONFIG(TAG, "  Level for '%s': %s", it.first.c_str(), LOG_LEVELS[it.second]);
+    ESP_LOGCONFIG(TAG, "  Level for '%s': %s", it.first.c_str(), LOG_STR_ARG(LOG_LEVELS[it.second]));
   }
 }
 
 void Logger::set_log_level(uint8_t level) {
   if (level > ESPHOME_LOG_LEVEL) {
     level = ESPHOME_LOG_LEVEL;
-    ESP_LOGW(TAG, "Cannot set log level higher than pre-compiled %s", LOG_LEVELS[ESPHOME_LOG_LEVEL]);
+    ESP_LOGW(TAG, "Cannot set log level higher than pre-compiled %s", LOG_STR_ARG(LOG_LEVELS[ESPHOME_LOG_LEVEL]));
   }
   this->current_level_ = level;
   this->level_callback_.call(level);

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -266,7 +266,8 @@ static const LogString *const LOG_LEVELS[] = {
     reinterpret_cast<const LogString *>(LOG_LEVEL_VERBOSE), reinterpret_cast<const LogString *>(LOG_LEVEL_VERY_VERBOSE),
 };
 #else
-static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
+static const LogString *const LOG_LEVELS[] = {"NONE",   "ERROR", "WARN",    "INFO",
+                                              "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
 #endif
 
 void Logger::dump_config() {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -246,9 +246,28 @@ void Logger::add_on_log_callback(std::function<void(uint8_t, const char *, const
   this->log_callback_.add(std::move(callback));
 }
 float Logger::get_setup_priority() const { return setup_priority::BUS + 500.0f; }
-static const LogString *const LOG_LEVELS[] = {LOG_STR("NONE"),    LOG_STR("ERROR"),       LOG_STR("WARN"),
-                                              LOG_STR("INFO"),    LOG_STR("CONFIG"),      LOG_STR("DEBUG"),
-                                              LOG_STR("VERBOSE"), LOG_STR("VERY_VERBOSE")};
+
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+// ESP8266: PSTR() cannot be used in array initializers, so we need to declare
+// each string separately as a global constant first
+static const char LOG_LEVEL_NONE[] PROGMEM = "NONE";
+static const char LOG_LEVEL_ERROR[] PROGMEM = "ERROR";
+static const char LOG_LEVEL_WARN[] PROGMEM = "WARN";
+static const char LOG_LEVEL_INFO[] PROGMEM = "INFO";
+static const char LOG_LEVEL_CONFIG[] PROGMEM = "CONFIG";
+static const char LOG_LEVEL_DEBUG[] PROGMEM = "DEBUG";
+static const char LOG_LEVEL_VERBOSE[] PROGMEM = "VERBOSE";
+static const char LOG_LEVEL_VERY_VERBOSE[] PROGMEM = "VERY_VERBOSE";
+
+static const LogString *const LOG_LEVELS[] = {
+    reinterpret_cast<const LogString *>(LOG_LEVEL_NONE),    reinterpret_cast<const LogString *>(LOG_LEVEL_ERROR),
+    reinterpret_cast<const LogString *>(LOG_LEVEL_WARN),    reinterpret_cast<const LogString *>(LOG_LEVEL_INFO),
+    reinterpret_cast<const LogString *>(LOG_LEVEL_CONFIG),  reinterpret_cast<const LogString *>(LOG_LEVEL_DEBUG),
+    reinterpret_cast<const LogString *>(LOG_LEVEL_VERBOSE), reinterpret_cast<const LogString *>(LOG_LEVEL_VERY_VERBOSE),
+};
+#else
+static const char *const LOG_LEVELS[] = {"NONE", "ERROR", "WARN", "INFO", "CONFIG", "DEBUG", "VERBOSE", "VERY_VERBOSE"};
+#endif
 
 void Logger::dump_config() {
   ESP_LOGCONFIG(TAG,


### PR DESCRIPTION
# What does this implement/fix?

Store logger component's LOG_LEVELS strings in flash memory (PROGMEM) on ESP8266 to reduce RAM usage.

This PR optimizes the logger component's `LOG_LEVELS` array on ESP8266 by using the `LogString` type to store the log level name strings in flash memory instead of RAM. The optimization is automatically applied when `esp8266_store_log_strings_in_flash` is enabled in the logger configuration.

Key changes:
- Convert `static const char *const LOG_LEVELS[]` array to use `LogString*`
- Wrap each log level string ("NONE", "ERROR", "WARN", etc.) with `LOG_STR()`
- Update all references to use `LOG_STR_ARG()` when passing to logging functions

Results on ESP8266 with `esp8266_store_log_strings_in_flash: true`:
- **Saved:** ~64 bytes of RAM (8 string pointers + string data)
- The strings are stored in PROGMEM instead of RAM
- No impact on other platforms

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Optimization is automatically applied when using:
logger:
  esp8266_store_log_strings_in_flash: true
  level: DEBUG  # The log level names will be stored in flash
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).