### PR TITLE
[waveshare_epaper] Add support for Waveshare 7.5inch (H) display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -16,6 +16,8 @@ from esphome.const import (
 
 DEPENDENCIES = ["spi"]
 
+CONF_POWER_PIN = "power_pin"
+
 waveshare_epaper_ns = cg.esphome_ns.namespace("waveshare_epaper")
 WaveshareEPaperBase = waveshare_epaper_ns.class_(
     "WaveshareEPaperBase", cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer
@@ -122,6 +124,9 @@ WaveshareEPaper2P13InV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper13P3InK = waveshare_epaper_ns.class_(
     "WaveshareEPaper13P3InK", WaveshareEPaper
 )
+WaveshareEPaper7P5InH = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InH", WaveshareEPaper
+)
 GDEW0154M09 = waveshare_epaper_ns.class_("GDEW0154M09", WaveshareEPaper)
 
 WaveshareEPaperTypeAModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeAModel")
@@ -168,6 +173,7 @@ MODELS = {
     "7.50inv2alt": ("b", WaveshareEPaper7P5InV2alt),
     "7.50inv2p": ("c", WaveshareEPaper7P5InV2P),
     "7.50in-hd-b": ("b", WaveshareEPaper7P5InHDB),
+    "7.50in-h": ("b", WaveshareEPaper7P5InH),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),
     "2.13inv3": ("c", WaveshareEPaper2P13InV3),
     "1.54in-m5coreink-m09": ("b", GDEW0154M09),
@@ -206,6 +212,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(WaveshareEPaperBase),
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_MODEL): cv.one_of(*MODELS, lower=True),
+            cv.Optional(CONF_POWER_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
             cv.Optional(CONF_FULL_UPDATE_EVERY): cv.int_range(min=1, max=4294967295),
@@ -249,6 +256,9 @@ async def to_code(config):
             config[CONF_LAMBDA], [(display.DisplayRef, "it")], return_type=cg.void
         )
         cg.add(var.set_writer(lambda_))
+    if CONF_POWER_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_POWER_PIN])
+        cg.add(var.set_power_pin(reset))
     if CONF_RESET_PIN in config:
         reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -4655,8 +4655,6 @@ void WaveshareEPaper7P5InH::deep_sleep() {
 }
 
 void HOT WaveshareEPaper7P5InH::display() {
-  uint32_t buf_len = this->get_buffer_length_();
-
   this->command(cmddata_7P5InH::R10_CMD_DTM1[0]);
   this->start_data_();
   this->write_array(this->buffer_, this->get_buffer_length_());
@@ -4672,12 +4670,12 @@ uint32_t WaveshareEPaper7P5InH::get_buffer_length_() {
 }
 
 void WaveshareEPaper7P5InH::fill(Color color) {
-  const uint8_t bits = this->color_to_2bit(color);
+  const uint8_t bits = this->color_to_2bit_(color);
   const uint8_t byte_val = bits | (bits << 2) | (bits << 4) | (bits << 6);  // replicate 4 pixels
   memset(this->buffer_, byte_val, this->get_buffer_length_());
 }
 
-uint8_t WaveshareEPaper7P5InH::color_to_2bit(const Color &color) {
+uint8_t WaveshareEPaper7P5InH::color_to_2bit_(const Color &color) {
   if (color.red > 127) {
     if (color.green > 170) {
       if (color.blue > 127) {
@@ -4706,7 +4704,7 @@ void HOT WaveshareEPaper7P5InH::draw_absolute_pixel_internal(int x, int y, Color
   const uint8_t pos = pixel_index & 0x03;
   const uint8_t shift = (3 - pos) * 2;
 
-  const uint8_t bits = this->color_to_2bit(color);
+  const uint8_t bits = this->color_to_2bit_(color);
   const uint8_t mask = (uint8_t) (0x03u << shift);
 
   this->buffer_[byte_index] = (uint8_t) ((this->buffer_[byte_index] & ~mask) | (uint8_t) (bits << shift));

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -128,6 +128,10 @@ void WaveshareEPaperBase::setup_pins_() {
   if (this->busy_pin_ != nullptr) {
     this->busy_pin_->setup();  // INPUT
   }
+  if (this->power_pin_ != nullptr) {
+    this->power_pin_->setup();  // OUTPUT
+    this->power_pin_->digital_write(true);
+  }
 }
 float WaveshareEPaperBase::get_setup_priority() const { return setup_priority::PROCESSOR; }
 void WaveshareEPaperBase::command(uint8_t value) {
@@ -4530,6 +4534,191 @@ int WaveshareEPaper7P5InHDB::get_height_internal() { return 528; }
 void WaveshareEPaper7P5InHDB::dump_config() {
   LOG_DISPLAY("", "Waveshare E-Paper", this);
   ESP_LOGCONFIG(TAG, "  Model: 7.5in-HD-b");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+namespace cmddata_7P5InH {
+// WaveshareEPaper7P5InH commands
+// https://files.waveshare.com/wiki/7.5inch_e-Paper_(H)/7.5inch_e-Paper_(H).pdf
+
+// R00H (PSR): Panel setting Register
+static const uint8_t R00_CMD_PSR[] = {0x00, 0x0f, 0x29};
+
+// R01H (PWR): Power setting Register
+// internal DC-DC power generation
+static const uint8_t R01_CMD_PWR[] = {0x01, 0x07, 0x00, 0x00, 0x00};
+
+// R02H (POF): Power OFF Command
+static const uint8_t R02_CMD_POF[] = {0x02, 00};
+
+// R03H (PFS): Power off sequence setting Register
+// T_VDS_OFF (00) = 1 frame
+static const uint8_t R03_CMD_PFS[] = {0x03, 0x00};
+
+// R04H (PON): Power ON Command
+static const uint8_t R04_CMD_PON[] = {0x04};
+
+// R06h (BTST): Booster Soft Start
+static const uint8_t R06_CMD_BTST[] = {0x06, 0x0f, 0x8b, 0x93, 0xa1};
+
+// R07H (DSLP): Deep sleep
+static const uint8_t R07_CMD_DSLP[] = {0x07, 0xA5};
+
+// R10H (DTM): Data Start Transmission
+static const uint8_t R10_CMD_DTM1[] = {0x10};
+
+// R11H (DSP): Data Stop
+static const uint8_t R11_CMD_DSP[] = {0x11};
+
+// R12H (DRF): Display Refresh
+static const uint8_t R12_CMD_DRF[] = {0x12, 0x00};
+
+// R30H (PLL): PLL Control
+static const uint8_t R30_CMD_PLL[] = {0x30, 0x08};
+
+// R41H (TSE): Temperature Sensor Enable
+static const uint8_t R41_CMD_TSE[] = {0x41, 0x00};
+
+// R50H (CDI) VCOM and Data interval setting
+static const uint8_t R50_CMD_CDI[] = {0x50, 0x97};
+
+// R60H (TCON) Gate and Source non overlap period command
+static const uint8_t R60_CMD_TCON[] = {0x60, 0x02, 0x02};
+
+// R61H (TRES) Resolution Setting
+// 0x320 = 800
+// 0x1e0 = 480
+static const uint8_t R61_CMD_TRES[] = {0x61, 0x03, 0x20, 0x01, 0xe0};
+
+// R62H (???) ???
+static const uint8_t R62_CMD[] = {0x62, 0x98, 0x98, 0x98, 0x75, 0xca, 0xb2, 0x98, 0x7e};
+
+// R65H (GSST) Gate/Source Start Setting Register
+static const uint8_t R65_CMD_GSST[] = {0x65, 0x00, 0x00, 0x00, 0x00};
+
+// RE3H (PWS) Power Savings
+static const uint8_t RE3_CMD_PWS[] = {0xe3, 0x00};
+
+// RE7H (???) ???
+static const uint8_t RE7_CMD[] = {0xe7, 0x1c};
+
+// RE9H (???) ???
+static const uint8_t RE9_CMD[] = {0xe9, 0x01};
+}  // namespace cmddata_7P5InH
+
+void WaveshareEPaper7P5InH::initialize() {
+  ESP_LOGI(TAG, "Initialize");
+
+  this->reset_();
+
+  using namespace cmddata_7P5InH;
+  this->cmd_data(R00_CMD_PSR, sizeof(R00_CMD_PSR));
+  this->cmd_data(R06_CMD_BTST, sizeof(R06_CMD_BTST));
+  this->cmd_data(R41_CMD_TSE, sizeof(R41_CMD_TSE));
+  this->cmd_data(R50_CMD_CDI, sizeof(R50_CMD_CDI));
+  this->cmd_data(R60_CMD_TCON, sizeof(R60_CMD_TCON));
+  this->cmd_data(R61_CMD_TRES, sizeof(R61_CMD_TRES));
+  this->cmd_data(R62_CMD, sizeof(R62_CMD));
+  this->cmd_data(R65_CMD_GSST, sizeof(R65_CMD_GSST));
+  this->cmd_data(RE7_CMD, sizeof(RE7_CMD));
+  this->cmd_data(RE3_CMD_PWS, sizeof(RE3_CMD_PWS));
+  this->cmd_data(RE9_CMD, sizeof(RE9_CMD));
+  this->cmd_data(R30_CMD_PLL, sizeof(R30_CMD_PLL));
+  this->cmd_data(R04_CMD_PON, sizeof(R04_CMD_PON));
+  this->wait_until_idle_();
+}
+
+bool WaveshareEPaper7P5InH::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+
+  const uint32_t start = millis();
+  while (!this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGE(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  return true;
+}
+
+void WaveshareEPaper7P5InH::deep_sleep() {
+  this->cmd_data(cmddata_7P5InH::R02_CMD_POF, sizeof(cmddata_7P5InH::R02_CMD_POF));
+  this->wait_until_idle_();
+  this->cmd_data(cmddata_7P5InH::R07_CMD_DSLP, sizeof(cmddata_7P5InH::R07_CMD_DSLP));
+}
+
+void HOT WaveshareEPaper7P5InH::display() {
+  uint32_t buf_len = this->get_buffer_length_();
+
+  this->command(cmddata_7P5InH::R10_CMD_DTM1[0]);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  this->cmd_data(cmddata_7P5InH::R12_CMD_DRF, sizeof(cmddata_7P5InH::R12_CMD_DRF));
+  this->wait_until_idle_();
+}
+
+uint32_t WaveshareEPaper7P5InH::get_buffer_length_() {
+  // 4 pixels packed into 1 byte
+  return this->get_width_controller() * this->get_height_internal() / 4u;
+}
+
+void WaveshareEPaper7P5InH::fill(Color color) {
+  const uint8_t bits = this->color_to_2bit(color);
+  const uint8_t byte_val = bits | (bits << 2) | (bits << 4) | (bits << 6);  // replicate 4 pixels
+  memset(this->buffer_, byte_val, this->get_buffer_length_());
+}
+
+uint8_t WaveshareEPaper7P5InH::color_to_2bit(const Color &color) {
+  if (color.red > 127) {
+    if (color.green > 170) {
+      if (color.blue > 127) {
+        // white
+        return 0b01;
+      }
+
+      // yellow
+      return 0b10;
+    }
+
+    // red
+    return 0b11;
+  }
+
+  // black
+  return 0b00;
+}
+
+void HOT WaveshareEPaper7P5InH::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal())
+    return;
+
+  const uint32_t pixel_index = x + y * this->get_width_internal();
+  const uint32_t byte_index = pixel_index >> 2;
+  const uint8_t pos = pixel_index & 0x03;
+  const uint8_t shift = (3 - pos) * 2;
+
+  const uint8_t bits = this->color_to_2bit(color);
+  const uint8_t mask = (uint8_t) (0x03u << shift);
+
+  this->buffer_[byte_index] = (uint8_t) ((this->buffer_[byte_index] & ~mask) | (uint8_t) (bits << shift));
+}
+
+int WaveshareEPaper7P5InH::get_width_internal() { return 800; }
+int WaveshareEPaper7P5InH::get_height_internal() { return 480; }
+uint32_t WaveshareEPaper7P5InH::idle_timeout_() { return 10000; }
+void WaveshareEPaper7P5InH::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5inH");
+  LOG_PIN("  Power Pin: ", this->power_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   LOG_PIN("  DC Pin: ", this->dc_pin_);
   LOG_PIN("  Busy Pin: ", this->busy_pin_);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -13,6 +13,7 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
  public:
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
   float get_setup_priority() const override;
+  void set_power_pin(GPIOPin *power) { this->power_pin_ = power; }
   void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
   void set_busy_pin(GPIOPin *busy) { this->busy_pin_ = busy; }
   void set_reset_duration(uint32_t reset_duration) { this->reset_duration_ = reset_duration; }
@@ -55,6 +56,7 @@ class WaveshareEPaperBase : public display::DisplayBuffer,
   void start_data_();
   void end_data_();
 
+  GPIOPin *power_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
   GPIOPin *dc_pin_;
   GPIOPin *busy_pin_{nullptr};
@@ -1011,6 +1013,49 @@ class WaveshareEPaper7P5InHDB : public WaveshareEPaper {
   int get_width_internal() override;
 
   int get_height_internal() override;
+};
+
+class WaveshareEPaper7P5InH : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+  void deep_sleep() override;
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+
+  uint32_t get_buffer_length_() override;
+
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  uint32_t idle_timeout_() override;
+
+  bool wait_until_idle_();
+
+  void reset_() {
+    if (this->reset_pin_ == nullptr) {
+      return;
+    }
+
+    this->reset_pin_->digital_write(true);
+    delay(200);  // NOLINT
+    this->reset_pin_->digital_write(false);
+    delay(2);
+    this->reset_pin_->digital_write(true);
+    delay(200);  // NOLINT
+  };
+
+  uint8_t color_to_2bit(const Color &color);
 };
 
 class WaveshareEPaper2P13InDKE : public WaveshareEPaper {

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -1055,7 +1055,7 @@ class WaveshareEPaper7P5InH : public WaveshareEPaper {
     delay(200);  // NOLINT
   };
 
-  uint8_t color_to_2bit(const Color &color);
+  uint8_t color_to_2bit_(const Color &color);
 };
 
 class WaveshareEPaper2P13InDKE : public WaveshareEPaper {

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -773,6 +773,25 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
+  - platform: waveshare_epaper
+    id: epd_7_50h
+    model: 7.50in-h
+    spi_id: spi_waveshare_epaper
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
   # 13.3 inch displays
   - platform: waveshare_epaper
     id: epd_13_3k


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for the [Waveshare 7.5inch (H) display](https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_(H)_Manual) with or without HAT.
![photo](https://github.com/user-attachments/assets/a86ff2ce-be47-4434-a220-38a0335c3b83)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml

font:
  - file: gfonts://Roboto
    id: roboto
    size: 128

spi:
  clk_pin: GPIO13
  mosi_pin: GPIO14

display:
  - platform: waveshare_epaper
    cs_pin: GPIO15
    dc_pin: GPIO17
    busy_pin: GPIO8
    reset_pin: GPIO18
    power_pin: GPIO16
    model: 7.50in-h
    update_interval: 12h
    lambda: |
      auto black = Color(0, 0, 0);
      auto red = Color(255, 0, 0);
      auto yellow = Color(255, 255, 0);
      auto white = Color(255, 255, 255);
      it.fill(white);
      it.filled_circle(40, 64, 30, red);
      it.filled_circle(80, 64, 30, yellow);
      it.filled_circle(120, 64, 30, black);
      it.print(20, 240, id(roboto), black, "ESPHome");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
