### PR TITLE
[select] Use const references to avoid unnecessary vector copies

### DIFF
--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -28,12 +28,12 @@ bool Select::has_option(const std::string &option) const { return this->index_of
 bool Select::has_index(size_t index) const { return index < this->size(); }
 
 size_t Select::size() const {
-  auto options = traits.get_options();
+  const auto &options = traits.get_options();
   return options.size();
 }
 
 optional<size_t> Select::index_of(const std::string &option) const {
-  auto options = traits.get_options();
+  const auto &options = traits.get_options();
   auto it = std::find(options.begin(), options.end(), option);
   if (it == options.end()) {
     return {};
@@ -51,7 +51,7 @@ optional<size_t> Select::active_index() const {
 
 optional<std::string> Select::at(size_t index) const {
   if (this->has_index(index)) {
-    auto options = traits.get_options();
+    const auto &options = traits.get_options();
     return options.at(index);
   } else {
     return {};

--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -45,7 +45,7 @@ void SelectCall::perform() {
   auto *parent = this->parent_;
   const auto *name = parent->get_name().c_str();
   const auto &traits = parent->traits;
-  auto options = traits.get_options();
+  const auto &options = traits.get_options();
 
   if (this->operation_ == SELECT_OP_NONE) {
     ESP_LOGW(TAG, "'%s' - SelectCall performed without selecting an operation", name);


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `select` component by using const references when accessing the options vector, avoiding unnecessary copies and reducing flash usage.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces flash usage by ~68 bytes on ESP32-IDF

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
select:
  - platform: template
    name: "Test Select"
    options:
      - "Option 1"
      - "Option 2"
      - "Option 3"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Details

Changed `auto options = traits.get_options()` to `const auto &options = traits.get_options()` in multiple places to avoid unnecessary vector copies. Since `get_options()` already returns a const reference, using `auto` was creating an unnecessary copy.

### Flash usage comparison (ESP32-IDF):
- Before: 1150002 bytes
- After: 1149934 bytes
- **Saved: 68 bytes**
