### PR TITLE
[api] Optimize HelloResponse server_info to reduce memory usage

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -42,7 +42,6 @@ static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;
 
-// Compile-time StringRef constant for ESPHome version
 static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
 
 static const char *const TAG = "api.connection";

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1427,7 +1427,6 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   std::string mac_address = get_mac_address_pretty();
   resp.set_mac_address(StringRef(mac_address));
 
-  // Use the ESPHOME_VERSION_REF constant defined in send_hello_response
   resp.set_esphome_version(ESPHOME_VERSION_REF);
 
   resp.set_compilation_time(App.get_compilation_time_ref());

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -42,6 +42,9 @@ static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;
 
+// Compile-time StringRef constant for ESPHome version
+static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
+
 static const char *const TAG = "api.connection";
 #ifdef USE_CAMERA
 static const int CAMERA_STOP_STREAM = 5000;
@@ -1376,9 +1379,8 @@ bool APIConnection::send_hello_response(const HelloRequest &msg) {
   HelloResponse resp;
   resp.api_version_major = 1;
   resp.api_version_minor = 12;
-  // Temporary string for concatenation - will be valid during send_message call
-  std::string server_info = App.get_name() + " (esphome v" ESPHOME_VERSION ")";
-  resp.set_server_info(StringRef(server_info));
+  // Send only the version string - the client only logs this for debugging and doesn't use it otherwise
+  resp.set_server_info(ESPHOME_VERSION_REF);
   resp.set_name(StringRef(App.get_name()));
 
 #ifdef USE_API_PASSWORD
@@ -1425,8 +1427,7 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
   std::string mac_address = get_mac_address_pretty();
   resp.set_mac_address(StringRef(mac_address));
 
-  // Compile-time StringRef constants
-  static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
+  // Use the ESPHOME_VERSION_REF constant defined in send_hello_response
   resp.set_esphome_version(ESPHOME_VERSION_REF);
 
   resp.set_compilation_time(App.get_compilation_time_ref());


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the API `HelloResponse` to eliminate wasteful string concatenation and redundant data transmission.

Previously, the `server_info` field contained `"{app_name} (esphome v{version})"` which:
- Required runtime string concatenation on every API connection
- Sent the app name twice (in both `server_info` and `name` fields)
- Included redundant text "(esphome v...)"

Now `server_info` only contains the version string, saving 32 bytes of flash memory and eliminating runtime allocation. The aioesphomeapi client only uses this field for debug logging and doesn't rely on the format.

Note: The ESPHome version is also sent in `DeviceInfoResponse.esphome_version`, but that field is part of the stable API and changing it would be a breaking change. The `HelloResponse.server_info` field is safe to optimize as it's only used for client-side debug logging.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory savings

**Before:**
- RAM: 58512 bytes (17.9%)
- Flash: 1386018 bytes (75.5%)

**After:**
- RAM: 58512 bytes (17.9%) - No change (eliminated runtime allocation)
- Flash: 1385986 bytes (75.5%) - Saved 32 bytes
