### PR TITLE
[core] Rename to clean-platform to clean-all

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -731,11 +731,11 @@ def command_clean_mqtt(args: ArgsProtocol, config: ConfigType) -> int | None:
     return clean_mqtt(config, args)
 
 
-def command_clean_platform(args: ArgsProtocol, config: ConfigType) -> int | None:
+def command_clean_all(args: ArgsProtocol) -> int | None:
     try:
-        writer.clean_platform()
+        writer.clean_all(args.configuration)
     except OSError as err:
-        _LOGGER.error("Error deleting platform files: %s", err)
+        _LOGGER.error("Error cleaning all files: %s", err)
         return 1
     _LOGGER.info("Done!")
     return 0
@@ -931,6 +931,7 @@ PRE_CONFIG_ACTIONS = {
     "dashboard": command_dashboard,
     "vscode": command_vscode,
     "update-all": command_update_all,
+    "clean-all": command_clean_all,
 }
 
 POST_CONFIG_ACTIONS = {
@@ -941,7 +942,6 @@ POST_CONFIG_ACTIONS = {
     "run": command_run,
     "clean": command_clean,
     "clean-mqtt": command_clean_mqtt,
-    "clean-platform": command_clean_platform,
     "mqtt-fingerprint": command_mqtt_fingerprint,
     "idedata": command_idedata,
     "rename": command_rename,
@@ -951,7 +951,6 @@ POST_CONFIG_ACTIONS = {
 SIMPLE_CONFIG_ACTIONS = [
     "clean",
     "clean-mqtt",
-    "clean-platform",
     "config",
 ]
 
@@ -1156,11 +1155,9 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file(s).", nargs="+"
     )
 
-    parser_clean = subparsers.add_parser(
-        "clean-platform", help="Delete all platform files."
-    )
-    parser_clean.add_argument(
-        "configuration", help="Your YAML configuration file(s).", nargs="+"
+    parser_clean_all = subparsers.add_parser("clean-all", help="Clean all files.")
+    parser_clean_all.add_argument(
+        "configuration", help="Your YAML configuration directory.", nargs="*"
     )
 
     parser_dashboard = subparsers.add_parser(
@@ -1209,7 +1206,7 @@ def parse_args(argv):
 
     parser_update = subparsers.add_parser("update-all")
     parser_update.add_argument(
-        "configuration", help="Your YAML configuration file directories.", nargs="+"
+        "configuration", help="Your YAML configuration file or directory.", nargs="+"
     )
 
     parser_idedata = subparsers.add_parser("idedata")

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -481,8 +481,10 @@ class EsphomeCleanMqttHandler(EsphomeCommandWebSocket):
 
 class EsphomeCleanAllHandler(EsphomeCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
-        config_file = settings.rel_path(json_message["configuration"])
-        return [*DASHBOARD_COMMAND, "clean-all", config_file]
+        clean_build_dir = json_message.get("clean_build_dir", True)
+        if clean_build_dir:
+            return [*DASHBOARD_COMMAND, "clean-all", settings.config_dir]
+        return [*DASHBOARD_COMMAND, "clean-all"]
 
 
 class EsphomeCleanHandler(EsphomeCommandWebSocket):

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -479,10 +479,10 @@ class EsphomeCleanMqttHandler(EsphomeCommandWebSocket):
         return [*DASHBOARD_COMMAND, "clean-mqtt", config_file]
 
 
-class EsphomeCleanPlatformHandler(EsphomeCommandWebSocket):
+class EsphomeCleanAllHandler(EsphomeCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         config_file = settings.rel_path(json_message["configuration"])
-        return [*DASHBOARD_COMMAND, "clean-platform", config_file]
+        return [*DASHBOARD_COMMAND, "clean-all", config_file]
 
 
 class EsphomeCleanHandler(EsphomeCommandWebSocket):
@@ -1319,7 +1319,7 @@ def make_app(debug=get_bool_env(ENV_DEV)) -> tornado.web.Application:
             (f"{rel}compile", EsphomeCompileHandler),
             (f"{rel}validate", EsphomeValidateHandler),
             (f"{rel}clean-mqtt", EsphomeCleanMqttHandler),
-            (f"{rel}clean-platform", EsphomeCleanPlatformHandler),
+            (f"{rel}clean-all", EsphomeCleanAllHandler),
             (f"{rel}clean", EsphomeCleanHandler),
             (f"{rel}vscode", EsphomeVscodeHandler),
             (f"{rel}ace", EsphomeAceEditorHandler),

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -335,13 +335,15 @@ def clean_build():
             shutil.rmtree(cache_dir)
 
 
-def clean_platform():
+def clean_all(configuration: list[str]):
     import shutil
 
     # Clean entire build dir
-    if CORE.build_path.is_dir():
-        _LOGGER.info("Deleting %s", CORE.build_path)
-        shutil.rmtree(CORE.build_path)
+    for dir in configuration:
+        buid_dir = Path(dir) / ".esphome"
+        if buid_dir.is_dir():
+            _LOGGER.info("Deleting %s", buid_dir)
+            shutil.rmtree(buid_dir)
 
     # Clean PlatformIO project files
     try:


### PR DESCRIPTION
# What does this implement/fix?

Usage info:
```
usage: esphome clean-all [-h] [configuration ...]

positional arguments:
  configuration  Your YAML configuration directory.

options:
  -h, --help     show this help message and exit
```

Removes all platformio folders, takes an optional list of config directories to and wipes .esphome

Fix update-all usage info as well. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/dashboard/pull/810

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
