### PR TITLE
[adc] Fix `FILTER_SOURCE_FILES` location

### DIFF
--- a/esphome/components/adc/__init__.py
+++ b/esphome/components/adc/__init__.py
@@ -11,15 +11,8 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
-from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_ANALOG,
-    CONF_INPUT,
-    CONF_NUMBER,
-    PLATFORM_ESP8266,
-    PlatformFramework,
-)
+from esphome.const import CONF_ANALOG, CONF_INPUT, CONF_NUMBER, PLATFORM_ESP8266
 from esphome.core import CORE
 
 CODEOWNERS = ["@esphome/core"]
@@ -273,21 +266,3 @@ def validate_adc_pin(value):
         )(value)
 
     raise NotImplementedError
-
-
-FILTER_SOURCE_FILES = filter_source_files_from_platform(
-    {
-        "adc_sensor_esp32.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
-            PlatformFramework.ESP32_IDF,
-        },
-        "adc_sensor_esp8266.cpp": {PlatformFramework.ESP8266_ARDUINO},
-        "adc_sensor_rp2040.cpp": {PlatformFramework.RP2040_ARDUINO},
-        "adc_sensor_libretiny.cpp": {
-            PlatformFramework.BK72XX_ARDUINO,
-            PlatformFramework.RTL87XX_ARDUINO,
-            PlatformFramework.LN882X_ARDUINO,
-        },
-        "adc_sensor_zephyr.cpp": {PlatformFramework.NRF52_ZEPHYR},
-    }
-)

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -9,6 +9,7 @@ from esphome.components.zephyr import (
     zephyr_add_prj_conf,
     zephyr_add_user,
 )
+from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ATTENUATION,
@@ -20,6 +21,7 @@ from esphome.const import (
     PLATFORM_NRF52,
     STATE_CLASS_MEASUREMENT,
     UNIT_VOLT,
+    PlatformFramework,
 )
 from esphome.core import CORE
 
@@ -174,3 +176,21 @@ async def to_code(config):
 }};
 """
         )
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "adc_sensor_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
+        "adc_sensor_esp8266.cpp": {PlatformFramework.ESP8266_ARDUINO},
+        "adc_sensor_rp2040.cpp": {PlatformFramework.RP2040_ARDUINO},
+        "adc_sensor_libretiny.cpp": {
+            PlatformFramework.BK72XX_ARDUINO,
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.LN882X_ARDUINO,
+        },
+        "adc_sensor_zephyr.cpp": {PlatformFramework.NRF52_ZEPHYR},
+    }
+)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`FILTER_SOURCE_FILES` is supposed to be located in the file of the component/platform that is actually being loaded. The `__init__.py` file for `adc` is simply a common file for `adc` stuff and not an actual component file.

```
Compiling .pioenvs/issues_10656_filter_files/src/esphome/components/adc/adc_sensor_common.cpp.o
Compiling .pioenvs/issues_10656_filter_files/src/esphome/components/adc/adc_sensor_esp32.cpp.o
Compiling .pioenvs/issues_10656_filter_files/src/esphome/components/esp32/core.cpp.o
Compiling .pioenvs/issues_10656_filter_files/src/esphome/components/esp32/gpio.cpp.o
Compiling .pioenvs/issues_10656_filter_files/src/esphome/components/esp32/helpers.cpp.o
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10656 and closes #10657

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
