### PR TITLE
Add additional dashboard and main tests

### DIFF
--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1148,10 +1148,8 @@ wifi:
 
     args = MockArgs(name="newname", dashboard=False)
 
-    # Use the fixture for run_external_process
-    mock_run_external_process.return_value = (
-        0  # Simulate successful validation and upload
-    )
+    # Simulate successful validation and upload
+    mock_run_external_process.return_value = 0
 
     result = command_rename(args, {})
 

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1164,7 +1164,11 @@ wifi:
 
     # Verify content was updated
     content = new_file.read_text()
-    assert 'name: "newname"' in content or 'name: "newname"' in content
+    assert (
+        'name: "newname"' in content
+        or "name: 'newname'" in content
+        or "name: newname" in content
+    )
 
     captured = capfd.readouterr()
     assert "SUCCESS" in captured.out

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -9,18 +9,27 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from pytest import CaptureFixture
 
-from esphome.__main__ import choose_upload_log_host, show_logs, upload_program
+from esphome.__main__ import (
+    choose_upload_log_host,
+    command_rename,
+    command_wizard,
+    show_logs,
+    upload_program,
+)
 from esphome.const import (
     CONF_BROKER,
     CONF_DISABLED,
     CONF_ESPHOME,
     CONF_MDNS,
     CONF_MQTT,
+    CONF_NAME,
     CONF_OTA,
     CONF_PASSWORD,
     CONF_PLATFORM,
     CONF_PORT,
+    CONF_SUBSTITUTIONS,
     CONF_USE_ADDRESS,
     CONF_WIFI,
     KEY_CORE,
@@ -167,6 +176,14 @@ def mock_no_mqtt_logging() -> Generator[Mock]:
 def mock_has_mqtt_logging() -> Generator[Mock]:
     """Mock has_mqtt_logging to return True."""
     with patch("esphome.__main__.has_mqtt_logging", return_value=True) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_run_external_process() -> Generator[Mock]:
+    """Mock run_external_process for testing."""
+    with patch("esphome.__main__.run_external_process") as mock:
+        mock.return_value = 0  # Default to success
         yield mock
 
 
@@ -606,6 +623,9 @@ class MockArgs:
     password: str | None = None
     client_id: str | None = None
     topic: str | None = None
+    configuration: str | None = None
+    name: str | None = None
+    dashboard: bool = False
 
 
 def test_upload_program_serial_esp32(
@@ -1053,3 +1073,176 @@ def test_show_logs_platform_specific_handler(
     assert result == 0
     mock_import.assert_called_once_with("esphome.components.custom_platform")
     mock_module.show_logs.assert_called_once_with(config, args, devices)
+
+
+def test_command_wizard(tmp_path: Path) -> None:
+    """Test command_wizard function."""
+    config_file = tmp_path / "test.yaml"
+
+    # Mock wizard.wizard to avoid interactive prompts
+    with patch("esphome.wizard.wizard") as mock_wizard:
+        mock_wizard.return_value = 0
+
+        args = MockArgs(configuration=str(config_file))
+        result = command_wizard(args)
+
+        assert result == 0
+        mock_wizard.assert_called_once_with(str(config_file))
+
+
+def test_command_rename_invalid_characters(
+    tmp_path: Path, capfd: CaptureFixture[str]
+) -> None:
+    """Test command_rename with invalid characters in name."""
+    setup_core(tmp_path=tmp_path)
+
+    # Test with invalid character (space)
+    args = MockArgs(name="invalid name")
+    result = command_rename(args, {})
+
+    assert result == 1
+    captured = capfd.readouterr()
+    assert "invalid character" in captured.out.lower()
+
+
+def test_command_rename_complex_yaml(
+    tmp_path: Path, capfd: CaptureFixture[str]
+) -> None:
+    """Test command_rename with complex YAML that cannot be renamed."""
+    config_file = tmp_path / "test.yaml"
+    config_file.write_text("# Complex YAML without esphome section\nsome_key: value\n")
+    setup_core(tmp_path=tmp_path)
+    CORE.config_path = str(config_file)
+
+    args = MockArgs(name="newname")
+    result = command_rename(args, {})
+
+    assert result == 1
+    captured = capfd.readouterr()
+    assert "complex yaml" in captured.out.lower()
+
+
+def test_command_rename_success(
+    tmp_path: Path,
+    capfd: CaptureFixture[str],
+    mock_run_external_process: Mock,
+) -> None:
+    """Test successful rename of a simple configuration."""
+    config_file = tmp_path / "oldname.yaml"
+    config_file.write_text("""
+esphome:
+  name: oldname
+
+esp32:
+  board: nodemcu-32s
+
+wifi:
+  ssid: "test"
+  password: "test1234"
+""")
+    setup_core(tmp_path=tmp_path)
+    CORE.config_path = str(config_file)
+
+    # Set up CORE.config to avoid ValueError when accessing CORE.address
+    CORE.config = {CONF_ESPHOME: {CONF_NAME: "oldname"}}
+
+    args = MockArgs(name="newname", dashboard=False)
+
+    # Use the fixture for run_external_process
+    mock_run_external_process.return_value = (
+        0  # Simulate successful validation and upload
+    )
+
+    result = command_rename(args, {})
+
+    assert result == 0
+
+    # Verify new file was created
+    new_file = tmp_path / "newname.yaml"
+    assert new_file.exists()
+
+    # Verify old file was removed
+    assert not config_file.exists()
+
+    # Verify content was updated
+    content = new_file.read_text()
+    assert 'name: "newname"' in content or 'name: "newname"' in content
+
+    captured = capfd.readouterr()
+    assert "SUCCESS" in captured.out
+
+
+def test_command_rename_with_substitutions(
+    tmp_path: Path,
+    mock_run_external_process: Mock,
+) -> None:
+    """Test rename with substitutions in YAML."""
+    config_file = tmp_path / "oldname.yaml"
+    config_file.write_text("""
+substitutions:
+  device_name: oldname
+
+esphome:
+  name: ${device_name}
+
+esp32:
+  board: nodemcu-32s
+""")
+    setup_core(tmp_path=tmp_path)
+    CORE.config_path = str(config_file)
+
+    # Set up CORE.config to avoid ValueError when accessing CORE.address
+    CORE.config = {
+        CONF_ESPHOME: {CONF_NAME: "oldname"},
+        CONF_SUBSTITUTIONS: {"device_name": "oldname"},
+    }
+
+    args = MockArgs(name="newname", dashboard=False)
+
+    mock_run_external_process.return_value = 0
+
+    result = command_rename(args, {})
+
+    assert result == 0
+
+    # Verify substitution was updated
+    new_file = tmp_path / "newname.yaml"
+    content = new_file.read_text()
+    assert 'device_name: "newname"' in content
+
+
+def test_command_rename_validation_failure(
+    tmp_path: Path,
+    capfd: CaptureFixture[str],
+    mock_run_external_process: Mock,
+) -> None:
+    """Test rename when validation fails."""
+    config_file = tmp_path / "oldname.yaml"
+    config_file.write_text("""
+esphome:
+  name: oldname
+
+esp32:
+  board: nodemcu-32s
+""")
+    setup_core(tmp_path=tmp_path)
+    CORE.config_path = str(config_file)
+
+    args = MockArgs(name="newname", dashboard=False)
+
+    # First call for validation fails
+    mock_run_external_process.return_value = 1
+
+    result = command_rename(args, {})
+
+    assert result == 1
+
+    # Verify new file was created but then removed due to failure
+    new_file = tmp_path / "newname.yaml"
+    assert not new_file.exists()
+
+    # Verify old file still exists (not removed on failure)
+    assert config_file.exists()
+
+    captured = capfd.readouterr()
+    assert "Rename failed" in captured.out


### PR DESCRIPTION
# What does this implement/fix?

Add additional dashboard and main tests

supports https://github.com/esphome/esphome/pull/10654

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
