### PR TITLE
[api] Revert unneeded GetTime bidirectional support added in #9790

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -27,9 +27,6 @@ service APIConnection {
   rpc subscribe_logs (SubscribeLogsRequest) returns (void) {}
   rpc subscribe_homeassistant_services (SubscribeHomeassistantServicesRequest) returns (void) {}
   rpc subscribe_home_assistant_states (SubscribeHomeAssistantStatesRequest) returns (void) {}
-  rpc get_time (GetTimeRequest) returns (GetTimeResponse) {
-    option (needs_authentication) = false;
-  }
   rpc execute_service (ExecuteServiceRequest) returns (void) {}
   rpc noise_encryption_set_key (NoiseEncryptionSetKeyRequest) returns (NoiseEncryptionSetKeyResponse) {}
 
@@ -809,12 +806,12 @@ message HomeAssistantStateResponse {
 // ==================== IMPORT TIME ====================
 message GetTimeRequest {
   option (id) = 36;
-  option (source) = SOURCE_BOTH;
+  option (source) = SOURCE_SERVER;
 }
 
 message GetTimeResponse {
   option (id) = 37;
-  option (source) = SOURCE_BOTH;
+  option (source) = SOURCE_CLIENT;
   option (no_delay) = true;
 
   fixed32 epoch_seconds = 1;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1081,12 +1081,6 @@ void APIConnection::on_get_time_response(const GetTimeResponse &value) {
 }
 #endif
 
-bool APIConnection::send_get_time_response(const GetTimeRequest &msg) {
-  GetTimeResponse resp;
-  resp.epoch_seconds = ::time(nullptr);
-  return this->send_message(resp, GetTimeResponse::MESSAGE_TYPE);
-}
-
 #ifdef USE_BLUETOOTH_PROXY
 void APIConnection::subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   bluetooth_proxy::global_bluetooth_proxy->subscribe_api_connection(this, msg.flags);

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -219,7 +219,6 @@ class APIConnection final : public APIServerConnection {
 #ifdef USE_API_HOMEASSISTANT_STATES
   void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) override;
 #endif
-  bool send_get_time_response(const GetTimeRequest &msg) override;
 #ifdef USE_API_SERVICES
   void execute_service(const ExecuteServiceRequest &msg) override;
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -921,14 +921,6 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
-void GetTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->epoch_seconds);
-  buffer.encode_string(2, this->timezone_ref_);
-}
-void GetTimeResponse::calculate_size(ProtoSize &size) const {
-  size.add_fixed32(1, this->epoch_seconds);
-  size.add_length(1, this->timezone_ref_.size());
-}
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name_ref_);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1180,10 +1180,6 @@ class GetTimeResponse final : public ProtoDecodableMessage {
 #endif
   uint32_t epoch_seconds{0};
   std::string timezone{};
-  StringRef timezone_ref_{};
-  void set_timezone(const StringRef &ref) { this->timezone_ref_ = ref; }
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1113,13 +1113,7 @@ void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeReques
 void GetTimeResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "GetTimeResponse");
   dump_field(out, "epoch_seconds", this->epoch_seconds);
-  out.append("  timezone: ");
-  if (!this->timezone_ref_.empty()) {
-    out.append("'").append(this->timezone_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append(this->timezone).append("'");
-  }
-  out.append("\n");
+  dump_field(out, "timezone", this->timezone);
 }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -160,15 +160,6 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
 #endif
-    case GetTimeRequest::MESSAGE_TYPE: {
-      GetTimeRequest msg;
-      // Empty message: no decode needed
-#ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_get_time_request: %s", msg.dump().c_str());
-#endif
-      this->on_get_time_request(msg);
-      break;
-    }
     case GetTimeResponse::MESSAGE_TYPE: {
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
@@ -656,11 +647,6 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
   }
 }
 #endif
-void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
-  if (this->check_connection_setup_() && !this->send_get_time_response(msg)) {
-    this->on_fatal_error();
-  }
-}
 #ifdef USE_API_SERVICES
 void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
   if (this->check_authenticated_()) {

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -71,7 +71,7 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_API_HOMEASSISTANT_STATES
   virtual void on_home_assistant_state_response(const HomeAssistantStateResponse &value){};
 #endif
-  virtual void on_get_time_request(const GetTimeRequest &value){};
+
   virtual void on_get_time_response(const GetTimeResponse &value){};
 
 #ifdef USE_API_SERVICES
@@ -226,7 +226,6 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_API_HOMEASSISTANT_STATES
   virtual void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) = 0;
 #endif
-  virtual bool send_get_time_response(const GetTimeRequest &msg) = 0;
 #ifdef USE_API_SERVICES
   virtual void execute_service(const ExecuteServiceRequest &msg) = 0;
 #endif
@@ -348,7 +347,6 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_API_HOMEASSISTANT_STATES
   void on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) override;
 #endif
-  void on_get_time_request(const GetTimeRequest &msg) override;
 #ifdef USE_API_SERVICES
   void on_execute_service_request(const ExecuteServiceRequest &msg) override;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

This optimizes the GetTime API messages to be unidirectional, matching their actual usage pattern. ESPHome devices only request time from clients (Home Assistant), never the reverse. This change eliminates unnecessary code generation and reduces flash usage by 368 bytes on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API change, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# Time synchronization continues to work as before:

time:
  - platform: homeassistant
    id: ha_time
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Details

### Changes Made:
1. Changed `GetTimeRequest` from `SOURCE_BOTH` to `SOURCE_SERVER` (devices send to clients)
2. Changed `GetTimeResponse` from `SOURCE_BOTH` to `SOURCE_CLIENT` (clients respond to devices)
3. Removed the unused RPC service definition for `get_time` since devices never receive GetTimeRequest
4. Removed `send_get_time_response()` implementation from device code
5. Regenerated protobuf files to reflect these changes

### Rationale:
The `send_get_time_response()` method was added in PR #9790 (zero-copy string optimization) but has never been used:
- While converting to zero-copy, a long-standing TODO was implemented to handle GetTime messages marked as `SOURCE_BOTH` (bidirectional)
- In hindsight, a TODO that existed for years without being needed should have been removed instead of implemented
- This is a classic YAGNI case - the functionality was never actually required
- ESPHome devices only send GetTimeRequest to get time from Home Assistant
- Home Assistant only sends GetTimeResponse back to devices
- The reverse direction (HA requesting time from devices) makes no sense because:
  - Devices have less accurate clocks than clients
  - There's no use case for clients to sync time from devices

**Important:** We need to remove this now before anyone starts using it. Once it's in use, it becomes much harder to remove due to backward compatibility concerns.

This is a case of YAGNI (You Aren't Gonna Need It) - the bidirectional capability was recently added based on incorrect assumptions about the protocol requirements.

### Performance Impact:
**ESP8266 Flash Usage:**
- Before: 348783 bytes (34.1%)
- After: 348415 bytes (34.0%)
- **Savings: 368 bytes**

RAM usage remains unchanged at 29984 bytes.

### Backward Compatibility:
This change is fully backwards compatible as it only removes unused code paths. The actual time synchronization functionality (device requesting time from client) remains unchanged.
