### PR TITLE
[api] Exclude ConnectRequest/Response when password is disabled

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -133,6 +133,7 @@ message ConnectRequest {
   option (id) = 3;
   option (source) = SOURCE_CLIENT;
   option (no_delay) = true;
+  option (ifdef) = "USE_API_PASSWORD";
 
   // The password to log in with
   string password = 1;
@@ -144,6 +145,7 @@ message ConnectResponse {
   option (id) = 4;
   option (source) = SOURCE_SERVER;
   option (no_delay) = true;
+  option (ifdef) = "USE_API_PASSWORD";
 
   bool invalid_password = 1;
 }

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -27,9 +27,6 @@ service APIConnection {
   rpc subscribe_logs (SubscribeLogsRequest) returns (void) {}
   rpc subscribe_homeassistant_services (SubscribeHomeassistantServicesRequest) returns (void) {}
   rpc subscribe_home_assistant_states (SubscribeHomeAssistantStatesRequest) returns (void) {}
-  rpc get_time (GetTimeRequest) returns (GetTimeResponse) {
-    option (needs_authentication) = false;
-  }
   rpc execute_service (ExecuteServiceRequest) returns (void) {}
   rpc noise_encryption_set_key (NoiseEncryptionSetKeyRequest) returns (NoiseEncryptionSetKeyResponse) {}
 
@@ -809,12 +806,12 @@ message HomeAssistantStateResponse {
 // ==================== IMPORT TIME ====================
 message GetTimeRequest {
   option (id) = 36;
-  option (source) = SOURCE_BOTH;
+  option (source) = SOURCE_SERVER;
 }
 
 message GetTimeResponse {
   option (id) = 37;
-  option (source) = SOURCE_BOTH;
+  option (source) = SOURCE_CLIENT;
   option (no_delay) = true;
 
   fixed32 epoch_seconds = 1;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1081,12 +1081,6 @@ void APIConnection::on_get_time_response(const GetTimeResponse &value) {
 }
 #endif
 
-bool APIConnection::send_get_time_response(const GetTimeRequest &msg) {
-  GetTimeResponse resp;
-  resp.epoch_seconds = ::time(nullptr);
-  return this->send_message(resp, GetTimeResponse::MESSAGE_TYPE);
-}
-
 #ifdef USE_BLUETOOTH_PROXY
 void APIConnection::subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) {
   bluetooth_proxy::global_bluetooth_proxy->subscribe_api_connection(this, msg.flags);

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1385,20 +1385,17 @@ bool APIConnection::send_hello_response(const HelloRequest &msg) {
 
   return this->send_message(resp, HelloResponse::MESSAGE_TYPE);
 }
-bool APIConnection::send_connect_response(const ConnectRequest &msg) {
-  bool correct = true;
 #ifdef USE_API_PASSWORD
-  correct = this->parent_->check_password(msg.password);
-#endif
-
+bool APIConnection::send_connect_response(const ConnectRequest &msg) {
   ConnectResponse resp;
   // bool invalid_password = 1;
-  resp.invalid_password = !correct;
-  if (correct) {
+  resp.invalid_password = !this->parent_->check_password(msg.password);
+  if (!resp.invalid_password) {
     this->complete_authentication_();
   }
   return this->send_message(resp, ConnectResponse::MESSAGE_TYPE);
 }
+#endif  // USE_API_PASSWORD
 
 bool APIConnection::send_ping_response(const PingRequest &msg) {
   PingResponse resp;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -197,7 +197,9 @@ class APIConnection final : public APIServerConnection {
   void on_get_time_response(const GetTimeResponse &value) override;
 #endif
   bool send_hello_response(const HelloRequest &msg) override;
+#ifdef USE_API_PASSWORD
   bool send_connect_response(const ConnectRequest &msg) override;
+#endif
   bool send_disconnect_response(const DisconnectRequest &msg) override;
   bool send_ping_response(const PingRequest &msg) override;
   bool send_device_info_response(const DeviceInfoRequest &msg) override;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -219,7 +219,6 @@ class APIConnection final : public APIServerConnection {
 #ifdef USE_API_HOMEASSISTANT_STATES
   void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) override;
 #endif
-  bool send_get_time_response(const GetTimeRequest &msg) override;
 #ifdef USE_API_SERVICES
   void execute_service(const ExecuteServiceRequest &msg) override;
 #endif

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -921,14 +921,6 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
-void GetTimeResponse::encode(ProtoWriteBuffer buffer) const {
-  buffer.encode_fixed32(1, this->epoch_seconds);
-  buffer.encode_string(2, this->timezone_ref_);
-}
-void GetTimeResponse::calculate_size(ProtoSize &size) const {
-  size.add_fixed32(1, this->epoch_seconds);
-  size.add_length(1, this->timezone_ref_.size());
-}
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name_ref_);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -42,6 +42,7 @@ void HelloResponse::calculate_size(ProtoSize &size) const {
   size.add_length(1, this->server_info_ref_.size());
   size.add_length(1, this->name_ref_.size());
 }
+#ifdef USE_API_PASSWORD
 bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1:
@@ -54,6 +55,7 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
 }
 void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
 void ConnectResponse::calculate_size(ProtoSize &size) const { size.add_bool(1, this->invalid_password); }
+#endif
 #ifdef USE_AREAS
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(1, this->area_id);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -360,6 +360,7 @@ class HelloResponse final : public ProtoMessage {
 
  protected:
 };
+#ifdef USE_API_PASSWORD
 class ConnectRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 3;
@@ -391,6 +392,7 @@ class ConnectResponse final : public ProtoMessage {
 
  protected:
 };
+#endif
 class DisconnectRequest final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 5;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1180,10 +1180,6 @@ class GetTimeResponse final : public ProtoDecodableMessage {
 #endif
   uint32_t epoch_seconds{0};
   std::string timezone{};
-  StringRef timezone_ref_{};
-  void set_timezone(const StringRef &ref) { this->timezone_ref_ = ref; }
-  void encode(ProtoWriteBuffer buffer) const override;
-  void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1113,13 +1113,7 @@ void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeReques
 void GetTimeResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "GetTimeResponse");
   dump_field(out, "epoch_seconds", this->epoch_seconds);
-  out.append("  timezone: ");
-  if (!this->timezone_ref_.empty()) {
-    out.append("'").append(this->timezone_ref_.c_str()).append("'");
-  } else {
-    out.append("'").append(this->timezone).append("'");
-  }
-  out.append("\n");
+  dump_field(out, "timezone", this->timezone);
 }
 #ifdef USE_API_SERVICES
 void ListEntitiesServicesArgument::dump_to(std::string &out) const {

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -669,8 +669,10 @@ void HelloResponse::dump_to(std::string &out) const {
   dump_field(out, "server_info", this->server_info_ref_);
   dump_field(out, "name", this->name_ref_);
 }
+#ifdef USE_API_PASSWORD
 void ConnectRequest::dump_to(std::string &out) const { dump_field(out, "password", this->password); }
 void ConnectResponse::dump_to(std::string &out) const { dump_field(out, "invalid_password", this->invalid_password); }
+#endif
 void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
 void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
 void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -160,15 +160,6 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
 #endif
-    case GetTimeRequest::MESSAGE_TYPE: {
-      GetTimeRequest msg;
-      // Empty message: no decode needed
-#ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_get_time_request: %s", msg.dump().c_str());
-#endif
-      this->on_get_time_request(msg);
-      break;
-    }
     case GetTimeResponse::MESSAGE_TYPE: {
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
@@ -656,11 +647,6 @@ void APIServerConnection::on_subscribe_home_assistant_states_request(const Subsc
   }
 }
 #endif
-void APIServerConnection::on_get_time_request(const GetTimeRequest &msg) {
-  if (this->check_connection_setup_() && !this->send_get_time_response(msg)) {
-    this->on_fatal_error();
-  }
-}
 #ifdef USE_API_SERVICES
 void APIServerConnection::on_execute_service_request(const ExecuteServiceRequest &msg) {
   if (this->check_authenticated_()) {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -24,6 +24,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       this->on_hello_request(msg);
       break;
     }
+#ifdef USE_API_PASSWORD
     case ConnectRequest::MESSAGE_TYPE: {
       ConnectRequest msg;
       msg.decode(msg_data, msg_size);
@@ -33,6 +34,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       this->on_connect_request(msg);
       break;
     }
+#endif
     case DisconnectRequest::MESSAGE_TYPE: {
       DisconnectRequest msg;
       // Empty message: no decode needed
@@ -597,11 +599,13 @@ void APIServerConnection::on_hello_request(const HelloRequest &msg) {
     this->on_fatal_error();
   }
 }
+#ifdef USE_API_PASSWORD
 void APIServerConnection::on_connect_request(const ConnectRequest &msg) {
   if (!this->send_connect_response(msg)) {
     this->on_fatal_error();
   }
 }
+#endif
 void APIServerConnection::on_disconnect_request(const DisconnectRequest &msg) {
   if (!this->send_disconnect_response(msg)) {
     this->on_fatal_error();

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -26,7 +26,9 @@ class APIServerConnectionBase : public ProtoService {
 
   virtual void on_hello_request(const HelloRequest &value){};
 
+#ifdef USE_API_PASSWORD
   virtual void on_connect_request(const ConnectRequest &value){};
+#endif
 
   virtual void on_disconnect_request(const DisconnectRequest &value){};
   virtual void on_disconnect_response(const DisconnectResponse &value){};
@@ -213,7 +215,9 @@ class APIServerConnectionBase : public ProtoService {
 class APIServerConnection : public APIServerConnectionBase {
  public:
   virtual bool send_hello_response(const HelloRequest &msg) = 0;
+#ifdef USE_API_PASSWORD
   virtual bool send_connect_response(const ConnectRequest &msg) = 0;
+#endif
   virtual bool send_disconnect_response(const DisconnectRequest &msg) = 0;
   virtual bool send_ping_response(const PingRequest &msg) = 0;
   virtual bool send_device_info_response(const DeviceInfoRequest &msg) = 0;
@@ -334,7 +338,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #endif
  protected:
   void on_hello_request(const HelloRequest &msg) override;
+#ifdef USE_API_PASSWORD
   void on_connect_request(const ConnectRequest &msg) override;
+#endif
   void on_disconnect_request(const DisconnectRequest &msg) override;
   void on_ping_request(const PingRequest &msg) override;
   void on_device_info_request(const DeviceInfoRequest &msg) override;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -71,7 +71,7 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef USE_API_HOMEASSISTANT_STATES
   virtual void on_home_assistant_state_response(const HomeAssistantStateResponse &value){};
 #endif
-  virtual void on_get_time_request(const GetTimeRequest &value){};
+
   virtual void on_get_time_response(const GetTimeResponse &value){};
 
 #ifdef USE_API_SERVICES
@@ -226,7 +226,6 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_API_HOMEASSISTANT_STATES
   virtual void subscribe_home_assistant_states(const SubscribeHomeAssistantStatesRequest &msg) = 0;
 #endif
-  virtual bool send_get_time_response(const GetTimeRequest &msg) = 0;
 #ifdef USE_API_SERVICES
   virtual void execute_service(const ExecuteServiceRequest &msg) = 0;
 #endif
@@ -348,7 +347,6 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_API_HOMEASSISTANT_STATES
   void on_subscribe_home_assistant_states_request(const SubscribeHomeAssistantStatesRequest &msg) override;
 #endif
-  void on_get_time_request(const GetTimeRequest &msg) override;
 #ifdef USE_API_SERVICES
   void on_execute_service_request(const ExecuteServiceRequest &msg) override;
 #endif


### PR DESCRIPTION
- [x] requires https://github.com/esphome/esphome/pull/10702
- [x] requires https://github.com/esphome/aioesphomeapi/pull/1345

# What does this implement/fix?

This PR excludes `ConnectRequest` and `ConnectResponse` protobuf messages when `USE_API_PASSWORD` is not defined, reducing flash memory usage by 636 bytes on devices without password authentication.

When no API password is configured, these messages are not needed as the Hello message is enough. This optimization helps devices with limited memory, particularly ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Implements #9443 (originally opened and closed, now ready for implementation)
- Depends on #10702 (must be merged first)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
api:
  # When password is not set, ConnectRequest/Response will be excluded
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Savings Verified

Testing on ESP8266 shows:

**Without password (this PR)**:
- Flash: 331,367 bytes

**With password (baseline)**:
- Flash: 332,003 bytes

**Total savings**: 636 bytes flash