### PR TITLE
Pin ruamel.yaml.clib to 0.2.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ aioesphomeapi==41.4.0
 zeroconf==0.147.2
 puremagic==1.30
 ruamel.yaml==0.18.15 # dashboard_import
+ruamel.yaml.clib==0.2.12 # dashboard_import
 esphome-glyphsets==0.2.0
 pillow==10.4.0
 cairosvg==2.8.2


### PR DESCRIPTION
# What does this implement/fix?

This fixes the docker builds

We were missing a pin for ruamel.yaml.clib

0.2.14 and 0.2.13 were released today without aarch64 wheels https://pypi.org/project/ruamel.yaml.clib/#history

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
