### PR TITLE
Patch pulse meter

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -155,7 +155,7 @@ void IRAM_ATTR PulseMeterSensor::edge_intr(PulseMeterSensor *sensor) {
     set.last_detected_edge_us_ = now;
     set.last_rising_edge_us_ = now;
     set.count_++;  // NOLINT(clang-diagnostic-deprecated-volatile)
-    sensor->updated_state = true;
+    sensor->updated_state_ = true;
   }
 
   // This ISR is bound to rising edges, so the pin is high

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -63,7 +63,6 @@ void PulseMeterSensor::loop() {
       std::swap(this->set_, this->get_);
       this->updated_state_ = false;
     }
-    
   }
 
   const uint32_t now = micros();

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -59,7 +59,11 @@ void PulseMeterSensor::loop() {
     this->last_pin_val_ = current;
 
     // Swap out set and get to get the latest state from the ISR
-    std::swap(this->set_, this->get_);
+    if (this->updated_state_) {
+      std::swap(this->set_, this->get_);
+      this->updated_state_ = false;
+    }
+    
   }
 
   const uint32_t now = micros();
@@ -151,6 +155,7 @@ void IRAM_ATTR PulseMeterSensor::edge_intr(PulseMeterSensor *sensor) {
     set.last_detected_edge_us_ = now;
     set.last_rising_edge_us_ = now;
     set.count_++;  // NOLINT(clang-diagnostic-deprecated-volatile)
+    sensor->updated_state = true;
   }
 
   // This ISR is bound to rising edges, so the pin is high
@@ -182,6 +187,7 @@ void IRAM_ATTR PulseMeterSensor::pulse_intr(PulseMeterSensor *sensor) {
   set.last_rising_edge_us_ = !state.latched_ && pin_val ? now : set.last_detected_edge_us_;
 
   state.last_intr_ = now;
+  sensor->updated_state_ = true;
   sensor->last_pin_val_ = pin_val;
 }
 

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -58,7 +58,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile State *set_ = state_;
   volatile State *get_ = state_ + 1;
 
-  // if ISR has runned since the last loop
+  // if ISR has updated the set_ state since the last loop
   bool updated_state_ = false;
 
   // Only use the following variables in the ISR or while guarded by an InterruptLock

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -48,7 +48,6 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   uint32_t last_processed_edge_us_ = 0;
 
   // This struct (and the two pointers) are used to pass data between the ISR and loop.
-  // These two pointers are exchanged each loop.
   // Use these to send data from the ISR to the loop not the other way around (except for resetting the values).
   struct State {
     uint32_t last_detected_edge_us_ = 0;
@@ -58,6 +57,9 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   State state_[2];
   volatile State *set_ = state_;
   volatile State *get_ = state_ + 1;
+
+  // if ISR has runned since the last loop
+  bool updated_state_ = false;
 
   // Only use the following variables in the ISR or while guarded by an InterruptLock
   ISRInternalGPIOPin isr_pin_;


### PR DESCRIPTION
# What does this implement/fix?

This fixes an issue related to the pulse meter component, expecting in the main `loop()` the latest state from ISR, but in fact swapping sometimes the latest state with an older one. This lead to false early edge detection, when `filter_mode_` is set to `FILTER_PULSE`, as described in this thread:
[](https://community.home-assistant.io/t/pulse-meter-seems-to-be-buggy/927035)

This bugfix adds the boolean variable `updated_state_` in the component class. The ISR set this boolean to `true`, if the state `set_` has been modified. The main `loop()` can then check with this variable, if the `set_` state has been modified by the ISR and swap the `get_` and `set_` state only in this case, ensuring `loop()` to always have the latest state from ISR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10605 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: stromzaehler
  friendly_name: Stromzähler

esp8266:
  board: d1_mini

# Enable logging
logger:


ota:
  - platform: esphome
    password: "4271de215c26d9a935fd0b0387717b6f"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Stromzahler Fallback Hotspot"
    password: "BB2pv48pNdCZ"

captive_portal:

substitutions:
  pulses_per_kWh: 96.0

external_components:
  - source: github://lefevrer/pulse_meter-esphome@patch-pulse_meter
    components: [pulse_meter]

# Configuration entry
sensor:
  # Used for testing and validation purposes
  #- platform: adc
  #  pin: GPIO17
  #  name: "Electricity Meter Analog Voltage Signal"
  #  update_interval: 100ms

  # Used for Energy Monitoring
  - platform: pulse_meter
    name: 'Electricity Power Usage'
    id: sensor_pulse_meter
    #unit_of_measurement: 'kW'
    device_class: power
    state_class: measurement
    internal_filter: 500ms
    internal_filter_mode: PULSE
    accuracy_decimals: 3
    pin: D5
    #filters:
    #  - multiply: !lambda return 60.0 / ${pulses_per_kWh};

    #total:
    #  name: "Electricity Energy Usage"
    #  #unit_of_measurement: 'kWh'
    #  accuracy_decimals: 1 
    #  filters:
    #    - multiply: !lambda return 1.0 / ${pulses_per_kWh};
    
    #on_raw_value: 
    #  then:
    #    - lambda: |-
    #        ESP_LOGD("custom", "Raw_value: %.5f >> Period of %.1f s", x, 60 / x );
    #        id(sensor_pulse_meter).set_filter_us((60.0f * 1000000.0f) / x / 5.0f);
    #      # Set the internal filter to 1/10 of the pulse period

# Enable Home Assistant API
api:
  encryption:
    key: "5Qj5gYvGeF22aWOrEXsf4eavx09TJ+ELhXzjuszCSe0="

  # Setting the total pulse count
  actions:
    - action: set_total
      variables:
        new_total: int
      then:
        - pulse_meter.set_total_pulses:
            id: sensor_pulse_meter
            value: !lambda 'return new_total;'

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
