### PR TITLE
Add coverage for dashboard ahead of Path conversion

### DIFF
--- a/tests/dashboard/test_entries.py
+++ b/tests/dashboard/test_entries.py
@@ -55,7 +55,8 @@ def test_dashboard_entry_path_initialization() -> None:
 
 def test_dashboard_entry_path_with_absolute_path() -> None:
     """Test DashboardEntry handles absolute paths."""
-    test_path = Path("/absolute/path/to/config.yaml")
+    # Use a truly absolute path for the platform
+    test_path = Path.cwd() / "absolute" / "path" / "to" / "config.yaml"
     cache_key = create_cache_key()
 
     entry = DashboardEntry(str(test_path), cache_key)

--- a/tests/dashboard/test_entries.py
+++ b/tests/dashboard/test_entries.py
@@ -1,0 +1,214 @@
+"""Tests for dashboard entries Path-related functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from esphome.core import CORE
+from esphome.dashboard.entries import DashboardEntries, DashboardEntry
+
+
+def create_cache_key() -> tuple[int, int, float, int]:
+    """Helper to create a valid DashboardCacheKeyType."""
+    return (0, 0, 0.0, 0)
+
+
+@pytest.fixture(autouse=True)
+def setup_core():
+    """Set up CORE for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        CORE.config_path = str(Path(tmpdir) / "test.yaml")
+        yield
+        CORE.reset()
+
+
+@pytest.fixture
+def mock_settings() -> MagicMock:
+    """Create mock dashboard settings."""
+    settings = MagicMock()
+    settings.config_dir = "/test/config"
+    settings.absolute_config_dir = Path("/test/config")
+    return settings
+
+
+@pytest_asyncio.fixture
+async def dashboard_entries(mock_settings: MagicMock) -> DashboardEntries:
+    """Create a DashboardEntries instance for testing."""
+    # DashboardEntries needs a running event loop
+    return DashboardEntries(mock_settings)
+
+
+def test_dashboard_entry_path_initialization() -> None:
+    """Test DashboardEntry initializes with path correctly."""
+    test_path = "/test/config/device.yaml"
+    cache_key = (
+        create_cache_key()
+    )  # DashboardCacheKeyType is tuple[int, int, float, int]
+
+    entry = DashboardEntry(test_path, cache_key)
+
+    assert entry.path == test_path
+    assert entry.cache_key == cache_key
+
+
+def test_dashboard_entry_path_with_absolute_path() -> None:
+    """Test DashboardEntry handles absolute paths."""
+    test_path = Path("/absolute/path/to/config.yaml")
+    cache_key = create_cache_key()
+
+    entry = DashboardEntry(str(test_path), cache_key)
+
+    assert entry.path == str(test_path)
+    assert Path(entry.path).is_absolute()
+
+
+def test_dashboard_entry_path_with_relative_path() -> None:
+    """Test DashboardEntry handles relative paths."""
+    test_path = "configs/device.yaml"
+    cache_key = create_cache_key()
+
+    entry = DashboardEntry(test_path, cache_key)
+
+    assert entry.path == test_path
+    assert not Path(entry.path).is_absolute()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_get_by_path(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test getting entry by path."""
+    test_path = "/test/config/device.yaml"
+    entry = DashboardEntry(test_path, create_cache_key())
+
+    # Add entry to internal storage
+    dashboard_entries._entries[test_path] = entry
+
+    result = dashboard_entries.get(test_path)
+    assert result == entry
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_get_nonexistent_path(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test getting non-existent entry returns None."""
+    result = dashboard_entries.get("/nonexistent/path.yaml")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_path_normalization(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test that paths are handled consistently."""
+    path1 = "/test/config/device.yaml"
+
+    entry = DashboardEntry(path1, create_cache_key())
+    dashboard_entries._entries[path1] = entry
+
+    # Should get the same entry with normalized path
+    result = dashboard_entries.get(path1)
+    assert result == entry
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_path_with_spaces(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test handling paths with spaces."""
+    test_path = "/test/config/my device.yaml"
+    entry = DashboardEntry(test_path, create_cache_key())
+
+    dashboard_entries._entries[test_path] = entry
+
+    result = dashboard_entries.get(test_path)
+    assert result == entry
+    assert result.path == test_path
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_path_with_special_chars(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test handling paths with special characters."""
+    test_path = "/test/config/device-01_test.yaml"
+    entry = DashboardEntry(test_path, create_cache_key())
+
+    dashboard_entries._entries[test_path] = entry
+
+    result = dashboard_entries.get(test_path)
+    assert result == entry
+
+
+def test_dashboard_entries_windows_path() -> None:
+    """Test handling Windows-style paths."""
+    test_path = r"C:\Users\test\esphome\device.yaml"
+    cache_key = create_cache_key()
+
+    entry = DashboardEntry(test_path, cache_key)
+
+    assert entry.path == test_path
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_path_to_cache_key_mapping(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test internal entries storage with paths and cache keys."""
+    path1 = "/test/config/device1.yaml"
+    path2 = "/test/config/device2.yaml"
+
+    entry1 = DashboardEntry(path1, create_cache_key())
+    entry2 = DashboardEntry(path2, (1, 1, 1.0, 1))  # Different cache key
+
+    dashboard_entries._entries[path1] = entry1
+    dashboard_entries._entries[path2] = entry2
+
+    # Verify entries are stored correctly with their paths and cache keys
+    assert path1 in dashboard_entries._entries
+    assert path2 in dashboard_entries._entries
+    assert dashboard_entries._entries[path1].cache_key == create_cache_key()
+    assert dashboard_entries._entries[path2].cache_key == (
+        1,
+        1,
+        1.0,
+        1,
+    )  # Different cache key
+
+
+def test_dashboard_entry_path_property() -> None:
+    """Test that path property returns expected value."""
+    test_path = "/test/config/device.yaml"
+    entry = DashboardEntry(test_path, create_cache_key())
+
+    assert entry.path == test_path
+    # Verify path is stored as string
+    assert isinstance(entry.path, str)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_entries_all_returns_entries_with_paths(
+    dashboard_entries: DashboardEntries,
+) -> None:
+    """Test that all() returns entries with their paths intact."""
+    paths = [
+        "/test/config/device1.yaml",
+        "/test/config/device2.yaml",
+        "/test/config/subfolder/device3.yaml",
+    ]
+
+    for path in paths:
+        entry = DashboardEntry(path, create_cache_key())
+        dashboard_entries._entries[path] = entry
+
+    all_entries = dashboard_entries.async_all()
+
+    assert len(all_entries) == len(paths)
+    retrieved_paths = [entry.path for entry in all_entries]
+    assert set(retrieved_paths) == set(paths)

--- a/tests/dashboard/test_entries.py
+++ b/tests/dashboard/test_entries.py
@@ -39,16 +39,13 @@ def mock_settings() -> MagicMock:
 @pytest_asyncio.fixture
 async def dashboard_entries(mock_settings: MagicMock) -> DashboardEntries:
     """Create a DashboardEntries instance for testing."""
-    # DashboardEntries needs a running event loop
     return DashboardEntries(mock_settings)
 
 
 def test_dashboard_entry_path_initialization() -> None:
     """Test DashboardEntry initializes with path correctly."""
     test_path = "/test/config/device.yaml"
-    cache_key = (
-        create_cache_key()
-    )  # DashboardCacheKeyType is tuple[int, int, float, int]
+    cache_key = create_cache_key()
 
     entry = DashboardEntry(test_path, cache_key)
 
@@ -86,7 +83,6 @@ async def test_dashboard_entries_get_by_path(
     test_path = "/test/config/device.yaml"
     entry = DashboardEntry(test_path, create_cache_key())
 
-    # Add entry to internal storage
     dashboard_entries._entries[test_path] = entry
 
     result = dashboard_entries.get(test_path)
@@ -112,7 +108,6 @@ async def test_dashboard_entries_path_normalization(
     entry = DashboardEntry(path1, create_cache_key())
     dashboard_entries._entries[path1] = entry
 
-    # Should get the same entry with normalized path
     result = dashboard_entries.get(path1)
     assert result == entry
 
@@ -165,21 +160,15 @@ async def test_dashboard_entries_path_to_cache_key_mapping(
     path2 = "/test/config/device2.yaml"
 
     entry1 = DashboardEntry(path1, create_cache_key())
-    entry2 = DashboardEntry(path2, (1, 1, 1.0, 1))  # Different cache key
+    entry2 = DashboardEntry(path2, (1, 1, 1.0, 1))
 
     dashboard_entries._entries[path1] = entry1
     dashboard_entries._entries[path2] = entry2
 
-    # Verify entries are stored correctly with their paths and cache keys
     assert path1 in dashboard_entries._entries
     assert path2 in dashboard_entries._entries
     assert dashboard_entries._entries[path1].cache_key == create_cache_key()
-    assert dashboard_entries._entries[path2].cache_key == (
-        1,
-        1,
-        1.0,
-        1,
-    )  # Different cache key
+    assert dashboard_entries._entries[path2].cache_key == (1, 1, 1.0, 1)
 
 
 def test_dashboard_entry_path_property() -> None:
@@ -188,7 +177,6 @@ def test_dashboard_entry_path_property() -> None:
     entry = DashboardEntry(test_path, create_cache_key())
 
     assert entry.path == test_path
-    # Verify path is stored as string
     assert isinstance(entry.path, str)
 
 

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -11,18 +11,11 @@ from esphome.dashboard.settings import DashboardSettings
 
 
 @pytest.fixture
-def temp_config_dir() -> Path:
-    """Create a temporary config directory."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield Path(tmpdir)
-
-
-@pytest.fixture
-def dashboard_settings(temp_config_dir: Path) -> DashboardSettings:
+def dashboard_settings(tmp_path: Path) -> DashboardSettings:
     """Create DashboardSettings instance with temp directory."""
     settings = DashboardSettings()
     # Resolve symlinks to ensure paths match
-    resolved_dir = temp_config_dir.resolve()
+    resolved_dir = tmp_path.resolve()
     settings.config_dir = str(resolved_dir)
     settings.absolute_config_dir = resolved_dir
     return settings
@@ -59,10 +52,7 @@ def test_rel_path_absolute_path_within_config(
     """Test rel_path with absolute path that's within config dir."""
     internal_path = dashboard_settings.absolute_config_dir / "internal.yaml"
 
-    # Create the file so path resolution works
     internal_path.touch()
-
-    # This should work as the absolute path is within config_dir
     result = dashboard_settings.rel_path("internal.yaml")
     expected = str(Path(dashboard_settings.config_dir) / "internal.yaml")
     assert result == expected
@@ -95,13 +85,8 @@ def test_rel_path_with_pathlib_path(dashboard_settings: DashboardSettings) -> No
 
 def test_rel_path_normalizes_slashes(dashboard_settings: DashboardSettings) -> None:
     """Test rel_path normalizes path separators."""
-    # Test with forward slashes
     result1 = dashboard_settings.rel_path("folder/subfolder/file.yaml")
-
-    # Test with backslashes (on Windows)
     result2 = dashboard_settings.rel_path("folder", "subfolder", "file.yaml")
-
-    # Both should produce the same normalized path
     assert result1 == result2
 
 
@@ -142,15 +127,10 @@ def test_absolute_config_dir_property(dashboard_settings: DashboardSettings) -> 
 
 def test_rel_path_symlink_inside_config(dashboard_settings: DashboardSettings) -> None:
     """Test rel_path with symlink that points inside config dir."""
-    # Create a target file inside config dir
     target = dashboard_settings.absolute_config_dir / "target.yaml"
     target.touch()
-
-    # Create a symlink pointing to it
     symlink = dashboard_settings.absolute_config_dir / "link.yaml"
     symlink.symlink_to(target)
-
-    # This should work as the symlink target is within config_dir
     result = dashboard_settings.rel_path("link.yaml")
     expected = str(Path(dashboard_settings.config_dir) / "link.yaml")
     assert result == expected
@@ -159,18 +139,14 @@ def test_rel_path_symlink_inside_config(dashboard_settings: DashboardSettings) -
 def test_rel_path_symlink_outside_config(dashboard_settings: DashboardSettings) -> None:
     """Test rel_path with symlink that points outside config dir."""
     with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
-        # Create a symlink pointing outside config dir
         symlink = dashboard_settings.absolute_config_dir / "external_link.yaml"
         symlink.symlink_to(tmp.name)
-
-        # This should raise ValueError as the resolved path is outside config_dir
         with pytest.raises(ValueError):
             dashboard_settings.rel_path("external_link.yaml")
 
 
 def test_rel_path_with_none_arg(dashboard_settings: DashboardSettings) -> None:
     """Test rel_path handles None arguments gracefully."""
-    # None should be converted to string "None"
     result = dashboard_settings.rel_path("None")
     expected = str(Path(dashboard_settings.config_dir) / "None")
     assert result == expected

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import tempfile
 
@@ -85,9 +86,17 @@ def test_rel_path_with_pathlib_path(dashboard_settings: DashboardSettings) -> No
 
 def test_rel_path_normalizes_slashes(dashboard_settings: DashboardSettings) -> None:
     """Test rel_path normalizes path separators."""
-    result1 = dashboard_settings.rel_path("folder/subfolder/file.yaml")
+    # os.path.join normalizes slashes on Windows but preserves them on Unix
+    # Test that providing components separately gives same result
+    result1 = dashboard_settings.rel_path("folder", "subfolder", "file.yaml")
     result2 = dashboard_settings.rel_path("folder", "subfolder", "file.yaml")
     assert result1 == result2
+
+    # Also test that the result is as expected
+    expected = os.path.join(
+        dashboard_settings.config_dir, "folder", "subfolder", "file.yaml"
+    )
+    assert result1 == expected
 
 
 def test_rel_path_handles_spaces(dashboard_settings: DashboardSettings) -> None:

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -1,0 +1,183 @@
+"""Tests for dashboard settings Path-related functionality."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from esphome.dashboard.settings import DashboardSettings
+
+
+@pytest.fixture
+def temp_config_dir() -> Path:
+    """Create a temporary config directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+@pytest.fixture
+def dashboard_settings(temp_config_dir: Path) -> DashboardSettings:
+    """Create DashboardSettings instance with temp directory."""
+    settings = DashboardSettings()
+    # Resolve symlinks to ensure paths match
+    resolved_dir = temp_config_dir.resolve()
+    settings.config_dir = str(resolved_dir)
+    settings.absolute_config_dir = resolved_dir
+    return settings
+
+
+def test_rel_path_simple(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path with simple relative path."""
+    result = dashboard_settings.rel_path("config.yaml")
+
+    expected = str(Path(dashboard_settings.config_dir) / "config.yaml")
+    assert result == expected
+
+
+def test_rel_path_multiple_components(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path with multiple path components."""
+    result = dashboard_settings.rel_path("subfolder", "device", "config.yaml")
+
+    expected = str(
+        Path(dashboard_settings.config_dir) / "subfolder" / "device" / "config.yaml"
+    )
+    assert result == expected
+
+
+def test_rel_path_with_dots(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path prevents directory traversal."""
+    # This should raise ValueError as it tries to go outside config_dir
+    with pytest.raises(ValueError):
+        dashboard_settings.rel_path("..", "outside.yaml")
+
+
+def test_rel_path_absolute_path_within_config(
+    dashboard_settings: DashboardSettings,
+) -> None:
+    """Test rel_path with absolute path that's within config dir."""
+    internal_path = dashboard_settings.absolute_config_dir / "internal.yaml"
+
+    # Create the file so path resolution works
+    internal_path.touch()
+
+    # This should work as the absolute path is within config_dir
+    result = dashboard_settings.rel_path("internal.yaml")
+    expected = str(Path(dashboard_settings.config_dir) / "internal.yaml")
+    assert result == expected
+
+
+def test_rel_path_absolute_path_outside_config(
+    dashboard_settings: DashboardSettings,
+) -> None:
+    """Test rel_path with absolute path outside config dir raises error."""
+    outside_path = "/tmp/outside/config.yaml"
+
+    with pytest.raises(ValueError):
+        dashboard_settings.rel_path(outside_path)
+
+
+def test_rel_path_empty_args(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path with no arguments returns config_dir."""
+    result = dashboard_settings.rel_path()
+    assert result == dashboard_settings.config_dir
+
+
+def test_rel_path_with_pathlib_path(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path works with Path objects as arguments."""
+    path_obj = Path("subfolder") / "config.yaml"
+    result = dashboard_settings.rel_path(path_obj)
+
+    expected = str(Path(dashboard_settings.config_dir) / "subfolder" / "config.yaml")
+    assert result == expected
+
+
+def test_rel_path_normalizes_slashes(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path normalizes path separators."""
+    # Test with forward slashes
+    result1 = dashboard_settings.rel_path("folder/subfolder/file.yaml")
+
+    # Test with backslashes (on Windows)
+    result2 = dashboard_settings.rel_path("folder", "subfolder", "file.yaml")
+
+    # Both should produce the same normalized path
+    assert result1 == result2
+
+
+def test_rel_path_handles_spaces(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path handles paths with spaces."""
+    result = dashboard_settings.rel_path("my folder", "my config.yaml")
+
+    expected = str(Path(dashboard_settings.config_dir) / "my folder" / "my config.yaml")
+    assert result == expected
+
+
+def test_rel_path_handles_special_chars(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path handles paths with special characters."""
+    result = dashboard_settings.rel_path("device-01_test", "config.yaml")
+
+    expected = str(
+        Path(dashboard_settings.config_dir) / "device-01_test" / "config.yaml"
+    )
+    assert result == expected
+
+
+def test_config_dir_as_path_property(dashboard_settings: DashboardSettings) -> None:
+    """Test that config_dir can be accessed and used with Path operations."""
+    config_path = Path(dashboard_settings.config_dir)
+
+    assert config_path.exists()
+    assert config_path.is_dir()
+    assert config_path.is_absolute()
+
+
+def test_absolute_config_dir_property(dashboard_settings: DashboardSettings) -> None:
+    """Test absolute_config_dir is a Path object."""
+    assert isinstance(dashboard_settings.absolute_config_dir, Path)
+    assert dashboard_settings.absolute_config_dir.exists()
+    assert dashboard_settings.absolute_config_dir.is_dir()
+    assert dashboard_settings.absolute_config_dir.is_absolute()
+
+
+def test_rel_path_symlink_inside_config(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path with symlink that points inside config dir."""
+    # Create a target file inside config dir
+    target = dashboard_settings.absolute_config_dir / "target.yaml"
+    target.touch()
+
+    # Create a symlink pointing to it
+    symlink = dashboard_settings.absolute_config_dir / "link.yaml"
+    symlink.symlink_to(target)
+
+    # This should work as the symlink target is within config_dir
+    result = dashboard_settings.rel_path("link.yaml")
+    expected = str(Path(dashboard_settings.config_dir) / "link.yaml")
+    assert result == expected
+
+
+def test_rel_path_symlink_outside_config(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path with symlink that points outside config dir."""
+    with tempfile.NamedTemporaryFile(suffix=".yaml") as tmp:
+        # Create a symlink pointing outside config dir
+        symlink = dashboard_settings.absolute_config_dir / "external_link.yaml"
+        symlink.symlink_to(tmp.name)
+
+        # This should raise ValueError as the resolved path is outside config_dir
+        with pytest.raises(ValueError):
+            dashboard_settings.rel_path("external_link.yaml")
+
+
+def test_rel_path_with_none_arg(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path handles None arguments gracefully."""
+    # None should be converted to string "None"
+    result = dashboard_settings.rel_path("None")
+    expected = str(Path(dashboard_settings.config_dir) / "None")
+    assert result == expected
+
+
+def test_rel_path_with_numeric_args(dashboard_settings: DashboardSettings) -> None:
+    """Test rel_path handles numeric arguments."""
+    result = dashboard_settings.rel_path("123", "456.789")
+    expected = str(Path(dashboard_settings.config_dir) / "123" / "456.789")
+    assert result == expected

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -1,0 +1,251 @@
+"""Tests for dashboard web_server Path-related functionality."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from esphome.dashboard import web_server
+
+
+def test_get_base_frontend_path_production() -> None:
+    """Test get_base_frontend_path in production mode."""
+    # Mock the esphome_dashboard module
+    with patch.dict(os.environ, {}, clear=True):
+        # Mock the import and the where function
+        mock_module = MagicMock()
+        mock_module.where.return_value = "/usr/local/lib/esphome_dashboard"
+
+        with patch.dict("sys.modules", {"esphome_dashboard": mock_module}):
+            result = web_server.get_base_frontend_path()
+
+            assert result == "/usr/local/lib/esphome_dashboard"
+            mock_module.where.assert_called_once()
+
+
+def test_get_base_frontend_path_dev_mode() -> None:
+    """Test get_base_frontend_path in development mode."""
+    test_path = "/home/user/esphome/dashboard"
+
+    with patch.dict(os.environ, {"ESPHOME_DASHBOARD_DEV": test_path}):
+        result = web_server.get_base_frontend_path()
+
+        # The function uses os.path.abspath which doesn't resolve symlinks
+        # We need to match that behavior
+        expected = os.path.abspath(
+            str(Path.cwd() / (test_path + "/") / "esphome_dashboard")
+        )
+        assert result == expected
+
+
+def test_get_base_frontend_path_dev_mode_with_trailing_slash() -> None:
+    """Test get_base_frontend_path in dev mode with trailing slash."""
+    test_path = "/home/user/esphome/dashboard/"
+
+    with patch.dict(os.environ, {"ESPHOME_DASHBOARD_DEV": test_path}):
+        result = web_server.get_base_frontend_path()
+
+        # The function uses os.path.abspath which doesn't resolve symlinks
+        expected = os.path.abspath(str(Path.cwd() / test_path / "esphome_dashboard"))
+        assert result == expected
+
+
+def test_get_base_frontend_path_dev_mode_relative_path() -> None:
+    """Test get_base_frontend_path with relative dev path."""
+    test_path = "./dashboard"
+
+    with patch.dict(os.environ, {"ESPHOME_DASHBOARD_DEV": test_path}):
+        result = web_server.get_base_frontend_path()
+
+        # The function uses os.path.abspath which doesn't resolve symlinks
+        # We need to match that behavior
+        expected = os.path.abspath(
+            str(Path.cwd() / (test_path + "/") / "esphome_dashboard")
+        )
+        assert result == expected
+        # Result should be absolute
+        assert Path(result).is_absolute()
+
+
+def test_get_static_path_single_component() -> None:
+    """Test get_static_path with single path component."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        result = web_server.get_static_path("file.js")
+
+        assert result == str(Path("/base/frontend") / "static" / "file.js")
+
+
+def test_get_static_path_multiple_components() -> None:
+    """Test get_static_path with multiple path components."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        result = web_server.get_static_path("js", "esphome", "index.js")
+
+        assert result == str(
+            Path("/base/frontend") / "static" / "js" / "esphome" / "index.js"
+        )
+
+
+def test_get_static_path_empty_args() -> None:
+    """Test get_static_path with no arguments."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        result = web_server.get_static_path()
+
+        assert result == str(Path("/base/frontend") / "static")
+
+
+def test_get_static_path_with_pathlib_path() -> None:
+    """Test get_static_path with Path objects."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        path_obj = Path("js") / "app.js"
+        result = web_server.get_static_path(str(path_obj))
+
+        assert result == str(Path("/base/frontend") / "static" / "js" / "app.js")
+
+
+def test_get_static_file_url_production() -> None:
+    """Test get_static_file_url in production mode."""
+    with patch.dict(os.environ, {}, clear=True):
+        # Clear the cache before test
+        web_server.get_static_file_url.cache_clear()
+
+        # Mock the esphome_dashboard module to avoid ImportError
+        mock_module = MagicMock()
+        with (
+            patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
+            patch("esphome.dashboard.web_server.get_static_path") as mock_get_path,
+        ):
+            mock_get_path.return_value = "/fake/path/js/app.js"
+
+            # Mock the open function at the module level to avoid file I/O
+            mock_file = MagicMock()
+            mock_file.read.return_value = b"test content"
+            mock_file.__enter__ = MagicMock(return_value=mock_file)
+            mock_file.__exit__ = MagicMock(return_value=None)
+
+            with patch(
+                "esphome.dashboard.web_server.open",
+                create=True,
+                return_value=mock_file,
+            ):
+                result = web_server.get_static_file_url("js/app.js")
+
+                # In production mode, should return path with hash
+                assert result.startswith("./static/js/app.js?hash=")
+
+
+def test_get_static_file_url_dev_mode() -> None:
+    """Test get_static_file_url in development mode."""
+    with patch.dict(os.environ, {"ESPHOME_DASHBOARD_DEV": "/dev/path"}):
+        # Clear the cache before test
+        web_server.get_static_file_url.cache_clear()
+
+        result = web_server.get_static_file_url("js/app.js")
+
+        assert result == "./static/js/app.js"
+
+
+def test_get_static_file_url_index_js_special_case() -> None:
+    """Test get_static_file_url replaces index.js with entrypoint."""
+    with patch.dict(os.environ, {}, clear=True):
+        # Mock the esphome_dashboard module to avoid ImportError
+        mock_module = MagicMock()
+        mock_module.entrypoint.return_value = "main.js"
+        with patch.dict("sys.modules", {"esphome_dashboard": mock_module}):
+            # Clear the cache before test
+            web_server.get_static_file_url.cache_clear()
+
+            result = web_server.get_static_file_url("js/esphome/index.js")
+
+            # index.js should be replaced with entrypoint
+            assert result == "./static/js/esphome/main.js"
+
+
+def test_load_file_path() -> None:
+    """Test loading a file."""
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt", delete=False) as tmp:
+        tmp.write(b"test content")
+        tmp.flush()
+
+        try:
+            with open(tmp.name, "rb") as f:
+                content = f.read()
+            assert content == b"test content"
+        finally:
+            Path(tmp.name).unlink()
+
+
+def test_load_file_compressed_path() -> None:
+    """Test loading a compressed file."""
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt.gz", delete=False) as tmp:
+        import gzip
+
+        with gzip.open(tmp.name, "wb") as gz:
+            gz.write(b"compressed content")
+
+        try:
+            with gzip.open(tmp.name, "rb") as gz:
+                content = gz.read()
+            assert content == b"compressed content"
+        finally:
+            Path(tmp.name).unlink()
+
+
+def test_path_normalization_in_static_path() -> None:
+    """Test that paths are normalized correctly."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        # Test with various path separators
+        result1 = web_server.get_static_path("js/app.js")
+        result2 = web_server.get_static_path("js", "app.js")
+
+        assert result1 == result2
+        assert result1 == str(Path("/base/frontend") / "static" / "js" / "app.js")
+
+
+def test_windows_path_handling() -> None:
+    """Test handling of Windows-style paths."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = r"C:\Program Files\esphome\frontend"
+
+        result = web_server.get_static_path("js", "app.js")
+
+        # Path should handle this correctly on the platform
+        expected = str(
+            Path(r"C:\Program Files\esphome\frontend") / "static" / "js" / "app.js"
+        )
+        assert result == expected
+
+
+def test_path_with_special_characters() -> None:
+    """Test paths with special characters."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/frontend"
+
+        result = web_server.get_static_path("js-modules", "app_v1.0.js")
+
+        assert result == str(
+            Path("/base/frontend") / "static" / "js-modules" / "app_v1.0.js"
+        )
+
+
+def test_path_with_spaces() -> None:
+    """Test paths with spaces."""
+    with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
+        mock_base.return_value = "/base/my frontend"
+
+        result = web_server.get_static_path("my js", "my app.js")
+
+        assert result == str(
+            Path("/base/my frontend") / "static" / "my js" / "my app.js"
+        )

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -13,15 +13,16 @@ from esphome.dashboard import web_server
 
 def test_get_base_frontend_path_production() -> None:
     """Test get_base_frontend_path in production mode."""
-    with patch.dict(os.environ, {}, clear=True):
-        mock_module = MagicMock()
-        mock_module.where.return_value = "/usr/local/lib/esphome_dashboard"
+    mock_module = MagicMock()
+    mock_module.where.return_value = "/usr/local/lib/esphome_dashboard"
 
-        with patch.dict("sys.modules", {"esphome_dashboard": mock_module}):
-            result = web_server.get_base_frontend_path()
-
-            assert result == "/usr/local/lib/esphome_dashboard"
-            mock_module.where.assert_called_once()
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
+    ):
+        result = web_server.get_base_frontend_path()
+        assert result == "/usr/local/lib/esphome_dashboard"
+        mock_module.where.assert_called_once()
 
 
 def test_get_base_frontend_path_dev_mode() -> None:
@@ -112,26 +113,22 @@ def test_get_static_path_with_pathlib_path() -> None:
 
 def test_get_static_file_url_production() -> None:
     """Test get_static_file_url in production mode."""
-    with patch.dict(os.environ, {}, clear=True):
-        web_server.get_static_file_url.cache_clear()
-        mock_module = MagicMock()
-        with (
-            patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
-            patch("esphome.dashboard.web_server.get_static_path") as mock_get_path,
-        ):
-            mock_get_path.return_value = "/fake/path/js/app.js"
-            mock_file = MagicMock()
-            mock_file.read.return_value = b"test content"
-            mock_file.__enter__ = MagicMock(return_value=mock_file)
-            mock_file.__exit__ = MagicMock(return_value=None)
+    web_server.get_static_file_url.cache_clear()
+    mock_module = MagicMock()
+    mock_file = MagicMock()
+    mock_file.read.return_value = b"test content"
+    mock_file.__enter__ = MagicMock(return_value=mock_file)
+    mock_file.__exit__ = MagicMock(return_value=None)
 
-            with patch(
-                "esphome.dashboard.web_server.open",
-                create=True,
-                return_value=mock_file,
-            ):
-                result = web_server.get_static_file_url("js/app.js")
-                assert result.startswith("./static/js/app.js?hash=")
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
+        patch("esphome.dashboard.web_server.get_static_path") as mock_get_path,
+        patch("esphome.dashboard.web_server.open", create=True, return_value=mock_file),
+    ):
+        mock_get_path.return_value = "/fake/path/js/app.js"
+        result = web_server.get_static_file_url("js/app.js")
+        assert result.startswith("./static/js/app.js?hash=")
 
 
 def test_get_static_file_url_dev_mode() -> None:
@@ -145,13 +142,16 @@ def test_get_static_file_url_dev_mode() -> None:
 
 def test_get_static_file_url_index_js_special_case() -> None:
     """Test get_static_file_url replaces index.js with entrypoint."""
-    with patch.dict(os.environ, {}, clear=True):
-        mock_module = MagicMock()
-        mock_module.entrypoint.return_value = "main.js"
-        with patch.dict("sys.modules", {"esphome_dashboard": mock_module}):
-            web_server.get_static_file_url.cache_clear()
-            result = web_server.get_static_file_url("js/esphome/index.js")
-            assert result == "./static/js/esphome/main.js"
+    web_server.get_static_file_url.cache_clear()
+    mock_module = MagicMock()
+    mock_module.entrypoint.return_value = "main.js"
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
+    ):
+        result = web_server.get_static_file_url("js/esphome/index.js")
+        assert result == "./static/js/esphome/main.js"
 
 
 def test_load_file_path() -> None:

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -156,17 +156,13 @@ def test_get_static_file_url_index_js_special_case() -> None:
 
 def test_load_file_path() -> None:
     """Test loading a file."""
-    with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt", delete=False) as tmp:
-        tmp.write(b"test content")
-        tmp.flush()
-        tmp_name = tmp.name
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_file = Path(tmpdir) / "test.txt"
+        test_file.write_bytes(b"test content")
 
-    try:
-        with open(tmp_name, "rb") as f:
+        with open(test_file, "rb") as f:
             content = f.read()
         assert content == b"test content"
-    finally:
-        Path(tmp_name).unlink()
 
 
 def test_load_file_compressed_path() -> None:

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gzip
 import os
 from pathlib import Path
 import tempfile
@@ -12,9 +13,7 @@ from esphome.dashboard import web_server
 
 def test_get_base_frontend_path_production() -> None:
     """Test get_base_frontend_path in production mode."""
-    # Mock the esphome_dashboard module
     with patch.dict(os.environ, {}, clear=True):
-        # Mock the import and the where function
         mock_module = MagicMock()
         mock_module.where.return_value = "/usr/local/lib/esphome_dashboard"
 
@@ -65,7 +64,6 @@ def test_get_base_frontend_path_dev_mode_relative_path() -> None:
             str(Path.cwd() / (test_path + "/") / "esphome_dashboard")
         )
         assert result == expected
-        # Result should be absolute
         assert Path(result).is_absolute()
 
 
@@ -115,18 +113,13 @@ def test_get_static_path_with_pathlib_path() -> None:
 def test_get_static_file_url_production() -> None:
     """Test get_static_file_url in production mode."""
     with patch.dict(os.environ, {}, clear=True):
-        # Clear the cache before test
         web_server.get_static_file_url.cache_clear()
-
-        # Mock the esphome_dashboard module to avoid ImportError
         mock_module = MagicMock()
         with (
             patch.dict("sys.modules", {"esphome_dashboard": mock_module}),
             patch("esphome.dashboard.web_server.get_static_path") as mock_get_path,
         ):
             mock_get_path.return_value = "/fake/path/js/app.js"
-
-            # Mock the open function at the module level to avoid file I/O
             mock_file = MagicMock()
             mock_file.read.return_value = b"test content"
             mock_file.__enter__ = MagicMock(return_value=mock_file)
@@ -138,17 +131,13 @@ def test_get_static_file_url_production() -> None:
                 return_value=mock_file,
             ):
                 result = web_server.get_static_file_url("js/app.js")
-
-                # In production mode, should return path with hash
                 assert result.startswith("./static/js/app.js?hash=")
 
 
 def test_get_static_file_url_dev_mode() -> None:
     """Test get_static_file_url in development mode."""
     with patch.dict(os.environ, {"ESPHOME_DASHBOARD_DEV": "/dev/path"}):
-        # Clear the cache before test
         web_server.get_static_file_url.cache_clear()
-
         result = web_server.get_static_file_url("js/app.js")
 
         assert result == "./static/js/app.js"
@@ -157,16 +146,11 @@ def test_get_static_file_url_dev_mode() -> None:
 def test_get_static_file_url_index_js_special_case() -> None:
     """Test get_static_file_url replaces index.js with entrypoint."""
     with patch.dict(os.environ, {}, clear=True):
-        # Mock the esphome_dashboard module to avoid ImportError
         mock_module = MagicMock()
         mock_module.entrypoint.return_value = "main.js"
         with patch.dict("sys.modules", {"esphome_dashboard": mock_module}):
-            # Clear the cache before test
             web_server.get_static_file_url.cache_clear()
-
             result = web_server.get_static_file_url("js/esphome/index.js")
-
-            # index.js should be replaced with entrypoint
             assert result == "./static/js/esphome/main.js"
 
 
@@ -187,8 +171,6 @@ def test_load_file_path() -> None:
 def test_load_file_compressed_path() -> None:
     """Test loading a compressed file."""
     with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt.gz", delete=False) as tmp:
-        import gzip
-
         with gzip.open(tmp.name, "wb") as gz:
             gz.write(b"compressed content")
 
@@ -205,7 +187,6 @@ def test_path_normalization_in_static_path() -> None:
     with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
         mock_base.return_value = "/base/frontend"
 
-        # Test with various path separators
         result1 = web_server.get_static_path("js/app.js")
         result2 = web_server.get_static_path("js", "app.js")
 

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -190,7 +190,8 @@ def test_path_normalization_in_static_path() -> None:
     with patch("esphome.dashboard.web_server.get_base_frontend_path") as mock_base:
         mock_base.return_value = "/base/frontend"
 
-        result1 = web_server.get_static_path("js/app.js")
+        # Test with separate components
+        result1 = web_server.get_static_path("js", "app.js")
         result2 = web_server.get_static_path("js", "app.js")
 
         assert result1 == result2

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -33,8 +33,10 @@ def test_get_base_frontend_path_dev_mode() -> None:
 
         # The function uses os.path.abspath which doesn't resolve symlinks
         # We need to match that behavior
+        # The actual function adds "/" to the path, so we simulate that
+        test_path_with_slash = test_path if test_path.endswith("/") else test_path + "/"
         expected = os.path.abspath(
-            str(Path.cwd() / (test_path + "/") / "esphome_dashboard")
+            os.path.join(os.getcwd(), test_path_with_slash, "esphome_dashboard")
         )
         assert result == expected
 
@@ -60,8 +62,10 @@ def test_get_base_frontend_path_dev_mode_relative_path() -> None:
 
         # The function uses os.path.abspath which doesn't resolve symlinks
         # We need to match that behavior
+        # The actual function adds "/" to the path, so we simulate that
+        test_path_with_slash = test_path if test_path.endswith("/") else test_path + "/"
         expected = os.path.abspath(
-            str(Path.cwd() / (test_path + "/") / "esphome_dashboard")
+            os.path.join(os.getcwd(), test_path_with_slash, "esphome_dashboard")
         )
         assert result == expected
         assert Path(result).is_absolute()

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -74,7 +74,7 @@ def test_get_static_path_single_component() -> None:
 
         result = web_server.get_static_path("file.js")
 
-        assert result == str(Path("/base/frontend") / "static" / "file.js")
+        assert result == os.path.join("/base/frontend", "static", "file.js")
 
 
 def test_get_static_path_multiple_components() -> None:
@@ -84,8 +84,8 @@ def test_get_static_path_multiple_components() -> None:
 
         result = web_server.get_static_path("js", "esphome", "index.js")
 
-        assert result == str(
-            Path("/base/frontend") / "static" / "js" / "esphome" / "index.js"
+        assert result == os.path.join(
+            "/base/frontend", "static", "js", "esphome", "index.js"
         )
 
 
@@ -96,7 +96,7 @@ def test_get_static_path_empty_args() -> None:
 
         result = web_server.get_static_path()
 
-        assert result == str(Path("/base/frontend") / "static")
+        assert result == os.path.join("/base/frontend", "static")
 
 
 def test_get_static_path_with_pathlib_path() -> None:
@@ -107,7 +107,7 @@ def test_get_static_path_with_pathlib_path() -> None:
         path_obj = Path("js") / "app.js"
         result = web_server.get_static_path(str(path_obj))
 
-        assert result == str(Path("/base/frontend") / "static" / "js" / "app.js")
+        assert result == os.path.join("/base/frontend", "static", "js", "app.js")
 
 
 def test_get_static_file_url_production() -> None:
@@ -159,27 +159,30 @@ def test_load_file_path() -> None:
     with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt", delete=False) as tmp:
         tmp.write(b"test content")
         tmp.flush()
+        tmp_name = tmp.name
 
-        try:
-            with open(tmp.name, "rb") as f:
-                content = f.read()
-            assert content == b"test content"
-        finally:
-            Path(tmp.name).unlink()
+    try:
+        with open(tmp_name, "rb") as f:
+            content = f.read()
+        assert content == b"test content"
+    finally:
+        Path(tmp_name).unlink()
 
 
 def test_load_file_compressed_path() -> None:
     """Test loading a compressed file."""
     with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt.gz", delete=False) as tmp:
-        with gzip.open(tmp.name, "wb") as gz:
-            gz.write(b"compressed content")
+        tmp_name = tmp.name
 
-        try:
-            with gzip.open(tmp.name, "rb") as gz:
-                content = gz.read()
-            assert content == b"compressed content"
-        finally:
-            Path(tmp.name).unlink()
+    with gzip.open(tmp_name, "wb") as gz:
+        gz.write(b"compressed content")
+
+    try:
+        with gzip.open(tmp_name, "rb") as gz:
+            content = gz.read()
+        assert content == b"compressed content"
+    finally:
+        Path(tmp_name).unlink()
 
 
 def test_path_normalization_in_static_path() -> None:
@@ -191,7 +194,7 @@ def test_path_normalization_in_static_path() -> None:
         result2 = web_server.get_static_path("js", "app.js")
 
         assert result1 == result2
-        assert result1 == str(Path("/base/frontend") / "static" / "js" / "app.js")
+        assert result1 == os.path.join("/base/frontend", "static", "js", "app.js")
 
 
 def test_windows_path_handling() -> None:
@@ -201,9 +204,9 @@ def test_windows_path_handling() -> None:
 
         result = web_server.get_static_path("js", "app.js")
 
-        # Path should handle this correctly on the platform
-        expected = str(
-            Path(r"C:\Program Files\esphome\frontend") / "static" / "js" / "app.js"
+        # os.path.join should handle this correctly on the platform
+        expected = os.path.join(
+            r"C:\Program Files\esphome\frontend", "static", "js", "app.js"
         )
         assert result == expected
 
@@ -215,8 +218,8 @@ def test_path_with_special_characters() -> None:
 
         result = web_server.get_static_path("js-modules", "app_v1.0.js")
 
-        assert result == str(
-            Path("/base/frontend") / "static" / "js-modules" / "app_v1.0.js"
+        assert result == os.path.join(
+            "/base/frontend", "static", "js-modules", "app_v1.0.js"
         )
 
 
@@ -227,6 +230,6 @@ def test_path_with_spaces() -> None:
 
         result = web_server.get_static_path("my js", "my app.js")
 
-        assert result == str(
-            Path("/base/my frontend") / "static" / "my js" / "my app.js"
+        assert result == os.path.join(
+            "/base/my frontend", "static", "my js", "my app.js"
         )

--- a/tests/dashboard/test_web_server_paths.py
+++ b/tests/dashboard/test_web_server_paths.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import gzip
 import os
 from pathlib import Path
-import tempfile
 from unittest.mock import MagicMock, patch
 
 from esphome.dashboard import web_server
@@ -154,31 +153,26 @@ def test_get_static_file_url_index_js_special_case() -> None:
         assert result == "./static/js/esphome/main.js"
 
 
-def test_load_file_path() -> None:
+def test_load_file_path(tmp_path: Path) -> None:
     """Test loading a file."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        test_file = Path(tmpdir) / "test.txt"
-        test_file.write_bytes(b"test content")
+    test_file = tmp_path / "test.txt"
+    test_file.write_bytes(b"test content")
 
-        with open(test_file, "rb") as f:
-            content = f.read()
-        assert content == b"test content"
+    with open(test_file, "rb") as f:
+        content = f.read()
+    assert content == b"test content"
 
 
-def test_load_file_compressed_path() -> None:
+def test_load_file_compressed_path(tmp_path: Path) -> None:
     """Test loading a compressed file."""
-    with tempfile.NamedTemporaryFile(mode="wb", suffix=".txt.gz", delete=False) as tmp:
-        tmp_name = tmp.name
+    test_file = tmp_path / "test.txt.gz"
 
-    with gzip.open(tmp_name, "wb") as gz:
+    with gzip.open(test_file, "wb") as gz:
         gz.write(b"compressed content")
 
-    try:
-        with gzip.open(tmp_name, "rb") as gz:
-            content = gz.read()
-        assert content == b"compressed content"
-    finally:
-        Path(tmp_name).unlink()
+    with gzip.open(test_file, "rb") as gz:
+        content = gz.read()
+    assert content == b"compressed content"
 
 
 def test_path_normalization_in_static_path() -> None:


### PR DESCRIPTION

# What does this implement/fix?

supports https://github.com/esphome/esphome/pull/10654

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
