### PR TITLE
[sensor] ESP8266: Use LogString for state_class_to_string() to save RAM

### DIFF
--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -59,11 +59,10 @@ void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
     root[MQTT_FORCE_UPDATE] = true;
 
   if (this->sensor_->get_state_class() != STATE_CLASS_NONE) {
-    auto state_class_s = state_class_to_string(this->sensor_->get_state_class());
 #ifdef USE_STORE_LOG_STR_IN_FLASH
-    root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_s;
+    root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_to_string(this->sensor_->get_state_class());
 #else
-    root[MQTT_STATE_CLASS] = LOG_STR_ARG(state_class_s);
+    root[MQTT_STATE_CLASS] = LOG_STR_ARG(state_class_to_string(this->sensor_->get_state_class()));
 #endif
   }
 

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -58,8 +58,13 @@ void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
   if (this->sensor_->get_force_update())
     root[MQTT_FORCE_UPDATE] = true;
 
-  if (this->sensor_->get_state_class() != STATE_CLASS_NONE)
+  if (this->sensor_->get_state_class() != STATE_CLASS_NONE) {
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+    root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_to_string(this->sensor_->get_state_class());
+#else
     root[MQTT_STATE_CLASS] = state_class_to_string(this->sensor_->get_state_class());
+#endif
+  }
 
   config.command_topic = false;
 }

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -59,10 +59,11 @@ void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
     root[MQTT_FORCE_UPDATE] = true;
 
   if (this->sensor_->get_state_class() != STATE_CLASS_NONE) {
+    auto state_class_s = state_class_to_string(this->sensor_->get_state_class());
 #ifdef USE_STORE_LOG_STR_IN_FLASH
-    root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_to_string(this->sensor_->get_state_class());
+    root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_s;
 #else
-    root[MQTT_STATE_CLASS] = state_class_to_string(this->sensor_->get_state_class());
+    root[MQTT_STATE_CLASS] = LOG_STR_ARG(state_class_s);
 #endif
   }
 

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -17,7 +17,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 "%s  State Class: '%s'\n"
                 "%s  Unit of Measurement: '%s'\n"
                 "%s  Accuracy Decimals: %d",
-                prefix, type, obj->get_name().c_str(), prefix, state_class_to_string(obj->get_state_class()), prefix,
+                prefix, type, obj->get_name().c_str(), prefix,
+                LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                 obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
   if (!obj->get_device_class_ref().empty()) {
@@ -33,17 +34,17 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
   }
 }
 
-const char *state_class_to_string(StateClass state_class) {
+const LogString *state_class_to_string(StateClass state_class) {
   switch (state_class) {
     case STATE_CLASS_MEASUREMENT:
-      return "measurement";
+      return LOG_STR("measurement");
     case STATE_CLASS_TOTAL_INCREASING:
-      return "total_increasing";
+      return LOG_STR("total_increasing");
     case STATE_CLASS_TOTAL:
-      return "total";
+      return LOG_STR("total");
     case STATE_CLASS_NONE:
     default:
-      return "";
+      return LOG_STR("");
   }
 }
 

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -33,7 +33,7 @@ enum StateClass : uint8_t {
   STATE_CLASS_TOTAL = 3,
 };
 
-const char *state_class_to_string(StateClass state_class);
+const LogString *state_class_to_string(StateClass state_class);
 
 /** Base-class for all sensors.
  *


### PR DESCRIPTION
# What does this implement/fix?

This PR reverts `state_class_to_string()` back to using `LogString*` with the proper casting fix for ArduinoJson compatibility, saving RAM on ESP8266 devices by storing state class strings in flash memory.

## Background

In 2021, PR #2331 changed `state_class_to_string()` from `LogString*` to `std::string` to fix MQTT discovery. However, the real issue was not the use of `LogString*` but the missing type cast required by ArduinoJson for PROGMEM strings.

As documented in [ArduinoJson PROGMEM support](https://arduinojson.org/v7/config/enable_progmem/), ArduinoJson requires strings from PROGMEM to be cast to `const __FlashStringHelper*`:

> ArduinoJson relies on the type const __FlashStringHelper* to detect if a string is in Flash.
> If you use a char[] with the PROGMEM attribute, you must cast the pointer before passing it to ArduinoJson.

## Changes

1. **sensor.h/sensor.cpp**: Reverted `state_class_to_string()` to return `const LogString*` using `LOG_STR()` macro
   - On ESP8266 with `USE_STORE_LOG_STR_IN_FLASH`, strings are stored in flash
   - Updated logging to use `LOG_STR_ARG()` for proper handling

2. **mqtt_sensor.cpp**: Added proper conditional casting for ArduinoJson:
   ```cpp
   #ifdef USE_STORE_LOG_STR_IN_FLASH
       root[MQTT_STATE_CLASS] = (const __FlashStringHelper *) state_class_to_string(this->sensor_->get_state_class());
   #else
       root[MQTT_STATE_CLASS] = LOG_STR_ARG(state_class_to_string(this->sensor_->get_state_class()));
   #endif
   ```
   
   The `#ifdef` is necessary because:
   - When `USE_STORE_LOG_STR_IN_FLASH` is defined (ESP8266): Cast to `const __FlashStringHelper*` for ArduinoJson to detect PROGMEM
   - When not defined (other platforms): Use `LOG_STR_ARG()` which converts `LogString*` to regular `const char*`
   
   The cast is correct because:
   - `state_class_to_string()` returns `const LogString*` (ESPHome's marker type for flash strings)
   - When `USE_STORE_LOG_STR_IN_FLASH` is defined, this points to PROGMEM data via `PSTR()` macro
   - ArduinoJson requires `const __FlashStringHelper*` (Arduino's marker type) to detect PROGMEM strings
   - Both types are just markers for pointers to flash memory, so the cast is safe and necessary

## Memory Impact

On ESP8266, this saves approximately 16-48 bytes of RAM per sensor with a state class (4 string literals × ~12 bytes average), which is significant given the limited 80KB RAM available.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Builds on #10533 which changed to `const char*` but this goes further to use PROGMEM on ESP8266
- Properly fixes the original issue from #2331 without the RAM overhead

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - internal optimization
sensor:
  - platform: uptime
    name: "Uptime"
    state_class: total_increasing  # Will use flash storage for "total_increasing" string on ESP8266
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).