### PR TITLE
[pca6416a] Migrate to CachedGpioExpander to reduce I2C bus usage

### DIFF
--- a/esphome/components/pca6416a/__init__.py
+++ b/esphome/components/pca6416a/__init__.py
@@ -14,6 +14,7 @@ from esphome.const import (
 
 CODEOWNERS = ["@Mat931"]
 DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["gpio_expander"]
 MULTI_CONF = True
 pca6416a_ns = cg.esphome_ns.namespace("pca6416a")
 


### PR DESCRIPTION
# What does this implement/fix?

This PR migrates the PCA6416A I/O expander component to use the `CachedGpioExpander` base class, eliminating redundant I2C reads when multiple pins from the same bank are accessed in a single loop cycle.

The PCA6416A component was performing one I2C read transaction for every `digital_read()` call, even when reading multiple pins from the same 8-bit bank. Since the PCA6416A reads an entire 8-bit bank at once via I2C, this created unnecessary bus traffic when multiple pins from the same bank were read in the same loop cycle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of the ongoing effort to reduce I2C bus usage across I/O expander components
- Similar optimizations: PR #10571 (PCA9554), PR #10573 (PCF8574), PR #10581 (MCP23016)
- Uses existing `CachedGpioExpander` base class that's already proven with MCP23008/MCP23017

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** I don't have PCA6416A hardware available for physical testing. The changes follow the same pattern successfully used in MCP23008/MCP23017/MCP23016 (which already use CachedGpioExpander) and the code compiles successfully. Testing assistance from the community would be appreciated.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
i2c:
  sda: GPIO21
  scl: GPIO22

pca6416a:
  - id: pca6416a_hub
    address: 0x21

binary_sensor:
  - platform: gpio
    name: "PCA6416A Input Pin 0"
    pin:
      pca6416a: pca6416a_hub
      number: 0
      mode: INPUT

switch:
  - platform: gpio
    name: "PCA6416A Output Pin 8"
    pin:
      pca6416a: pca6416a_hub
      number: 8
      mode: OUTPUT
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Changes Made

1. **Migrated PCA6416A to CachedGpioExpander base class:**
   - PCA6416A now inherits from `gpio_expander::CachedGpioExpander<uint8_t, 16>`
   - Uses 2 banks of 8 pins each, matching the hardware's bank-separated reading pattern
   - Added `AUTO_LOAD = ["gpio_expander"]` to Python configuration

2. **Implemented required virtual methods:**
   - `digital_read_hw(uint8_t pin)` - Reads the relevant 8-bit bank (INPUT0 or INPUT1) based on pin number, returns true/false for success/failure
   - `digital_read_cache(uint8_t pin)` - Returns cached pin value from `input_mask_`
   - `digital_write_hw(uint8_t pin, bool value)` - Updates output register via existing `update_register_()` method

3. **Cache management:**
   - Added `loop()` method that calls `reset_pin_cache_()` to invalidate cache at start of each loop
   - Maintains separate cache validity for each 8-bit bank
   - Follows the same pattern as MCP23008/MCP23017/MCP23016 components

4. **Preserved existing functionality:**
   - Pin mode configuration remains unchanged (including PCAL6416A pull-up support)
   - Output control through OUTPUT0/OUTPUT1 registers unchanged
   - All existing features and error handling preserved
   - Maintains compatibility with both PCA6416A and PCAL6416A variants

## Expected Performance Impact

Based on similar optimizations in other I/O expander components:
- **Reduced I2C bus usage**: Multiple reads from the same 8-bit bank within a loop cycle now share a single I2C transaction
- **Lower latency**: Cached reads are instantaneous after the first read in a bank
- **Better scalability**: Systems with multiple PCA6416A chips or other I2C devices benefit from reduced bus congestion

The optimization is particularly beneficial when:
- Reading multiple pins from the same bank (pins 0-7 or pins 8-15) in a single loop cycle
- Using the PCA6416A in mixed input/output configurations
- Operating in I2C bus-constrained environments

## Technical Details

The PCA6416A reads its GPIO banks separately:
- Bank 0 (pins 0-7): Register INPUT0 (0x00)
- Bank 1 (pins 8-15): Register INPUT1 (0x01)

Using `CachedGpioExpander<uint8_t, 16>` with 2 banks perfectly matches this hardware pattern:
- First read in bank 0 fetches all 8 pins via I2C
- Subsequent reads from bank 0 use cache until next loop
- Same behavior for bank 1 (pins 8-15)
- Cache invalidated at start of each loop to ensure fresh data

This approach is identical to the already-proven MCP23016/MCP23017 implementation, which uses the same 2-bank architecture.
