### PR TITLE
[mdns] Move constant strings to flash on ESP8266

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -10,6 +10,8 @@
 // Macro to define strings in PROGMEM on ESP8266, regular memory on other platforms
 #define MDNS_STATIC_CONST_CHAR(name, value) static const char name[] PROGMEM = value
 // Helper to get string from PROGMEM - returns a temporary std::string
+// Only define this function if we have services that will use it
+#if defined(USE_API) || defined(USE_PROMETHEUS) || defined(USE_WEBSERVER) || defined(USE_MDNS_EXTRA_SERVICES)
 static std::string mdns_string_p(const char *src) {
   char buf[64];
   strncpy_P(buf, src, sizeof(buf) - 1);
@@ -17,6 +19,10 @@ static std::string mdns_string_p(const char *src) {
   return std::string(buf);
 }
 #define MDNS_STR(name) mdns_string_p(name)
+#else
+// If no services are configured, we still need the fallback service but it uses string literals
+#define MDNS_STR(name) std::string(name)
+#endif
 #else
 // On non-ESP8266 platforms, use regular const char*
 #define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char *name = value

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -5,6 +5,24 @@
 #include "esphome/core/version.h"
 #include "mdns_component.h"
 
+#ifdef USE_ESP8266
+#include <pgmspace.h>
+// Macro to define strings in PROGMEM on ESP8266, regular memory on other platforms
+#define MDNS_STATIC_CONST_CHAR(name, value) static const char name[] PROGMEM = value
+// Helper to get string from PROGMEM - returns a temporary std::string
+static std::string mdns_string_p(const char *src) {
+  char buf[64];
+  strncpy_P(buf, src, sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
+  return std::string(buf);
+}
+#define MDNS_STR(name) mdns_string_p(name)
+#else
+// On non-ESP8266 platforms, use regular const char*
+#define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char *name = value
+#define MDNS_STR(name) name
+#endif
+
 #ifdef USE_API
 #include "esphome/components/api/api_server.h"
 #endif
@@ -20,6 +38,32 @@ static const char *const TAG = "mdns";
 #ifndef USE_WEBSERVER_PORT
 #define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
+
+// Define all constant strings using the macro
+MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
+MDNS_STATIC_CONST_CHAR(SERVICE_TCP, "_tcp");
+MDNS_STATIC_CONST_CHAR(SERVICE_PROMETHEUS, "_prometheus-http");
+MDNS_STATIC_CONST_CHAR(SERVICE_HTTP, "_http");
+
+MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
+MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
+MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
+MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
+MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
+MDNS_STATIC_CONST_CHAR(TXT_NETWORK, "network");
+MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION, "api_encryption");
+MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION_SUPPORTED, "api_encryption_supported");
+MDNS_STATIC_CONST_CHAR(TXT_PROJECT_NAME, "project_name");
+MDNS_STATIC_CONST_CHAR(TXT_PROJECT_VERSION, "project_version");
+MDNS_STATIC_CONST_CHAR(TXT_PACKAGE_IMPORT_URL, "package_import_url");
+
+MDNS_STATIC_CONST_CHAR(PLATFORM_ESP8266, "ESP8266");
+MDNS_STATIC_CONST_CHAR(PLATFORM_ESP32, "ESP32");
+MDNS_STATIC_CONST_CHAR(PLATFORM_RP2040, "RP2040");
+
+MDNS_STATIC_CONST_CHAR(NETWORK_WIFI, "wifi");
+MDNS_STATIC_CONST_CHAR(NETWORK_ETHERNET, "ethernet");
+MDNS_STATIC_CONST_CHAR(NETWORK_THREAD, "thread");
 
 void MDNSComponent::compile_records_() {
   this->hostname_ = App.get_name();
@@ -50,8 +94,8 @@ void MDNSComponent::compile_records_() {
   if (api::global_api_server != nullptr) {
     this->services_.emplace_back();
     auto &service = this->services_.back();
-    service.service_type = "_esphomelib";
-    service.proto = "_tcp";
+    service.service_type = MDNS_STR(SERVICE_ESPHOMELIB);
+    service.proto = MDNS_STR(SERVICE_TCP);
     service.port = api::global_api_server->get_port();
 
     const std::string &friendly_name = App.get_friendly_name();
@@ -82,47 +126,47 @@ void MDNSComponent::compile_records_() {
     txt_records.reserve(txt_count);
 
     if (!friendly_name_empty) {
-      txt_records.emplace_back(MDNSTXTRecord{"friendly_name", friendly_name});
+      txt_records.push_back({MDNS_STR(TXT_FRIENDLY_NAME), friendly_name});
     }
-    txt_records.emplace_back(MDNSTXTRecord{"version", ESPHOME_VERSION});
-    txt_records.emplace_back(MDNSTXTRecord{"mac", get_mac_address()});
+    txt_records.push_back({MDNS_STR(TXT_VERSION), ESPHOME_VERSION});
+    txt_records.push_back({MDNS_STR(TXT_MAC), get_mac_address()});
 
 #ifdef USE_ESP8266
-    txt_records.emplace_back(MDNSTXTRecord{"platform", "ESP8266"});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP8266)});
 #elif defined(USE_ESP32)
-    txt_records.emplace_back(MDNSTXTRecord{"platform", "ESP32"});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP32)});
 #elif defined(USE_RP2040)
-    txt_records.emplace_back(MDNSTXTRecord{"platform", "RP2040"});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_RP2040)});
 #elif defined(USE_LIBRETINY)
     txt_records.emplace_back(MDNSTXTRecord{"platform", lt_cpu_get_model_name()});
 #endif
 
-    txt_records.emplace_back(MDNSTXTRecord{"board", ESPHOME_BOARD});
+    txt_records.push_back({MDNS_STR(TXT_BOARD), ESPHOME_BOARD});
 
 #if defined(USE_WIFI)
-    txt_records.emplace_back(MDNSTXTRecord{"network", "wifi"});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_WIFI)});
 #elif defined(USE_ETHERNET)
-    txt_records.emplace_back(MDNSTXTRecord{"network", "ethernet"});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_ETHERNET)});
 #elif defined(USE_OPENTHREAD)
-    txt_records.emplace_back(MDNSTXTRecord{"network", "thread"});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_THREAD)});
 #endif
 
 #ifdef USE_API_NOISE
-    static constexpr const char *NOISE_ENCRYPTION = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
+    MDNS_STATIC_CONST_CHAR(NOISE_ENCRYPTION, "Noise_NNpsk0_25519_ChaChaPoly_SHA256");
     if (api::global_api_server->get_noise_ctx()->has_psk()) {
-      txt_records.emplace_back(MDNSTXTRecord{"api_encryption", NOISE_ENCRYPTION});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION), MDNS_STR(NOISE_ENCRYPTION)});
     } else {
-      txt_records.emplace_back(MDNSTXTRecord{"api_encryption_supported", NOISE_ENCRYPTION});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION_SUPPORTED), MDNS_STR(NOISE_ENCRYPTION)});
     }
 #endif
 
 #ifdef ESPHOME_PROJECT_NAME
-    txt_records.emplace_back(MDNSTXTRecord{"project_name", ESPHOME_PROJECT_NAME});
-    txt_records.emplace_back(MDNSTXTRecord{"project_version", ESPHOME_PROJECT_VERSION});
+    txt_records.push_back({MDNS_STR(TXT_PROJECT_NAME), ESPHOME_PROJECT_NAME});
+    txt_records.push_back({MDNS_STR(TXT_PROJECT_VERSION), ESPHOME_PROJECT_VERSION});
 #endif  // ESPHOME_PROJECT_NAME
 
 #ifdef USE_DASHBOARD_IMPORT
-    txt_records.emplace_back(MDNSTXTRecord{"package_import_url", dashboard_import::get_package_import_url()});
+    txt_records.push_back({MDNS_STR(TXT_PACKAGE_IMPORT_URL), dashboard_import::get_package_import_url()});
 #endif
   }
 #endif  // USE_API
@@ -130,16 +174,16 @@ void MDNSComponent::compile_records_() {
 #ifdef USE_PROMETHEUS
   this->services_.emplace_back();
   auto &prom_service = this->services_.back();
-  prom_service.service_type = "_prometheus-http";
-  prom_service.proto = "_tcp";
+  prom_service.service_type = MDNS_STR(SERVICE_PROMETHEUS);
+  prom_service.proto = MDNS_STR(SERVICE_TCP);
   prom_service.port = USE_WEBSERVER_PORT;
 #endif
 
 #ifdef USE_WEBSERVER
   this->services_.emplace_back();
   auto &web_service = this->services_.back();
-  web_service.service_type = "_http";
-  web_service.proto = "_tcp";
+  web_service.service_type = MDNS_STR(SERVICE_HTTP);
+  web_service.proto = MDNS_STR(SERVICE_TCP);
   web_service.port = USE_WEBSERVER_PORT;
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage on ESP8266 by moving constant strings in the mDNS component to flash memory using PROGMEM. The mDNS component previously stored all service type strings, TXT record keys, and other constants in RAM, which is limited on ESP8266 devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces RAM usage on ESP8266 devices with mDNS enabled

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Standard mDNS usage (unchanged):
mdns:
  disabled: false  # default

api:
  encryption:
    key: "your-base64-encoded-32-byte-key"

web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Memory Impact

**ESP8266 (optimization target):**
- RAM saved: **64 bytes** (32,128 → 32,064 bytes)
- Flash saved: **16 bytes** (386,873 → 386,857 bytes)

**ESP32 (no regression):**
- RAM: No change (16,084 bytes)
- Flash: No change (501,802 bytes)

### Implementation

The optimization introduces platform-specific macros to handle string storage:
- `MDNS_STATIC_CONST_CHAR(name, value)` - Defines strings in PROGMEM on ESP8266, regular memory on others
- `MDNS_STR(name)` - Transparently accesses strings regardless of storage location

Strings moved to flash on ESP8266:
- Service types: `"_esphomelib"`, `"_tcp"`, `"_prometheus-http"`, `"_http"`
- TXT record keys: `"friendly_name"`, `"version"`, `"mac"`, `"platform"`, `"board"`, `"network"`, `"api_encryption"`, `"api_encryption_supported"`, `"project_name"`, `"project_version"`, `"package_import_url"`
- Platform identifiers: `"ESP8266"`, `"ESP32"`, `"RP2040"`
- Network types: `"wifi"`, `"ethernet"`, `"thread"`
- Noise protocol: `"Noise_NNpsk0_25519_ChaChaPoly_SHA256"`

The implementation uses a single 64-byte stack buffer for safe PROGMEM string access on ESP8266, with bounds checking via `strncpy_P` to prevent buffer overflows.