### PR TITLE
[dashboard] Fix archive handler to properly delete build folders using correct path

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1039,11 +1039,11 @@ class ArchiveRequestHandler(BaseHandler):
 
         storage_json = StorageJSON.load(storage_path)
         if storage_json is not None:
-            # Delete build folder (if exists)
+            # Move build folder to archive (if exists)
             name = storage_json.name
             build_folder = os.path.join(settings.config_dir, name)
-            if build_folder is not None:
-                shutil.rmtree(build_folder, os.path.join(archive_path, name))
+            if os.path.exists(build_folder):
+                shutil.move(build_folder, os.path.join(archive_path, name))
 
 
 class UnArchiveRequestHandler(BaseHandler):

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1038,12 +1038,11 @@ class ArchiveRequestHandler(BaseHandler):
         shutil.move(config_file, os.path.join(archive_path, configuration))
 
         storage_json = StorageJSON.load(storage_path)
-        if storage_json is not None:
-            # Move build folder to archive (if exists)
-            name = storage_json.name
-            build_folder = os.path.join(settings.config_dir, name)
+        if storage_json is not None and storage_json.build_path:
+            # Delete build folder (if exists)
+            build_folder = storage_json.build_path
             if os.path.exists(build_folder):
-                shutil.move(build_folder, os.path.join(archive_path, name))
+                shutil.rmtree(build_folder, ignore_errors=True)
 
 
 class UnArchiveRequestHandler(BaseHandler):

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -1040,9 +1040,7 @@ class ArchiveRequestHandler(BaseHandler):
         storage_json = StorageJSON.load(storage_path)
         if storage_json is not None and storage_json.build_path:
             # Delete build folder (if exists)
-            build_folder = storage_json.build_path
-            if os.path.exists(build_folder):
-                shutil.rmtree(build_folder, ignore_errors=True)
+            shutil.rmtree(storage_json.build_path, ignore_errors=True)
 
 
 class UnArchiveRequestHandler(BaseHandler):

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -589,7 +589,7 @@ async def test_archive_request_handler_post(
     mock_ext_storage_path: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """Test ArchiveRequestHandler.post method."""
+    """Test ArchiveRequestHandler.post method without storage_json."""
 
     # Set up temp directories
     config_dir = Path(get_fixture_path("conf"))
@@ -599,14 +599,18 @@ async def test_archive_request_handler_post(
     test_config = config_dir / "test_archive.yaml"
     test_config.write_text("esphome:\n  name: test_archive\n")
 
-    # Archive the configuration
-    response = await dashboard.fetch(
-        "/archive",
-        method="POST",
-        body="configuration=test_archive.yaml",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-    )
-    assert response.code == 200
+    # Mock storage_json to return None (no storage)
+    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
+        mock_load.return_value = None
+
+        # Archive the configuration
+        response = await dashboard.fetch(
+            "/archive",
+            method="POST",
+            body="configuration=test_archive.yaml",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert response.code == 200
 
     # Verify file was moved to archive
     assert not test_config.exists()
@@ -614,6 +618,112 @@ async def test_archive_request_handler_post(
     assert (
         archive_dir / "test_archive.yaml"
     ).read_text() == "esphome:\n  name: test_archive\n"
+
+
+@pytest.mark.asyncio
+async def test_archive_handler_with_build_folder(
+    dashboard: DashboardTestHelper,
+    mock_archive_storage_path: MagicMock,
+    mock_ext_storage_path: MagicMock,
+    mock_dashboard_settings: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test ArchiveRequestHandler.post with storage_json and build folder."""
+    # Set up temp directories
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+
+    # Create a test configuration file
+    configuration = "test_device.yaml"
+    test_config = config_dir / configuration
+    test_config.write_text("esphome:\n  name: test_device\n")
+
+    # Create build folder with content
+    build_folder = config_dir / "test_device"
+    build_folder.mkdir()
+    (build_folder / "firmware.bin").write_text("binary content")
+    (build_folder / ".pioenvs").mkdir()
+
+    # Mock settings to use our temp directory
+    mock_dashboard_settings.config_dir = str(config_dir)
+    mock_dashboard_settings.rel_path.return_value = str(test_config)
+    mock_archive_storage_path.return_value = str(archive_dir)
+
+    # Mock storage_json with device name
+    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
+        mock_storage = MagicMock()
+        mock_storage.name = "test_device"
+        mock_load.return_value = mock_storage
+
+        # Archive the configuration
+        response = await dashboard.fetch(
+            "/archive",
+            method="POST",
+            body=f"configuration={configuration}",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert response.code == 200
+
+    # Verify config file was moved to archive
+    assert not test_config.exists()
+    assert (archive_dir / configuration).exists()
+
+    # Verify build folder was moved to archive
+    assert not build_folder.exists()
+    assert (archive_dir / "test_device").exists()
+    assert (archive_dir / "test_device" / "firmware.bin").exists()
+
+
+@pytest.mark.asyncio
+async def test_archive_handler_no_build_folder(
+    dashboard: DashboardTestHelper,
+    mock_archive_storage_path: MagicMock,
+    mock_ext_storage_path: MagicMock,
+    mock_dashboard_settings: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test ArchiveRequestHandler.post with storage_json but no build folder."""
+    # Set up temp directories
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+
+    # Create a test configuration file
+    configuration = "test_device.yaml"
+    test_config = config_dir / configuration
+    test_config.write_text("esphome:\n  name: test_device\n")
+
+    # Note: No build folder created
+
+    # Mock settings to use our temp directory
+    mock_dashboard_settings.config_dir = str(config_dir)
+    mock_dashboard_settings.rel_path.return_value = str(test_config)
+    mock_archive_storage_path.return_value = str(archive_dir)
+
+    # Mock storage_json with device name
+    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
+        mock_storage = MagicMock()
+        mock_storage.name = "test_device"
+        mock_load.return_value = mock_storage
+
+        # Archive the configuration (should not fail even without build folder)
+        response = await dashboard.fetch(
+            "/archive",
+            method="POST",
+            body=f"configuration={configuration}",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert response.code == 200
+
+    # Verify config file was moved to archive
+    assert not test_config.exists()
+    assert (archive_dir / configuration).exists()
+
+    # Verify no build folder in archive (since it didn't exist)
+    assert not (archive_dir / "test_device").exists()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Unix sockets are not supported on Windows")

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -634,14 +634,16 @@ async def test_archive_handler_with_build_folder(
     config_dir.mkdir()
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
 
     # Create a test configuration file
     configuration = "test_device.yaml"
     test_config = config_dir / configuration
     test_config.write_text("esphome:\n  name: test_device\n")
 
-    # Create build folder with content
-    build_folder = config_dir / "test_device"
+    # Create build folder with content (in proper location)
+    build_folder = build_dir / "test_device"
     build_folder.mkdir()
     (build_folder / "firmware.bin").write_text("binary content")
     (build_folder / ".pioenvs").mkdir()
@@ -651,10 +653,11 @@ async def test_archive_handler_with_build_folder(
     mock_dashboard_settings.rel_path.return_value = str(test_config)
     mock_archive_storage_path.return_value = str(archive_dir)
 
-    # Mock storage_json with device name
+    # Mock storage_json with device name and build_path
     with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
         mock_storage = MagicMock()
         mock_storage.name = "test_device"
+        mock_storage.build_path = str(build_folder)
         mock_load.return_value = mock_storage
 
         # Archive the configuration
@@ -670,10 +673,10 @@ async def test_archive_handler_with_build_folder(
     assert not test_config.exists()
     assert (archive_dir / configuration).exists()
 
-    # Verify build folder was moved to archive
+    # Verify build folder was deleted (not archived)
     assert not build_folder.exists()
-    assert (archive_dir / "test_device").exists()
-    assert (archive_dir / "test_device" / "firmware.bin").exists()
+    # Build folder should NOT be in archive
+    assert not (archive_dir / "test_device").exists()
 
 
 @pytest.mark.asyncio
@@ -703,10 +706,11 @@ async def test_archive_handler_no_build_folder(
     mock_dashboard_settings.rel_path.return_value = str(test_config)
     mock_archive_storage_path.return_value = str(archive_dir)
 
-    # Mock storage_json with device name
+    # Mock storage_json with device name but no build_path
     with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
         mock_storage = MagicMock()
         mock_storage.name = "test_device"
+        mock_storage.build_path = None
         mock_load.return_value = mock_storage
 
         # Archive the configuration (should not fail even without build folder)

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -671,31 +671,24 @@ async def test_archive_handler_no_build_folder(
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post with storage_json but no build folder."""
-    # Set up temp directories
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     archive_dir = tmp_path / "archive"
     archive_dir.mkdir()
 
-    # Create a test configuration file
     configuration = "test_device.yaml"
     test_config = config_dir / configuration
     test_config.write_text("esphome:\n  name: test_device\n")
 
-    # Note: No build folder created
-
-    # Mock settings to use our temp directory
     mock_dashboard_settings.config_dir = str(config_dir)
     mock_dashboard_settings.rel_path.return_value = str(test_config)
     mock_archive_storage_path.return_value = str(archive_dir)
 
-    # Mock storage_json with device name but no build_path
     mock_storage = MagicMock()
     mock_storage.name = "test_device"
     mock_storage.build_path = None
     mock_storage_json.load.return_value = mock_storage
 
-    # Archive the configuration (should not fail even without build folder)
     response = await dashboard.fetch(
         "/archive",
         method="POST",
@@ -704,11 +697,8 @@ async def test_archive_handler_no_build_folder(
     )
     assert response.code == 200
 
-    # Verify config file was moved to archive
     assert not test_config.exists()
     assert (archive_dir / configuration).exists()
-
-    # Verify no build folder in archive (since it didn't exist)
     assert not (archive_dir / "test_device").exists()
 
 

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -621,7 +621,6 @@ async def test_archive_handler_with_build_folder(
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post with storage_json and build folder."""
-    # Set up temp directories
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     archive_dir = tmp_path / "archive"
@@ -629,29 +628,24 @@ async def test_archive_handler_with_build_folder(
     build_dir = tmp_path / "build"
     build_dir.mkdir()
 
-    # Create a test configuration file
     configuration = "test_device.yaml"
     test_config = config_dir / configuration
     test_config.write_text("esphome:\n  name: test_device\n")
 
-    # Create build folder with content (in proper location)
     build_folder = build_dir / "test_device"
     build_folder.mkdir()
     (build_folder / "firmware.bin").write_text("binary content")
     (build_folder / ".pioenvs").mkdir()
 
-    # Mock settings to use our temp directory
     mock_dashboard_settings.config_dir = str(config_dir)
     mock_dashboard_settings.rel_path.return_value = str(test_config)
     mock_archive_storage_path.return_value = str(archive_dir)
 
-    # Mock storage_json with device name and build_path
     mock_storage = MagicMock()
     mock_storage.name = "test_device"
     mock_storage.build_path = str(build_folder)
     mock_storage_json.load.return_value = mock_storage
 
-    # Archive the configuration
     response = await dashboard.fetch(
         "/archive",
         method="POST",
@@ -660,13 +654,10 @@ async def test_archive_handler_with_build_folder(
     )
     assert response.code == 200
 
-    # Verify config file was moved to archive
     assert not test_config.exists()
     assert (archive_dir / configuration).exists()
 
-    # Verify build folder was deleted (not archived)
     assert not build_folder.exists()
-    # Build folder should NOT be in archive
     assert not (archive_dir / "test_device").exists()
 
 

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -599,18 +599,14 @@ async def test_archive_request_handler_post(
     test_config = config_dir / "test_archive.yaml"
     test_config.write_text("esphome:\n  name: test_archive\n")
 
-    # Mock storage_json to return None (no storage)
-    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
-        mock_load.return_value = None
-
-        # Archive the configuration
-        response = await dashboard.fetch(
-            "/archive",
-            method="POST",
-            body="configuration=test_archive.yaml",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-        assert response.code == 200
+    # Archive the configuration
+    response = await dashboard.fetch(
+        "/archive",
+        method="POST",
+        body="configuration=test_archive.yaml",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.code == 200
 
     # Verify file was moved to archive
     assert not test_config.exists()
@@ -626,6 +622,7 @@ async def test_archive_handler_with_build_folder(
     mock_archive_storage_path: MagicMock,
     mock_ext_storage_path: MagicMock,
     mock_dashboard_settings: MagicMock,
+    mock_storage_json: MagicMock,
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post with storage_json and build folder."""
@@ -654,20 +651,19 @@ async def test_archive_handler_with_build_folder(
     mock_archive_storage_path.return_value = str(archive_dir)
 
     # Mock storage_json with device name and build_path
-    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
-        mock_storage = MagicMock()
-        mock_storage.name = "test_device"
-        mock_storage.build_path = str(build_folder)
-        mock_load.return_value = mock_storage
+    mock_storage = MagicMock()
+    mock_storage.name = "test_device"
+    mock_storage.build_path = str(build_folder)
+    mock_storage_json.load.return_value = mock_storage
 
-        # Archive the configuration
-        response = await dashboard.fetch(
-            "/archive",
-            method="POST",
-            body=f"configuration={configuration}",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-        assert response.code == 200
+    # Archive the configuration
+    response = await dashboard.fetch(
+        "/archive",
+        method="POST",
+        body=f"configuration={configuration}",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.code == 200
 
     # Verify config file was moved to archive
     assert not test_config.exists()
@@ -685,6 +681,7 @@ async def test_archive_handler_no_build_folder(
     mock_archive_storage_path: MagicMock,
     mock_ext_storage_path: MagicMock,
     mock_dashboard_settings: MagicMock,
+    mock_storage_json: MagicMock,
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post with storage_json but no build folder."""
@@ -707,20 +704,19 @@ async def test_archive_handler_no_build_folder(
     mock_archive_storage_path.return_value = str(archive_dir)
 
     # Mock storage_json with device name but no build_path
-    with patch("esphome.dashboard.web_server.StorageJSON.load") as mock_load:
-        mock_storage = MagicMock()
-        mock_storage.name = "test_device"
-        mock_storage.build_path = None
-        mock_load.return_value = mock_storage
+    mock_storage = MagicMock()
+    mock_storage.name = "test_device"
+    mock_storage.build_path = None
+    mock_storage_json.load.return_value = mock_storage
 
-        # Archive the configuration (should not fail even without build folder)
-        response = await dashboard.fetch(
-            "/archive",
-            method="POST",
-            body=f"configuration={configuration}",
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
-        assert response.code == 200
+    # Archive the configuration (should not fail even without build folder)
+    response = await dashboard.fetch(
+        "/archive",
+        method="POST",
+        body=f"configuration={configuration}",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.code == 200
 
     # Verify config file was moved to archive
     assert not test_config.exists()

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -590,16 +590,12 @@ async def test_archive_request_handler_post(
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post method without storage_json."""
-
-    # Set up temp directories
     config_dir = Path(get_fixture_path("conf"))
     archive_dir = tmp_path / "archive"
 
-    # Create a test configuration file
     test_config = config_dir / "test_archive.yaml"
     test_config.write_text("esphome:\n  name: test_archive\n")
 
-    # Archive the configuration
     response = await dashboard.fetch(
         "/archive",
         method="POST",
@@ -608,7 +604,6 @@ async def test_archive_request_handler_post(
     )
     assert response.code == 200
 
-    # Verify file was moved to archive
     assert not test_config.exists()
     assert (archive_dir / "test_archive.yaml").exists()
     assert (

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -590,12 +590,16 @@ async def test_archive_request_handler_post(
     tmp_path: Path,
 ) -> None:
     """Test ArchiveRequestHandler.post method without storage_json."""
+
+    # Set up temp directories
     config_dir = Path(get_fixture_path("conf"))
     archive_dir = tmp_path / "archive"
 
+    # Create a test configuration file
     test_config = config_dir / "test_archive.yaml"
     test_config.write_text("esphome:\n  name: test_archive\n")
 
+    # Archive the configuration
     response = await dashboard.fetch(
         "/archive",
         method="POST",
@@ -604,6 +608,7 @@ async def test_archive_request_handler_post(
     )
     assert response.code == 200
 
+    # Verify file was moved to archive
     assert not test_config.exists()
     assert (archive_dir / "test_archive.yaml").exists()
     assert (

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -385,7 +385,8 @@ def test_preload_core_config_basic(setup_core: Path) -> None:
     assert KEY_CORE in CORE.data
     assert CONF_BUILD_PATH in config[CONF_ESPHOME]
     # Verify default build path is "build/<device_name>"
-    assert config[CONF_ESPHOME][CONF_BUILD_PATH].endswith("build/test_device")
+    build_path = config[CONF_ESPHOME][CONF_BUILD_PATH]
+    assert build_path.endswith(os.path.join("build", "test_device"))
 
 
 def test_preload_core_config_with_build_path(setup_core: Path) -> None:
@@ -421,7 +422,11 @@ def test_preload_core_config_env_build_path(setup_core: Path) -> None:
     assert CONF_BUILD_PATH in config[CONF_ESPHOME]
     assert "test_device" in config[CONF_ESPHOME][CONF_BUILD_PATH]
     # Verify it uses the env var path with device name appended
-    assert config[CONF_ESPHOME][CONF_BUILD_PATH].endswith("/env/build/test_device")
+    build_path = config[CONF_ESPHOME][CONF_BUILD_PATH]
+    expected_path = os.path.join("/env/build", "test_device")
+    assert build_path == expected_path or build_path == expected_path.replace(
+        "/", os.sep
+    )
     assert platform == "rp2040"
 
 

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -384,6 +384,8 @@ def test_preload_core_config_basic(setup_core: Path) -> None:
     assert platform == "esp32"
     assert KEY_CORE in CORE.data
     assert CONF_BUILD_PATH in config[CONF_ESPHOME]
+    # Verify default build path is "build/<device_name>"
+    assert config[CONF_ESPHOME][CONF_BUILD_PATH].endswith("build/test_device")
 
 
 def test_preload_core_config_with_build_path(setup_core: Path) -> None:
@@ -418,6 +420,8 @@ def test_preload_core_config_env_build_path(setup_core: Path) -> None:
 
     assert CONF_BUILD_PATH in config[CONF_ESPHOME]
     assert "test_device" in config[CONF_ESPHOME][CONF_BUILD_PATH]
+    # Verify it uses the env var path with device name appended
+    assert config[CONF_ESPHOME][CONF_BUILD_PATH].endswith("/env/build/test_device")
     assert platform == "rp2040"
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes multiple bugs in the dashboard's archive handler that prevented proper deletion of build folders when archiving configurations.

## The Bugs

The archive handler had three critical issues:

1. **Incorrect API usage**: `shutil.rmtree()` was being called with two arguments:
   ```python
   shutil.rmtree(build_folder, os.path.join(archive_path, name))
   ```
   But `rmtree` only accepts one argument for deletion. The second argument was being interpreted as `ignore_errors=True`.

2. **Wrong build folder path**: The code incorrectly constructed the build path as:
   ```python
   build_folder = os.path.join(settings.config_dir, name)
   ```
   But build folders are actually located at the path stored in `storage_json.build_path` (typically `.esphome/build/<name>` but can be overridden via YAML config).

3. **Invalid existence check**: The code checked `if build_folder is not None:` which would always be true for a string path.

## The Fix

Corrected all three issues:
```python
if storage_json is not None and storage_json.build_path:
    # Delete build folder (if exists)
    shutil.rmtree(storage_json.build_path, ignore_errors=True)
```

This properly:
- Uses the correct build path from storage JSON
- Correctly calls `rmtree` with proper arguments to delete the folder
- The `ignore_errors=True` handles the case where the folder doesn't exist

## Behavior

The intended and now correct behavior:
- **YAML files**: Archived (moved to archive folder) - small files worth keeping
- **Build folders**: Deleted to free disk space - can be regenerated from YAML if needed

## History

This bug has existed since March 16, 2019 (commit d332e491a) when the delete functionality was first added. The incorrect code survived multiple refactorings because it "appeared to work" - it was deleting folders (due to the misinterpreted `ignore_errors` parameter), just not from the correct location.

## Potential Footgun

There is a slight concern about users who may have incorrectly configured their `build_path` in YAML to point to an important directory, then later archive/delete the device which would delete that directory. However, no practical solution exists for this since:
- ESPHome consistently trusts user-provided configuration throughout the system
- The user explicitly specified this path for ESPHome to use for build artifacts
- Adding path restrictions would break legitimate use cases where users want builds in specific locations

Following the principle of trusting user configuration, the fix deletes the exact path the user configured, which is consistent with ESPHome's behavior elsewhere.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None filed yet - discovered during test coverage improvements

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a dashboard-only change that doesn't affect device firmware.

## Example entry for `config.yaml`:

```yaml
# N/A - Dashboard functionality, not configuration related
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Added `test_archive_handler_with_build_folder` - Tests archiving with storage_json and build folder
    - Added `test_archive_handler_no_build_folder` - Tests archiving with storage_json but no build folder
    - Updated `test_archive_request_handler_post` - Tests archiving without storage_json

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
