### PR TITLE
[ili9xxx] Runtime display rotation

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -53,6 +53,8 @@ void ILI9XXXDisplay::setup() {
       break;
   }
 
+  this->is_initialized_ = true;
+
   this->set_madctl();
   this->command(this->pre_invertcolors_ ? ILI9XXX_INVON : ILI9XXX_INVOFF);
   this->x_low_ = this->width_;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -89,18 +89,21 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
       this->set_madctl();
     }
   }
+  bool get_swap_xy() { return this->swap_xy_; }
   void set_mirror_x(bool mirror_x) {
     this->mirror_x_ = mirror_x;
     if (this->is_initialized_) {
       this->set_madctl();
     }
   }
+  bool get_mirror_x() { return this->mirror_x_; }
   void set_mirror_y(bool mirror_y) {
     this->mirror_y_ = mirror_y;
     if (this->is_initialized_) {
       this->set_madctl();
     }
   }
+  bool get_mirror_y() { return this->mirror_y_; }
   void set_pixel_mode(PixelMode mode) { this->pixel_mode_ = mode; }
 
   void update() override;

--- a/esphome/components/ili9xxx/ili9xxx_display.h
+++ b/esphome/components/ili9xxx/ili9xxx_display.h
@@ -77,10 +77,30 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   virtual void command(uint8_t value);
   virtual void data(uint8_t value);
   void send_command(uint8_t command_byte, const uint8_t *data_bytes, uint8_t num_data_bytes);
-  void set_color_order(display::ColorOrder color_order) { this->color_order_ = color_order; }
-  void set_swap_xy(bool swap_xy) { this->swap_xy_ = swap_xy; }
-  void set_mirror_x(bool mirror_x) { this->mirror_x_ = mirror_x; }
-  void set_mirror_y(bool mirror_y) { this->mirror_y_ = mirror_y; }
+  void set_color_order(display::ColorOrder color_order) {
+    this->color_order_ = color_order;
+    if (this->is_initialized_) {
+      this->set_madctl();
+    }
+  }
+  void set_swap_xy(bool swap_xy) {
+    this->swap_xy_ = swap_xy;
+    if (this->is_initialized_) {
+      this->set_madctl();
+    }
+  }
+  void set_mirror_x(bool mirror_x) {
+    this->mirror_x_ = mirror_x;
+    if (this->is_initialized_) {
+      this->set_madctl();
+    }
+  }
+  void set_mirror_y(bool mirror_y) {
+    this->mirror_y_ = mirror_y;
+    if (this->is_initialized_) {
+      this->set_madctl();
+    }
+  }
   void set_pixel_mode(PixelMode mode) { this->pixel_mode_ = mode; }
 
   void update() override;
@@ -151,6 +171,9 @@ class ILI9XXXDisplay : public display::DisplayBuffer,
   bool swap_xy_{};
   bool mirror_x_{};
   bool mirror_y_{};
+
+ private:
+  bool is_initialized_ = false;
 };
 
 //-----------   M5Stack display --------------


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a few minor changes to the `ili9xxx` platform to enable screen rotation manipulation during runtime.

ILI9xxx handles screen orientation in hardware - during init, MADCTL is set to specific values depending on the four parameters `color_order`, `swap_xy`, `mirror_x` and `mirror_y` (technically also refresh direction, but this is not exposed to ESPHome at the moment, or utilised at all).

To handle this during runtime, `set_madctl()` needs to be called on the display. I've opted to instead apply the changes within the four parameters' getter method, to ensure the display actually updates.

I am looking for feedback on two main aspects:
- the usage of a simple boolean field to ensure `set_madctl` is not called before the display is initialised - any recommendation for another approach to check for this initialisation status is most welcome, as I find this a quite dirty solution
- sending `set_madctl()` immediately after a setter method is called - while this works, in many cases it will result in multiple resets of MADCTL right after another. If `set_madctl()` was made public and the users were to handle the refresh themselves, this could be avoided, but I'm not comfortable exposing an internal method for everyone to abuse, but I also don't see the point in writing an event accumulator/reducer implementation here (debouncing the `set_madctl()` call by 50-80ms to allow for other setters). Recommendations on this are also most welcome.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here> - WIP

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: ili9xxx
    id: main_display
	[...]

switch:
  - platform: template
    name: "Display Swap XY"
    id: display_swap_xy_switch
    icon: mdi:arrow-top-left-bottom-right
    restore_mode: RESTORE_DEFAULT_OFF
    lambda: |-
      return id(main_display)->get_swap_xy();
    turn_on_action:
      then:
        - lambda: |-
            id(main_display)->set_swap_xy(true);
    turn_off_action:
      then:
        - lambda: |-
            id(main_display)->set_swap_xy(false);
  - platform: template
    name: "Display Mirror X"
    id: display_mirror_x_switch
    icon: mdi:mirror-rectangle
    restore_mode: RESTORE_DEFAULT_OFF
    lambda: |-
      return id(main_display)->get_mirror_x();
    turn_on_action:
      then:
        - lambda: |-
            id(main_display)->set_mirror_x(true);
    turn_off_action:
      then:
        - lambda: |-
            id(main_display)->set_mirror_x(false);
  - platform: template
    name: "Display Mirror Y"
    id: display_mirror_y_switch
    icon: mdi:mirror-rectangle
    restore_mode: RESTORE_DEFAULT_OFF
    lambda: |-
      return id(main_display)->get_mirror_y();
    turn_on_action:
      then:
        - lambda: |-
            id(main_display)->set_mirror_y(true);
    turn_off_action:
      then:
        - lambda: |-
            id(main_display)->set_mirror_y(false);

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
