### PR TITLE
[ethernet] Remove redundant Arduino framework version check

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -117,19 +117,15 @@ ManualIP = ethernet_ns.struct("ManualIP")
 
 def _is_framework_spi_polling_mode_supported():
     # SPI Ethernet without IRQ feature is added in
-    # esp-idf >= (5.3+ ,5.2.1+, 5.1.4) and arduino-esp32 >= 3.0.0
+    # esp-idf >= (5.3+ ,5.2.1+, 5.1.4)
+    # Note: Arduino now uses ESP-IDF as a component, so we only check IDF version
     framework_version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
-    if CORE.using_esp_idf:
-        if framework_version >= cv.Version(5, 3, 0):
-            return True
-        if cv.Version(5, 3, 0) > framework_version >= cv.Version(5, 2, 1):
-            return True
-        if cv.Version(5, 2, 0) > framework_version >= cv.Version(5, 1, 4):  # noqa: SIM103
-            return True
-        return False
-    if CORE.using_arduino:
-        return framework_version >= cv.Version(3, 0, 0)
-    # fail safe: Unknown framework
+    if framework_version >= cv.Version(5, 3, 0):
+        return True
+    if cv.Version(5, 3, 0) > framework_version >= cv.Version(5, 2, 1):
+        return True
+    if cv.Version(5, 2, 0) > framework_version >= cv.Version(5, 1, 4):  # noqa: SIM103
+        return True
     return False
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR removes Arduino-specific framework version checks in the ethernet component that are no longer necessary since PR #10647 changed ESP32 Arduino builds to use Arduino as an ESP-IDF component.

Previously, the `_is_framework_spi_polling_mode_supported()` function had separate logic paths for Arduino and ESP-IDF frameworks to check version compatibility for SPI Ethernet polling mode. Since Arduino now runs as an IDF component, we only need to check the ESP-IDF version.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10647 (ESP32: Use arduino as an idf component)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal code cleanup, no documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Ethernet configuration works the same for both Arduino and ESP-IDF
ethernet:
  type: W5500
  clk_pin: GPIO19
  mosi_pin: GPIO23
  miso_pin: GPIO25
  cs_pin: GPIO26
  # SPI polling mode now available on Arduino builds with compatible IDF versions
  polling_interval: 10ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).