### PR TITLE
[light] ESP8266: Store log strings in flash memory

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -11,19 +11,21 @@ static const char *const TAG = "light";
 
 // Helper functions to reduce code size for logging
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_WARN
-static void log_validation_warning(const char *name, const char *param_name, float val, float min, float max) {
-  ESP_LOGW(TAG, "'%s': %s value %.2f is out of range [%.1f - %.1f]", name, param_name, val, min, max);
+static void log_validation_warning(const char *name, const LogString *param_name, float val, float min, float max) {
+  ESP_LOGW(TAG, "'%s': %s value %.2f is out of range [%.1f - %.1f]", name, LOG_STR_ARG(param_name), val, min, max);
 }
 
-static void log_feature_not_supported(const char *name, const char *feature) {
-  ESP_LOGW(TAG, "'%s': %s not supported", name, feature);
+static void log_feature_not_supported(const char *name, const LogString *feature) {
+  ESP_LOGW(TAG, "'%s': %s not supported", name, LOG_STR_ARG(feature));
 }
 
-static void log_color_mode_not_supported(const char *name, const char *feature) {
-  ESP_LOGW(TAG, "'%s': color mode does not support setting %s", name, feature);
+static void log_color_mode_not_supported(const char *name, const LogString *feature) {
+  ESP_LOGW(TAG, "'%s': color mode does not support setting %s", name, LOG_STR_ARG(feature));
 }
 
-static void log_invalid_parameter(const char *name, const char *message) { ESP_LOGW(TAG, "'%s': %s", name, message); }
+static void log_invalid_parameter(const char *name, const LogString *message) {
+  ESP_LOGW(TAG, "'%s': %s", name, LOG_STR_ARG(message));
+}
 #else
 #define log_validation_warning(name, param_name, val, min, max)
 #define log_feature_not_supported(name, feature)
@@ -201,19 +203,19 @@ LightColorValues LightCall::validate_() {
 
   // Brightness exists check
   if (this->has_brightness() && this->brightness_ > 0.0f && !(color_mode & ColorCapability::BRIGHTNESS)) {
-    log_feature_not_supported(name, "brightness");
+    log_feature_not_supported(name, LOG_STR("brightness"));
     this->set_flag_(FLAG_HAS_BRIGHTNESS, false);
   }
 
   // Transition length possible check
   if (this->has_transition_() && this->transition_length_ != 0 && !(color_mode & ColorCapability::BRIGHTNESS)) {
-    log_feature_not_supported(name, "transitions");
+    log_feature_not_supported(name, LOG_STR("transitions"));
     this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
   // Color brightness exists check
   if (this->has_color_brightness() && this->color_brightness_ > 0.0f && !(color_mode & ColorCapability::RGB)) {
-    log_color_mode_not_supported(name, "RGB brightness");
+    log_color_mode_not_supported(name, LOG_STR("RGB brightness"));
     this->set_flag_(FLAG_HAS_COLOR_BRIGHTNESS, false);
   }
 
@@ -221,7 +223,7 @@ LightColorValues LightCall::validate_() {
   if ((this->has_red() && this->red_ > 0.0f) || (this->has_green() && this->green_ > 0.0f) ||
       (this->has_blue() && this->blue_ > 0.0f)) {
     if (!(color_mode & ColorCapability::RGB)) {
-      log_color_mode_not_supported(name, "RGB color");
+      log_color_mode_not_supported(name, LOG_STR("RGB color"));
       this->set_flag_(FLAG_HAS_RED, false);
       this->set_flag_(FLAG_HAS_GREEN, false);
       this->set_flag_(FLAG_HAS_BLUE, false);
@@ -231,21 +233,21 @@ LightColorValues LightCall::validate_() {
   // White value exists check
   if (this->has_white() && this->white_ > 0.0f &&
       !(color_mode & ColorCapability::WHITE || color_mode & ColorCapability::COLD_WARM_WHITE)) {
-    log_color_mode_not_supported(name, "white value");
+    log_color_mode_not_supported(name, LOG_STR("white value"));
     this->set_flag_(FLAG_HAS_WHITE, false);
   }
 
   // Color temperature exists check
   if (this->has_color_temperature() &&
       !(color_mode & ColorCapability::COLOR_TEMPERATURE || color_mode & ColorCapability::COLD_WARM_WHITE)) {
-    log_color_mode_not_supported(name, "color temperature");
+    log_color_mode_not_supported(name, LOG_STR("color temperature"));
     this->set_flag_(FLAG_HAS_COLOR_TEMPERATURE, false);
   }
 
   // Cold/warm white value exists check
   if ((this->has_cold_white() && this->cold_white_ > 0.0f) || (this->has_warm_white() && this->warm_white_ > 0.0f)) {
     if (!(color_mode & ColorCapability::COLD_WARM_WHITE)) {
-      log_color_mode_not_supported(name, "cold/warm white value");
+      log_color_mode_not_supported(name, LOG_STR("cold/warm white value"));
       this->set_flag_(FLAG_HAS_COLD_WHITE, false);
       this->set_flag_(FLAG_HAS_WARM_WHITE, false);
     }
@@ -255,7 +257,7 @@ LightColorValues LightCall::validate_() {
   if (this->has_##name_()) { \
     auto val = this->name_##_; \
     if (val < (min) || val > (max)) { \
-      log_validation_warning(name, LOG_STR_LITERAL(upper_name), val, (min), (max)); \
+      log_validation_warning(name, LOG_STR(upper_name), val, (min), (max)); \
       this->name_##_ = clamp(val, (min), (max)); \
     } \
   }
@@ -319,7 +321,7 @@ LightColorValues LightCall::validate_() {
 
   // Flash length check
   if (this->has_flash_() && this->flash_length_ == 0) {
-    log_invalid_parameter(name, "flash length must be greater than zero");
+    log_invalid_parameter(name, LOG_STR("flash length must be greater than zero"));
     this->set_flag_(FLAG_HAS_FLASH, false);
   }
 
@@ -338,13 +340,13 @@ LightColorValues LightCall::validate_() {
   }
 
   if (this->has_effect_() && (this->has_transition_() || this->has_flash_())) {
-    log_invalid_parameter(name, "effect cannot be used with transition/flash");
+    log_invalid_parameter(name, LOG_STR("effect cannot be used with transition/flash"));
     this->set_flag_(FLAG_HAS_TRANSITION, false);
     this->set_flag_(FLAG_HAS_FLASH, false);
   }
 
   if (this->has_flash_() && this->has_transition_()) {
-    log_invalid_parameter(name, "flash cannot be used with transition");
+    log_invalid_parameter(name, LOG_STR("flash cannot be used with transition"));
     this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
@@ -361,7 +363,7 @@ LightColorValues LightCall::validate_() {
   }
 
   if (this->has_transition_() && !supports_transition) {
-    log_feature_not_supported(name, "transitions");
+    log_feature_not_supported(name, LOG_STR("transitions"));
     this->set_flag_(FLAG_HAS_TRANSITION, false);
   }
 
@@ -371,7 +373,7 @@ LightColorValues LightCall::validate_() {
   bool target_state = this->has_state() ? this->state_ : v.is_on();
   if (!this->has_flash_() && !target_state) {
     if (this->has_effect_()) {
-      log_invalid_parameter(name, "cannot start effect when turning off");
+      log_invalid_parameter(name, LOG_STR("cannot start effect when turning off"));
       this->set_flag_(FLAG_HAS_EFFECT, false);
     } else if (this->parent_->active_effect_index_ != 0 && explicit_turn_off_request) {
       // Auto turn off effect


### PR DESCRIPTION
# What does this implement/fix?

This PR builds on #9924 (which introduced logging helper functions to reduce flash usage) by further optimizing the light component on ESP8266 to store log strings in flash memory (PROGMEM) instead of RAM. This is part of the ongoing effort to reduce RAM usage on memory-constrained ESP8266 devices.

The changes convert the logging helper functions introduced in #9924 in `light_call.cpp` to use `LogString*` instead of `const char*`, allowing the string literals to be stored in flash when `esp8266_store_log_strings_in_flash` is enabled.

**Memory impact on ESP8266:**
- Moves approximately 200+ bytes of string literals from RAM to flash
- Strings moved include error messages like:
  - "flash cannot be used with transition" (36 bytes)
  - "effect cannot be used with transition/flash" (43 bytes)  
  - "flash length must be greater than zero" (38 bytes)
  - "cannot start effect when turning off" (36 bytes)
  - Various feature names like "RGB brightness", "color temperature", "cold/warm white value", etc.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of memory optimization efforts for ESP8266

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# To benefit from these optimizations on ESP8266, enable:
logger:
  esp8266_store_log_strings_in_flash: true

light:
  - platform: rgbw
    name: "My Light"
    red: red_pin
    green: green_pin
    blue: blue_pin
    white: white_pin
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary

This PR extends the logging helper functions introduced in #9924 to store strings in flash memory on ESP8266:

1. Updated the helper functions (`log_validation_warning()`, `log_feature_not_supported()`, `log_color_mode_not_supported()`, and `log_invalid_parameter()`) to accept `LogString*` parameters instead of `const char*`
2. Converted all string literals passed to these functions to use `LOG_STR()` macro
3. Updated the `VALIDATE_RANGE_` macro to use `LOG_STR()` instead of `LOG_STR_LITERAL()` for proper type compatibility

The changes are:
- Transparent to other platforms (LOG_STR is a no-op on non-ESP8266)
- Only active when `esp8266_store_log_strings_in_flash` is enabled in logger config
- Consistent with existing PROGMEM optimization patterns in ESPHome
- Builds upon the code size reduction work in #9924