### PR TITLE
[ethernet] Fix permanent component failure from undocumented ESP_FAIL in IPv6 setup

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -491,8 +491,9 @@ void EthernetComponent::finish_connect_() {
 #if USE_NETWORK_IPV6
   // Retry IPv6 link-local setup if it failed during initial connect
   // This handles the case where IPv6 setup failed in start_connect_()
-  // because the interface was still down (e.g., cable unplugged).
-  // By now we're in CONNECTED state so the interface is up.
+  // because the interface wasn't ready (usually cable unplugged/link down,
+  // rarely a timing issue during state transitions).
+  // By now we're in CONNECTED state so the interface is definitely up.
   if (!this->ipv6_setup_done_) {
     esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
     if (err == ESP_OK) {
@@ -569,9 +570,9 @@ void EthernetComponent::start_connect_() {
   }
 #if USE_NETWORK_IPV6
   // Attempt to create IPv6 link-local address
-  // Note: this may fail with ESP_FAIL if the interface is not fully up yet,
-  // which can happen after network interruptions. We'll retry in the
-  // CONNECTED state if it fails here.
+  // Note: this may fail with ESP_FAIL if the interface is not up yet
+  // (typically cable unplugged, but could be timing during link transitions).
+  // We'll retry in the CONNECTED state if it fails here.
   err = esp_netif_create_ip6_linklocal(this->eth_netif_);
   if (err != ESP_OK) {
     if (err == ESP_ERR_ESP_NETIF_INVALID_PARAMS) {

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -300,6 +300,7 @@ void EthernetComponent::loop() {
         this->state_ = EthernetComponentState::CONNECTING;
         this->start_connect_();
       } else {
+        this->finish_connect_();
         // When connected and stable, disable the loop to save CPU cycles
         this->disable_loop();
       }
@@ -486,10 +487,27 @@ void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_
 }
 #endif /* USE_NETWORK_IPV6 */
 
+void EthernetComponent::finish_connect_() {
+#if USE_NETWORK_IPV6
+  // Retry IPv6 link-local setup if it failed during initial connect
+  // This handles the case where IPv6 setup failed in start_connect_()
+  // due to the interface not being fully ready (timing issue).
+  // By now the interface is stable since we're in CONNECTED state.
+  if (!this->ipv6_setup_done_) {
+    esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
+    if (err == ESP_OK) {
+      ESP_LOGD(TAG, "IPv6 link-local address created (retry succeeded)");
+    }
+    this->ipv6_setup_done_ = true;  // Only try once in CONNECTED state
+  }
+#endif /* USE_NETWORK_IPV6 */
+}
+
 void EthernetComponent::start_connect_() {
   global_eth_component->got_ipv4_address_ = false;
 #if USE_NETWORK_IPV6
   global_eth_component->ipv6_count_ = 0;
+  this->ipv6_setup_done_ = false;
 #endif /* USE_NETWORK_IPV6 */
   this->connect_begin_ = millis();
   this->status_set_warning(LOG_STR("waiting for IP configuration"));
@@ -545,9 +563,21 @@ void EthernetComponent::start_connect_() {
     }
   }
 #if USE_NETWORK_IPV6
+  // Attempt to create IPv6 link-local address
+  // Note: this may fail with ESP_FAIL if the interface is not fully up yet,
+  // which can happen after network interruptions. We'll retry in the CONNECTED state if it fails here.
   err = esp_netif_create_ip6_linklocal(this->eth_netif_);
   if (err != ESP_OK) {
-    ESPHL_ERROR_CHECK(err, "Enable IPv6 link local failed");
+    if (err == ESP_ERR_ESP_NETIF_INVALID_PARAMS) {
+      // This is a programming error, not a transient failure
+      ESPHL_ERROR_CHECK(err, "esp_netif_create_ip6_linklocal invalid parameters");
+    } else {
+      // ESP_FAIL typically means the interface isn't fully up yet
+      // This is a timing issue that can occur after network interruptions
+      // We'll retry once we reach CONNECTED state and the interface is stable
+      ESP_LOGW(TAG, "esp_netif_create_ip6_linklocal failed: %s", esp_err_to_name(err));
+      // Don't mark component as failed - this is a transient error
+    }
   }
 #endif /* USE_NETWORK_IPV6 */
 

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -491,17 +491,18 @@ void EthernetComponent::finish_connect_() {
 #if USE_NETWORK_IPV6
   // Retry IPv6 link-local setup if it failed during initial connect
   // This handles the case where IPv6 setup failed in start_connect_()
-  // due to the interface not being fully ready (timing issue).
-  // By now the interface is stable since we're in CONNECTED state.
+  // because the interface was still down (e.g., cable unplugged).
+  // By now we're in CONNECTED state so the interface is up.
   if (!this->ipv6_setup_done_) {
     esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
     if (err == ESP_OK) {
       ESP_LOGD(TAG, "IPv6 link-local address created (retry succeeded)");
     }
     // Always set the flag to prevent continuous retries
-    // If IPv6 setup fails here with the interface up and stable, it's likely
-    // a persistent issue (IPv6 disabled at router, hardware limitation, etc.)
-    // that won't be resolved by further retries. The device continues to work with IPv4.
+    // If IPv6 setup fails here with the interface up and stable, it's
+    // likely a persistent issue (IPv6 disabled at router, hardware
+    // limitation, etc.) that won't be resolved by further retries.
+    // The device continues to work with IPv4.
     this->ipv6_setup_done_ = true;
   }
 #endif /* USE_NETWORK_IPV6 */
@@ -569,7 +570,8 @@ void EthernetComponent::start_connect_() {
 #if USE_NETWORK_IPV6
   // Attempt to create IPv6 link-local address
   // Note: this may fail with ESP_FAIL if the interface is not fully up yet,
-  // which can happen after network interruptions. We'll retry in the CONNECTED state if it fails here.
+  // which can happen after network interruptions. We'll retry in the
+  // CONNECTED state if it fails here.
   err = esp_netif_create_ip6_linklocal(this->eth_netif_);
   if (err != ESP_OK) {
     if (err == ESP_ERR_ESP_NETIF_INVALID_PARAMS) {

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -492,9 +492,10 @@ void EthernetComponent::finish_connect_() {
   // Retry IPv6 link-local setup if it failed during initial connect
   // This handles the case where min_ipv6_addr_count is NOT set (or is 0),
   // allowing us to reach CONNECTED state with just IPv4.
-  // If IPv6 setup failed in start_connect_() because the interface wasn't ready
-  // (usually cable unplugged/link down, rarely a timing issue during state transitions),
-  // we can now retry since we're in CONNECTED state and the interface is definitely up.
+  // If IPv6 setup failed in start_connect_() because the interface wasn't ready:
+  // - Bootup timing issues (#10281)
+  // - Cable unplugged/network interruption (#10705)
+  // We can now retry since we're in CONNECTED state and the interface is definitely up.
   if (!this->ipv6_setup_done_) {
     esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
     if (err == ESP_OK) {

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -576,9 +576,9 @@ void EthernetComponent::start_connect_() {
       // This is a programming error, not a transient failure
       ESPHL_ERROR_CHECK(err, "esp_netif_create_ip6_linklocal invalid parameters");
     } else {
-      // ESP_FAIL typically means the interface isn't fully up yet
-      // This is a timing issue that can occur after network interruptions
-      // We'll retry once we reach CONNECTED state and the interface is stable
+      // ESP_FAIL means the interface isn't up yet (e.g., cable unplugged, link down)
+      // This is expected during reconnection attempts after network interruptions
+      // We'll retry once we reach CONNECTED state and the interface is actually up
       ESP_LOGW(TAG, "esp_netif_create_ip6_linklocal failed: %s", esp_err_to_name(err));
       // Don't mark component as failed - this is a transient error
     }

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -498,7 +498,11 @@ void EthernetComponent::finish_connect_() {
     if (err == ESP_OK) {
       ESP_LOGD(TAG, "IPv6 link-local address created (retry succeeded)");
     }
-    this->ipv6_setup_done_ = true;  // Only try once in CONNECTED state
+    // Always set the flag to prevent continuous retries
+    // If IPv6 setup fails here with the interface up and stable, it's likely
+    // a persistent issue (IPv6 disabled at router, hardware limitation, etc.)
+    // that won't be resolved by further retries. The device continues to work with IPv4.
+    this->ipv6_setup_done_ = true;
   }
 #endif /* USE_NETWORK_IPV6 */
 }

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -490,10 +490,11 @@ void EthernetComponent::got_ip6_event_handler(void *arg, esp_event_base_t event_
 void EthernetComponent::finish_connect_() {
 #if USE_NETWORK_IPV6
   // Retry IPv6 link-local setup if it failed during initial connect
-  // This handles the case where IPv6 setup failed in start_connect_()
-  // because the interface wasn't ready (usually cable unplugged/link down,
-  // rarely a timing issue during state transitions).
-  // By now we're in CONNECTED state so the interface is definitely up.
+  // This handles the case where min_ipv6_addr_count is NOT set (or is 0),
+  // allowing us to reach CONNECTED state with just IPv4.
+  // If IPv6 setup failed in start_connect_() because the interface wasn't ready
+  // (usually cable unplugged/link down, rarely a timing issue during state transitions),
+  // we can now retry since we're in CONNECTED state and the interface is definitely up.
   if (!this->ipv6_setup_done_) {
     esp_err_t err = esp_netif_create_ip6_linklocal(this->eth_netif_);
     if (err == ESP_OK) {
@@ -570,18 +571,23 @@ void EthernetComponent::start_connect_() {
   }
 #if USE_NETWORK_IPV6
   // Attempt to create IPv6 link-local address
-  // Note: this may fail with ESP_FAIL if the interface is not up yet
-  // (typically cable unplugged, but could be timing during link transitions).
-  // We'll retry in the CONNECTED state if it fails here.
+  // We MUST attempt this here, not just in finish_connect_(), because with
+  // min_ipv6_addr_count set, the component won't reach CONNECTED state without IPv6.
+  // However, this may fail with ESP_FAIL if the interface is not up yet:
+  // - At bootup when link isn't ready (#10281)
+  // - After disconnection/cable unplugged (#10705)
+  // We'll retry in finish_connect_() if it fails here.
   err = esp_netif_create_ip6_linklocal(this->eth_netif_);
   if (err != ESP_OK) {
     if (err == ESP_ERR_ESP_NETIF_INVALID_PARAMS) {
       // This is a programming error, not a transient failure
       ESPHL_ERROR_CHECK(err, "esp_netif_create_ip6_linklocal invalid parameters");
     } else {
-      // ESP_FAIL means the interface isn't up yet (e.g., cable unplugged, link down)
-      // This is expected during reconnection attempts after network interruptions
-      // We'll retry once we reach CONNECTED state and the interface is actually up
+      // ESP_FAIL means the interface isn't up yet
+      // This is expected and non-fatal, happens in multiple scenarios:
+      // - During reconnection after network interruptions (#10705)
+      // - At bootup when the link isn't ready yet (#10281)
+      // We'll retry once we reach CONNECTED state and the interface is up
       ESP_LOGW(TAG, "esp_netif_create_ip6_linklocal failed: %s", esp_err_to_name(err));
       // Don't mark component as failed - this is a transient error
     }

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -102,6 +102,7 @@ class EthernetComponent : public Component {
 #endif /* LWIP_IPV6 */
 
   void start_connect_();
+  void finish_connect_();
   void dump_connect_params_();
   /// @brief Set `RMII Reference Clock Select` bit for KSZ8081.
   void ksz8081_set_clock_reference_(esp_eth_mac_t *mac);
@@ -144,6 +145,7 @@ class EthernetComponent : public Component {
   bool got_ipv4_address_{false};
 #if LWIP_IPV6
   uint8_t ipv6_count_{0};
+  bool ipv6_setup_done_{false};
 #endif /* LWIP_IPV6 */
 
   // Pointers at the end (naturally aligned)


### PR DESCRIPTION
# What does this implement/fix?

This fixes critical issues where ESP32 ethernet components would permanently fail when IPv6 is enabled, occurring in two scenarios:
1. **During network interruptions** (#10705) - Component fails after cable disconnect/reconnect or switch port flapping
2. **At bootup** (#10281) - Component fails to initialize if the link isn't immediately ready

## Root Cause: Undocumented Return Value

The ESP-IDF documentation states that `esp_netif_create_ip6_linklocal()` can only return:
- `ESP_OK` - Success
- `ESP_ERR_ESP_NETIF_INVALID_PARAMS` - Invalid parameters

**However, the actual implementation also returns:**
- `ESP_FAIL` - When the interface is not up (`!netif_is_up()`)

This undocumented `ESP_FAIL` return value likely reflects Espressif's assumption that the function would only be called when the interface is already up. However, there are two scenarios where this fails:
1. **Extended disconnections**: When a cable is unplugged for several seconds, `start_connect_()` is called while the interface is still down
2. **Race conditions**: During brief network interruptions, the interface state can change between checking connectivity and attempting IPv6 setup

The original ESPHome code used `ESPHL_ERROR_CHECK` which treats ANY non-ESP_OK error as fatal, causing permanent component failure whenever the interface wasn't ready - whether from a brief blip or an extended disconnection.

## The Problem

When a network interruption occurs (cable unplugged, switch port flap, etc.), the ethernet component attempts to reconnect. During this process, IPv6 link-local address creation may fail with `ESP_FAIL` if the interface isn't fully ready. The `ESPHL_ERROR_CHECK` macro would then call `mark_failed()`, permanently disabling the component even after the network recovered.

### Before Fix - Permanent Failure
```
[08:59:08.320][W][ethernet:290]: Connecting failed; reconnecting
[08:59:08.328][E][ethernet:550]: Enable IPv6 link local failed: (-1) ESP_FAIL
[08:59:08.334][E][component:201]: ethernet was marked as failed
[08:59:08.339][E][component:304]: ethernet set Error flag: unspecified
```
**Result:** Device never recovers, ethernet permanently broken until reboot.

### After Fix - Successful Recovery
```
[09:00:40.923][W][ethernet:290]: Connecting failed; reconnecting
[09:00:40.931][W][ethernet:578]: esp_netif_create_ip6_linklocal failed: ESP_FAIL
[09:01:01.743][I][ethernet:284]: Connected
[09:01:01.763][C][ethernet:618]:   IPv6: fe80:0000:0000:0000:264c:abff:fe03:e6bb
[09:01:01.832][D][ethernet:499]: IPv6 link-local address created (retry succeeded)
```
**Result:** Transient failure logged as warning, device recovers fully with IPv6 working.

## The Solution

1. **Handle undocumented ESP_FAIL**: Recognize it as an expected condition when the interface isn't ready (whether from extended disconnection or brief interruption)
2. **Made IPv6 setup non-fatal**: Changed from `ESPHL_ERROR_CHECK` (fatal) to warning log for ESP_FAIL since the interface being down is temporary
3. **Added retry mechanism**: Created `finish_connect_()` helper that retries IPv6 setup once after reaching CONNECTED state when the interface is guaranteed to be up and stable
4. **Proper error handling**: Only treat `ESP_ERR_ESP_NETIF_INVALID_PARAMS` as fatal (actual programming error), while the undocumented `ESP_FAIL` is handled as an expected temporary condition

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10705 (Ethernet component permanently fails after network interruptions with IPv6)
- fixes #10281 (IPv6 + Ethernet fails at bootup)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Configuration that triggered the issue
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0
  power_pin: GPIO12

network:
  enable_ipv6: true
  # This configuration especially triggers the issue
  # min_ipv6_addr_count: 2
```

## Testing Performed

Tested on Olimex ESP32-POE-ISO (addressing #10705) with the following scenarios:

1. **Cable unplug/replug**: Component recovers successfully, IPv6 address created on retry
2. **Switch port flapping**: Brief interruptions no longer cause permanent failure
3. **Cold boot**: IPv6 setup retry handles timing issues during initial startup
4. **With `min_ipv6_addr_count: 2`**: Properly waits for IPv6 before marking as connected

All scenarios now recover properly instead of permanently failing the ethernet component.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).