### PR TITLE
[mqtt] Fix KeyError when MQTT logging configured without explicit level

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -212,7 +212,7 @@ def has_mqtt_logging() -> bool:
     if CONF_TOPIC not in log_topic:
         return False
 
-    return log_topic[CONF_LEVEL] != "NONE"
+    return log_topic.get(CONF_LEVEL, None) != "NONE"
 
 
 def has_mqtt() -> bool:

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1226,6 +1226,18 @@ def test_has_mqtt_logging_no_log_topic() -> None:
     setup_core(config={})
     assert has_mqtt_logging() is False
 
+    # Setup MQTT config with CONF_LOG_TOPIC but no CONF_LEVEL (regression test for #10771)
+    # This simulates the default configuration created by validate_config in the MQTT component
+    setup_core(
+        config={
+            CONF_MQTT: {
+                CONF_BROKER: "mqtt.local",
+                CONF_LOG_TOPIC: {CONF_TOPIC: "esphome/debug"},
+            }
+        }
+    )
+    assert has_mqtt_logging() is True
+
 
 def test_has_mqtt() -> None:
     """Test has_mqtt function."""


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a regression introduced in #10632 (commit d3592c451) where MQTT logging would fail with a `KeyError` when no explicit log level was set in the configuration.

The issue occurred because the code was changed from using the safe `.get()` method to direct dictionary access with `log_topic[CONF_LEVEL]`, but the MQTT component's default configuration doesn't include the `CONF_LEVEL` key when it auto-generates the log topic configuration. This caused the application to crash when trying to start logging via MQTT without an explicitly configured log level.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10771
- fixes #10775

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes required)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration previously caused a KeyError in 2025.9.0
mqtt:
  broker: mqtt.local
  username: myuser
  password: mypass
  # No explicit log_topic configuration - uses defaults

logger:
  # No explicit level configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A (this is a bug fix that restores previous behavior)

## Additional Notes

The fix restores the original safe access pattern using `.get(CONF_LEVEL, None)` instead of direct dictionary access. This handles the case where the MQTT component's `validate_config()` function creates a default `CONF_LOG_TOPIC` dictionary with only `CONF_TOPIC`, `CONF_QOS`, and `CONF_RETAIN` keys, but no `CONF_LEVEL` key.

A regression test has been added to `tests/unit_tests/test_main.py` to ensure this scenario is properly covered going forward.