### PR TITLE
[htu21d] Fix I2C NACK issue and buffer overrun

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -107,7 +107,7 @@ bool HTU21DComponent::is_heater_enabled() {
     this->status_set_warning();
     return false;
   }
-  return (bool) (((raw_heater) >> (HTU21D_REG_HTRE_BIT)) & 0x01);
+  return (bool) ((raw_heater >> HTU21D_REG_HTRE_BIT) & 0x01);
 }
 
 void HTU21DComponent::set_heater(bool status) {
@@ -117,9 +117,9 @@ void HTU21DComponent::set_heater(bool status) {
     return;
   }
   if (status) {
-    raw_heater |= (1 << (HTU21D_REG_HTRE_BIT));
+    raw_heater |= (1 << HTU21D_REG_HTRE_BIT);
   } else {
-    raw_heater &= ~(1 << (HTU21D_REG_HTRE_BIT));
+    raw_heater &= ~(1 << HTU21D_REG_HTRE_BIT);
   }
   if (this->write_register(HTU21D_WRITERHT_REG_CMD, &raw_heater, 1) != i2c::ERROR_OK) {
     this->status_set_warning();

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -79,10 +79,9 @@ void HTU21DComponent::update() {
       if (this->humidity_ != nullptr)
         this->humidity_->publish_state(humidity);
 
-      int8_t heater_level;
-
       // HTU21D does have a heater module but does not have heater level
       // Setting heater level to 1 in case the heater is ON
+      uint8_t heater_level = 0;
       if (this->sensor_model_ == HTU21D_SENSOR_MODEL_HTU21D) {
         if (this->is_heater_enabled()) {
           heater_level = 1;
@@ -104,27 +103,24 @@ void HTU21DComponent::update() {
 
 bool HTU21DComponent::is_heater_enabled() {
   uint8_t raw_heater;
-  if (this->read_register(HTU21D_REGISTER_STATUS, reinterpret_cast<uint8_t *>(&raw_heater), 2) != i2c::ERROR_OK) {
+  if (this->read_register(HTU21D_REGISTER_STATUS, &raw_heater, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return false;
   }
-  raw_heater = i2c::i2ctohs(raw_heater);
   return (bool) (((raw_heater) >> (HTU21D_REG_HTRE_BIT)) & 0x01);
 }
 
 void HTU21DComponent::set_heater(bool status) {
   uint8_t raw_heater;
-  if (this->read_register(HTU21D_REGISTER_STATUS, reinterpret_cast<uint8_t *>(&raw_heater), 2) != i2c::ERROR_OK) {
+  if (this->read_register(HTU21D_REGISTER_STATUS, &raw_heater, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }
-  raw_heater = i2c::i2ctohs(raw_heater);
   if (status) {
     raw_heater |= (1 << (HTU21D_REG_HTRE_BIT));
   } else {
     raw_heater &= ~(1 << (HTU21D_REG_HTRE_BIT));
   }
-
   if (this->write_register(HTU21D_WRITERHT_REG_CMD, &raw_heater, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return;
@@ -138,14 +134,13 @@ void HTU21DComponent::set_heater_level(uint8_t level) {
   }
 }
 
-int8_t HTU21DComponent::get_heater_level() {
-  int8_t raw_heater;
-  if (this->read_register(HTU21D_READHEATER_REG_CMD, reinterpret_cast<uint8_t *>(&raw_heater), 2) != i2c::ERROR_OK) {
+uint8_t HTU21DComponent::get_heater_level() {
+  uint8_t raw_heater;
+  if (this->read_register(HTU21D_READHEATER_REG_CMD, &raw_heater, 1) != i2c::ERROR_OK) {
     this->status_set_warning();
     return 0;
   }
-  raw_heater = i2c::i2ctohs(raw_heater);
-  return raw_heater;
+  return raw_heater & 0xF;
 }
 
 float HTU21DComponent::get_setup_priority() const { return setup_priority::DATA; }

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -57,7 +57,6 @@ void HTU21DComponent::update() {
 
     if (this->temperature_ != nullptr)
       this->temperature_->publish_state(temperature);
-    this->status_clear_warning();
 
     if (this->write(&HTU21D_REGISTER_HUMIDITY, 1) != i2c::ERROR_OK) {
       this->status_set_warning();
@@ -79,6 +78,8 @@ void HTU21DComponent::update() {
       if (this->humidity_ != nullptr)
         this->humidity_->publish_state(humidity);
 
+      this->status_clear_warning();
+
       // HTU21D does have a heater module but does not have heater level
       // Setting heater level to 1 in case the heater is ON
       uint8_t heater_level = 0;
@@ -96,7 +97,6 @@ void HTU21DComponent::update() {
 
       if (this->heater_ != nullptr)
         this->heater_->publish_state(heater_level);
-      this->status_clear_warning();
     });
   });
 }

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -9,8 +9,8 @@ static const char *const TAG = "htu21d";
 
 static const uint8_t HTU21D_ADDRESS = 0x40;
 static const uint8_t HTU21D_REGISTER_RESET = 0xFE;
-static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xF3;
-static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xF5;
+static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xE3;
+static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xE5;
 static const uint8_t HTU21D_WRITERHT_REG_CMD = 0xE6; /**< Write RH/T User Register 1 */
 static const uint8_t HTU21D_REGISTER_STATUS = 0xE7;
 static const uint8_t HTU21D_WRITEHEATER_REG_CMD = 0x51; /**< Write Heater Control Register */

--- a/esphome/components/htu21d/htu21d.h
+++ b/esphome/components/htu21d/htu21d.h
@@ -26,7 +26,7 @@ class HTU21DComponent : public PollingComponent, public i2c::I2CDevice {
   bool is_heater_enabled();
   void set_heater(bool status);
   void set_heater_level(uint8_t level);
-  int8_t get_heater_level();
+  uint8_t get_heater_level();
 
   float get_setup_priority() const override;
 


### PR DESCRIPTION
# What does this implement/fix?

Fix issues:
- Use hold mode instead so I2C doesnt get a NACK while a measurement is in progress (different register addresses)
- Fix buffer overruns, was reading two bytes into a single byte

https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10738

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
