### PR TITLE
[version] Reduce flash usage by optimizing string concatenation in setup()

### DIFF
--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 #include "esphome/core/version.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace version {
@@ -12,7 +13,7 @@ void VersionTextSensor::setup() {
   if (this->hide_timestamp_) {
     this->publish_state(ESPHOME_VERSION);
   } else {
-    this->publish_state(ESPHOME_VERSION " " + App.get_compilation_time());
+    this->publish_state(str_sprintf(ESPHOME_VERSION " %s", App.get_compilation_time().c_str()));
   }
 }
 float VersionTextSensor::get_setup_priority() const { return setup_priority::DATA; }


### PR DESCRIPTION
# What does this implement/fix?

Optimize the version text sensor's `setup()` method to reduce flash usage by replacing inefficient string concatenation with `str_sprintf()`.

The previous implementation used std::string's operator+ for concatenation, which created multiple temporary string objects and generated excessive code. The new implementation uses a single `str_sprintf()` call that formats directly into the result string.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing efforts to reduce memory usage on ESP32, ESP8266 and other memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
text_sensor:
  - platform: version
    name: "ESPHome Version"
    hide_timestamp: false  # When false, includes compilation timestamp
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

Tested on ESP32 with a typical configuration:

**Before:**
- RAM: 4.9% (used 16084 bytes from 327680 bytes)
- Flash: 27.3% (used 500066 bytes from 1835008 bytes)
- Symbol size: `esphome::version::VersionTextSensor::setup()` - 301 bytes

**After:**
- RAM: 4.9% (used 16084 bytes from 327680 bytes)
- Flash: 27.2% (used 499814 bytes from 1835008 bytes)
- Symbol size: `esphome::version::VersionTextSensor::setup()` - 76 bytes

**Result:** 252 bytes flash saved (75% reduction in function size) with no RAM impact

## Implementation Details

The change replaces:
```cpp
this->publish_state(ESPHOME_VERSION " " + App.get_compilation_time());
```

With:
```cpp
this->publish_state(str_sprintf(ESPHOME_VERSION " %s", App.get_compilation_time().c_str()));
```

This eliminates:
- Temporary std::string object creation
- String operator+ overhead and template instantiation
- Multiple string allocations and copies