### PR TITLE
[esp32_improv] Disable loop by default until provisioning needed

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -31,6 +31,9 @@ void ESP32ImprovComponent::setup() {
 #endif
   global_ble_server->on(BLEServerEvt::EmptyEvt::ON_DISCONNECT,
                         [this](uint16_t conn_id) { this->set_error_(improv::ERROR_NONE); });
+
+  // Start with loop disabled - will be enabled by start() when needed
+  this->disable_loop();
 }
 
 void ESP32ImprovComponent::setup_characteristics() {


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the esp32_improv component to properly persist its disabled state across reboots. The component already calls `disable_loop()` after successful provisioning, but this doesn't persist after a restart - causing it to consume ~213ms per minute unnecessarily on already-provisioned devices.

The fix adds `disable_loop()` to the component's setup, ensuring it starts disabled by default. The WiFi component already explicitly calls `start()` when provisioning is needed (no WiFi configured or connection lost), which re-enables the loop. This appears to be the original intent of the design, as evidenced by:

1. The component already calls `disable_loop()` after provisioning completes
2. The WiFi component already has logic to call `start()` when needed
3. The `start()` method already calls `enable_loop()`

This change makes the disable state persist across reboots, eliminating unnecessary overhead for devices that boot with WiFi already configured.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered through runtime statistics analysis showing esp32_improv consuming resources on already-provisioned devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable - internal optimization only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
esp32_improv:
  authorizer: none
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing performed:

1. Tested device with WiFi credentials in YAML - esp32_improv does not run (0ms runtime)
2. Tested device without WiFi credentials - esp32_improv starts when needed via WiFi component calling `start()`
3. Verified provisioning still works correctly through BLE
4. Confirmed `disable_loop()` is called after successful provisioning
5. Verified the disabled state now persists across reboots (previously would re-enable on boot)
6. Factory reset device and confirmed esp32_improv properly starts and allows re-provisioning
7. Measured ~213ms/minute runtime savings on provisioned devices

## Why this is safe:

- The WiFi component already has complete logic to call `esp32_improv::start()` when needed (wifi_component.cpp lines 121 and 210)
- The component's `start()` method already calls `enable_loop()` to re-enable when provisioning is needed
- This change only makes the already-existing `disable_loop()` call persist across reboots
- No functionality is lost - provisioning still works exactly as before