### PR TITLE
[kmeteriso] Fix i2c call

### DIFF
--- a/esphome/components/kmeteriso/kmeteriso.cpp
+++ b/esphome/components/kmeteriso/kmeteriso.cpp
@@ -33,7 +33,7 @@ void KMeterISOComponent::setup() {
   }
 
   uint8_t read_buf[4] = {1};
-  if (!this->read_register(KMETER_ERROR_STATUS_REG, read_buf, 1)) {
+  if (!this->read_bytes(KMETER_ERROR_STATUS_REG, read_buf, 1)) {
     ESP_LOGCONFIG(TAG, "Could not read from the device.");
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Revert incorrect change from previous PR https://github.com/esphome/esphome/pull/10389

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10574 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
