### PR TITLE
[core] Optimize MAC address formatting to eliminate sprintf dependency

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -638,7 +638,9 @@ void EthernetComponent::get_eth_mac_address_raw(uint8_t *mac) {
 std::string EthernetComponent::get_eth_mac_address_pretty() {
   uint8_t mac[6];
   get_eth_mac_address_raw(mac);
-  return str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  char buf[18];
+  format_mac_addr_upper(mac, buf);
+  return std::string(buf);
 }
 
 eth_duplex_t EthernetComponent::get_duplex_mode() {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -255,22 +255,21 @@ size_t parse_hex(const char *str, size_t length, uint8_t *data, size_t count) {
 }
 
 std::string format_mac_address_pretty(const uint8_t *mac) {
-  return str_snprintf("%02X:%02X:%02X:%02X:%02X:%02X", 17, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  char buf[18];
+  format_mac_addr_upper(mac, buf);
+  return std::string(buf);
 }
 
-static char format_hex_char(uint8_t v) { return v >= 10 ? 'a' + (v - 10) : '0' + v; }
 std::string format_hex(const uint8_t *data, size_t length) {
   std::string ret;
   ret.resize(length * 2);
   for (size_t i = 0; i < length; i++) {
-    ret[2 * i] = format_hex_char((data[i] & 0xF0) >> 4);
-    ret[2 * i + 1] = format_hex_char(data[i] & 0x0F);
+    ret[2 * i] = format_hex_char_lower(data[i] >> 4);
+    ret[2 * i + 1] = format_hex_char_lower(data[i] & 0x0F);
   }
   return ret;
 }
 std::string format_hex(const std::vector<uint8_t> &data) { return format_hex(data.data(), data.size()); }
-
-static char format_hex_pretty_char(uint8_t v) { return v >= 10 ? 'A' + (v - 10) : '0' + v; }
 
 // Shared implementation for uint8_t and string hex formatting
 static std::string format_hex_pretty_uint8(const uint8_t *data, size_t length, char separator, bool show_length) {
@@ -280,7 +279,7 @@ static std::string format_hex_pretty_uint8(const uint8_t *data, size_t length, c
   uint8_t multiple = separator ? 3 : 2;  // 3 if separator is not \0, 2 otherwise
   ret.resize(multiple * length - (separator ? 1 : 0));
   for (size_t i = 0; i < length; i++) {
-    ret[multiple * i] = format_hex_pretty_char((data[i] & 0xF0) >> 4);
+    ret[multiple * i] = format_hex_pretty_char(data[i] >> 4);
     ret[multiple * i + 1] = format_hex_pretty_char(data[i] & 0x0F);
     if (separator && i != length - 1)
       ret[multiple * i + 2] = separator;
@@ -591,7 +590,9 @@ bool HighFrequencyLoopRequester::is_high_frequency() { return num_requests > 0; 
 std::string get_mac_address() {
   uint8_t mac[6];
   get_mac_address_raw(mac);
-  return str_snprintf("%02x%02x%02x%02x%02x%02x", 12, mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  char buf[13];
+  format_mac_addr_lower_no_sep(mac, buf);
+  return std::string(buf);
 }
 
 std::string get_mac_address_pretty() {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -264,8 +264,8 @@ std::string format_hex(const uint8_t *data, size_t length) {
   std::string ret;
   ret.resize(length * 2);
   for (size_t i = 0; i < length; i++) {
-    ret[2 * i] = format_hex_char_lower(data[i] >> 4);
-    ret[2 * i + 1] = format_hex_char_lower(data[i] & 0x0F);
+    ret[2 * i] = format_hex_char(data[i] >> 4);
+    ret[2 * i + 1] = format_hex_char(data[i] & 0x0F);
   }
   return ret;
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -381,7 +381,7 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> optional<
 }
 
 /// Convert a nibble (0-15) to lowercase hex char
-inline char format_hex_char_lower(uint8_t v) { return v >= 10 ? 'a' + (v - 10) : '0' + v; }
+inline char format_hex_char(uint8_t v) { return v >= 10 ? 'a' + (v - 10) : '0' + v; }
 
 /// Convert a nibble (0-15) to uppercase hex char (used for pretty printing)
 /// This always uses uppercase (A-F) for pretty/human-readable output
@@ -403,8 +403,8 @@ inline void format_mac_addr_upper(const uint8_t *mac, char *output) {
 inline void format_mac_addr_lower_no_sep(const uint8_t *mac, char *output) {
   for (size_t i = 0; i < 6; i++) {
     uint8_t byte = mac[i];
-    output[i * 2] = format_hex_char_lower(byte >> 4);
-    output[i * 2 + 1] = format_hex_char_lower(byte & 0x0F);
+    output[i * 2] = format_hex_char(byte >> 4);
+    output[i * 2 + 1] = format_hex_char(byte & 0x0F);
   }
   output[12] = '\0';
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -380,6 +380,35 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> optional<
   return parse_hex<T>(str.c_str(), str.length());
 }
 
+/// Convert a nibble (0-15) to lowercase hex char
+inline char format_hex_char_lower(uint8_t v) { return v >= 10 ? 'a' + (v - 10) : '0' + v; }
+
+/// Convert a nibble (0-15) to uppercase hex char (used for pretty printing)
+/// This always uses uppercase (A-F) for pretty/human-readable output
+inline char format_hex_pretty_char(uint8_t v) { return v >= 10 ? 'A' + (v - 10) : '0' + v; }
+
+/// Format MAC address as XX:XX:XX:XX:XX:XX (uppercase)
+inline void format_mac_addr_upper(const uint8_t *mac, char *output) {
+  for (size_t i = 0; i < 6; i++) {
+    uint8_t byte = mac[i];
+    output[i * 3] = format_hex_pretty_char(byte >> 4);
+    output[i * 3 + 1] = format_hex_pretty_char(byte & 0x0F);
+    if (i < 5)
+      output[i * 3 + 2] = ':';
+  }
+  output[17] = '\0';
+}
+
+/// Format MAC address as xxxxxxxxxxxxxx (lowercase, no separators)
+inline void format_mac_addr_lower_no_sep(const uint8_t *mac, char *output) {
+  for (size_t i = 0; i < 6; i++) {
+    uint8_t byte = mac[i];
+    output[i * 2] = format_hex_char_lower(byte >> 4);
+    output[i * 2 + 1] = format_hex_char_lower(byte & 0x0F);
+  }
+  output[12] = '\0';
+}
+
 /// Format the six-byte array \p mac into a MAC address.
 std::string format_mac_address_pretty(const uint8_t mac[6]);
 /// Format the byte array \p data of length \p len in lowercased hex.


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes MAC address formatting functions to use direct arithmetic conversion instead of `sprintf`/`snprintf`, resulting in:
- **~20x performance improvement** (117ns → 5.3ns for pretty format, 101ns → 5.4ns for compact format)
- **RAM savings on ESP8266** - Format strings like `"%02X:%02X:%02X:%02X:%02X:%02X"` and `"%02x%02x%02x%02x%02x%02x"` were being stored in RAM, consuming precious memory on this memory-constrained platform
- **Flash savings** on both ESP8266 (-8 bytes) and ESP32 (-88 bytes)
- Elimination of heavy sprintf formatting code dependency for MAC operations
- Cleaner code with common helper functions and no duplication

The optimization replaces sprintf-based MAC formatting with efficient nibble-to-hex character conversion using simple arithmetic operations. On ESP8266, this is particularly important as the format strings were consuming RAM rather than being stored in Flash/PROGMEM, making this optimization even more valuable for memory-constrained devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** Builds on optimization approach from #10710

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Changes Made

### 1. Added Common Helper Functions in `core/helpers.h`
- `format_hex_char_lower(uint8_t v)` - Convert nibble to lowercase hex char (a-f)
- `format_hex_pretty_char(uint8_t v)` - Convert nibble to uppercase hex char (A-F)
- `format_mac_addr_upper(const uint8_t *mac, char *output)` - Format as XX:XX:XX:XX:XX:XX
- `format_mac_addr_lower_no_sep(const uint8_t *mac, char *output)` - Format as xxxxxxxxxxxx

### 2. Updated Implementations
- `core/helpers.cpp`:
  - `format_mac_address_pretty()` - Now uses `format_mac_addr_upper()`
  - `get_mac_address()` - Now uses `format_mac_addr_lower_no_sep()`
  - `format_hex()` - Now uses `format_hex_char_lower()`
  - Kept `format_hex_pretty_char` as-is for backwards compatibility

- `ethernet/ethernet_component.cpp`:
  - `get_eth_mac_address_pretty()` - Now uses `format_mac_addr_upper()`

## Memory Impact Results

### ESP8266
Before:
```
RAM:   [====      ]  36.6% (used 29984 bytes from 81920 bytes)
Flash: [===       ]  34.1% (used 348783 bytes from 1023984 bytes)
```

After:
```
RAM:   [====      ]  36.6% (used 29968 bytes from 81920 bytes)  // -16 bytes
Flash: [===       ]  34.1% (used 348775 bytes from 1023984 bytes)  // -8 bytes
```

### ESP32
Before:
```
RAM:   [          ]   4.9% (used 16084 bytes from 327680 bytes)
Flash: [===       ]  27.4% (used 502006 bytes from 1835008 bytes)
```

After:
```
RAM:   [          ]   4.9% (used 16084 bytes from 327680 bytes)  // No change
Flash: [===       ]  27.4% (used 501918 bytes from 1835008 bytes)  // -88 bytes
```

## Performance Benchmark Results

Benchmark with 10,000 iterations on 1,000 test MAC addresses:

### Pretty Format (XX:XX:XX:XX:XX:XX)
```
sprintf                  : mean=117.14 ns (±5.90)
arithmetic               : mean=5.30   ns (±0.62) | 22.1x faster
lookup table             : mean=5.29   ns (±0.43) | 22.1x faster
```

### Compact Format (xxxxxxxxxxxx)
```
sprintf                  : mean=100.59 ns (±4.50)
arithmetic               : mean=5.41   ns (±0.20) | 18.6x faster
lookup table             : mean=5.13   ns (±0.33) | 19.6x faster
```

The arithmetic approach matches lookup table performance while avoiding memory overhead.

## Verification Tests

The attached `mac_formatting_tests.zip` contains:

1. **test_mac_format.cpp** - Basic correctness test verifying:
   - Edge cases (all zeros, all 0xFF)
   - Real MAC addresses
   - All 256 possible byte values

2. **test_mac_comprehensive.cpp** - Comprehensive test with:
   - Multiple real-world MAC addresses (Apple, VMware, etc.)
   - Boundary values and alternating patterns
   - 1000 random MAC addresses
   - Exhaustive validation

3. **benchmark_mac_format.cpp** - Performance benchmark comparing:
   - Original sprintf implementation
   - New arithmetic implementation
   - Alternative lookup table approaches
   - Detailed statistics with standard deviation and percentiles

All tests confirm 100% compatibility with identical output while delivering massive performance improvements.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (see attached `mac_formatting_tests.zip`).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation change only, no user-facing changes.

## Additional Notes

This optimization applies the same proven approach from the MD5 hex conversion (PR #10710) to MAC address formatting, which is used much more frequently throughout the codebase for:
- Network status logging
- Device identification
- BLE device tracking
- Ethernet connectivity
- WiFi operations

The ~20x performance improvement will benefit all network-related operations while reducing memory usage.

[mac_formatting_tests.zip](https://github.com/user-attachments/files/22324171/mac_formatting_tests.zip)

