### PR TITLE
[sim800l] Fixed ignoring incoming calls.

### DIFF
--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -288,11 +288,15 @@ void Sim800LComponent::parse_cmd_(std::string message) {
           if (item == 3) {  // stat
             uint8_t current_call_state = parse_number<uint8_t>(message.substr(start, end - start)).value_or(6);
             if (current_call_state != this->call_state_) {
-              ESP_LOGD(TAG, "Call state is now: %d", current_call_state);
-              if (current_call_state == 0)
-                this->call_connected_callback_.call();
+              if (current_call_state == 4) {
+                ESP_LOGV(TAG, "Premature call state '4'. Ignoring, waiting for RING");    
+              } else {
+                this->call_state_ = current_call_state;
+                ESP_LOGD(TAG, "Call state is now: %d", current_call_state);
+                if (current_call_state == 0)
+                  this->call_connected_callback_.call();
+              }
             }
-            this->call_state_ = current_call_state;
             break;
           }
           // item 4 = ""

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -289,7 +289,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
             uint8_t current_call_state = parse_number<uint8_t>(message.substr(start, end - start)).value_or(6);
             if (current_call_state != this->call_state_) {
               if (current_call_state == 4) {
-                ESP_LOGV(TAG, "Premature call state '4'. Ignoring, waiting for RING");    
+                ESP_LOGV(TAG, "Premature call state '4'. Ignoring, waiting for RING");
               } else {
                 this->call_state_ = current_call_state;
                 ESP_LOGD(TAG, "Call state is now: %d", current_call_state);


### PR DESCRIPTION
# What does this implement/fix?

In some cases, the `sim800l` component doesn't react to incoming voice calls (the `on_incoming_call` action doesn't trigger).

This happens when a call arrives approximately at the same moment when the component is checking the call status (`AT+CLCC`).

The `+CLCC` response sets `call_state_` to `4`, which causes the subsequent processing of the incoming `+CLIP` to mistakenly assume that the `incoming_call_callback_` has already been called, so it doesn't trigger it.

This fix adds an additional call state check when processing `+CLCC` and doesn't transition to state `4` if there was no `RING` command.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10864

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: ${device_name}
  
esp32:
  board: esp32dev

logger:
  baud_rate: 0
  level: VERBOSE

text_sensor:
  - platform: template
    id: caller_id_text_sensor
    name: Caller ID

uart:
  baud_rate: 9600
  tx_pin: GPIO27
  rx_pin: GPIO26

sim800l:
  on_incoming_call:
    - lambda: |-
        id(caller_id_text_sensor).publish_state(caller_id);
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
