### PR TITLE
[ektf2232] Rename `rts_pin` to `reset_pin`

### DIFF
--- a/esphome/components/ektf2232/touchscreen/__init__.py
+++ b/esphome/components/ektf2232/touchscreen/__init__.py
@@ -2,7 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 from esphome.components import i2c, touchscreen
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_INTERRUPT_PIN
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN, CONF_RESET_PIN
 
 CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["i2c"]
@@ -15,7 +15,7 @@ EKTF2232Touchscreen = ektf2232_ns.class_(
 )
 
 CONF_EKTF2232_ID = "ektf2232_id"
-CONF_RTS_PIN = "rts_pin"
+CONF_RTS_PIN = "rts_pin"  # To be removed before 2026.4.0
 
 CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     cv.Schema(
@@ -24,7 +24,10 @@ CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
             cv.Required(CONF_INTERRUPT_PIN): cv.All(
                 pins.internal_gpio_input_pin_schema
             ),
-            cv.Required(CONF_RTS_PIN): pins.gpio_output_pin_schema,
+            cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_RTS_PIN): cv.invalid(
+                f"{CONF_RTS_PIN} has been renamed to {CONF_RESET_PIN}"
+            ),
         }
     ).extend(i2c.i2c_device_schema(0x15))
 )
@@ -37,5 +40,5 @@ async def to_code(config):
 
     interrupt_pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])
     cg.add(var.set_interrupt_pin(interrupt_pin))
-    rts_pin = await cg.gpio_pin_expression(config[CONF_RTS_PIN])
-    cg.add(var.set_rts_pin(rts_pin))
+    reset_pin = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+    cg.add(var.set_reset_pin(reset_pin))

--- a/esphome/components/ektf2232/touchscreen/ektf2232.cpp
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.cpp
@@ -21,7 +21,7 @@ void EKTF2232Touchscreen::setup() {
 
   this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
 
-  this->rts_pin_->setup();
+  this->reset_pin_->setup();
 
   this->hard_reset_();
   if (!this->soft_reset_()) {
@@ -98,9 +98,9 @@ bool EKTF2232Touchscreen::get_power_state() {
 }
 
 void EKTF2232Touchscreen::hard_reset_() {
-  this->rts_pin_->digital_write(false);
+  this->reset_pin_->digital_write(false);
   delay(15);
-  this->rts_pin_->digital_write(true);
+  this->reset_pin_->digital_write(true);
   delay(15);
 }
 
@@ -127,7 +127,7 @@ void EKTF2232Touchscreen::dump_config() {
   ESP_LOGCONFIG(TAG, "EKT2232 Touchscreen:");
   LOG_I2C_DEVICE(this);
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
-  LOG_PIN("  RTS Pin: ", this->rts_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
 }
 
 }  // namespace ektf2232

--- a/esphome/components/ektf2232/touchscreen/ektf2232.h
+++ b/esphome/components/ektf2232/touchscreen/ektf2232.h
@@ -17,7 +17,7 @@ class EKTF2232Touchscreen : public Touchscreen, public i2c::I2CDevice {
   void dump_config() override;
 
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
-  void set_rts_pin(GPIOPin *pin) { this->rts_pin_ = pin; }
+  void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
 
   void set_power_state(bool enable);
   bool get_power_state();
@@ -28,7 +28,7 @@ class EKTF2232Touchscreen : public Touchscreen, public i2c::I2CDevice {
   void update_touches() override;
 
   InternalGPIOPin *interrupt_pin_;
-  GPIOPin *rts_pin_;
+  GPIOPin *reset_pin_;
 };
 
 }  // namespace ektf2232

--- a/tests/components/ektf2232/common.yaml
+++ b/tests/components/ektf2232/common.yaml
@@ -7,7 +7,7 @@ display:
   - platform: ssd1306_i2c
     id: ssd1306_display
     model: SSD1306_128X64
-    reset_pin: ${reset_pin}
+    reset_pin: ${display_reset_pin}
     pages:
       - id: page1
         lambda: |-
@@ -16,7 +16,7 @@ display:
 touchscreen:
   - platform: ektf2232
     interrupt_pin: ${interrupt_pin}
-    rts_pin: ${rts_pin}
+    reset_pin: ${touch_reset_pin}
     display: ssd1306_display
     on_touch:
       - logger.log:

--- a/tests/components/ektf2232/test.esp32-ard.yaml
+++ b/tests/components/ektf2232/test.esp32-ard.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO16
   sda_pin: GPIO17
-  reset_pin: GPIO13
+  display_reset_pin: GPIO13
   interrupt_pin: GPIO14
-  rts_pin: GPIO15
+  touch_reset_pin: GPIO15
 
 <<: !include common.yaml

--- a/tests/components/ektf2232/test.esp32-c3-ard.yaml
+++ b/tests/components/ektf2232/test.esp32-c3-ard.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO5
   sda_pin: GPIO4
-  reset_pin: GPIO3
+  display_reset_pin: GPIO3
   interrupt_pin: GPIO6
-  rts_pin: GPIO7
+  touch_reset_pin: GPIO7
 
 <<: !include common.yaml

--- a/tests/components/ektf2232/test.esp32-c3-idf.yaml
+++ b/tests/components/ektf2232/test.esp32-c3-idf.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO5
   sda_pin: GPIO4
-  reset_pin: GPIO3
+  display_reset_pin: GPIO3
   interrupt_pin: GPIO6
-  rts_pin: GPIO7
+  touch_reset_pin: GPIO7
 
 <<: !include common.yaml

--- a/tests/components/ektf2232/test.esp32-idf.yaml
+++ b/tests/components/ektf2232/test.esp32-idf.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO16
   sda_pin: GPIO17
-  reset_pin: GPIO13
+  display_reset_pin: GPIO13
   interrupt_pin: GPIO14
-  rts_pin: GPIO15
+  touch_reset_pin: GPIO15
 
 <<: !include common.yaml

--- a/tests/components/ektf2232/test.esp8266-ard.yaml
+++ b/tests/components/ektf2232/test.esp8266-ard.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO5
   sda_pin: GPIO4
-  reset_pin: GPIO3
+  display_reset_pin: GPIO3
   interrupt_pin: GPIO12
-  rts_pin: GPIO13
+  touch_reset_pin: GPIO13
 
 <<: !include common.yaml

--- a/tests/components/ektf2232/test.rp2040-ard.yaml
+++ b/tests/components/ektf2232/test.rp2040-ard.yaml
@@ -1,8 +1,8 @@
 substitutions:
   scl_pin: GPIO5
   sda_pin: GPIO4
-  reset_pin: GPIO3
+  display_reset_pin: GPIO3
   interrupt_pin: GPIO6
-  rts_pin: GPIO7
+  touch_reset_pin: GPIO7
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5358

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
