### PR TITLE
[web_server] Remove std::find_if overhead matching IDF implementation

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -108,14 +108,14 @@ static UrlMatch match_url(const char *url_ptr, size_t url_len, bool only_domain)
 void DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
   DeferredEvent item(source, message_generator);
 
-  auto iter = std::find_if(this->deferred_queue_.begin(), this->deferred_queue_.end(),
-                           [&item](const DeferredEvent &test) -> bool { return test == item; });
-
-  if (iter != this->deferred_queue_.end()) {
-    (*iter) = item;
-  } else {
-    this->deferred_queue_.push_back(item);
+  // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
+  for (auto &event : this->deferred_queue_) {
+    if (event == item) {
+      event = item;
+      return;
+    }
   }
+  this->deferred_queue_.push_back(item);
 }
 
 void DeferredUpdateEventSource::process_deferred_queue_() {


### PR DESCRIPTION
# What does this implement/fix?

Remove `std::find_if` algorithm overhead in the Arduino web server component to reduce flash usage on memory-constrained devices.

This PR applies the same optimization that was already implemented in the IDF web server component. It replaces `std::find_if` with a simple range-based for loop in the `deq_push_back_with_dedup_()` method. This reduces template instantiation overhead and binary size while maintaining the same functionality.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follows the same pattern already implemented in web_server_idf component
- Part of ongoing efforts to reduce memory usage on ESP32 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change only

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
web_server:
  port: 80
  auth:
    username: admin
    password: admin
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

Tested on ESP32 (Arduino framework) with a typical configuration:

**Before:**
- RAM: 11.9% (used 39032 bytes from 327680 bytes)
- Flash: 58.2% (used 1067442 bytes from 1835008 bytes)

**After:**
- RAM: 11.9% (used 39032 bytes from 327680 bytes)
- Flash: 58.2% (used 1067150 bytes from 1835008 bytes)

**Result:** 292 bytes flash saved with no RAM impact

## Implementation Details

The change replaces:
```cpp
auto iter = std::find_if(this->deferred_queue_.begin(), this->deferred_queue_.end(),
                        [&item](const DeferredEvent &test) -> bool { return test == item; });

if (iter != this->deferred_queue_.end()) {
  (*iter) = item;
} else {
  this->deferred_queue_.push_back(item);
}
```

With:
```cpp
// Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
for (auto &event : this->deferred_queue_) {
  if (event == item) {
    event = item;
    return;
  }
}
this->deferred_queue_.push_back(item);
```

This follows the exact same pattern already implemented in `web_server_idf/web_server_idf.cpp`.