### PR TITLE
[scheduler] Fix timing accumulation in scheduler causing incorrect execution measurements

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -254,7 +254,7 @@ class Scheduler {
   }
 
   // Helper to execute a scheduler item
-  void execute_item_(SchedulerItem *item, uint32_t now);
+  uint32_t execute_item_(SchedulerItem *item, uint32_t now);
 
   // Helper to check if item should be skipped
   bool should_skip_item_(SchedulerItem *item) const {


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a critical timing bug in the scheduler where multiple scheduled items executing in the same batch would accumulate execution time incorrectly. The last items to execute would be incorrectly measured as taking the cumulative time of all previous items, leading to false performance warnings and misleading runtime statistics.

The issue occurred because `execute_item_()` was using a stale `now` timestamp passed from the beginning of the scheduler run, rather than the actual start time of each individual item's execution. This caused later scheduled items to be measured from the start of the entire batch rather than from when they actually began executing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #[Issue number if applicable]

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal scheduler fix.
# The fix improves timing accuracy for all scheduled components.

# Example of components that benefit from this fix:
sensor:
  - platform: template
    name: "Test Sensor"
    lambda: return 42.0;
    update_interval: 60s

# Runtime stats (if enabled) will now show accurate timing:
runtime_stats:
  # Component timings will now reflect actual execution time
  # instead of accumulated time from previous components
```

## Impact of the Fix

### Before:
- Template sensors showing 60-115ms execution time for simple lambdas that actually take microseconds
- False warnings about components blocking for >30ms when they actually execute quickly
- Runtime stats showing inflated and misleading timing information
- Later scheduled items incorrectly accumulating the execution time of all previous items

### After:
- Accurate timing measurements for each component
- Warnings only triggered for components that genuinely block >30ms
- Runtime stats provide trustworthy performance data
- Each scheduled item measured from its actual start time, not from the beginning of the scheduler batch

## Technical Details

The fix modifies `execute_item_()` to return the finish time from `WarnIfComponentBlockingGuard`, which is then used as the start time for the next scheduled item. This creates a proper timing chain:
- Item 1: starts at T0, finishes at T1
- Item 2: starts at T1 (not T0!), finishes at T2
- Item 3: starts at T2 (not T0!), finishes at T3

This ensures each component is only charged for its actual execution time, eliminating the accumulation effect that was causing incorrect measurements.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).