### PR TITLE
Fix packet_transport not initializing packet data after flushing

### DIFF
--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -270,6 +270,7 @@ void PacketTransport::add_binary_data_(uint8_t key, const char *id, bool data) {
   auto len = 1 + 1 + 1 + strlen(id);
   if (len + this->header_.size() + this->data_.size() > this->get_max_packet_size()) {
     this->flush_();
+    this->init_data_();
   }
   add(this->data_, key);
   add(this->data_, (uint8_t) data);
@@ -284,6 +285,7 @@ void PacketTransport::add_data_(uint8_t key, const char *id, uint32_t data) {
   auto len = 4 + 1 + 1 + strlen(id);
   if (len + this->header_.size() + this->data_.size() > this->get_max_packet_size()) {
     this->flush_();
+    this->init_data_();
   }
   add(this->data_, key);
   add(this->data_, data);


### PR DESCRIPTION
# What does this implement/fix?

I found a bug while trying to parse trough the `packet_transport` component:

When adding the state of sensors to a packet, the `add_data_` method computes the size of the packet if the data is added, and if it exceeds the max determined by the transport, it runs `flush_`, sending the bytes in `data_` trough the transport, and then continues adding on the remaining sensors. However, `flush_` does not reinitialize `data_`, in fact, it doesn't even clear it. I think the correct approach would be to call `PacketTransport::init_data_()`, which clears the buffer and starts a new packet.

I think maybe the reason this hasn't come up is because testing uses a small number of sensors thus it never gets to a point where it needs to send two packets for an update.

I'd appreciate any feedback on how to make tests to detect this kind of issues. Maybe using the host platform and two "devices" running as different programs?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
