### PR TITLE
[zwave_proxy] Fix race condition sending zero home ID on reboot

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -1,4 +1,5 @@
 #include "zwave_proxy.h"
+#include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
@@ -12,6 +13,7 @@ static constexpr uint8_t ZWAVE_COMMAND_GET_NETWORK_IDS = 0x20;
 // GET_NETWORK_IDS response: [SOF][LENGTH][TYPE][CMD][HOME_ID(4)][NODE_ID][...]
 static constexpr uint8_t ZWAVE_COMMAND_TYPE_RESPONSE = 0x01;    // Response type field value
 static constexpr uint8_t ZWAVE_MIN_GET_NETWORK_IDS_LENGTH = 9;  // TYPE + CMD + HOME_ID(4) + NODE_ID + checksum
+static constexpr uint32_t HOME_ID_TIMEOUT_MS = 100;             // Timeout for waiting for home ID during setup
 
 static uint8_t calculate_frame_checksum(const uint8_t *data, uint8_t length) {
   // Calculate Z-Wave frame checksum
@@ -26,7 +28,44 @@ static uint8_t calculate_frame_checksum(const uint8_t *data, uint8_t length) {
 
 ZWaveProxy::ZWaveProxy() { global_zwave_proxy = this; }
 
-void ZWaveProxy::setup() { this->send_simple_command_(ZWAVE_COMMAND_GET_NETWORK_IDS); }
+void ZWaveProxy::setup() {
+  this->setup_time_ = App.get_loop_component_start_time();
+  this->send_simple_command_(ZWAVE_COMMAND_GET_NETWORK_IDS);
+}
+
+float ZWaveProxy::get_setup_priority() const {
+  // Set up before API so home ID is ready when API starts
+  return setup_priority::BEFORE_CONNECTION;
+}
+
+bool ZWaveProxy::can_proceed() {
+  // If we already have the home ID, we can proceed
+  if (this->home_id_ready_) {
+    return true;
+  }
+
+  // Handle any pending responses
+  if (this->response_handler_()) {
+    ESP_LOGV(TAG, "Handled response during setup");
+  }
+
+  // Process UART data to check for home ID
+  this->process_uart_();
+
+  // Check if we got the home ID after processing
+  if (this->home_id_ready_) {
+    return true;
+  }
+
+  // Wait up to HOME_ID_TIMEOUT_MS for home ID response
+  const uint32_t now = App.get_loop_component_start_time();
+  if (now - this->setup_time_ > HOME_ID_TIMEOUT_MS) {
+    ESP_LOGW(TAG, "Timeout waiting for Z-Wave home ID during setup");
+    return true;  // Proceed anyway after timeout
+  }
+
+  return false;  // Keep waiting
+}
 
 void ZWaveProxy::loop() {
   if (this->response_handler_()) {
@@ -37,6 +76,11 @@ void ZWaveProxy::loop() {
     this->api_connection_ = nullptr;  // Unsubscribe if disconnected
   }
 
+  this->process_uart_();
+  this->status_clear_warning();
+}
+
+void ZWaveProxy::process_uart_() {
   while (this->available()) {
     uint8_t byte;
     if (!this->read_byte(&byte)) {
@@ -56,6 +100,7 @@ void ZWaveProxy::loop() {
         // Extract the 4-byte Home ID starting at offset 4
         // The frame parser has already validated the checksum and ensured all bytes are present
         std::memcpy(this->home_id_.data(), this->buffer_.data() + 4, this->home_id_.size());
+        this->home_id_ready_ = true;
         ESP_LOGI(TAG, "Home ID: %s",
                  format_hex_pretty(this->home_id_.data(), this->home_id_.size(), ':', false).c_str());
       }
@@ -73,7 +118,6 @@ void ZWaveProxy::loop() {
       }
     }
   }
-  this->status_clear_warning();
 }
 
 void ZWaveProxy::dump_config() { ESP_LOGCONFIG(TAG, "Z-Wave Proxy"); }

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -60,7 +60,7 @@ bool ZWaveProxy::can_proceed() {
   // Wait up to HOME_ID_TIMEOUT_MS for home ID response
   const uint32_t now = App.get_loop_component_start_time();
   if (now - this->setup_time_ > HOME_ID_TIMEOUT_MS) {
-    ESP_LOGW(TAG, "Timeout waiting for Z-Wave home ID during setup");
+    ESP_LOGW(TAG, "Timeout reading Home ID during setup");
     return true;  // Proceed anyway after timeout
   }
 

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -44,6 +44,8 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
+  float get_setup_priority() const override;
+  bool can_proceed() override;
 
   void zwave_proxy_request(api::APIConnection *api_connection, api::enums::ZWaveProxyRequestType type);
   api::APIConnection *get_api_connection() { return this->api_connection_; }
@@ -60,19 +62,24 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   bool parse_byte_(uint8_t byte);  // Returns true if frame parsing was completed (a frame is ready in the buffer)
   void parse_start_(uint8_t byte);
   bool response_handler_();
-
-  api::APIConnection *api_connection_{nullptr};  // Current subscribed client
-
-  std::array<uint8_t, 4> home_id_{0, 0, 0, 0};                      // Fixed buffer for home ID
-  std::array<uint8_t, sizeof(api::ZWaveProxyFrame::data)> buffer_;  // Fixed buffer for incoming data
-  uint8_t buffer_index_{0};                                         // Index for populating the data buffer
-  uint8_t end_frame_after_{0};                                      // Payload reception ends after this index
-  uint8_t last_response_{0};                                        // Last response type sent
-  ZWaveParsingState parsing_state_{ZWAVE_PARSING_STATE_WAIT_START};
-  bool in_bootloader_{false};  // True if the device is detected to be in bootloader mode
+  void process_uart_();  // Process all available UART data
 
   // Pre-allocated message - always ready to send
   api::ZWaveProxyFrame outgoing_proto_msg_;
+  std::array<uint8_t, sizeof(api::ZWaveProxyFrame::data)> buffer_;  // Fixed buffer for incoming data
+  std::array<uint8_t, 4> home_id_{0, 0, 0, 0};                      // Fixed buffer for home ID
+
+  // Pointers and 32-bit values (aligned together)
+  api::APIConnection *api_connection_{nullptr};  // Current subscribed client
+  uint32_t setup_time_{0};                       // Time when setup() was called
+
+  // 8-bit values (grouped together to minimize padding)
+  uint8_t buffer_index_{0};     // Index for populating the data buffer
+  uint8_t end_frame_after_{0};  // Payload reception ends after this index
+  uint8_t last_response_{0};    // Last response type sent
+  ZWaveParsingState parsing_state_{ZWAVE_PARSING_STATE_WAIT_START};
+  bool in_bootloader_{false};  // True if the device is detected to be in bootloader mode
+  bool home_id_ready_{false};  // True when home ID has been received from Z-Wave module
 };
 
 extern ZWaveProxy *global_zwave_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a race condition in the Z-Wave proxy component where the API server could respond with a zero home ID during device reboots. The issue occurred because the API server would start and respond to `DeviceInfoRequest` messages before the Z-Wave module had time to respond with its home ID.

The fix ensures that the Z-Wave proxy component initializes before the API server and waits (up to 100ms) for the home ID to be received from the Z-Wave module before allowing other components to proceed with initialization.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes race condition where Z-Wave home ID is sent as zero on reboot

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal fix for the existing zwave_proxy component

uart:
  tx_pin: 17
  rx_pin: 16
  baud_rate: 115200

zwave_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Summary of Changes

1. **Added setup priority**: Z-Wave proxy now uses `setup_priority::BEFORE_CONNECTION` to ensure it initializes before the API server (which uses `AFTER_WIFI`).

2. **Implemented `can_proceed()` method**: Blocks component initialization until either:
   - The home ID is successfully received from the Z-Wave module
   - A 100ms timeout expires (to prevent indefinite blocking)

3. **Refactored UART processing**: Extracted the UART processing logic into a separate `process_uart_()` method to safely handle data during the initialization phase without triggering API-related operations.

4. **Added state tracking**:
   - `home_id_ready_` flag tracks when the home ID has been received
   - `setup_time_` tracks when setup started for timeout calculation

5. **Optimized memory layout**: Reordered member variables to minimize padding on 32-bit systems.

This ensures that when the API server starts and responds to device info requests, the Z-Wave home ID will already be available (or the timeout will have expired), preventing the transmission of a zero home ID during device reboots.