### PR TITLE
[mcp23016] Migrate to CachedGpioExpander to reduce I2C bus usage

### DIFF
--- a/esphome/components/mcp23016/__init__.py
+++ b/esphome/components/mcp23016/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     CONF_OUTPUT,
 )
 
+AUTO_LOAD = ["gpio_expander"]
 DEPENDENCIES = ["i2c"]
 MULTI_CONF = True
 

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -56,7 +56,7 @@ void MCP23016::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->update_reg_(pin, false, iodir);
   }
 }
-float MCP23016::get_setup_priority() const { return setup_priority::IO; }
+float MCP23016::get_setup_priority() const { return setup_priority::HARDWARE; }
 bool MCP23016::read_reg_(uint8_t reg, uint8_t *value) {
   if (this->is_failed())
     return false;

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -22,14 +22,29 @@ void MCP23016::setup() {
   this->write_reg_(MCP23016_IODIR0, 0xFF);
   this->write_reg_(MCP23016_IODIR1, 0xFF);
 }
-bool MCP23016::digital_read(uint8_t pin) {
-  uint8_t bit = pin % 8;
+
+void MCP23016::loop() {
+  // Invalidate cache at the start of each loop
+  this->reset_pin_cache_();
+}
+bool MCP23016::digital_read_hw(uint8_t pin) {
   uint8_t reg_addr = pin < 8 ? MCP23016_GP0 : MCP23016_GP1;
   uint8_t value = 0;
-  this->read_reg_(reg_addr, &value);
-  return value & (1 << bit);
+  if (!this->read_reg_(reg_addr, &value)) {
+    return false;
+  }
+
+  // Update the appropriate part of input_mask_
+  if (pin < 8) {
+    this->input_mask_ = (this->input_mask_ & 0xFF00) | value;
+  } else {
+    this->input_mask_ = (this->input_mask_ & 0x00FF) | (uint16_t(value) << 8);
+  }
+  return true;
 }
-void MCP23016::digital_write(uint8_t pin, bool value) {
+
+bool MCP23016::digital_read_cache(uint8_t pin) { return this->input_mask_ & (1 << pin); }
+void MCP23016::digital_write_hw(uint8_t pin, bool value) {
   uint8_t reg_addr = pin < 8 ? MCP23016_OLAT0 : MCP23016_OLAT1;
   this->update_reg_(pin, value, reg_addr);
 }
@@ -41,7 +56,7 @@ void MCP23016::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->update_reg_(pin, false, iodir);
   }
 }
-float MCP23016::get_setup_priority() const { return setup_priority::HARDWARE; }
+float MCP23016::get_setup_priority() const { return setup_priority::IO; }
 bool MCP23016::read_reg_(uint8_t reg, uint8_t *value) {
   if (this->is_failed())
     return false;


### PR DESCRIPTION
# What does this implement/fix?

This PR migrates the MCP23016 I/O expander component to use the `CachedGpioExpander` base class, eliminating redundant I2C reads when multiple pins from the same bank are accessed in a single loop cycle.

The MCP23016 component was performing one I2C read transaction for every `digital_read()` call, even when reading multiple pins from the same 8-bit bank. Since the MCP23016 reads an entire 8-bit bank at once via I2C, this created unnecessary bus traffic when multiple pins from the same bank were read in the same loop cycle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the ongoing effort to reduce I2C bus usage across I/O expander components
- Similar optimizations: PR #10571 (PCA9554), PR #10573 (PCF8574)
- Uses existing `CachedGpioExpander` base class that's already proven with MCP23008/MCP23017

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** I don't have MCP23016 hardware available for physical testing. The changes follow the same pattern successfully used in MCP23008/MCP23017 (which already use CachedGpioExpander) and the code compiles successfully. Testing assistance from the community would be appreciated.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
i2c:
  sda: GPIO21
  scl: GPIO22

mcp23016:
  - id: mcp23016_hub
    address: 0x20

binary_sensor:
  - platform: gpio
    name: "MCP23016 Input Pin 0"
    pin:
      mcp23016: mcp23016_hub
      number: 0
      mode: INPUT

switch:
  - platform: gpio
    name: "MCP23016 Output Pin 8"
    pin:
      mcp23016: mcp23016_hub
      number: 8
      mode: OUTPUT
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Changes Made

1. **Migrated MCP23016 to CachedGpioExpander base class:**
   - MCP23016 now inherits from `gpio_expander::CachedGpioExpander<uint8_t, 16>`
   - Uses 2 banks of 8 pins each, matching the hardware's bank-separated reading pattern
   - Added `AUTO_LOAD = ["gpio_expander"]` to Python configuration

2. **Implemented required virtual methods:**
   - `digital_read_hw(uint8_t pin)` - Reads the relevant 8-bit bank (GP0 or GP1) based on pin number, returns true/false for success/failure
   - `digital_read_cache(uint8_t pin)` - Returns cached pin value from `input_mask_`
   - `digital_write_hw(uint8_t pin, bool value)` - Updates output latch register via existing `update_reg_()` method

3. **Cache management:**
   - Added `loop()` method that calls `reset_pin_cache_()` to invalidate cache at start of each loop
   - Maintains separate cache validity for each 8-bit bank
   - Follows the same pattern as MCP23008/MCP23017 components without custom loop priority

4. **Preserved existing functionality:**
   - Pin mode configuration remains unchanged
   - Output control through OLAT registers unchanged
   - All existing features and error handling preserved

## Expected Performance Impact

Based on similar optimizations in other I/O expander components:
- **Reduced I2C bus usage**: Multiple reads from the same 8-bit bank within a loop cycle now share a single I2C transaction
- **Lower latency**: Cached reads are instantaneous after the first read in a bank
- **Better scalability**: Systems with multiple MCP23016 chips or other I2C devices benefit from reduced bus congestion

The optimization is particularly beneficial when:
- Reading multiple pins from the same bank (pins 0-7 or pins 8-15) in a single loop cycle
- Using the MCP23016 in mixed input/output configurations
- Operating in I2C bus-constrained environments

## Technical Details

The MCP23016 reads its GPIO banks separately:
- Bank 0 (pins 0-7): Register GP0 (0x00)
- Bank 1 (pins 8-15): Register GP1 (0x01)

Using `CachedGpioExpander<uint8_t, 16>` with 2 banks perfectly matches this hardware pattern:
- First read in bank 0 fetches all 8 pins via I2C
- Subsequent reads from bank 0 use cache until next loop
- Same behavior for bank 1 (pins 8-15)
- Cache invalidated at start of each loop to ensure fresh data

This approach is identical to the already-proven MCP23017 implementation, which uses the same 2-bank architecture.