### PR TITLE
[esp8266] Store component warning strings in flash to reduce RAM usage

### DIFF
--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -64,7 +64,7 @@ void AbsoluteHumidityComponent::loop() {
       ESP_LOGW(TAG, "No valid state from humidity sensor!");
     }
     this->publish_state(NAN);
-    this->status_set_warning("Unable to calculate absolute humidity.");
+    this->status_set_warning(LOG_STR("Unable to calculate absolute humidity."));
     return;
   }
 

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -96,7 +96,7 @@ void AHT10Component::read_data_() {
     ESP_LOGD(TAG, "Read attempt %d at %ums", this->read_count_, (unsigned) (millis() - this->start_time_));
   }
   if (this->read(data, 6) != i2c::ERROR_OK) {
-    this->status_set_warning("Read failed, will retry");
+    this->status_set_warning(LOG_STR("Read failed, will retry"));
     this->restart_read_();
     return;
   }
@@ -113,7 +113,7 @@ void AHT10Component::read_data_() {
     } else {
       ESP_LOGD(TAG, "Invalid humidity, retrying");
       if (this->write(AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD)) != i2c::ERROR_OK) {
-        this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+        this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
       }
       this->restart_read_();
       return;
@@ -144,7 +144,7 @@ void AHT10Component::update() {
     return;
   this->start_time_ = millis();
   if (this->write(AHT10_MEASURE_CMD, sizeof(AHT10_MEASURE_CMD)) != i2c::ERROR_OK) {
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
     return;
   }
   this->restart_read_();

--- a/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
+++ b/esphome/components/axs15231/touchscreen/axs15231_touchscreen.cpp
@@ -12,7 +12,7 @@ constexpr static const uint8_t AXS_READ_TOUCHPAD[11] = {0xb5, 0xab, 0xa5, 0x5a, 
 
 #define ERROR_CHECK(err) \
   if ((err) != i2c::ERROR_OK) { \
-    this->status_set_warning("Failed to communicate"); \
+    this->status_set_warning(LOG_STR("Failed to communicate")); \
     return; \
   }
 

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -149,7 +149,7 @@ void BL0942::setup() {
   this->write_reg_(BL0942_REG_USR_WRPROT, 0);
 
   if (this->read_reg_(BL0942_REG_MODE) != mode)
-    this->status_set_warning("BL0942 setup failed!");
+    this->status_set_warning(LOG_STR("BL0942 setup failed!"));
 
   this->flush();
 }

--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -64,7 +64,7 @@ bool DallasTemperatureSensor::read_scratch_pad_() {
     }
   } else {
     ESP_LOGW(TAG, "'%s' - reading scratch pad failed bus reset", this->get_name().c_str());
-    this->status_set_warning("bus reset failed");
+    this->status_set_warning(LOG_STR("bus reset failed"));
   }
   return success;
 }
@@ -124,7 +124,7 @@ bool DallasTemperatureSensor::check_scratch_pad_() {
             crc8(this->scratch_pad_, 8));
 #endif
   if (!chksum_validity) {
-    this->status_set_warning("scratch pad checksum invalid");
+    this->status_set_warning(LOG_STR("scratch pad checksum invalid"));
     ESP_LOGD(TAG, "Scratch pad: %02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X.%02X (%02X)", this->scratch_pad_[0],
              this->scratch_pad_[1], this->scratch_pad_[2], this->scratch_pad_[3], this->scratch_pad_[4],
              this->scratch_pad_[5], this->scratch_pad_[6], this->scratch_pad_[7], this->scratch_pad_[8],

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -492,7 +492,7 @@ void EthernetComponent::start_connect_() {
   global_eth_component->ipv6_count_ = 0;
 #endif /* USE_NETWORK_IPV6 */
   this->connect_begin_ = millis();
-  this->status_set_warning("waiting for IP configuration");
+  this->status_set_warning(LOG_STR("waiting for IP configuration"));
 
   esp_err_t err;
   err = esp_netif_set_hostname(this->eth_netif_, App.get_name().c_str());

--- a/esphome/components/gdk101/gdk101.cpp
+++ b/esphome/components/gdk101/gdk101.cpp
@@ -11,22 +11,22 @@ static const uint8_t NUMBER_OF_READ_RETRIES = 5;
 void GDK101Component::update() {
   uint8_t data[2];
   if (!this->read_dose_1m_(data)) {
-    this->status_set_warning("Failed to read dose 1m");
+    this->status_set_warning(LOG_STR("Failed to read dose 1m"));
     return;
   }
 
   if (!this->read_dose_10m_(data)) {
-    this->status_set_warning("Failed to read dose 10m");
+    this->status_set_warning(LOG_STR("Failed to read dose 10m"));
     return;
   }
 
   if (!this->read_status_(data)) {
-    this->status_set_warning("Failed to read status");
+    this->status_set_warning(LOG_STR("Failed to read status"));
     return;
   }
 
   if (!this->read_measurement_duration_(data)) {
-    this->status_set_warning("Failed to read measurement duration");
+    this->status_set_warning(LOG_STR("Failed to read measurement duration"));
     return;
   }
   this->status_clear_warning();

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -20,7 +20,7 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 #define ERROR_CHECK(err) \
   if ((err) != i2c::ERROR_OK) { \
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL); \
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL)); \
     return; \
   }
 

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "honeywellabp2";
 void HONEYWELLABP2Sensor::read_sensor_data() {
   if (this->read(raw_data_, 7) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-    this->status_set_warning("couldn't read sensor data");
+    this->status_set_warning(LOG_STR("couldn't read sensor data"));
     return;
   }
   float press_counts = encode_uint24(raw_data_[1], raw_data_[2], raw_data_[3]);  // calculate digital pressure counts
@@ -31,7 +31,7 @@ void HONEYWELLABP2Sensor::read_sensor_data() {
 void HONEYWELLABP2Sensor::start_measurement() {
   if (this->write(i2c_cmd_, 3) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-    this->status_set_warning("couldn't start measurement");
+    this->status_set_warning(LOG_STR("couldn't start measurement"));
     return;
   }
   this->measurement_running_ = true;
@@ -40,7 +40,7 @@ void HONEYWELLABP2Sensor::start_measurement() {
 bool HONEYWELLABP2Sensor::is_measurement_ready() {
   if (this->read(raw_data_, 1) != i2c::ERROR_OK) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-    this->status_set_warning("couldn't check measurement");
+    this->status_set_warning(LOG_STR("couldn't check measurement"));
     return false;
   }
   if ((raw_data_[0] & (0x1 << STATUS_BIT_BUSY)) > 0) {
@@ -53,7 +53,7 @@ bool HONEYWELLABP2Sensor::is_measurement_ready() {
 void HONEYWELLABP2Sensor::measurement_timeout() {
   ESP_LOGE(TAG, "Timeout!");
   this->measurement_running_ = false;
-  this->status_set_warning("measurement timed out");
+  this->status_set_warning(LOG_STR("measurement timed out"));
 }
 
 float HONEYWELLABP2Sensor::get_pressure() { return this->last_pressure_; }

--- a/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.cpp
+++ b/esphome/components/m5stack_8angle/binary_sensor/m5stack_8angle_binary_sensor.cpp
@@ -6,7 +6,7 @@ namespace m5stack_8angle {
 void M5Stack8AngleSwitchBinarySensor::update() {
   int8_t out = this->parent_->read_switch();
   if (out == -1) {
-    this->status_set_warning("Could not read binary sensor state from M5Stack 8Angle.");
+    this->status_set_warning(LOG_STR("Could not read binary sensor state from M5Stack 8Angle."));
     return;
   }
   this->publish_state(out != 0);

--- a/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.cpp
+++ b/esphome/components/m5stack_8angle/sensor/m5stack_8angle_sensor.cpp
@@ -7,7 +7,7 @@ void M5Stack8AngleKnobSensor::update() {
   if (this->parent_ != nullptr) {
     int32_t raw_pos = this->parent_->read_knob_pos_raw(this->channel_, this->bits_);
     if (raw_pos == -1) {
-      this->status_set_warning("Could not read knob position from M5Stack 8Angle.");
+      this->status_set_warning(LOG_STR("Could not read knob position from M5Stack 8Angle."));
       return;
     }
     if (this->raw_) {

--- a/esphome/components/max17043/max17043.cpp
+++ b/esphome/components/max17043/max17043.cpp
@@ -22,7 +22,7 @@ void MAX17043Component::update() {
 
   if (this->voltage_sensor_ != nullptr) {
     if (!this->read_byte_16(MAX17043_VCELL, &raw_voltage)) {
-      this->status_set_warning("Unable to read MAX17043_VCELL");
+      this->status_set_warning(LOG_STR("Unable to read MAX17043_VCELL"));
     } else {
       float voltage = (1.25 * (float) (raw_voltage >> 4)) / 1000.0;
       this->voltage_sensor_->publish_state(voltage);
@@ -31,7 +31,7 @@ void MAX17043Component::update() {
   }
   if (this->battery_remaining_sensor_ != nullptr) {
     if (!this->read_byte_16(MAX17043_SOC, &raw_percent)) {
-      this->status_set_warning("Unable to read MAX17043_SOC");
+      this->status_set_warning(LOG_STR("Unable to read MAX17043_SOC"));
     } else {
       float percent = (float) ((raw_percent >> 8) + 0.003906f * (raw_percent & 0x00ff));
       this->battery_remaining_sensor_->publish_state(percent);

--- a/esphome/components/mcp23x08_base/mcp23x08_base.cpp
+++ b/esphome/components/mcp23x08_base/mcp23x08_base.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "mcp23x08_base";
 
 bool MCP23X08Base::digital_read_hw(uint8_t pin) {
   if (!this->read_reg(mcp23x08_base::MCP23X08_GPIO, &this->input_mask_)) {
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
     return false;
   }
   return true;

--- a/esphome/components/mcp23x17_base/mcp23x17_base.cpp
+++ b/esphome/components/mcp23x17_base/mcp23x17_base.cpp
@@ -11,13 +11,13 @@ bool MCP23X17Base::digital_read_hw(uint8_t pin) {
   uint8_t data;
   if (pin < 8) {
     if (!this->read_reg(mcp23x17_base::MCP23X17_GPIOA, &data)) {
-      this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+      this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
       return false;
     }
     this->input_mask_ = encode_uint16(this->input_mask_ >> 8, data);
   } else {
     if (!this->read_reg(mcp23x17_base::MCP23X17_GPIOB, &data)) {
-      this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+      this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
       return false;
     }
     this->input_mask_ = encode_uint16(data, this->input_mask_ & 0xFF);

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -68,7 +68,7 @@ bool PI4IOE5V6408Component::read_gpio_outputs_() {
 
   uint8_t data;
   if (!this->read_byte(PI4IOE5V6408_REGISTER_OUT_SET, &data)) {
-    this->status_set_warning("Failed to read output register");
+    this->status_set_warning(LOG_STR("Failed to read output register"));
     return false;
   }
   this->output_mask_ = data;
@@ -82,7 +82,7 @@ bool PI4IOE5V6408Component::read_gpio_modes_() {
 
   uint8_t data;
   if (!this->read_byte(PI4IOE5V6408_REGISTER_IO_DIR, &data)) {
-    this->status_set_warning("Failed to read GPIO modes");
+    this->status_set_warning(LOG_STR("Failed to read GPIO modes"));
     return false;
   }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
@@ -99,7 +99,7 @@ bool PI4IOE5V6408Component::digital_read_hw(uint8_t pin) {
 
   uint8_t data;
   if (!this->read_byte(PI4IOE5V6408_REGISTER_IN_STATE, &data)) {
-    this->status_set_warning("Failed to read GPIO state");
+    this->status_set_warning(LOG_STR("Failed to read GPIO state"));
     return false;
   }
   this->input_mask_ = data;
@@ -117,7 +117,7 @@ void PI4IOE5V6408Component::digital_write_hw(uint8_t pin, bool value) {
     this->output_mask_ &= ~(1 << pin);
   }
   if (!this->write_byte(PI4IOE5V6408_REGISTER_OUT_SET, this->output_mask_)) {
-    this->status_set_warning("Failed to write output register");
+    this->status_set_warning(LOG_STR("Failed to write output register"));
     return;
   }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
@@ -131,15 +131,15 @@ bool PI4IOE5V6408Component::write_gpio_modes_() {
     return false;
 
   if (!this->write_byte(PI4IOE5V6408_REGISTER_IO_DIR, this->mode_mask_)) {
-    this->status_set_warning("Failed to write GPIO modes");
+    this->status_set_warning(LOG_STR("Failed to write GPIO modes"));
     return false;
   }
   if (!this->write_byte(PI4IOE5V6408_REGISTER_PULL_SELECT, this->pull_up_down_mask_)) {
-    this->status_set_warning("Failed to write GPIO pullup/pulldown");
+    this->status_set_warning(LOG_STR("Failed to write GPIO pullup/pulldown"));
     return false;
   }
   if (!this->write_byte(PI4IOE5V6408_REGISTER_PULL_ENABLE, this->pull_enable_mask_)) {
-    this->status_set_warning("Failed to write GPIO pull enable");
+    this->status_set_warning(LOG_STR("Failed to write GPIO pull enable"));
     return false;
   }
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -211,7 +211,7 @@ void SGP4xComponent::measure_raw_() {
 
   if (!this->write_command(command, data, 2)) {
     ESP_LOGD(TAG, "write error (%d)", this->last_error_);
-    this->status_set_warning("measurement request failed");
+    this->status_set_warning(LOG_STR("measurement request failed"));
     return;
   }
 
@@ -220,7 +220,7 @@ void SGP4xComponent::measure_raw_() {
     raw_data[1] = 0;
     if (!this->read_data(raw_data, response_words)) {
       ESP_LOGD(TAG, "read error (%d)", this->last_error_);
-      this->status_set_warning("measurement read failed");
+      this->status_set_warning(LOG_STR("measurement read failed"));
       this->voc_index_ = this->nox_index_ = UINT16_MAX;
       return;
     }

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -65,7 +65,7 @@ void SHT4XComponent::update() {
   // Send command
   if (!this->write_command(MEASURECOMMANDS[this->precision_])) {
     // Warning will be printed only if warning status is not set yet
-    this->status_set_warning("Failed to send measurement command");
+    this->status_set_warning(LOG_STR("Failed to send measurement command"));
     return;
   }
 

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -56,7 +56,7 @@ void SoundLevelComponent::loop() {
     }
   } else {
     if (!this->status_has_warning()) {
-      this->status_set_warning("Microphone isn't running, can't compute statistics");
+      this->status_set_warning(LOG_STR("Microphone isn't running, can't compute statistics"));
 
       // Deallocate buffers, if necessary
       this->stop_();

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -50,7 +50,7 @@ bool TCA9555Component::read_gpio_outputs_() {
     return false;
   uint8_t data[2];
   if (!this->read_bytes(TCA9555_OUTPUT_PORT_REGISTER_0, data, 2)) {
-    this->status_set_warning("Failed to read output register");
+    this->status_set_warning(LOG_STR("Failed to read output register"));
     return false;
   }
   this->output_mask_ = (uint16_t(data[1]) << 8) | (uint16_t(data[0]) << 0);
@@ -64,7 +64,7 @@ bool TCA9555Component::read_gpio_modes_() {
   uint8_t data[2];
   bool success = this->read_bytes(TCA9555_CONFIGURATION_PORT_0, data, 2);
   if (!success) {
-    this->status_set_warning("Failed to read mode register");
+    this->status_set_warning(LOG_STR("Failed to read mode register"));
     return false;
   }
   this->mode_mask_ = (uint16_t(data[1]) << 8) | (uint16_t(data[0]) << 0);
@@ -79,7 +79,7 @@ bool TCA9555Component::digital_read_hw(uint8_t pin) {
   uint8_t bank_number = pin < 8 ? 0 : 1;
   uint8_t register_to_read = bank_number ? TCA9555_INPUT_PORT_REGISTER_1 : TCA9555_INPUT_PORT_REGISTER_0;
   if (!this->read_bytes(register_to_read, &data, 1)) {
-    this->status_set_warning("Failed to read input register");
+    this->status_set_warning(LOG_STR("Failed to read input register"));
     return false;
   }
   uint8_t second_half = this->input_mask_ >> 8;
@@ -108,7 +108,7 @@ void TCA9555Component::digital_write_hw(uint8_t pin, bool value) {
   data[0] = this->output_mask_;
   data[1] = this->output_mask_ >> 8;
   if (!this->write_bytes(TCA9555_OUTPUT_PORT_REGISTER_0, data, 2)) {
-    this->status_set_warning("Failed to write output register");
+    this->status_set_warning(LOG_STR("Failed to write output register"));
     return;
   }
 
@@ -123,7 +123,7 @@ bool TCA9555Component::write_gpio_modes_() {
   data[0] = this->mode_mask_;
   data[1] = this->mode_mask_ >> 8;
   if (!this->write_bytes(TCA9555_CONFIGURATION_PORT_0, data, 2)) {
-    this->status_set_warning("Failed to write mode register");
+    this->status_set_warning(LOG_STR("Failed to write mode register"));
     return false;
   }
   this->status_clear_warning();

--- a/esphome/components/tmp1075/tmp1075.cpp
+++ b/esphome/components/tmp1075/tmp1075.cpp
@@ -32,7 +32,7 @@ void TMP1075Sensor::update() {
   uint16_t regvalue;
   if (!read_byte_16(REG_TEMP, &regvalue)) {
     ESP_LOGW(TAG, "'%s' - unable to read temperature register", this->name_.c_str());
-    this->status_set_warning("can't read");
+    this->status_set_warning(LOG_STR("can't read"));
     return;
   }
   this->status_clear_warning();

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -28,12 +28,12 @@ void UDPComponent::setup() {
     int enable = 1;
     auto err = this->broadcast_socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
     if (err != 0) {
-      this->status_set_warning("Socket unable to set reuseaddr");
+      this->status_set_warning(LOG_STR("Socket unable to set reuseaddr"));
       // we can still continue
     }
     err = this->broadcast_socket_->setsockopt(SOL_SOCKET, SO_BROADCAST, &enable, sizeof(int));
     if (err != 0) {
-      this->status_set_warning("Socket unable to set broadcast");
+      this->status_set_warning(LOG_STR("Socket unable to set broadcast"));
     }
   }
   // create listening socket if we either want to subscribe to providers, or need to listen
@@ -55,7 +55,7 @@ void UDPComponent::setup() {
     int enable = 1;
     err = this->listen_socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
     if (err != 0) {
-      this->status_set_warning("Socket unable to set reuseaddr");
+      this->status_set_warning(LOG_STR("Socket unable to set reuseaddr"));
       // we can still continue
     }
     struct sockaddr_in server {};

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -266,7 +266,7 @@ void USBUartTypeCdcAcm::on_connected() {
   for (auto *channel : this->channels_) {
     if (i == cdc_devs.size()) {
       ESP_LOGE(TAG, "No configuration found for channel %d", channel->index_);
-      this->status_set_warning("No configuration found for channel");
+      this->status_set_warning(LOG_STR("No configuration found for channel"));
       break;
     }
     channel->cdc_dev_ = cdc_devs[i++];

--- a/esphome/components/wake_on_lan/wake_on_lan.cpp
+++ b/esphome/components/wake_on_lan/wake_on_lan.cpp
@@ -74,12 +74,12 @@ void WakeOnLanButton::setup() {
   int enable = 1;
   auto err = this->broadcast_socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
   if (err != 0) {
-    this->status_set_warning("Socket unable to set reuseaddr");
+    this->status_set_warning(LOG_STR("Socket unable to set reuseaddr"));
     // we can still continue
   }
   err = this->broadcast_socket_->setsockopt(SOL_SOCKET, SO_BROADCAST, &enable, sizeof(int));
   if (err != 0) {
-    this->status_set_warning("Socket unable to set broadcast");
+    this->status_set_warning(LOG_STR("Socket unable to set broadcast"));
   }
 #endif
 }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -148,7 +148,7 @@ void WiFiComponent::loop() {
 
     switch (this->state_) {
       case WIFI_COMPONENT_STATE_COOLDOWN: {
-        this->status_set_warning("waiting to reconnect");
+        this->status_set_warning(LOG_STR("waiting to reconnect"));
         if (millis() - this->action_started_ > 5000) {
           if (this->fast_connect_ || this->retry_hidden_) {
             if (!this->selected_ap_.get_bssid().has_value())
@@ -161,13 +161,13 @@ void WiFiComponent::loop() {
         break;
       }
       case WIFI_COMPONENT_STATE_STA_SCANNING: {
-        this->status_set_warning("scanning for networks");
+        this->status_set_warning(LOG_STR("scanning for networks"));
         this->check_scanning_finished();
         break;
       }
       case WIFI_COMPONENT_STATE_STA_CONNECTING:
       case WIFI_COMPONENT_STATE_STA_CONNECTING_2: {
-        this->status_set_warning("associating to network");
+        this->status_set_warning(LOG_STR("associating to network"));
         this->check_connecting_finished();
         break;
       }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -280,26 +280,24 @@ bool Component::can_proceed() { return true; }
 bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
 bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
 
-void Component::status_set_warning_flag_() {
+void Component::status_set_warning(const char *message) {
   // Don't spam the log. This risks missing different warning messages though.
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
     return;
   this->component_state_ |= STATUS_LED_WARNING;
   App.app_state_ |= STATUS_LED_WARNING;
-}
-
-void Component::status_set_warning(const char *message) {
-  this->status_set_warning_flag_();
-  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
-    ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
-             message ? message : LOG_STR_LITERAL("unspecified"));
+  ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
+           message ? message : LOG_STR_LITERAL("unspecified"));
 }
 #ifdef USE_STORE_LOG_STR_IN_FLASH
 void Component::status_set_warning(const LogString *message) {
-  this->status_set_warning_flag_();
+  // Don't spam the log. This risks missing different warning messages though.
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
-    ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
-             message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
+    return;
+  this->component_state_ |= STATUS_LED_WARNING;
+  App.app_state_ |= STATUS_LED_WARNING;
+  ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
+           message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
 #endif
 void Component::status_set_error(const char *message) {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -16,7 +16,6 @@
 namespace esphome {
 
 static const char *const TAG = "component";
-static const auto *const UNSPECIFIED_MESSAGE = LOG_STR("unspecified");
 
 // Global vectors for component data that doesn't belong in every instance.
 // Using vector instead of unordered_map for both because:
@@ -143,7 +142,7 @@ void Component::call_dump_config() {
       }
     }
     ESP_LOGE(TAG, "  %s is marked FAILED: %s", this->get_component_source(),
-             error_msg ? error_msg : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+             error_msg ? error_msg : LOG_STR_LITERAL("unspecified"));
   }
 }
 
@@ -293,14 +292,14 @@ void Component::status_set_warning(const char *message) {
   this->status_set_warning_flag_();
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
     ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
-             message ? message : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+             message ? message : LOG_STR_LITERAL("unspecified"));
 }
 #ifdef USE_STORE_LOG_STR_IN_FLASH
 void Component::status_set_warning(const LogString *message) {
   this->status_set_warning_flag_();
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
     ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
-             message ? LOG_STR_ARG(message) : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+             message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
 #endif
 void Component::status_set_error(const char *message) {
@@ -309,7 +308,7 @@ void Component::status_set_error(const char *message) {
   this->component_state_ |= STATUS_LED_ERROR;
   App.app_state_ |= STATUS_LED_ERROR;
   ESP_LOGE(TAG, "%s set Error flag: %s", this->get_component_source(),
-           message ? message : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+           message ? message : LOG_STR_LITERAL("unspecified"));
   if (message != nullptr) {
     // Lazy allocate the error messages vector if needed
     if (!component_error_messages) {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -289,7 +289,6 @@ void Component::status_set_warning(const char *message) {
   ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
            message ? message : LOG_STR_LITERAL("unspecified"));
 }
-#ifdef USE_STORE_LOG_STR_IN_FLASH
 void Component::status_set_warning(const LogString *message) {
   // Don't spam the log. This risks missing different warning messages though.
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
@@ -299,7 +298,6 @@ void Component::status_set_warning(const LogString *message) {
   ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
-#endif
 void Component::status_set_error(const char *message) {
   if ((this->component_state_ & STATUS_LED_ERROR) != 0)
     return;

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -16,7 +16,7 @@
 namespace esphome {
 
 static const char *const TAG = "component";
-static const char *const UNSPECIFIED_MESSAGE = "unspecified";
+static const auto *const UNSPECIFIED_MESSAGE = LOG_STR("unspecified");
 
 // Global vectors for component data that doesn't belong in every instance.
 // Using vector instead of unordered_map for both because:
@@ -143,7 +143,7 @@ void Component::call_dump_config() {
       }
     }
     ESP_LOGE(TAG, "  %s is marked FAILED: %s", this->get_component_source(),
-             error_msg ? error_msg : UNSPECIFIED_MESSAGE);
+             error_msg ? error_msg : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
   }
 }
 
@@ -280,20 +280,36 @@ bool Component::is_ready() const {
 bool Component::can_proceed() { return true; }
 bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
 bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
-void Component::status_set_warning(const char *message) {
+
+void Component::status_set_warning_flag_() {
   // Don't spam the log. This risks missing different warning messages though.
   if ((this->component_state_ & STATUS_LED_WARNING) != 0)
     return;
   this->component_state_ |= STATUS_LED_WARNING;
   App.app_state_ |= STATUS_LED_WARNING;
-  ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(), message ? message : UNSPECIFIED_MESSAGE);
 }
+
+void Component::status_set_warning(const char *message) {
+  this->status_set_warning_flag_();
+  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
+    ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
+             message ? message : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+}
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+void Component::status_set_warning(const LogString *message) {
+  this->status_set_warning_flag_();
+  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
+    ESP_LOGW(TAG, "%s set Warning flag: %s", this->get_component_source(),
+             message ? LOG_STR_ARG(message) : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
+}
+#endif
 void Component::status_set_error(const char *message) {
   if ((this->component_state_ & STATUS_LED_ERROR) != 0)
     return;
   this->component_state_ |= STATUS_LED_ERROR;
   App.app_state_ |= STATUS_LED_ERROR;
-  ESP_LOGE(TAG, "%s set Error flag: %s", this->get_component_source(), message ? message : UNSPECIFIED_MESSAGE);
+  ESP_LOGE(TAG, "%s set Error flag: %s", this->get_component_source(),
+           message ? message : LOG_STR_ARG(UNSPECIFIED_MESSAGE));
   if (message != nullptr) {
     // Lazy allocate the error messages vector if needed
     if (!component_error_messages) {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -206,9 +206,7 @@ class Component {
   bool status_has_error() const;
 
   void status_set_warning(const char *message = nullptr);
-#ifdef USE_STORE_LOG_STR_IN_FLASH
   void status_set_warning(const LogString *message);
-#endif
 
   void status_set_error(const char *message = nullptr);
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -203,6 +203,9 @@ class Component {
   bool status_has_error() const;
 
   void status_set_warning(const char *message = nullptr);
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  void status_set_warning(const LogString *message);
+#endif
 
   void status_set_error(const char *message = nullptr);
 
@@ -238,6 +241,9 @@ class Component {
 
   /// Helper to set component state (clears state bits and sets new state)
   void set_component_state_(uint8_t state);
+
+  /// Helper to set warning flag without duplicating logic
+  void status_set_warning_flag_();
 
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -245,9 +245,6 @@ class Component {
   /// Helper to set component state (clears state bits and sets new state)
   void set_component_state_(uint8_t state);
 
-  /// Helper to set warning flag without duplicating logic
-  void status_set_warning_flag_();
-
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f every interval ms. Can be cancelled via CancelInterval().

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -9,6 +9,9 @@
 
 namespace esphome {
 
+// Forward declaration for LogString
+struct LogString;
+
 /** Default setup priorities for components of different types.
  *
  * Components should return one of these setup priorities in get_setup_priority.


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes RAM usage on ESP8266 by storing component warning message strings in flash memory (PROGMEM) instead of RAM. The ESP8266 has very limited RAM (80KB) and every byte counts.

### Changes:
1. Added a `LogString*` overload for `Component::status_set_warning()` to support PROGMEM strings on ESP8266
2. Updated WiFi component to use `LOG_STR()` for status warning messages
3. Converted 20+ components to use `LOG_STR()` for their warning messages
4. Wrapped existing `ESP_LOG_MSG_*` constants with `LOG_STR()` for consistency
5. Used `LOG_STR_LITERAL()` for the "unspecified" message in component.cpp

### Impact:
- **Guaranteed RAM savings**: 76 bytes for all ESP8266 builds (core + WiFi)
- **Additional savings**: Up to 1,250+ bytes when using affected components
- **Flash cost**: Minimal increase (~150 bytes)
- **No functional changes**: Identical behavior, just different memory storage

### Technical Details:
The `LOG_STR()` macro on ESP8266 uses the `PSTR()` macro to store strings in flash memory. The new overload allows components to pass `LogString*` pointers directly to `status_set_warning()`, which are then properly accessed using `LOG_STR_ARG()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing ESP8266 memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Example ESP8266 config that benefits from these changes:

esphome:
  name: esp8266-device
  platform: ESP8266
  board: d1_mini

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

# Components that benefit from this optimization:
dallas:
  - pin: GPIO4

sensor:
  - platform: dallas
    address: 0x1234567890ABCDEF
    name: "Temperature"
  
  - platform: aht10
    temperature:
      name: "AHT10 Temperature"
    humidity:
      name: "AHT10 Humidity"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing Results

### Before (baseline):
```
RAM:   [====      ]  38.9% (used 31828 bytes from 81920 bytes)
Flash: [====      ]  38.3% (used 392525 bytes from 1023984 bytes)
```

### After:
```
RAM:   [====      ]  38.8% (used 31752 bytes from 81920 bytes)
Flash: [====      ]  38.3% (used 392613 bytes from 1023984 bytes)
```

### Components Modified:
- `absolute_humidity`
- `aht10`
- `axs15231`
- `bl0942`
- `dallas_temp`
- `ethernet`
- `gdk101`
- `gt911`
- `honeywellabp2_i2c`
- `m5stack_8angle`
- `max17043`
- `mcp23x08_base`
- `mcp23x17_base`
- `pi4ioe5v6408`
- `sgp4x`
- `sht4x`
- `sound_level`
- `tca9555`
- `tmp1075`
- `udp`
- `usb_uart`
- `wake_on_lan`
- `wifi`