### PR TITLE
[substitutions] Recursive substitutions and better jinja error handling and debug help

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -6,7 +6,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_SUBSTITUTIONS, VALID_SUBSTITUTIONS_CHARACTERS
 from esphome.yaml_util import ESPHomeDataBase, ESPLiteralValue, make_data_base
 
-from .jinja import Jinja, JinjaStr, TemplateError, TemplateRuntimeError, has_jinja
+from .jinja import Jinja, JinjaError, JinjaStr, has_jinja
 
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
@@ -57,17 +57,12 @@ def _expand_jinja(value, orig_value, path, jinja, ignore_missing):
                     "->".join(str(x) for x in path),
                     err.message,
                 )
-        except (
-            TemplateError,
-            TemplateRuntimeError,
-            RuntimeError,
-            ArithmeticError,
-            AttributeError,
-            TypeError,
-        ) as err:
+        except JinjaError as err:
             raise cv.Invalid(
-                f"{type(err).__name__} Error evaluating jinja expression '{value}': {str(err)}."
-                f" See {'->'.join(str(x) for x in path)}",
+                f"{err.error_name()} Error evaluating jinja expression '{value}': {str(err.parent())}."
+                f"\nEvaluation stack: (most recent evaluation last)\n{err.stack_trace_str()}"
+                f"\nRelevant context:\n{err.context_trace_str()}"
+                f"\nSee {'->'.join(str(x) for x in path)}",
                 path,
             )
     return value

--- a/tests/unit_tests/fixtures/substitutions/02-expressions.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/02-expressions.approved.yaml
@@ -8,6 +8,7 @@ substitutions:
   area: 25
   numberOne: 1
   var1: 79
+  double_width: 14
 test_list:
   - The area is 56
   - 56
@@ -25,3 +26,4 @@ test_list:
   - ord("a") = 97
   - chr(97) = a
   - len([1,2,3]) = 3
+  - width = 7, double_width = 14

--- a/tests/unit_tests/fixtures/substitutions/02-expressions.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/02-expressions.input.yaml
@@ -8,6 +8,7 @@ substitutions:
   area: 25
   numberOne: 1
   var1: 79
+  double_width: ${width * 2}
 
 test_list:
   - "The area is ${width * height}"
@@ -23,3 +24,4 @@ test_list:
   - ord("a") = ${ ord("a") }
   - chr(97) = ${ chr(97) }
   - len([1,2,3]) = ${ len([1,2,3]) }
+  - width = ${width}, double_width = ${double_width}


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a jinja evaluation tracer to support the user when a jinja expression throws an error. It shows a useful trace of evaluations and the variables involved in that evaluation

Additionally, this PR introduces recursive substitutions and using jinja expressions as part of `!include` variables.

Considered like a bugfix because intuitively one would expect this to work this way.

See examples below.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

(platform independent, python-only change)

## Example entry for `config.yaml`:

### Error tracing example:
```yaml
substitutions:
  name: "My Name"
  a: 3

esphome:
  name: "test"
  friendly_name: ${ name + a }

host:
```
Example error printed:
```
Failed config

TypeError Error evaluating jinja expression '${ name + a }': can only concatenate str (not "EInt") to str.
Evaluation stack: (most recent evaluation last)
 1: ${ name + a } <-- TypeError
Relevant context:
  name = 'My Name' (EStr)
  a = 3 (EInt)
See esphome->friendly_name
```

### Recursive substitutions example:
```yaml
substitutions:
  pin_map: 
    A: { "number": 1, "inverted": false}
    B: { "number": 12, "inverted": true}
    C: { "number": 9, "inverted": true}
  pin: ${ pin_map[selected_pin] }

  selected_pin: B

esphome:
  name: "test"

binary_sensor:
  - platform: gpio
    id: test
    pin:
      number: ${ pin.number }
      inverted: ${ pin.inverted }

host:
```

### Jinja in `!include` vars

```yaml
substitutions:
  sensors: 
    WINDOW: { "name": "Window", "location": "Top Left"}
    GARAGE: { "name": "Garage Door", "location": "Bottom Right"}
    GATE: { "name": "Gate", location: "Top Right"}

packages:
  mysensor: !include
    file: mysensor.yaml
    vars:
      name: ${ sensors.WINDOW.name } is open
      location: ${ sensors.WINDOW.location }
      
esphome:
  name: "test"

host:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
