### PR TITLE
[libretiny] Fix lib_ignore handling and ignore incompatible libraries

### DIFF
--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -128,4 +128,4 @@ async def to_code(config):
 
     cg.add_library("tonia/HeatpumpIR", "1.0.37")
     if CORE.is_libretiny or CORE.is_esp32:
-        CORE.add_platformio_option("lib_ignore", "IRremoteESP8266")
+        CORE.add_platformio_option("lib_ignore", ["IRremoteESP8266"])

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -40,5 +40,7 @@ async def to_code(config):
             cg.add_library("Update", None)
         if CORE.is_esp8266:
             cg.add_library("ESP8266WiFi", None)
+        if CORE.is_libretiny:
+            CORE.add_platformio_option("lib_ignore", ["ESPAsyncTCP", "RPAsyncTCP"])
         # https://github.com/ESP32Async/ESPAsyncWebServer/blob/main/library.json
         cg.add_library("ESP32Async/ESPAsyncWebServer", "3.7.10")

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -396,7 +396,7 @@ async def add_includes(includes: list[str]) -> None:
 async def _add_platformio_options(pio_options):
     # Add includes at the very end, so that they override everything
     for key, val in pio_options.items():
-        if key == "build_flags" and not isinstance(val, list):
+        if key in ["build_flags", "lib_ignore"] and not isinstance(val, list):
             val = [val]
         cg.add_platformio_option(key, val)
 


### PR DESCRIPTION
# What does this implement/fix?

Fix lib_ignore handling, needs to be a list and ignore incompatible libraries on libretiny

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/9566
- related https://github.com/esphome/esphome/pull/9648

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
