### PR TITLE
Add Doxygen GENERATE_TAGFILE to create lookup for classes and files

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2485,7 +2485,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = api-docs/tags.xml
 
 # If the ALLEXTERNALS tag is set to YES, all external classes and namespaces
 # will be listed in the class and namespace index. If set to NO, only the


### PR DESCRIPTION
# What does this implement/fix?

This adds `GENERATE_TAGFILE` which creates an XML file with entries like
```xml
  <compound kind="file">
    <name>sensor.h</name>
    <path>esphome/components/sensor/</path>
    <filename>sensor_8h.html</filename>
    <class kind="class">esphome::sensor::Sensor</class>
    <class kind="struct">esphome::sensor::Sensor::SensorFlags</class>
    <namespace>esphome</namespace>
    <namespace>esphome::sensor</namespace>
  </compound>
```
and
```xml
  <compound kind="class">
    <name>esphome::sensor::Sensor</name>
    <filename>classesphome_1_1sensor_1_1_sensor.html</filename>
    <base>esphome::EntityBase</base>
    <base>esphome::EntityBase_DeviceClass</base>
    <base>esphome::EntityBase_UnitOfMeasurement</base>
    <class kind="struct">esphome::sensor::Sensor::SensorFlags</class>
    <member kind="function">
      <type></type>
      <name>Sensor</name>
      <anchorfile>classesphome_1_1sensor_1_1_sensor.html</anchorfile>
      <anchor>a69ac0d61f73625d69ecb571878d6fc1d</anchor>
      <arglist>()</arglist>
    </member>
    <!-- ... -->
  </compound>
```
for looking up symbols like `esphome::sensor::Sensor` or file paths like `esphome/components/sensor/sensor.h` to find their corresponding Doxygen url (e.g. `classesphome_1_1sensor_1_1_sensor.html` or `sensor_8h.html`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other