### PR TITLE
[ledc] Fix the max duty cycle so that all duty cycle levels are available.

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -105,8 +105,14 @@ void LEDCOutput::write_state(float state) {
   auto speed_mode = get_speed_mode(this->channel_);
   auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
-  ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
-  ledc_update_duty(speed_mode, chan_num);
+  if (duty == max_duty) {
+    ledc_stop(speed_mode, chan_num, 1);
+  } else if (duty == 0) {
+    ledc_stop(speed_mode, chan_num, 0);
+  } else {
+    ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
+    ledc_update_duty(speed_mode, chan_num);
+  }
 }
 
 void LEDCOutput::setup() {

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -98,21 +98,15 @@ void LEDCOutput::write_state(float state) {
     state = 1.0f - state;
 
   this->duty_ = state;
-  const uint32_t max_duty = (uint32_t(1) << this->bit_depth_) - 1;
+  const uint32_t max_duty = uint32_t(1) << this->bit_depth_;
   const float duty_rounded = roundf(state * max_duty);
   auto duty = static_cast<uint32_t>(duty_rounded);
   ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
   auto speed_mode = get_speed_mode(this->channel_);
   auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
-  if (duty == max_duty) {
-    ledc_stop(speed_mode, chan_num, 1);
-  } else if (duty == 0) {
-    ledc_stop(speed_mode, chan_num, 0);
-  } else {
-    ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
-    ledc_update_duty(speed_mode, chan_num);
-  }
+  ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
+  ledc_update_duty(speed_mode, chan_num);
 }
 
 void LEDCOutput::setup() {


### PR DESCRIPTION
Hi All, I'm pretty new to ESPHome. Apologies in advance for any mistakes in the below, Comments, corrections, etc... welcome!

# What does this implement/fix?

Fix LEDC duty cycle calculation. The correct range is `[0, 2 ** duty_bits]` but the code implicitly assumes it is actually `[0, 2 ** duty_bits - 1]`. There's code further below to manually disable PWM if the selected duty cycle is equal to `max_duty` but that just shifts the problem back one step because now `2 ** duty_bits - 1` isn't usable! Instead of hacks, it's better to just fix the problem at its source.

I've also removed the code to disable PWM. With this fix, all duty cycle levels are available so there's no need for it anymore.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

I wasn't sure how to test this change. Any advice welcome! Thanks!

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
