### PR TITLE
[esp32] Optimize NVS preferences memory usage by replacing vector with unique_ptr

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -17,7 +17,14 @@ static const char *const TAG = "esp32.preferences";
 
 struct NVSData {
   std::string key;
-  std::vector<uint8_t> data;
+  std::unique_ptr<uint8_t[]> data;
+  size_t len;
+
+  void set_data(const uint8_t *src, size_t size) {
+    data = std::make_unique<uint8_t[]>(size);
+    memcpy(data.get(), src, size);
+    len = size;
+  }
 };
 
 static std::vector<NVSData> s_pending_save;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -30,14 +37,14 @@ class ESP32PreferenceBackend : public ESPPreferenceBackend {
     // try find in pending saves and update that
     for (auto &obj : s_pending_save) {
       if (obj.key == key) {
-        obj.data.assign(data, data + len);
+        obj.set_data(data, len);
         return true;
       }
     }
     NVSData save{};
     save.key = key;
-    save.data.assign(data, data + len);
-    s_pending_save.emplace_back(save);
+    save.set_data(data, len);
+    s_pending_save.emplace_back(std::move(save));
     ESP_LOGVV(TAG, "s_pending_save: key: %s, len: %d", key.c_str(), len);
     return true;
   }
@@ -45,11 +52,11 @@ class ESP32PreferenceBackend : public ESPPreferenceBackend {
     // try find in pending saves and load from that
     for (auto &obj : s_pending_save) {
       if (obj.key == key) {
-        if (obj.data.size() != len) {
+        if (obj.len != len) {
           // size mismatch
           return false;
         }
-        memcpy(data, obj.data.data(), len);
+        memcpy(data, obj.data.get(), len);
         return true;
       }
     }
@@ -123,11 +130,10 @@ class ESP32Preferences : public ESPPreferences {
       const auto &save = s_pending_save[i];
       ESP_LOGVV(TAG, "Checking if NVS data %s has changed", save.key.c_str());
       if (is_changed(nvs_handle, save)) {
-        esp_err_t err = nvs_set_blob(nvs_handle, save.key.c_str(), save.data.data(), save.data.size());
-        ESP_LOGV(TAG, "sync: key: %s, len: %d", save.key.c_str(), save.data.size());
+        esp_err_t err = nvs_set_blob(nvs_handle, save.key.c_str(), save.data.get(), save.len);
+        ESP_LOGV(TAG, "sync: key: %s, len: %d", save.key.c_str(), save.len);
         if (err != 0) {
-          ESP_LOGV(TAG, "nvs_set_blob('%s', len=%u) failed: %s", save.key.c_str(), save.data.size(),
-                   esp_err_to_name(err));
+          ESP_LOGV(TAG, "nvs_set_blob('%s', len=%u) failed: %s", save.key.c_str(), save.len, esp_err_to_name(err));
           failed++;
           last_err = err;
           last_key = save.key;
@@ -135,7 +141,7 @@ class ESP32Preferences : public ESPPreferences {
         }
         written++;
       } else {
-        ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%u", save.key.c_str(), save.data.size());
+        ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%u", save.key.c_str(), save.len);
         cached++;
       }
       s_pending_save.erase(s_pending_save.begin() + i);
@@ -164,7 +170,7 @@ class ESP32Preferences : public ESPPreferences {
       return true;
     }
     // Check size first before allocating memory
-    if (actual_len != to_save.data.size()) {
+    if (actual_len != to_save.len) {
       return true;
     }
     auto stored_data = std::make_unique<uint8_t[]>(actual_len);
@@ -173,7 +179,7 @@ class ESP32Preferences : public ESPPreferences {
       ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", to_save.key.c_str(), esp_err_to_name(err));
       return true;
     }
-    return memcmp(to_save.data.data(), stored_data.get(), to_save.data.size()) != 0;
+    return memcmp(to_save.data.get(), stored_data.get(), to_save.len) != 0;
   }
 
   bool reset() override {

--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -45,7 +45,7 @@ class ESP32PreferenceBackend : public ESPPreferenceBackend {
     save.key = key;
     save.set_data(data, len);
     s_pending_save.emplace_back(std::move(save));
-    ESP_LOGVV(TAG, "s_pending_save: key: %s, len: %d", key.c_str(), len);
+    ESP_LOGVV(TAG, "s_pending_save: key: %s, len: %zu", key.c_str(), len);
     return true;
   }
   bool load(uint8_t *data, size_t len) override {
@@ -68,7 +68,7 @@ class ESP32PreferenceBackend : public ESPPreferenceBackend {
       return false;
     }
     if (actual_len != len) {
-      ESP_LOGVV(TAG, "NVS length does not match (%u!=%u)", actual_len, len);
+      ESP_LOGVV(TAG, "NVS length does not match (%zu!=%zu)", actual_len, len);
       return false;
     }
     err = nvs_get_blob(nvs_handle, key.c_str(), data, &len);
@@ -76,7 +76,7 @@ class ESP32PreferenceBackend : public ESPPreferenceBackend {
       ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", key.c_str(), esp_err_to_name(err));
       return false;
     } else {
-      ESP_LOGVV(TAG, "nvs_get_blob: key: %s, len: %d", key.c_str(), len);
+      ESP_LOGVV(TAG, "nvs_get_blob: key: %s, len: %zu", key.c_str(), len);
     }
     return true;
   }
@@ -119,7 +119,7 @@ class ESP32Preferences : public ESPPreferences {
     if (s_pending_save.empty())
       return true;
 
-    ESP_LOGV(TAG, "Saving %d items...", s_pending_save.size());
+    ESP_LOGV(TAG, "Saving %zu items...", s_pending_save.size());
     // goal try write all pending saves even if one fails
     int cached = 0, written = 0, failed = 0;
     esp_err_t last_err = ESP_OK;
@@ -131,9 +131,9 @@ class ESP32Preferences : public ESPPreferences {
       ESP_LOGVV(TAG, "Checking if NVS data %s has changed", save.key.c_str());
       if (is_changed(nvs_handle, save)) {
         esp_err_t err = nvs_set_blob(nvs_handle, save.key.c_str(), save.data.get(), save.len);
-        ESP_LOGV(TAG, "sync: key: %s, len: %d", save.key.c_str(), save.len);
+        ESP_LOGV(TAG, "sync: key: %s, len: %zu", save.key.c_str(), save.len);
         if (err != 0) {
-          ESP_LOGV(TAG, "nvs_set_blob('%s', len=%u) failed: %s", save.key.c_str(), save.len, esp_err_to_name(err));
+          ESP_LOGV(TAG, "nvs_set_blob('%s', len=%zu) failed: %s", save.key.c_str(), save.len, esp_err_to_name(err));
           failed++;
           last_err = err;
           last_key = save.key;
@@ -141,7 +141,7 @@ class ESP32Preferences : public ESPPreferences {
         }
         written++;
       } else {
-        ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%u", save.key.c_str(), save.len);
+        ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%zu", save.key.c_str(), save.len);
         cached++;
       }
       s_pending_save.erase(s_pending_save.begin() + i);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the ESP32 NVS (Non-Volatile Storage) preferences implementation by replacing `std::vector<uint8_t>` with `std::unique_ptr<uint8_t[]>` for storing preference data. Since the data size is fixed at allocation time and never resized, using `std::vector` was unnecessary overhead.

**Benefits:**
- **Flash savings: 312 bytes** (503850 → 503538 bytes on ESP32 Arduino)
- **RAM savings: 4 bytes per pending preference item** (vector's 3 pointers vs unique_ptr + size_t on 32-bit ESP32)
- **Cleaner code**: Uses the right data structure for fixed-size buffers

The optimization:
- Replaces `std::vector<uint8_t>` with `std::unique_ptr<uint8_t[]>` + `size_t len` in `NVSData` struct
- Eliminates vector's dynamic resizing machinery (grow/shrink/capacity management) which was never used
- Uses move semantics to avoid expensive copies during vector reallocation
- Adds a helper method `set_data()` to reduce code duplication

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (internal implementation detail)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Any existing ESP32 configuration will benefit from reduced flash usage
esphome:
  name: example

esp32:
  board: esp32dev

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
