### PR TITLE
[esp32_ble] Reduce RAM usage and firmware size by disabling unused GATT functionality

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -242,6 +242,19 @@ def final_validation(config):
                 f"Name '{name}' is too long, maximum length is {max_length} characters"
             )
 
+    # Set GATT Client/Server sdkconfig options based on which components are loaded
+    full_config = fv.full_config.get()
+
+    # Check if BLE Server is needed
+    has_ble_server = "esp32_ble_server" in full_config
+    add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server)
+
+    # Check if BLE Client is needed (via esp32_ble_tracker or esp32_ble_client)
+    has_ble_client = (
+        "esp32_ble_tracker" in full_config or "esp32_ble_client" in full_config
+    )
+    add_idf_sdkconfig_option("CONFIG_BT_GATTC_ENABLE", has_ble_client)
+
     return config
 
 

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -319,6 +319,7 @@ void ESP32BLE::loop() {
         break;
       }
 #endif
+#ifdef USE_ESP32_BLE_CLIENT
       case BLEEvent::GATTC: {
         esp_gattc_cb_event_t event = ble_event->event_.gattc.gattc_event;
         esp_gatt_if_t gattc_if = ble_event->event_.gattc.gattc_if;
@@ -329,6 +330,7 @@ void ESP32BLE::loop() {
         }
         break;
       }
+#endif
       case BLEEvent::GAP: {
         esp_gap_ble_cb_event_t gap_event = ble_event->event_.gap.gap_event;
         switch (gap_event) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -424,13 +424,17 @@ void load_ble_event(BLEEvent *event, esp_gap_ble_cb_event_t e, esp_ble_gap_cb_pa
   event->load_gap_event(e, p);
 }
 
+#ifdef USE_ESP32_BLE_CLIENT
 void load_ble_event(BLEEvent *event, esp_gattc_cb_event_t e, esp_gatt_if_t i, esp_ble_gattc_cb_param_t *p) {
   event->load_gattc_event(e, i, p);
 }
+#endif
 
+#ifdef USE_ESP32_BLE_SERVER
 void load_ble_event(BLEEvent *event, esp_gatts_cb_event_t e, esp_gatt_if_t i, esp_ble_gatts_cb_param_t *p) {
   event->load_gatts_event(e, i, p);
 }
+#endif
 
 template<typename... Args> void enqueue_ble_event(Args... args) {
   // Allocate an event from the pool
@@ -451,8 +455,12 @@ template<typename... Args> void enqueue_ble_event(Args... args) {
 
 // Explicit template instantiations for the friend function
 template void enqueue_ble_event(esp_gap_ble_cb_event_t, esp_ble_gap_cb_param_t *);
+#ifdef USE_ESP32_BLE_SERVER
 template void enqueue_ble_event(esp_gatts_cb_event_t, esp_gatt_if_t, esp_ble_gatts_cb_param_t *);
+#endif
+#ifdef USE_ESP32_BLE_CLIENT
 template void enqueue_ble_event(esp_gattc_cb_event_t, esp_gatt_if_t, esp_ble_gattc_cb_param_t *);
+#endif
 
 void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param) {
   switch (event) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -167,6 +167,7 @@ bool ESP32BLE::ble_setup_() {
     }
   }
 
+#ifdef USE_ESP32_BLE_SERVER
   if (!this->gatts_event_handlers_.empty()) {
     err = esp_ble_gatts_register_callback(ESP32BLE::gatts_event_handler);
     if (err != ESP_OK) {
@@ -174,7 +175,9 @@ bool ESP32BLE::ble_setup_() {
       return false;
     }
   }
+#endif
 
+#ifdef USE_ESP32_BLE_CLIENT
   if (!this->gattc_event_handlers_.empty()) {
     err = esp_ble_gattc_register_callback(ESP32BLE::gattc_event_handler);
     if (err != ESP_OK) {
@@ -182,6 +185,7 @@ bool ESP32BLE::ble_setup_() {
       return false;
     }
   }
+#endif
 
   std::string name;
   if (this->name_.has_value()) {
@@ -303,6 +307,7 @@ void ESP32BLE::loop() {
   BLEEvent *ble_event = this->ble_events_.pop();
   while (ble_event != nullptr) {
     switch (ble_event->type_) {
+#ifdef USE_ESP32_BLE_SERVER
       case BLEEvent::GATTS: {
         esp_gatts_cb_event_t event = ble_event->event_.gatts.gatts_event;
         esp_gatt_if_t gatts_if = ble_event->event_.gatts.gatts_if;
@@ -313,6 +318,7 @@ void ESP32BLE::loop() {
         }
         break;
       }
+#endif
       case BLEEvent::GATTC: {
         esp_gattc_cb_event_t event = ble_event->event_.gattc.gattc_event;
         esp_gatt_if_t gattc_if = ble_event->event_.gattc.gattc_if;
@@ -484,15 +490,19 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
   ESP_LOGW(TAG, "Ignoring unexpected GAP event type: %d", event);
 }
 
+#ifdef USE_ESP32_BLE_SERVER
 void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) {
   enqueue_ble_event(event, gatts_if, param);
 }
+#endif
 
+#ifdef USE_ESP32_BLE_CLIENT
 void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) {
   enqueue_ble_event(event, gattc_if, param);
 }
+#endif
 
 float ESP32BLE::get_setup_priority() const { return setup_priority::BLUETOOTH; }
 

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -131,8 +131,12 @@ class ESP32BLE : public Component {
   void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
 
  protected:
+#ifdef USE_ESP32_BLE_SERVER
   static void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
+#endif
+#ifdef USE_ESP32_BLE_CLIENT
   static void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if, esp_ble_gattc_cb_param_t *param);
+#endif
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
   bool ble_setup_();

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -74,17 +74,21 @@ class GAPScanEventHandler {
   virtual void gap_scan_event_handler(const BLEScanResult &scan_result) = 0;
 };
 
+#ifdef USE_ESP32_BLE_CLIENT
 class GATTcEventHandler {
  public:
   virtual void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) = 0;
 };
+#endif
 
+#ifdef USE_ESP32_BLE_SERVER
 class GATTsEventHandler {
  public:
   virtual void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) = 0;
 };
+#endif
 
 class BLEStatusEventHandler {
  public:
@@ -123,8 +127,12 @@ class ESP32BLE : public Component {
   void register_gap_scan_event_handler(GAPScanEventHandler *handler) {
     this->gap_scan_event_handlers_.push_back(handler);
   }
+#ifdef USE_ESP32_BLE_CLIENT
   void register_gattc_event_handler(GATTcEventHandler *handler) { this->gattc_event_handlers_.push_back(handler); }
+#endif
+#ifdef USE_ESP32_BLE_SERVER
   void register_gatts_event_handler(GATTsEventHandler *handler) { this->gatts_event_handlers_.push_back(handler); }
+#endif
   void register_ble_status_event_handler(BLEStatusEventHandler *handler) {
     this->ble_status_event_handlers_.push_back(handler);
   }
@@ -152,8 +160,12 @@ class ESP32BLE : public Component {
   // Vectors (12 bytes each on 32-bit, naturally aligned to 4 bytes)
   std::vector<GAPEventHandler *> gap_event_handlers_;
   std::vector<GAPScanEventHandler *> gap_scan_event_handlers_;
+#ifdef USE_ESP32_BLE_CLIENT
   std::vector<GATTcEventHandler *> gattc_event_handlers_;
+#endif
+#ifdef USE_ESP32_BLE_SERVER
   std::vector<GATTsEventHandler *> gatts_event_handlers_;
+#endif
   std::vector<BLEStatusEventHandler *> ble_status_event_handlers_;
 
   // Large objects (size depends on template parameters, but typically aligned to 4 bytes)


### PR DESCRIPTION
# What does this implement/fix?

This PR automatically disables unused GATT Client (GATTC) and GATT Server (GATTS) functionality in the ESP32 BLE stack to reduce both RAM usage and firmware size. The optimization detects which BLE components are actually being used and only enables the required GATT functionality.

**Memory & Size Improvements:**
- **Runtime RAM**: +2-17KB available heap memory across various ESP32 devices
- **Compile-time RAM**: ~2KB reduction in static RAM usage
- **Flash Storage**: ~36KB reduction in firmware size (from 908KB to 871KB)

The optimization works by:
1. Checking which components are loaded (`esp32_ble_server`, `esp32_ble_tracker`, etc.)
2. Setting `CONFIG_BT_GATTS_ENABLE` and `CONFIG_BT_GATTC_ENABLE` accordingly in the sdkconfig
3. Using existing defines (`USE_ESP32_BLE_SERVER`, `USE_ESP32_BLE_CLIENT`) for conditional compilation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

This addresses memory constraints on ESP32 devices, particularly beneficial for BLE proxy/tracker configurations that don't need server functionality.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - This is an internal optimization that requires no user configuration changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - optimization is automatic

# Example 1: BLE Server only (GATTS enabled, GATTC disabled)
esp32_ble:
esp32_ble_server:
  services:
    - uuid: "4fafc201-1fb5-459e-8fcc-c5c9c331914b"
      characteristics:
        - uuid: "beb5483e-36e1-4688-b7f5-ea07361b26a8"

# Example 2: BLE Tracker only (GATTC enabled, GATTS disabled)
esp32_ble:
esp32_ble_tracker:
  scan_parameters:
    interval: 1100ms

# Example 3: Both disabled (minimal BLE, maximum RAM savings)
esp32_ble:
  enable_on_boot: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
