### PR TITLE
[usb_host] Prevent USB data corruption from missed events

### DIFF
--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -5,13 +5,20 @@
 #include "esphome/core/component.h"
 #include <vector>
 #include "usb/usb_host.h"
-
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/semphr.h>
+#include <freertos/queue.h>
 #include <list>
 
 namespace esphome {
 namespace usb_host {
 
 static const char *const TAG = "usb_host";
+
+// Forward declarations
+struct TransferRequest;
+class USBClient;
 
 // constants for setup packet type
 static const uint8_t USB_RECIP_DEVICE = 0;
@@ -49,6 +56,30 @@ struct TransferRequest {
   USBClient *client;
 };
 
+// Lightweight event types for queue
+enum EventType {
+  EVENT_DEVICE_NEW,
+  EVENT_DEVICE_GONE,
+  EVENT_TRANSFER_COMPLETE,
+  EVENT_CONTROL_COMPLETE,
+};
+
+struct UsbEvent {
+  EventType type;
+  union {
+    struct {
+      uint8_t address;
+    } device_new;
+    struct {
+      usb_device_handle_t handle;
+    } device_gone;
+    struct {
+      TransferRequest *trq;
+      bool callback_executed;  // Flag to indicate callback was already executed in USB task
+    } transfer;
+  } data;
+};
+
 // callback function type.
 
 enum ClientState {
@@ -83,6 +114,7 @@ class USBClient : public Component {
   void release_trq(TransferRequest *trq);
   bool control_transfer(uint8_t type, uint8_t request, uint16_t value, uint16_t index, const transfer_cb_t &callback,
                         const std::vector<uint8_t> &data = {});
+  QueueHandle_t get_event_queue() { return event_queue_; }
 
  protected:
   bool register_();
@@ -90,6 +122,13 @@ class USBClient : public Component {
   virtual void disconnect();
   virtual void on_connected() {}
   virtual void on_disconnected() { this->init_pool(); }
+
+  // USB task management
+  static void usb_task_fn(void *arg);
+  void usb_task_loop();
+
+  TaskHandle_t usb_task_handle_{nullptr};
+  QueueHandle_t event_queue_{nullptr};  // Queue of UsbEvent structs
 
   usb_host_client_handle_t handle_{};
   usb_device_handle_t device_handle_{};

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -35,6 +35,7 @@ static const size_t SETUP_PACKET_SIZE = 8;
 static const size_t MAX_REQUESTS = 16;               // maximum number of outstanding requests possible.
 static constexpr size_t USB_EVENT_QUEUE_SIZE = 32;   // Size of event queue between USB task and main loop
 static constexpr size_t USB_TASK_STACK_SIZE = 4096;  // Stack size for USB task (same as ESP-IDF USB examples)
+static constexpr UBaseType_t USB_TASK_PRIORITY = 5;  // Higher priority than main loop (tskIDLE_PRIORITY + 5)
 
 // used to report a transfer status
 struct TransferStatus {

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -58,7 +58,6 @@ struct TransferRequest {
   USBClient *client;
 };
 
-// Lightweight event types for queue
 enum EventType : uint8_t {
   EVENT_DEVICE_NEW,
   EVENT_DEVICE_GONE,

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -7,8 +7,8 @@
 #include "usb/usb_host.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
-#include <freertos/semphr.h>
-#include <freertos/queue.h>
+#include "esphome/core/lock_free_queue.h"
+#include "esphome/core/event_pool.h"
 #include <list>
 
 namespace esphome {
@@ -79,6 +79,9 @@ struct UsbEvent {
       TransferRequest *trq;
     } transfer;
   } data;
+
+  // Required for EventPool - no cleanup needed for POD types
+  void release() {}
 };
 
 // callback function type.
@@ -115,7 +118,11 @@ class USBClient : public Component {
   void release_trq(TransferRequest *trq);
   bool control_transfer(uint8_t type, uint8_t request, uint16_t value, uint16_t index, const transfer_cb_t &callback,
                         const std::vector<uint8_t> &data = {});
-  QueueHandle_t get_event_queue() { return event_queue_; }
+
+  // Lock-free event queue and pool for USB task to main loop communication
+  // Must be public for access from static callbacks
+  LockFreeQueue<UsbEvent, USB_EVENT_QUEUE_SIZE> event_queue;
+  EventPool<UsbEvent, USB_EVENT_QUEUE_SIZE> event_pool;
 
  protected:
   bool register_();
@@ -129,7 +136,6 @@ class USBClient : public Component {
   void usb_task_loop();
 
   TaskHandle_t usb_task_handle_{nullptr};
-  QueueHandle_t event_queue_{nullptr};  // Queue of UsbEvent structs
 
   usb_host_client_handle_t handle_{};
   usb_device_handle_t device_handle_{};

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -32,7 +32,9 @@ static const uint8_t USB_DIR_IN = 1 << 7;
 static const uint8_t USB_DIR_OUT = 0;
 static const size_t SETUP_PACKET_SIZE = 8;
 
-static const size_t MAX_REQUESTS = 16;  // maximum number of outstanding requests possible.
+static const size_t MAX_REQUESTS = 16;               // maximum number of outstanding requests possible.
+static constexpr size_t USB_EVENT_QUEUE_SIZE = 32;   // Size of event queue between USB task and main loop
+static constexpr size_t USB_TASK_STACK_SIZE = 4096;  // Stack size for USB task (same as ESP-IDF USB examples)
 
 // used to report a transfer status
 struct TransferStatus {

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -57,7 +57,7 @@ struct TransferRequest {
 };
 
 // Lightweight event types for queue
-enum EventType {
+enum EventType : uint8_t {
   EVENT_DEVICE_NEW,
   EVENT_DEVICE_GONE,
   EVENT_TRANSFER_COMPLETE,

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -75,7 +75,6 @@ struct UsbEvent {
     } device_gone;
     struct {
       TransferRequest *trq;
-      bool callback_executed;  // Flag to indicate callback was already executed in USB task
     } transfer;
   } data;
 };

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -191,7 +191,7 @@ void USBClient::setup() {
 
   // Create and start USB task
   xTaskCreatePinnedToCore(usb_task_fn, "usb_task",
-                          2048,  // Stack size (minimal - just handles USB events)
+                          4096,  // Stack size (same as ESP-IDF USB examples)
                           this,  // Task parameter
                           5,     // Priority (higher than main loop)
                           &this->usb_task_handle_,

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -212,9 +212,7 @@ void USBClient::usb_task_fn(void *arg) {
 void USBClient::usb_task_loop() {
   ESP_LOGI(TAG, "USB task started on core %d", xPortGetCoreID());
 
-  // Run forever - ESPHome reboots rather than shutting down cleanly
   while (true) {
-    // Handle USB events with a timeout to prevent blocking forever
     usb_host_client_handle_events(this->handle_, pdMS_TO_TICKS(10));
   }
 }
@@ -327,7 +325,6 @@ static void control_callback(const usb_transfer_t *xfer) {
   UsbEvent event;
   event.type = EVENT_CONTROL_COMPLETE;
   event.data.transfer.trq = trq;
-  event.data.transfer.callback_executed = true;
   xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
 }
 

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -307,6 +307,14 @@ void USBClient::on_removed(usb_device_handle_t handle) {
   }
 }
 
+// Helper to queue transfer cleanup to main loop
+static void queue_transfer_cleanup(TransferRequest *trq, EventType type) {
+  UsbEvent event;
+  event.type = type;
+  event.data.transfer.trq = trq;
+  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
+}
+
 // CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)
 static void control_callback(const usb_transfer_t *xfer) {
   auto *trq = static_cast<TransferRequest *>(xfer->context);
@@ -322,10 +330,7 @@ static void control_callback(const usb_transfer_t *xfer) {
   }
 
   // Queue cleanup to main loop
-  UsbEvent event;
-  event.type = EVENT_CONTROL_COMPLETE;
-  event.data.transfer.trq = trq;
-  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
+  queue_transfer_cleanup(trq, EVENT_CONTROL_COMPLETE);
 }
 
 TransferRequest *USBClient::get_trq_() {
@@ -402,11 +407,7 @@ static void transfer_callback(usb_transfer_t *xfer) {
   }
 
   // Queue cleanup to main loop
-  UsbEvent event;
-  event.type = EVENT_TRANSFER_COMPLETE;
-  event.data.transfer.trq = trq;
-  event.data.transfer.callback_executed = true;
-  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
+  queue_transfer_cleanup(trq, EVENT_TRANSFER_COMPLETE);
 }
 /**
  * Performs a transfer input operation.

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -139,18 +139,25 @@ static std::string get_descriptor_string(const usb_str_desc_t *desc) {
   return {buffer};
 }
 
+// CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)
 static void client_event_cb(const usb_host_client_event_msg_t *event_msg, void *ptr) {
   auto *client = static_cast<USBClient *>(ptr);
+  UsbEvent event;
+
+  // Queue events to be processed in main loop
   switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV: {
-      auto addr = event_msg->new_dev.address;
       ESP_LOGD(TAG, "New device %d", event_msg->new_dev.address);
-      client->on_opened(addr);
+      event.type = EVENT_DEVICE_NEW;
+      event.data.device_new.address = event_msg->new_dev.address;
+      xQueueSend(client->get_event_queue(), &event, portMAX_DELAY);
       break;
     }
     case USB_HOST_CLIENT_EVENT_DEV_GONE: {
-      client->on_removed(event_msg->dev_gone.dev_hdl);
-      ESP_LOGD(TAG, "Device gone %d", event_msg->new_dev.address);
+      ESP_LOGD(TAG, "Device gone");
+      event.type = EVENT_DEVICE_GONE;
+      event.data.device_gone.handle = event_msg->dev_gone.dev_hdl;
+      xQueueSend(client->get_event_queue(), &event, portMAX_DELAY);
       break;
     }
     default:
@@ -173,9 +180,66 @@ void USBClient::setup() {
     usb_host_transfer_alloc(64, 0, &trq->transfer);
     trq->client = this;
   }
+
+  // Create event queue for communication between USB task and main loop
+  this->event_queue_ = xQueueCreate(32, sizeof(UsbEvent));
+  if (this->event_queue_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create event queue");
+    this->mark_failed();
+    return;
+  }
+
+  // Create and start USB task
+  xTaskCreatePinnedToCore(usb_task_fn, "usb_task",
+                          2048,  // Stack size (minimal - just handles USB events)
+                          this,  // Task parameter
+                          5,     // Priority (higher than main loop)
+                          &this->usb_task_handle_,
+                          1  // Core 1
+  );
+
+  if (this->usb_task_handle_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create USB task");
+    this->mark_failed();
+  }
+}
+
+void USBClient::usb_task_fn(void *arg) {
+  auto *client = static_cast<USBClient *>(arg);
+  client->usb_task_loop();
+}
+
+void USBClient::usb_task_loop() {
+  ESP_LOGI(TAG, "USB task started on core %d", xPortGetCoreID());
+
+  // Run forever - ESPHome reboots rather than shutting down cleanly
+  while (true) {
+    // Handle USB events with a timeout to prevent blocking forever
+    usb_host_client_handle_events(this->handle_, pdMS_TO_TICKS(10));
+  }
 }
 
 void USBClient::loop() {
+  // Process any events from the USB task
+  UsbEvent event;
+  while (xQueueReceive(this->event_queue_, &event, 0) == pdTRUE) {
+    switch (event.type) {
+      case EVENT_DEVICE_NEW:
+        this->on_opened(event.data.device_new.address);
+        break;
+      case EVENT_DEVICE_GONE:
+        this->on_removed(event.data.device_gone.handle);
+        break;
+      case EVENT_TRANSFER_COMPLETE:
+      case EVENT_CONTROL_COMPLETE: {
+        auto *trq = event.data.transfer.trq;
+        // Callback was already executed in USB task, just cleanup
+        this->release_trq(trq);
+        break;
+      }
+    }
+  }
+
   switch (this->state_) {
     case USB_CLIENT_OPEN: {
       int err;
@@ -228,7 +292,7 @@ void USBClient::loop() {
     }
 
     default:
-      usb_host_client_handle_events(this->handle_, 0);
+      // USB events are now handled in the dedicated task
       break;
   }
 }
@@ -245,6 +309,7 @@ void USBClient::on_removed(usb_device_handle_t handle) {
   }
 }
 
+// CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)
 static void control_callback(const usb_transfer_t *xfer) {
   auto *trq = static_cast<TransferRequest *>(xfer->context);
   trq->status.error_code = xfer->status;
@@ -252,9 +317,18 @@ static void control_callback(const usb_transfer_t *xfer) {
   trq->status.endpoint = xfer->bEndpointAddress;
   trq->status.data = xfer->data_buffer;
   trq->status.data_len = xfer->actual_num_bytes;
-  if (trq->callback != nullptr)
+
+  // Execute callback in USB task context
+  if (trq->callback != nullptr) {
     trq->callback(trq->status);
-  trq->client->release_trq(trq);
+  }
+
+  // Queue cleanup to main loop
+  UsbEvent event;
+  event.type = EVENT_CONTROL_COMPLETE;
+  event.data.transfer.trq = trq;
+  event.data.transfer.callback_executed = true;
+  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
 }
 
 TransferRequest *USBClient::get_trq_() {
@@ -315,6 +389,7 @@ bool USBClient::control_transfer(uint8_t type, uint8_t request, uint16_t value, 
   return true;
 }
 
+// CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)
 static void transfer_callback(usb_transfer_t *xfer) {
   auto *trq = static_cast<TransferRequest *>(xfer->context);
   trq->status.error_code = xfer->status;
@@ -322,9 +397,19 @@ static void transfer_callback(usb_transfer_t *xfer) {
   trq->status.endpoint = xfer->bEndpointAddress;
   trq->status.data = xfer->data_buffer;
   trq->status.data_len = xfer->actual_num_bytes;
-  if (trq->callback != nullptr)
+
+  // Always execute callback in USB task context
+  // Callbacks should be fast and non-blocking (e.g., copy data to queue)
+  if (trq->callback != nullptr) {
     trq->callback(trq->status);
-  trq->client->release_trq(trq);
+  }
+
+  // Queue cleanup to main loop
+  UsbEvent event;
+  event.type = EVENT_TRANSFER_COMPLETE;
+  event.data.transfer.trq = trq;
+  event.data.transfer.callback_executed = true;
+  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
 }
 /**
  * Performs a transfer input operation.
@@ -345,6 +430,7 @@ void USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
   trq->transfer->callback = transfer_callback;
   trq->transfer->bEndpointAddress = ep_address | USB_DIR_IN;
   trq->transfer->num_bytes = length;
+
   auto err = usb_host_transfer_submit(trq->transfer);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to submit transfer, address=%x, length=%d, err=%x", ep_address, length, err);

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -299,7 +299,6 @@ void USBClient::loop() {
     }
 
     default:
-      // USB events are now handled in the dedicated task
       break;
   }
 }

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -182,7 +182,7 @@ void USBClient::setup() {
   }
 
   // Create event queue for communication between USB task and main loop
-  this->event_queue_ = xQueueCreate(32, sizeof(UsbEvent));
+  this->event_queue_ = xQueueCreate(USB_EVENT_QUEUE_SIZE, sizeof(UsbEvent));
   if (this->event_queue_ == nullptr) {
     ESP_LOGE(TAG, "Failed to create event queue");
     this->mark_failed();
@@ -191,9 +191,9 @@ void USBClient::setup() {
 
   // Create and start USB task
   xTaskCreatePinnedToCore(usb_task_fn, "usb_task",
-                          4096,  // Stack size (same as ESP-IDF USB examples)
-                          this,  // Task parameter
-                          5,     // Priority (higher than main loop)
+                          USB_TASK_STACK_SIZE,  // Stack size
+                          this,                 // Task parameter
+                          5,                    // Priority (higher than main loop)
                           &this->usb_task_handle_,
                           1  // Core 1
   );

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -142,28 +142,37 @@ static std::string get_descriptor_string(const usb_str_desc_t *desc) {
 // CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)
 static void client_event_cb(const usb_host_client_event_msg_t *event_msg, void *ptr) {
   auto *client = static_cast<USBClient *>(ptr);
-  UsbEvent event;
+
+  // Allocate event from pool
+  UsbEvent *event = client->event_pool.allocate();
+  if (event == nullptr) {
+    // No events available - increment counter for periodic logging
+    client->event_queue.increment_dropped_count();
+    return;
+  }
 
   // Queue events to be processed in main loop
   switch (event_msg->event) {
     case USB_HOST_CLIENT_EVENT_NEW_DEV: {
       ESP_LOGD(TAG, "New device %d", event_msg->new_dev.address);
-      event.type = EVENT_DEVICE_NEW;
-      event.data.device_new.address = event_msg->new_dev.address;
-      xQueueSend(client->get_event_queue(), &event, portMAX_DELAY);
+      event->type = EVENT_DEVICE_NEW;
+      event->data.device_new.address = event_msg->new_dev.address;
       break;
     }
     case USB_HOST_CLIENT_EVENT_DEV_GONE: {
       ESP_LOGD(TAG, "Device gone");
-      event.type = EVENT_DEVICE_GONE;
-      event.data.device_gone.handle = event_msg->dev_gone.dev_hdl;
-      xQueueSend(client->get_event_queue(), &event, portMAX_DELAY);
+      event->type = EVENT_DEVICE_GONE;
+      event->data.device_gone.handle = event_msg->dev_gone.dev_hdl;
       break;
     }
     default:
       ESP_LOGD(TAG, "Unknown event %d", event_msg->event);
-      break;
+      client->event_pool.release(event);
+      return;
   }
+
+  // Push to lock-free queue (always succeeds since pool size == queue size)
+  client->event_queue.push(event);
 }
 void USBClient::setup() {
   usb_host_client_config_t config{.is_synchronous = false,
@@ -179,14 +188,6 @@ void USBClient::setup() {
   for (auto *trq : this->trq_pool_) {
     usb_host_transfer_alloc(64, 0, &trq->transfer);
     trq->client = this;
-  }
-
-  // Create event queue for communication between USB task and main loop
-  this->event_queue_ = xQueueCreate(USB_EVENT_QUEUE_SIZE, sizeof(UsbEvent));
-  if (this->event_queue_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create event queue");
-    this->mark_failed();
-    return;
   }
 
   // Create and start USB task
@@ -219,23 +220,31 @@ void USBClient::usb_task_loop() {
 
 void USBClient::loop() {
   // Process any events from the USB task
-  UsbEvent event;
-  while (xQueueReceive(this->event_queue_, &event, 0) == pdTRUE) {
-    switch (event.type) {
+  UsbEvent *event;
+  while ((event = this->event_queue.pop()) != nullptr) {
+    switch (event->type) {
       case EVENT_DEVICE_NEW:
-        this->on_opened(event.data.device_new.address);
+        this->on_opened(event->data.device_new.address);
         break;
       case EVENT_DEVICE_GONE:
-        this->on_removed(event.data.device_gone.handle);
+        this->on_removed(event->data.device_gone.handle);
         break;
       case EVENT_TRANSFER_COMPLETE:
       case EVENT_CONTROL_COMPLETE: {
-        auto *trq = event.data.transfer.trq;
+        auto *trq = event->data.transfer.trq;
         // Callback was already executed in USB task, just cleanup
         this->release_trq(trq);
         break;
       }
     }
+    // Return event to pool for reuse
+    this->event_pool.release(event);
+  }
+
+  // Log dropped events periodically
+  uint16_t dropped = this->event_queue.get_and_reset_dropped_count();
+  if (dropped > 0) {
+    ESP_LOGW(TAG, "Dropped %u USB events due to queue overflow", dropped);
   }
 
   switch (this->state_) {
@@ -309,10 +318,21 @@ void USBClient::on_removed(usb_device_handle_t handle) {
 
 // Helper to queue transfer cleanup to main loop
 static void queue_transfer_cleanup(TransferRequest *trq, EventType type) {
-  UsbEvent event;
-  event.type = type;
-  event.data.transfer.trq = trq;
-  xQueueSend(trq->client->get_event_queue(), &event, portMAX_DELAY);
+  auto *client = trq->client;
+
+  // Allocate event from pool
+  UsbEvent *event = client->event_pool.allocate();
+  if (event == nullptr) {
+    // No events available - increment counter for periodic logging
+    client->event_queue.increment_dropped_count();
+    return;
+  }
+
+  event->type = type;
+  event->data.transfer.trq = trq;
+
+  // Push to lock-free queue (always succeeds since pool size == queue size)
+  client->event_queue.push(event);
 }
 
 // CALLBACK CONTEXT: USB task (called from usb_host_client_handle_events in USB task)

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -210,7 +210,7 @@ void USBClient::usb_task_fn(void *arg) {
 
 void USBClient::usb_task_loop() {
   while (true) {
-    usb_host_client_handle_events(this->handle_, pdMS_TO_TICKS(10));
+    usb_host_client_handle_events(this->handle_, portMAX_DELAY);
   }
 }
 

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -191,13 +191,11 @@ void USBClient::setup() {
   }
 
   // Create and start USB task
-  xTaskCreatePinnedToCore(usb_task_fn, "usb_task",
-                          USB_TASK_STACK_SIZE,  // Stack size
-                          this,                 // Task parameter
-                          5,                    // Priority (higher than main loop)
-                          &this->usb_task_handle_,
-                          1  // Core 1
-  );
+  xTaskCreate(usb_task_fn, "usb_task",
+              USB_TASK_STACK_SIZE,  // Stack size
+              this,                 // Task parameter
+              USB_TASK_PRIORITY,    // Priority (higher than main loop)
+              &this->usb_task_handle_);
 
   if (this->usb_task_handle_ == nullptr) {
     ESP_LOGE(TAG, "Failed to create USB task");

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -211,8 +211,6 @@ void USBClient::usb_task_fn(void *arg) {
 }
 
 void USBClient::usb_task_loop() {
-  ESP_LOGI(TAG, "USB task started on core %d", xPortGetCoreID());
-
   while (true) {
     usb_host_client_handle_events(this->handle_, pdMS_TO_TICKS(10));
   }
@@ -232,7 +230,6 @@ void USBClient::loop() {
       case EVENT_TRANSFER_COMPLETE:
       case EVENT_CONTROL_COMPLETE: {
         auto *trq = event->data.transfer.trq;
-        // Callback was already executed in USB task, just cleanup
         this->release_trq(trq);
         break;
       }

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -447,7 +447,6 @@ void USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
   trq->transfer->callback = transfer_callback;
   trq->transfer->bEndpointAddress = ep_address | USB_DIR_IN;
   trq->transfer->num_bytes = length;
-
   auto err = usb_host_transfer_submit(trq->transfer);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to submit transfer, address=%x, length=%d, err=%x", ep_address, length, err);

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -16,12 +16,12 @@ using namespace bytebuffer;
 void USBUartTypeCH34X::enable_channels() {
   // enable the channels
   for (auto channel : this->channels_) {
-    if (!channel->initialised_)
+    if (!channel->initialised_.load())
       continue;
     usb_host::transfer_cb_t callback = [=](const usb_host::TransferStatus &status) {
       if (!status.success) {
         ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-        channel->initialised_ = false;
+        channel->initialised_.store(false);
       }
     };
 
@@ -48,7 +48,7 @@ void USBUartTypeCH34X::enable_channels() {
     auto factor = static_cast<uint8_t>(clk / baud_rate);
     if (factor == 0 || factor == 0xFF) {
       ESP_LOGE(TAG, "Invalid baud rate %" PRIu32, baud_rate);
-      channel->initialised_ = false;
+      channel->initialised_.store(false);
       continue;
     }
     if ((clk / factor - baud_rate) > (baud_rate - clk / (factor + 1)))

--- a/esphome/components/usb_uart/cp210x.cpp
+++ b/esphome/components/usb_uart/cp210x.cpp
@@ -100,12 +100,12 @@ std::vector<CdcEps> USBUartTypeCP210X::parse_descriptors(usb_device_handle_t dev
 void USBUartTypeCP210X::enable_channels() {
   // enable the channels
   for (auto channel : this->channels_) {
-    if (!channel->initialised_)
+    if (!channel->initialised_.load())
       continue;
     usb_host::transfer_cb_t callback = [=](const usb_host::TransferStatus &status) {
       if (!status.success) {
         ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-        channel->initialised_ = false;
+        channel->initialised_.store(false);
       }
     };
     this->control_transfer(USB_VENDOR_IFC | usb_host::USB_DIR_OUT, IFC_ENABLE, 1, channel->index_, callback);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -188,9 +188,7 @@ void USBUartComponent::loop() {
 #endif
 
     // Push data to ring buffer (now safe in main loop)
-    for (size_t i = 0; i < chunk->length; i++) {
-      channel->input_buffer_.push(chunk->data[i]);
-    }
+    channel->input_buffer_.push(chunk->data, chunk->length);
 
     // Return chunk to pool for reuse
     this->chunk_pool_.release(chunk);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -193,7 +193,7 @@ void USBUartComponent::loop() {
     }
 
     // Return chunk to pool for reuse
-    this->free_chunks_.push(chunk);
+    this->chunk_pool_.release(chunk);
   }
 
   static constexpr int LOG_CHUNK_THRESHOLD = 5;
@@ -231,8 +231,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     }
 
     if (!channel->dummy_receiver_ && status.data_len > 0) {
-      // Get a free chunk from the pool
-      UsbDataChunk *chunk = this->free_chunks_.pop();
+      // Allocate a chunk from the pool
+      UsbDataChunk *chunk = this->chunk_pool_.allocate();
       if (chunk == nullptr) {
         ESP_LOGW(TAG, "No free chunks available, dropping %u bytes", status.data_len);
         // Mark input as not started so we can retry
@@ -249,7 +249,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       if (!this->usb_data_queue_.push(chunk)) {
         ESP_LOGW(TAG, "USB data queue full, dropping %u bytes", status.data_len);
         // Return chunk to pool
-        this->free_chunks_.push(chunk);
+        this->chunk_pool_.release(chunk);
       }
     }
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -198,6 +198,12 @@ void USBUartComponent::loop() {
   if (chunks_processed > LOG_CHUNK_THRESHOLD) {
     ESP_LOGV(TAG, "Processed %d chunks from USB queue", chunks_processed);
   }
+
+  // Log dropped USB data periodically
+  uint16_t dropped = this->usb_data_queue_.get_and_reset_dropped_count();
+  if (dropped > 0) {
+    ESP_LOGW(TAG, "Dropped %u USB data chunks due to buffer overflow", dropped);
+  }
 }
 void USBUartComponent::dump_config() {
   USBClient::dump_config();
@@ -232,7 +238,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       // Allocate a chunk from the pool
       UsbDataChunk *chunk = this->chunk_pool_.allocate();
       if (chunk == nullptr) {
-        ESP_LOGW(TAG, "No free chunks available, dropping %u bytes", status.data_len);
+        // No chunks available - queue is full or we're out of memory
+        this->usb_data_queue_.increment_dropped_count();
         // Mark input as not started so we can retry
         channel->input_started_.store(false);
         return;

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -170,7 +170,37 @@ bool USBUartChannel::read_array(uint8_t *data, size_t len) {
   return status;
 }
 void USBUartComponent::setup() { USBClient::setup(); }
-void USBUartComponent::loop() { USBClient::loop(); }
+void USBUartComponent::loop() {
+  USBClient::loop();
+
+  // Process USB data from the lock-free queue
+  UsbDataChunk *chunk;
+  int chunks_processed = 0;
+  while ((chunk = this->usb_data_queue_.pop()) != nullptr) {
+    chunks_processed++;
+    auto *channel = chunk->channel;
+
+#ifdef USE_UART_DEBUGGER
+    if (channel->debug_) {
+      uart::UARTDebug::log_hex(uart::UART_DIRECTION_RX, std::vector<uint8_t>(chunk->data, chunk->data + chunk->length),
+                               ',');  // NOLINT()
+    }
+#endif
+
+    // Push data to ring buffer (now safe in main loop)
+    for (size_t i = 0; i < chunk->length; i++) {
+      channel->input_buffer_.push(chunk->data[i]);
+    }
+
+    // Return chunk to pool for reuse
+    this->free_chunks_.push(chunk);
+  }
+
+  static constexpr int LOG_CHUNK_THRESHOLD = 5;
+  if (chunks_processed > LOG_CHUNK_THRESHOLD) {
+    ESP_LOGV(TAG, "Processed %d chunks from USB queue", chunks_processed);
+  }
+}
 void USBUartComponent::dump_config() {
   USBClient::dump_config();
   for (auto &channel : this->channels_) {
@@ -187,31 +217,46 @@ void USBUartComponent::dump_config() {
   }
 }
 void USBUartComponent::start_input(USBUartChannel *channel) {
-  if (!channel->initialised_ || channel->input_started_ ||
-      channel->input_buffer_.get_free_space() < channel->cdc_dev_.in_ep->wMaxPacketSize)
+  if (!channel->initialised_ || channel->input_started_)
     return;
+  // Note: We no longer check ring buffer space here since this may be called from USB task
+  // The lock-free queue provides backpressure instead
   const auto *ep = channel->cdc_dev_.in_ep;
+  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
   auto callback = [this, channel](const usb_host::TransferStatus &status) {
     ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
       return;
     }
-#ifdef USE_UART_DEBUGGER
-    if (channel->debug_) {
-      uart::UARTDebug::log_hex(uart::UART_DIRECTION_RX,
-                               std::vector<uint8_t>(status.data, status.data + status.data_len), ',');  // NOLINT()
-    }
-#endif
-    channel->input_started_ = false;
-    if (!channel->dummy_receiver_) {
-      for (size_t i = 0; i != status.data_len; i++) {
-        channel->input_buffer_.push(status.data[i]);
+
+    if (!channel->dummy_receiver_ && status.data_len > 0) {
+      // Get a free chunk from the pool
+      UsbDataChunk *chunk = this->free_chunks_.pop();
+      if (chunk == nullptr) {
+        ESP_LOGW(TAG, "No free chunks available, dropping %u bytes", status.data_len);
+        // Mark input as not started so we can retry
+        channel->input_started_ = false;
+        return;
+      }
+
+      // Copy data to chunk (this is fast, happens in USB task)
+      memcpy(chunk->data, status.data, status.data_len);
+      chunk->length = status.data_len;
+      chunk->channel = channel;
+
+      // Push to lock-free queue for main loop processing
+      if (!this->usb_data_queue_.push(chunk)) {
+        ESP_LOGW(TAG, "USB data queue full, dropping %u bytes", status.data_len);
+        // Return chunk to pool
+        this->free_chunks_.push(chunk);
       }
     }
-    if (channel->input_buffer_.get_free_space() >= channel->cdc_dev_.in_ep->wMaxPacketSize) {
-      this->defer([this, channel] { this->start_input(channel); });
-    }
+
+    // Always restart input immediately from USB task
+    // The lock-free queue will handle backpressure
+    channel->input_started_ = false;
+    this->start_input(channel);
   };
   channel->input_started_ = true;
   this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
@@ -224,9 +269,12 @@ void USBUartComponent::start_output(USBUartChannel *channel) {
     return;
   }
   const auto *ep = channel->cdc_dev_.out_ep;
+  // CALLBACK CONTEXT: This lambda is stored in TransferRequest and will be executed
+  // in MAIN LOOP after being queued by transfer_callback in USB task
   auto callback = [this, channel](const usb_host::TransferStatus &status) {
     ESP_LOGV(TAG, "Output Transfer result: length: %u; status %X", status.data_len, status.error_code);
     channel->output_started_ = false;
+    // DEFERRED CONTEXT: Main loop (restart output in main loop)
     this->defer([this, channel] { this->start_output(channel); });
   };
   channel->output_started_ = true;

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -266,12 +266,11 @@ void USBUartComponent::start_output(USBUartChannel *channel) {
     return;
   }
   const auto *ep = channel->cdc_dev_.out_ep;
-  // CALLBACK CONTEXT: This lambda is stored in TransferRequest and will be executed
-  // in MAIN LOOP after being queued by transfer_callback in USB task
+  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
   auto callback = [this, channel](const usb_host::TransferStatus &status) {
     ESP_LOGV(TAG, "Output Transfer result: length: %u; status %X", status.data_len, status.error_code);
     channel->output_started_ = false;
-    // DEFERRED CONTEXT: Main loop (restart output in main loop)
+    // Defer restart to main loop (defer is thread-safe)
     this->defer([this, channel] { this->start_output(channel); });
   };
   channel->output_started_ = true;

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -246,11 +246,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       chunk->channel = channel;
 
       // Push to lock-free queue for main loop processing
-      if (!this->usb_data_queue_.push(chunk)) {
-        ESP_LOGW(TAG, "USB data queue full, dropping %u bytes", status.data_len);
-        // Return chunk to pool
-        this->chunk_pool_.release(chunk);
-      }
+      // Push always succeeds because pool size == queue size
+      this->usb_data_queue_.push(chunk);
     }
 
     // Always restart input immediately from USB task

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -130,7 +130,7 @@ size_t RingBuffer::pop(uint8_t *data, size_t len) {
   return len;
 }
 void USBUartChannel::write_array(const uint8_t *data, size_t len) {
-  if (!this->initialised_) {
+  if (!this->initialised_.load()) {
     ESP_LOGV(TAG, "Channel not initialised - write ignored");
     return;
   }
@@ -152,7 +152,7 @@ bool USBUartChannel::peek_byte(uint8_t *data) {
   return true;
 }
 bool USBUartChannel::read_array(uint8_t *data, size_t len) {
-  if (!this->initialised_) {
+  if (!this->initialised_.load()) {
     ESP_LOGV(TAG, "Channel not initialised - read ignored");
     return false;
   }
@@ -215,7 +215,7 @@ void USBUartComponent::dump_config() {
   }
 }
 void USBUartComponent::start_input(USBUartChannel *channel) {
-  if (!channel->initialised_ || channel->input_started_)
+  if (!channel->initialised_.load() || channel->input_started_.load())
     return;
   // Note: We no longer check ring buffer space here since this may be called from USB task
   // The lock-free queue provides backpressure instead
@@ -234,7 +234,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       if (chunk == nullptr) {
         ESP_LOGW(TAG, "No free chunks available, dropping %u bytes", status.data_len);
         // Mark input as not started so we can retry
-        channel->input_started_ = false;
+        channel->input_started_.store(false);
         return;
       }
 
@@ -250,15 +250,15 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
 
     // Always restart input immediately from USB task
     // The lock-free queue will handle backpressure
-    channel->input_started_ = false;
+    channel->input_started_.store(false);
     this->start_input(channel);
   };
-  channel->input_started_ = true;
+  channel->input_started_.store(true);
   this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
 }
 
 void USBUartComponent::start_output(USBUartChannel *channel) {
-  if (channel->output_started_)
+  if (channel->output_started_.load())
     return;
   if (channel->output_buffer_.is_empty()) {
     return;
@@ -267,11 +267,11 @@ void USBUartComponent::start_output(USBUartChannel *channel) {
   // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
   auto callback = [this, channel](const usb_host::TransferStatus &status) {
     ESP_LOGV(TAG, "Output Transfer result: length: %u; status %X", status.data_len, status.error_code);
-    channel->output_started_ = false;
+    channel->output_started_.store(false);
     // Defer restart to main loop (defer is thread-safe)
     this->defer([this, channel] { this->start_output(channel); });
   };
-  channel->output_started_ = true;
+  channel->output_started_.store(true);
   uint8_t data[ep->wMaxPacketSize];
   auto len = channel->output_buffer_.pop(data, ep->wMaxPacketSize);
   this->transfer_out(ep->bEndpointAddress, callback, data, len);
@@ -314,7 +314,7 @@ void USBUartTypeCdcAcm::on_connected() {
     channel->cdc_dev_ = cdc_devs[i++];
     fix_mps(channel->cdc_dev_.in_ep);
     fix_mps(channel->cdc_dev_.out_ep);
-    channel->initialised_ = true;
+    channel->initialised_.store(true);
     auto err =
         usb_host_interface_claim(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number, 0);
     if (err != ESP_OK) {
@@ -343,9 +343,9 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
     }
     usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number);
-    channel->initialised_ = false;
-    channel->input_started_ = false;
-    channel->output_started_ = false;
+    channel->initialised_.store(false);
+    channel->input_started_.store(false);
+    channel->output_started_.store(false);
     channel->input_buffer_.clear();
     channel->output_buffer_.clear();
   }
@@ -354,10 +354,10 @@ void USBUartTypeCdcAcm::on_disconnected() {
 
 void USBUartTypeCdcAcm::enable_channels() {
   for (auto *channel : this->channels_) {
-    if (!channel->initialised_)
+    if (!channel->initialised_.load())
       continue;
-    channel->input_started_ = false;
-    channel->output_started_ = false;
+    channel->input_started_.store(false);
+    channel->output_started_.store(false);
     this->start_input(channel);
   }
 }

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -175,9 +175,7 @@ void USBUartComponent::loop() {
 
   // Process USB data from the lock-free queue
   UsbDataChunk *chunk;
-  int chunks_processed = 0;
   while ((chunk = this->usb_data_queue_.pop()) != nullptr) {
-    chunks_processed++;
     auto *channel = chunk->channel;
 
 #ifdef USE_UART_DEBUGGER
@@ -192,11 +190,6 @@ void USBUartComponent::loop() {
 
     // Return chunk to pool for reuse
     this->chunk_pool_.release(chunk);
-  }
-
-  static constexpr int LOG_CHUNK_THRESHOLD = 5;
-  if (chunks_processed > LOG_CHUNK_THRESHOLD) {
-    ESP_LOGV(TAG, "Processed %d chunks from USB queue", chunks_processed);
   }
 
   // Log dropped USB data periodically

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -223,8 +223,9 @@ void USBUartComponent::dump_config() {
 void USBUartComponent::start_input(USBUartChannel *channel) {
   if (!channel->initialised_.load() || channel->input_started_.load())
     return;
-  // Note: We no longer check ring buffer space here since this may be called from USB task
-  // The lock-free queue provides backpressure instead
+  // Note: This function is called from both USB task and main loop, so we cannot
+  // directly check ring buffer space here. Backpressure is handled by the chunk pool:
+  // when exhausted, USB input stops until chunks are freed by the main loop
   const auto *ep = channel->cdc_dev_.in_ep;
   // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
   auto callback = [this, channel](const usb_host::TransferStatus &status) {

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -225,6 +225,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
+      // On failure, don't restart - let next read_array() trigger it
+      channel->input_started_.store(false);
       return;
     }
 
@@ -249,7 +251,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       this->usb_data_queue_.push(chunk);
     }
 
-    // Always restart input immediately from USB task
+    // On success, restart input immediately from USB task for performance
     // The lock-free queue will handle backpressure
     channel->input_started_.store(false);
     this->start_input(channel);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -266,6 +266,9 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
 }
 
 void USBUartComponent::start_output(USBUartChannel *channel) {
+  // IMPORTANT: This function must only be called from the main loop!
+  // The output_buffer_ is not thread-safe and can only be accessed from main loop.
+  // USB callbacks use defer() to ensure this function runs in the correct context.
   if (channel->output_started_.load())
     return;
   if (channel->output_buffer_.is_empty()) {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -5,11 +5,13 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/uart/uart_component.h"
 #include "esphome/components/usb_host/usb_host.h"
+#include "esphome/core/lock_free_queue.h"
 
 namespace esphome {
 namespace usb_uart {
 class USBUartTypeCdcAcm;
 class USBUartComponent;
+class USBUartChannel;
 
 static const char *const TAG = "usb_uart";
 
@@ -68,6 +70,14 @@ class RingBuffer {
   uint8_t *buffer_;
 };
 
+// Structure for queuing received USB data chunks
+struct UsbDataChunk {
+  static constexpr size_t MAX_CHUNK_SIZE = 64;  // USB packet size
+  uint8_t data[MAX_CHUNK_SIZE];
+  size_t length;
+  USBUartChannel *channel;
+};
+
 class USBUartChannel : public uart::UARTComponent, public Parented<USBUartComponent> {
   friend class USBUartComponent;
   friend class USBUartTypeCdcAcm;
@@ -104,7 +114,18 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
 
 class USBUartComponent : public usb_host::USBClient {
  public:
-  USBUartComponent(uint16_t vid, uint16_t pid) : usb_host::USBClient(vid, pid) {}
+  USBUartComponent(uint16_t vid, uint16_t pid) : usb_host::USBClient(vid, pid) {
+    // Allocate pool of data chunks
+    for (int i = 0; i < MAX_DATA_CHUNKS; i++) {
+      this->data_chunk_pool_[i] = new UsbDataChunk();
+      this->free_chunks_.push(this->data_chunk_pool_[i]);
+    }
+  }
+  ~USBUartComponent() {
+    for (int i = 0; i < MAX_DATA_CHUNKS; i++) {
+      delete this->data_chunk_pool_[i];
+    }
+  }
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -115,8 +136,16 @@ class USBUartComponent : public usb_host::USBClient {
   void start_input(USBUartChannel *channel);
   void start_output(USBUartChannel *channel);
 
+  // Lock-free data transfer from USB task to main loop
+  LockFreeQueue<UsbDataChunk, 32> usb_data_queue_;
+
  protected:
   std::vector<USBUartChannel *> channels_{};
+
+  // Pool of pre-allocated data chunks to avoid dynamic allocation
+  static constexpr int MAX_DATA_CHUNKS = 32;
+  UsbDataChunk *data_chunk_pool_[MAX_DATA_CHUNKS];
+  LockFreeQueue<UsbDataChunk, MAX_DATA_CHUNKS> free_chunks_;
 };
 
 class USBUartTypeCdcAcm : public USBUartComponent {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -108,16 +108,20 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   void set_dummy_receiver(bool dummy_receiver) { this->dummy_receiver_ = dummy_receiver; }
 
  protected:
-  const uint8_t index_;
+  // Larger structures first for better alignment
   RingBuffer input_buffer_;
   RingBuffer output_buffer_;
+  CdcEps cdc_dev_{};
+  // Enum (likely 4 bytes)
   UARTParityOptions parity_{UART_CONFIG_PARITY_NONE};
+  // Group atomics together (each 1 byte)
   std::atomic<bool> input_started_{true};
   std::atomic<bool> output_started_{true};
-  CdcEps cdc_dev_{};
+  std::atomic<bool> initialised_{false};
+  // Group regular bytes together to minimize padding
+  const uint8_t index_;
   bool debug_{};
   bool dummy_receiver_{};
-  std::atomic<bool> initialised_{false};
 };
 
 class USBUartComponent : public usb_host::USBClient {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -137,9 +137,6 @@ class USBUartComponent : public usb_host::USBClient {
   // Lock-free data transfer from USB task to main loop
   static constexpr int USB_DATA_QUEUE_SIZE = 32;
   LockFreeQueue<UsbDataChunk, USB_DATA_QUEUE_SIZE> usb_data_queue_;
-
-  // Pool for allocating data chunks (uses EventPool pattern like BLE)
-  // MUST be same size as queue to guarantee push always succeeds after allocate
   EventPool<UsbDataChunk, USB_DATA_QUEUE_SIZE> chunk_pool_;
 
  protected:

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -137,8 +137,8 @@ class USBUartComponent : public usb_host::USBClient {
   LockFreeQueue<UsbDataChunk, USB_DATA_QUEUE_SIZE> usb_data_queue_;
 
   // Pool for allocating data chunks (uses EventPool pattern like BLE)
-  static constexpr int MAX_DATA_CHUNKS = 40;
-  EventPool<UsbDataChunk, MAX_DATA_CHUNKS> chunk_pool_;
+  // MUST be same size as queue to guarantee push always succeeds after allocate
+  EventPool<UsbDataChunk, USB_DATA_QUEUE_SIZE> chunk_pool_;
 
  protected:
   std::vector<USBUartChannel *> channels_{};

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -7,6 +7,7 @@
 #include "esphome/components/usb_host/usb_host.h"
 #include "esphome/core/lock_free_queue.h"
 #include "esphome/core/event_pool.h"
+#include <atomic>
 
 namespace esphome {
 namespace usb_uart {
@@ -111,12 +112,12 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   RingBuffer input_buffer_;
   RingBuffer output_buffer_;
   UARTParityOptions parity_{UART_CONFIG_PARITY_NONE};
-  bool input_started_{true};
-  bool output_started_{true};
+  std::atomic<bool> input_started_{true};
+  std::atomic<bool> output_started_{true};
   CdcEps cdc_dev_{};
   bool debug_{};
   bool dummy_receiver_{};
-  bool initialised_{};
+  std::atomic<bool> initialised_{false};
 };
 
 class USBUartComponent : public usb_host::USBClient {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -79,11 +79,8 @@ struct UsbDataChunk {
   uint8_t length;  // Max 64 bytes, so uint8_t is sufficient
   USBUartChannel *channel;
 
-  // Required for EventPool - reset to clean state
-  void release() {
-    this->length = 0;
-    this->channel = nullptr;
-  }
+  // Required for EventPool - no cleanup needed for POD types
+  void release() {}
 };
 
 class USBUartChannel : public uart::UARTComponent, public Parented<USBUartComponent> {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -115,15 +115,10 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
 class USBUartComponent : public usb_host::USBClient {
  public:
   USBUartComponent(uint16_t vid, uint16_t pid) : usb_host::USBClient(vid, pid) {
-    // Allocate pool of data chunks
+    // Allocate pool of data chunks (never freed - ESPHome reboots instead)
     for (int i = 0; i < MAX_DATA_CHUNKS; i++) {
       this->data_chunk_pool_[i] = new UsbDataChunk();
       this->free_chunks_.push(this->data_chunk_pool_[i]);
-    }
-  }
-  ~USBUartComponent() {
-    for (int i = 0; i < MAX_DATA_CHUNKS; i++) {
-      delete this->data_chunk_pool_[i];
     }
   }
   void setup() override;
@@ -137,14 +132,17 @@ class USBUartComponent : public usb_host::USBClient {
   void start_output(USBUartChannel *channel);
 
   // Lock-free data transfer from USB task to main loop
-  LockFreeQueue<UsbDataChunk, 32> usb_data_queue_;
+  static constexpr int USB_DATA_QUEUE_SIZE = 32;
+  LockFreeQueue<UsbDataChunk, USB_DATA_QUEUE_SIZE> usb_data_queue_;
 
  protected:
   std::vector<USBUartChannel *> channels_{};
 
   // Pool of pre-allocated data chunks to avoid dynamic allocation
-  static constexpr int MAX_DATA_CHUNKS = 32;
+  static constexpr int MAX_DATA_CHUNKS = 40;
   UsbDataChunk *data_chunk_pool_[MAX_DATA_CHUNKS];
+  // IMPORTANT: This is used bidirectionally (USB task pops, main loop pushes)
+  // which technically violates SPSC, but works in practice because operations are atomic
   LockFreeQueue<UsbDataChunk, MAX_DATA_CHUNKS> free_chunks_;
 };
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -6,6 +6,7 @@
 #include "esphome/components/uart/uart_component.h"
 #include "esphome/components/usb_host/usb_host.h"
 #include "esphome/core/lock_free_queue.h"
+#include "esphome/core/event_pool.h"
 
 namespace esphome {
 namespace usb_uart {
@@ -76,6 +77,12 @@ struct UsbDataChunk {
   uint8_t data[MAX_CHUNK_SIZE];
   size_t length;
   USBUartChannel *channel;
+
+  // Required for EventPool - reset to clean state
+  void release() {
+    this->length = 0;
+    this->channel = nullptr;
+  }
 };
 
 class USBUartChannel : public uart::UARTComponent, public Parented<USBUartComponent> {
@@ -114,13 +121,7 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
 
 class USBUartComponent : public usb_host::USBClient {
  public:
-  USBUartComponent(uint16_t vid, uint16_t pid) : usb_host::USBClient(vid, pid) {
-    // Allocate pool of data chunks (never freed - ESPHome reboots instead)
-    for (int i = 0; i < MAX_DATA_CHUNKS; i++) {
-      this->data_chunk_pool_[i] = new UsbDataChunk();
-      this->free_chunks_.push(this->data_chunk_pool_[i]);
-    }
-  }
+  USBUartComponent(uint16_t vid, uint16_t pid) : usb_host::USBClient(vid, pid) {}
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -135,15 +136,12 @@ class USBUartComponent : public usb_host::USBClient {
   static constexpr int USB_DATA_QUEUE_SIZE = 32;
   LockFreeQueue<UsbDataChunk, USB_DATA_QUEUE_SIZE> usb_data_queue_;
 
+  // Pool for allocating data chunks (uses EventPool pattern like BLE)
+  static constexpr int MAX_DATA_CHUNKS = 40;
+  EventPool<UsbDataChunk, MAX_DATA_CHUNKS> chunk_pool_;
+
  protected:
   std::vector<USBUartChannel *> channels_{};
-
-  // Pool of pre-allocated data chunks to avoid dynamic allocation
-  static constexpr int MAX_DATA_CHUNKS = 40;
-  UsbDataChunk *data_chunk_pool_[MAX_DATA_CHUNKS];
-  // IMPORTANT: This is used bidirectionally (USB task pops, main loop pushes)
-  // which technically violates SPSC, but works in practice because operations are atomic
-  LockFreeQueue<UsbDataChunk, MAX_DATA_CHUNKS> free_chunks_;
 };
 
 class USBUartTypeCdcAcm : public USBUartComponent {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -75,7 +75,7 @@ class RingBuffer {
 struct UsbDataChunk {
   static constexpr size_t MAX_CHUNK_SIZE = 64;  // USB packet size
   uint8_t data[MAX_CHUNK_SIZE];
-  size_t length;
+  uint8_t length;  // Max 64 bytes, so uint8_t is sufficient
   USBUartChannel *channel;
 
   // Required for EventPool - reset to clean state


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes frame corruption and data loss in USB UART communication by moving USB event handling to a dedicated FreeRTOS task. Previously, `usb_host_client_handle_events()` was called in the main loop, which could cause USB events to be dropped when the main loop was blocked by other operations, leading to corrupted data frames.

The fix implements a dedicated USB task that continuously processes USB events, ensuring reliable data transfer even when the main loop is busy. This architecture matches the pattern used by ESP32 BLE and other components that require real-time event processing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- discovered while testing #10836 (zero-copy implementation for zwave)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing API changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
# Example USB UART configuration remains the same:

usb_host:

usb_uart:
  - id: zwave
    vid: 0x0658
    pid: 0x0200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).