### PR TITLE
Fix esphome run

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -453,7 +453,7 @@ def upload_using_esptool(
             "detect",
         ]
         for img in flash_images:
-            cmd += [img.offset, img.path]
+            cmd += [img.offset, str(img.path)]
 
         if os.environ.get("ESPHOME_USE_SUBPROCESS") is None:
             import esptool


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Looks like https://github.com/esphome/esphome/pull/10654 accidentally started passing a `Path` to esptool, which expects `str`.

```
ERROR Running command failed: 'PosixPath' object has no attribute 'startswith'
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/esphome/esphome/util.py", line 207, in run_external_command
    retval = func() or 0
             ~~~~^^
  File "/Users/paulus/dev/hass/esphome/.venv/lib/python3.13/site-packages/esptool/__init__.py", line 1030, in main
    args = expand_file_arguments(argv or sys.argv[1:])
  File "/Users/paulus/dev/hass/esphome/.venv/lib/python3.13/site-packages/esptool/__init__.py", line 1079, in expand_file_arguments
    if arg.startswith("@"):
       ^^^^^^^^^^^^^^
AttributeError: 'PosixPath' object has no attribute 'startswith'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
