### PR TITLE
[uart] Add support for driver enable pin (RS485) on ESP-IDF

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -119,6 +119,13 @@ def validate_rx_pin(value):
     return value
 
 
+def validate_de_pin(value):
+    value = pins.internal_gpio_input_pin_schema(value)
+    if not CORE.using_esp_idf:
+        raise cv.Invalid("DE pin is only supported with ESP-IDF.")
+    return value
+
+
 def validate_invert_esp32(config):
     if (
         CORE.is_esp32
@@ -174,6 +181,7 @@ UART_PARITY_OPTIONS = {
 CONF_STOP_BITS = "stop_bits"
 CONF_DATA_BITS = "data_bits"
 CONF_PARITY = "parity"
+CONF_DE_PIN = "de_pin"
 
 UARTDirection = uart_ns.enum("UARTDirection")
 UART_DIRECTIONS = {
@@ -241,6 +249,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_BAUD_RATE): cv.int_range(min=1),
             cv.Optional(CONF_TX_PIN): pins.internal_gpio_output_pin_schema,
             cv.Optional(CONF_RX_PIN): validate_rx_pin,
+            cv.Optional(CONF_DE_PIN): validate_de_pin,
             cv.Optional(CONF_PORT): cv.All(validate_port, cv.only_on(PLATFORM_HOST)),
             cv.Optional(CONF_RX_BUFFER_SIZE, default=256): cv.validate_bytes,
             cv.Optional(CONF_STOP_BITS, default=1): cv.one_of(1, 2, int=True),
@@ -298,6 +307,9 @@ async def to_code(config):
     if CONF_RX_PIN in config:
         rx_pin = await cg.gpio_pin_expression(config[CONF_RX_PIN])
         cg.add(var.set_rx_pin(rx_pin))
+    if CONF_DE_PIN in config:
+        de_pin = await cg.gpio_pin_expression(config[CONF_DE_PIN])
+        cg.add(var.set_de_pin(de_pin))
     if CONF_PORT in config:
         cg.add(var.set_name(config[CONF_PORT]))
     cg.add(var.set_rx_buffer_size(config[CONF_RX_BUFFER_SIZE]))

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -100,6 +100,7 @@ void IDFUARTComponent::setup() {
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
+  int8_t rts = this->de_pin_ != nullptr ? this->de_pin_->get_pin() : UART_PIN_NO_CHANGE;
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted())
@@ -114,7 +115,7 @@ void IDFUARTComponent::setup() {
     return;
   }
 
-  err = uart_set_pin(this->uart_num_, tx, rx, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
+  err = uart_set_pin(this->uart_num_, tx, rx, rts, UART_PIN_NO_CHANGE);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_pin failed: %s", esp_err_to_name(err));
     this->mark_failed();
@@ -131,6 +132,15 @@ void IDFUARTComponent::setup() {
     ESP_LOGW(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
+  }
+
+  if (this->de_pin_ != nullptr) {
+    err = uart_set_mode(this->uart_num_, UART_MODE_RS485_HALF_DUPLEX);
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "uart_set_mode failed: %s", esp_err_to_name(err));
+      this->mark_failed();
+      return;
+    }
   }
 
   xSemaphoreGive(this->lock_);

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -23,6 +23,10 @@ class IDFUARTComponent : public UARTComponent, public Component {
   int available() override;
   void flush() override;
 
+  // Sets the DE (driver enable) pin for the UART bus.
+  // @param de_pin Pointer to the internal GPIO pin used for transmission.
+  void set_de_pin(InternalGPIOPin *de_pin) { this->de_pin_ = de_pin; }
+
   uint8_t get_hw_serial_number() { return this->uart_num_; }
   QueueHandle_t *get_uart_event_queue() { return &this->uart_event_queue_; }
 
@@ -50,6 +54,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
 
   bool has_peek_{false};
   uint8_t peek_byte_;
+  InternalGPIOPin *de_pin_;
 };
 
 }  // namespace uart

--- a/tests/components/uart/test.esp32-idf.yaml
+++ b/tests/components/uart/test.esp32-idf.yaml
@@ -8,6 +8,7 @@ uart:
   - id: uart_uart
     tx_pin: 17
     rx_pin: 16
+    de_pin: 4
     baud_rate: 9600
     data_bits: 8
     rx_buffer_size: 512


### PR DESCRIPTION
# What does this implement/fix?

Adds a `de_pin` to the `uart` component that triggers ESP-IDF's RS485 handling of DE (Driver Enable) pin, allowing easy use of half-duplex communication that requires an external enable, such as the common MAX485 chipset.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/421

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5363

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
external_components:
  - source: github://pr#10743
    components:
      - uart

uart:
  id: rs485
  tx_pin: GPIO17
  rx_pin: GPIO16
  de_pin: GPIO4
  parity: EVEN
  baud_rate: 57600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
