### PR TITLE
[http_request] Fix Path object passed to C++ codegen

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -194,7 +194,7 @@ async def to_code(config):
             cg.add_define("CPPHTTPLIB_OPENSSL_SUPPORT")
         elif path := config.get(CONF_CA_CERTIFICATE_PATH):
             cg.add_define("CPPHTTPLIB_OPENSSL_SUPPORT")
-            cg.add(var.set_ca_path(path))
+            cg.add(var.set_ca_path(str(path)))
             cg.add_build_flag("-lssl")
             cg.add_build_flag("-lcrypto")
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the `http_request` component compilation on the host platform that was broken after #10654 migrated `os.path` to `Path` objects. The component was passing a `Path` object directly to C++ code generation, which expects a string, causing a `ValueError: ('Object is not an expression', PosixPath('/etc/passwd'))`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes build failure introduced in #10654

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal fix only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example configuration that was failing
http_request:
  enable_ssl: true
  ca_certificate_path: /path/to/ca_certificate.pem
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - internal fix only