### PR TITLE
[esp32_ble_tracker] Simplify BLE client state machine by removing READY_TO_CONNECT

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -43,13 +43,6 @@ void BLEClientBase::setup() {
 void BLEClientBase::set_state(espbt::ClientState st) {
   ESP_LOGV(TAG, "[%d] [%s] Set state %d", this->connection_index_, this->address_str_.c_str(), (int) st);
   ESPBTClient::set_state(st);
-
-  if (st == espbt::ClientState::READY_TO_CONNECT) {
-    // Enable loop for state processing
-    this->enable_loop();
-    // Connect immediately instead of waiting for next loop
-    this->connect();
-  }
 }
 
 void BLEClientBase::loop() {
@@ -111,6 +104,8 @@ void BLEClientBase::connect() {
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Connecting", this->connection_index_, this->address_str_.c_str(),
            this->remote_addr_type_);
   this->paired_ = false;
+  // Enable loop for state processing
+  this->enable_loop();
 
   // Determine connection parameters based on connection type
   if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
@@ -168,7 +163,7 @@ void BLEClientBase::unconditional_disconnect() {
     this->log_gattc_warning_("esp_ble_gattc_close", err);
   }
 
-  if (this->state_ == espbt::ClientState::READY_TO_CONNECT || this->state_ == espbt::ClientState::DISCOVERED) {
+  if (this->state_ == espbt::ClientState::DISCOVERED) {
     this->set_address(0);
     this->set_state(espbt::ClientState::IDLE);
   } else {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -106,6 +106,8 @@ void BLEClientBase::connect() {
   this->paired_ = false;
   // Enable loop for state processing
   this->enable_loop();
+  // Immediately transition to CONNECTING to prevent duplicate connection attempts
+  this->set_state(espbt::ClientState::CONNECTING);
 
   // Determine connection parameters based on connection type
   if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
@@ -207,8 +209,6 @@ void BLEClientBase::handle_connection_result_(esp_err_t ret) {
   if (ret) {
     this->log_gattc_warning_("esp_ble_gattc_open", ret);
     this->set_state(espbt::ClientState::IDLE);
-  } else {
-    this->set_state(espbt::ClientState::CONNECTING);
   }
 }
 

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -58,8 +58,8 @@ void BLEClientBase::loop() {
     }
     this->set_state(espbt::ClientState::IDLE);
   }
-  // If its idle, we can disable the loop as set_state
-  // will enable it again when we need to connect.
+  // If idle, we can disable the loop as connect()
+  // will enable it again when a connection is needed.
   else if (this->state_ == espbt::ClientState::IDLE) {
     this->disable_loop();
   }
@@ -101,6 +101,13 @@ bool BLEClientBase::parse_device(const espbt::ESPBTDevice &device) {
 #endif
 
 void BLEClientBase::connect() {
+  // Prevent duplicate connection attempts
+  if (this->state_ == espbt::ClientState::CONNECTING || this->state_ == espbt::ClientState::CONNECTED ||
+      this->state_ == espbt::ClientState::ESTABLISHED) {
+    ESP_LOGW(TAG, "[%d] [%s] Connection already in progress, state=%s", this->connection_index_,
+             this->address_str_.c_str(), espbt::client_state_to_string(this->state_));
+    return;
+  }
   ESP_LOGI(TAG, "[%d] [%s] 0x%02x Connecting", this->connection_index_, this->address_str_.c_str(),
            this->remote_addr_type_);
   this->paired_ = false;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -51,8 +51,6 @@ const char *client_state_to_string(ClientState state) {
       return "IDLE";
     case ClientState::DISCOVERED:
       return "DISCOVERED";
-    case ClientState::READY_TO_CONNECT:
-      return "READY_TO_CONNECT";
     case ClientState::CONNECTING:
       return "CONNECTING";
     case ClientState::CONNECTED:
@@ -795,7 +793,7 @@ void ESP32BLETracker::try_promote_discovered_clients_() {
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
     this->update_coex_preference_(true);
 #endif
-    client->set_state(ClientState::READY_TO_CONNECT);
+    client->connect();
     break;
   }
 }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -159,8 +159,6 @@ enum class ClientState : uint8_t {
   IDLE,
   // Device advertisement found.
   DISCOVERED,
-  // Device is discovered and the scanner is stopped
-  READY_TO_CONNECT,
   // Connection in progress.
   CONNECTING,
   // Initial connection established.
@@ -313,7 +311,6 @@ class ESP32BLETracker : public Component,
           counts.discovered++;
           break;
         case ClientState::CONNECTING:
-        case ClientState::READY_TO_CONNECT:
           counts.connecting++;
           break;
         default:


### PR DESCRIPTION
# What does this implement/fix?

This PR removes the `ClientState::READY_TO_CONNECT` state from the BLE client state machine, simplifying the connection flow by eliminating an unnecessary intermediate state.

Following the recent optimizations in #10051 (which made connections immediate when `READY_TO_CONNECT` is set) and #10318 (which removed the unused `SEARCHING` state), this change continues the trend of simplifying the BLE state machine. The `READY_TO_CONNECT` state has become redundant as it only serves as a signal to initiate connection - a role that can be fulfilled by directly calling `connect()`.

## Changes Made

- **Removed `READY_TO_CONNECT` from `ClientState` enum** - One less state to track
- **Updated `esp32_ble_tracker`** - Now calls `client->connect()` directly instead of setting an intermediate state
- **Enhanced `BLEClientBase::connect()`**:
  - Added guard to prevent duplicate connection attempts
  - Added `enable_loop()` call to ensure proper state processing
  - Immediate transition to `CONNECTING` state to prevent race conditions
- **Simplified `handle_connection_result_()`** - Removed redundant state transition since `connect()` now handles it
- **Updated stale comment** - Fixed loop disable comment to reflect that `connect()` (not `set_state()`) enables the loop
- **Cleaned up state transition logic** - Removed all special handling for the eliminated state

## Benefits

- Simpler state machine with fewer transitions
- Clearer code flow - direct connection instead of state-based signaling
- Reduced complexity in state management
- **Fixes potential bug**: Added guard prevents multiple simultaneous `connect()` calls from automations and reconnection logic that could have caused race conditions and resource leaks (tracker-initiated connections were already protected)
- Maintains all existing functionality while improving robustness

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10051 (Connect immediately on READY_TO_CONNECT)
- Related to #10318 (Remove unused SEARCHING state)
- Related to #10321 (Remove duplicate client promotion logic)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal state machine change, no user-facing changes

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-exposed changes
