### PR TITLE
Update stale bot rules

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'esphome'
     runs-on: ubuntu-latest
     steps:
-      # The 60 day stale policy for PRs
+      # The 90 day stale policy for PRs
       # - PRs
       # - No PRs marked as "not-stale"
       # - No Issues (see below)

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,14 +15,21 @@ concurrency:
 
 jobs:
   stale:
+    if: github.repository_owner == 'esphome'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+      # The 60 day stale policy for PRs
+      # - PRs
+      # - No PRs marked as "not-stale"
+      # - No Issues (see below)
+      - name: 90 days stale PRs
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
-          days-before-pr-stale: 90
-          days-before-pr-close: 7
+          days-before-stale: 90
+          days-before-close: 7
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          operations-per-run: 150
           remove-stale-when-updated: true
           stale-pr-label: "stale"
           exempt-pr-labels: "not-stale"
@@ -30,21 +37,36 @@ jobs:
             There hasn't been any activity on this pull request recently. This
             pull request has been automatically marked as stale because of that
             and will be closed if no further activity occurs within 7 days.
-            Thank you for your contributions.
 
-  # Use stale to automatically close issues with a
-  # reference to the issue tracker
-  close-issues:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+            If you are the author of this PR, please leave a comment if you want
+            to keep it open. Also, please rebase your PR onto the latest dev
+            branch to ensure that it's up to date with the latest changes.
+
+            Thank you for your contribution!
+
+      # The 90 day stale policy for Issues
+      # - Issues
+      # - No Issues marked as "not-stale"
+      # - No PRs (see above)
+      - name: 90 days stale issues
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
+          days-before-stale: 90
+          days-before-close: 7
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          days-before-issue-stale: 1
-          days-before-issue-close: 1
           remove-stale-when-updated: true
           stale-issue-label: "stale"
           exempt-issue-labels: "not-stale"
           stale-issue-message: >
-            https://github.com/esphome/esphome/issues/430
+            There hasn't been any activity on this issue recently. Due to the
+            high number of incoming GitHub notifications, we have to clean some
+            of the old issues, as many of them have already been resolved with
+            the latest updates.
+
+            Please make sure to update to the latest ESPHome version and
+            check if that solves the issue. Let us know if that works for you by
+            adding a comment 👍
+
+            This issue has now been marked as stale and will be closed if no
+            further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

To account for this repository utilising the issues now, I have altered the rules so it doesn't close them automatically right away. 

We now have a 90 day stale policy for both PRs and issues.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
