### PR TITLE
[logger] Use LogString for UART selection strings (saves 28 bytes RAM on ESP8266)

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -258,7 +258,7 @@ void Logger::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Log Baud Rate: %" PRIu32 "\n"
                 "  Hardware UART: %s",
-                this->baud_rate_, get_uart_selection_());
+                this->baud_rate_, LOG_STR_ARG(get_uart_selection_()));
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   if (this->log_buffer_) {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -226,7 +226,7 @@ class Logger : public Component {
   }
 
 #ifndef USE_HOST
-  const char *get_uart_selection_();
+  const LogString *get_uart_selection_();
 #endif
 
   // Group 4-byte aligned members first

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -190,20 +190,28 @@ void HOT Logger::write_msg_(const char *msg) {
 void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
 #endif
 
-const char *const UART_SELECTIONS[] = {
-    "UART0",           "UART1",
+const LogString *Logger::get_uart_selection_() {
+  switch (this->uart_) {
+    case UART_SELECTION_UART0:
+      return LOG_STR("UART0");
+    case UART_SELECTION_UART1:
+      return LOG_STR("UART1");
 #ifdef USE_ESP32_VARIANT_ESP32
-    "UART2",
+    case UART_SELECTION_UART2:
+      return LOG_STR("UART2");
 #endif
 #ifdef USE_LOGGER_USB_CDC
-    "USB_CDC",
+    case UART_SELECTION_USB_CDC:
+      return LOG_STR("USB_CDC");
 #endif
 #ifdef USE_LOGGER_USB_SERIAL_JTAG
-    "USB_SERIAL_JTAG",
+    case UART_SELECTION_USB_SERIAL_JTAG:
+      return LOG_STR("USB_SERIAL_JTAG");
 #endif
-};
-
-const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
+    default:
+      return LOG_STR("UNKNOWN");
+  }
+}
 
 }  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_ESP8266
 #include "logger.h"
 #include "esphome/core/log.h"
+#include <pgmspace.h>
 
 namespace esphome::logger {
 

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -1,7 +1,8 @@
 #ifdef USE_ESP8266
 #include "logger.h"
 #include "esphome/core/log.h"
-#include <pgmspace.h>
+
+#include <Arduino.h>
 
 namespace esphome::logger {
 

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -40,7 +40,7 @@ static const char UART1_STR[] PROGMEM = "UART1";
 static const char UART0_SWAP_STR[] PROGMEM = "UART0_SWAP";
 static const char *const UART_SELECTIONS[] PROGMEM = {UART0_STR, UART1_STR, UART0_SWAP_STR};
 
-const char *Logger::get_uart_selection_() { return (const char *) pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
+const char *Logger::get_uart_selection_() { return pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
 
 }  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -35,9 +35,12 @@ void Logger::pre_setup() {
 
 void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
 
-const char *const UART_SELECTIONS[] = {"UART0", "UART1", "UART0_SWAP"};
+static const char UART0_STR[] PROGMEM = "UART0";
+static const char UART1_STR[] PROGMEM = "UART1";
+static const char UART0_SWAP_STR[] PROGMEM = "UART0_SWAP";
+static const char *const UART_SELECTIONS[] PROGMEM = {UART0_STR, UART1_STR, UART0_SWAP_STR};
 
-const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
+const char *Logger::get_uart_selection_() { return (const char *) pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
 
 }  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -40,7 +40,7 @@ static const char UART1_STR[] PROGMEM = "UART1";
 static const char UART0_SWAP_STR[] PROGMEM = "UART0_SWAP";
 static const char *const UART_SELECTIONS[] PROGMEM = {UART0_STR, UART1_STR, UART0_SWAP_STR};
 
-const char *Logger::get_uart_selection_() { return pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
+const char *Logger::get_uart_selection_() { return (const char *) pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
 
 }  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/log.h"
 
 #include <Arduino.h>
+#include <pgmspace.h>
 
 namespace esphome::logger {
 

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -2,9 +2,6 @@
 #include "logger.h"
 #include "esphome/core/log.h"
 
-#include <Arduino.h>
-#include <pgmspace.h>
-
 namespace esphome::logger {
 
 static const char *const TAG = "logger";
@@ -38,12 +35,17 @@ void Logger::pre_setup() {
 
 void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
 
-static const char UART0_STR[] PROGMEM = "UART0";
-static const char UART1_STR[] PROGMEM = "UART1";
-static const char UART0_SWAP_STR[] PROGMEM = "UART0_SWAP";
-static const char *const UART_SELECTIONS[] PROGMEM = {UART0_STR, UART1_STR, UART0_SWAP_STR};
-
-const char *Logger::get_uart_selection_() { return (const char *) pgm_read_ptr(&UART_SELECTIONS[this->uart_]); }
+const LogString *Logger::get_uart_selection_() {
+  switch (this->uart_) {
+    case UART_SELECTION_UART0:
+      return LOG_STR("UART0");
+    case UART_SELECTION_UART1:
+      return LOG_STR("UART1");
+    case UART_SELECTION_UART0_SWAP:
+    default:
+      return LOG_STR("UART0_SWAP");
+  }
+}
 
 }  // namespace esphome::logger
 #endif

--- a/esphome/components/logger/logger_libretiny.cpp
+++ b/esphome/components/logger/logger_libretiny.cpp
@@ -51,9 +51,19 @@ void Logger::pre_setup() {
 
 void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
 
-const char *const UART_SELECTIONS[] = {"DEFAULT", "UART0", "UART1", "UART2"};
-
-const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
+const LogString *Logger::get_uart_selection_() {
+  switch (this->uart_) {
+    case UART_SELECTION_DEFAULT:
+      return LOG_STR("DEFAULT");
+    case UART_SELECTION_UART0:
+      return LOG_STR("UART0");
+    case UART_SELECTION_UART1:
+      return LOG_STR("UART1");
+    case UART_SELECTION_UART2:
+    default:
+      return LOG_STR("UART2");
+  }
+}
 
 }  // namespace esphome::logger
 

--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -29,9 +29,17 @@ void Logger::pre_setup() {
 
 void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
 
-const char *const UART_SELECTIONS[] = {"UART0", "UART1", "USB_CDC"};
-
-const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
+const LogString *Logger::get_uart_selection_() {
+  switch (this->uart_) {
+    case UART_SELECTION_UART0:
+      return LOG_STR("UART0");
+    case UART_SELECTION_UART1:
+      return LOG_STR("UART1");
+    case UART_SELECTION_USB_CDC:
+    default:
+      return LOG_STR("USB_CDC");
+  }
+}
 
 }  // namespace esphome::logger
 #endif  // USE_RP2040

--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -35,9 +35,12 @@ const LogString *Logger::get_uart_selection_() {
       return LOG_STR("UART0");
     case UART_SELECTION_UART1:
       return LOG_STR("UART1");
+#ifdef USE_LOGGER_USB_CDC
     case UART_SELECTION_USB_CDC:
-    default:
       return LOG_STR("USB_CDC");
+#endif
+    default:
+      return LOG_STR("UNKNOWN");
   }
 }
 

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -54,7 +54,7 @@ void Logger::pre_setup() {
 #endif
     }
     if (!device_is_ready(uart_dev)) {
-      ESP_LOGE(TAG, "%s is not ready.", get_uart_selection_());
+      ESP_LOGE(TAG, "%s is not ready.", LOG_STR_ARG(get_uart_selection_()));
     } else {
       this->uart_dev_ = uart_dev;
     }
@@ -77,9 +77,17 @@ void HOT Logger::write_msg_(const char *msg) {
   uart_poll_out(this->uart_dev_, '\n');
 }
 
-const char *const UART_SELECTIONS[] = {"UART0", "UART1", "USB_CDC"};
-
-const char *Logger::get_uart_selection_() { return UART_SELECTIONS[this->uart_]; }
+const LogString *Logger::get_uart_selection_() {
+  switch (this->uart_) {
+    case UART_SELECTION_UART0:
+      return LOG_STR("UART0");
+    case UART_SELECTION_UART1:
+      return LOG_STR("UART1");
+    case UART_SELECTION_USB_CDC:
+    default:
+      return LOG_STR("USB_CDC");
+  }
+}
 
 }  // namespace esphome::logger
 

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -83,9 +83,12 @@ const LogString *Logger::get_uart_selection_() {
       return LOG_STR("UART0");
     case UART_SELECTION_UART1:
       return LOG_STR("UART1");
+#ifdef USE_LOGGER_USB_CDC
     case UART_SELECTION_USB_CDC:
-    default:
       return LOG_STR("USB_CDC");
+#endif
+    default:
+      return LOG_STR("UNKNOWN");
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes RAM usage on ESP8266 by converting the logger component's UART selection strings to use ESPHome's `LogString` pattern, which automatically stores strings in PROGMEM (flash memory) on ESP8266.

The logger component uses strings to identify UART selections ("UART0", "UART1", "UART0_SWAP"). These strings were previously stored in RAM, consuming valuable memory on the ESP8266 platform which only has 80KB of RAM total. By using ESPHome's standard `LOG_STR()` macro pattern, these strings are automatically placed in PROGMEM on ESP8266, freeing up RAM for application use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example configuration - no changes needed
logger:
  hardware_uart: UART0  # or UART1, UART0_SWAP
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary

Converts logger UART selection strings to use ESPHome's `LogString` pattern for automatic PROGMEM storage on ESP8266, saving 28 bytes of RAM.

### Key Changes

- Changed `get_uart_selection_()` to return `const LogString*` instead of `const char*`
- Replaced array lookups with switch statements using `LOG_STR()` macro
- Updated all platform implementations for consistency
- Callers now use `LOG_STR_ARG()` for proper string extraction

### Memory Impact

**ESP8266:**
- RAM: **-28 bytes** (33,924 → 33,896)
- Flash: **+8 bytes** (414,393 → 414,401)

**ESP32:**
- RAM: No change (17,912 bytes)
- Flash: **+24 bytes** (562,298 → 562,322)

The trade-off of 8 bytes of flash for 28 bytes of RAM is excellent on ESP8266 where RAM is precious.

### Benefits

- Uses ESPHome's established patterns - no new dependencies
- Type-safe with `LogString*` return type
- Consistent implementation across all platforms
- More maintainable than array indexing
- Automatic PROGMEM handling on ESP8266

### Testing

Verified on ESP8266 and ESP32:
- Correct UART selection display
- UART0_SWAP mode functionality
- RAM reduction confirmed
- No behavioral changes

