### PR TITLE
[i2s] add support for ESP32-C6

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -4,6 +4,7 @@ from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
 from esphome.components.esp32.const import (
     VARIANT_ESP32,
     VARIANT_ESP32C3,
+    VARIANT_ESP32C6,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -68,6 +69,7 @@ I2S_PORTS = {
     VARIANT_ESP32S2: 1,
     VARIANT_ESP32S3: 2,
     VARIANT_ESP32C3: 1,
+    VARIANT_ESP32C6: 1,
     VARIANT_ESP32P4: 3,
 }
 

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -9,6 +9,7 @@ from esphome.components.esp32 import (
     get_esp32_variant,
 )
 from esphome.components.esp32.const import (
+    VARIANT_ESP32C6,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -48,6 +49,7 @@ CONF_ENABLE_ECC = "enable_ecc"
 
 SPIRAM_MODES = {
     VARIANT_ESP32: (TYPE_QUAD,),
+    VARIANT_ESP32C6: (TYPE_QUAD,),
     VARIANT_ESP32S2: (TYPE_QUAD,),
     VARIANT_ESP32S3: (TYPE_QUAD, TYPE_OCTAL),
     VARIANT_ESP32P4: (TYPE_HEX,),
@@ -56,6 +58,7 @@ SPIRAM_MODES = {
 
 SPIRAM_SPEEDS = {
     VARIANT_ESP32: (40, 80, 120),
+    VARIANT_ESP32C6: (40, 80, 120),
     VARIANT_ESP32S2: (40, 80, 120),
     VARIANT_ESP32S3: (40, 80, 120),
     VARIANT_ESP32P4: (20, 100, 200),


### PR DESCRIPTION
# What does this implement/fix?

Fixes [feature-requests 2481](https://github.com/esphome/feature-requests/issues/2481).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes [<link to issue>](https://github.com/esphome/feature-requests/issues/2481)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

<details><summary>Click here to see the example config.yaml</summary>

```yaml
esphome:  # https://esphome.io/components/esphome.html
  name: test-i2s-on-c6
  platformio_options:
    upload_port: /dev/ttyACM1
    framework: espidf
    board_build.flash_mode: dio

esp32:  # https://esphome.io/components/esp32.html
  variant: esp32c6
  board: esp32-c6-devkitc-1
  framework:
    advanced:
      compiler_optimization: PERF
    type: esp-idf
    sdkconfig_options:
      CONFIG_ESPTOOLPY_FLASHSIZE_DETECT: y

# Enable logging
logger:  # https://esphome.io/components/logger.html
  #level: NONE
  #level: INFO
  level: DEBUG
  hardware_uart: UART0

psram:
  disabled: true

debug:  # https://esphome.io/components/debug/
  update_interval: 2s

sensor:
  - platform: debug
    free:
      name: "Heap Free"
  - platform: uptime
    type: seconds
    name: Uptime Sensor
    entity_category: diagnostic # https://developers.home-assistant.io/docs/core/entity/#generic-properties
  - platform: internal_temperature
    entity_category: diagnostic
    name: "Internal Temperature" # https://developers.home-assistant.io/docs/core/entity/#generic-properties
  #- platform: template
  #  name: "GPIO7 State"
  #  lambda: |-
  #    return id(i2s_test_button).state ? 1.0 : 0.0;
  #  update_interval: 500ms


binary_sensor:  # https://esphome.io/components/binary_sensor.html
  - platform: gpio
    pin:
      number: GPIO7
      mode: INPUT_PULLUP
      inverted: true
    name: "i2s Test Button"
    id: i2s_test_button
    filters:
      - delayed_on: 10ms
      - delayed_off: 10ms
    on_press:
      then:
        - logger.log:
            format: "Test button pressed, playing test_tone.wav"
            level: INFO
        - media_player.speaker.play_on_device_media_file:
            id: speaker_media_player
            media_file: test_tone

i2s_audio:
  id: i2s_audio_bus
  i2s_lrclk_pin: GPIO6
  i2s_bclk_pin: GPIO5
  # use_legacy: true

speaker:
  - platform: i2s_audio
    id: i2s_speaker
    i2s_audio_id: i2s_audio_bus
    i2s_dout_pin: GPIO4
    dac_type: external
    channel: stereo
    sample_rate: 48000
    bits_per_sample: 16bit
    # use_apll: true
    # i2s_comm_fmt: stand_i2s
    buffer_duration: 128ms

media_player:
  - platform: speaker
    name: "I2S DAC Speaker"
    id: speaker_media_player
    #codec_support_enabled: false
    buffer_size: 32768
    announcement_pipeline:
      speaker: i2s_speaker
      num_channels: 2
      sample_rate: 48000
      format: FLAC
    files:
      - id: test_tone
        ## cd config; sox -n -r 48000 -b 16 -c 1 test_tone.wav synth 5 sine 440; cd -
        #file: test_tone.wav
        # cd config; sox -n -r 48000 -b 16 -c 1 test_tone.flac synth 5 sine 440; cd -
        file: test_tone.flac
```

</details>

## How to test

<details><summary>Click here to see the description of manual test, including log output.</summary>

```bash
# Download this PR branch.
git clone --branch i2s-on-esp32c6 --single-branch https://github.com/kabakaev/esphome i2s-c6-repo
cd i2s-c6-repo
# Create an example config yaml.
mkdir config
cat <<'EOF' > ./config/test-i2s-on-c6.yaml
->insert here the YAML text from the example config.yaml in the PR description
EOF
# Generate an example sound file.
cd config; sox -n -r 48000 -b 16 -c 1 test_tone.flac synth 5 sine 440; cd -
# Install esphome from the local repo.
./script/setup
source venv/bin/activate
uv pip install -e ".[dev,test]" --config-settings editable_mode=compat
# Put an esp32-c6 board into programming mode: 
# 1. Press and hold "BOOT" button.
# 2. Attach USB cable.
# 3. Release "BOOT" button.
# Then, find which TTY device is the ESP:
sudo dmesg | grep -i "USB ACM device"
# cdc_acm 1-4.1.1:1.0: ttyACM1: USB ACM device
# Upload custom esphome from this repo to an esp32-c6 board. Adjust ACM device name if needed.
esphome run --device /dev/ttyACM1 config/test-i2s-on-c6.yaml
# Press "Reset" button on the microcontroller and read the tty log.
esphome logs --device /dev/ttyACM1 config/test-i2s-on-c6.yaml
# [18:05:31][D][sensor:130]: 'Heap Free': Sending state 418240.00000 B with 0 decimals of accuracy

# Connect MAX98357A I2S board:
# LRC -> GPIO6
# BCLK -> GPIO5
# DIN -> GPIO4
# GAIN -> do not connect
# SD -> +3.3V
# GND -> GND
# VIN -> +3.3V

# Connect GPIO7 to GND to trigger sound file playback.
# The log will print:

# [18:05:36][I][main:245]: Test button pressed, playing test_tone.wav
# [18:05:36][D][binary_sensor:039]: 'i2s Test Button': New state is ON
# [18:05:36][D][speaker_media_player:406]: State changed to ANNOUNCING
# [18:05:36][D][speaker_media_player.pipeline:114]: Reading FLAC file type
# [18:05:36][D][ring_buffer:034][ann_read]: Created ring buffer with size 32768
# [18:05:36][D][speaker_media_player.pipeline:124]: Decoded audio has 1 channels, 48000 Hz sample rate, and 16 bits per sample
# [18:05:36][D][i2s_audio.speaker:102]: Starting
# [18:05:36][D][i2s_audio.speaker:106]: Started
# [18:05:36][D][ring_buffer:034][speaker_task]: Created ring buffer with size 12288
# [18:05:36][D][binary_sensor:039]: 'i2s Test Button': New state is OFF
# [18:05:37][D][sensor:130]: 'Heap Free': Sending state 319068.00000 B with 0 decimals of accuracy
# [18:05:41][D][i2s_audio.speaker:111]: Stopping
# [18:05:41][D][i2s_audio.speaker:116]: Stopped
# [18:05:41][D][speaker_media_player:406]: State changed to IDLE
# [18:05:41][D][sensor:130]: 'Heap Free': Sending state 418224.00000 B with 0 decimals of accuracy
```

</details>

The log shows that around 100kB RAM is used by the FLAC decode and I2S playback. The ESP32-C6 has 512kB RAM.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
