### PR TITLE
[core] Convert LOG_UPDATE_INTERVAL macro to function to reduce flash usage

### DIFF
--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -493,7 +493,7 @@ void BedJetHub::dump_config() {
                 "  ble_client.app_id: %d\n"
                 "  ble_client.conn_id: %d",
                 this->get_name().c_str(), this->parent()->app_id, this->parent()->get_conn_id());
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG, "  Child components (%d):", this->children_.size());
   for (auto *child : this->children_) {
     ESP_LOGCONFIG(TAG, "    - %s", child->describe().c_str());

--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -152,7 +152,7 @@ void CCS811Component::send_env_data_() {
 void CCS811Component::dump_config() {
   ESP_LOGCONFIG(TAG, "CCS811");
   LOG_I2C_DEVICE(this)
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "CO2 Sensor", this->co2_);
   LOG_SENSOR("  ", "TVOC Sensor", this->tvoc_);
   LOG_TEXT_SENSOR("  ", "Firmware Version Sensor", this->version_)

--- a/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.cpp
+++ b/esphome/components/grove_gas_mc_v2/grove_gas_mc_v2.cpp
@@ -57,7 +57,7 @@ void GroveGasMultichannelV2Component::update() {
 void GroveGasMultichannelV2Component::dump_config() {
   ESP_LOGCONFIG(TAG, "Grove Multichannel Gas Sensor V2");
   LOG_I2C_DEVICE(this)
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Nitrogen Dioxide", this->nitrogen_dioxide_sensor_);
   LOG_SENSOR("  ", "Ethanol", this->ethanol_sensor_);
   LOG_SENSOR("  ", "Carbon Monoxide", this->carbon_monoxide_sensor_);

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -42,7 +42,7 @@ void HLW8012Component::dump_config() {
                 "  Current resistor: %.1f mΩ\n"
                 "  Voltage Divider: %.1f",
                 this->change_mode_every_, this->current_resistor_ * 1000.0f, this->voltage_divider_);
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Current", this->current_sensor_);
   LOG_SENSOR("  ", "Power", this->power_sensor_);

--- a/esphome/components/pulse_width/pulse_width.cpp
+++ b/esphome/components/pulse_width/pulse_width.cpp
@@ -18,7 +18,7 @@ void IRAM_ATTR PulseWidthSensorStore::gpio_intr(PulseWidthSensorStore *arg) {
 
 void PulseWidthSensor::dump_config() {
   LOG_SENSOR("", "Pulse Width", this);
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_PIN("  Pin: ", this->pin_);
 }
 void PulseWidthSensor::update() {

--- a/esphome/components/ufire_ec/ufire_ec.cpp
+++ b/esphome/components/ufire_ec/ufire_ec.cpp
@@ -104,7 +104,7 @@ void UFireECComponent::write_data_(uint8_t reg, float data) {
 void UFireECComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "uFire-EC");
   LOG_I2C_DEVICE(this)
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "EC Sensor", this->ec_sensor_);
   LOG_SENSOR("  ", "Temperature Sensor", this->temperature_sensor_);
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_);

--- a/esphome/components/ufire_ise/ufire_ise.cpp
+++ b/esphome/components/ufire_ise/ufire_ise.cpp
@@ -141,7 +141,7 @@ void UFireISEComponent::write_data_(uint8_t reg, float data) {
 void UFireISEComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "uFire-ISE");
   LOG_I2C_DEVICE(this)
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "PH Sensor", this->ph_sensor_);
   LOG_SENSOR("  ", "Temperature Sensor", this->temperature_sensor_);
   LOG_SENSOR("  ", "Temperature Sensor external", this->temperature_sensor_external_);

--- a/esphome/components/waveshare_epaper/waveshare_213v3.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_213v3.cpp
@@ -181,7 +181,7 @@ void WaveshareEPaper2P13InV3::dump_config() {
   LOG_PIN("  Reset Pin: ", this->reset_pin_)
   LOG_PIN("  DC Pin: ", this->dc_pin_)
   LOG_PIN("  Busy Pin: ", this->busy_pin_)
-  LOG_UPDATE_INTERVAL(this)
+  LOG_UPDATE_INTERVAL(this);
 }
 
 void WaveshareEPaper2P13InV3::set_full_update_every(uint32_t full_update_every) {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -342,6 +342,18 @@ void Component::status_momentary_error(const std::string &name, uint32_t length)
   this->set_timeout(name, length, [this]() { this->status_clear_error(); });
 }
 void Component::dump_config() {}
+
+// Function implementation of LOG_UPDATE_INTERVAL macro to reduce code size
+void log_update_interval(const char *tag, PollingComponent *component) {
+  uint32_t update_interval = component->get_update_interval();
+  if (update_interval == SCHEDULER_DONT_RUN) {
+    ESP_LOGCONFIG(tag, "  Update Interval: never");
+  } else if (update_interval < 100) {
+    ESP_LOGCONFIG(tag, "  Update Interval: %.3fs", update_interval / 1000.0f);
+  } else {
+    ESP_LOGCONFIG(tag, "  Update Interval: %.1fs", update_interval / 1000.0f);
+  }
+}
 float Component::get_actual_setup_priority() const {
   // Check if there's an override in the global vector
   if (setup_priority_overrides) {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -47,14 +47,13 @@ extern const float LATE;
 
 static const uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
 
-#define LOG_UPDATE_INTERVAL(this) \
-  if (this->get_update_interval() == SCHEDULER_DONT_RUN) { \
-    ESP_LOGCONFIG(TAG, "  Update Interval: never"); \
-  } else if (this->get_update_interval() < 100) { \
-    ESP_LOGCONFIG(TAG, "  Update Interval: %.3fs", this->get_update_interval() / 1000.0f); \
-  } else { \
-    ESP_LOGCONFIG(TAG, "  Update Interval: %.1fs", this->get_update_interval() / 1000.0f); \
-  }
+// Forward declaration
+class PollingComponent;
+
+// Function declaration for LOG_UPDATE_INTERVAL
+void log_update_interval(const char *tag, PollingComponent *component);
+
+#define LOG_UPDATE_INTERVAL(this) log_update_interval(TAG, this)
 
 extern const uint8_t COMPONENT_STATE_MASK;
 extern const uint8_t COMPONENT_STATE_CONSTRUCTION;


### PR DESCRIPTION
# What does this implement/fix?

This PR converts the `LOG_UPDATE_INTERVAL` macro to a function to reduce flash memory usage on ESP devices, similar to the optimization done for `LOG_SENSOR` in #10290.

The `LOG_UPDATE_INTERVAL` macro is used extensively throughout the codebase (200+ files) to log component update intervals. By converting it from a macro that expands inline to a function call, we consolidate the logging code into a single implementation, significantly reducing flash usage.

**Impact:**
- **Flash savings:** ~884 bytes on ESP32 (scales with number of components using the macro)
- **RAM usage:** No change
- **Functionality:** No change - identical output

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- Related to memory optimization efforts for ESP8266 and other flash-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# Example showing components that benefit from this optimization:

sensor:
  - platform: bh1750
    name: "BH1750 Illuminance"
    update_interval: 10s
    
  - platform: adc
    pin: 34
    name: "ADC Voltage"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Technical Details

### Changes Made:
1. Added `log_update_interval()` function in `esphome/core/component.cpp`
2. Modified `LOG_UPDATE_INTERVAL` macro in `esphome/core/component.h` to call the new function
3. Updated all usage sites to add semicolons after `LOG_UPDATE_INTERVAL()` calls (required when converting from macro to function call)

### Memory Test Results (ESP32):
```
Before:
RAM:   [=         ]  13.1% (used 42836 bytes from 327680 bytes)
Flash: [======    ]  60.5% (used 1110910 bytes from 1835008 bytes)

After:
RAM:   [=         ]  13.1% (used 42836 bytes from 327680 bytes)
Flash: [======    ]  60.5% (used 1110026 bytes from 1835008 bytes)

Savings: 884 bytes of flash
```

The savings scale with the number of components using `LOG_UPDATE_INTERVAL` - projects with more polling components will see larger savings.