### PR TITLE
[core] Refactor insertion sort functions to eliminate code duplication

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -34,37 +34,20 @@ namespace esphome {
 
 static const char *const TAG = "app";
 
-// Helper function for insertion sort of components by setup priority
+// Helper function for insertion sort of components by priority
 // Using insertion sort instead of std::stable_sort saves ~1.3KB of flash
 // by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)
 // IMPORTANT: This sort is stable (preserves relative order of equal elements),
 // which is necessary to maintain user-defined component order for same priority
-template<typename Iterator> static void insertion_sort_by_setup_priority(Iterator first, Iterator last) {
+template<typename Iterator, float (Component::*GetPriority)() const>
+static void insertion_sort_by_priority(Iterator first, Iterator last) {
   for (auto it = first + 1; it != last; ++it) {
     auto key = *it;
-    float key_priority = key->get_actual_setup_priority();
+    float key_priority = (key->*GetPriority)();
     auto j = it - 1;
 
     // Using '<' (not '<=') ensures stability - equal priority components keep their order
-    while (j >= first && (*j)->get_actual_setup_priority() < key_priority) {
-      *(j + 1) = *j;
-      j--;
-    }
-    *(j + 1) = key;
-  }
-}
-
-// Helper function for insertion sort of components by loop priority
-// IMPORTANT: This sort is stable (preserves relative order of equal elements),
-// which is required when components are re-sorted during setup() if they block
-template<typename Iterator> static void insertion_sort_by_loop_priority(Iterator first, Iterator last) {
-  for (auto it = first + 1; it != last; ++it) {
-    auto key = *it;
-    float key_priority = key->get_loop_priority();
-    auto j = it - 1;
-
-    // Using '<' (not '<=') ensures stability - equal priority components keep their order
-    while (j >= first && (*j)->get_loop_priority() < key_priority) {
+    while (j >= first && ((*j)->*GetPriority)() < key_priority) {
       *(j + 1) = *j;
       j--;
     }
@@ -91,7 +74,8 @@ void Application::setup() {
   ESP_LOGV(TAG, "Sorting components by setup priority");
 
   // Sort by setup priority using our helper function
-  insertion_sort_by_setup_priority(this->components_.begin(), this->components_.end());
+  insertion_sort_by_priority<decltype(this->components_.begin()), &Component::get_actual_setup_priority>(
+      this->components_.begin(), this->components_.end());
 
   // Initialize looping_components_ early so enable_pending_loops_() works during setup
   this->calculate_looping_components_();
@@ -108,7 +92,8 @@ void Application::setup() {
       continue;
 
     // Sort components 0 through i by loop priority
-    insertion_sort_by_loop_priority(this->components_.begin(), this->components_.begin() + i + 1);
+    insertion_sort_by_priority<decltype(this->components_.begin()), &Component::get_loop_priority>(
+        this->components_.begin(), this->components_.begin() + i + 1);
 
     do {
       uint8_t new_app_state = STATUS_LED_WARNING;


### PR DESCRIPTION
# What does this implement/fix?

Refactors the insertion sort implementation in Application to eliminate code duplication by combining `insertion_sort_by_setup_priority` and `insertion_sort_by_loop_priority` into a single template function `insertion_sort_by_priority` that accepts a member function pointer as a template parameter.

This change maintains the exact same functionality while reducing code duplication and improving maintainability. The template parameter approach allows the compiler to optimize the function calls effectively, resulting in no change to memory usage.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal implementation detail, no user-facing changes

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
