### PR TITLE
[core] Fix serial upload regression from DNS resolution PR #10595

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -554,7 +554,7 @@ def command_upload(args: ArgsProtocol, config: ConfigType) -> int | None:
         purpose="uploading",
     )
 
-    exit_code, successful_device = upload_program(config, args, devices)
+    exit_code, _ = upload_program(config, args, devices)
     if exit_code == 0:
         _LOGGER.info("Successfully uploaded program.")
     else:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -398,28 +398,29 @@ def check_permissions(port: str):
 
 def upload_program(
     config: ConfigType, args: ArgsProtocol, devices: list[str]
-) -> int | str:
+) -> tuple[int, str | None]:
     host = devices[0]
     try:
         module = importlib.import_module("esphome.components." + CORE.target_platform)
         if getattr(module, "upload_program")(config, args, host):
-            return 0
+            return 0, host
     except AttributeError:
         pass
 
     if get_port_type(host) == "SERIAL":
         check_permissions(host)
+
+        exit_code = 1
         if CORE.target_platform in (PLATFORM_ESP32, PLATFORM_ESP8266):
             file = getattr(args, "file", None)
-            return upload_using_esptool(config, host, file, args.upload_speed)
+            exit_code = upload_using_esptool(config, host, file, args.upload_speed)
+        elif CORE.target_platform == PLATFORM_RP2040 or CORE.is_libretiny:
+            exit_code = upload_using_platformio(config, host)
+        else:
+            # Unknown target platform
+            pass
 
-        if CORE.target_platform in (PLATFORM_RP2040):
-            return upload_using_platformio(config, host)
-
-        if CORE.is_libretiny:
-            return upload_using_platformio(config, host)
-
-        return 1  # Unknown target platform
+        return exit_code, host if exit_code == 0 else None
 
     ota_conf = {}
     for ota_item in config.get(CONF_OTA, []):
@@ -553,7 +554,7 @@ def command_upload(args: ArgsProtocol, config: ConfigType) -> int | None:
         purpose="uploading",
     )
 
-    exit_code = upload_program(config, args, devices)
+    exit_code, successful_device = upload_program(config, args, devices)
     if exit_code == 0:
         _LOGGER.info("Successfully uploaded program.")
     else:
@@ -610,19 +611,11 @@ def command_run(args: ArgsProtocol, config: ConfigType) -> int | None:
         purpose="uploading",
     )
 
-    # Try each device for upload until one succeeds
-    successful_device: str | None = None
-    for device in devices:
-        _LOGGER.info("Uploading to %s", device)
-        exit_code = upload_program(config, args, device)
-        if exit_code == 0:
-            _LOGGER.info("Successfully uploaded program.")
-            successful_device = device
-            break
-        if len(devices) > 1:
-            _LOGGER.warning("Failed to upload to %s", device)
-
-    if successful_device is None:
+    exit_code, successful_device = upload_program(config, args, devices)
+    if exit_code == 0:
+        _LOGGER.info("Successfully uploaded program.")
+    else:
+        _LOGGER.warning("Failed to upload to %s", devices)
         return exit_code
 
     if args.no_logs:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -416,9 +416,7 @@ def upload_program(
             exit_code = upload_using_esptool(config, host, file, args.upload_speed)
         elif CORE.target_platform == PLATFORM_RP2040 or CORE.is_libretiny:
             exit_code = upload_using_platformio(config, host)
-        else:
-            # Unknown target platform
-            pass
+        # else: Unknown target platform, exit_code remains 1
 
         return exit_code, host if exit_code == 0 else None
 

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -310,7 +310,7 @@ def perform_ota(
 
 def run_ota_impl_(
     remote_host: str | list[str], remote_port: int, password: str, filename: str
-) -> int:
+) -> tuple[int, str | None]:
     # Handle both single host and list of hosts
     try:
         # Resolve all hosts at once for parallel DNS resolution
@@ -344,21 +344,22 @@ def run_ota_impl_(
                 perform_ota(sock, password, file_handle, filename)
             except OTAError as err:
                 _LOGGER.error(str(err))
-                return 1
+                return 1, None
             finally:
                 sock.close()
 
-        return 0
+        # Successfully uploaded to sa[0]
+        return 0, sa[0]
 
     _LOGGER.error("Connection failed.")
-    return 1
+    return 1, None
 
 
 def run_ota(
     remote_host: str | list[str], remote_port: int, password: str, filename: str
-) -> int:
+) -> tuple[int, str | None]:
     try:
         return run_ota_impl_(remote_host, remote_port, password, filename)
     except OTAError as err:
         _LOGGER.error(err)
-        return 1
+        return 1, None


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a regression introduced in #10595 where serial/USB uploads fail on macOS (and potentially other platforms) with a permissions error. The issue was caused by `command_run` passing individual device strings to `upload_program` instead of a list, which caused serial port paths to be incorrectly parsed character by character.

Additionally, this PR improves the upload and logging flow by:
- Modifying `upload_program` to return both the exit code and the successful device
- Using the successful device for subsequent log connections (avoiding unnecessary retries)
- Cleaning up duplicated code in the serial upload path

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes regression from #10595

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this fixes existing upload functionality
esphome:
  name: test-device

esp32:
  board: esp32dev

# Serial upload via USB should work correctly after this fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

## Technical Details

The main changes are:

1. **Fixed `command_run` to match the pattern from #10595**: Now passes the full devices list to `upload_program` instead of iterating and passing individual strings.

2. **Enhanced `upload_program` return value**: Now returns `tuple[int, str | None]` with the exit code and the successful device (or None if failed).

3. **Updated `espota2.run_ota`**: Modified to track and return which host successfully received the OTA update.

4. **Code cleanup**: Consolidated duplicated serial upload code paths for different platforms.

This ensures that:
- Serial port paths like `/dev/tty.usbserial-*` are correctly handled as single strings
- The successful upload device is used for log connections (more efficient)
- The code is cleaner and more maintainable