### PR TITLE
[gpio] Fix unused function warnings when compiling with log level below DEBUG

### DIFF
--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
@@ -6,6 +6,7 @@ namespace gpio {
 
 static const char *const TAG = "gpio.binary_sensor";
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
 static const LogString *interrupt_type_to_string(gpio::InterruptType type) {
   switch (type) {
     case gpio::INTERRUPT_RISING_EDGE:
@@ -22,6 +23,7 @@ static const LogString *interrupt_type_to_string(gpio::InterruptType type) {
 static const LogString *gpio_mode_to_string(bool use_interrupt) {
   return use_interrupt ? LOG_STR("interrupt") : LOG_STR("polling");
 }
+#endif
 
 void IRAM_ATTR GPIOBinarySensorStore::gpio_intr(GPIOBinarySensorStore *arg) {
   bool new_state = arg->isr_pin_.digital_read();


### PR DESCRIPTION
# What does this implement/fix?

This fixes compiler warnings about unused static functions in the GPIO binary sensor component when compiling with log levels below DEBUG.

The functions `interrupt_type_to_string()` and `gpio_mode_to_string()` are only used in `dump_config()` which calls them within `ESP_LOGCONFIG` macros. When `ESPHOME_LOG_LEVEL < ESPHOME_LOG_LEVEL_DEBUG`, the `ESP_LOGCONFIG` macro expands to nothing, but the `dump_config()` function itself is still compiled. This means the helper functions are still defined but never actually called (since the macro that would call them expands to nothing), causing compiler warnings:

```
src/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp:22:25: warning: 'const esphome::LogString* esphome::gpio::gpio_mode_to_string(bool)' defined but not used [-Wunused-function]
src/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp:9:25: warning: 'const esphome::LogString esphome::gpio::interrupt_type_to_string(esphome::gpio::InterruptType)' defined but not used [-Wunused-function]
```

The fix wraps these helper functions in `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG` to match when `ESP_LOGCONFIG` is actually functional, following the same pattern used in other components like `rtttl`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes issue reported on Discord: https://ptb.discord.com/channels/429907082951524364/1417838916748185700/1417838919445385236

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no documentation changes needed

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a compiler warning fix
binary_sensor:
  - platform: gpio
    pin: GPIO0
    name: "GPIO Binary Sensor"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).