### PR TITLE
[script] ESP8266: Store log format strings in PROGMEM (saves 240 bytes RAM)

### DIFF
--- a/esphome/components/script/script.cpp
+++ b/esphome/components/script/script.cpp
@@ -6,9 +6,15 @@ namespace script {
 
 static const char *const TAG = "script";
 
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+void ScriptLogger::esp_log_(int level, int line, const __FlashStringHelper *format, const char *param) {
+  esp_log_printf_(level, TAG, line, format, param);
+}
+#else
 void ScriptLogger::esp_log_(int level, int line, const char *format, const char *param) {
   esp_log_printf_(level, TAG, line, format, param);
 }
+#endif
 
 }  // namespace script
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes RAM usage on ESP8266 by moving script component log format strings to PROGMEM (flash memory) when the `esp8266_store_log_strings_in_flash` logger option is enabled.

The script component uses custom logging helper functions that format log messages. These format strings were previously stored in RAM, consuming valuable memory on the ESP8266 platform which only has 80KB of RAM total. By using the `ESPHOME_LOG_FORMAT` macro, these strings are now stored in flash memory when the appropriate logger option is enabled.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Enable PROGMEM storage for log strings on ESP8266
logger:
  esp8266_store_log_strings_in_flash: true

# Example scripts that will use PROGMEM for log messages
script:
  - id: my_single_script
    mode: single
    then:
      - delay: 5s
      
  - id: my_restart_script
    mode: restart
    then:
      - delay: 5s
      
  - id: my_queued_script
    mode: queued
    max_runs: 2
    then:
      - delay: 2s
      
  - id: my_parallel_script
    mode: parallel
    max_runs: 2
    then:
      - delay: 2s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary

### Changes Made

1. Modified `script.h` to add conditional compilation for `__FlashStringHelper*` overloads of the logging functions when `USE_STORE_LOG_STR_IN_FLASH` is defined
2. Modified `script.cpp` to implement the `__FlashStringHelper*` version of `esp_log_` 
3. Updated all script log format strings in the template classes to use `ESPHOME_LOG_FORMAT` macro

### Memory Impact

**Measured results on ESP8266:**
- **RAM saved: 240 bytes** (from 33,108 to 32,868 bytes)
- **Flash saved: 220 bytes** (from 415,373 to 415,153 bytes)

This optimization moves the following strings to PROGMEM:
- "Script '%s' is already running! (mode: single)" (46 bytes)
- "Script '%s' restarting (mode: restart)" (39 bytes)
- "Script '%s' maximum number of queued runs exceeded!" (52 bytes)
- "Script '%s' queueing new instance (mode: queued)" (49 bytes)
- "Script '%s' maximum number of parallel runs exceeded!" (54 bytes)

### Technical Details

The changes ensure that:
- On ESP8266 with `esp8266_store_log_strings_in_flash: true`: Format strings are stored in PROGMEM using the F() macro
- On other platforms or without the flag: No changes, strings remain in RAM as before

This is consistent with how the core ESP_LOG* macros work in ESPHome and provides meaningful RAM savings on memory-constrained ESP8266 devices.

### Testing

Tested on ESP8266 with all script modes (single, restart, queued, parallel). Verified that:
1. Scripts compile successfully with the changes
2. All log messages appear correctly when scripts run
3. RAM usage is reduced by 240 bytes when `esp8266_store_log_strings_in_flash` is enabled
4. All script modes correctly trigger their respective warning messages from PROGMEM

