### PR TITLE
[inkplate] Added inkplate6 COLOR support

### DIFF
--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -246,8 +246,8 @@ async def to_code(config):
         # Define USE_INKPLATE_I2C for conditional I2C compilation
         cg.add_define("USE_INKPLATE_I2C")
     else:
-        # SPI models don't use the I2C fields from schema
-        pass
+        # SPI models need SPI functionality available for compilation
+        cg.add_define("USE_SPI")
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -5,6 +5,7 @@ from esphome.components.esp32 import CONF_CPU_FREQUENCY
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FULL_UPDATE_EVERY,
+    CONF_I2C_ID,
     CONF_ID,
     CONF_LAMBDA,
     CONF_MIRROR_X,
@@ -20,7 +21,7 @@ import esphome.final_validate as fv
 
 from .const import INKPLATE_10_CUSTOM_WAVEFORMS, WAVEFORMS
 
-DEPENDENCIES = ["i2c", "esp32"]
+DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["psram"]
 
 CONF_DISPLAY_DATA_0_PIN = "display_data_0_pin"
@@ -44,6 +45,14 @@ CONF_SPH_PIN = "sph_pin"
 CONF_SPV_PIN = "spv_pin"
 CONF_VCOM_PIN = "vcom_pin"
 
+# SPI pins for COLOR model
+CONF_EPAPER_RST_PIN = "epaper_rst_pin"
+CONF_EPAPER_DC_PIN = "epaper_dc_pin"
+CONF_EPAPER_CS_PIN = "epaper_cs_pin"
+CONF_EPAPER_BUSY_PIN = "epaper_busy_pin"
+CONF_CLK_PIN = "clk_pin"
+CONF_MOSI_PIN = "mosi_pin"
+
 inkplate_ns = cg.esphome_ns.namespace("inkplate")
 Inkplate = inkplate_ns.class_(
     "Inkplate",
@@ -62,14 +71,66 @@ MODELS = {
     "inkplate_6_v2": InkplateModel.INKPLATE_6_V2,
     "inkplate_5": InkplateModel.INKPLATE_5,
     "inkplate_5_v2": InkplateModel.INKPLATE_5_V2,
+    "inkplate_6_color": InkplateModel.INKPLATE_6_COLOR,
 }
 
+# Models that use SPI communication instead of parallel GPIO
+SPI_MODELS = ["inkplate_6_color"]
+
 CONF_CUSTOM_WAVEFORM = "custom_waveform"
+
+
+def _is_spi_model(model):
+    """Check if the given model uses SPI communication."""
+    return model in SPI_MODELS
+
+
+def _is_parallel_model(model):
+    """Check if the given model uses parallel GPIO communication."""
+    return not _is_spi_model(model)
 
 
 def _validate_custom_waveform(config):
     if CONF_CUSTOM_WAVEFORM in config and config[CONF_MODEL] != "inkplate_10":
         raise cv.Invalid("Custom waveforms are only supported on the Inkplate 10")
+    return config
+
+
+def _validate_pins_for_model(config):
+    model = config[CONF_MODEL]
+
+    if _is_parallel_model(model):
+        # Note: I2C_ID validation is handled in to_code function
+
+        # Parallel GPIO models require these control pins
+        required_parallel_pins = [
+            CONF_CKV_PIN,
+            CONF_GMOD_PIN,
+            CONF_GPIO0_ENABLE_PIN,
+            CONF_OE_PIN,
+            CONF_POWERUP_PIN,
+            CONF_SPH_PIN,
+            CONF_SPV_PIN,
+            CONF_VCOM_PIN,
+            CONF_WAKEUP_PIN,
+        ]
+        missing_pins = [pin for pin in required_parallel_pins if pin not in config]
+        if missing_pins:
+            raise cv.Invalid(
+                f"Parallel GPIO models require the following pins: {', '.join(missing_pins)}"
+            )
+
+    elif _is_spi_model(model):
+        # SPI models will have defaults applied in to_code function
+        # No validation needed here since defaults will be applied automatically
+        pass
+
+    return config
+
+
+def _apply_defaults_for_model(config):
+    """Apply model-specific defaults to configuration."""
+    # Defaults will be handled in to_code function to avoid pin schema issues
     return config
 
 
@@ -92,49 +153,53 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
                 MODELS, lower=True, space="_"
             ),
-            # Control pins
-            cv.Required(CONF_CKV_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_GMOD_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_GPIO0_ENABLE_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_OE_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_POWERUP_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_SPH_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_SPV_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_VCOM_PIN): pins.gpio_output_pin_schema,
-            cv.Required(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
+            # Control pins (for non-COLOR models)
+            cv.Optional(CONF_CKV_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_GMOD_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_GPIO0_ENABLE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_POWERUP_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_SPH_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_SPV_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_VCOM_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
+            # SPI pins
+            cv.Optional(CONF_EPAPER_RST_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_EPAPER_DC_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_EPAPER_CS_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(
+                "cs_pin"
+            ): pins.gpio_output_pin_schema,  # Alternative to epaper_cs_pin
+            cv.Optional(CONF_EPAPER_BUSY_PIN): pins.gpio_input_pin_schema,
+            cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+            cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_CL_PIN, default=0): pins.internal_gpio_output_pin_schema,
             cv.Optional(CONF_LE_PIN, default=2): pins.internal_gpio_output_pin_schema,
             # Data pins
-            cv.Optional(
-                CONF_DISPLAY_DATA_0_PIN, default=4
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_1_PIN, default=5
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_2_PIN, default=18
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_3_PIN, default=19
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_4_PIN, default=23
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_5_PIN, default=25
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_6_PIN, default=26
-            ): pins.internal_gpio_output_pin_schema,
-            cv.Optional(
-                CONF_DISPLAY_DATA_7_PIN, default=27
-            ): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_0_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_1_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_2_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_3_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_4_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_5_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_6_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_DISPLAY_DATA_7_PIN): pins.internal_gpio_output_pin_schema,
         }
     )
     .extend(cv.polling_component_schema("5s"))
-    .extend(i2c.i2c_device_schema(0x48)),
+    .extend(
+        cv.Schema(
+            {
+                # I2C configuration (automatically assigned for all models, used only by parallel models)
+                cv.GenerateID(CONF_I2C_ID): cv.use_id(i2c.I2CBus),
+                cv.Optional("address", default=0x48): cv.i2c_address,
+            }
+        )
+    ),
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
     _validate_custom_waveform,
+    _apply_defaults_for_model,
+    _validate_pins_for_model,
 )
 
 
@@ -154,7 +219,13 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     await display.register_display(var, config)
-    await i2c.register_i2c_device(var, config)
+
+    # Only register with I2C for parallel GPIO models
+    # SPI models handle their own communication without ESPHome SPI component
+    if _is_parallel_model(config[CONF_MODEL]):
+        await i2c.register_i2c_device(var, config)
+        # Define USE_INKPLATE_I2C for conditional I2C compilation
+        cg.add_define("USE_INKPLATE_I2C")
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(
@@ -175,64 +246,103 @@ async def to_code(config):
         waveform = INKPLATE_10_CUSTOM_WAVEFORMS[custom_waveform - 1]
         waveform = [element for tupl in waveform for element in tupl]
         cg.add(var.set_waveform(waveform, True))
-    else:
+    elif _is_parallel_model(config[CONF_MODEL]):
         waveform = WAVEFORMS[config[CONF_MODEL]]
         waveform = [element for tupl in waveform for element in tupl]
         cg.add(var.set_waveform(waveform, False))
 
-    ckv = await cg.gpio_pin_expression(config[CONF_CKV_PIN])
-    cg.add(var.set_ckv_pin(ckv))
+    # Set pins based on communication method
+    if _is_spi_model(config[CONF_MODEL]):
+        # Configure SPI communication pins
+        rst = await cg.gpio_pin_expression(config[CONF_EPAPER_RST_PIN])
+        cg.add(var.set_epaper_rst_pin(rst))
 
-    gmod = await cg.gpio_pin_expression(config[CONF_GMOD_PIN])
-    cg.add(var.set_gmod_pin(gmod))
+        dc = await cg.gpio_pin_expression(config[CONF_EPAPER_DC_PIN])
+        cg.add(var.set_epaper_dc_pin(dc))
 
-    gpio0_enable = await cg.gpio_pin_expression(config[CONF_GPIO0_ENABLE_PIN])
-    cg.add(var.set_gpio0_enable_pin(gpio0_enable))
+        # Check for cs_pin first, then epaper_cs_pin
+        if "cs_pin" in config:
+            cs = await cg.gpio_pin_expression(config["cs_pin"])
+        else:
+            cs = await cg.gpio_pin_expression(config[CONF_EPAPER_CS_PIN])
+        cg.add(var.set_epaper_cs_pin(cs))
 
-    oe = await cg.gpio_pin_expression(config[CONF_OE_PIN])
-    cg.add(var.set_oe_pin(oe))
+        busy = await cg.gpio_pin_expression(config[CONF_EPAPER_BUSY_PIN])
+        cg.add(var.set_epaper_busy_pin(busy))
 
-    powerup = await cg.gpio_pin_expression(config[CONF_POWERUP_PIN])
-    cg.add(var.set_powerup_pin(powerup))
+        clk = await cg.gpio_pin_expression(config[CONF_CLK_PIN])
+        cg.add(var.set_epaper_clk_pin(clk))
 
-    sph = await cg.gpio_pin_expression(config[CONF_SPH_PIN])
-    cg.add(var.set_sph_pin(sph))
+        mosi = await cg.gpio_pin_expression(config[CONF_MOSI_PIN])
+        cg.add(var.set_epaper_din_pin(mosi))
 
-    spv = await cg.gpio_pin_expression(config[CONF_SPV_PIN])
-    cg.add(var.set_spv_pin(spv))
+    elif _is_parallel_model(config[CONF_MODEL]):
+        # Configure parallel GPIO control pins
+        if CONF_CKV_PIN in config:
+            ckv = await cg.gpio_pin_expression(config[CONF_CKV_PIN])
+            cg.add(var.set_ckv_pin(ckv))
 
-    vcom = await cg.gpio_pin_expression(config[CONF_VCOM_PIN])
-    cg.add(var.set_vcom_pin(vcom))
+        if CONF_GMOD_PIN in config:
+            gmod = await cg.gpio_pin_expression(config[CONF_GMOD_PIN])
+            cg.add(var.set_gmod_pin(gmod))
 
-    wakeup = await cg.gpio_pin_expression(config[CONF_WAKEUP_PIN])
-    cg.add(var.set_wakeup_pin(wakeup))
+        if CONF_GPIO0_ENABLE_PIN in config:
+            gpio0_enable = await cg.gpio_pin_expression(config[CONF_GPIO0_ENABLE_PIN])
+            cg.add(var.set_gpio0_enable_pin(gpio0_enable))
 
+        if CONF_OE_PIN in config:
+            oe = await cg.gpio_pin_expression(config[CONF_OE_PIN])
+            cg.add(var.set_oe_pin(oe))
+
+        if CONF_POWERUP_PIN in config:
+            powerup = await cg.gpio_pin_expression(config[CONF_POWERUP_PIN])
+            cg.add(var.set_powerup_pin(powerup))
+
+        if CONF_SPH_PIN in config:
+            sph = await cg.gpio_pin_expression(config[CONF_SPH_PIN])
+            cg.add(var.set_sph_pin(sph))
+
+        if CONF_SPV_PIN in config:
+            spv = await cg.gpio_pin_expression(config[CONF_SPV_PIN])
+            cg.add(var.set_spv_pin(spv))
+
+        if CONF_VCOM_PIN in config:
+            vcom = await cg.gpio_pin_expression(config[CONF_VCOM_PIN])
+            cg.add(var.set_vcom_pin(vcom))
+
+        if CONF_WAKEUP_PIN in config:
+            wakeup = await cg.gpio_pin_expression(config[CONF_WAKEUP_PIN])
+            cg.add(var.set_wakeup_pin(wakeup))
+
+    # Set up pins that all models use (even COLOR model uses these for GPIO expander communication)
     cl = await cg.gpio_pin_expression(config[CONF_CL_PIN])
     cg.add(var.set_cl_pin(cl))
 
     le = await cg.gpio_pin_expression(config[CONF_LE_PIN])
     cg.add(var.set_le_pin(le))
 
-    display_data_0 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_0_PIN])
-    cg.add(var.set_display_data_0_pin(display_data_0))
+    # Only set up data pins for parallel GPIO models
+    if _is_parallel_model(config[CONF_MODEL]):
+        display_data_0 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_0_PIN])
+        cg.add(var.set_display_data_0_pin(display_data_0))
 
-    display_data_1 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_1_PIN])
-    cg.add(var.set_display_data_1_pin(display_data_1))
+        display_data_1 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_1_PIN])
+        cg.add(var.set_display_data_1_pin(display_data_1))
 
-    display_data_2 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_2_PIN])
-    cg.add(var.set_display_data_2_pin(display_data_2))
+        display_data_2 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_2_PIN])
+        cg.add(var.set_display_data_2_pin(display_data_2))
 
-    display_data_3 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_3_PIN])
-    cg.add(var.set_display_data_3_pin(display_data_3))
+        display_data_3 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_3_PIN])
+        cg.add(var.set_display_data_3_pin(display_data_3))
 
-    display_data_4 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_4_PIN])
-    cg.add(var.set_display_data_4_pin(display_data_4))
+        display_data_4 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_4_PIN])
+        cg.add(var.set_display_data_4_pin(display_data_4))
 
-    display_data_5 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_5_PIN])
-    cg.add(var.set_display_data_5_pin(display_data_5))
+        display_data_5 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_5_PIN])
+        cg.add(var.set_display_data_5_pin(display_data_5))
 
-    display_data_6 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_6_PIN])
-    cg.add(var.set_display_data_6_pin(display_data_6))
+        display_data_6 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_6_PIN])
+        cg.add(var.set_display_data_6_pin(display_data_6))
 
-    display_data_7 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_7_PIN])
-    cg.add(var.set_display_data_7_pin(display_data_7))
+        display_data_7 = await cg.gpio_pin_expression(config[CONF_DISPLAY_DATA_7_PIN])
+        cg.add(var.set_display_data_7_pin(display_data_7))

--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -4,12 +4,14 @@ from esphome.components import display, i2c
 from esphome.components.esp32 import CONF_CPU_FREQUENCY
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_CLK_PIN,
     CONF_FULL_UPDATE_EVERY,
     CONF_ID,
     CONF_LAMBDA,
     CONF_MIRROR_X,
     CONF_MIRROR_Y,
     CONF_MODEL,
+    CONF_MOSI_PIN,
     CONF_OE_PIN,
     CONF_PAGES,
     CONF_TRANSFORM,
@@ -49,8 +51,6 @@ CONF_EPAPER_RST_PIN = "epaper_rst_pin"
 CONF_EPAPER_DC_PIN = "epaper_dc_pin"
 CONF_EPAPER_CS_PIN = "epaper_cs_pin"
 CONF_EPAPER_BUSY_PIN = "epaper_busy_pin"
-CONF_CLK_PIN = "clk_pin"
-CONF_MOSI_PIN = "mosi_pin"
 
 inkplate_ns = cg.esphome_ns.namespace("inkplate")
 Inkplate = inkplate_ns.class_(

--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -245,9 +245,6 @@ async def to_code(config):
         await i2c.register_i2c_device(var, config)
         # Define USE_INKPLATE_I2C for conditional I2C compilation
         cg.add_define("USE_INKPLATE_I2C")
-    else:
-        # SPI models need SPI functionality available for compilation
-        cg.add_define("USE_SPI")
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -5,7 +5,6 @@ from esphome.components.esp32 import CONF_CPU_FREQUENCY
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FULL_UPDATE_EVERY,
-    CONF_I2C_ID,
     CONF_ID,
     CONF_LAMBDA,
     CONF_MIRROR_X,
@@ -100,7 +99,9 @@ def _validate_pins_for_model(config):
     model = config[CONF_MODEL]
 
     if _is_parallel_model(model):
-        # Note: I2C_ID validation is handled in to_code function
+        # Parallel models require I2C to be available in the configuration
+        # but i2c_id can be omitted to use the default I2C bus
+        # I2C validation is handled by i2c.register_i2c_device() in to_code
 
         # Parallel GPIO models require these control pins
         required_parallel_pins = [
@@ -134,72 +135,90 @@ def _apply_defaults_for_model(config):
     return config
 
 
-CONFIG_SCHEMA = cv.All(
-    display.FULL_DISPLAY_SCHEMA.extend(
-        {
-            cv.GenerateID(): cv.declare_id(Inkplate),
-            cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
-            cv.Optional(CONF_CUSTOM_WAVEFORM): cv.All(
-                cv.uint8_t, cv.Range(min=1, max=len(INKPLATE_10_CUSTOM_WAVEFORMS))
-            ),
-            cv.Optional(CONF_TRANSFORM): cv.Schema(
-                {
-                    cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
-                    cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
-            cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
-            cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
-                MODELS, lower=True, space="_"
-            ),
-            # Control pins (for non-COLOR models)
-            cv.Optional(CONF_CKV_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_GMOD_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_GPIO0_ENABLE_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_POWERUP_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_SPH_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_SPV_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_VCOM_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
-            # SPI pins
-            cv.Optional(CONF_EPAPER_RST_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_EPAPER_DC_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_EPAPER_CS_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(
-                "cs_pin"
-            ): pins.gpio_output_pin_schema,  # Alternative to epaper_cs_pin
-            cv.Optional(CONF_EPAPER_BUSY_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_CL_PIN, default=0): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_LE_PIN, default=2): pins.internal_gpio_output_pin_schema,
-            # Data pins
-            cv.Optional(CONF_DISPLAY_DATA_0_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_1_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_2_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_3_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_4_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_5_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_6_PIN): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_DISPLAY_DATA_7_PIN): pins.internal_gpio_output_pin_schema,
-        }
-    )
-    .extend(cv.polling_component_schema("5s"))
-    .extend(
-        cv.Schema(
+def _build_schema_for_model(config):
+    """Build the appropriate schema based on model type."""
+    # Just validate - schema building is handled by _conditional_schema
+    return config
+
+
+# Base schema without I2C extension
+_BASE_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(Inkplate),
+        cv.Optional(CONF_GREYSCALE, default=False): cv.boolean,
+        cv.Optional(CONF_CUSTOM_WAVEFORM): cv.All(
+            cv.uint8_t, cv.Range(min=1, max=len(INKPLATE_10_CUSTOM_WAVEFORMS))
+        ),
+        cv.Optional(CONF_TRANSFORM): cv.Schema(
             {
-                # I2C configuration (automatically assigned for all models, used only by parallel models)
-                cv.GenerateID(CONF_I2C_ID): cv.use_id(i2c.I2CBus),
-                cv.Optional("address", default=0x48): cv.i2c_address,
+                cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
             }
-        )
-    ),
+        ),
+        cv.Optional(CONF_PARTIAL_UPDATING, default=True): cv.boolean,
+        cv.Optional(CONF_FULL_UPDATE_EVERY, default=10): cv.uint32_t,
+        cv.Optional(CONF_MODEL, default="inkplate_6"): cv.enum(
+            MODELS, lower=True, space="_"
+        ),
+        # Control pins (for non-COLOR models)
+        cv.Optional(CONF_CKV_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_GMOD_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_GPIO0_ENABLE_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_OE_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_POWERUP_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SPH_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_SPV_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_VCOM_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
+        # SPI pins
+        cv.Optional(CONF_EPAPER_RST_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_EPAPER_DC_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_EPAPER_CS_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(
+            "cs_pin"
+        ): pins.gpio_output_pin_schema,  # Alternative to epaper_cs_pin
+        cv.Optional(CONF_EPAPER_BUSY_PIN): pins.gpio_input_pin_schema,
+        cv.Optional(CONF_CLK_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_MOSI_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_CL_PIN, default=0): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_LE_PIN, default=2): pins.internal_gpio_output_pin_schema,
+        # Data pins
+        cv.Optional(CONF_DISPLAY_DATA_0_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_1_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_2_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_3_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_4_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_5_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_6_PIN): pins.internal_gpio_output_pin_schema,
+        cv.Optional(CONF_DISPLAY_DATA_7_PIN): pins.internal_gpio_output_pin_schema,
+    }
+).extend(cv.polling_component_schema("5s"))
+
+
+def _conditional_schema(value):
+    """Conditionally extend schema based on model."""
+    if not isinstance(value, dict):
+        return value
+
+    model = value.get(CONF_MODEL, "inkplate_6")
+
+    if _is_parallel_model(model):
+        # Apply I2C device schema for parallel models
+        schema = _BASE_SCHEMA.extend(i2c.i2c_device_schema(0x48))
+    else:
+        # SPI models don't need I2C schema
+        schema = _BASE_SCHEMA
+
+    return schema(value)
+
+
+CONFIG_SCHEMA = cv.All(
+    _conditional_schema,
     cv.has_at_most_one_key(CONF_PAGES, CONF_LAMBDA),
     _validate_custom_waveform,
     _apply_defaults_for_model,
     _validate_pins_for_model,
+    _build_schema_for_model,
 )
 
 
@@ -226,6 +245,9 @@ async def to_code(config):
         await i2c.register_i2c_device(var, config)
         # Define USE_INKPLATE_I2C for conditional I2C compilation
         cg.add_define("USE_INKPLATE_I2C")
+    else:
+        # SPI models don't use the I2C fields from schema
+        pass
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -122,6 +122,12 @@ void Inkplate::setup() {
   this->wakeup_pin_->digital_write(false);
 }
 
+Inkplate::~Inkplate() {
+#ifdef USE_ESP32
+  delete this->spi_class_;  // NOLINT(cppcoreguidelines-owning-memory)
+#endif
+}
+
 /**
  * Allocate buffers. May be called after setup to re-initialise if e.g. greyscale is changed.
  */

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -38,7 +38,7 @@ void Inkplate::setup() {
       this->epaper_rst_pin_->digital_write(true);
 
     ESP_LOGD(TAG, "Initializing SPI for SPI-based model");
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
     this->spi_class_ = new SPIClass(VSPI);
     if (this->spi_class_ == nullptr) {
       ESP_LOGE(TAG, "Failed to create SPI class");
@@ -123,7 +123,7 @@ void Inkplate::setup() {
 }
 
 Inkplate::~Inkplate() {
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   delete this->spi_class_;  // NOLINT(cppcoreguidelines-owning-memory)
 #endif
 }
@@ -756,7 +756,7 @@ void Inkplate::display_color_() {
   // Send pixel data via SPI
   ESP_LOGD(TAG, "Sending %d bytes to COLOR display via SPI", this->get_buffer_length_());
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized for pixel data transfer!");
     return;
@@ -851,7 +851,7 @@ void Inkplate::send_command_(uint8_t command) {
 
   ESP_LOGV(TAG, "Sending SPI command: 0x%02X", command);
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;
@@ -878,7 +878,7 @@ void Inkplate::send_data_(uint8_t *data, int length) {
 
   ESP_LOGV(TAG, "Sending SPI data: %d bytes", length);
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;
@@ -903,7 +903,7 @@ void Inkplate::send_data_(uint8_t data) {
   if (!is_spi_model(this->model_))
     return;
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -11,6 +11,52 @@ namespace inkplate {
 static const char *const TAG = "inkplate";
 
 void Inkplate::setup() {
+  ESP_LOGD(TAG, "Inkplate setup starting");
+
+  if (is_spi_model(this->model_)) {
+    ESP_LOGI(TAG, "Setting up Inkplate SPI-based model");
+
+    ESP_LOGD(TAG, "Setting up SPI model pins");
+    if (this->epaper_rst_pin_) {
+      this->epaper_rst_pin_->setup();
+    }
+    if (this->epaper_dc_pin_) {
+      this->epaper_dc_pin_->setup();
+    }
+    if (this->epaper_cs_pin_) {
+      this->epaper_cs_pin_->setup();
+    }
+    if (this->epaper_busy_pin_) {
+      this->epaper_busy_pin_->setup();
+    }
+
+    if (this->epaper_dc_pin_)
+      this->epaper_dc_pin_->digital_write(true);
+    if (this->epaper_cs_pin_)
+      this->epaper_cs_pin_->digital_write(true);
+    if (this->epaper_rst_pin_)
+      this->epaper_rst_pin_->digital_write(true);
+
+    ESP_LOGD(TAG, "Initializing SPI for SPI-based model");
+#ifdef USE_ESP32
+    this->spi_class_ = new SPIClass(VSPI);
+    if (this->spi_class_ == nullptr) {
+      ESP_LOGE(TAG, "Failed to create SPI class");
+      return;
+    }
+
+    this->spi_settings_ = SPISettings(2000000, MSBFIRST, SPI_MODE0);
+    this->spi_class_->begin();
+    ESP_LOGD(TAG, "SPI initialized successfully");
+#endif
+
+    this->initialize_();
+    return;
+  }
+
+  // Setup for parallel GPIO models
+  ESP_LOGD(TAG, "Setting up Inkplate with parallel interface");
+
   for (uint32_t i = 0; i < 256; i++) {
     this->pin_lut_[i] = ((i & 0b00000011) << 4) | (((i & 0b00001100) >> 2) << 18) | (((i & 0b00010000) >> 4) << 23) |
                         (((i & 0b11100000) >> 5) << 25);
@@ -18,37 +64,60 @@ void Inkplate::setup() {
 
   this->initialize_();
 
-  this->vcom_pin_->setup();
-  this->powerup_pin_->setup();
-  this->wakeup_pin_->setup();
-  this->gpio0_enable_pin_->setup();
-  this->gpio0_enable_pin_->digital_write(true);
+  if (this->vcom_pin_)
+    this->vcom_pin_->setup();
+  if (this->powerup_pin_)
+    this->powerup_pin_->setup();
+  if (this->wakeup_pin_)
+    this->wakeup_pin_->setup();
+  if (this->gpio0_enable_pin_)
+    this->gpio0_enable_pin_->setup();
+  if (this->gpio0_enable_pin_)
+    this->gpio0_enable_pin_->digital_write(true);
 
-  this->cl_pin_->setup();
-  this->le_pin_->setup();
-  this->ckv_pin_->setup();
-  this->gmod_pin_->setup();
-  this->oe_pin_->setup();
-  this->sph_pin_->setup();
-  this->spv_pin_->setup();
+  if (this->cl_pin_)
+    this->cl_pin_->setup();
+  if (this->le_pin_)
+    this->le_pin_->setup();
+  if (this->ckv_pin_)
+    this->ckv_pin_->setup();
+  if (this->gmod_pin_)
+    this->gmod_pin_->setup();
+  if (this->oe_pin_)
+    this->oe_pin_->setup();
+  if (this->sph_pin_)
+    this->sph_pin_->setup();
+  if (this->spv_pin_)
+    this->spv_pin_->setup();
 
-  this->display_data_0_pin_->setup();
-  this->display_data_1_pin_->setup();
-  this->display_data_2_pin_->setup();
-  this->display_data_3_pin_->setup();
-  this->display_data_4_pin_->setup();
-  this->display_data_5_pin_->setup();
-  this->display_data_6_pin_->setup();
-  this->display_data_7_pin_->setup();
+  if (this->display_data_0_pin_)
+    this->display_data_0_pin_->setup();
+  if (this->display_data_1_pin_)
+    this->display_data_1_pin_->setup();
+  if (this->display_data_2_pin_)
+    this->display_data_2_pin_->setup();
+  if (this->display_data_3_pin_)
+    this->display_data_3_pin_->setup();
+  if (this->display_data_4_pin_)
+    this->display_data_4_pin_->setup();
+  if (this->display_data_5_pin_)
+    this->display_data_5_pin_->setup();
+  if (this->display_data_6_pin_)
+    this->display_data_6_pin_->setup();
+  if (this->display_data_7_pin_)
+    this->display_data_7_pin_->setup();
 
-  this->wakeup_pin_->digital_write(true);
+  if (this->wakeup_pin_)
+    this->wakeup_pin_->digital_write(true);
   delay(1);
+#ifdef USE_INKPLATE_I2C
   this->write_bytes(0x09, {
                               0b00011011,  // Power up seq.
                               0b00000000,  // Power up delay (3mS per rail)
                               0b00011011,  // Power down seq.
                               0b00000000,  // Power down delay (6mS per rail)
                           });
+#endif
   delay(1);
   this->wakeup_pin_->digital_write(false);
 }
@@ -57,11 +126,17 @@ void Inkplate::setup() {
  * Allocate buffers. May be called after setup to re-initialise if e.g. greyscale is changed.
  */
 void Inkplate::initialize_() {
+  ESP_LOGD(TAG, "Initializing Inkplate buffers");
   RAMAllocator<uint8_t> allocator;
   RAMAllocator<uint32_t> allocator32;
+
   uint32_t buffer_size = this->get_buffer_length_();
-  if (buffer_size == 0)
+  ESP_LOGD(TAG, "Buffer size: %d bytes", buffer_size);
+
+  if (buffer_size == 0) {
+    ESP_LOGW(TAG, "Buffer size is 0, cannot initialize");
     return;
+  }
 
   if (this->partial_buffer_ != nullptr)
     allocator.deallocate(this->partial_buffer_, buffer_size);
@@ -80,7 +155,19 @@ void Inkplate::initialize_() {
     this->mark_failed();
     return;
   }
-  if (this->greyscale_) {
+
+  if (is_spi_model(this->model_)) {
+    ESP_LOGD(TAG, "Allocating SPI model buffers");
+    // SPI models only need the main buffer, no partial buffers or waveform data
+    this->partial_buffer_ = allocator.allocate(buffer_size);
+    if (this->partial_buffer_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate partial buffer for SPI display!");
+      this->mark_failed();
+      return;
+    }
+    memset(this->partial_buffer_, 0, buffer_size);
+    ESP_LOGD(TAG, "SPI model buffers allocated successfully");
+  } else if (this->greyscale_) {
     this->glut_ = allocator32.allocate(256 * GLUT_SIZE);
     if (this->glut_ == nullptr) {
       ESP_LOGE(TAG, "Could not allocate glut!");
@@ -106,6 +193,7 @@ void Inkplate::initialize_() {
     }
 
   } else {
+    // Parallel GPIO, non-greyscale models need partial buffers
     this->partial_buffer_ = allocator.allocate(buffer_size);
     if (this->partial_buffer_ == nullptr) {
       ESP_LOGE(TAG, "Could not allocate partial buffer for display!");
@@ -121,6 +209,7 @@ void Inkplate::initialize_() {
 
     memset(this->partial_buffer_, 0, buffer_size);
     memset(this->partial_buffer_2_, 0, buffer_size * 2);
+    ESP_LOGD(TAG, "Parallel model buffers allocated: %d + %d bytes", buffer_size, buffer_size * 2);
   }
 
   memset(this->buffer_, 0, buffer_size);
@@ -129,7 +218,10 @@ void Inkplate::initialize_() {
 float Inkplate::get_setup_priority() const { return setup_priority::PROCESSOR; }
 
 size_t Inkplate::get_buffer_length_() {
-  if (this->greyscale_) {
+  if (this->model_ == INKPLATE_6_COLOR) {
+    // COLOR model uses 4-bit per pixel (2 pixels per byte)
+    return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 2u;
+  } else if (this->greyscale_) {
     return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 2u;
   } else {
     return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 8u;
@@ -156,7 +248,24 @@ void HOT Inkplate::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (this->mirror_x_)
     x = this->get_width_internal() - x - 1;
 
-  if (this->greyscale_) {
+  if (this->model_ == INKPLATE_6_COLOR) {
+    // COLOR model: 4-bit per pixel, 2 pixels per byte
+    int x1 = x / 2;
+    int x_sub = x % 2;
+    uint32_t pos = (x1 + y * (this->get_width_internal() / 2));
+    uint8_t current = this->partial_buffer_[pos];
+
+    uint8_t color_value = this->map_color_to_palette_(color);
+
+    if (x_sub == 0) {
+      // Left pixel (upper 4 bits)
+      this->partial_buffer_[pos] = (current & 0x0F) | (color_value << 4);
+    } else {
+      // Right pixel (lower 4 bits)
+      this->partial_buffer_[pos] = (current & 0xF0) | color_value;
+    }
+
+  } else if (this->greyscale_) {
     int x1 = x / 2;
     int x_sub = x % 2;
     uint32_t pos = (x1 + y * (this->get_width_internal() / 2));
@@ -226,11 +335,13 @@ void Inkplate::eink_off_() {
 
   this->vcom_pin_->digital_write(false);
 
+#ifdef USE_INKPLATE_I2C
   this->write_byte(0x01, 0x6F);  // Put TPS65186 into standby mode
 
   delay(100);  // NOLINT
 
   this->write_byte(0x01, 0x4f);  // Disable 3V3 to the panel
+#endif
 
   if (this->model_ != INKPLATE_6_PLUS)
     this->wakeup_pin_->digital_write(false);
@@ -249,11 +360,13 @@ void Inkplate::eink_on_() {
   this->vcom_pin_->digital_write(true);
   delay(2);
 
+#ifdef USE_INKPLATE_I2C
   this->write_byte(0x01, 0b00101111);  // Enable all rails
 
   delay(1);
 
   this->write_byte(0x01, 0b10101111);  // Switch TPS65186 into active mode
+#endif
 
   this->le_pin_->digital_write(false);
   this->oe_pin_->digital_write(false);
@@ -281,19 +394,27 @@ void Inkplate::eink_on_() {
 }
 
 bool Inkplate::read_power_status_() {
+#ifdef USE_INKPLATE_I2C
   uint8_t data;
   auto err = this->read_register(0x0F, &data, 1);
   if (err == i2c::ERROR_OK) {
     return data == 0b11111010;
   }
+#endif
   return false;
 }
 
 void Inkplate::fill(Color color) {
-  ESP_LOGV(TAG, "Fill called");
+  ESP_LOGVV(TAG, "Fill called with color R:%d G:%d B:%d", color.red, color.green, color.blue);
   uint32_t start_time = millis();
 
-  if (this->greyscale_) {
+  if (this->model_ == INKPLATE_6_COLOR) {
+    // COLOR model: 4-bit per pixel, 2 pixels per byte
+    uint8_t color_value = this->map_color_to_palette_(color);
+    ESP_LOGVV(TAG, "Mapped color to palette value: 0x%02X", color_value);
+    uint8_t fill_byte = (color_value << 4) | color_value;  // Same color for both pixels in byte
+    memset(this->partial_buffer_, fill_byte, this->get_buffer_length_());
+  } else if (this->greyscale_) {
     uint8_t fill = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
     memset(this->buffer_, (fill << 4) | fill, this->get_buffer_length_());
   } else {
@@ -301,14 +422,16 @@ void Inkplate::fill(Color color) {
     memset(this->partial_buffer_, fill, this->get_buffer_length_());
   }
 
-  ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);
+  ESP_LOGVV(TAG, "Fill completed in %ums", millis() - start_time);
 }
 
 void Inkplate::display() {
   ESP_LOGV(TAG, "Display called");
   uint32_t start_time = millis();
 
-  if (this->greyscale_) {
+  if (is_spi_model(this->model_)) {
+    this->display_color_();
+  } else if (this->greyscale_) {
     this->display3b_();
   } else {
     if (this->partial_updating_ && this->partial_update_()) {
@@ -598,6 +721,330 @@ void Inkplate::display3b_() {
   vscan_start_();
   eink_off_();
   ESP_LOGV(TAG, "Display3b finished (%ums)", millis() - start_time);
+}
+
+void Inkplate::display_color_() {
+  ESP_LOGD(TAG, "Starting COLOR display update");
+  uint32_t start_time = millis();
+
+  // Wake the panel back up
+  if (!this->set_panel_deep_sleep_(false)) {
+    ESP_LOGE(TAG, "Failed to wake panel");
+    return;
+  }
+
+  // Set resolution setting (600x448 for COLOR model)
+  uint8_t res_set_data[] = {0x02, 0x58, 0x01, 0xc0};  // From Arduino library
+  this->send_command_(0x61);                          // Resolution setting register
+  this->send_data_(res_set_data, 4);
+
+  // Push pixel data via SPI
+  this->send_command_(0x10);  // Data start transmission register
+  // Copy buffer data to display
+  memcpy(this->buffer_, this->partial_buffer_, this->get_buffer_length_());
+
+  // Send pixel data via SPI
+  ESP_LOGD(TAG, "Sending %d bytes to COLOR display via SPI", this->get_buffer_length_());
+
+#ifdef USE_ESP32
+  if (this->spi_class_ == nullptr) {
+    ESP_LOGE(TAG, "SPI not initialized for pixel data transfer!");
+    return;
+  }
+
+  this->epaper_dc_pin_->digital_write(true);   // Data mode
+  this->epaper_cs_pin_->digital_write(false);  // Select device
+
+  this->spi_class_->beginTransaction(this->spi_settings_);
+
+  this->spi_class_->writeBytes(this->buffer_, this->get_buffer_length_());
+
+  this->spi_class_->endTransaction();
+
+  this->epaper_cs_pin_->digital_write(true);  // Deselect device
+#endif
+  ESP_LOGD(TAG, "Sent %d bytes of pixel data via SPI", this->get_buffer_length_());
+
+  // Refresh display sequence
+  this->send_command_(0x04);  // Power off register
+  // Wait for busy high signal with timeout
+  ESP_LOGD(TAG, "Waiting for power off complete");
+  ESP_LOGW(TAG, "Initial busy pin state after power off command: %d", this->epaper_busy_pin_->digital_read());
+
+  uint32_t timeout = millis() + 5000;  // 5 second timeout
+  uint32_t loop_count = 0;
+  while (!this->epaper_busy_pin_->digital_read() && millis() < timeout) {
+    delay(1);
+    loop_count++;
+    if (loop_count % 1000 == 0) {  // Log every second and feed watchdog
+      ESP_LOGW(TAG, "Still waiting for busy pin... (count: %d, pin state: %d)", loop_count,
+               this->epaper_busy_pin_->digital_read());
+      App.feed_wdt();  // Feed the watchdog during wait
+    }
+  }
+  if (millis() >= timeout) {
+    ESP_LOGE(TAG, "Timeout waiting for busy pin after power off command (final state: %d)",
+             this->epaper_busy_pin_->digital_read());
+    ESP_LOGE(TAG, "Display may not be responding to SPI commands. Check wiring and SPI initialization.");
+    return;
+  }
+  ESP_LOGW(TAG, "Busy pin went HIGH after power off");
+
+  ESP_LOGW(TAG, "Sending display refresh command...");
+  ESP_LOGW(TAG, "Busy pin state before display refresh command: %d", this->epaper_busy_pin_->digital_read());
+  this->send_command_(0x12);  // Display refresh register
+  // Wait for busy high signal with timeout
+  ESP_LOGW(TAG, "Waiting for busy pin to go HIGH after display refresh...");
+  ESP_LOGW(TAG, "Initial busy pin state after display refresh command: %d", this->epaper_busy_pin_->digital_read());
+  timeout = millis() + 30000;  // 30 second timeout for refresh
+  loop_count = 0;
+  while (!this->epaper_busy_pin_->digital_read() && millis() < timeout) {
+    delay(1);
+    loop_count++;
+    if (loop_count % 1000 == 0) {  // Log every second and feed watchdog
+      ESP_LOGW(TAG, "Still waiting for display refresh... (count: %d, pin state: %d)", loop_count,
+               this->epaper_busy_pin_->digital_read());
+      App.feed_wdt();  // Feed the watchdog during long wait
+    }
+  }
+  if (millis() >= timeout) {
+    ESP_LOGE(TAG, "Timeout waiting for busy pin after display refresh command (final state: %d)",
+             this->epaper_busy_pin_->digital_read());
+    return;
+  }
+  ESP_LOGW(TAG, "Busy pin went HIGH after display refresh");
+
+  this->send_command_(0x02);  // Additional command from Arduino library
+  // Wait for busy low signal with timeout
+  timeout = millis() + 5000;  // 5 second timeout
+  loop_count = 0;
+  while (this->epaper_busy_pin_->digital_read() && millis() < timeout) {
+    delay(1);
+    loop_count++;
+    if (loop_count % 1000 == 0) {  // Feed watchdog every second
+      App.feed_wdt();
+    }
+  }
+  if (millis() >= timeout) {
+    ESP_LOGE(TAG, "Timeout waiting for busy pin to go low after command 0x02");
+  }
+  delay(200);
+
+  // Put the panel to sleep again
+  this->set_panel_deep_sleep_(true);
+
+  ESP_LOGV(TAG, "Display color finished (%ums)", millis() - start_time);
+}
+
+void Inkplate::send_command_(uint8_t command) {
+  if (!is_spi_model(this->model_))
+    return;
+
+  ESP_LOGW(TAG, "Sending SPI command: 0x%02X", command);
+
+#ifdef USE_ESP32
+  if (this->spi_class_ == nullptr) {
+    ESP_LOGE(TAG, "SPI not initialized!");
+    return;
+  }
+
+  ESP_LOGW(TAG, "Setting DC=LOW (command mode), CS=LOW");
+  this->epaper_dc_pin_->digital_write(false);  // Command mode
+  this->epaper_cs_pin_->digital_write(false);  // Select device
+
+  ESP_LOGW(TAG, "Starting SPI transaction for command");
+  this->spi_class_->beginTransaction(this->spi_settings_);
+  this->spi_class_->transfer(command);
+  this->spi_class_->endTransaction();
+  ESP_LOGW(TAG, "Command 0x%02X sent via SPI", command);
+
+  this->epaper_cs_pin_->digital_write(true);  // Deselect device
+  ESP_LOGV(TAG, "SPI Command: 0x%02X", command);
+#endif
+}
+
+void Inkplate::send_data_(uint8_t *data, int length) {
+  if (!is_spi_model(this->model_))
+    return;
+
+  ESP_LOGW(TAG, "Sending SPI data: %d bytes", length);
+
+#ifdef USE_ESP32
+  if (this->spi_class_ == nullptr) {
+    ESP_LOGE(TAG, "SPI not initialized!");
+    return;
+  }
+
+  ESP_LOGW(TAG, "Setting DC=HIGH (data mode), CS=LOW");
+  this->epaper_dc_pin_->digital_write(true);   // Data mode
+  this->epaper_cs_pin_->digital_write(false);  // Select device
+
+  ESP_LOGW(TAG, "Starting SPI transaction for data");
+  this->spi_class_->beginTransaction(this->spi_settings_);
+  this->spi_class_->writeBytes(data, length);
+  this->spi_class_->endTransaction();
+  ESP_LOGW(TAG, "Sent %d bytes of data via SPI", length);
+
+  this->epaper_cs_pin_->digital_write(true);  // Deselect device
+  ESP_LOGV(TAG, "SPI Data: %d bytes", length);
+#endif
+}
+
+void Inkplate::send_data_(uint8_t data) {
+  if (!is_spi_model(this->model_))
+    return;
+
+#ifdef USE_ESP32
+  if (this->spi_class_ == nullptr) {
+    ESP_LOGE(TAG, "SPI not initialized!");
+    return;
+  }
+
+  this->epaper_dc_pin_->digital_write(true);   // Data mode
+  this->epaper_cs_pin_->digital_write(false);  // Select device
+
+  this->spi_class_->beginTransaction(this->spi_settings_);
+  this->spi_class_->transfer(data);
+  this->spi_class_->endTransaction();
+
+  this->epaper_cs_pin_->digital_write(true);  // Deselect device
+  ESP_LOGV(TAG, "SPI Data: 0x%02X", data);
+#endif
+}
+
+bool Inkplate::set_panel_deep_sleep_(bool state) {
+  if (!state) {
+    // Wake the panel - full initialization sequence from Arduino library
+    ESP_LOGW(TAG, "Waking panel with full initialization...");
+
+    // Set pin modes
+    this->epaper_busy_pin_->pin_mode(gpio::FLAG_INPUT);
+    this->epaper_rst_pin_->pin_mode(gpio::FLAG_OUTPUT);
+    this->epaper_dc_pin_->pin_mode(gpio::FLAG_OUTPUT);
+    this->epaper_cs_pin_->pin_mode(gpio::FLAG_OUTPUT);
+
+    // De-select epaper and set initial states
+    this->epaper_dc_pin_->digital_write(true);
+    this->epaper_cs_pin_->digital_write(true);
+
+    // Wait to charge capacitors and avoid big in-rush current
+    delay(100);
+
+    ESP_LOGW(TAG, "Performing reset sequence...");
+
+    // Reset sequence
+    this->epaper_rst_pin_->digital_write(false);
+    delay(1);
+    this->epaper_rst_pin_->digital_write(true);
+    delay(200);
+
+    // Wait for ePaper to be ready by reading busy HIGH signal
+    ESP_LOGW(TAG, "Waiting for panel to be ready after reset...");
+    uint32_t init_timeout = millis() + 10000;  // 10 second timeout
+    while (!this->epaper_busy_pin_->digital_read() && millis() < init_timeout) {
+      delay(1);
+    }
+
+    if (!this->epaper_busy_pin_->digital_read()) {
+      ESP_LOGE(TAG, "Panel not ready after reset - busy pin stuck LOW");
+      return false;
+    }
+    ESP_LOGW(TAG, "Panel ready after reset");
+
+    // Send initialization commands - critical for proper display operation
+    ESP_LOGW(TAG, "Sending panel initialization commands...");
+
+    // Panel setting
+    uint8_t panel_set_data[] = {0xEF, 0x08};
+    this->send_command_(0x00);  // PANEL_SET_REGISTER
+    this->send_data_(panel_set_data, 2);
+
+    // Power setting
+    uint8_t power_set_data[] = {0x37, 0x00, 0x05, 0x05};
+    this->send_command_(0x01);  // POWER_SET_REGISTER
+    this->send_data_(power_set_data, 4);
+
+    // Power off sequence setting
+    this->send_command_(0x03);  // POWER_OFF_SEQ_SET_REGISTER
+    this->send_data_(0x00);
+
+    // Booster soft start
+    uint8_t booster_softstart_data[] = {0xC7, 0xC7, 0x1D};
+    this->send_command_(0x06);  // BOOSTER_SOFTSTART_REGISTER
+    this->send_data_(booster_softstart_data, 3);
+
+    // Temperature sensor enable
+    this->send_command_(0x41);  // TEMP_SENSOR_EN_REGISTER
+    this->send_data_(0x00);
+
+    // VCOM data interval
+    this->send_command_(0x50);  // VCOM_DATA_INTERVAL_REGISTER
+    this->send_data_(0x37);
+
+    ESP_LOGW(TAG, "Panel initialization completed, busy pin state: %d", this->epaper_busy_pin_->digital_read());
+    return true;
+  } else {
+    // Put panel to sleep
+    ESP_LOGW(TAG, "Putting panel to deep sleep...");
+    this->send_command_(0x07);  // Deep sleep command
+    this->send_data_(0xA5);     // Deep sleep data
+    ESP_LOGW(TAG, "Panel put to sleep");
+    return true;
+  }
+}
+
+uint8_t Inkplate::map_color_to_palette_(Color color) {
+  // Map RGB colors to Inkplate COLOR 7-color palette
+  // Based on Inkplate6Color.h definitions:
+  // INKPLATE_BLACK  0b00000000
+  // INKPLATE_WHITE  0b00000001
+  // INKPLATE_GREEN  0b00000010
+  // INKPLATE_BLUE   0b00000011
+  // INKPLATE_RED    0b00000100
+  // INKPLATE_YELLOW 0b00000101
+  // INKPLATE_ORANGE 0b00000110
+
+  uint8_t r = color.red;
+  uint8_t g = color.green;
+  uint8_t b = color.blue;
+
+  // White: high R, G, B
+  if (r > 200 && g > 200 && b > 200) {
+    return 0b00000001;  // INKPLATE_WHITE
+  }
+
+  // Black: low R, G, B
+  if (r < 50 && g < 50 && b < 50) {
+    return 0b00000000;  // INKPLATE_BLACK
+  }
+
+  // Red: high R, low G, B
+  if (r > 150 && g < 100 && b < 100) {
+    return 0b00000100;  // INKPLATE_RED
+  }
+
+  // Green: low R, high G, low B
+  if (r < 100 && g > 150 && b < 100) {
+    return 0b00000010;  // INKPLATE_GREEN
+  }
+
+  // Blue: low R, G, high B
+  if (r < 100 && g < 100 && b > 150) {
+    return 0b00000011;  // INKPLATE_BLUE
+  }
+
+  // Orange: high R, medium-high G, low B (check first since it's more specific)
+  if (r > 200 && g > 80 && g < 200 && b < 80) {
+    return 0b00000110;  // INKPLATE_ORANGE
+  }
+
+  // Yellow: high R, G, low B
+  if (r > 150 && g > 150 && b < 100) {
+    return 0b00000101;  // INKPLATE_YELLOW
+  }
+
+  // Default to black for unrecognized colors
+  return 0b00000000;  // INKPLATE_BLACK
 }
 
 bool Inkplate::partial_update_() {

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -775,7 +775,7 @@ void Inkplate::display_color_() {
   this->send_command_(0x04);  // Power off register
   // Wait for busy high signal with timeout
   ESP_LOGD(TAG, "Waiting for power off complete");
-  ESP_LOGW(TAG, "Initial busy pin state after power off command: %d", this->epaper_busy_pin_->digital_read());
+  ESP_LOGV(TAG, "Initial busy pin state after power off command: %d", this->epaper_busy_pin_->digital_read());
 
   uint32_t timeout = millis() + 5000;  // 5 second timeout
   uint32_t loop_count = 0;
@@ -783,7 +783,7 @@ void Inkplate::display_color_() {
     delay(1);
     loop_count++;
     if (loop_count % 1000 == 0) {  // Log every second and feed watchdog
-      ESP_LOGW(TAG, "Still waiting for busy pin... (count: %d, pin state: %d)", loop_count,
+      ESP_LOGV(TAG, "Still waiting for busy pin... (count: %d, pin state: %d)", loop_count,
                this->epaper_busy_pin_->digital_read());
       App.feed_wdt();  // Feed the watchdog during wait
     }
@@ -794,21 +794,20 @@ void Inkplate::display_color_() {
     ESP_LOGE(TAG, "Display may not be responding to SPI commands. Check wiring and SPI initialization.");
     return;
   }
-  ESP_LOGW(TAG, "Busy pin went HIGH after power off");
-
-  ESP_LOGW(TAG, "Sending display refresh command...");
-  ESP_LOGW(TAG, "Busy pin state before display refresh command: %d", this->epaper_busy_pin_->digital_read());
+  ESP_LOGV(TAG, "Busy pin went HIGH after power off");
+  ESP_LOGD(TAG, "Sending display refresh command...");
+  ESP_LOGV(TAG, "Busy pin state before display refresh command: %d", this->epaper_busy_pin_->digital_read());
   this->send_command_(0x12);  // Display refresh register
   // Wait for busy high signal with timeout
-  ESP_LOGW(TAG, "Waiting for busy pin to go HIGH after display refresh...");
-  ESP_LOGW(TAG, "Initial busy pin state after display refresh command: %d", this->epaper_busy_pin_->digital_read());
+  ESP_LOGD(TAG, "Waiting for busy pin to go HIGH after display refresh...");
+  ESP_LOGD(TAG, "Initial busy pin state after display refresh command: %d", this->epaper_busy_pin_->digital_read());
   timeout = millis() + 30000;  // 30 second timeout for refresh
   loop_count = 0;
   while (!this->epaper_busy_pin_->digital_read() && millis() < timeout) {
     delay(1);
     loop_count++;
     if (loop_count % 1000 == 0) {  // Log every second and feed watchdog
-      ESP_LOGW(TAG, "Still waiting for display refresh... (count: %d, pin state: %d)", loop_count,
+      ESP_LOGV(TAG, "Still waiting for display refresh... (count: %d, pin state: %d)", loop_count,
                this->epaper_busy_pin_->digital_read());
       App.feed_wdt();  // Feed the watchdog during long wait
     }
@@ -818,7 +817,7 @@ void Inkplate::display_color_() {
              this->epaper_busy_pin_->digital_read());
     return;
   }
-  ESP_LOGW(TAG, "Busy pin went HIGH after display refresh");
+  ESP_LOGD(TAG, "Busy pin went HIGH after display refresh");
 
   this->send_command_(0x02);  // Additional command from Arduino library
   // Wait for busy low signal with timeout
@@ -846,7 +845,7 @@ void Inkplate::send_command_(uint8_t command) {
   if (!is_spi_model(this->model_))
     return;
 
-  ESP_LOGW(TAG, "Sending SPI command: 0x%02X", command);
+  ESP_LOGV(TAG, "Sending SPI command: 0x%02X", command);
 
 #ifdef USE_ESP32
   if (this->spi_class_ == nullptr) {
@@ -854,15 +853,15 @@ void Inkplate::send_command_(uint8_t command) {
     return;
   }
 
-  ESP_LOGW(TAG, "Setting DC=LOW (command mode), CS=LOW");
+  ESP_LOGV(TAG, "Setting DC=LOW (command mode), CS=LOW");
   this->epaper_dc_pin_->digital_write(false);  // Command mode
   this->epaper_cs_pin_->digital_write(false);  // Select device
 
-  ESP_LOGW(TAG, "Starting SPI transaction for command");
+  ESP_LOGV(TAG, "Starting SPI transaction for command");
   this->spi_class_->beginTransaction(this->spi_settings_);
   this->spi_class_->transfer(command);
   this->spi_class_->endTransaction();
-  ESP_LOGW(TAG, "Command 0x%02X sent via SPI", command);
+  ESP_LOGV(TAG, "Command 0x%02X sent via SPI", command);
 
   this->epaper_cs_pin_->digital_write(true);  // Deselect device
   ESP_LOGV(TAG, "SPI Command: 0x%02X", command);
@@ -873,7 +872,7 @@ void Inkplate::send_data_(uint8_t *data, int length) {
   if (!is_spi_model(this->model_))
     return;
 
-  ESP_LOGW(TAG, "Sending SPI data: %d bytes", length);
+  ESP_LOGV(TAG, "Sending SPI data: %d bytes", length);
 
 #ifdef USE_ESP32
   if (this->spi_class_ == nullptr) {
@@ -881,15 +880,15 @@ void Inkplate::send_data_(uint8_t *data, int length) {
     return;
   }
 
-  ESP_LOGW(TAG, "Setting DC=HIGH (data mode), CS=LOW");
+  ESP_LOGV(TAG, "Setting DC=HIGH (data mode), CS=LOW");
   this->epaper_dc_pin_->digital_write(true);   // Data mode
   this->epaper_cs_pin_->digital_write(false);  // Select device
 
-  ESP_LOGW(TAG, "Starting SPI transaction for data");
+  ESP_LOGV(TAG, "Starting SPI transaction for data");
   this->spi_class_->beginTransaction(this->spi_settings_);
   this->spi_class_->writeBytes(data, length);
   this->spi_class_->endTransaction();
-  ESP_LOGW(TAG, "Sent %d bytes of data via SPI", length);
+  ESP_LOGV(TAG, "Sent %d bytes of data via SPI", length);
 
   this->epaper_cs_pin_->digital_write(true);  // Deselect device
   ESP_LOGV(TAG, "SPI Data: %d bytes", length);
@@ -921,7 +920,7 @@ void Inkplate::send_data_(uint8_t data) {
 bool Inkplate::set_panel_deep_sleep_(bool state) {
   if (!state) {
     // Wake the panel - full initialization sequence from Arduino library
-    ESP_LOGW(TAG, "Waking panel with full initialization...");
+    ESP_LOGD(TAG, "Waking panel with full initialization...");
 
     // Set pin modes
     this->epaper_busy_pin_->pin_mode(gpio::FLAG_INPUT);
@@ -936,7 +935,7 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
     // Wait to charge capacitors and avoid big in-rush current
     delay(100);
 
-    ESP_LOGW(TAG, "Performing reset sequence...");
+    ESP_LOGD(TAG, "Performing reset sequence...");
 
     // Reset sequence
     this->epaper_rst_pin_->digital_write(false);
@@ -945,7 +944,7 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
     delay(200);
 
     // Wait for ePaper to be ready by reading busy HIGH signal
-    ESP_LOGW(TAG, "Waiting for panel to be ready after reset...");
+    ESP_LOGD(TAG, "Waiting for panel to be ready after reset...");
     uint32_t init_timeout = millis() + 10000;  // 10 second timeout
     while (!this->epaper_busy_pin_->digital_read() && millis() < init_timeout) {
       delay(1);
@@ -955,10 +954,10 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
       ESP_LOGE(TAG, "Panel not ready after reset - busy pin stuck LOW");
       return false;
     }
-    ESP_LOGW(TAG, "Panel ready after reset");
+    ESP_LOGD(TAG, "Panel ready after reset");
 
     // Send initialization commands - critical for proper display operation
-    ESP_LOGW(TAG, "Sending panel initialization commands...");
+    ESP_LOGD(TAG, "Sending panel initialization commands...");
 
     // Panel setting
     uint8_t panel_set_data[] = {0xEF, 0x08};
@@ -987,14 +986,14 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
     this->send_command_(0x50);  // VCOM_DATA_INTERVAL_REGISTER
     this->send_data_(0x37);
 
-    ESP_LOGW(TAG, "Panel initialization completed, busy pin state: %d", this->epaper_busy_pin_->digital_read());
+    ESP_LOGD(TAG, "Panel initialization completed, busy pin state: %d", this->epaper_busy_pin_->digital_read());
     return true;
   } else {
     // Put panel to sleep
-    ESP_LOGW(TAG, "Putting panel to deep sleep...");
+    ESP_LOGD(TAG, "Putting panel to deep sleep...");
     this->send_command_(0x07);  // Deep sleep command
     this->send_data_(0xA5);     // Deep sleep data
-    ESP_LOGW(TAG, "Panel put to sleep");
+    ESP_LOGD(TAG, "Panel put to sleep");
     return true;
   }
 }

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -38,7 +38,7 @@ void Inkplate::setup() {
       this->epaper_rst_pin_->digital_write(true);
 
     ESP_LOGD(TAG, "Initializing SPI for SPI-based model");
-#ifdef USE_ESP32
+#ifdef USE_SPI
     this->spi_class_ = new SPIClass(VSPI);
     if (this->spi_class_ == nullptr) {
       ESP_LOGE(TAG, "Failed to create SPI class");
@@ -123,7 +123,7 @@ void Inkplate::setup() {
 }
 
 Inkplate::~Inkplate() {
-#ifdef USE_ESP32
+#ifdef USE_SPI
   delete this->spi_class_;  // NOLINT(cppcoreguidelines-owning-memory)
 #endif
 }
@@ -756,7 +756,7 @@ void Inkplate::display_color_() {
   // Send pixel data via SPI
   ESP_LOGD(TAG, "Sending %d bytes to COLOR display via SPI", this->get_buffer_length_());
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized for pixel data transfer!");
     return;
@@ -851,7 +851,7 @@ void Inkplate::send_command_(uint8_t command) {
 
   ESP_LOGV(TAG, "Sending SPI command: 0x%02X", command);
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;
@@ -878,7 +878,7 @@ void Inkplate::send_data_(uint8_t *data, int length) {
 
   ESP_LOGV(TAG, "Sending SPI data: %d bytes", length);
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;
@@ -903,7 +903,7 @@ void Inkplate::send_data_(uint8_t data) {
   if (!is_spi_model(this->model_))
     return;
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
   if (this->spi_class_ == nullptr) {
     ESP_LOGE(TAG, "SPI not initialized!");
     return;

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -837,7 +837,7 @@ void Inkplate::display_color_() {
   if (millis() >= timeout) {
     ESP_LOGE(TAG, "Timeout waiting for busy pin to go low after command 0x02");
   }
-  delay(200);
+  delay(200);  // NOLINT
 
   // Put the panel to sleep again
   this->set_panel_deep_sleep_(true);
@@ -937,7 +937,7 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
     this->epaper_cs_pin_->digital_write(true);
 
     // Wait to charge capacitors and avoid big in-rush current
-    delay(100);
+    delay(100);  // NOLINT
 
     ESP_LOGD(TAG, "Performing reset sequence...");
 
@@ -945,7 +945,7 @@ bool Inkplate::set_panel_deep_sleep_(bool state) {
     this->epaper_rst_pin_->digital_write(false);
     delay(1);
     this->epaper_rst_pin_->digital_write(true);
-    delay(200);
+    delay(200);  // NOLINT
 
     // Wait for ePaper to be ready by reading busy HIGH signal
     ESP_LOGD(TAG, "Waiting for panel to be ready after reset...");

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -224,10 +224,8 @@ void Inkplate::initialize_() {
 float Inkplate::get_setup_priority() const { return setup_priority::PROCESSOR; }
 
 size_t Inkplate::get_buffer_length_() {
-  if (this->model_ == INKPLATE_6_COLOR) {
-    // COLOR model uses 4-bit per pixel (2 pixels per byte)
-    return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 2u;
-  } else if (this->greyscale_) {
+  if (this->model_ == INKPLATE_6_COLOR || this->greyscale_) {
+    // COLOR model and greyscale both use 4-bit per pixel (2 pixels per byte)
     return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 2u;
   } else {
     return size_t(this->get_width_internal()) * size_t(this->get_height_internal()) / 8u;
@@ -517,6 +515,9 @@ void Inkplate::display1b_() {
       clean_fast_(0, 11);
       rep = 3;
       break;
+    case INKPLATE_6_COLOR:
+      // COLOR model doesn't support 1-bit display mode
+      break;
   }
 
   uint32_t clock = (1 << this->cl_pin_->get_pin());
@@ -684,6 +685,9 @@ void Inkplate::display3b_() {
       clean_fast_(1, 11);
       clean_fast_(2, 1);
       clean_fast_(0, 11);
+      break;
+    case INKPLATE_6_COLOR:
+      // COLOR model doesn't support 3-bit display mode
       break;
   }
 

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -116,6 +116,8 @@ class Inkplate : public display::DisplayBuffer
 
   void setup() override;
 
+  ~Inkplate();
+
   uint8_t get_panel_state() { return this->panel_on_; }
   bool get_greyscale() { return this->greyscale_; }
   bool get_partial_updating() { return this->partial_updating_; }

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -9,7 +9,7 @@
 #include "esphome/components/i2c/i2c.h"
 #endif
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
 #include <SPI.h>
 #endif
 
@@ -267,7 +267,7 @@ class Inkplate : public display::DisplayBuffer
   GPIOPin *epaper_clk_pin_;
   GPIOPin *epaper_din_pin_;
 
-#ifdef USE_ESP32
+#ifdef USE_SPI
   // SPI communication for SPI-based models
   SPIClass *spi_class_{nullptr};
   SPISettings spi_settings_;

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -1,9 +1,17 @@
 #pragma once
 
 #include "esphome/components/display/display_buffer.h"
-#include "esphome/components/i2c/i2c.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+
+// Only include I2C for parallel GPIO models that need it
+#ifdef USE_INKPLATE_I2C
+#include "esphome/components/i2c/i2c.h"
+#endif
+
+#ifdef USE_ESP32
+#include <SPI.h>
+#endif
 
 #include <array>
 
@@ -17,7 +25,13 @@ enum InkplateModel : uint8_t {
   INKPLATE_6_V2 = 3,
   INKPLATE_5 = 4,
   INKPLATE_5_V2 = 5,
+  INKPLATE_6_COLOR = 6,
 };
+
+// Communication interface helpers for extensibility
+inline bool is_spi_model(InkplateModel model) { return model == INKPLATE_6_COLOR; }
+
+inline bool is_parallel_model(InkplateModel model) { return !is_spi_model(model); }
 
 static constexpr uint8_t GLUT_SIZE = 9;
 static constexpr uint8_t GLUT_COUNT = 8;
@@ -32,7 +46,12 @@ static constexpr uint8_t LUTB[16] = {0xFF, 0xFD, 0xF7, 0xF5, 0xDF, 0xDD, 0xD7, 0
 static constexpr uint8_t PIXEL_MASK_LUT[8] = {0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80};
 static constexpr uint8_t PIXEL_MASK_GLUT[2] = {0x0F, 0xF0};
 
-class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
+class Inkplate : public display::DisplayBuffer
+#ifdef USE_INKPLATE_I2C
+    ,
+                 public i2c::I2CDevice
+#endif
+{
  public:
   void set_greyscale(bool greyscale) {
     this->greyscale_ = greyscale;
@@ -77,6 +96,14 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
   void set_vcom_pin(GPIOPin *vcom) { this->vcom_pin_ = vcom; }
   void set_wakeup_pin(GPIOPin *wakeup) { this->wakeup_pin_ = wakeup; }
 
+  // SPI pins for SPI-based models
+  void set_epaper_rst_pin(GPIOPin *rst) { this->epaper_rst_pin_ = rst; }
+  void set_epaper_dc_pin(GPIOPin *dc) { this->epaper_dc_pin_ = dc; }
+  void set_epaper_cs_pin(GPIOPin *cs) { this->epaper_cs_pin_ = cs; }
+  void set_epaper_busy_pin(GPIOPin *busy) { this->epaper_busy_pin_ = busy; }
+  void set_epaper_clk_pin(GPIOPin *clk) { this->epaper_clk_pin_ = clk; }
+  void set_epaper_din_pin(GPIOPin *din) { this->epaper_din_pin_ = din; }
+
   float get_setup_priority() const override;
 
   void dump_config() override;
@@ -97,6 +124,9 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
   void block_partial() { this->block_partial_ = true; }
 
   display::DisplayType get_display_type() override {
+    if (is_spi_model(this->model_)) {
+      return display::DisplayType::DISPLAY_TYPE_COLOR;
+    }
     return get_greyscale() ? display::DisplayType::DISPLAY_TYPE_GRAYSCALE : display::DisplayType::DISPLAY_TYPE_BINARY;
   }
 
@@ -104,7 +134,15 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
   void display1b_();
   void display3b_();
+  void display_color_();
   void initialize_();
+
+  // SPI communication functions for SPI-based models
+  void send_command_(uint8_t command);
+  void send_data_(uint8_t *data, int length);
+  void send_data_(uint8_t data);
+  bool set_panel_deep_sleep_(bool state);
+  uint8_t map_color_to_palette_(Color color);
   bool partial_update_();
   void clean_fast_(uint8_t c, uint8_t rep);
 
@@ -131,6 +169,11 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
       return 1280;
     } else if (this->model_ == INKPLATE_6_PLUS) {
       return 1024;
+    } else if (is_spi_model(this->model_)) {
+      // SPI-based models (currently only COLOR)
+      if (this->model_ == INKPLATE_6_COLOR) {
+        return 600;
+      }
     }
     return 0;
   }
@@ -146,6 +189,11 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
       return 825;
     } else if (this->model_ == INKPLATE_6_PLUS) {
       return 758;
+    } else if (is_spi_model(this->model_)) {
+      // SPI-based models (currently only COLOR)
+      if (this->model_ == INKPLATE_6_COLOR) {
+        return 448;
+      }
     }
     return 0;
   }
@@ -208,6 +256,20 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
   GPIOPin *spv_pin_;
   GPIOPin *vcom_pin_;
   GPIOPin *wakeup_pin_;
+
+  // SPI pins for SPI-based models
+  GPIOPin *epaper_rst_pin_;
+  GPIOPin *epaper_dc_pin_;
+  GPIOPin *epaper_cs_pin_;
+  GPIOPin *epaper_busy_pin_;
+  GPIOPin *epaper_clk_pin_;
+  GPIOPin *epaper_din_pin_;
+
+#ifdef USE_ESP32
+  // SPI communication for SPI-based models
+  SPIClass *spi_class_{nullptr};
+  SPISettings spi_settings_;
+#endif
 };
 
 }  // namespace inkplate

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -9,7 +9,7 @@
 #include "esphome/components/i2c/i2c.h"
 #endif
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
 #include <SPI.h>
 #endif
 
@@ -267,7 +267,7 @@ class Inkplate : public display::DisplayBuffer
   GPIOPin *epaper_clk_pin_;
   GPIOPin *epaper_din_pin_;
 
-#ifdef USE_SPI
+#ifdef USE_ARDUINO
   // SPI communication for SPI-based models
   SPIClass *spi_class_{nullptr};
   SPISettings spi_settings_;

--- a/esphome/core/color.cpp
+++ b/esphome/core/color.cpp
@@ -5,5 +5,10 @@ namespace esphome {
 // C++20 constinit ensures compile-time initialization (stored in ROM)
 constinit const Color Color::BLACK(0, 0, 0, 0);
 constinit const Color Color::WHITE(255, 255, 255, 255);
+constinit const Color Color::RED(255, 0, 0, 0);
+constinit const Color Color::GREEN(0, 255, 0, 0);
+constinit const Color Color::BLUE(0, 0, 255, 0);
+constinit const Color Color::YELLOW(255, 255, 0, 0);
+constinit const Color Color::ORANGE(255, 166, 0, 0);
 
 }  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -182,6 +182,11 @@ struct Color {
 
   static const Color BLACK;
   static const Color WHITE;
+  static const Color RED;
+  static const Color GREEN;
+  static const Color BLUE;
+  static const Color YELLOW;
+  static const Color ORANGE;
 };
 
 }  // namespace esphome

--- a/tests/components/inkplate/common_6color.yaml
+++ b/tests/components/inkplate/common_6color.yaml
@@ -1,0 +1,22 @@
+# I2C is required by schema but not used by SPI model
+i2c:
+  - id: i2c_inkplate
+    scl: 16
+    sda: 17
+
+esp32:
+  cpu_frequency: 240MHz
+
+display:
+  - platform: inkplate
+    id: inkplate_display
+    model: inkplate_6_color
+    partial_updating: false
+    update_interval: 60s
+    # SPI pins for inkplate_6_color
+    epaper_rst_pin: 19
+    epaper_dc_pin: 33
+    epaper_cs_pin: 27
+    epaper_busy_pin: 32
+    clk_pin: 18
+    mosi_pin: 23

--- a/tests/components/inkplate/common_6color.yaml
+++ b/tests/components/inkplate/common_6color.yaml
@@ -1,9 +1,3 @@
-# I2C is required by schema but not used by SPI model
-i2c:
-  - id: i2c_inkplate
-    scl: 16
-    sda: 17
-
 esp32:
   cpu_frequency: 240MHz
 

--- a/tests/components/inkplate/test_color.esp32-ard.yaml
+++ b/tests/components/inkplate/test_color.esp32-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common_6color.yaml

--- a/tests/components/inkplate/test_color.esp32-idf.yaml
+++ b/tests/components/inkplate/test_color.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common_6color.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support for the Inkplate 6 COLOR, and paves the way for future SPI-based inkplates (2, 4, 5, and 7).

Much of the code here mimics the first-party Arduino library for driving this display.

There is a lot of added complexity in here around adding SPI to the existing I2C stuff.
The schema is much more complex now, and I didn't try to make I2C completely optional, which would require even more change. I could try this on a subsequent PR?

I tried to make it a little bit generic, so that we are casing on if a model is SPI or I2C, and NOT just COLOR or not. In practice it isn't that clear, and it can further be refined when we add the _next_ SPI-based inkplate (which I don't own).

Also I added some color consts to make it easier to use without every user having to manually define, ORANGE.

Also, it works! :)

![PXL_20250924_173012327](https://github.com/user-attachments/assets/0ea1fddf-aa0a-4d52-8184-f079cdcbb6c5)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [1942](https://github.com/esphome/feature-requests/issues/1942)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5418

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
substitutions:
  name: inkplate3
  friendly_name: Inkplate 3
  static_ip: "10.0.2.84"

<<: !include common.yaml

esp32:
  board: esp32dev
  framework:
    type: arduino
  cpu_frequency: 240MHz

api:
  reboot_timeout: 0s

# I2C is required by schema but not used by SPI model  
i2c:


font:
  - file: "fonts/Roboto-Bold.ttf"
    id: font_medium
    size: 24
  - file: "fonts/Roboto-Bold.ttf"
    id: font_large
    size: 48

display:
- platform: inkplate
  id: inkplate_display
  model: inkplate_6_color
  partial_updating: false  
  update_interval: 600s
  # SPI pins for inkplate_6_color
  epaper_rst_pin: 19
  epaper_dc_pin: 33
  epaper_cs_pin: 27
  epaper_busy_pin: 32
  clk_pin: 18
  mosi_pin: 23
  lambda: |-
    // Fill background with white
    it.fill(Color::WHITE);
    
    // Draw colorful test patterns for COLOR display
    it.filled_rectangle(50, 50, 100, 80, Color::RED);
    it.print(60, 70, id(font_medium), Color::WHITE, "RED");
    
    it.filled_rectangle(200, 50, 100, 80, Color::GREEN);
    it.print(210, 70, id(font_medium), Color::WHITE, "GREEN");
    
    it.filled_rectangle(350, 50, 100, 80, Color::BLUE);
    it.print(360, 70, id(font_medium), Color::WHITE, "BLUE");
    
    it.filled_rectangle(50, 180, 100, 80, Color::YELLOW);
    it.print(60, 200, id(font_medium), Color::BLACK, "YELLOW");
    
    it.filled_rectangle(200, 180, 100, 80, Color::ORANGE);
    it.print(210, 200, id(font_medium), Color::BLACK, "ORANGE");
    
    // Draw some black shapes
    it.filled_rectangle(350, 180, 100, 80, Color::BLACK);
    it.print(360, 200, id(font_medium), Color::WHITE, "BLACK");
    
    // Title
    it.print(60, 320, id(font_large), Color::BLACK, "Inkplate COLOR Test");

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
