### PR TITLE
[core] Store BASE64 chars in flash memory array

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -374,10 +374,7 @@ int8_t step_to_accuracy_decimals(float step) {
 }
 
 // Store BASE64 characters as array - automatically placed in flash/ROM on embedded platforms
-static const char BASE64_CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-                                    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-                                    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                                    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
+static const char BASE64_CHARS[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
 // Helper function to find the index of a base64 character in the lookup table.
 // Returns the character's position (0-63) if found, or 0 if not found.

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -373,10 +373,11 @@ int8_t step_to_accuracy_decimals(float step) {
   return str.length() - dot_pos - 1;
 }
 
-// Use C-style string constant to store in ROM instead of RAM (saves 24 bytes)
-static constexpr const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                                            "abcdefghijklmnopqrstuvwxyz"
-                                            "0123456789+/";
+// Store BASE64 characters as array - automatically placed in flash/ROM on embedded platforms
+static const char BASE64_CHARS[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                                    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                                    'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                                    'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
 
 // Helper function to find the index of a base64 character in the lookup table.
 // Returns the character's position (0-63) if found, or 0 if not found.
@@ -386,8 +387,8 @@ static constexpr const char *BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 // stops processing at the first invalid character due to the is_base64() check in its
 // while loop condition, making this edge case harmless in practice.
 static inline uint8_t base64_find_char(char c) {
-  const char *pos = strchr(BASE64_CHARS, c);
-  return pos ? (pos - BASE64_CHARS) : 0;
+  const void *ptr = memchr(BASE64_CHARS, c, sizeof(BASE64_CHARS));
+  return ptr ? (static_cast<const char *>(ptr) - BASE64_CHARS) : 0;
 }
 
 static inline bool is_base64(char c) { return (isalnum(c) || (c == '+') || (c == '/')); }


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the BASE64_CHARS storage by using a `static const char[]` array instead of a string literal pointer. The array is automatically placed in flash memory on all platforms while maintaining the same performance.

The change replaces `strchr()` with `memchr()` for character lookups, which benchmarks show has equivalent performance (differences < 5%, within measurement noise).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows similar optimization patterns from #10598 (Store Noise protocol prologue in flash on ESP8266)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

### Changes Made:
- Changed `BASE64_CHARS` from `const char*` to `static const char[]` array
- Replaced `strchr()` with `memchr()` for character lookups

### Performance Impact:
Comprehensive benchmarks show performance is essentially identical (all differences < 5%):
- **Encoding**: Within 1% (noise)
- **Decoding**: Within 4% (noise)
- **Character lookup**: Within 5% (noise)

### Memory Impact:
- **ESP8266**: Potential RAM savings when BASE64 is used (array stored in flash)
- **ESP32 & others**: No change (const data already in flash)

### Code Quality:
- Consistent approach across all platforms
- Works uniformly without special handling
