### PR TITLE
Add additional coverage for yaml_util

### DIFF
--- a/tests/unit_tests/fixtures/yaml_util/named_dir/.hidden.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/named_dir/.hidden.yaml
@@ -1,0 +1,3 @@
+# This file should be ignored
+platform: template
+name: "Hidden Sensor"

--- a/tests/unit_tests/fixtures/yaml_util/named_dir/not_yaml.txt
+++ b/tests/unit_tests/fixtures/yaml_util/named_dir/not_yaml.txt
@@ -1,0 +1,1 @@
+This is not a YAML file and should be ignored

--- a/tests/unit_tests/fixtures/yaml_util/named_dir/sensor1.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/named_dir/sensor1.yaml
@@ -1,0 +1,4 @@
+platform: template
+name: "Sensor 1"
+lambda: |-
+  return 42.0;

--- a/tests/unit_tests/fixtures/yaml_util/named_dir/sensor2.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/named_dir/sensor2.yaml
@@ -1,0 +1,4 @@
+platform: template
+name: "Sensor 2"
+lambda: |-
+  return 100.0;

--- a/tests/unit_tests/fixtures/yaml_util/named_dir/subdir/sensor3.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/named_dir/subdir/sensor3.yaml
@@ -1,0 +1,4 @@
+platform: template
+name: "Sensor 3 in subdir"
+lambda: |-
+  return 200.0;

--- a/tests/unit_tests/fixtures/yaml_util/secrets.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/secrets.yaml
@@ -1,0 +1,4 @@
+test_secret: "my_secret_value"
+another_secret: "another_value"
+wifi_password: "super_secret_wifi"
+api_key: "0123456789abcdef"

--- a/tests/unit_tests/fixtures/yaml_util/test_secret.yaml
+++ b/tests/unit_tests/fixtures/yaml_util/test_secret.yaml
@@ -1,0 +1,17 @@
+esphome:
+  name: test_device
+  platform: ESP32
+  board: esp32dev
+
+wifi:
+  ssid: "TestNetwork"
+  password: !secret wifi_password
+
+api:
+  encryption:
+    key: !secret api_key
+
+sensor:
+  - platform: template
+    name: "Test Sensor"
+    id: !secret test_secret

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 from unittest.mock import patch
 
 import pytest
@@ -143,10 +144,15 @@ wifi:
         assert actual["wifi"]["password"] == "main_secret_value"
 
 
-def test_construct_include_dir_named(fixture_path: Path) -> None:
+def test_construct_include_dir_named(fixture_path: Path, tmp_path: Path) -> None:
     """Test !include_dir_named directive."""
+    # Copy fixture directory to temporary location
+    src_dir = fixture_path / "yaml_util"
+    dst_dir = tmp_path / "yaml_util"
+    shutil.copytree(src_dir, dst_dir)
+
     # Create test YAML that uses include_dir_named
-    test_yaml = fixture_path / "yaml_util" / "test_include_named.yaml"
+    test_yaml = dst_dir / "test_include_named.yaml"
     test_yaml.write_text("""
 sensor: !include_dir_named named_dir
 """)
@@ -229,10 +235,15 @@ test: !include_dir_named test_dir
     assert ".hidden_dir" not in actual["test"]
 
 
-def test_find_files_recursive(fixture_path: Path) -> None:
+def test_find_files_recursive(fixture_path: Path, tmp_path: Path) -> None:
     """Test that _find_files works recursively through include_dir_named."""
+    # Copy fixture directory to temporary location
+    src_dir = fixture_path / "yaml_util"
+    dst_dir = tmp_path / "yaml_util"
+    shutil.copytree(src_dir, dst_dir)
+
     # This indirectly tests _find_files by using include_dir_named
-    test_yaml = fixture_path / "yaml_util" / "test_include_recursive.yaml"
+    test_yaml = dst_dir / "test_include_recursive.yaml"
     test_yaml.write_text("""
 all_sensors: !include_dir_named named_dir
 """)

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -152,28 +152,27 @@ sensor: !include_dir_named named_dir
 """)
 
     actual = yaml_util.load_yaml(str(test_yaml))
+    actual_sensor = actual["sensor"]
 
     # Check that files were loaded with their names as keys
-    assert isinstance(actual["sensor"], OrderedDict)
-    assert "sensor1" in actual["sensor"]
-    assert "sensor2" in actual["sensor"]
-    assert (
-        "sensor3" in actual["sensor"]
-    )  # Files from subdirs are included with basename
+    assert isinstance(actual_sensor, OrderedDict)
+    assert "sensor1" in actual_sensor
+    assert "sensor2" in actual_sensor
+    assert "sensor3" in actual_sensor  # Files from subdirs are included with basename
 
     # Check content of loaded files
-    assert actual["sensor"]["sensor1"]["platform"] == "template"
-    assert actual["sensor"]["sensor1"]["name"] == "Sensor 1"
-    assert actual["sensor"]["sensor2"]["platform"] == "template"
-    assert actual["sensor"]["sensor2"]["name"] == "Sensor 2"
+    assert actual_sensor["sensor1"]["platform"] == "template"
+    assert actual_sensor["sensor1"]["name"] == "Sensor 1"
+    assert actual_sensor["sensor2"]["platform"] == "template"
+    assert actual_sensor["sensor2"]["name"] == "Sensor 2"
 
     # Check that subdirectory files are included with their basename
-    assert actual["sensor"]["sensor3"]["platform"] == "template"
-    assert actual["sensor"]["sensor3"]["name"] == "Sensor 3 in subdir"
+    assert actual_sensor["sensor3"]["platform"] == "template"
+    assert actual_sensor["sensor3"]["name"] == "Sensor 3 in subdir"
 
     # Check that hidden files and non-YAML files are not included
-    assert ".hidden" not in actual["sensor"]
-    assert "not_yaml" not in actual["sensor"]
+    assert ".hidden" not in actual_sensor
+    assert "not_yaml" not in actual_sensor
 
 
 def test_construct_include_dir_named_empty_dir(tmp_path: Path) -> None:

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -70,7 +70,7 @@ def test_parsing_with_custom_loader(fixture_path):
     assert loader_calls[2].endswith("includes/scalar.yaml")
 
 
-def test_construct_secret_simple(fixture_path):
+def test_construct_secret_simple(fixture_path: Path) -> None:
     """Test loading a YAML file with !secret tags."""
     yaml_file = fixture_path / "yaml_util" / "test_secret.yaml"
 
@@ -82,7 +82,7 @@ def test_construct_secret_simple(fixture_path):
     assert actual["sensor"][0]["id"] == "my_secret_value"
 
 
-def test_construct_secret_missing(fixture_path, tmp_path):
+def test_construct_secret_missing(fixture_path: Path, tmp_path: Path) -> None:
     """Test that missing secrets raise proper errors."""
     # Create a YAML file with a secret that doesn't exist
     test_yaml = tmp_path / "test.yaml"
@@ -102,7 +102,7 @@ wifi:
         yaml_util.load_yaml(str(test_yaml))
 
 
-def test_construct_secret_no_secrets_file(tmp_path):
+def test_construct_secret_no_secrets_file(tmp_path: Path) -> None:
     """Test that missing secrets.yaml file raises proper error."""
     # Create a YAML file with a secret but no secrets.yaml
     test_yaml = tmp_path / "test.yaml"
@@ -119,7 +119,9 @@ wifi:
         yaml_util.load_yaml(str(test_yaml))
 
 
-def test_construct_secret_fallback_to_main_config_dir(fixture_path, tmp_path):
+def test_construct_secret_fallback_to_main_config_dir(
+    fixture_path: Path, tmp_path: Path
+) -> None:
     """Test fallback to main config directory for secrets."""
     # Create a subdirectory with a YAML file that uses secrets
     subdir = tmp_path / "subdir"
@@ -141,7 +143,7 @@ wifi:
         assert actual["wifi"]["password"] == "main_secret_value"
 
 
-def test_construct_include_dir_named(fixture_path):
+def test_construct_include_dir_named(fixture_path: Path) -> None:
     """Test !include_dir_named directive."""
     # Create test YAML that uses include_dir_named
     test_yaml = fixture_path / "yaml_util" / "test_include_named.yaml"

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -1,9 +1,15 @@
-from esphome import yaml_util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from esphome import core, yaml_util
 from esphome.components import substitutions
 from esphome.core import EsphomeError
+from esphome.util import OrderedDict
 
 
-def test_include_with_vars(fixture_path):
+def test_include_with_vars(fixture_path: Path) -> None:
     yaml_file = fixture_path / "yaml_util" / "includetest.yaml"
 
     actual = yaml_util.load_yaml(yaml_file)
@@ -62,3 +68,194 @@ def test_parsing_with_custom_loader(fixture_path):
     assert loader_calls[0].endswith("includes/included.yaml")
     assert loader_calls[1].endswith("includes/list.yaml")
     assert loader_calls[2].endswith("includes/scalar.yaml")
+
+
+def test_construct_secret_simple(fixture_path):
+    """Test loading a YAML file with !secret tags."""
+    yaml_file = fixture_path / "yaml_util" / "test_secret.yaml"
+
+    actual = yaml_util.load_yaml(yaml_file)
+
+    # Check that secrets were properly loaded
+    assert actual["wifi"]["password"] == "super_secret_wifi"
+    assert actual["api"]["encryption"]["key"] == "0123456789abcdef"
+    assert actual["sensor"][0]["id"] == "my_secret_value"
+
+
+def test_construct_secret_missing(fixture_path, tmp_path):
+    """Test that missing secrets raise proper errors."""
+    # Create a YAML file with a secret that doesn't exist
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("""
+esphome:
+  name: test
+
+wifi:
+  password: !secret nonexistent_secret
+""")
+
+    # Create an empty secrets file
+    secrets_yaml = tmp_path / "secrets.yaml"
+    secrets_yaml.write_text("some_other_secret: value")
+
+    with pytest.raises(EsphomeError, match="Secret 'nonexistent_secret' not defined"):
+        yaml_util.load_yaml(str(test_yaml))
+
+
+def test_construct_secret_no_secrets_file(tmp_path):
+    """Test that missing secrets.yaml file raises proper error."""
+    # Create a YAML file with a secret but no secrets.yaml
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("""
+wifi:
+  password: !secret some_secret
+""")
+
+    # Mock CORE.config_path to avoid NoneType error
+    with (
+        patch.object(core.CORE, "config_path", str(tmp_path / "main.yaml")),
+        pytest.raises(EsphomeError, match="secrets.yaml"),
+    ):
+        yaml_util.load_yaml(str(test_yaml))
+
+
+def test_construct_secret_fallback_to_main_config_dir(fixture_path, tmp_path):
+    """Test fallback to main config directory for secrets."""
+    # Create a subdirectory with a YAML file that uses secrets
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    test_yaml = subdir / "test.yaml"
+    test_yaml.write_text("""
+wifi:
+  password: !secret test_secret
+""")
+
+    # Create secrets.yaml in the main directory
+    main_secrets = tmp_path / "secrets.yaml"
+    main_secrets.write_text("test_secret: main_secret_value")
+
+    # Mock CORE.config_path to point to main directory
+    with patch.object(core.CORE, "config_path", str(tmp_path / "main.yaml")):
+        actual = yaml_util.load_yaml(str(test_yaml))
+        assert actual["wifi"]["password"] == "main_secret_value"
+
+
+def test_construct_include_dir_named(fixture_path):
+    """Test !include_dir_named directive."""
+    # Create test YAML that uses include_dir_named
+    test_yaml = fixture_path / "yaml_util" / "test_include_named.yaml"
+    test_yaml.write_text("""
+sensor: !include_dir_named named_dir
+""")
+
+    actual = yaml_util.load_yaml(str(test_yaml))
+
+    # Check that files were loaded with their names as keys
+    assert isinstance(actual["sensor"], OrderedDict)
+    assert "sensor1" in actual["sensor"]
+    assert "sensor2" in actual["sensor"]
+    assert (
+        "sensor3" in actual["sensor"]
+    )  # Files from subdirs are included with basename
+
+    # Check content of loaded files
+    assert actual["sensor"]["sensor1"]["platform"] == "template"
+    assert actual["sensor"]["sensor1"]["name"] == "Sensor 1"
+    assert actual["sensor"]["sensor2"]["platform"] == "template"
+    assert actual["sensor"]["sensor2"]["name"] == "Sensor 2"
+
+    # Check that subdirectory files are included with their basename
+    assert actual["sensor"]["sensor3"]["platform"] == "template"
+    assert actual["sensor"]["sensor3"]["name"] == "Sensor 3 in subdir"
+
+    # Check that hidden files and non-YAML files are not included
+    assert ".hidden" not in actual["sensor"]
+    assert "not_yaml" not in actual["sensor"]
+
+
+def test_construct_include_dir_named_empty_dir(tmp_path):
+    """Test !include_dir_named with empty directory."""
+    # Create empty directory
+    empty_dir = tmp_path / "empty_dir"
+    empty_dir.mkdir()
+
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("""
+sensor: !include_dir_named empty_dir
+""")
+
+    actual = yaml_util.load_yaml(str(test_yaml))
+
+    # Should return empty OrderedDict
+    assert isinstance(actual["sensor"], OrderedDict)
+    assert len(actual["sensor"]) == 0
+
+
+def test_construct_include_dir_named_with_dots(tmp_path):
+    """Test that include_dir_named ignores files starting with dots."""
+    # Create directory with various files
+    test_dir = tmp_path / "test_dir"
+    test_dir.mkdir()
+
+    # Create visible file
+    visible_file = test_dir / "visible.yaml"
+    visible_file.write_text("key: visible_value")
+
+    # Create hidden file
+    hidden_file = test_dir / ".hidden.yaml"
+    hidden_file.write_text("key: hidden_value")
+
+    # Create hidden directory with files
+    hidden_dir = test_dir / ".hidden_dir"
+    hidden_dir.mkdir()
+    hidden_subfile = hidden_dir / "subfile.yaml"
+    hidden_subfile.write_text("key: hidden_subfile_value")
+
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("""
+test: !include_dir_named test_dir
+""")
+
+    actual = yaml_util.load_yaml(str(test_yaml))
+
+    # Should only include visible file
+    assert "visible" in actual["test"]
+    assert actual["test"]["visible"]["key"] == "visible_value"
+
+    # Should not include hidden files or directories
+    assert ".hidden" not in actual["test"]
+    assert ".hidden_dir" not in actual["test"]
+
+
+def test_find_files_recursive(fixture_path):
+    """Test that _find_files works recursively through include_dir_named."""
+    # This indirectly tests _find_files by using include_dir_named
+    test_yaml = fixture_path / "yaml_util" / "test_include_recursive.yaml"
+    test_yaml.write_text("""
+all_sensors: !include_dir_named named_dir
+""")
+
+    actual = yaml_util.load_yaml(str(test_yaml))
+
+    # Should find sensor1.yaml, sensor2.yaml, and subdir/sensor3.yaml (all flattened)
+    assert len(actual["all_sensors"]) == 3
+    assert "sensor1" in actual["all_sensors"]
+    assert "sensor2" in actual["all_sensors"]
+    assert "sensor3" in actual["all_sensors"]
+
+
+def test_secret_values_tracking(fixture_path):
+    """Test that secret values are properly tracked for dumping."""
+    yaml_file = fixture_path / "yaml_util" / "test_secret.yaml"
+
+    # Clear secret cache first
+    yaml_util._SECRET_VALUES.clear()
+
+    yaml_util.load_yaml(yaml_file)
+
+    # Check that secret values are tracked
+    assert "super_secret_wifi" in yaml_util._SECRET_VALUES
+    assert yaml_util._SECRET_VALUES["super_secret_wifi"] == "wifi_password"
+    assert "0123456789abcdef" in yaml_util._SECRET_VALUES
+    assert yaml_util._SECRET_VALUES["0123456789abcdef"] == "api_key"

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -176,7 +176,7 @@ sensor: !include_dir_named named_dir
     assert "not_yaml" not in actual["sensor"]
 
 
-def test_construct_include_dir_named_empty_dir(tmp_path):
+def test_construct_include_dir_named_empty_dir(tmp_path: Path) -> None:
     """Test !include_dir_named with empty directory."""
     # Create empty directory
     empty_dir = tmp_path / "empty_dir"
@@ -194,7 +194,7 @@ sensor: !include_dir_named empty_dir
     assert len(actual["sensor"]) == 0
 
 
-def test_construct_include_dir_named_with_dots(tmp_path):
+def test_construct_include_dir_named_with_dots(tmp_path: Path) -> None:
     """Test that include_dir_named ignores files starting with dots."""
     # Create directory with various files
     test_dir = tmp_path / "test_dir"
@@ -230,7 +230,7 @@ test: !include_dir_named test_dir
     assert ".hidden_dir" not in actual["test"]
 
 
-def test_find_files_recursive(fixture_path):
+def test_find_files_recursive(fixture_path: Path) -> None:
     """Test that _find_files works recursively through include_dir_named."""
     # This indirectly tests _find_files by using include_dir_named
     test_yaml = fixture_path / "yaml_util" / "test_include_recursive.yaml"
@@ -247,7 +247,7 @@ all_sensors: !include_dir_named named_dir
     assert "sensor3" in actual["all_sensors"]
 
 
-def test_secret_values_tracking(fixture_path):
+def test_secret_values_tracking(fixture_path: Path) -> None:
     """Test that secret values are properly tracked for dumping."""
     yaml_file = fixture_path / "yaml_util" / "test_secret.yaml"
 

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -16,7 +16,6 @@ def clear_secrets_cache() -> None:
     yaml_util._SECRET_VALUES.clear()
     yaml_util._SECRET_CACHE.clear()
     yield
-    # Optionally clear after test as well for better isolation
     yaml_util._SECRET_VALUES.clear()
     yaml_util._SECRET_CACHE.clear()
 

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -10,6 +10,17 @@ from esphome.core import EsphomeError
 from esphome.util import OrderedDict
 
 
+@pytest.fixture(autouse=True)
+def clear_secrets_cache() -> None:
+    """Clear the secrets cache before each test."""
+    yaml_util._SECRET_VALUES.clear()
+    yaml_util._SECRET_CACHE.clear()
+    yield
+    # Optionally clear after test as well for better isolation
+    yaml_util._SECRET_VALUES.clear()
+    yaml_util._SECRET_CACHE.clear()
+
+
 def test_include_with_vars(fixture_path: Path) -> None:
     yaml_file = fixture_path / "yaml_util" / "includetest.yaml"
 
@@ -260,9 +271,6 @@ all_sensors: !include_dir_named named_dir
 def test_secret_values_tracking(fixture_path: Path) -> None:
     """Test that secret values are properly tracked for dumping."""
     yaml_file = fixture_path / "yaml_util" / "test_secret.yaml"
-
-    # Clear secret cache first
-    yaml_util._SECRET_VALUES.clear()
 
     yaml_util.load_yaml(yaml_file)
 


### PR DESCRIPTION
# What does this implement/fix?

Add additional coverage for yaml_util

supports https://github.com/esphome/esphome/pull/10654

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
