### PR TITLE
[substitutions] fix #10825 set evaluation error

### DIFF
--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.approved.yaml
@@ -5,6 +5,9 @@ substitutions:
   var21: '79'
   value: 33
   values: 44
+  position:
+    x: 79
+    y: 82
 
 esphome:
   name: test
@@ -26,3 +29,7 @@ test_list:
   - Literal $values ${are not substituted}
   - ["list $value", "${is not}", "${substituted}"]
   - {"$dictionary": "$value", "${is not}": "${substituted}"}
+  - |-
+    {{{ "x", "79"}, { "y", "82"}}}
+  - '{{{"AA"}}}'
+  - '"HELLO"'

--- a/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/00-simple_var.input.yaml
@@ -8,6 +8,9 @@ substitutions:
   var21: "79"
   value: 33
   values: 44
+  position:
+    x: 79
+    y: 82
 
 test_list:
   - "$var1"
@@ -27,3 +30,7 @@ test_list:
   - !literal Literal $values ${are not substituted}
   - !literal ["list $value", "${is not}", "${substituted}"]
   - !literal {"$dictionary": "$value", "${is not}": "${substituted}"}
+  - |- # Test parsing things that look like a python set of sets when rendered:
+    {{{ "x", "${ position.x }"}, { "y", "${ position.y }"}}}
+  - ${ '{{{"AA"}}}' }
+  - ${ '"HELLO"' }


### PR DESCRIPTION
# What does this implement/fix?

Jinja in `NativeEnvironment` mode attempts to convert the actual string output to a native Python type in the last step of a render. In the linked issue, the user is attempting to generate a C++ literal 2D `char*` array. Because the intended output looks like a Python _set of sets_ literal, Jinja attempts a conversion and fails because a `set` is itself not hashable, and items of a set must be hashable.

To reproduce:

```bash
python -c 'a= {{ "  XXX  " }} '

"TypeError: unhashable type: 'set'"

```

To work around this issue, we implement a similar solution as in HomeAssistant PR[#41227](https://github.com/home-assistant/core/pull/41227/files#top) whereupon a `SandboxedEnvironment` is used and a controlled attempt to convert to a native type is done in the last step. In case it fails, a string is returned.

Tests have been added to cover this case and similar ones.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10825

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] python-only change

## Example entry for `config.yaml`:


```yaml
esphome:
  name: bug
  friendly_name: ${ '{{{"AA"}}}' }

host:
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
