### PR TITLE
[zephyr] Fix compilation after Path migration

### DIFF
--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from typing import TypedDict
 
 import esphome.codegen as cg
@@ -48,7 +48,7 @@ class ZephyrData(TypedDict):
     bootloader: str
     prj_conf: dict[str, tuple[PrjConfValueType, bool]]
     overlay: str
-    extra_build_files: dict[str, str]
+    extra_build_files: dict[str, Path]
     pm_static: list[Section]
     user: dict[str, list[str]]
 
@@ -93,7 +93,7 @@ def zephyr_add_overlay(content):
     zephyr_data()[KEY_OVERLAY] += content
 
 
-def add_extra_build_file(filename: str, path: str) -> bool:
+def add_extra_build_file(filename: str, path: Path) -> bool:
     """Add an extra build file to the project."""
     extra_build_files = zephyr_data()[KEY_EXTRA_BUILD_FILES]
     if filename not in extra_build_files:
@@ -102,7 +102,7 @@ def add_extra_build_file(filename: str, path: str) -> bool:
     return False
 
 
-def add_extra_script(stage: str, filename: str, path: str):
+def add_extra_script(stage: str, filename: str, path: Path) -> None:
     """Add an extra script to the project."""
     key = f"{stage}:{filename}"
     if add_extra_build_file(filename, path):
@@ -144,7 +144,7 @@ def zephyr_to_code(config):
     add_extra_script(
         "pre",
         "pre_build.py",
-        os.path.join(os.path.dirname(__file__), "pre_build.py.script"),
+        Path(__file__).parent / "pre_build.py.script",
     )
 
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the Zephyr/nRF52 platform compilation that was broken after #10654 migrated `os.path` to `Path` objects. The `zephyr` component's `__init__.py` was not updated to use `Path` objects, causing build failures with missing SConscript file errors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes build failure introduced in #10654

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal fix only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed
# This fixes existing nRF52/Zephyr configurations
esphome:
  name: test-nrf52

nrf52:
  board: adafruit_itsybitsy_nrf52840
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - internal fix only