### PR TITLE
fix lwip pbuf_free race condition using unique pointers

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -26,6 +26,12 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
+struct PbufDeleter {
+  void operator()(pbuf* b) { pbuf_free(b); }
+};
+
+using unique_pbuf_t = std::unique_ptr<pbuf, PbufDeleter>;
+
 class LWIPRawImpl : public Socket {
  public:
   LWIPRawImpl(sa_family_t family, struct tcp_pcb *pcb) : pcb_(pcb), family_(family) {}
@@ -311,20 +317,20 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return -1;
     }
-    if (rx_closed_ && rx_buf_ == nullptr) {
+    if (rx_closed_ && !rx_buf_) {
       return 0;
     }
     if (len == 0) {
       return 0;
     }
-    if (rx_buf_ == nullptr) {
+    if (!rx_buf_) {
       errno = EWOULDBLOCK;
       return -1;
     }
 
     size_t read = 0;
     uint8_t *buf8 = reinterpret_cast<uint8_t *>(buf);
-    while (len && rx_buf_ != nullptr) {
+    while (len && rx_buf_) {
       size_t pb_len = rx_buf_->len;
       size_t pb_left = pb_len - rx_buf_offset_;
       if (pb_left == 0)
@@ -336,15 +342,13 @@ class LWIPRawImpl : public Socket {
         // full pb copied, free it
         if (rx_buf_->next == nullptr) {
           // last buffer in chain
-          pbuf_free(rx_buf_);
-          rx_buf_ = nullptr;
-          rx_buf_offset_ = 0;
+          rx_buf_.reset();
+          // no need to reset rx_buf_offset_, it will be reset in recv_fn
         } else {
-          auto *old_buf = rx_buf_;
-          rx_buf_ = rx_buf_->next;
-          pbuf_ref(rx_buf_);
-          pbuf_free(old_buf);
+          auto *new_buf = rx_buf_->next;
           rx_buf_offset_ = 0;
+          pbuf_ref(new_buf);
+          rx_buf_.reset(new_buf);
         }
       } else {
         rx_buf_offset_ += copysize;
@@ -520,12 +524,12 @@ class LWIPRawImpl : public Socket {
       rx_closed_ = true;
       return ERR_OK;
     }
-    if (rx_buf_ == nullptr) {
+    if (!rx_buf_) {
       // no need to copy because lwIP gave control of it to us
-      rx_buf_ = pb;
+      rx_buf_.reset(pb);
       rx_buf_offset_ = 0;
     } else {
-      pbuf_cat(rx_buf_, pb);
+      pbuf_cat(rx_buf_.get(), pb);
     }
     return ERR_OK;
   }
@@ -589,7 +593,7 @@ class LWIPRawImpl : public Socket {
   struct tcp_pcb *pcb_;
   std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
   bool rx_closed_ = false;
-  pbuf *rx_buf_ = nullptr;
+  unique_pbuf_t rx_buf_{nullptr};
   size_t rx_buf_offset_ = 0;
   // don't use lwip nodelay flag, it sometimes causes reconnect
   // instead use it for determining whether to call lwip_output

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -27,7 +27,7 @@ static const char *const TAG = "socket.lwip";
 #endif
 
 struct PbufDeleter {
-  void operator()(pbuf* b) { pbuf_free(b); }
+  void operator()(pbuf *b) { pbuf_free(b); }
 };
 
 using unique_pbuf_t = std::unique_ptr<pbuf, PbufDeleter>;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -13,6 +13,7 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/lock_free_queue.h"
 
 namespace esphome {
 namespace socket {
@@ -25,6 +26,19 @@ static const char *const TAG = "socket.lwip";
 #else
 #define LWIP_LOG(msg, ...)
 #endif
+
+template<class T, uint8_t SIZE> class PbufQueue : public LockFreeQueue<T, SIZE, false> {
+ public:
+  bool push(T *element) = delete;
+
+  T *push_or_get_last(T *element) {
+    bool was_empty;
+    uint8_t old_tail_idx;
+    bool result = this->push_internal_(element, was_empty, old_tail_idx);
+
+    return result ? nullptr : this->buffer_[(old_tail_idx == 0 ? SIZE : old_tail_idx) - 1];
+  }
+};
 
 class LWIPRawImpl : public Socket {
  public:
@@ -311,41 +325,38 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return -1;
     }
-    if (rx_closed_ && rx_buf_ == nullptr) {
-      return 0;
-    }
     if (len == 0) {
       return 0;
     }
-    if (rx_buf_ == nullptr) {
-      errno = EWOULDBLOCK;
-      return -1;
+    if (partial_rx_buf_ == nullptr) {
+      if (rx_closed_) {
+        return 0;
+      }
+
+      partial_rx_buf_ = rx_bufs_.pop();
     }
 
     size_t read = 0;
     uint8_t *buf8 = reinterpret_cast<uint8_t *>(buf);
-    while (len && rx_buf_ != nullptr) {
-      size_t pb_len = rx_buf_->len;
+    while (len && partial_rx_buf_ != nullptr) {
+      size_t pb_len = partial_rx_buf_->len;
       size_t pb_left = pb_len - rx_buf_offset_;
       if (pb_left == 0)
         break;
       size_t copysize = std::min(len, pb_left);
-      memcpy(buf8, reinterpret_cast<uint8_t *>(rx_buf_->payload) + rx_buf_offset_, copysize);
+      memcpy(buf8, reinterpret_cast<uint8_t *>(partial_rx_buf_->payload) + rx_buf_offset_, copysize);
 
       if (pb_left == copysize) {
         // full pb copied, free it
-        if (rx_buf_->next == nullptr) {
-          // last buffer in chain
-          pbuf_free(rx_buf_);
-          rx_buf_ = nullptr;
-          rx_buf_offset_ = 0;
+        auto *old_buf = partial_rx_buf_;
+        if (partial_rx_buf_->next == nullptr) {
+          partial_rx_buf_ = rx_bufs_.pop();
         } else {
-          auto *old_buf = rx_buf_;
-          rx_buf_ = rx_buf_->next;
-          pbuf_ref(rx_buf_);
-          pbuf_free(old_buf);
-          rx_buf_offset_ = 0;
+          pbuf_ref(partial_rx_buf_->next);
+          partial_rx_buf_ = partial_rx_buf_->next;
         }
+        rx_buf_offset_ = 0;
+        pbuf_free(old_buf);
       } else {
         rx_buf_offset_ += copysize;
       }
@@ -520,12 +531,11 @@ class LWIPRawImpl : public Socket {
       rx_closed_ = true;
       return ERR_OK;
     }
-    if (rx_buf_ == nullptr) {
-      // no need to copy because lwIP gave control of it to us
-      rx_buf_ = pb;
-      rx_buf_offset_ = 0;
-    } else {
-      pbuf_cat(rx_buf_, pb);
+    // no need to copy because lwIP gave control of it to us
+    pbuf *last_pb = rx_bufs_.push_or_get_last(pb);
+    if (last_pb != nullptr) {
+      // queue was full, so we append to the last pbuf in the queue, which is safe
+      pbuf_cat(last_pb, pb);
     }
     return ERR_OK;
   }
@@ -589,7 +599,8 @@ class LWIPRawImpl : public Socket {
   struct tcp_pcb *pcb_;
   std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
   bool rx_closed_ = false;
-  pbuf *rx_buf_ = nullptr;
+  PbufQueue<pbuf, 4> rx_bufs_;
+  pbuf *partial_rx_buf_ = nullptr;
   size_t rx_buf_offset_ = 0;
   // don't use lwip nodelay flag, it sometimes causes reconnect
   // instead use it for determining whether to call lwip_output

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -13,7 +13,6 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "esphome/core/lock_free_queue.h"
 
 namespace esphome {
 namespace socket {
@@ -26,19 +25,6 @@ static const char *const TAG = "socket.lwip";
 #else
 #define LWIP_LOG(msg, ...)
 #endif
-
-template<class T, uint8_t SIZE> class PbufQueue : public LockFreeQueue<T, SIZE, false> {
- public:
-  bool push(T *element) = delete;
-
-  T *push_or_get_last(T *element) {
-    bool was_empty;
-    uint8_t old_tail_idx;
-    bool result = this->push_internal_(element, was_empty, old_tail_idx);
-
-    return result ? nullptr : this->buffer_[(old_tail_idx == 0 ? SIZE : old_tail_idx) - 1];
-  }
-};
 
 class LWIPRawImpl : public Socket {
  public:
@@ -325,38 +311,41 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return -1;
     }
+    if (rx_closed_ && rx_buf_ == nullptr) {
+      return 0;
+    }
     if (len == 0) {
       return 0;
     }
-    if (partial_rx_buf_ == nullptr) {
-      if (rx_closed_) {
-        return 0;
-      }
-
-      partial_rx_buf_ = rx_bufs_.pop();
+    if (rx_buf_ == nullptr) {
+      errno = EWOULDBLOCK;
+      return -1;
     }
 
     size_t read = 0;
     uint8_t *buf8 = reinterpret_cast<uint8_t *>(buf);
-    while (len && partial_rx_buf_ != nullptr) {
-      size_t pb_len = partial_rx_buf_->len;
+    while (len && rx_buf_ != nullptr) {
+      size_t pb_len = rx_buf_->len;
       size_t pb_left = pb_len - rx_buf_offset_;
       if (pb_left == 0)
         break;
       size_t copysize = std::min(len, pb_left);
-      memcpy(buf8, reinterpret_cast<uint8_t *>(partial_rx_buf_->payload) + rx_buf_offset_, copysize);
+      memcpy(buf8, reinterpret_cast<uint8_t *>(rx_buf_->payload) + rx_buf_offset_, copysize);
 
       if (pb_left == copysize) {
         // full pb copied, free it
-        auto *old_buf = partial_rx_buf_;
-        if (partial_rx_buf_->next == nullptr) {
-          partial_rx_buf_ = rx_bufs_.pop();
+        if (rx_buf_->next == nullptr) {
+          // last buffer in chain
+          pbuf_free(rx_buf_);
+          rx_buf_ = nullptr;
+          rx_buf_offset_ = 0;
         } else {
-          pbuf_ref(partial_rx_buf_->next);
-          partial_rx_buf_ = partial_rx_buf_->next;
+          auto *old_buf = rx_buf_;
+          rx_buf_ = rx_buf_->next;
+          pbuf_ref(rx_buf_);
+          pbuf_free(old_buf);
+          rx_buf_offset_ = 0;
         }
-        rx_buf_offset_ = 0;
-        pbuf_free(old_buf);
       } else {
         rx_buf_offset_ += copysize;
       }
@@ -531,11 +520,12 @@ class LWIPRawImpl : public Socket {
       rx_closed_ = true;
       return ERR_OK;
     }
-    // no need to copy because lwIP gave control of it to us
-    pbuf *last_pb = rx_bufs_.push_or_get_last(pb);
-    if (last_pb != nullptr) {
-      // queue was full, so we append to the last pbuf in the queue, which is safe
-      pbuf_cat(last_pb, pb);
+    if (rx_buf_ == nullptr) {
+      // no need to copy because lwIP gave control of it to us
+      rx_buf_ = pb;
+      rx_buf_offset_ = 0;
+    } else {
+      pbuf_cat(rx_buf_, pb);
     }
     return ERR_OK;
   }
@@ -599,8 +589,7 @@ class LWIPRawImpl : public Socket {
   struct tcp_pcb *pcb_;
   std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
   bool rx_closed_ = false;
-  PbufQueue<pbuf, 4> rx_bufs_;
-  pbuf *partial_rx_buf_ = nullptr;
+  pbuf *rx_buf_ = nullptr;
   size_t rx_buf_offset_ = 0;
   // don't use lwip nodelay flag, it sometimes causes reconnect
   // instead use it for determining whether to call lwip_output

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -18,6 +18,7 @@
 namespace esphome {
 namespace socket {
 
+static const size_t Max_Accepted_Queued_Sockets = 16u;
 static const char *const TAG = "socket.lwip";
 
 // set to 1 to enable verbose lwip logging
@@ -64,12 +65,13 @@ class LWIPRawImpl : public Socket {
       errno = EBADF;
       return nullptr;
     }
-    if (accepted_sockets_.empty()) {
+    tcp_pcb *newpcb = accepted_sockets_.pop();
+    if (newpcb == nullptr) {
       errno = EWOULDBLOCK;
       return nullptr;
     }
-    std::unique_ptr<LWIPRawImpl> sock = std::move(accepted_sockets_.front());
-    accepted_sockets_.pop();
+    auto sock = make_unique<LWIPRawImpl>(family_, newpcb);
+    sock->init();
     if (addr != nullptr) {
       sock->getpeername(addr, addrlen);
     }
@@ -505,9 +507,7 @@ class LWIPRawImpl : public Socket {
       // nothing to do here, we just don't push it to the queue
       return ERR_OK;
     }
-    auto sock = make_unique<LWIPRawImpl>(family_, newpcb);
-    sock->init();
-    accepted_sockets_.push(std::move(sock));
+    accepted_sockets_.push(newpcb);
     return ERR_OK;
   }
   void err_fn(err_t err) {
@@ -518,6 +518,7 @@ class LWIPRawImpl : public Socket {
     // ERR_RST: connection was reset by remote host
     // ERR_ABRT: aborted through tcp_abort or TCP timer
     pcb_ = nullptr;
+    // FIXME - this could be called anytime, and no operation is allowed on pcb_ after this
   }
   err_t recv_fn(struct pbuf *pb, err_t err) {
     LWIP_LOG("recv(pb=%p err=%d)", pb, err);
@@ -597,7 +598,7 @@ class LWIPRawImpl : public Socket {
   }
 
   struct tcp_pcb *pcb_;
-  std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
+  LockFreeQueue<tcp_pcb, Max_Accepted_Queued_Sockets, false> accepted_sockets_;
   bool rx_closed_ = false;
   PbufQueue<pbuf, 4> rx_bufs_;
   pbuf *partial_rx_buf_ = nullptr;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -26,10 +26,18 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
+#ifdef USE_RP2040
+#define LOCK_INTERRUPTS InterruptLock lock
+#else
+#define LOCK_INTERRUPTS
+// FIXME need to figure out if this is a problem on ESP8266
+#endif
+
 class LWIPRawImpl : public Socket {
  public:
   LWIPRawImpl(sa_family_t family, struct tcp_pcb *pcb) : pcb_(pcb), family_(family) {}
   ~LWIPRawImpl() override {
+    LOCK_INTERRUPTS;
     if (pcb_ != nullptr) {
       LWIP_LOG("tcp_abort(%p)", pcb_);
       tcp_abort(pcb_);
@@ -38,6 +46,7 @@ class LWIPRawImpl : public Socket {
   }
 
   void init() {
+    LOCK_INTERRUPTS;
     LWIP_LOG("init(%p)", pcb_);
     tcp_arg(pcb_, this);
     tcp_accept(pcb_, LWIPRawImpl::s_accept_fn);
@@ -46,6 +55,7 @@ class LWIPRawImpl : public Socket {
   }
 
   std::unique_ptr<Socket> accept(struct sockaddr *addr, socklen_t *addrlen) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = EBADF;
       return nullptr;
@@ -63,6 +73,7 @@ class LWIPRawImpl : public Socket {
     return std::unique_ptr<Socket>(std::move(sock));
   }
   int bind(const struct sockaddr *name, socklen_t addrlen) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = EBADF;
       return -1;
@@ -127,6 +138,7 @@ class LWIPRawImpl : public Socket {
     return 0;
   }
   int close() override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return -1;
@@ -144,6 +156,7 @@ class LWIPRawImpl : public Socket {
     return 0;
   }
   int shutdown(int how) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return -1;
@@ -170,6 +183,7 @@ class LWIPRawImpl : public Socket {
   }
 
   int getpeername(struct sockaddr *name, socklen_t *addrlen) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return -1;
@@ -181,6 +195,7 @@ class LWIPRawImpl : public Socket {
     return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
   }
   std::string getpeername() override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return "";
@@ -197,6 +212,7 @@ class LWIPRawImpl : public Socket {
     return std::string(buffer);
   }
   int getsockname(struct sockaddr *name, socklen_t *addrlen) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return -1;
@@ -208,6 +224,7 @@ class LWIPRawImpl : public Socket {
     return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
   }
   std::string getsockname() override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return "";
@@ -286,6 +303,7 @@ class LWIPRawImpl : public Socket {
     return -1;
   }
   int listen(int backlog) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = EBADF;
       return -1;
@@ -307,6 +325,7 @@ class LWIPRawImpl : public Socket {
     return 0;
   }
   ssize_t read(void *buf, size_t len) override {
+    LOCK_INTERRUPTS;
     if (pcb_ == nullptr) {
       errno = ECONNRESET;
       return -1;
@@ -430,6 +449,7 @@ class LWIPRawImpl : public Socket {
     return 0;
   }
   ssize_t write(const void *buf, size_t len) override {
+    LOCK_INTERRUPTS;
     ssize_t written = internal_write(buf, len);
     if (written == -1)
       return -1;
@@ -444,6 +464,7 @@ class LWIPRawImpl : public Socket {
     return written;
   }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {
+    LOCK_INTERRUPTS;
     ssize_t written = 0;
     for (int i = 0; i < iovcnt; i++) {
       ssize_t err = internal_write(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -26,12 +26,6 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
-struct PbufDeleter {
-  void operator()(pbuf *b) { pbuf_free(b); }
-};
-
-using unique_pbuf_t = std::unique_ptr<pbuf, PbufDeleter>;
-
 class LWIPRawImpl : public Socket {
  public:
   LWIPRawImpl(sa_family_t family, struct tcp_pcb *pcb) : pcb_(pcb), family_(family) {}
@@ -317,20 +311,20 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return -1;
     }
-    if (rx_closed_ && !rx_buf_) {
+    if (rx_closed_ && rx_buf_ == nullptr) {
       return 0;
     }
     if (len == 0) {
       return 0;
     }
-    if (!rx_buf_) {
+    if (rx_buf_ == nullptr) {
       errno = EWOULDBLOCK;
       return -1;
     }
 
     size_t read = 0;
     uint8_t *buf8 = reinterpret_cast<uint8_t *>(buf);
-    while (len && rx_buf_) {
+    while (len && rx_buf_ != nullptr) {
       size_t pb_len = rx_buf_->len;
       size_t pb_left = pb_len - rx_buf_offset_;
       if (pb_left == 0)
@@ -342,13 +336,15 @@ class LWIPRawImpl : public Socket {
         // full pb copied, free it
         if (rx_buf_->next == nullptr) {
           // last buffer in chain
-          rx_buf_.reset();
-          // no need to reset rx_buf_offset_, it will be reset in recv_fn
-        } else {
-          auto *new_buf = rx_buf_->next;
+          pbuf_free(rx_buf_);
+          rx_buf_ = nullptr;
           rx_buf_offset_ = 0;
-          pbuf_ref(new_buf);
-          rx_buf_.reset(new_buf);
+        } else {
+          auto *old_buf = rx_buf_;
+          rx_buf_ = rx_buf_->next;
+          pbuf_ref(rx_buf_);
+          pbuf_free(old_buf);
+          rx_buf_offset_ = 0;
         }
       } else {
         rx_buf_offset_ += copysize;
@@ -524,12 +520,12 @@ class LWIPRawImpl : public Socket {
       rx_closed_ = true;
       return ERR_OK;
     }
-    if (!rx_buf_) {
+    if (rx_buf_ == nullptr) {
       // no need to copy because lwIP gave control of it to us
-      rx_buf_.reset(pb);
+      rx_buf_ = pb;
       rx_buf_offset_ = 0;
     } else {
-      pbuf_cat(rx_buf_.get(), pb);
+      pbuf_cat(rx_buf_, pb);
     }
     return ERR_OK;
   }
@@ -593,7 +589,7 @@ class LWIPRawImpl : public Socket {
   struct tcp_pcb *pcb_;
   std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
   bool rx_closed_ = false;
-  unique_pbuf_t rx_buf_{nullptr};
+  pbuf *rx_buf_ = nullptr;
   size_t rx_buf_offset_ = 0;
   // don't use lwip nodelay flag, it sometimes causes reconnect
   // instead use it for determining whether to call lwip_output

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -18,7 +18,6 @@
 namespace esphome {
 namespace socket {
 
-static const size_t Max_Accepted_Queued_Sockets = 16u;
 static const char *const TAG = "socket.lwip";
 
 // set to 1 to enable verbose lwip logging
@@ -65,13 +64,12 @@ class LWIPRawImpl : public Socket {
       errno = EBADF;
       return nullptr;
     }
-    tcp_pcb *newpcb = accepted_sockets_.pop();
-    if (newpcb == nullptr) {
+    if (accepted_sockets_.empty()) {
       errno = EWOULDBLOCK;
       return nullptr;
     }
-    auto sock = make_unique<LWIPRawImpl>(family_, newpcb);
-    sock->init();
+    std::unique_ptr<LWIPRawImpl> sock = std::move(accepted_sockets_.front());
+    accepted_sockets_.pop();
     if (addr != nullptr) {
       sock->getpeername(addr, addrlen);
     }
@@ -507,7 +505,9 @@ class LWIPRawImpl : public Socket {
       // nothing to do here, we just don't push it to the queue
       return ERR_OK;
     }
-    accepted_sockets_.push(newpcb);
+    auto sock = make_unique<LWIPRawImpl>(family_, newpcb);
+    sock->init();
+    accepted_sockets_.push(std::move(sock));
     return ERR_OK;
   }
   void err_fn(err_t err) {
@@ -518,7 +518,6 @@ class LWIPRawImpl : public Socket {
     // ERR_RST: connection was reset by remote host
     // ERR_ABRT: aborted through tcp_abort or TCP timer
     pcb_ = nullptr;
-    // FIXME - this could be called anytime, and no operation is allowed on pcb_ after this
   }
   err_t recv_fn(struct pbuf *pb, err_t err) {
     LWIP_LOG("recv(pb=%p err=%d)", pb, err);
@@ -598,7 +597,7 @@ class LWIPRawImpl : public Socket {
   }
 
   struct tcp_pcb *pcb_;
-  LockFreeQueue<tcp_pcb, Max_Accepted_Queued_Sockets, false> accepted_sockets_;
+  std::queue<std::unique_ptr<LWIPRawImpl>> accepted_sockets_;
   bool rx_closed_ = false;
   PbufQueue<pbuf, 4> rx_bufs_;
   pbuf *partial_rx_buf_ = nullptr;

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -1,7 +1,12 @@
 #pragma once
 
+#if defined(USE_ESP32)
+
 #include <atomic>
 #include <cstddef>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 /*
  * Lock-free queue for single-producer single-consumer scenarios.
@@ -17,16 +22,12 @@
  *
  * @tparam T The type of elements stored in the queue (must be a pointer type)
  * @tparam SIZE The maximum number of elements (1-255, limited by uint8_t indices)
- * @tparam TRACK_DROPPED flag to disable tracking of queue overflows (because this may introduce locking on some
- * platforms)
  */
 
 namespace esphome {
 
 // Base lock-free queue without task notification
-template<class T, uint8_t SIZE, bool TRACK_DROPPED = true> class LockFreeQueue {
-  static_assert(SIZE > 0);
-
+template<class T, uint8_t SIZE> class LockFreeQueue {
  public:
   LockFreeQueue() : dropped_count_(0), head_(0), tail_(0) {}
 
@@ -48,16 +49,14 @@ template<class T, uint8_t SIZE, bool TRACK_DROPPED = true> class LockFreeQueue {
     // Read head before incrementing tail
     uint8_t head_before = head_.load(std::memory_order_acquire);
 
-    was_empty = (current_tail == head_before);
-    old_tail = current_tail;
-
     if (next_tail == head_before) {
       // Buffer full
-      if constexpr (TRACK_DROPPED) {
-        dropped_count_.fetch_add(1, std::memory_order_relaxed);
-      }
+      dropped_count_.fetch_add(1, std::memory_order_relaxed);
       return false;
     }
+
+    was_empty = (current_tail == head_before);
+    old_tail = current_tail;
 
     buffer_[current_tail] = element;
     tail_.store(next_tail, std::memory_order_release);
@@ -84,11 +83,9 @@ template<class T, uint8_t SIZE, bool TRACK_DROPPED = true> class LockFreeQueue {
     return (tail - head + SIZE) % SIZE;
   }
 
-  uint16_t get_and_reset_dropped_count() requires TRACK_DROPPED {
-    return dropped_count_.exchange(0, std::memory_order_relaxed);
-  }
+  uint16_t get_and_reset_dropped_count() { return dropped_count_.exchange(0, std::memory_order_relaxed); }
 
-  void increment_dropped_count() requires TRACK_DROPPED { dropped_count_.fetch_add(1, std::memory_order_relaxed); }
+  void increment_dropped_count() { dropped_count_.fetch_add(1, std::memory_order_relaxed); }
 
   bool empty() const { return head_.load(std::memory_order_acquire) == tail_.load(std::memory_order_acquire); }
 
@@ -108,11 +105,6 @@ template<class T, uint8_t SIZE, bool TRACK_DROPPED = true> class LockFreeQueue {
   // Atomic: written by producer (push), read by consumer (pop) to check if empty
   std::atomic<uint8_t> tail_;
 };
-
-#if defined(USE_ESP32)
-
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
 
 // Extended queue with task notification support
 template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQueue<T, SIZE> {
@@ -149,6 +141,6 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
   TaskHandle_t task_to_notify_;
 };
 
-#endif  // defined(USE_ESP32)
-
 }  // namespace esphome
+
+#endif  // defined(USE_ESP32)

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -1,12 +1,7 @@
 #pragma once
 
-#if defined(USE_ESP32)
-
 #include <atomic>
 #include <cstddef>
-
-#include <freertos/FreeRTOS.h>
-#include <freertos/task.h>
 
 /*
  * Lock-free queue for single-producer single-consumer scenarios.
@@ -22,12 +17,16 @@
  *
  * @tparam T The type of elements stored in the queue (must be a pointer type)
  * @tparam SIZE The maximum number of elements (1-255, limited by uint8_t indices)
+ * @tparam TRACK_DROPPED flag to disable tracking of queue overflows (because this may introduce locking on some
+ * platforms)
  */
 
 namespace esphome {
 
 // Base lock-free queue without task notification
-template<class T, uint8_t SIZE> class LockFreeQueue {
+template<class T, uint8_t SIZE, bool TRACK_DROPPED = true> class LockFreeQueue {
+  static_assert(SIZE > 0);
+
  public:
   LockFreeQueue() : dropped_count_(0), head_(0), tail_(0) {}
 
@@ -49,14 +48,16 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     // Read head before incrementing tail
     uint8_t head_before = head_.load(std::memory_order_acquire);
 
-    if (next_tail == head_before) {
-      // Buffer full
-      dropped_count_.fetch_add(1, std::memory_order_relaxed);
-      return false;
-    }
-
     was_empty = (current_tail == head_before);
     old_tail = current_tail;
+
+    if (next_tail == head_before) {
+      // Buffer full
+      if constexpr (TRACK_DROPPED) {
+        dropped_count_.fetch_add(1, std::memory_order_relaxed);
+      }
+      return false;
+    }
 
     buffer_[current_tail] = element;
     tail_.store(next_tail, std::memory_order_release);
@@ -83,9 +84,11 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     return (tail - head + SIZE) % SIZE;
   }
 
-  uint16_t get_and_reset_dropped_count() { return dropped_count_.exchange(0, std::memory_order_relaxed); }
+  uint16_t get_and_reset_dropped_count() requires TRACK_DROPPED {
+    return dropped_count_.exchange(0, std::memory_order_relaxed);
+  }
 
-  void increment_dropped_count() { dropped_count_.fetch_add(1, std::memory_order_relaxed); }
+  void increment_dropped_count() requires TRACK_DROPPED { dropped_count_.fetch_add(1, std::memory_order_relaxed); }
 
   bool empty() const { return head_.load(std::memory_order_acquire) == tail_.load(std::memory_order_acquire); }
 
@@ -105,6 +108,11 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   // Atomic: written by producer (push), read by consumer (pop) to check if empty
   std::atomic<uint8_t> tail_;
 };
+
+#if defined(USE_ESP32)
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 // Extended queue with task notification support
 template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQueue<T, SIZE> {
@@ -141,6 +149,6 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
   TaskHandle_t task_to_notify_;
 };
 
-}  // namespace esphome
-
 #endif  // defined(USE_ESP32)
+
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

I've finally debugged sporadic crashes occurring on my rp2040. It turns out an assertion in LwIP was failing ([`*** PANIC *** Creating an infinite loop`](https://github.com/lwip-tcpip/lwip/blob/77dcd25a72509eb83f72b033d219b1d40cd8eb95/src/core/pbuf.c#L863) when called from [here](https://github.com/esphome/esphome/blob/625f108183fc58575315789033c5ed67fa2f0f8c/esphome/components/socket/lwip_raw_tcp_impl.cpp#L528)).

The issue is this code: https://github.com/esphome/esphome/blob/625f108183fc58575315789033c5ed67fa2f0f8c/esphome/components/socket/lwip_raw_tcp_impl.cpp#L339-L340
On most rp2040 boards, incoming packets are processed in an interrupt context, therefore `recv_fn` may be called before `rx_buf_` is cleared. If the received pbuf is of the same size as the one previously freed, the assertion fails.

I've decided to replace `pbuf*` with a `unique_ptr<pbuf, pbuf_free>` to prevent these type of issues.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). `N/A`

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). `N/A`
