### PR TITLE
[select] Remove STL algorithm overhead to reduce flash usage

### DIFF
--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -34,11 +34,12 @@ size_t Select::size() const {
 
 optional<size_t> Select::index_of(const std::string &option) const {
   const auto &options = traits.get_options();
-  auto it = std::find(options.begin(), options.end(), option);
-  if (it == options.end()) {
-    return {};
+  for (size_t i = 0; i < options.size(); i++) {
+    if (options[i] == option) {
+      return i;
+    }
   }
-  return std::distance(options.begin(), it);
+  return {};
 }
 
 optional<size_t> Select::active_index() const {

--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -107,7 +107,7 @@ void SelectCall::perform() {
     }
   }
 
-  if (std::find(options.begin(), options.end(), target_value) == options.end()) {
+  if (!parent->has_option(target_value)) {
     ESP_LOGW(TAG, "'%s' - Option %s is not a valid option", name, target_value.c_str());
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Remove STL algorithm overhead in the Select component to reduce flash usage on memory-constrained devices.

This PR replaces `std::find` and `std::distance` calls with simpler implementations:
1. In `Select::index_of()` - replaced STL algorithms with a simple for loop
2. In `SelectCall::perform()` - replaced `std::find` with existing `has_option()` method

These STL algorithms add unnecessary overhead for simple linear searches. By using basic loops and existing methods, we achieve the same functionality with significantly less compiled code size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing efforts to reduce memory usage on ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
select:
  - platform: template
    name: "Test Select"
    options:
      - "Option 1"
      - "Option 2"
      - "Option 3"
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

Tested on ESP8266 with a typical configuration:

**Before:**
- RAM: 43.1% (used 35344 bytes from 81920 bytes)
- Flash: 45.6% (used 476721 bytes from 1044464 bytes)

**After:**
- RAM: 43.1% (used 35344 bytes from 81920 bytes)
- Flash: 45.6% (used 476353 bytes from 1044464 bytes)

**Result:** 368 bytes flash saved with no RAM impact