### PR TITLE
[climate] Remove STL algorithm overhead in save_state() method

### DIFF
--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -368,7 +368,7 @@ void Climate::save_state_() {
     const auto &supported = traits.get_supported_custom_fan_modes();
     std::vector<std::string> vec{supported.begin(), supported.end()};
     for (size_t i = 0; i < vec.size(); i++) {
-      if (vec[i] == custom_fan_mode.value()) {
+      if (vec[i] == custom_fan_mode) {
         state.custom_fan_mode = i;
         break;
       }
@@ -383,7 +383,7 @@ void Climate::save_state_() {
     const auto &supported = traits.get_supported_custom_presets();
     std::vector<std::string> vec{supported.begin(), supported.end()};
     for (size_t i = 0; i < vec.size(); i++) {
-      if (vec[i] == custom_preset.value()) {
+      if (vec[i] == custom_preset) {
         state.custom_preset = i;
         break;
       }

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -367,9 +367,11 @@ void Climate::save_state_() {
     state.uses_custom_fan_mode = true;
     const auto &supported = traits.get_supported_custom_fan_modes();
     std::vector<std::string> vec{supported.begin(), supported.end()};
-    auto it = std::find(vec.begin(), vec.end(), custom_fan_mode);
-    if (it != vec.end()) {
-      state.custom_fan_mode = std::distance(vec.begin(), it);
+    for (size_t i = 0; i < vec.size(); i++) {
+      if (vec[i] == custom_fan_mode.value()) {
+        state.custom_fan_mode = i;
+        break;
+      }
     }
   }
   if (traits.get_supports_presets() && preset.has_value()) {
@@ -380,10 +382,11 @@ void Climate::save_state_() {
     state.uses_custom_preset = true;
     const auto &supported = traits.get_supported_custom_presets();
     std::vector<std::string> vec{supported.begin(), supported.end()};
-    auto it = std::find(vec.begin(), vec.end(), custom_preset);
-    // only set custom preset if value exists, otherwise leave it as is
-    if (it != vec.cend()) {
-      state.custom_preset = std::distance(vec.begin(), it);
+    for (size_t i = 0; i < vec.size(); i++) {
+      if (vec[i] == custom_preset.value()) {
+        state.custom_preset = i;
+        break;
+      }
     }
   }
   if (traits.get_supports_swing_modes()) {


### PR DESCRIPTION
# What does this implement/fix?

Remove STL algorithm overhead in the Climate component to reduce flash usage on memory-constrained devices.

This PR replaces `std::find` and `std::distance` calls with simple for loops in the `save_state_()` method when saving custom fan mode and custom preset indices. These STL algorithms add unnecessary overhead for simple linear searches through small vectors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing efforts to reduce memory usage on ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change only

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
climate:
  - platform: thermostat
    name: "Test Thermostat"
    sensor: temperature_sensor
    custom_fan_mode: "Silent"
    custom_preset: "Eco Mode"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

Tested on ESP32 with a typical configuration:

**Before:**
- RAM: 13.0% (used 42468 bytes from 327680 bytes)
- Flash: 60.0% (used 1101554 bytes from 1835008 bytes)

**After:**
- RAM: 13.0% (used 42468 bytes from 327680 bytes)
- Flash: 60.0% (used 1101390 bytes from 1835008 bytes)

**Result:** 164 bytes flash saved with no RAM impact