### PR TITLE
[core] Skip redundant process_to_add() call when no scheduler items added

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -326,6 +326,9 @@ void HOT Scheduler::call(uint32_t now) {
   const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from Application::loop()
   this->process_to_add();
 
+  // Track if we add any interval items during this call
+  bool added_intervals = false;
+
 #ifdef ESPHOME_DEBUG_SCHEDULER
   static uint64_t last_print = 0;
 
@@ -470,10 +473,14 @@ void HOT Scheduler::call(uint32_t now) {
         // since we have the lock held
         this->to_add_.push_back(std::move(item));
       }
+
+      added_intervals |= this->to_add_.empty() == false;
     }
   }
 
-  this->process_to_add();
+  if (added_intervals) {
+    this->process_to_add();
+  }
 }
 void HOT Scheduler::process_to_add() {
   LockGuard guard{this->lock_};

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -327,7 +327,7 @@ void HOT Scheduler::call(uint32_t now) {
   this->process_to_add();
 
   // Track if any items were added to to_add_ during this call (intervals or from callbacks)
-  bool added_items = false;
+  bool has_added_items = false;
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
   static uint64_t last_print = 0;
@@ -474,11 +474,11 @@ void HOT Scheduler::call(uint32_t now) {
         this->to_add_.push_back(std::move(item));
       }
 
-      added_items |= this->to_add_.empty() == false;
+      has_added_items |= !this->to_add_.empty();
     }
   }
 
-  if (added_items) {
+  if (has_added_items) {
     this->process_to_add();
   }
 }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -474,7 +474,7 @@ void HOT Scheduler::call(uint32_t now) {
         this->to_add_.push_back(std::move(item));
       }
 
-      added_items |= this->to_add_.empty() == false;
+      added_items |= !this->to_add_.empty();
     }
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -326,8 +326,8 @@ void HOT Scheduler::call(uint32_t now) {
   const auto now_64 = this->millis_64_(now);  // 'now' from parameter - fresh from Application::loop()
   this->process_to_add();
 
-  // Track if we add any interval items during this call
-  bool added_intervals = false;
+  // Track if any items were added to to_add_ during this call (intervals or from callbacks)
+  bool added_items = false;
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
   static uint64_t last_print = 0;
@@ -474,11 +474,11 @@ void HOT Scheduler::call(uint32_t now) {
         this->to_add_.push_back(std::move(item));
       }
 
-      added_intervals |= this->to_add_.empty() == false;
+      added_items |= this->to_add_.empty() == false;
     }
   }
 
-  if (added_intervals) {
+  if (added_items) {
     this->process_to_add();
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the scheduler to avoid unnecessary lock acquisition and processing when no items need to be added to the scheduler heap.

The scheduler's `call()` method previously always called `process_to_add()` twice - once at the beginning to process items added between calls, and once at the end to process items added during the current call execution. The second call would always acquire a lock and iterate the `to_add_` vector, even when it was empty.

This change tracks whether any items were actually added to `to_add_` during the current `call()` execution (either interval re-scheduling or new items from callbacks) and only calls `process_to_add()` at the end if needed. This avoids:
- Unnecessary lock acquisition
- Empty vector iteration  
- Function call overhead

This optimization helps in common scenarios where:
- No intervals fire during a particular loop iteration
- Callbacks don't schedule new timeouts/intervals
- Systems primarily use one-shot timeouts rather than intervals

This is particularly beneficial for ESP8266 and other resource-constrained devices where lock operations have measurable overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal optimization with no user-visible changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
