### PR TITLE
[web_server] ESP8266: Move strings to PROGMEM (saves 128 bytes RAM)

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -307,7 +307,7 @@ std::string WebServer::get_config_json() {
     root[F("ota")] = true;
 #endif
     root[F("log")] = this->expose_log_;
-    root[F("lang")] = F("en");
+    root[F("lang")] = "en";
   });
 }
 
@@ -802,12 +802,12 @@ std::string WebServer::light_all_json_generator(WebServer *web_server, void *sou
 std::string WebServer::light_json(light::LightState *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "light-" + obj->get_object_id(), start_config);
-    root[F("state")] = obj->remote_values.is_on() ? F("ON") : F("OFF");
+    root[F("state")] = obj->remote_values.is_on() ? "ON" : "OFF";
 
     light::LightJSONSchema::dump_json(*obj, root);
     if (start_config == DETAIL_ALL) {
       JsonArray opt = root[F("effects")].to<JsonArray>();
-      opt.add(F("None"));
+      opt.add("None");
       for (auto const &option : obj->get_effects()) {
         opt.add(option->get_name());
       }
@@ -942,8 +942,8 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
       this->add_sorting_info_(root, obj);
     }
     if (std::isnan(value)) {
-      root[F("value")] = F("\"NaN\"");
-      root[F("state")] = F("NA");
+      root[F("value")] = "\"NaN\"";
+      root[F("state")] = "NA";
     } else {
       root[F("value")] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       std::string state = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
@@ -1167,7 +1167,7 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
     root[F("max_length")] = obj->traits.get_max_length();
     root[F("pattern")] = obj->traits.get_pattern();
     if (obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD) {
-      root[F("state")] = F("********");
+      root[F("state")] = "********";
     } else {
       root[F("state")] = value;
     }
@@ -1353,7 +1353,7 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
       if (!std::isnan(obj->current_temperature)) {
         root[F("current_temperature")] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
       } else {
-        root[F("current_temperature")] = F("NA");
+        root[F("current_temperature")] = "NA";
       }
     }
     if (traits.get_supports_two_point_target_temperature()) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -262,8 +262,8 @@ void DeferredUpdateEventSourceList::on_client_connect_(WebServer *ws, DeferredUp
 #ifdef USE_WEBSERVER_SORTING
   for (auto &group : ws->sorting_groups_) {
     message = json::build_json([group](JsonObject root) {
-      root[F("name")] = group.second.name;
-      root[F("sorting_weight")] = group.second.weight;
+      root["name"] = group.second.name;
+      root["sorting_weight"] = group.second.weight;
     });
 
     // up to 31 groups should be able to be queued initially without defer
@@ -299,15 +299,15 @@ void WebServer::set_js_include(const char *js_include) { this->js_include_ = js_
 
 std::string WebServer::get_config_json() {
   return json::build_json([this](JsonObject root) {
-    root[F("title")] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
-    root[F("comment")] = App.get_comment();
+    root["title"] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
+    root["comment"] = App.get_comment();
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
-    root[F("ota")] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
+    root["ota"] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else
-    root[F("ota")] = true;
+    root["ota"] = true;
 #endif
-    root[F("log")] = this->expose_log_;
-    root[F("lang")] = "en";
+    root["log"] = this->expose_log_;
+    root["lang"] = "en";
   });
 }
 
@@ -411,14 +411,14 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 
 // Helper functions to reduce code size by avoiding macro expansion
 static void set_json_id(JsonObject &root, EntityBase *obj, const std::string &id, JsonDetail start_config) {
-  root[F("id")] = id;
+  root["id"] = id;
   if (start_config == DETAIL_ALL) {
-    root[F("name")] = obj->get_name();
-    root[F("icon")] = obj->get_icon();
-    root[F("entity_category")] = obj->get_entity_category();
+    root["name"] = obj->get_name();
+    root["icon"] = obj->get_icon();
+    root["entity_category"] = obj->get_entity_category();
     bool is_disabled = obj->is_disabled_by_default();
     if (is_disabled)
-      root[F("is_disabled_by_default")] = is_disabled;
+      root["is_disabled_by_default"] = is_disabled;
   }
 }
 
@@ -426,14 +426,14 @@ template<typename T>
 static void set_json_value(JsonObject &root, EntityBase *obj, const std::string &id, const T &value,
                            JsonDetail start_config) {
   set_json_id(root, obj, id, start_config);
-  root[F("value")] = value;
+  root["value"] = value;
 }
 
 template<typename T>
 static void set_json_icon_state_value(JsonObject &root, EntityBase *obj, const std::string &id,
                                       const std::string &state, const T &value, JsonDetail start_config) {
   set_json_value(root, obj, id, value, start_config);
-  root[F("state")] = state;
+  root["state"] = state;
 }
 
 // Helper to get request detail parameter
@@ -481,7 +481,7 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
       if (!obj->get_unit_of_measurement().empty())
-        root[F("uom")] = obj->get_unit_of_measurement();
+        root["uom"] = obj->get_unit_of_measurement();
     }
   });
 }
@@ -589,7 +589,7 @@ std::string WebServer::switch_json(switch_::Switch *obj, bool value, JsonDetail 
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "switch-" + obj->get_object_id(), value ? "ON" : "OFF", value, start_config);
     if (start_config == DETAIL_ALL) {
-      root[F("assumed_state")] = obj->assumed_state();
+      root["assumed_state"] = obj->assumed_state();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -732,11 +732,11 @@ std::string WebServer::fan_json(fan::Fan *obj, JsonDetail start_config) {
                               start_config);
     const auto traits = obj->get_traits();
     if (traits.supports_speed()) {
-      root[F("speed_level")] = obj->speed;
-      root[F("speed_count")] = traits.supported_speed_count();
+      root["speed_level"] = obj->speed;
+      root["speed_count"] = traits.supported_speed_count();
     }
     if (obj->get_traits().supports_oscillation())
-      root[F("oscillation")] = obj->oscillating;
+      root["oscillation"] = obj->oscillating;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -802,11 +802,11 @@ std::string WebServer::light_all_json_generator(WebServer *web_server, void *sou
 std::string WebServer::light_json(light::LightState *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "light-" + obj->get_object_id(), start_config);
-    root[F("state")] = obj->remote_values.is_on() ? "ON" : "OFF";
+    root["state"] = obj->remote_values.is_on() ? "ON" : "OFF";
 
     light::LightJSONSchema::dump_json(*obj, root);
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root[F("effects")].to<JsonArray>();
+      JsonArray opt = root["effects"].to<JsonArray>();
       opt.add("None");
       for (auto const &option : obj->get_effects()) {
         opt.add(option->get_name());
@@ -875,12 +875,12 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "cover-" + obj->get_object_id(), obj->is_fully_closed() ? "CLOSED" : "OPEN",
                               obj->position, start_config);
-    root[F("current_operation")] = cover::cover_operation_to_str(obj->current_operation);
+    root["current_operation"] = cover::cover_operation_to_str(obj->current_operation);
 
     if (obj->get_traits().get_supports_position())
-      root[F("position")] = obj->position;
+      root["position"] = obj->position;
     if (obj->get_traits().get_supports_tilt())
-      root[F("tilt")] = obj->tilt;
+      root["tilt"] = obj->tilt;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -930,26 +930,26 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_id(root, obj, "number-" + obj->get_object_id(), start_config);
     if (start_config == DETAIL_ALL) {
-      root[F("min_value")] =
+      root["min_value"] =
           value_accuracy_to_string(obj->traits.get_min_value(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root[F("max_value")] =
+      root["max_value"] =
           value_accuracy_to_string(obj->traits.get_max_value(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root[F("step")] =
+      root["step"] =
           value_accuracy_to_string(obj->traits.get_step(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root[F("mode")] = (int) obj->traits.get_mode();
+      root["mode"] = (int) obj->traits.get_mode();
       if (!obj->traits.get_unit_of_measurement().empty())
-        root[F("uom")] = obj->traits.get_unit_of_measurement();
+        root["uom"] = obj->traits.get_unit_of_measurement();
       this->add_sorting_info_(root, obj);
     }
     if (std::isnan(value)) {
-      root[F("value")] = "\"NaN\"";
-      root[F("state")] = "NA";
+      root["value"] = "\"NaN\"";
+      root["state"] = "NA";
     } else {
-      root[F("value")] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
+      root["value"] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       std::string state = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       if (!obj->traits.get_unit_of_measurement().empty())
         state += " " + obj->traits.get_unit_of_measurement();
-      root[F("state")] = state;
+      root["state"] = state;
     }
   });
 }
@@ -1002,8 +1002,8 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "date-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
-    root[F("value")] = value;
-    root[F("state")] = value;
+    root["value"] = value;
+    root["state"] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1057,8 +1057,8 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "time-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
-    root[F("value")] = value;
-    root[F("state")] = value;
+    root["value"] = value;
+    root["state"] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1113,8 +1113,8 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
     set_json_id(root, obj, "datetime-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour,
                                     obj->minute, obj->second);
-    root[F("value")] = value;
-    root[F("state")] = value;
+    root["value"] = value;
+    root["state"] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1163,17 +1163,17 @@ std::string WebServer::text_all_json_generator(WebServer *web_server, void *sour
 std::string WebServer::text_json(text::Text *obj, const std::string &value, JsonDetail start_config) {
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_id(root, obj, "text-" + obj->get_object_id(), start_config);
-    root[F("min_length")] = obj->traits.get_min_length();
-    root[F("max_length")] = obj->traits.get_max_length();
-    root[F("pattern")] = obj->traits.get_pattern();
+    root["min_length"] = obj->traits.get_min_length();
+    root["max_length"] = obj->traits.get_max_length();
+    root["pattern"] = obj->traits.get_pattern();
     if (obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD) {
-      root[F("state")] = "********";
+      root["state"] = "********";
     } else {
-      root[F("state")] = value;
+      root["state"] = value;
     }
-    root[F("value")] = value;
+    root["value"] = value;
     if (start_config == DETAIL_ALL) {
-      root[F("mode")] = (int) obj->traits.get_mode();
+      root["mode"] = (int) obj->traits.get_mode();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1222,7 +1222,7 @@ std::string WebServer::select_json(select::Select *obj, const std::string &value
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "select-" + obj->get_object_id(), value, value, start_config);
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root[F("option")].to<JsonArray>();
+      JsonArray opt = root["option"].to<JsonArray>();
       for (auto &option : obj->traits.get_options()) {
         opt.add(option);
       }
@@ -1292,32 +1292,32 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
     char buf[16];
 
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root[F("modes")].to<JsonArray>();
+      JsonArray opt = root["modes"].to<JsonArray>();
       for (climate::ClimateMode m : traits.get_supported_modes())
         opt.add(PSTR_LOCAL(climate::climate_mode_to_string(m)));
       if (!traits.get_supported_custom_fan_modes().empty()) {
-        JsonArray opt = root[F("fan_modes")].to<JsonArray>();
+        JsonArray opt = root["fan_modes"].to<JsonArray>();
         for (climate::ClimateFanMode m : traits.get_supported_fan_modes())
           opt.add(PSTR_LOCAL(climate::climate_fan_mode_to_string(m)));
       }
 
       if (!traits.get_supported_custom_fan_modes().empty()) {
-        JsonArray opt = root[F("custom_fan_modes")].to<JsonArray>();
+        JsonArray opt = root["custom_fan_modes"].to<JsonArray>();
         for (auto const &custom_fan_mode : traits.get_supported_custom_fan_modes())
           opt.add(custom_fan_mode);
       }
       if (traits.get_supports_swing_modes()) {
-        JsonArray opt = root[F("swing_modes")].to<JsonArray>();
+        JsonArray opt = root["swing_modes"].to<JsonArray>();
         for (auto swing_mode : traits.get_supported_swing_modes())
           opt.add(PSTR_LOCAL(climate::climate_swing_mode_to_string(swing_mode)));
       }
       if (traits.get_supports_presets() && obj->preset.has_value()) {
-        JsonArray opt = root[F("presets")].to<JsonArray>();
+        JsonArray opt = root["presets"].to<JsonArray>();
         for (climate::ClimatePreset m : traits.get_supported_presets())
           opt.add(PSTR_LOCAL(climate::climate_preset_to_string(m)));
       }
       if (!traits.get_supported_custom_presets().empty() && obj->custom_preset.has_value()) {
-        JsonArray opt = root[F("custom_presets")].to<JsonArray>();
+        JsonArray opt = root["custom_presets"].to<JsonArray>();
         for (auto const &custom_preset : traits.get_supported_custom_presets())
           opt.add(custom_preset);
       }
@@ -1325,48 +1325,48 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
     }
 
     bool has_state = false;
-    root[F("mode")] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
-    root[F("max_temp")] = value_accuracy_to_string(traits.get_visual_max_temperature(), target_accuracy);
-    root[F("min_temp")] = value_accuracy_to_string(traits.get_visual_min_temperature(), target_accuracy);
-    root[F("step")] = traits.get_visual_target_temperature_step();
+    root["mode"] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
+    root["max_temp"] = value_accuracy_to_string(traits.get_visual_max_temperature(), target_accuracy);
+    root["min_temp"] = value_accuracy_to_string(traits.get_visual_min_temperature(), target_accuracy);
+    root["step"] = traits.get_visual_target_temperature_step();
     if (traits.get_supports_action()) {
-      root[F("action")] = PSTR_LOCAL(climate_action_to_string(obj->action));
-      root[F("state")] = root[F("action")];
+      root["action"] = PSTR_LOCAL(climate_action_to_string(obj->action));
+      root["state"] = root["action"];
       has_state = true;
     }
     if (traits.get_supports_fan_modes() && obj->fan_mode.has_value()) {
-      root[F("fan_mode")] = PSTR_LOCAL(climate_fan_mode_to_string(obj->fan_mode.value()));
+      root["fan_mode"] = PSTR_LOCAL(climate_fan_mode_to_string(obj->fan_mode.value()));
     }
     if (!traits.get_supported_custom_fan_modes().empty() && obj->custom_fan_mode.has_value()) {
-      root[F("custom_fan_mode")] = obj->custom_fan_mode.value().c_str();
+      root["custom_fan_mode"] = obj->custom_fan_mode.value().c_str();
     }
     if (traits.get_supports_presets() && obj->preset.has_value()) {
-      root[F("preset")] = PSTR_LOCAL(climate_preset_to_string(obj->preset.value()));
+      root["preset"] = PSTR_LOCAL(climate_preset_to_string(obj->preset.value()));
     }
     if (!traits.get_supported_custom_presets().empty() && obj->custom_preset.has_value()) {
-      root[F("custom_preset")] = obj->custom_preset.value().c_str();
+      root["custom_preset"] = obj->custom_preset.value().c_str();
     }
     if (traits.get_supports_swing_modes()) {
-      root[F("swing_mode")] = PSTR_LOCAL(climate_swing_mode_to_string(obj->swing_mode));
+      root["swing_mode"] = PSTR_LOCAL(climate_swing_mode_to_string(obj->swing_mode));
     }
     if (traits.get_supports_current_temperature()) {
       if (!std::isnan(obj->current_temperature)) {
-        root[F("current_temperature")] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
+        root["current_temperature"] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
       } else {
-        root[F("current_temperature")] = "NA";
+        root["current_temperature"] = "NA";
       }
     }
     if (traits.get_supports_two_point_target_temperature()) {
-      root[F("target_temperature_low")] = value_accuracy_to_string(obj->target_temperature_low, target_accuracy);
-      root[F("target_temperature_high")] = value_accuracy_to_string(obj->target_temperature_high, target_accuracy);
+      root["target_temperature_low"] = value_accuracy_to_string(obj->target_temperature_low, target_accuracy);
+      root["target_temperature_high"] = value_accuracy_to_string(obj->target_temperature_high, target_accuracy);
       if (!has_state) {
-        root[F("state")] = value_accuracy_to_string((obj->target_temperature_high + obj->target_temperature_low) / 2.0f,
-                                                    target_accuracy);
+        root["state"] = value_accuracy_to_string((obj->target_temperature_high + obj->target_temperature_low) / 2.0f,
+                                                 target_accuracy);
       }
     } else {
-      root[F("target_temperature")] = value_accuracy_to_string(obj->target_temperature, target_accuracy);
+      root["target_temperature"] = value_accuracy_to_string(obj->target_temperature, target_accuracy);
       if (!has_state)
-        root[F("state")] = root[F("target_temperature")];
+        root["state"] = root["target_temperature"];
     }
   });
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
@@ -1500,10 +1500,10 @@ std::string WebServer::valve_json(valve::Valve *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "valve-" + obj->get_object_id(), obj->is_fully_closed() ? "CLOSED" : "OPEN",
                               obj->position, start_config);
-    root[F("current_operation")] = valve::valve_operation_to_str(obj->current_operation);
+    root["current_operation"] = valve::valve_operation_to_str(obj->current_operation);
 
     if (obj->get_traits().get_supports_position())
-      root[F("position")] = obj->position;
+      root["position"] = obj->position;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1613,14 +1613,14 @@ std::string WebServer::event_json(event::Event *obj, const std::string &event_ty
   return json::build_json([this, obj, event_type, start_config](JsonObject root) {
     set_json_id(root, obj, "event-" + obj->get_object_id(), start_config);
     if (!event_type.empty()) {
-      root[F("event_type")] = event_type;
+      root["event_type"] = event_type;
     }
     if (start_config == DETAIL_ALL) {
-      JsonArray event_types = root[F("event_types")].to<JsonArray>();
+      JsonArray event_types = root["event_types"].to<JsonArray>();
       for (auto const &event_type : obj->get_event_types()) {
         event_types.add(event_type);
       }
-      root[F("device_class")] = obj->get_device_class();
+      root["device_class"] = obj->get_device_class();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1679,13 +1679,13 @@ std::string WebServer::update_json(update::UpdateEntity *obj, JsonDetail start_c
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "update-" + obj->get_object_id(), start_config);
-    root[F("value")] = obj->update_info.latest_version;
-    root[F("state")] = update_state_to_string(obj->state);
+    root["value"] = obj->update_info.latest_version;
+    root["state"] = update_state_to_string(obj->state);
     if (start_config == DETAIL_ALL) {
-      root[F("current_version")] = obj->update_info.current_version;
-      root[F("title")] = obj->update_info.title;
-      root[F("summary")] = obj->update_info.summary;
-      root[F("release_url")] = obj->update_info.release_url;
+      root["current_version"] = obj->update_info.current_version;
+      root["title"] = obj->update_info.title;
+      root["summary"] = obj->update_info.summary;
+      root["release_url"] = obj->update_info.release_url;
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1948,9 +1948,9 @@ bool WebServer::isRequestHandlerTrivial() const { return false; }
 void WebServer::add_sorting_info_(JsonObject &root, EntityBase *entity) {
 #ifdef USE_WEBSERVER_SORTING
   if (this->sorting_entitys_.find(entity) != this->sorting_entitys_.end()) {
-    root[F("sorting_weight")] = this->sorting_entitys_[entity].weight;
+    root["sorting_weight"] = this->sorting_entitys_[entity].weight;
     if (this->sorting_groups_.find(this->sorting_entitys_[entity].group_id) != this->sorting_groups_.end()) {
-      root[F("sorting_group")] = this->sorting_groups_[this->sorting_entitys_[entity].group_id].name;
+      root["sorting_group"] = this->sorting_groups_[this->sorting_entitys_[entity].group_id].name;
     }
   }
 #endif

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -39,11 +39,57 @@ namespace web_server {
 
 static const char *const TAG = "web_server";
 
+#ifdef USE_ESP8266
+// Common strings used multiple times - deduplicated in PROGMEM on ESP8266
+static const char CONTENT_TYPE_JSON[] PROGMEM = "application/json";
+static const char CONTENT_TYPE_HTML[] PROGMEM = "text/html";
+static const char CONTENT_TYPE_CSS[] PROGMEM = "text/css";
+static const char CONTENT_TYPE_JS[] PROGMEM = "text/javascript";
+static const char CONTENT_TYPE_PLAIN[] PROGMEM = "text/plain";
+static const char HEADER_CONTENT_ENCODING[] PROGMEM = "Content-Encoding";
+static const char ENCODING_GZIP[] PROGMEM = "gzip";
+static const char EVENT_STATE[] PROGMEM = "state";
+
+// Helper macros to get __FlashStringHelper* from PROGMEM strings
+#define CONTENT_JSON_F FPSTR(CONTENT_TYPE_JSON)
+#define CONTENT_HTML_F FPSTR(CONTENT_TYPE_HTML)
+#define CONTENT_CSS_F FPSTR(CONTENT_TYPE_CSS)
+#define CONTENT_JS_F FPSTR(CONTENT_TYPE_JS)
+#define CONTENT_PLAIN_F FPSTR(CONTENT_TYPE_PLAIN)
+#define HEADER_ENCODING_F FPSTR(HEADER_CONTENT_ENCODING)
+#define GZIP_F FPSTR(ENCODING_GZIP)
+#define STATE_F FPSTR(EVENT_STATE)
+#else
+// For all other platforms, define the same names as regular string literals
+#define CONTENT_JSON_F "application/json"
+#define CONTENT_HTML_F "text/html"
+#define CONTENT_CSS_F "text/css"
+#define CONTENT_JS_F "text/javascript"
+#define CONTENT_PLAIN_F "text/plain"
+#define HEADER_ENCODING_F "Content-Encoding"
+#define GZIP_F "gzip"
+#define STATE_F "state"
+#endif
+
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
+#ifdef USE_ESP8266
+// Store single copy in PROGMEM on ESP8266
+static const char HEADER_PNA_NAME_P[] PROGMEM = "Private-Network-Access-Name";
+static const char HEADER_PNA_ID_P[] PROGMEM = "Private-Network-Access-ID";
+static const char HEADER_CORS_REQ_PNA_P[] PROGMEM = "Access-Control-Request-Private-Network";
+static const char HEADER_CORS_ALLOW_PNA_P[] PROGMEM = "Access-Control-Allow-Private-Network";
+// Use FPSTR() to get __FlashStringHelper* from PROGMEM data
+#define HEADER_PNA_NAME FPSTR(HEADER_PNA_NAME_P)
+#define HEADER_PNA_ID FPSTR(HEADER_PNA_ID_P)
+#define HEADER_CORS_REQ_PNA FPSTR(HEADER_CORS_REQ_PNA_P)
+#define HEADER_CORS_ALLOW_PNA FPSTR(HEADER_CORS_ALLOW_PNA_P)
+#else
+// For all other platforms, use regular strings
 static const char *const HEADER_PNA_NAME = "Private-Network-Access-Name";
 static const char *const HEADER_PNA_ID = "Private-Network-Access-ID";
 static const char *const HEADER_CORS_REQ_PNA = "Access-Control-Request-Private-Network";
 static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-Network";
+#endif
 #endif
 
 // Parse URL and return match info
@@ -122,7 +168,7 @@ void DeferredUpdateEventSource::process_deferred_queue_() {
   while (!deferred_queue_.empty()) {
     DeferredEvent &de = deferred_queue_.front();
     std::string message = de.message_generator_(web_server_, de.source_);
-    if (this->send(message.c_str(), "state") != DISCARDED) {
+    if (this->send(message.c_str(), STATE_F) != DISCARDED) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
       this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
@@ -171,7 +217,7 @@ void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *
     deq_push_back_with_dedup_(source, message_generator);
   } else {
     std::string message = message_generator(web_server_, source);
-    if (this->send(message.c_str(), "state") == DISCARDED) {
+    if (this->send(message.c_str(), STATE_F) == DISCARDED) {
       deq_push_back_with_dedup_(source, message_generator);
     } else {
       this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
@@ -206,7 +252,7 @@ void DeferredUpdateEventSourceList::try_send_nodefer(const char *message, const 
 }
 
 void DeferredUpdateEventSourceList::add_new_client(WebServer *ws, AsyncWebServerRequest *request) {
-  DeferredUpdateEventSource *es = new DeferredUpdateEventSource(ws, "/events");
+  DeferredUpdateEventSource *es = new DeferredUpdateEventSource(ws, F("/events"));
   this->push_back(es);
 
   es->onConnect([this, ws, es](AsyncEventSourceClient *client) {
@@ -316,21 +362,21 @@ float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f
 #ifdef USE_WEBSERVER_LOCAL
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
-  AsyncWebServerResponse *response = request->beginResponse(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
+  AsyncWebServerResponse *response = request->beginResponse(200, CONTENT_HTML_F, INDEX_GZ, sizeof(INDEX_GZ));
 #else
-  AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, CONTENT_HTML_F, INDEX_GZ, sizeof(INDEX_GZ));
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(HEADER_ENCODING_F, GZIP_F);
   request->send(response);
 }
 #elif USE_WEBSERVER_VERSION >= 2
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, "text/html", ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
+      request->beginResponse(200, CONTENT_HTML_F, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
 #else
   AsyncWebServerResponse *response =
-      request->beginResponse_P(200, "text/html", ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
+      request->beginResponse_P(200, CONTENT_HTML_F, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
 #endif
   // No gzip header here because the HTML file is so small
   request->send(response);
@@ -339,8 +385,8 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
-  AsyncWebServerResponse *response = request->beginResponse(200, "");
-  response->addHeader(HEADER_CORS_ALLOW_PNA, "true");
+  AsyncWebServerResponse *response = request->beginResponse(200, F(""));
+  response->addHeader(HEADER_CORS_ALLOW_PNA, F("true"));
   response->addHeader(HEADER_PNA_NAME, App.get_name().c_str());
   std::string mac = get_mac_address_pretty();
   response->addHeader(HEADER_PNA_ID, mac.c_str());
@@ -352,12 +398,12 @@ void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
 void WebServer::handle_css_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, "text/css", ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
+      request->beginResponse(200, CONTENT_CSS_F, ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
 #else
   AsyncWebServerResponse *response =
-      request->beginResponse_P(200, "text/css", ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
+      request->beginResponse_P(200, CONTENT_CSS_F, ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(HEADER_ENCODING_F, GZIP_F);
   request->send(response);
 }
 #endif
@@ -366,12 +412,12 @@ void WebServer::handle_css_request(AsyncWebServerRequest *request) {
 void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, "text/javascript", ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
+      request->beginResponse(200, CONTENT_JS_F, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
 #else
   AsyncWebServerResponse *response =
-      request->beginResponse_P(200, "text/javascript", ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
+      request->beginResponse_P(200, CONTENT_JS_F, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(HEADER_ENCODING_F, GZIP_F);
   request->send(response);
 }
 #endif
@@ -422,7 +468,7 @@ void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->sensor_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
   }
@@ -467,7 +513,7 @@ void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->text_sensor_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
   }
@@ -506,7 +552,7 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->switch_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -571,7 +617,7 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->button_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
     } else if (match.method_equals("press")) {
       this->defer([obj]() { obj->press(); });
       request->send(200);
@@ -612,7 +658,7 @@ void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, con
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->binary_sensor_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
   }
@@ -651,7 +697,7 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->fan_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
     } else if (match.method_equals("toggle")) {
       this->defer([obj]() { obj->toggle().perform(); });
       request->send(200);
@@ -725,7 +771,7 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->light_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
     } else if (match.method_equals("toggle")) {
       this->defer([obj]() { obj->toggle().perform(); });
       request->send(200);
@@ -798,7 +844,7 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->cover_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -869,7 +915,7 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->number_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -935,7 +981,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->date_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -991,7 +1037,7 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->time_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1046,7 +1092,7 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->datetime_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1103,7 +1149,7 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->text_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1161,7 +1207,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->select_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1216,7 +1262,7 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->climate_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1354,7 +1400,7 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->lock_json(obj, obj->state, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1425,7 +1471,7 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->valve_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1492,7 +1538,7 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->alarm_control_panel_json(obj, obj->get_state(), detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1557,7 +1603,7 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->event_json(obj, "", detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
   }
@@ -1621,7 +1667,7 @@ void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->update_json(obj, detail);
-      request->send(200, "application/json", data.c_str());
+      request->send(200, CONTENT_JSON_F, data.c_str());
       return;
     }
 
@@ -1907,7 +1953,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // No matching handler found - send 404
   ESP_LOGV(TAG, "Request for unknown URL: %s", url.c_str());
-  request->send(404, "text/plain", "Not Found");
+  request->send(404, CONTENT_PLAIN_F, F("Not Found"));
 }
 
 bool WebServer::isRequestHandlerTrivial() const { return false; }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -49,40 +49,27 @@ static const char CONTENT_TYPE_PLAIN[] PROGMEM = "text/plain";
 static const char HEADER_CONTENT_ENCODING[] PROGMEM = "Content-Encoding";
 static const char ENCODING_GZIP[] PROGMEM = "gzip";
 static const char EVENT_STATE[] PROGMEM = "state";
-
-// Helper macros to get __FlashStringHelper* from PROGMEM strings
-#define CONTENT_JSON_F FPSTR(CONTENT_TYPE_JSON)
-#define CONTENT_HTML_F FPSTR(CONTENT_TYPE_HTML)
-#define CONTENT_CSS_F FPSTR(CONTENT_TYPE_CSS)
-#define CONTENT_JS_F FPSTR(CONTENT_TYPE_JS)
-#define CONTENT_PLAIN_F FPSTR(CONTENT_TYPE_PLAIN)
-#define HEADER_ENCODING_F FPSTR(HEADER_CONTENT_ENCODING)
-#define GZIP_F FPSTR(ENCODING_GZIP)
-#define STATE_F FPSTR(EVENT_STATE)
+static const char MSG_NOT_FOUND[] PROGMEM = "Not Found";
 #else
-// For all other platforms, define the same names as regular string literals
-#define CONTENT_JSON_F "application/json"
-#define CONTENT_HTML_F "text/html"
-#define CONTENT_CSS_F "text/css"
-#define CONTENT_JS_F "text/javascript"
-#define CONTENT_PLAIN_F "text/plain"
-#define HEADER_ENCODING_F "Content-Encoding"
-#define GZIP_F "gzip"
-#define STATE_F "state"
+// For all other platforms, regular string constants
+static const char *const CONTENT_TYPE_JSON = "application/json";
+static const char *const CONTENT_TYPE_HTML = "text/html";
+static const char *const CONTENT_TYPE_CSS = "text/css";
+static const char *const CONTENT_TYPE_JS = "text/javascript";
+static const char *const CONTENT_TYPE_PLAIN = "text/plain";
+static const char *const HEADER_CONTENT_ENCODING = "Content-Encoding";
+static const char *const ENCODING_GZIP = "gzip";
+static const char *const EVENT_STATE = "state";
+static const char *const MSG_NOT_FOUND = "Not Found";
 #endif
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 #ifdef USE_ESP8266
 // Store single copy in PROGMEM on ESP8266
-static const char HEADER_PNA_NAME_P[] PROGMEM = "Private-Network-Access-Name";
-static const char HEADER_PNA_ID_P[] PROGMEM = "Private-Network-Access-ID";
-static const char HEADER_CORS_REQ_PNA_P[] PROGMEM = "Access-Control-Request-Private-Network";
-static const char HEADER_CORS_ALLOW_PNA_P[] PROGMEM = "Access-Control-Allow-Private-Network";
-// Use FPSTR() to get __FlashStringHelper* from PROGMEM data
-#define HEADER_PNA_NAME FPSTR(HEADER_PNA_NAME_P)
-#define HEADER_PNA_ID FPSTR(HEADER_PNA_ID_P)
-#define HEADER_CORS_REQ_PNA FPSTR(HEADER_CORS_REQ_PNA_P)
-#define HEADER_CORS_ALLOW_PNA FPSTR(HEADER_CORS_ALLOW_PNA_P)
+static const char HEADER_PNA_NAME[] PROGMEM = "Private-Network-Access-Name";
+static const char HEADER_PNA_ID[] PROGMEM = "Private-Network-Access-ID";
+static const char HEADER_CORS_REQ_PNA[] PROGMEM = "Access-Control-Request-Private-Network";
+static const char HEADER_CORS_ALLOW_PNA[] PROGMEM = "Access-Control-Allow-Private-Network";
 #else
 // For all other platforms, use regular strings
 static const char *const HEADER_PNA_NAME = "Private-Network-Access-Name";
@@ -168,7 +155,7 @@ void DeferredUpdateEventSource::process_deferred_queue_() {
   while (!deferred_queue_.empty()) {
     DeferredEvent &de = deferred_queue_.front();
     std::string message = de.message_generator_(web_server_, de.source_);
-    if (this->send(message.c_str(), STATE_F) != DISCARDED) {
+    if (this->send(message.c_str(), EVENT_STATE) != DISCARDED) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
       this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
@@ -217,7 +204,7 @@ void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *
     deq_push_back_with_dedup_(source, message_generator);
   } else {
     std::string message = message_generator(web_server_, source);
-    if (this->send(message.c_str(), STATE_F) == DISCARDED) {
+    if (this->send(message.c_str(), EVENT_STATE) == DISCARDED) {
       deq_push_back_with_dedup_(source, message_generator);
     } else {
       this->consecutive_send_failures_ = 0;  // Reset failure count on successful send
@@ -362,21 +349,21 @@ float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f
 #ifdef USE_WEBSERVER_LOCAL
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
-  AsyncWebServerResponse *response = request->beginResponse(200, CONTENT_HTML_F, INDEX_GZ, sizeof(INDEX_GZ));
+  AsyncWebServerResponse *response = request->beginResponse(200, CONTENT_TYPE_HTML, INDEX_GZ, sizeof(INDEX_GZ));
 #else
-  AsyncWebServerResponse *response = request->beginResponse_P(200, CONTENT_HTML_F, INDEX_GZ, sizeof(INDEX_GZ));
+  AsyncWebServerResponse *response = request->beginResponse_P(200, CONTENT_TYPE_HTML, INDEX_GZ, sizeof(INDEX_GZ));
 #endif
-  response->addHeader(HEADER_ENCODING_F, GZIP_F);
+  response->addHeader(HEADER_CONTENT_ENCODING, ENCODING_GZIP);
   request->send(response);
 }
 #elif USE_WEBSERVER_VERSION >= 2
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, CONTENT_HTML_F, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
+      request->beginResponse(200, CONTENT_TYPE_HTML, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
 #else
   AsyncWebServerResponse *response =
-      request->beginResponse_P(200, CONTENT_HTML_F, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
+      request->beginResponse_P(200, CONTENT_TYPE_HTML, ESPHOME_WEBSERVER_INDEX_HTML, ESPHOME_WEBSERVER_INDEX_HTML_SIZE);
 #endif
   // No gzip header here because the HTML file is so small
   request->send(response);
@@ -398,12 +385,12 @@ void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
 void WebServer::handle_css_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, CONTENT_CSS_F, ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
+      request->beginResponse(200, CONTENT_TYPE_CSS, ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
 #else
-  AsyncWebServerResponse *response =
-      request->beginResponse_P(200, CONTENT_CSS_F, ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
+  AsyncWebServerResponse *response = request->beginResponse_P(200, CONTENT_TYPE_CSS, ESPHOME_WEBSERVER_CSS_INCLUDE,
+                                                              ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
 #endif
-  response->addHeader(HEADER_ENCODING_F, GZIP_F);
+  response->addHeader(HEADER_CONTENT_ENCODING, ENCODING_GZIP);
   request->send(response);
 }
 #endif
@@ -412,12 +399,12 @@ void WebServer::handle_css_request(AsyncWebServerRequest *request) {
 void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 #ifndef USE_ESP8266
   AsyncWebServerResponse *response =
-      request->beginResponse(200, CONTENT_JS_F, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
+      request->beginResponse(200, CONTENT_TYPE_JS, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
 #else
   AsyncWebServerResponse *response =
-      request->beginResponse_P(200, CONTENT_JS_F, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
+      request->beginResponse_P(200, CONTENT_TYPE_JS, ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
 #endif
-  response->addHeader(HEADER_ENCODING_F, GZIP_F);
+  response->addHeader(HEADER_CONTENT_ENCODING, ENCODING_GZIP);
   request->send(response);
 }
 #endif
@@ -468,7 +455,7 @@ void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->sensor_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
   }
@@ -513,7 +500,7 @@ void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->text_sensor_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
   }
@@ -552,7 +539,7 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->switch_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -617,7 +604,7 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->button_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
     } else if (match.method_equals("press")) {
       this->defer([obj]() { obj->press(); });
       request->send(200);
@@ -658,7 +645,7 @@ void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, con
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->binary_sensor_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
   }
@@ -697,7 +684,7 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->fan_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
     } else if (match.method_equals("toggle")) {
       this->defer([obj]() { obj->toggle().perform(); });
       request->send(200);
@@ -771,7 +758,7 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->light_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
     } else if (match.method_equals("toggle")) {
       this->defer([obj]() { obj->toggle().perform(); });
       request->send(200);
@@ -844,7 +831,7 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->cover_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -915,7 +902,7 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->number_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -981,7 +968,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->date_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1037,7 +1024,7 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->time_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1092,7 +1079,7 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->datetime_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1149,7 +1136,7 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->text_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
     if (!match.method_equals("set")) {
@@ -1207,7 +1194,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->select_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1262,7 +1249,7 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->climate_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1400,7 +1387,7 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->lock_json(obj, obj->state, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1471,7 +1458,7 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->valve_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1538,7 +1525,7 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->alarm_control_panel_json(obj, obj->get_state(), detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1603,7 +1590,7 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->event_json(obj, "", detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
   }
@@ -1667,7 +1654,7 @@ void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlM
     if (request->method() == HTTP_GET && match.method_empty()) {
       auto detail = get_request_detail(request);
       std::string data = this->update_json(obj, detail);
-      request->send(200, CONTENT_JSON_F, data.c_str());
+      request->send(200, CONTENT_TYPE_JSON, data.c_str());
       return;
     }
 
@@ -1953,7 +1940,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // No matching handler found - send 404
   ESP_LOGV(TAG, "Request for unknown URL: %s", url.c_str());
-  request->send(404, CONTENT_PLAIN_F, F("Not Found"));
+  request->send(404, CONTENT_TYPE_PLAIN, MSG_NOT_FOUND);
 }
 
 bool WebServer::isRequestHandlerTrivial() const { return false; }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1940,7 +1940,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 
   // No matching handler found - send 404
   ESP_LOGV(TAG, "Request for unknown URL: %s", url.c_str());
-  request->send(404, CONTENT_TYPE_PLAIN, MSG_NOT_FOUND);
+  request->send(404, CONTENT_TYPE_PLAIN, MSG_NOT_FOUND);  // NOLINT(readability-suspicious-call-argument)
 }
 
 bool WebServer::isRequestHandlerTrivial() const { return false; }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -307,7 +307,7 @@ std::string WebServer::get_config_json() {
     root[F("ota")] = true;
 #endif
     root[F("log")] = this->expose_log_;
-    root[F("lang")] = "en";
+    root[F("lang")] = F("en");
   });
 }
 
@@ -802,12 +802,12 @@ std::string WebServer::light_all_json_generator(WebServer *web_server, void *sou
 std::string WebServer::light_json(light::LightState *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "light-" + obj->get_object_id(), start_config);
-    root[F("state")] = obj->remote_values.is_on() ? "ON" : "OFF";
+    root[F("state")] = obj->remote_values.is_on() ? F("ON") : F("OFF");
 
     light::LightJSONSchema::dump_json(*obj, root);
     if (start_config == DETAIL_ALL) {
       JsonArray opt = root[F("effects")].to<JsonArray>();
-      opt.add("None");
+      opt.add(F("None"));
       for (auto const &option : obj->get_effects()) {
         opt.add(option->get_name());
       }
@@ -942,8 +942,8 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
       this->add_sorting_info_(root, obj);
     }
     if (std::isnan(value)) {
-      root[F("value")] = "\"NaN\"";
-      root[F("state")] = "NA";
+      root[F("value")] = F("\"NaN\"");
+      root[F("state")] = F("NA");
     } else {
       root[F("value")] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       std::string state = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
@@ -1167,7 +1167,7 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
     root[F("max_length")] = obj->traits.get_max_length();
     root[F("pattern")] = obj->traits.get_pattern();
     if (obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD) {
-      root[F("state")] = "********";
+      root[F("state")] = F("********");
     } else {
       root[F("state")] = value;
     }
@@ -1353,7 +1353,7 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
       if (!std::isnan(obj->current_temperature)) {
         root[F("current_temperature")] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
       } else {
-        root[F("current_temperature")] = "NA";
+        root[F("current_temperature")] = F("NA");
       }
     }
     if (traits.get_supports_two_point_target_temperature()) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -262,8 +262,8 @@ void DeferredUpdateEventSourceList::on_client_connect_(WebServer *ws, DeferredUp
 #ifdef USE_WEBSERVER_SORTING
   for (auto &group : ws->sorting_groups_) {
     message = json::build_json([group](JsonObject root) {
-      root["name"] = group.second.name;
-      root["sorting_weight"] = group.second.weight;
+      root[F("name")] = group.second.name;
+      root[F("sorting_weight")] = group.second.weight;
     });
 
     // up to 31 groups should be able to be queued initially without defer
@@ -299,15 +299,15 @@ void WebServer::set_js_include(const char *js_include) { this->js_include_ = js_
 
 std::string WebServer::get_config_json() {
   return json::build_json([this](JsonObject root) {
-    root["title"] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
-    root["comment"] = App.get_comment();
+    root[F("title")] = App.get_friendly_name().empty() ? App.get_name() : App.get_friendly_name();
+    root[F("comment")] = App.get_comment();
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
-    root["ota"] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
+    root[F("ota")] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else
-    root["ota"] = true;
+    root[F("ota")] = true;
 #endif
-    root["log"] = this->expose_log_;
-    root["lang"] = "en";
+    root[F("log")] = this->expose_log_;
+    root[F("lang")] = "en";
   });
 }
 
@@ -411,14 +411,14 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
 
 // Helper functions to reduce code size by avoiding macro expansion
 static void set_json_id(JsonObject &root, EntityBase *obj, const std::string &id, JsonDetail start_config) {
-  root["id"] = id;
+  root[F("id")] = id;
   if (start_config == DETAIL_ALL) {
-    root["name"] = obj->get_name();
-    root["icon"] = obj->get_icon();
-    root["entity_category"] = obj->get_entity_category();
+    root[F("name")] = obj->get_name();
+    root[F("icon")] = obj->get_icon();
+    root[F("entity_category")] = obj->get_entity_category();
     bool is_disabled = obj->is_disabled_by_default();
     if (is_disabled)
-      root["is_disabled_by_default"] = is_disabled;
+      root[F("is_disabled_by_default")] = is_disabled;
   }
 }
 
@@ -426,14 +426,14 @@ template<typename T>
 static void set_json_value(JsonObject &root, EntityBase *obj, const std::string &id, const T &value,
                            JsonDetail start_config) {
   set_json_id(root, obj, id, start_config);
-  root["value"] = value;
+  root[F("value")] = value;
 }
 
 template<typename T>
 static void set_json_icon_state_value(JsonObject &root, EntityBase *obj, const std::string &id,
                                       const std::string &state, const T &value, JsonDetail start_config) {
   set_json_value(root, obj, id, value, start_config);
-  root["state"] = state;
+  root[F("state")] = state;
 }
 
 // Helper to get request detail parameter
@@ -481,7 +481,7 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
       if (!obj->get_unit_of_measurement().empty())
-        root["uom"] = obj->get_unit_of_measurement();
+        root[F("uom")] = obj->get_unit_of_measurement();
     }
   });
 }
@@ -589,7 +589,7 @@ std::string WebServer::switch_json(switch_::Switch *obj, bool value, JsonDetail 
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "switch-" + obj->get_object_id(), value ? "ON" : "OFF", value, start_config);
     if (start_config == DETAIL_ALL) {
-      root["assumed_state"] = obj->assumed_state();
+      root[F("assumed_state")] = obj->assumed_state();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -732,11 +732,11 @@ std::string WebServer::fan_json(fan::Fan *obj, JsonDetail start_config) {
                               start_config);
     const auto traits = obj->get_traits();
     if (traits.supports_speed()) {
-      root["speed_level"] = obj->speed;
-      root["speed_count"] = traits.supported_speed_count();
+      root[F("speed_level")] = obj->speed;
+      root[F("speed_count")] = traits.supported_speed_count();
     }
     if (obj->get_traits().supports_oscillation())
-      root["oscillation"] = obj->oscillating;
+      root[F("oscillation")] = obj->oscillating;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -802,11 +802,11 @@ std::string WebServer::light_all_json_generator(WebServer *web_server, void *sou
 std::string WebServer::light_json(light::LightState *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "light-" + obj->get_object_id(), start_config);
-    root["state"] = obj->remote_values.is_on() ? "ON" : "OFF";
+    root[F("state")] = obj->remote_values.is_on() ? "ON" : "OFF";
 
     light::LightJSONSchema::dump_json(*obj, root);
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root["effects"].to<JsonArray>();
+      JsonArray opt = root[F("effects")].to<JsonArray>();
       opt.add("None");
       for (auto const &option : obj->get_effects()) {
         opt.add(option->get_name());
@@ -875,12 +875,12 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "cover-" + obj->get_object_id(), obj->is_fully_closed() ? "CLOSED" : "OPEN",
                               obj->position, start_config);
-    root["current_operation"] = cover::cover_operation_to_str(obj->current_operation);
+    root[F("current_operation")] = cover::cover_operation_to_str(obj->current_operation);
 
     if (obj->get_traits().get_supports_position())
-      root["position"] = obj->position;
+      root[F("position")] = obj->position;
     if (obj->get_traits().get_supports_tilt())
-      root["tilt"] = obj->tilt;
+      root[F("tilt")] = obj->tilt;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -930,26 +930,26 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_id(root, obj, "number-" + obj->get_object_id(), start_config);
     if (start_config == DETAIL_ALL) {
-      root["min_value"] =
+      root[F("min_value")] =
           value_accuracy_to_string(obj->traits.get_min_value(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root["max_value"] =
+      root[F("max_value")] =
           value_accuracy_to_string(obj->traits.get_max_value(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root["step"] =
+      root[F("step")] =
           value_accuracy_to_string(obj->traits.get_step(), step_to_accuracy_decimals(obj->traits.get_step()));
-      root["mode"] = (int) obj->traits.get_mode();
+      root[F("mode")] = (int) obj->traits.get_mode();
       if (!obj->traits.get_unit_of_measurement().empty())
-        root["uom"] = obj->traits.get_unit_of_measurement();
+        root[F("uom")] = obj->traits.get_unit_of_measurement();
       this->add_sorting_info_(root, obj);
     }
     if (std::isnan(value)) {
-      root["value"] = "\"NaN\"";
-      root["state"] = "NA";
+      root[F("value")] = "\"NaN\"";
+      root[F("state")] = "NA";
     } else {
-      root["value"] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
+      root[F("value")] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       std::string state = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
       if (!obj->traits.get_unit_of_measurement().empty())
         state += " " + obj->traits.get_unit_of_measurement();
-      root["state"] = state;
+      root[F("state")] = state;
     }
   });
 }
@@ -1002,8 +1002,8 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "date-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
-    root["value"] = value;
-    root["state"] = value;
+    root[F("value")] = value;
+    root[F("state")] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1057,8 +1057,8 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "time-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
-    root["value"] = value;
-    root["state"] = value;
+    root[F("value")] = value;
+    root[F("state")] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1113,8 +1113,8 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
     set_json_id(root, obj, "datetime-" + obj->get_object_id(), start_config);
     std::string value = str_sprintf("%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour,
                                     obj->minute, obj->second);
-    root["value"] = value;
-    root["state"] = value;
+    root[F("value")] = value;
+    root[F("state")] = value;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1163,17 +1163,17 @@ std::string WebServer::text_all_json_generator(WebServer *web_server, void *sour
 std::string WebServer::text_json(text::Text *obj, const std::string &value, JsonDetail start_config) {
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_id(root, obj, "text-" + obj->get_object_id(), start_config);
-    root["min_length"] = obj->traits.get_min_length();
-    root["max_length"] = obj->traits.get_max_length();
-    root["pattern"] = obj->traits.get_pattern();
+    root[F("min_length")] = obj->traits.get_min_length();
+    root[F("max_length")] = obj->traits.get_max_length();
+    root[F("pattern")] = obj->traits.get_pattern();
     if (obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD) {
-      root["state"] = "********";
+      root[F("state")] = "********";
     } else {
-      root["state"] = value;
+      root[F("state")] = value;
     }
-    root["value"] = value;
+    root[F("value")] = value;
     if (start_config == DETAIL_ALL) {
-      root["mode"] = (int) obj->traits.get_mode();
+      root[F("mode")] = (int) obj->traits.get_mode();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1222,7 +1222,7 @@ std::string WebServer::select_json(select::Select *obj, const std::string &value
   return json::build_json([this, obj, value, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "select-" + obj->get_object_id(), value, value, start_config);
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root["option"].to<JsonArray>();
+      JsonArray opt = root[F("option")].to<JsonArray>();
       for (auto &option : obj->traits.get_options()) {
         opt.add(option);
       }
@@ -1292,32 +1292,32 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
     char buf[16];
 
     if (start_config == DETAIL_ALL) {
-      JsonArray opt = root["modes"].to<JsonArray>();
+      JsonArray opt = root[F("modes")].to<JsonArray>();
       for (climate::ClimateMode m : traits.get_supported_modes())
         opt.add(PSTR_LOCAL(climate::climate_mode_to_string(m)));
       if (!traits.get_supported_custom_fan_modes().empty()) {
-        JsonArray opt = root["fan_modes"].to<JsonArray>();
+        JsonArray opt = root[F("fan_modes")].to<JsonArray>();
         for (climate::ClimateFanMode m : traits.get_supported_fan_modes())
           opt.add(PSTR_LOCAL(climate::climate_fan_mode_to_string(m)));
       }
 
       if (!traits.get_supported_custom_fan_modes().empty()) {
-        JsonArray opt = root["custom_fan_modes"].to<JsonArray>();
+        JsonArray opt = root[F("custom_fan_modes")].to<JsonArray>();
         for (auto const &custom_fan_mode : traits.get_supported_custom_fan_modes())
           opt.add(custom_fan_mode);
       }
       if (traits.get_supports_swing_modes()) {
-        JsonArray opt = root["swing_modes"].to<JsonArray>();
+        JsonArray opt = root[F("swing_modes")].to<JsonArray>();
         for (auto swing_mode : traits.get_supported_swing_modes())
           opt.add(PSTR_LOCAL(climate::climate_swing_mode_to_string(swing_mode)));
       }
       if (traits.get_supports_presets() && obj->preset.has_value()) {
-        JsonArray opt = root["presets"].to<JsonArray>();
+        JsonArray opt = root[F("presets")].to<JsonArray>();
         for (climate::ClimatePreset m : traits.get_supported_presets())
           opt.add(PSTR_LOCAL(climate::climate_preset_to_string(m)));
       }
       if (!traits.get_supported_custom_presets().empty() && obj->custom_preset.has_value()) {
-        JsonArray opt = root["custom_presets"].to<JsonArray>();
+        JsonArray opt = root[F("custom_presets")].to<JsonArray>();
         for (auto const &custom_preset : traits.get_supported_custom_presets())
           opt.add(custom_preset);
       }
@@ -1325,48 +1325,48 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
     }
 
     bool has_state = false;
-    root["mode"] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
-    root["max_temp"] = value_accuracy_to_string(traits.get_visual_max_temperature(), target_accuracy);
-    root["min_temp"] = value_accuracy_to_string(traits.get_visual_min_temperature(), target_accuracy);
-    root["step"] = traits.get_visual_target_temperature_step();
+    root[F("mode")] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
+    root[F("max_temp")] = value_accuracy_to_string(traits.get_visual_max_temperature(), target_accuracy);
+    root[F("min_temp")] = value_accuracy_to_string(traits.get_visual_min_temperature(), target_accuracy);
+    root[F("step")] = traits.get_visual_target_temperature_step();
     if (traits.get_supports_action()) {
-      root["action"] = PSTR_LOCAL(climate_action_to_string(obj->action));
-      root["state"] = root["action"];
+      root[F("action")] = PSTR_LOCAL(climate_action_to_string(obj->action));
+      root[F("state")] = root[F("action")];
       has_state = true;
     }
     if (traits.get_supports_fan_modes() && obj->fan_mode.has_value()) {
-      root["fan_mode"] = PSTR_LOCAL(climate_fan_mode_to_string(obj->fan_mode.value()));
+      root[F("fan_mode")] = PSTR_LOCAL(climate_fan_mode_to_string(obj->fan_mode.value()));
     }
     if (!traits.get_supported_custom_fan_modes().empty() && obj->custom_fan_mode.has_value()) {
-      root["custom_fan_mode"] = obj->custom_fan_mode.value().c_str();
+      root[F("custom_fan_mode")] = obj->custom_fan_mode.value().c_str();
     }
     if (traits.get_supports_presets() && obj->preset.has_value()) {
-      root["preset"] = PSTR_LOCAL(climate_preset_to_string(obj->preset.value()));
+      root[F("preset")] = PSTR_LOCAL(climate_preset_to_string(obj->preset.value()));
     }
     if (!traits.get_supported_custom_presets().empty() && obj->custom_preset.has_value()) {
-      root["custom_preset"] = obj->custom_preset.value().c_str();
+      root[F("custom_preset")] = obj->custom_preset.value().c_str();
     }
     if (traits.get_supports_swing_modes()) {
-      root["swing_mode"] = PSTR_LOCAL(climate_swing_mode_to_string(obj->swing_mode));
+      root[F("swing_mode")] = PSTR_LOCAL(climate_swing_mode_to_string(obj->swing_mode));
     }
     if (traits.get_supports_current_temperature()) {
       if (!std::isnan(obj->current_temperature)) {
-        root["current_temperature"] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
+        root[F("current_temperature")] = value_accuracy_to_string(obj->current_temperature, current_accuracy);
       } else {
-        root["current_temperature"] = "NA";
+        root[F("current_temperature")] = "NA";
       }
     }
     if (traits.get_supports_two_point_target_temperature()) {
-      root["target_temperature_low"] = value_accuracy_to_string(obj->target_temperature_low, target_accuracy);
-      root["target_temperature_high"] = value_accuracy_to_string(obj->target_temperature_high, target_accuracy);
+      root[F("target_temperature_low")] = value_accuracy_to_string(obj->target_temperature_low, target_accuracy);
+      root[F("target_temperature_high")] = value_accuracy_to_string(obj->target_temperature_high, target_accuracy);
       if (!has_state) {
-        root["state"] = value_accuracy_to_string((obj->target_temperature_high + obj->target_temperature_low) / 2.0f,
-                                                 target_accuracy);
+        root[F("state")] = value_accuracy_to_string((obj->target_temperature_high + obj->target_temperature_low) / 2.0f,
+                                                    target_accuracy);
       }
     } else {
-      root["target_temperature"] = value_accuracy_to_string(obj->target_temperature, target_accuracy);
+      root[F("target_temperature")] = value_accuracy_to_string(obj->target_temperature, target_accuracy);
       if (!has_state)
-        root["state"] = root["target_temperature"];
+        root[F("state")] = root[F("target_temperature")];
     }
   });
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
@@ -1500,10 +1500,10 @@ std::string WebServer::valve_json(valve::Valve *obj, JsonDetail start_config) {
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_icon_state_value(root, obj, "valve-" + obj->get_object_id(), obj->is_fully_closed() ? "CLOSED" : "OPEN",
                               obj->position, start_config);
-    root["current_operation"] = valve::valve_operation_to_str(obj->current_operation);
+    root[F("current_operation")] = valve::valve_operation_to_str(obj->current_operation);
 
     if (obj->get_traits().get_supports_position())
-      root["position"] = obj->position;
+      root[F("position")] = obj->position;
     if (start_config == DETAIL_ALL) {
       this->add_sorting_info_(root, obj);
     }
@@ -1613,14 +1613,14 @@ std::string WebServer::event_json(event::Event *obj, const std::string &event_ty
   return json::build_json([this, obj, event_type, start_config](JsonObject root) {
     set_json_id(root, obj, "event-" + obj->get_object_id(), start_config);
     if (!event_type.empty()) {
-      root["event_type"] = event_type;
+      root[F("event_type")] = event_type;
     }
     if (start_config == DETAIL_ALL) {
-      JsonArray event_types = root["event_types"].to<JsonArray>();
+      JsonArray event_types = root[F("event_types")].to<JsonArray>();
       for (auto const &event_type : obj->get_event_types()) {
         event_types.add(event_type);
       }
-      root["device_class"] = obj->get_device_class();
+      root[F("device_class")] = obj->get_device_class();
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1679,13 +1679,13 @@ std::string WebServer::update_json(update::UpdateEntity *obj, JsonDetail start_c
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return json::build_json([this, obj, start_config](JsonObject root) {
     set_json_id(root, obj, "update-" + obj->get_object_id(), start_config);
-    root["value"] = obj->update_info.latest_version;
-    root["state"] = update_state_to_string(obj->state);
+    root[F("value")] = obj->update_info.latest_version;
+    root[F("state")] = update_state_to_string(obj->state);
     if (start_config == DETAIL_ALL) {
-      root["current_version"] = obj->update_info.current_version;
-      root["title"] = obj->update_info.title;
-      root["summary"] = obj->update_info.summary;
-      root["release_url"] = obj->update_info.release_url;
+      root[F("current_version")] = obj->update_info.current_version;
+      root[F("title")] = obj->update_info.title;
+      root[F("summary")] = obj->update_info.summary;
+      root[F("release_url")] = obj->update_info.release_url;
       this->add_sorting_info_(root, obj);
     }
   });
@@ -1948,9 +1948,9 @@ bool WebServer::isRequestHandlerTrivial() const { return false; }
 void WebServer::add_sorting_info_(JsonObject &root, EntityBase *entity) {
 #ifdef USE_WEBSERVER_SORTING
   if (this->sorting_entitys_.find(entity) != this->sorting_entitys_.end()) {
-    root["sorting_weight"] = this->sorting_entitys_[entity].weight;
+    root[F("sorting_weight")] = this->sorting_entitys_[entity].weight;
     if (this->sorting_groups_.find(this->sorting_entitys_[entity].group_id) != this->sorting_groups_.end()) {
-      root["sorting_group"] = this->sorting_groups_[this->sorting_entitys_[entity].group_id].name;
+      root[F("sorting_group")] = this->sorting_groups_[this->sorting_entitys_[entity].group_id].name;
     }
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes memory usage on ESP8266 by moving web_server component's constant strings to flash memory (PROGMEM). The web_server component previously stored numerous string literals in RAM, particularly content type strings that were used repeatedly.

**Measured results on ESP8266:**
- **RAM saved: 128 bytes** (33,924 → 33,796 bytes)
- **Flash increase: 176 bytes** (414,393 → 414,569 bytes)

This is a valuable optimization for memory-constrained ESP8266 devices, trading abundant flash space for scarce RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves ESP8266 memory usage, particularly important for devices with many components enabled

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Standard web_server configuration works as before:
web_server:
  port: 80

# Optional: Include sensors to test the API endpoints
sensor:
  - platform: template
    name: "Test Sensor"
    update_interval: 10s
    lambda: return 42.0;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Details

### Implementation Approach

The optimization stores frequently used strings in PROGMEM on ESP8266:

```cpp
#ifdef USE_ESP8266
// Strings stored in PROGMEM on ESP8266
static const char CONTENT_TYPE_JSON[] PROGMEM = "application/json";
static const char CONTENT_TYPE_HTML[] PROGMEM = "text/html";
// ... etc
#else
// Regular string constants on other platforms
static const char *const CONTENT_TYPE_JSON = "application/json";
static const char *const CONTENT_TYPE_HTML = "text/html";
// ... etc
#endif
```

The AsyncWebServer library handles PROGMEM strings correctly on ESP8266, so we can use the same variable names across all platforms. This keeps the code clean and maintainable.

### Strings Optimized

**Deduplicated strings (stored once in PROGMEM):**
- Content types:
  - `"application/json"` (used 20 times)
  - `"text/html"` (used 4 times)
  - `"text/css"` (used 2 times)
  - `"text/javascript"` (used 2 times)
  - `"text/plain"` (used 1 time)
- Headers:
  - `"Content-Encoding"` (used 3 times)
  - `"gzip"` (used 3 times)
- Event types:
  - `"state"` (used 2 times)
- Messages:
  - `"Not Found"` (404 response)
- Private Network Access headers (when enabled):
  - `"Private-Network-Access-Name"`
  - `"Private-Network-Access-ID"`
  - `"Access-Control-Request-Private-Network"`
  - `"Access-Control-Allow-Private-Network"`

### Technical Notes

- All changes are wrapped in `#ifdef USE_ESP8266` to only apply on ESP8266 where PROGMEM actually saves RAM
- Uses `static const char name[] PROGMEM` for storage on ESP8266
- Uses `static const char *const name` for storage on other platforms
- The same variable names are used everywhere, making the code clean and consistent
- The AsyncWebServer library automatically handles PROGMEM strings on ESP8266, no special conversion needed
- On non-ESP8266 platforms, regular string constants are used with no performance impact