### PR TITLE
[json] Only compile SpiRamAllocator when PSRAM is enabled

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -8,7 +8,9 @@ namespace json {
 
 static const char *const TAG = "json";
 
+#ifdef USE_PSRAM
 // Build an allocator for the JSON Library using the RAMAllocator class
+// This is only compiled when PSRAM is enabled
 struct SpiRamAllocator : ArduinoJson::Allocator {
   void *allocate(size_t size) override { return this->allocator_.allocate(size); }
 
@@ -29,11 +31,16 @@ struct SpiRamAllocator : ArduinoJson::Allocator {
  protected:
   RAMAllocator<uint8_t> allocator_{RAMAllocator<uint8_t>(RAMAllocator<uint8_t>::NONE)};
 };
+#endif
 
 std::string build_json(const json_build_t &f) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
+#ifdef USE_PSRAM
   auto doc_allocator = SpiRamAllocator();
   JsonDocument json_document(&doc_allocator);
+#else
+  JsonDocument json_document;
+#endif
   if (json_document.overflowed()) {
     ESP_LOGE(TAG, "Could not allocate memory for JSON document!");
     return "{}";
@@ -52,8 +59,12 @@ std::string build_json(const json_build_t &f) {
 
 bool parse_json(const std::string &data, const json_parse_t &f) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
+#ifdef USE_PSRAM
   auto doc_allocator = SpiRamAllocator();
   JsonDocument json_document(&doc_allocator);
+#else
+  JsonDocument json_document;
+#endif
   if (json_document.overflowed()) {
     ESP_LOGE(TAG, "Could not allocate memory for JSON document!");
     return false;


### PR DESCRIPTION
# What does this implement/fix?

This PR conditionally compiles the `SpiRamAllocator` class in the JSON component only when PSRAM is enabled, eliminating unnecessary code bloat on devices without PSRAM support.

Previously, the `SpiRamAllocator` class and its vtable were always compiled in, even on ESP8266 and ESP32 devices without PSRAM, consuming approximately 139 bytes of flash memory for code that would never be used. The allocator would fall back to regular malloc anyway on these devices.

**Flash savings:**
- ESP8266: 12 bytes
- ESP32 (without PSRAM): 116 bytes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
