### PR TITLE
[api] Store Noise protocol prologue in flash on ESP8266

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -10,10 +10,18 @@
 #include <cstring>
 #include <cinttypes>
 
+#ifdef USE_ESP8266
+#include <pgmspace.h>
+#endif
+
 namespace esphome::api {
 
 static const char *const TAG = "api.noise";
+#ifdef USE_ESP8266
+static const char PROLOGUE_INIT[] PROGMEM = "NoiseAPIInit";
+#else
 static const char *const PROLOGUE_INIT = "NoiseAPIInit";
+#endif
 static constexpr size_t PROLOGUE_INIT_LEN = 12;  // strlen("NoiseAPIInit")
 
 #define HELPER_LOG(msg, ...) ESP_LOGVV(TAG, "%s: " msg, this->client_info_->get_combined_info().c_str(), ##__VA_ARGS__)
@@ -75,7 +83,11 @@ APIError APINoiseFrameHelper::init() {
   // init prologue
   size_t old_size = prologue_.size();
   prologue_.resize(old_size + PROLOGUE_INIT_LEN);
+#ifdef USE_ESP8266
+  memcpy_P(prologue_.data() + old_size, PROLOGUE_INIT, PROLOGUE_INIT_LEN);
+#else
   std::memcpy(prologue_.data() + old_size, PROLOGUE_INIT, PROLOGUE_INIT_LEN);
+#endif
 
   state_ = State::CLIENT_HELLO;
   return APIError::OK;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage on ESP8266 by moving the Noise protocol prologue string to flash memory using PROGMEM. The constant string "NoiseAPIInit" was previously stored in RAM, consuming 13 bytes of precious RAM on the ESP8266 platform.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces RAM usage on ESP8266 devices using API encryption

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example of API with encryption (existing functionality):
api:
  encryption:
    key: "your-base64-encoded-32-byte-key"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This change:
- Uses conditional compilation to apply PROGMEM storage only on ESP8266
- Maintains existing behavior on all other platforms
- Uses `memcpy_P()` to correctly read from flash on ESP8266
- Saves 13 bytes of RAM on ESP8266 devices using API encryption