### PR TITLE
[thermostat] Rename timer enums to mitigate naming conflict

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -14,17 +14,17 @@ namespace esphome {
 namespace thermostat {
 
 enum ThermostatClimateTimerIndex : uint8_t {
-  TIMER_COOLING_MAX_RUN_TIME = 0,
-  TIMER_COOLING_OFF = 1,
-  TIMER_COOLING_ON = 2,
-  TIMER_FAN_MODE = 3,
-  TIMER_FANNING_OFF = 4,
-  TIMER_FANNING_ON = 5,
-  TIMER_HEATING_MAX_RUN_TIME = 6,
-  TIMER_HEATING_OFF = 7,
-  TIMER_HEATING_ON = 8,
-  TIMER_IDLE_ON = 9,
-  TIMER_COUNT = 10,
+  THERMOSTAT_TIMER_COOLING_MAX_RUN_TIME = 0,
+  THERMOSTAT_TIMER_COOLING_OFF = 1,
+  THERMOSTAT_TIMER_COOLING_ON = 2,
+  THERMOSTAT_TIMER_FAN_MODE = 3,
+  THERMOSTAT_TIMER_FANNING_OFF = 4,
+  THERMOSTAT_TIMER_FANNING_ON = 5,
+  THERMOSTAT_TIMER_HEATING_MAX_RUN_TIME = 6,
+  THERMOSTAT_TIMER_HEATING_OFF = 7,
+  THERMOSTAT_TIMER_HEATING_ON = 8,
+  THERMOSTAT_TIMER_IDLE_ON = 9,
+  THERMOSTAT_TIMER_COUNT = 10,
 };
 
 enum OnBootRestoreFrom : uint8_t {
@@ -467,7 +467,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   std::string default_custom_preset_{};
 
   /// Climate action timers
-  std::array<ThermostatClimateTimer, TIMER_COUNT> timer_{
+  std::array<ThermostatClimateTimer, THERMOSTAT_TIMER_COUNT> timer_{
       ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_max_run_time_timer_callback_, this)),
       ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_off_timer_callback_, this)),
       ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_on_timer_callback_, this)),


### PR DESCRIPTION
# What does this implement/fix?

SSIA

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
