### PR TITLE
[captive_portal] ESP8266: Move strings to PROGMEM (saves 192 bytes RAM)

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -11,17 +11,37 @@ namespace captive_portal {
 static const char *const TAG = "captive_portal";
 
 void CaptivePortal::handle_config(AsyncWebServerRequest *request) {
-  AsyncResponseStream *stream = request->beginResponseStream("application/json");
-  stream->addHeader("cache-control", "public, max-age=0, must-revalidate");
+#ifdef USE_ESP8266
+  AsyncResponseStream *stream = request->beginResponseStream(F("application/json"));
+  stream->addHeader(F("cache-control"), F("public, max-age=0, must-revalidate"));
+  stream->print(F("{\"mac\":\""));
+  stream->print(get_mac_address_pretty().c_str());
+  stream->print(F("\",\"name\":\""));
+  stream->print(App.get_name().c_str());
+  stream->print(F("\",\"aps\":["));
+#else
+  AsyncResponseStream *stream = request->beginResponseStream(F("application/json"));
+  stream->addHeader(F("cache-control"), F("public, max-age=0, must-revalidate"));
   stream->printf(R"({"mac":"%s","name":"%s","aps":[{})", get_mac_address_pretty().c_str(), App.get_name().c_str());
+#endif
 
   for (auto &scan : wifi::global_wifi_component->get_scan_result()) {
     if (scan.get_is_hidden())
       continue;
 
-    // Assumes no " in ssid, possible unicode isses?
+      // Assumes no " in ssid, possible unicode isses?
+#ifdef USE_ESP8266
+    stream->print(F(",{\"ssid\":\""));
+    stream->print(scan.get_ssid().c_str());
+    stream->print(F("\",\"rssi\":"));
+    stream->print(scan.get_rssi());
+    stream->print(F(",\"lock\":"));
+    stream->print(scan.get_with_auth());
+    stream->print(F("}"));
+#else
     stream->printf(R"(,{"ssid":"%s","rssi":%d,"lock":%d})", scan.get_ssid().c_str(), scan.get_rssi(),
                    scan.get_with_auth());
+#endif
   }
   stream->print(F("]}"));
   request->send(stream);
@@ -34,7 +54,7 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   wifi::global_wifi_component->save_wifi_sta(ssid, psk);
   wifi::global_wifi_component->start_scanning();
-  request->redirect("/?save");
+  request->redirect(F("/?save"));
 }
 
 void CaptivePortal::setup() {
@@ -53,18 +73,23 @@ void CaptivePortal::start() {
   this->dns_server_ = make_unique<DNSServer>();
   this->dns_server_->setErrorReplyCode(DNSReplyCode::NoError);
   network::IPAddress ip = wifi::global_wifi_component->wifi_soft_ap_ip();
-  this->dns_server_->start(53, "*", ip);
+  this->dns_server_->start(53, F("*"), ip);
   // Re-enable loop() when DNS server is started
   this->enable_loop();
 #endif
 
   this->base_->get_server()->onNotFound([this](AsyncWebServerRequest *req) {
     if (!this->active_ || req->host().c_str() == wifi::global_wifi_component->wifi_soft_ap_ip().str()) {
-      req->send(404, "text/html", "File not found");
+      req->send(404, F("text/html"), F("File not found"));
       return;
     }
 
+#ifdef USE_ESP8266
+    String url = F("http://");
+    url += wifi::global_wifi_component->wifi_soft_ap_ip().str().c_str();
+#else
     auto url = "http://" + wifi::global_wifi_component->wifi_soft_ap_ip().str();
+#endif
     req->redirect(url.c_str());
   });
 
@@ -73,19 +98,19 @@ void CaptivePortal::start() {
 }
 
 void CaptivePortal::handleRequest(AsyncWebServerRequest *req) {
-  if (req->url() == "/") {
+  if (req->url() == F("/")) {
 #ifndef USE_ESP8266
-    auto *response = req->beginResponse(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
+    auto *response = req->beginResponse(200, F("text/html"), INDEX_GZ, sizeof(INDEX_GZ));
 #else
     auto *response = req->beginResponse_P(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
 #endif
-    response->addHeader("Content-Encoding", "gzip");
+    response->addHeader(F("Content-Encoding"), F("gzip"));
     req->send(response);
     return;
-  } else if (req->url() == "/config.json") {
+  } else if (req->url() == F("/config.json")) {
     this->handle_config(req);
     return;
-  } else if (req->url() == "/wifisave") {
+  } else if (req->url() == F("/wifisave")) {
     this->handle_wifisave(req);
     return;
   }

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -18,7 +18,7 @@ void CaptivePortal::handle_config(AsyncWebServerRequest *request) {
   stream->print(get_mac_address_pretty().c_str());
   stream->print(F("\",\"name\":\""));
   stream->print(App.get_name().c_str());
-  stream->print(F("\",\"aps\":["));
+  stream->print(F("\",\"aps\":[{}"));
 #else
   AsyncResponseStream *stream = request->beginResponseStream(F("application/json"));
   stream->addHeader(F("cache-control"), F("public, max-age=0, must-revalidate"));

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -100,7 +100,7 @@ void CaptivePortal::handleRequest(AsyncWebServerRequest *req) {
 #ifndef USE_ESP8266
     auto *response = req->beginResponse(200, F("text/html"), INDEX_GZ, sizeof(INDEX_GZ));
 #else
-    auto *response = req->beginResponse_P(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
+    auto *response = req->beginResponse_P(200, F("text/html"), INDEX_GZ, sizeof(INDEX_GZ));
 #endif
     response->addHeader(F("Content-Encoding"), F("gzip"));
     req->send(response);

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -11,17 +11,15 @@ namespace captive_portal {
 static const char *const TAG = "captive_portal";
 
 void CaptivePortal::handle_config(AsyncWebServerRequest *request) {
-#ifdef USE_ESP8266
   AsyncResponseStream *stream = request->beginResponseStream(F("application/json"));
   stream->addHeader(F("cache-control"), F("public, max-age=0, must-revalidate"));
+#ifdef USE_ESP8266
   stream->print(F("{\"mac\":\""));
   stream->print(get_mac_address_pretty().c_str());
   stream->print(F("\",\"name\":\""));
   stream->print(App.get_name().c_str());
   stream->print(F("\",\"aps\":[{}"));
 #else
-  AsyncResponseStream *stream = request->beginResponseStream(F("application/json"));
-  stream->addHeader(F("cache-control"), F("public, max-age=0, must-revalidate"));
   stream->printf(R"({"mac":"%s","name":"%s","aps":[{})", get_mac_address_pretty().c_str(), App.get_name().c_str());
 #endif
 

--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -45,11 +45,11 @@ class CaptivePortal : public AsyncWebHandler, public Component {
       return false;
 
     if (request->method() == HTTP_GET) {
-      if (request->url() == "/")
+      if (request->url() == F("/"))
         return true;
-      if (request->url() == "/config.json")
+      if (request->url() == F("/config.json"))
         return true;
-      if (request->url() == "/wifisave")
+      if (request->url() == F("/wifisave"))
         return true;
     }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage on ESP8266 by using the F() macro to store constant strings in flash memory (PROGMEM) for the captive portal component. The captive portal previously stored all string literals in RAM, including JSON format strings, URL paths, HTTP headers, and error messages.

**Measured impact on ESP8266:**
- **RAM saved: 192 bytes** (consistent across multiple tests)
- **Flash increase: 32-64 bytes** (minimal overhead)

This is a significant RAM saving for memory-constrained ESP8266 devices where every byte of RAM matters.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves ESP8266 memory usage, particularly important for devices with many components enabled

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Standard captive portal configuration works as before:
captive_portal:

wifi:
  ap:
    ssid: "MyDevice-AP"
    password: "mypassword"

web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

### Implementation Details

The optimization uses the Arduino F() macro to store string literals in PROGMEM:
- On ESP8266: Strings are moved from RAM to flash memory
- On ESP32: F() is a no-op (strings already in flash by default), ensuring compatibility
- The code remains clean without platform-specific `#ifdef` guards for most F() usage

### Strings Moved to Flash

- JSON response format strings (broken into multiple `print()` calls for ESP8266 compatibility)
- URL paths (`"/"`, `"/config.json"`, `"/wifisave"`)
- HTTP headers and content types (`"application/json"`, `"text/html"`, `"cache-control"`, etc.)
- Error messages (`"File not found"`)
- Other constants (`"http://"`, `"/?save"`, `"*"` for DNS wildcard)

### Technical Notes

- `stream->printf()` doesn't support F() macro, so format strings are broken into multiple `stream->print()` calls on ESP8266
- URL comparisons use F() macro directly: `req->url() == F("/path")`
- All AsyncWebServer methods that accept strings also accept F() wrapped strings
- Changes are applied to both `captive_portal.cpp` and `captive_portal.h` to ensure all string literals are optimized
