### PR TITLE
[core] Add millisecond precision to logging timestamps

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -226,7 +226,9 @@ def run_miniterm(config: ConfigType, port: str, args) -> int:
                         .replace(b"\n", b"")
                         .decode("utf8", "backslashreplace")
                     )
-                    time_str = datetime.now().time().strftime("[%H:%M:%S]")
+                    time_ = datetime.now()
+                    nanoseconds = time_.microsecond // 1000
+                    time_str = f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}.{nanoseconds:03}]"
                     safe_print(parser.parse_line(line, time_str))
 
                     backtrace_state = platformio_api.process_stacktrace(

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -62,9 +62,11 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
         time_ = datetime.now()
         message: bytes = msg.message
         text = message.decode("utf8", "backslashreplace")
-        for parsed_msg in parse_log_message(
-            text, f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}]"
-        ):
+        nanoseconds = time_.microsecond // 1000
+        timestamp = (
+            f"[{time_.hour:02}:{time_.minute:02}:{time_.second:02}.{nanoseconds:03}]"
+        )
+        for parsed_msg in parse_log_message(text, timestamp):
             print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
 
     stop = await async_run(cli, on_log, name=name)


### PR DESCRIPTION
# What does this implement/fix?

This PR adds millisecond precision to ESPHome CLI logging timestamps to match the precision already used in aioesphomeapi. This improvement helps with debugging timing-sensitive operations where second-level precision is insufficient.

Previously, ESPHome CLI used second-level precision `[HH:MM:SS]` while aioesphomeapi used millisecond precision `[HH:MM:SS.mmm]`. This inconsistency made it difficult to correlate events and debug timing issues across different logging outputs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Improves debugging capabilities for timing-sensitive operations

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This change affects log output formatting only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
