### PR TITLE
[gpio_expander] Add intelligent pin type selection to CachedGpioExpander template

### DIFF
--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -16,12 +16,12 @@ namespace esphome::gpio_expander {
 ///           T - Type which represents internal register. Could be uint8_t or uint16_t. Adjust to
 ///               match size of your internal GPIO bank register.
 ///           N - Number of pins
-template<typename T, T N> class CachedGpioExpander {
+template<typename T, uint8_t N> class CachedGpioExpander {
  public:
   /// @brief Read the state of the given pin. This will invalidate the cache for the given pin number.
   /// @param pin Pin number to read
   /// @return Pin state
-  bool digital_read(T pin) {
+  bool digital_read(uint8_t pin) {
     const uint8_t bank = pin / BANK_SIZE;
     const T pin_mask = (1 << (pin % BANK_SIZE));
     // Check if specific pin cache is valid
@@ -38,15 +38,25 @@ template<typename T, T N> class CachedGpioExpander {
     return this->digital_read_cache(pin);
   }
 
-  void digital_write(T pin, bool value) { this->digital_write_hw(pin, value); }
+  void digital_write(uint8_t pin, bool value) { this->digital_write_hw(pin, value); }
 
  protected:
-  /// @brief Call component low level function to read GPIO state from device
-  virtual bool digital_read_hw(T pin) = 0;
-  /// @brief Call component read function from internal cache.
-  virtual bool digital_read_cache(T pin) = 0;
-  /// @brief Call component low level function to write GPIO state to device
-  virtual void digital_write_hw(T pin, bool value) = 0;
+  /// @brief Read GPIO bank from hardware into internal state
+  /// @param pin Pin number (used to determine which bank to read)
+  /// @return true if read succeeded, false on communication error
+  /// @note This does NOT return the pin state. It returns whether the read operation succeeded.
+  ///       The actual pin state should be returned by digital_read_cache().
+  virtual bool digital_read_hw(uint8_t pin) = 0;
+
+  /// @brief Get cached pin value from internal state
+  /// @param pin Pin number to read
+  /// @return Pin state (true = HIGH, false = LOW)
+  virtual bool digital_read_cache(uint8_t pin) = 0;
+
+  /// @brief Write GPIO state to hardware
+  /// @param pin Pin number to write
+  /// @param value Pin state to write (true = HIGH, false = LOW)
+  virtual void digital_write_hw(uint8_t pin, bool value) = 0;
 
   /// @brief Invalidate cache. This function should be called in component loop().
   void reset_pin_cache_() { memset(this->read_cache_valid_, 0x00, CACHE_SIZE_BYTES); }

--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <type_traits>
 #include "esphome/core/hal.h"
 
 namespace esphome::gpio_expander {
@@ -20,14 +21,18 @@ namespace esphome::gpio_expander {
 ///                          Examples: MCP23017 (2x8-bit banks), TCA9555 (2x8-bit banks)
 ///               * uint16_t: For chips that read all pins at once (up to 16 pins)
 ///                          Examples: PCF8574/8575 (8/16 pins), PCA9554/9555 (8/16 pins)
-///           N - Total number of pins (as uint8_t)
-template<typename T, uint8_t N> class CachedGpioExpander {
+///           N - Total number of pins (maximum 65535)
+///           P - Type for pin number parameters (automatically selected based on N:
+///               uint8_t for N<=256, uint16_t for N>256). Can be explicitly specified
+///               if needed (e.g., for components like SN74HC165 with >256 pins)
+template<typename T, uint16_t N, typename P = typename std::conditional<(N > 256), uint16_t, uint8_t>::type>
+class CachedGpioExpander {
  public:
   /// @brief Read the state of the given pin. This will invalidate the cache for the given pin number.
   /// @param pin Pin number to read
   /// @return Pin state
-  bool digital_read(uint8_t pin) {
-    const uint8_t bank = pin / BANK_SIZE;
+  bool digital_read(P pin) {
+    const P bank = pin / BANK_SIZE;
     const T pin_mask = (1 << (pin % BANK_SIZE));
     // Check if specific pin cache is valid
     if (this->read_cache_valid_[bank] & pin_mask) {
@@ -43,7 +48,7 @@ template<typename T, uint8_t N> class CachedGpioExpander {
     return this->digital_read_cache(pin);
   }
 
-  void digital_write(uint8_t pin, bool value) { this->digital_write_hw(pin, value); }
+  void digital_write(P pin, bool value) { this->digital_write_hw(pin, value); }
 
  protected:
   /// @brief Read GPIO bank from hardware into internal state
@@ -51,23 +56,23 @@ template<typename T, uint8_t N> class CachedGpioExpander {
   /// @return true if read succeeded, false on communication error
   /// @note This does NOT return the pin state. It returns whether the read operation succeeded.
   ///       The actual pin state should be returned by digital_read_cache().
-  virtual bool digital_read_hw(uint8_t pin) = 0;
+  virtual bool digital_read_hw(P pin) = 0;
 
   /// @brief Get cached pin value from internal state
   /// @param pin Pin number to read
   /// @return Pin state (true = HIGH, false = LOW)
-  virtual bool digital_read_cache(uint8_t pin) = 0;
+  virtual bool digital_read_cache(P pin) = 0;
 
   /// @brief Write GPIO state to hardware
   /// @param pin Pin number to write
   /// @param value Pin state to write (true = HIGH, false = LOW)
-  virtual void digital_write_hw(uint8_t pin, bool value) = 0;
+  virtual void digital_write_hw(P pin, bool value) = 0;
 
   /// @brief Invalidate cache. This function should be called in component loop().
   void reset_pin_cache_() { memset(this->read_cache_valid_, 0x00, CACHE_SIZE_BYTES); }
 
-  static constexpr uint8_t BITS_PER_BYTE = 8;
-  static constexpr uint8_t BANK_SIZE = sizeof(T) * BITS_PER_BYTE;
+  static constexpr uint16_t BITS_PER_BYTE = 8;
+  static constexpr uint16_t BANK_SIZE = sizeof(T) * BITS_PER_BYTE;
   static constexpr size_t BANKS = N / BANK_SIZE;
   static constexpr size_t CACHE_SIZE_BYTES = BANKS * sizeof(T);
 

--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -11,11 +11,16 @@ namespace esphome::gpio_expander {
 /// @brief A class to cache the read state of a GPIO expander.
 ///        This class caches reads between GPIO Pins which are on the same bank.
 ///        This means that for reading whole Port (ex. 8 pins) component needs only one
-///        I2C/SPI read per main loop call. It assumes, that one bit in byte identifies one GPIO pin
+///        I2C/SPI read per main loop call. It assumes that one bit in byte identifies one GPIO pin.
+///
 ///        Template parameters:
-///           T - Type which represents internal register. Could be uint8_t or uint16_t. Adjust to
-///               match size of your internal GPIO bank register.
-///           N - Number of pins
+///           T - Type which represents internal bank register. Could be uint8_t or uint16_t.
+///               Choose based on how your I/O expander reads pins:
+///               * uint8_t:  For chips that read banks separately (8 pins at a time)
+///                          Examples: MCP23017 (2x8-bit banks), TCA9555 (2x8-bit banks)
+///               * uint16_t: For chips that read all pins at once (up to 16 pins)
+///                          Examples: PCF8574/8575 (8/16 pins), PCA9554/9555 (8/16 pins)
+///           N - Total number of pins (as uint8_t)
 template<typename T, uint8_t N> class CachedGpioExpander {
  public:
   /// @brief Read the state of the given pin. This will invalidate the cache for the given pin number.

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.cpp
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component/gpio_expander_test_component.cpp
@@ -27,11 +27,13 @@ void GPIOExpanderTestComponent::setup() {
 
 bool GPIOExpanderTestComponent::digital_read_hw(uint8_t pin) {
   ESP_LOGD(TAG, "digital_read_hw pin=%d", pin);
+  // Return true to indicate successful read operation
   return true;
 }
 
 bool GPIOExpanderTestComponent::digital_read_cache(uint8_t pin) {
   ESP_LOGD(TAG, "digital_read_cache pin=%d", pin);
+  // Return the pin state (always HIGH for testing)
   return true;
 }
 

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/__init__.py
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/__init__.py
@@ -1,0 +1,24 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["gpio_expander"]
+
+gpio_expander_test_component_uint16_ns = cg.esphome_ns.namespace(
+    "gpio_expander_test_component_uint16"
+)
+
+GPIOExpanderTestUint16Component = gpio_expander_test_component_uint16_ns.class_(
+    "GPIOExpanderTestUint16Component", cg.Component
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(GPIOExpanderTestUint16Component),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/gpio_expander_test_component_uint16.cpp
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/gpio_expander_test_component_uint16.cpp
@@ -1,0 +1,43 @@
+#include "gpio_expander_test_component_uint16.h"
+#include "esphome/core/log.h"
+
+namespace esphome::gpio_expander_test_component_uint16 {
+
+static const char *const TAG = "gpio_expander_test_uint16";
+
+void GPIOExpanderTestUint16Component::setup() {
+  ESP_LOGD(TAG, "Testing uint16_t bank (single 16-pin bank)");
+
+  // Test reading all 16 pins - first should trigger hw read, rest use cache
+  for (uint8_t pin = 0; pin < 16; pin++) {
+    this->digital_read(pin);
+  }
+
+  // Reset cache and test specific reads
+  ESP_LOGD(TAG, "Resetting cache for uint16_t test");
+  this->reset_pin_cache_();
+
+  // First read triggers hw for entire bank
+  this->digital_read(5);
+  // These should all use cache since they're in the same bank
+  this->digital_read(10);
+  this->digital_read(15);
+  this->digital_read(0);
+
+  ESP_LOGD(TAG, "DONE_UINT16");
+}
+
+bool GPIOExpanderTestUint16Component::digital_read_hw(uint8_t pin) {
+  ESP_LOGD(TAG, "uint16_digital_read_hw pin=%d", pin);
+  // In a real component, this would read from I2C/SPI into internal state
+  // For testing, we just return true to indicate successful read
+  return true;  // Return true to indicate successful read
+}
+
+bool GPIOExpanderTestUint16Component::digital_read_cache(uint8_t pin) {
+  ESP_LOGD(TAG, "uint16_digital_read_cache pin=%d", pin);
+  // Return the actual pin state from our test pattern
+  return (this->test_state_ >> pin) & 1;
+}
+
+}  // namespace esphome::gpio_expander_test_component_uint16

--- a/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/gpio_expander_test_component_uint16.h
+++ b/tests/integration/fixtures/external_components/gpio_expander_test_component_uint16/gpio_expander_test_component_uint16.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/components/gpio_expander/cached_gpio.h"
+#include "esphome/core/component.h"
+
+namespace esphome::gpio_expander_test_component_uint16 {
+
+// Test component using uint16_t bank type (single 16-pin bank)
+class GPIOExpanderTestUint16Component : public Component,
+                                        public esphome::gpio_expander::CachedGpioExpander<uint16_t, 16> {
+ public:
+  void setup() override;
+
+ protected:
+  bool digital_read_hw(uint8_t pin) override;
+  bool digital_read_cache(uint8_t pin) override;
+  void digital_write_hw(uint8_t pin, bool value) override{};
+
+ private:
+  uint16_t test_state_{0xAAAA};  // Test pattern: alternating bits
+};
+
+}  // namespace esphome::gpio_expander_test_component_uint16

--- a/tests/integration/fixtures/gpio_expander_cache.yaml
+++ b/tests/integration/fixtures/gpio_expander_cache.yaml
@@ -12,6 +12,10 @@ external_components:
   - source:
       type: local
       path: EXTERNAL_COMPONENT_PATH
-    components: [gpio_expander_test_component]
+    components: [gpio_expander_test_component, gpio_expander_test_component_uint16]
 
+# Test with uint8_t (multiple banks)
 gpio_expander_test_component:
+
+# Test with uint16_t (single bank)
+gpio_expander_test_component_uint16:


### PR DESCRIPTION
# What does this implement/fix?

This PR enhances the `CachedGpioExpander` template to properly support I/O expanders with any number of pins, including those with more than 256 pins (e.g., SN74HC165 with up to 2048 pins).

The original template design `template<typename T, T N>` worked well for 8-bit expanders but had limitations: it coupled the bank type `T` with the pin parameter type, making it challenging for components that needed different types for bank storage vs. pin indexing.

This PR refines the template to `template<typename T, uint16_t N, typename P = ...>`, introducing:
- `T`: Bank register type (uint8_t or uint16_t)
- `N`: Total number of pins (now supports up to 65535)
- `P`: Pin parameter type (automatically selected: uint8_t for ≤256 pins, uint16_t for >256 pins)

The template now intelligently selects the optimal pin parameter type based on the total pin count, avoiding memory waste from struct padding while supporting components with large pin counts.

**Key distinction**: Some I/O expanders read all pins at once (PCF8574/8575, PCA9554/9555) and benefit from a single `uint16_t` bank, while others read banks separately (MCP23017, TCA9555) and use multiple `uint8_t` banks. This fix enables both patterns.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes template design issue preventing proper support for 16-bit I/O expanders
- Required for PR #10571 ([pca9554] Migrate to CachedGpioExpander to reduce I2C bus usage)
- Required for PR #10573 ([pcf8574] Migrate to CachedGpioExpander to reduce I2C bus usage)
- Required for PR #10588 ([sx1509] Migrate to CachedGpioExpander to reduce I2C bus usage)
- Enables migration of I/O expander components with >8 pins per bank

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation fix)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
# Example showing components that benefit from this fix:

i2c:
  sda: GPIO21
  scl: GPIO22

# PCF8574/PCF8575 - up to 16 pins
pcf8574:
  - id: pcf8574_hub
    address: 0x20
    pcf8575: true  # 16-pin variant

# PCA9554/PCA9555 - up to 16 pins  
pca9554:
  - id: pca9554_hub
    address: 0x21
    pin_count: 16  # PCA9555 variant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Changes Made

1. **Refined CachedGpioExpander template design:**
   - Enhanced template from `template<typename T, T N>` to `template<typename T, uint16_t N, typename P = ...>`
   - Added intelligent pin parameter type selection using `std::conditional`
   - Automatically uses `uint8_t` for components with ≤256 pins (avoiding memory waste)
   - Automatically uses `uint16_t` for components with >256 pins (enabling large pin counts)
   - All virtual methods now use template parameter `P` for pin parameters, providing optimal memory usage

2. **Updated documentation:**
   - Clarified that `digital_read_hw()` returns operation success/failure, not pin state
   - Added explicit documentation that pin state should be returned by `digital_read_cache()`

3. **Added comprehensive tests:**
   - Created `GPIOExpanderTestUint16Component` to validate `uint16_t` bank type support
   - Tests confirm proper caching behavior with 16-bit banks
   - Integration tests verify both `uint8_t` and `uint16_t` bank types work correctly

## Impact

This fix enables proper support for:
1. **I/O expander components with 16-bit registers** for their GPIO banks:
   - PCF8575 (16-pin variant of PCF8574)
   - PCA9555 (16-pin variant of PCA9554)
   - TCA9555 (already using the base class)

2. **Components with more than 256 pins** (automatically use uint16_t for pin parameters):
   - SN74HC165 (supports up to 2048 pins through daisy-chaining)
   - Future large-scale GPIO expander implementations

3. **Memory optimization** for existing components:
   - Components with ≤256 pins continue using uint8_t, avoiding struct padding issues
   - Prevents up to 4 bytes of wasted memory per GPIO pin object due to alignment

Without this fix, these components would have to work around the template limitation or implement their own caching logic.

## Related Optimization Efforts

This PR is a prerequisite for migrating I/O expander components to use the CachedGpioExpander base class:

### Current Migration PRs (Dependent on this fix):
1. **PR #10571**: [pca9554] Migrate to CachedGpioExpander to reduce I2C bus usage
   - Reduces I2C bus usage by 98% for output-only use cases
   - Supports PCA9554/9555/9557 family (4/8/16 pin variants)
   - Uses `CachedGpioExpander<uint16_t, 16>` - reads all pins in single I2C transaction

2. **PR #10573**: [pcf8574] Migrate to CachedGpioExpander to reduce I2C bus usage
   - Reduces I2C bus usage by 57% when reading multiple pins
   - 53% faster average read time
   - Supports PCF8574/PCF8575 (8/16 pin variants)
   - Uses `CachedGpioExpander<uint16_t, 16>` - reads all pins in single I2C transaction

3. **PR #10588**: [sx1509] Migrate to CachedGpioExpander to reduce I2C bus usage
   - Reduces I2C bus usage by up to 16x when reading multiple GPIO pins
   - Supports all 16 GPIO pins plus keypad and LED driver features
   - Uses `CachedGpioExpander<uint16_t, 16>` - reads all pins in single I2C transaction

### Why This Enhancement is Important:
The original template design worked well for many use cases but had a coupling between the bank storage type and pin parameter type. This enhancement:
1. Allows components with 16-bit registers (like PCF8575 and PCA9555) to seamlessly use the CachedGpioExpander base class
2. Enables support for components with >256 pins by automatically selecting uint16_t for pin parameters
3. Preserves memory efficiency by using the minimal required type for each component's pin count
4. Provides a clean, backward-compatible API that existing components can use without modification

### Additional Components Recently Migrated:

Other I/O expander components have been migrated to CachedGpioExpander:
- **MCP23016**: 16-bit I/O expander (PR #10581 - submitted)
  - Reads banks separately (like MCP23017), uses `CachedGpioExpander<uint8_t, 16>` with 2 banks
- **PCA6416A**: 16-bit I/O expander (PR #10587 - submitted)
  - Reads banks separately (like MCP23017), uses `CachedGpioExpander<uint8_t, 16>` with 2 banks

These components achieve similar 50-98% reductions in I2C bus usage through migration to CachedGpioExpander.

These optimizations collectively reduce I2C bus usage by 50-98% depending on the usage pattern, improving system performance and reducing power consumption.