### PR TITLE
[text_sensor] Convert LOG_TEXT_SENSOR macro to function to reduce flash usage

### DIFF
--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -155,7 +155,7 @@ void CCS811Component::dump_config() {
   LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "CO2 Sensor", this->co2_);
   LOG_SENSOR("  ", "TVOC Sensor", this->tvoc_);
-  LOG_TEXT_SENSOR("  ", "Firmware Version Sensor", this->version_)
+  LOG_TEXT_SENSOR("  ", "Firmware Version Sensor", this->version_);
   if (this->baseline_) {
     ESP_LOGCONFIG(TAG, "  Baseline: %04X", *this->baseline_);
   } else {

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -6,6 +6,23 @@ namespace text_sensor {
 
 static const char *const TAG = "text_sensor";
 
+// Function implementation of LOG_TEXT_SENSOR macro to reduce code size
+void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
+  if (obj == nullptr) {
+    return;
+  }
+
+  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+
+  if (!obj->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
+  }
+
+  if (!obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
+  }
+}
+
 void TextSensor::publish_state(const std::string &state) {
   this->raw_state = state;
   if (this->raw_callback_) {

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -6,7 +6,6 @@ namespace text_sensor {
 
 static const char *const TAG = "text_sensor";
 
-// Function implementation of LOG_TEXT_SENSOR macro to reduce code size
 void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
   if (obj == nullptr) {
     return;

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -11,16 +11,9 @@
 namespace esphome {
 namespace text_sensor {
 
-#define LOG_TEXT_SENSOR(prefix, type, obj) \
-  if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
-  }
+void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj);
+
+#define LOG_TEXT_SENSOR(prefix, type, obj) log_text_sensor(TAG, prefix, LOG_STR_LITERAL(type), obj)
 
 #define SUB_TEXT_SENSOR(name) \
  protected: \


### PR DESCRIPTION

# What does this implement/fix?

This PR converts the `LOG_TEXT_SENSOR` macro to a function call to reduce flash memory usage, following the same pattern successfully implemented for `LOG_SENSOR` in #10290.

The `LOG_TEXT_SENSOR` macro was expanding inline at every call site, duplicating logging code and consuming unnecessary flash memory. By centralizing this into a single function, we achieve significant flash savings with no impact on RAM usage.

**Measured Impact:**
- Flash reduction: **572 bytes** on a typical ESP32 configuration with text sensors
- RAM usage: No change
- Estimated savings: ~150-170 bytes per text sensor component using `LOG_TEXT_SENSOR`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
text_sensor:
  - platform: wifi_info
    mac_address:
      name: "WiFi MAC Address"
    ip_address:
      name: "WiFi IP Address"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
