### PR TITLE
[api] Rename ConnectRequest/Response to AuthenticationRequest/Response

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -7,7 +7,7 @@ service APIConnection {
     option (needs_setup_connection) = false;
     option (needs_authentication) = false;
   }
-  rpc connect (ConnectRequest) returns (ConnectResponse) {
+  rpc authenticate (AuthenticationRequest) returns (AuthenticationResponse) {
     option (needs_setup_connection) = false;
     option (needs_authentication) = false;
   }
@@ -129,7 +129,7 @@ message HelloResponse {
 
 // Message sent at the beginning of each connection to authenticate the client
 // Can only be sent by the client and only at the beginning of the connection
-message ConnectRequest {
+message AuthenticationRequest {
   option (id) = 3;
   option (source) = SOURCE_CLIENT;
   option (no_delay) = true;
@@ -141,7 +141,7 @@ message ConnectRequest {
 
 // Confirmation of successful connection. After this the connection is available for all traffic.
 // Can only be sent by the server and only at the beginning of the connection
-message ConnectResponse {
+message AuthenticationResponse {
   option (id) = 4;
   option (source) = SOURCE_SERVER;
   option (no_delay) = true;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1387,14 +1387,14 @@ bool APIConnection::send_hello_response(const HelloRequest &msg) {
   return this->send_message(resp, HelloResponse::MESSAGE_TYPE);
 }
 #ifdef USE_API_PASSWORD
-bool APIConnection::send_connect_response(const ConnectRequest &msg) {
-  ConnectResponse resp;
+bool APIConnection::send_authenticate_response(const AuthenticationRequest &msg) {
+  AuthenticationResponse resp;
   // bool invalid_password = 1;
   resp.invalid_password = !this->parent_->check_password(msg.password);
   if (!resp.invalid_password) {
     this->complete_authentication_();
   }
-  return this->send_message(resp, ConnectResponse::MESSAGE_TYPE);
+  return this->send_message(resp, AuthenticationResponse::MESSAGE_TYPE);
 }
 #endif  // USE_API_PASSWORD
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -198,7 +198,7 @@ class APIConnection final : public APIServerConnection {
 #endif
   bool send_hello_response(const HelloRequest &msg) override;
 #ifdef USE_API_PASSWORD
-  bool send_connect_response(const ConnectRequest &msg) override;
+  bool send_authenticate_response(const AuthenticationRequest &msg) override;
 #endif
   bool send_disconnect_response(const DisconnectRequest &msg) override;
   bool send_ping_response(const PingRequest &msg) override;

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -43,7 +43,7 @@ void HelloResponse::calculate_size(ProtoSize &size) const {
   size.add_length(1, this->name_ref_.size());
 }
 #ifdef USE_API_PASSWORD
-bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+bool AuthenticationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1:
       this->password = value.as_string();
@@ -53,8 +53,8 @@ bool ConnectRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value
   }
   return true;
 }
-void ConnectResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
-void ConnectResponse::calculate_size(ProtoSize &size) const { size.add_bool(1, this->invalid_password); }
+void AuthenticationResponse::encode(ProtoWriteBuffer buffer) const { buffer.encode_bool(1, this->invalid_password); }
+void AuthenticationResponse::calculate_size(ProtoSize &size) const { size.add_bool(1, this->invalid_password); }
 #endif
 #ifdef USE_AREAS
 void AreaInfo::encode(ProtoWriteBuffer buffer) const {

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -361,12 +361,12 @@ class HelloResponse final : public ProtoMessage {
  protected:
 };
 #ifdef USE_API_PASSWORD
-class ConnectRequest final : public ProtoDecodableMessage {
+class AuthenticationRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 3;
   static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  const char *message_name() const override { return "connect_request"; }
+  const char *message_name() const override { return "authentication_request"; }
 #endif
   std::string password{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -376,12 +376,12 @@ class ConnectRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
-class ConnectResponse final : public ProtoMessage {
+class AuthenticationResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 4;
   static constexpr uint8_t ESTIMATED_SIZE = 2;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  const char *message_name() const override { return "connect_response"; }
+  const char *message_name() const override { return "authentication_response"; }
 #endif
   bool invalid_password{false};
   void encode(ProtoWriteBuffer buffer) const override;

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -670,8 +670,11 @@ void HelloResponse::dump_to(std::string &out) const {
   dump_field(out, "name", this->name_ref_);
 }
 #ifdef USE_API_PASSWORD
-void ConnectRequest::dump_to(std::string &out) const { dump_field(out, "password", this->password); }
-void ConnectResponse::dump_to(std::string &out) const { dump_field(out, "invalid_password", this->invalid_password); }
+void AuthenticationRequest::dump_to(std::string &out) const { dump_field(out, "password", this->password); }
+void AuthenticationResponse::dump_to(std::string &out) const {
+  MessageDumpHelper helper(out, "AuthenticationResponse");
+  dump_field(out, "invalid_password", this->invalid_password);
+}
 #endif
 void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
 void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -25,13 +25,13 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
 #ifdef USE_API_PASSWORD
-    case ConnectRequest::MESSAGE_TYPE: {
-      ConnectRequest msg;
+    case AuthenticationRequest::MESSAGE_TYPE: {
+      AuthenticationRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_connect_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_authentication_request: %s", msg.dump().c_str());
 #endif
-      this->on_connect_request(msg);
+      this->on_authentication_request(msg);
       break;
     }
 #endif
@@ -600,8 +600,8 @@ void APIServerConnection::on_hello_request(const HelloRequest &msg) {
   }
 }
 #ifdef USE_API_PASSWORD
-void APIServerConnection::on_connect_request(const ConnectRequest &msg) {
-  if (!this->send_connect_response(msg)) {
+void APIServerConnection::on_authentication_request(const AuthenticationRequest &msg) {
+  if (!this->send_authenticate_response(msg)) {
     this->on_fatal_error();
   }
 }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -27,7 +27,7 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_hello_request(const HelloRequest &value){};
 
 #ifdef USE_API_PASSWORD
-  virtual void on_connect_request(const ConnectRequest &value){};
+  virtual void on_authentication_request(const AuthenticationRequest &value){};
 #endif
 
   virtual void on_disconnect_request(const DisconnectRequest &value){};
@@ -216,7 +216,7 @@ class APIServerConnection : public APIServerConnectionBase {
  public:
   virtual bool send_hello_response(const HelloRequest &msg) = 0;
 #ifdef USE_API_PASSWORD
-  virtual bool send_connect_response(const ConnectRequest &msg) = 0;
+  virtual bool send_authenticate_response(const AuthenticationRequest &msg) = 0;
 #endif
   virtual bool send_disconnect_response(const DisconnectRequest &msg) = 0;
   virtual bool send_ping_response(const PingRequest &msg) = 0;
@@ -339,7 +339,7 @@ class APIServerConnection : public APIServerConnectionBase {
  protected:
   void on_hello_request(const HelloRequest &msg) override;
 #ifdef USE_API_PASSWORD
-  void on_connect_request(const ConnectRequest &msg) override;
+  void on_authentication_request(const AuthenticationRequest &msg) override;
 #endif
   void on_disconnect_request(const DisconnectRequest &msg) override;
   void on_ping_request(const PingRequest &msg) override;


### PR DESCRIPTION
# What does this implement/fix?

This PR renames the API protocol messages `ConnectRequest` and `ConnectResponse` to `AuthenticationRequest` and `AuthenticationResponse` respectively. This naming change better reflects the actual purpose of these messages - they handle authentication via password validation, not the connection establishment itself.

The RPC method is also renamed from `connect` to `authenticate` to maintain consistency.

This change was suggested by @jesserockz in #10704 and aligns the naming with the actual functionality - these messages are only used when `USE_API_PASSWORD` is defined and handle password authentication, not the TCP connection process.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to discussion in #10704

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal API protocol change

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal API protocol change
api:
  password: "your_password"  # Still works the same way
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - This is an internal protocol change that doesn't affect user-facing configuration

## Additional Notes

### Breaking Change Details
While this is technically a breaking change at the protocol level (only for consumers of api.proto as the wire protocol is the same), it should have minimal impact because:
1. The primary consumer of this API (aioesphomeapi) handles this as an internal implementation detail
2. The companion PR for aioesphomeapi updates it to use the new message names
3. Home Assistant uses aioesphomeapi and won't be directly affected
4. The messages are only used when password authentication is enabled (`USE_API_PASSWORD`)

### Changes Made
- Renamed `ConnectRequest` to `AuthenticationRequest` in api.proto
- Renamed `ConnectResponse` to `AuthenticationResponse` in api.proto
- Renamed RPC method from `connect` to `authenticate`
- Updated all C++ references:
  - `send_connect_response()` → `send_authenticate_response()`
  - `on_connect_request()` → `on_authentication_request()`
- Regenerated protobuf files with new names

### Coordination Required
This PR should be merged in coordination with the corresponding aioesphomeapi PR to ensure compatibility. https://github.com/esphome/aioesphomeapi/pull/1346