### PR TITLE
Add external wake word message

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1871,7 +1871,8 @@ message VoiceAssistantExternalWakeWord {
   repeated string trained_languages = 3;
   string model_type = 4;
   uint32 model_size = 5;
-  string url = 6;
+  string model_hash = 6;
+  string url = 7;
 }
 
 message VoiceAssistantConfigurationRequest {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1870,7 +1870,8 @@ message VoiceAssistantExternalWakeWord {
   string wake_word = 2;
   repeated string trained_languages = 3;
   string model_type = 4;
-  string url = 5;
+  uint32 model_size = 5;
+  string url = 6;
 }
 
 message VoiceAssistantConfigurationRequest {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1865,10 +1865,20 @@ message VoiceAssistantWakeWord {
   repeated string trained_languages = 3;
 }
 
+message VoiceAssistantExternalWakeWord {
+  string id = 1;
+  string wake_word = 2;
+  repeated string trained_languages = 3;
+  string model_type = 4;
+  string url = 5;
+}
+
 message VoiceAssistantConfigurationRequest {
   option (id) = 121;
   option (source) = SOURCE_CLIENT;
   option (ifdef) = "USE_VOICE_ASSISTANT";
+
+  repeated VoiceAssistantExternalWakeWord external_wake_words = 1;
 }
 
 message VoiceAssistantConfigurationResponse {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1202,6 +1202,23 @@ bool APIConnection::send_voice_assistant_get_configuration_response(const VoiceA
       resp_wake_word.trained_languages.push_back(lang);
     }
   }
+
+  // Filter external wake words
+  for (auto &wake_word : msg.external_wake_words) {
+    if (wake_word.model_type != "micro") {
+      // microWakeWord only
+      continue;
+    }
+
+    resp.available_wake_words.emplace_back();
+    auto &resp_wake_word = resp.available_wake_words.back();
+    resp_wake_word.set_id(StringRef(wake_word.id));
+    resp_wake_word.set_wake_word(StringRef(wake_word.wake_word));
+    for (const auto &lang : wake_word.trained_languages) {
+      resp_wake_word.trained_languages.push_back(lang);
+    }
+  }
+
   resp.active_wake_words = &config.active_wake_words;
   resp.max_active_wake_words = config.max_active_wake_words;
   return this->send_message(resp, VoiceAssistantConfigurationResponse::MESSAGE_TYPE);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2397,6 +2397,39 @@ void VoiceAssistantWakeWord::calculate_size(ProtoSize &size) const {
     }
   }
 }
+bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1:
+      this->id = value.as_string();
+      break;
+    case 2:
+      this->wake_word = value.as_string();
+      break;
+    case 3:
+      this->trained_languages.push_back(value.as_string());
+      break;
+    case 4:
+      this->model_type = value.as_string();
+      break;
+    case 5:
+      this->url = value.as_string();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 1:
+      this->external_wake_words.emplace_back();
+      value.decode_to_message(this->external_wake_words.back());
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
 void VoiceAssistantConfigurationResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->available_wake_words) {
     buffer.encode_message(1, it, true);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2397,6 +2397,16 @@ void VoiceAssistantWakeWord::calculate_size(ProtoSize &size) const {
     }
   }
 }
+bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 5:
+      this->model_size = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
 bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1:
@@ -2411,7 +2421,7 @@ bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengt
     case 4:
       this->model_type = value.as_string();
       break;
-    case 5:
+    case 6:
       this->url = value.as_string();
       break;
     default:

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2422,6 +2422,9 @@ bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengt
       this->model_type = value.as_string();
       break;
     case 6:
+      this->model_hash = value.as_string();
+      break;
+    case 7:
       this->url = value.as_string();
       break;
     default:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2462,6 +2462,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
   std::string wake_word{};
   std::vector<std::string> trained_languages{};
   std::string model_type{};
+  uint32_t model_size{0};
   std::string url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -2469,6 +2470,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2456,18 +2456,34 @@ class VoiceAssistantWakeWord final : public ProtoMessage {
 
  protected:
 };
-class VoiceAssistantConfigurationRequest final : public ProtoMessage {
+class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
  public:
-  static constexpr uint8_t MESSAGE_TYPE = 121;
-  static constexpr uint8_t ESTIMATED_SIZE = 0;
-#ifdef HAS_PROTO_MESSAGE_DUMP
-  const char *message_name() const override { return "voice_assistant_configuration_request"; }
-#endif
+  std::string id{};
+  std::string wake_word{};
+  std::vector<std::string> trained_languages{};
+  std::string model_type{};
+  std::string url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
 
  protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+};
+class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 121;
+  static constexpr uint8_t ESTIMATED_SIZE = 34;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "voice_assistant_configuration_request"; }
+#endif
+  std::vector<VoiceAssistantExternalWakeWord> external_wake_words{};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  void dump_to(std::string &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class VoiceAssistantConfigurationResponse final : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2463,6 +2463,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
   std::vector<std::string> trained_languages{};
   std::string model_type{};
   uint32_t model_size{0};
+  std::string model_hash{};
   std::string url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1824,8 +1824,23 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
     dump_field(out, "trained_languages", it, 4);
   }
 }
+void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
+  MessageDumpHelper helper(out, "VoiceAssistantExternalWakeWord");
+  dump_field(out, "id", this->id);
+  dump_field(out, "wake_word", this->wake_word);
+  for (const auto &it : this->trained_languages) {
+    dump_field(out, "trained_languages", it, 4);
+  }
+  dump_field(out, "model_type", this->model_type);
+  dump_field(out, "url", this->url);
+}
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
-  out.append("VoiceAssistantConfigurationRequest {}");
+  MessageDumpHelper helper(out, "VoiceAssistantConfigurationRequest");
+  for (const auto &it : this->external_wake_words) {
+    out.append("  external_wake_words: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
 }
 void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationResponse");

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1833,6 +1833,7 @@ void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
   }
   dump_field(out, "model_type", this->model_type);
   dump_field(out, "model_size", this->model_size);
+  dump_field(out, "model_hash", this->model_hash);
   dump_field(out, "url", this->url);
 }
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1832,6 +1832,7 @@ void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
     dump_field(out, "trained_languages", it, 4);
   }
   dump_field(out, "model_type", this->model_type);
+  dump_field(out, "model_size", this->model_size);
   dump_field(out, "url", this->url);
 }
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -548,7 +548,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
 #ifdef USE_VOICE_ASSISTANT
     case VoiceAssistantConfigurationRequest::MESSAGE_TYPE: {
       VoiceAssistantConfigurationRequest msg;
-      // Empty message: no decode needed
+      msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
       ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump().c_str());
 #endif


### PR DESCRIPTION
# What does this implement/fix?

- Parent issue: https://github.com/OHF-Voice/backlog-issues/issues/54
- `aioesphomeapi` PR: https://github.com/esphome/aioesphomeapi/pull/1363
- Core PR: https://github.com/home-assistant/core/pull/152919

Extends the `VoiceAssistantConfigurationRequest` message with an `external_wake_words` list. This list contains wake word models that will be downloaded from HA if selected.

More code will be added in future PRs to the voice assistant and microWakeWord components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
