### PR TITLE
[time] Prevent Home Assistant from overriding manually configured timezones

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1078,7 +1078,9 @@ void APIConnection::on_get_time_response(const GetTimeResponse &value) {
   if (homeassistant::global_homeassistant_time != nullptr) {
     homeassistant::global_homeassistant_time->set_epoch_time(value.epoch_seconds);
 #ifdef USE_TIME_TIMEZONE
-    if (!value.timezone.empty() && value.timezone != homeassistant::global_homeassistant_time->get_timezone()) {
+    // Only update timezone if it wasn't manually configured and differs from current
+    if (!value.timezone.empty() && !homeassistant::global_homeassistant_time->is_timezone_manually_configured() &&
+        value.timezone != homeassistant::global_homeassistant_time->get_timezone()) {
       homeassistant::global_homeassistant_time->set_timezone(value.timezone);
     }
 #endif

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -269,16 +269,7 @@ def validate_tz(value: str) -> str:
 
 TIME_SCHEMA = cv.Schema(
     {
-        cv.SplitDefault(
-            CONF_TIMEZONE,
-            esp8266=detect_tz,
-            esp32=detect_tz,
-            rp2040=detect_tz,
-            bk72xx=detect_tz,
-            rtl87xx=detect_tz,
-            ln882x=detect_tz,
-            host=detect_tz,
-        ): cv.All(
+        cv.Optional(CONF_TIMEZONE): cv.All(
             cv.only_with_framework(["arduino", "esp-idf", "host"]),
             validate_tz,
         ),
@@ -306,9 +297,23 @@ TIME_SCHEMA = cv.Schema(
 
 
 async def setup_time_core_(time_var, config):
-    if timezone := config.get(CONF_TIMEZONE):
-        cg.add(time_var.set_timezone(timezone))
+    if CONF_TIMEZONE in config:
+        # Timezone was explicitly set in config - mark as manual
+        timezone = config[CONF_TIMEZONE]
+        cg.add(time_var.set_timezone_manual(timezone))
         cg.add_define("USE_TIME_TIMEZONE")
+    else:
+        # Auto-detect timezone if not explicitly set
+        try:
+            timezone = detect_tz()
+        except cv.Invalid:
+            # Could not auto-detect, silently continue without timezone
+            pass
+        else:
+            cg.add(
+                time_var.set_timezone(timezone)
+            )  # Use regular set_timezone for auto-detected
+            cg.add_define("USE_TIME_TIMEZONE")
 
     for conf in config.get(CONF_ON_TIME, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], time_var)

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -24,11 +24,22 @@ class RealTimeClock : public PollingComponent {
   /// Set the time zone.
   void set_timezone(const std::string &tz) {
     this->timezone_ = tz;
+    this->timezone_manually_configured_ = false;
+    this->apply_timezone_();
+  }
+
+  /// Set the timezone and mark it as manually configured
+  void set_timezone_manual(const std::string &tz) {
+    this->timezone_ = tz;
+    this->timezone_manually_configured_ = true;
     this->apply_timezone_();
   }
 
   /// Get the time zone currently in use.
   std::string get_timezone() { return this->timezone_; }
+
+  /// Check if the timezone was manually configured
+  bool is_timezone_manually_configured() const { return this->timezone_manually_configured_; }
 #endif
 
   /// Get the time in the currently defined timezone.
@@ -50,6 +61,7 @@ class RealTimeClock : public PollingComponent {
 
 #ifdef USE_TIME_TIMEZONE
   std::string timezone_{};
+  bool timezone_manually_configured_{false};  /// Track if timezone was manually configured
   void apply_timezone_();
 #endif
 


### PR DESCRIPTION
## ❌ PR CLOSED - Wrong Approach

**This PR was closed because the approach is fundamentally incorrect.** When users choose the `homeassistant` time platform, they are explicitly indicating that Home Assistant should be the source of truth for all time settings, including timezone. Having this platform ignore Home Assistant's timezone would be counterintuitive and defeat its purpose.

The actual issue is that Home Assistant is sending UTC instead of the configured timezone. This could be due to:
- A bug in Home Assistant not properly getting or setting its system timezone
- A bug in aioesphomeapi's handling of timezone data
- A misconfiguration of the Home Assistant container where the timezone isn't properly passed through from the host

Users who need a fixed timezone should use the `sntp` or other time platforms instead of `homeassistant`.

**⚠️ WARNING: I am currently traveling and cannot test this change at the moment. I will undraft when I'm in a position to test. ⚠️**

# What does this implement/fix?

This PR fixes an issue where manually configured timezones in ESPHome YAML configurations were being overridden by Home Assistant's timezone when using the `homeassistant` time platform. After updating to ESPHome 2025.9.0+, users reported their devices' timezones unexpectedly changing to UTC, causing scheduling issues.

The fix introduces tracking of whether a timezone was manually configured (explicitly set in YAML) versus auto-detected. When a timezone is manually configured, it will not be overridden by Home Assistant's timezone updates.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10817

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (No documentation changes needed - this restores previous expected behavior)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example 1: Manually configured timezone (will NOT be overridden by Home Assistant)
time:
  - platform: homeassistant
    id: ha_time_manual
    timezone: "MST7MDT,M3.2.0,M11.1.0"

# Example 2: Auto-detected timezone (will be overridden by Home Assistant if different)
time:
  - platform: homeassistant
    id: ha_time_auto
    # No timezone specified - will auto-detect and can be overridden by HA
```

The implementation:

1. **C++ Changes** (`esphome/components/time/real_time_clock.h`):
   - Added `timezone_manually_configured_` flag to track configuration source
   - Added `set_timezone_manual()` method for manually configured timezones
   - Modified `set_timezone()` to mark timezone as auto-detected
   - Added `is_timezone_manually_configured()` getter method

2. **Python Changes** (`esphome/components/time/__init__.py`):
   - Made timezone configuration optional (removed auto-detect default)
   - Modified `setup_time_core_()` to:
     - Call `set_timezone_manual()` when timezone is explicitly in config
     - Auto-detect and call `set_timezone()` when not specified
     - Handle auto-detection failures gracefully

3. **API Changes** (`esphome/components/api/api_connection.cpp`):
   - Modified `on_get_time_response()` to check `is_timezone_manually_configured()`
   - Only updates timezone from Home Assistant if it was auto-detected

This ensures backward compatibility while fixing the reported issue where users' manually configured timezones were being unexpectedly overridden.

## Checklist:
  - [ ] The code change is tested and works locally. (**⚠️ Cannot test while traveling**)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).