### PR TITLE
[dashboard] Replace polling with WebSocket for real-time updates

### DIFF
--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -6,18 +6,19 @@ from esphome.enum import StrEnum
 class DashboardEvent(StrEnum):
     """Dashboard WebSocket event types."""
 
-    # Internal dashboard events
+    # Server -> Client events (backend sends to frontend)
     ENTRY_ADDED = "entry_added"
     ENTRY_REMOVED = "entry_removed"
     ENTRY_UPDATED = "entry_updated"
     ENTRY_STATE_CHANGED = "entry_state_changed"
     IMPORTABLE_DEVICE_ADDED = "importable_device_added"
     IMPORTABLE_DEVICE_REMOVED = "importable_device_removed"
-
-    # Connection level events
     INITIAL_STATE = "initial_state"  # Sent on WebSocket connection
-    PING = "ping"  # WebSocket keepalive
-    PONG = "pong"  # WebSocket keepalive response
+    PONG = "pong"  # Response to client ping
+
+    # Client -> Server events (frontend sends to backend)
+    PING = "ping"  # WebSocket keepalive from client
+    REFRESH = "refresh"  # Force backend to poll for changes
 
 
 MAX_EXECUTOR_WORKERS = 48

--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -1,9 +1,25 @@
 from __future__ import annotations
 
-EVENT_ENTRY_ADDED = "entry_added"
-EVENT_ENTRY_REMOVED = "entry_removed"
-EVENT_ENTRY_UPDATED = "entry_updated"
-EVENT_ENTRY_STATE_CHANGED = "entry_state_changed"
+from esphome.enum import StrEnum
+
+
+class DashboardEvent(StrEnum):
+    """Dashboard WebSocket event types."""
+
+    # Internal dashboard events
+    ENTRY_ADDED = "entry_added"
+    ENTRY_REMOVED = "entry_removed"
+    ENTRY_UPDATED = "entry_updated"
+    ENTRY_STATE_CHANGED = "entry_state_changed"
+    IMPORTABLE_DEVICE_ADDED = "importable_device_added"
+    IMPORTABLE_DEVICE_REMOVED = "importable_device_removed"
+
+    # Connection level events
+    INITIAL_STATE = "initial_state"  # Sent on WebSocket connection
+    PING = "ping"  # WebSocket keepalive
+    PONG = "pong"  # WebSocket keepalive response
+
+
 MAX_EXECUTOR_WORKERS = 48
 
 

--- a/esphome/dashboard/core.py
+++ b/esphome/dashboard/core.py
@@ -13,6 +13,7 @@ from typing import Any
 from esphome.storage_json import ignored_devices_storage_path
 
 from ..zeroconf import DiscoveredImport
+from .const import DashboardEvent
 from .dns import DNSCache
 from .entries import DashboardEntries
 from .settings import DashboardSettings
@@ -30,7 +31,7 @@ MDNS_BOOTSTRAP_TIME = 7.5
 class Event:
     """Dashboard Event."""
 
-    event_type: str
+    event_type: DashboardEvent
     data: dict[str, Any]
 
 
@@ -39,22 +40,24 @@ class EventBus:
 
     def __init__(self) -> None:
         """Initialize the Dashboard event bus."""
-        self._listeners: dict[str, set[Callable[[Event], None]]] = {}
+        self._listeners: dict[DashboardEvent, set[Callable[[Event], None]]] = {}
 
     def async_add_listener(
-        self, event_type: str, listener: Callable[[Event], None]
+        self, event_type: DashboardEvent, listener: Callable[[Event], None]
     ) -> Callable[[], None]:
         """Add a listener to the event bus."""
         self._listeners.setdefault(event_type, set()).add(listener)
         return partial(self._async_remove_listener, event_type, listener)
 
     def _async_remove_listener(
-        self, event_type: str, listener: Callable[[Event], None]
+        self, event_type: DashboardEvent, listener: Callable[[Event], None]
     ) -> None:
         """Remove a listener from the event bus."""
         self._listeners[event_type].discard(listener)
 
-    def async_fire(self, event_type: str, event_data: dict[str, Any]) -> None:
+    def async_fire(
+        self, event_type: DashboardEvent, event_data: dict[str, Any]
+    ) -> None:
         """Fire an event."""
         event = Event(event_type, event_data)
 

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -96,12 +96,12 @@ class DashboardEntries:
         #   "path/to/file.yaml": DashboardEntry,
         #   ...
         # }
-        self._entries: dict[str, DashboardEntry] = {}
+        self._entries: dict[Path, DashboardEntry] = {}
         self._loaded_entries = False
         self._update_lock = asyncio.Lock()
         self._name_to_entry: dict[str, set[DashboardEntry]] = defaultdict(set)
 
-    def get(self, path: str) -> DashboardEntry | None:
+    def get(self, path: Path) -> DashboardEntry | None:
         """Get an entry by path."""
         return self._entries.get(path)
 
@@ -267,9 +267,9 @@ class DashboardEntries:
                 name_to_entry[current_name].add(entry)
             bus.async_fire(DashboardEvent.ENTRY_UPDATED, {"entry": entry})
 
-    def _get_path_to_cache_key(self) -> dict[str, DashboardCacheKeyType]:
+    def _get_path_to_cache_key(self) -> dict[Path, DashboardCacheKeyType]:
         """Return a dict of path to cache key."""
-        path_to_cache_key: dict[str, DashboardCacheKeyType] = {}
+        path_to_cache_key: dict[Path, DashboardCacheKeyType] = {}
         #
         # The cache key is (inode, device, mtime, size)
         # which allows us to avoid locking since it ensures

--- a/esphome/dashboard/entries.py
+++ b/esphome/dashboard/entries.py
@@ -12,13 +12,7 @@ from esphome import const, util
 from esphome.enum import StrEnum
 from esphome.storage_json import StorageJSON, ext_storage_path
 
-from .const import (
-    DASHBOARD_COMMAND,
-    EVENT_ENTRY_ADDED,
-    EVENT_ENTRY_REMOVED,
-    EVENT_ENTRY_STATE_CHANGED,
-    EVENT_ENTRY_UPDATED,
-)
+from .const import DASHBOARD_COMMAND, DashboardEvent
 from .util.subprocess import async_run_system_command
 
 if TYPE_CHECKING:
@@ -192,7 +186,7 @@ class DashboardEntries:
             return
         entry.state = state
         self._dashboard.bus.async_fire(
-            EVENT_ENTRY_STATE_CHANGED, {"entry": entry, "state": state}
+            DashboardEvent.ENTRY_STATE_CHANGED, {"entry": entry, "state": state}
         )
 
     async def async_request_update_entries(self) -> None:
@@ -260,18 +254,18 @@ class DashboardEntries:
         for entry in added:
             entries[entry.path] = entry
             name_to_entry[entry.name].add(entry)
-            bus.async_fire(EVENT_ENTRY_ADDED, {"entry": entry})
+            bus.async_fire(DashboardEvent.ENTRY_ADDED, {"entry": entry})
 
         for entry in removed:
             del entries[entry.path]
             name_to_entry[entry.name].discard(entry)
-            bus.async_fire(EVENT_ENTRY_REMOVED, {"entry": entry})
+            bus.async_fire(DashboardEvent.ENTRY_REMOVED, {"entry": entry})
 
         for entry in updated:
             if (original_name := original_names[entry]) != (current_name := entry.name):
                 name_to_entry[original_name].discard(entry)
                 name_to_entry[current_name].add(entry)
-            bus.async_fire(EVENT_ENTRY_UPDATED, {"entry": entry})
+            bus.async_fire(DashboardEvent.ENTRY_UPDATED, {"entry": entry})
 
     def _get_path_to_cache_key(self) -> dict[str, DashboardCacheKeyType]:
         """Return a dict of path to cache key."""

--- a/esphome/dashboard/models.py
+++ b/esphome/dashboard/models.py
@@ -1,0 +1,76 @@
+"""Data models and builders for the dashboard."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    from esphome.zeroconf import DiscoveredImport
+
+    from .core import ESPHomeDashboard
+    from .entries import DashboardEntry
+
+
+class ImportableDeviceDict(TypedDict):
+    """Dictionary representation of an importable device."""
+
+    name: str
+    friendly_name: str | None
+    package_import_url: str
+    project_name: str
+    project_version: str
+    network: str
+    ignored: bool
+
+
+class ConfiguredDeviceDict(TypedDict, total=False):
+    """Dictionary representation of a configured device."""
+
+    name: str
+    friendly_name: str | None
+    configuration: str
+    loaded_integrations: list[str] | None
+    deployed_version: str | None
+    current_version: str | None
+    path: str
+    comment: str | None
+    address: str | None
+    web_port: int | None
+    target_platform: str | None
+
+
+class DeviceListResponse(TypedDict):
+    """Response for device list API."""
+
+    configured: list[ConfiguredDeviceDict]
+    importable: list[ImportableDeviceDict]
+
+
+def build_importable_device_dict(
+    dashboard: ESPHomeDashboard, discovered: DiscoveredImport
+) -> ImportableDeviceDict:
+    """Build the importable device dictionary."""
+    return ImportableDeviceDict(
+        name=discovered.device_name,
+        friendly_name=discovered.friendly_name,
+        package_import_url=discovered.package_import_url,
+        project_name=discovered.project_name,
+        project_version=discovered.project_version,
+        network=discovered.network,
+        ignored=discovered.device_name in dashboard.ignored_devices,
+    )
+
+
+def build_device_list_response(
+    dashboard: ESPHomeDashboard, entries: list[DashboardEntry]
+) -> DeviceListResponse:
+    """Build the device list response data."""
+    configured = {entry.name for entry in entries}
+    return DeviceListResponse(
+        configured=[entry.to_dict() for entry in entries],
+        importable=[
+            build_importable_device_dict(dashboard, res)
+            for res in dashboard.import_result.values()
+            if res.device_name not in configured
+        ],
+    )

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -576,7 +576,7 @@ class DashboardSubscriber:
                 if settings.status_use_mqtt:
                     dashboard.mqtt_ping_request.set()
                 await asyncio.sleep(DASHBOARD_POLL_INTERVAL)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Error in ping loop")
                 break
 
@@ -587,7 +587,7 @@ class DashboardSubscriber:
             try:
                 await dashboard.entries.async_request_update_entries()
                 await asyncio.sleep(DASHBOARD_ENTRIES_UPDATE_INTERVAL)
-            except Exception:
+            except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Error in filesystem polling loop")
                 break
 
@@ -612,7 +612,7 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
         self._authenticated = False
         self._dashboard_unsubscribe: Callable[[], None] | None = None
 
-    async def open(self, *args: str, **kwargs: str) -> None:
+    async def open(self, *args: str, **kwargs: str) -> None:  # pylint: disable=invalid-overridden-method
         """Handle new WebSocket connection."""
         # Check authentication
         if settings.using_password and not is_authenticated(self):

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -538,6 +538,7 @@ class DashboardSubscriber:
         """Initialize the dashboard subscriber."""
         self._subscribers: set[DashboardEventsWebSocket] = set()
         self._event_loop_task: asyncio.Task | None = None
+        self._refresh_event: asyncio.Event = asyncio.Event()
 
     def subscribe(self, subscriber: DashboardEventsWebSocket) -> Callable[[], None]:
         """Subscribe to dashboard updates and start event loop if needed."""
@@ -559,6 +560,10 @@ class DashboardSubscriber:
             self._event_loop_task = None
             _LOGGER.info("Stopped dashboard event loop - no subscribers")
 
+    def request_refresh(self) -> None:
+        """Signal the polling loop to refresh immediately."""
+        self._refresh_event.set()
+
     async def _event_loop(self) -> None:
         """Run the event polling loop while there are subscribers."""
         dashboard = DASHBOARD
@@ -570,13 +575,25 @@ class DashboardSubscriber:
             if settings.status_use_mqtt:
                 dashboard.mqtt_ping_request.set()
 
-            # Check if it's time to update entries (every DASHBOARD_ENTRIES_UPDATE_ITERATIONS)
+            # Check if it's time to update entries or if refresh was requested
             entries_update_counter += 1
-            if entries_update_counter >= DASHBOARD_ENTRIES_UPDATE_ITERATIONS:
+            if (
+                entries_update_counter >= DASHBOARD_ENTRIES_UPDATE_ITERATIONS
+                or self._refresh_event.is_set()
+            ):
                 entries_update_counter = 0
                 await dashboard.entries.async_request_update_entries()
+                # Clear the refresh event if it was set
+                self._refresh_event.clear()
 
-            await asyncio.sleep(DASHBOARD_POLL_INTERVAL)
+            # Wait for either timeout or refresh event
+            try:
+                async with asyncio.timeout(DASHBOARD_POLL_INTERVAL):
+                    await self._refresh_event.wait()
+                    # If we get here, refresh was requested - continue loop immediately
+            except TimeoutError:
+                # Normal timeout - continue with regular polling
+                pass
 
 
 # Global dashboard subscriber instance
@@ -724,6 +741,10 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
             # Send pong response for client ping
             _LOGGER.debug("Received client ping, sending pong")
             self._safe_send_message({"event": DashboardEvent.PONG})
+        elif event == DashboardEvent.REFRESH:
+            # Signal the polling loop to refresh immediately
+            _LOGGER.debug("Received refresh request, signaling polling loop")
+            DASHBOARD_SUBSCRIBER.request_refresh()
 
     def on_close(self) -> None:
         """Handle WebSocket close."""

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -600,8 +600,8 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
 
     async def open(self, *args: str, **kwargs: str) -> None:  # pylint: disable=invalid-overridden-method
         """Handle new WebSocket connection."""
-        # Ensure messages from the subprocess are sent immediately
-        # to avoid a 200-500ms delay when nodelay is not set.
+        # Ensure messages are sent immediately to avoid
+        # a 200-500ms delay when nodelay is not set.
         self.set_nodelay(True)
 
         # Check authentication

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -4,8 +4,10 @@ import asyncio
 import base64
 import binascii
 from collections.abc import Callable, Iterable
+import contextlib
 import datetime
 import functools
+from functools import partial
 import gzip
 import hashlib
 import importlib
@@ -50,9 +52,10 @@ from esphome.util import get_serial_ports, shlex_quote
 from esphome.yaml_util import FastestAvailableSafeLoader
 
 from ..helpers import write_file
-from .const import DASHBOARD_COMMAND
-from .core import DASHBOARD, ESPHomeDashboard
+from .const import DASHBOARD_COMMAND, DashboardEvent
+from .core import DASHBOARD, ESPHomeDashboard, Event
 from .entries import UNKNOWN_STATE, DashboardEntry, entry_state_to_bool
+from .models import build_device_list_response
 from .util.subprocess import async_run_system_command
 from .util.text import friendly_name_slugify
 
@@ -520,6 +523,242 @@ class EsphomeUpdateAllHandler(EsphomeCommandWebSocket):
         return [*DASHBOARD_COMMAND, "update-all", settings.config_dir]
 
 
+# Dashboard polling constants
+DASHBOARD_POLL_INTERVAL = 2  # seconds
+DASHBOARD_ENTRIES_UPDATE_INTERVAL = 10  # seconds
+DASHBOARD_ENTRIES_UPDATE_ITERATIONS = (
+    DASHBOARD_ENTRIES_UPDATE_INTERVAL // DASHBOARD_POLL_INTERVAL
+)
+
+
+class DashboardSubscriber:
+    """Manages dashboard event polling task lifecycle based on active subscribers."""
+
+    def __init__(self) -> None:
+        """Initialize the dashboard subscriber."""
+        self._subscribers: set[DashboardEventsWebSocket] = set()
+        self._ping_task: asyncio.Task | None = None
+        self._filesystem_poll_task: asyncio.Task | None = None
+
+    def subscribe(self, subscriber: DashboardEventsWebSocket) -> Callable[[], None]:
+        """Subscribe to dashboard updates and start tasks if needed."""
+        self._subscribers.add(subscriber)
+        if not self._ping_task or self._ping_task.done():
+            self._ping_task = asyncio.create_task(self._ping_loop())
+            _LOGGER.info("Started dashboard ping task")
+        if not self._filesystem_poll_task or self._filesystem_poll_task.done():
+            self._filesystem_poll_task = asyncio.create_task(
+                self._filesystem_poll_loop()
+            )
+            _LOGGER.info("Started dashboard filesystem polling")
+        return partial(self._unsubscribe, subscriber)
+
+    def _unsubscribe(self, subscriber: DashboardEventsWebSocket) -> None:
+        """Unsubscribe from dashboard updates and stop tasks if no subscribers."""
+        self._subscribers.discard(subscriber)
+        if not self._subscribers:
+            if self._ping_task and not self._ping_task.done():
+                self._ping_task.cancel()
+                self._ping_task = None
+                _LOGGER.info("Stopped dashboard ping task - no subscribers")
+            if self._filesystem_poll_task and not self._filesystem_poll_task.done():
+                self._filesystem_poll_task.cancel()
+                self._filesystem_poll_task = None
+                _LOGGER.info("Stopped dashboard filesystem polling - no subscribers")
+
+    async def _ping_loop(self) -> None:
+        """Run the ping loop while there are subscribers."""
+        dashboard = DASHBOARD
+        while self._subscribers:
+            try:
+                # Signal that we need ping updates (non-blocking)
+                dashboard.ping_request.set()
+                if settings.status_use_mqtt:
+                    dashboard.mqtt_ping_request.set()
+                await asyncio.sleep(DASHBOARD_POLL_INTERVAL)
+            except Exception:
+                _LOGGER.exception("Error in ping loop")
+                break
+
+    async def _filesystem_poll_loop(self) -> None:
+        """Run the filesystem polling loop while there are subscribers."""
+        dashboard = DASHBOARD
+        while self._subscribers:
+            try:
+                await dashboard.entries.async_request_update_entries()
+                await asyncio.sleep(DASHBOARD_ENTRIES_UPDATE_INTERVAL)
+            except Exception:
+                _LOGGER.exception("Error in filesystem polling loop")
+                break
+
+
+# Global dashboard subscriber instance
+DASHBOARD_SUBSCRIBER = DashboardSubscriber()
+
+
+@websocket_class
+class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
+    """WebSocket handler for real-time dashboard events."""
+
+    def __init__(
+        self,
+        application: tornado.web.Application,
+        request: tornado.httputil.HTTPServerRequest,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the websocket."""
+        super().__init__(application, request, **kwargs)
+        self._event_listeners: list[Callable[[], None]] = []
+        self._authenticated = False
+        self._dashboard_unsubscribe: Callable[[], None] | None = None
+
+    async def open(self, *args: str, **kwargs: str) -> None:
+        """Handle new WebSocket connection."""
+        # Check authentication
+        if settings.using_password and not is_authenticated(self):
+            self.close(code=401, reason="Unauthorized")
+            return
+
+        self._authenticated = True
+        dashboard = DASHBOARD
+        # Update entries first
+        await dashboard.entries.async_request_update_entries()
+        # Send initial state
+        self._send_initial_state()
+        # Subscribe to events
+        self._subscribe_to_events()
+        # Subscribe to dashboard updates
+        self._dashboard_unsubscribe = DASHBOARD_SUBSCRIBER.subscribe(self)
+        _LOGGER.debug("Dashboard status WebSocket opened")
+
+    def _send_initial_state(self) -> None:
+        """Send initial device list and ping status."""
+        entries = DASHBOARD.entries.async_all()
+
+        # Send initial state
+        self._safe_send_message(
+            {
+                "event": DashboardEvent.INITIAL_STATE,
+                "data": {
+                    "devices": build_device_list_response(DASHBOARD, entries),
+                    "ping": {
+                        entry.filename: entry_state_to_bool(entry.state)
+                        for entry in entries
+                    },
+                },
+            }
+        )
+
+    def _subscribe_to_events(self) -> None:
+        """Subscribe to dashboard events."""
+        bus = DASHBOARD.bus
+
+        # Subscribe to all events
+        self._event_listeners.extend(
+            [
+                bus.async_add_listener(
+                    DashboardEvent.ENTRY_STATE_CHANGED, self._on_entry_state_changed
+                ),
+                bus.async_add_listener(
+                    DashboardEvent.ENTRY_ADDED,
+                    self._make_entry_handler(DashboardEvent.ENTRY_ADDED),
+                ),
+                bus.async_add_listener(
+                    DashboardEvent.ENTRY_REMOVED,
+                    self._make_entry_handler(DashboardEvent.ENTRY_REMOVED),
+                ),
+                bus.async_add_listener(
+                    DashboardEvent.ENTRY_UPDATED,
+                    self._make_entry_handler(DashboardEvent.ENTRY_UPDATED),
+                ),
+                bus.async_add_listener(
+                    DashboardEvent.IMPORTABLE_DEVICE_ADDED, self._on_importable_added
+                ),
+                bus.async_add_listener(
+                    DashboardEvent.IMPORTABLE_DEVICE_REMOVED,
+                    self._on_importable_removed,
+                ),
+            ]
+        )
+
+    def _on_entry_state_changed(self, event: Event) -> None:
+        """Handle entry state change event."""
+        entry = event.data["entry"]
+        state = event.data["state"]
+        self._safe_send_message(
+            {
+                "event": DashboardEvent.ENTRY_STATE_CHANGED,
+                "data": {
+                    "filename": entry.filename,
+                    "name": entry.name,
+                    "state": entry_state_to_bool(state),
+                },
+            }
+        )
+
+    def _make_entry_handler(
+        self, event_type: DashboardEvent
+    ) -> Callable[[Event], None]:
+        """Create an entry event handler."""
+
+        def handler(event: Event) -> None:
+            self._safe_send_message(
+                {"event": event_type, "data": {"device": event.data["entry"].to_dict()}}
+            )
+
+        return handler
+
+    def _on_importable_added(self, event: Event) -> None:
+        """Handle importable device added event."""
+        # Don't send if device is already configured
+        device_name = event.data.get("device", {}).get("name")
+        if device_name and DASHBOARD.entries.get_by_name(device_name):
+            return
+        self._safe_send_message(
+            {"event": DashboardEvent.IMPORTABLE_DEVICE_ADDED, "data": event.data}
+        )
+
+    def _on_importable_removed(self, event: Event) -> None:
+        """Handle importable device removed event."""
+        self._safe_send_message(
+            {"event": DashboardEvent.IMPORTABLE_DEVICE_REMOVED, "data": event.data}
+        )
+
+    def _safe_send_message(self, message: dict[str, Any]) -> None:
+        """Send a message to the WebSocket client, ignoring closed errors."""
+        with contextlib.suppress(tornado.websocket.WebSocketClosedError):
+            self.write_message(json.dumps(message))
+
+    def on_message(self, message: str) -> None:
+        """Handle incoming WebSocket messages."""
+        _LOGGER.debug("WebSocket received message: %s", message)
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError as err:
+            _LOGGER.debug("Failed to parse WebSocket message: %s", err)
+            return
+
+        event = data.get("event")
+        _LOGGER.debug("WebSocket message event: %s", event)
+        if event == DashboardEvent.PING:
+            # Send pong response for client ping
+            _LOGGER.debug("Received client ping, sending pong")
+            self._safe_send_message({"event": DashboardEvent.PONG})
+
+    def on_close(self) -> None:
+        """Handle WebSocket close."""
+        # Unsubscribe from dashboard updates
+        if self._dashboard_unsubscribe:
+            self._dashboard_unsubscribe()
+            self._dashboard_unsubscribe = None
+
+        # Unsubscribe from events
+        for remove_listener in self._event_listeners:
+            remove_listener()
+
+        _LOGGER.debug("Dashboard status WebSocket closed")
+
+
 class SerialPortRequestHandler(BaseHandler):
     @authenticated
     async def get(self) -> None:
@@ -874,28 +1113,7 @@ class ListDevicesHandler(BaseHandler):
         await dashboard.entries.async_request_update_entries()
         entries = dashboard.entries.async_all()
         self.set_header("content-type", "application/json")
-        configured = {entry.name for entry in entries}
-
-        self.write(
-            json.dumps(
-                {
-                    "configured": [entry.to_dict() for entry in entries],
-                    "importable": [
-                        {
-                            "name": res.device_name,
-                            "friendly_name": res.friendly_name,
-                            "package_import_url": res.package_import_url,
-                            "project_name": res.project_name,
-                            "project_version": res.project_version,
-                            "network": res.network,
-                            "ignored": res.device_name in dashboard.ignored_devices,
-                        }
-                        for res in dashboard.import_result.values()
-                        if res.device_name not in configured
-                    ],
-                }
-            )
-        )
+        self.write(json.dumps(build_device_list_response(dashboard, entries)))
 
 
 class MainRequestHandler(BaseHandler):
@@ -1351,6 +1569,7 @@ def make_app(debug=get_bool_env(ENV_DEV)) -> tornado.web.Application:
             (f"{rel}wizard", WizardRequestHandler),
             (f"{rel}static/(.*)", StaticFileHandler, {"path": get_static_path()}),
             (f"{rel}devices", ListDevicesHandler),
+            (f"{rel}events", DashboardEventsWebSocket),
             (f"{rel}import", ImportRequestHandler),
             (f"{rel}secret_keys", SecretKeysRequestHandler),
             (f"{rel}json-config", JsonConfigRequestHandler),

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -587,16 +587,8 @@ DASHBOARD_SUBSCRIBER = DashboardSubscriber()
 class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
     """WebSocket handler for real-time dashboard events."""
 
-    def __init__(
-        self,
-        application: tornado.web.Application,
-        request: tornado.httputil.HTTPServerRequest,
-        **kwargs: Any,
-    ) -> None:
-        """Initialize the websocket."""
-        super().__init__(application, request, **kwargs)
-        self._event_listeners: list[Callable[[], None]] = []
-        self._dashboard_unsubscribe: Callable[[], None] | None = None
+    _event_listeners: list[Callable[[], None]] | None = None
+    _dashboard_unsubscribe: Callable[[], None] | None = None
 
     async def get(self, *args: str, **kwargs: str) -> None:
         """Handle WebSocket upgrade request."""
@@ -642,35 +634,32 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
 
     def _subscribe_to_events(self) -> None:
         """Subscribe to dashboard events."""
-        bus = DASHBOARD.bus
-
+        async_add_listener = DASHBOARD.bus.async_add_listener
         # Subscribe to all events
-        self._event_listeners.extend(
-            [
-                bus.async_add_listener(
-                    DashboardEvent.ENTRY_STATE_CHANGED, self._on_entry_state_changed
-                ),
-                bus.async_add_listener(
-                    DashboardEvent.ENTRY_ADDED,
-                    self._make_entry_handler(DashboardEvent.ENTRY_ADDED),
-                ),
-                bus.async_add_listener(
-                    DashboardEvent.ENTRY_REMOVED,
-                    self._make_entry_handler(DashboardEvent.ENTRY_REMOVED),
-                ),
-                bus.async_add_listener(
-                    DashboardEvent.ENTRY_UPDATED,
-                    self._make_entry_handler(DashboardEvent.ENTRY_UPDATED),
-                ),
-                bus.async_add_listener(
-                    DashboardEvent.IMPORTABLE_DEVICE_ADDED, self._on_importable_added
-                ),
-                bus.async_add_listener(
-                    DashboardEvent.IMPORTABLE_DEVICE_REMOVED,
-                    self._on_importable_removed,
-                ),
-            ]
-        )
+        self._event_listeners = [
+            async_add_listener(
+                DashboardEvent.ENTRY_STATE_CHANGED, self._on_entry_state_changed
+            ),
+            async_add_listener(
+                DashboardEvent.ENTRY_ADDED,
+                self._make_entry_handler(DashboardEvent.ENTRY_ADDED),
+            ),
+            async_add_listener(
+                DashboardEvent.ENTRY_REMOVED,
+                self._make_entry_handler(DashboardEvent.ENTRY_REMOVED),
+            ),
+            async_add_listener(
+                DashboardEvent.ENTRY_UPDATED,
+                self._make_entry_handler(DashboardEvent.ENTRY_UPDATED),
+            ),
+            async_add_listener(
+                DashboardEvent.IMPORTABLE_DEVICE_ADDED, self._on_importable_added
+            ),
+            async_add_listener(
+                DashboardEvent.IMPORTABLE_DEVICE_REMOVED,
+                self._on_importable_removed,
+            ),
+        ]
 
     def _on_entry_state_changed(self, event: Event) -> None:
         """Handle entry state change event."""
@@ -744,7 +733,7 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
             self._dashboard_unsubscribe = None
 
         # Unsubscribe from events
-        for remove_listener in self._event_listeners:
+        for remove_listener in self._event_listeners or []:
             remove_listener()
 
         _LOGGER.debug("Dashboard status WebSocket closed")

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -598,16 +598,19 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
         self._event_listeners: list[Callable[[], None]] = []
         self._dashboard_unsubscribe: Callable[[], None] | None = None
 
+    async def get(self, *args: str, **kwargs: str) -> None:
+        """Handle WebSocket upgrade request."""
+        if not is_authenticated(self):
+            self.set_status(401)
+            self.finish("Unauthorized")
+            return
+        await super().get(*args, **kwargs)
+
     async def open(self, *args: str, **kwargs: str) -> None:  # pylint: disable=invalid-overridden-method
         """Handle new WebSocket connection."""
         # Ensure messages are sent immediately to avoid
         # a 200-500ms delay when nodelay is not set.
         self.set_nodelay(True)
-
-        # Check authentication
-        if not is_authenticated(self):
-            self.close(code=401, reason="Unauthorized")
-            return
 
         # Update entries first
         await DASHBOARD.entries.async_request_update_entries()

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -596,20 +596,21 @@ class DashboardEventsWebSocket(tornado.websocket.WebSocketHandler):
         """Initialize the websocket."""
         super().__init__(application, request, **kwargs)
         self._event_listeners: list[Callable[[], None]] = []
-        self._authenticated = False
         self._dashboard_unsubscribe: Callable[[], None] | None = None
 
     async def open(self, *args: str, **kwargs: str) -> None:  # pylint: disable=invalid-overridden-method
         """Handle new WebSocket connection."""
+        # Ensure messages from the subprocess are sent immediately
+        # to avoid a 200-500ms delay when nodelay is not set.
+        self.set_nodelay(True)
+
         # Check authentication
-        if settings.using_password and not is_authenticated(self):
+        if not is_authenticated(self):
             self.close(code=401, reason="Unauthorized")
             return
 
-        self._authenticated = True
-        dashboard = DASHBOARD
         # Update entries first
-        await dashboard.entries.async_request_update_entries()
+        await DASHBOARD.entries.async_request_update_entries()
         # Send initial state
         self._send_initial_state()
         # Subscribe to events

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -537,59 +537,46 @@ class DashboardSubscriber:
     def __init__(self) -> None:
         """Initialize the dashboard subscriber."""
         self._subscribers: set[DashboardEventsWebSocket] = set()
-        self._ping_task: asyncio.Task | None = None
-        self._filesystem_poll_task: asyncio.Task | None = None
+        self._event_loop_task: asyncio.Task | None = None
 
     def subscribe(self, subscriber: DashboardEventsWebSocket) -> Callable[[], None]:
-        """Subscribe to dashboard updates and start tasks if needed."""
+        """Subscribe to dashboard updates and start event loop if needed."""
         self._subscribers.add(subscriber)
-        if not self._ping_task or self._ping_task.done():
-            self._ping_task = asyncio.create_task(self._ping_loop())
-            _LOGGER.info("Started dashboard ping task")
-        if not self._filesystem_poll_task or self._filesystem_poll_task.done():
-            self._filesystem_poll_task = asyncio.create_task(
-                self._filesystem_poll_loop()
-            )
-            _LOGGER.info("Started dashboard filesystem polling")
+        if not self._event_loop_task or self._event_loop_task.done():
+            self._event_loop_task = asyncio.create_task(self._event_loop())
+            _LOGGER.info("Started dashboard event loop")
         return partial(self._unsubscribe, subscriber)
 
     def _unsubscribe(self, subscriber: DashboardEventsWebSocket) -> None:
-        """Unsubscribe from dashboard updates and stop tasks if no subscribers."""
+        """Unsubscribe from dashboard updates and stop event loop if no subscribers."""
         self._subscribers.discard(subscriber)
-        if not self._subscribers:
-            if self._ping_task and not self._ping_task.done():
-                self._ping_task.cancel()
-                self._ping_task = None
-                _LOGGER.info("Stopped dashboard ping task - no subscribers")
-            if self._filesystem_poll_task and not self._filesystem_poll_task.done():
-                self._filesystem_poll_task.cancel()
-                self._filesystem_poll_task = None
-                _LOGGER.info("Stopped dashboard filesystem polling - no subscribers")
+        if (
+            not self._subscribers
+            and self._event_loop_task
+            and not self._event_loop_task.done()
+        ):
+            self._event_loop_task.cancel()
+            self._event_loop_task = None
+            _LOGGER.info("Stopped dashboard event loop - no subscribers")
 
-    async def _ping_loop(self) -> None:
-        """Run the ping loop while there are subscribers."""
+    async def _event_loop(self) -> None:
+        """Run the event polling loop while there are subscribers."""
         dashboard = DASHBOARD
-        while self._subscribers:
-            try:
-                # Signal that we need ping updates (non-blocking)
-                dashboard.ping_request.set()
-                if settings.status_use_mqtt:
-                    dashboard.mqtt_ping_request.set()
-                await asyncio.sleep(DASHBOARD_POLL_INTERVAL)
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Error in ping loop")
-                break
+        entries_update_counter = 0
 
-    async def _filesystem_poll_loop(self) -> None:
-        """Run the filesystem polling loop while there are subscribers."""
-        dashboard = DASHBOARD
         while self._subscribers:
-            try:
+            # Signal that we need ping updates (non-blocking)
+            dashboard.ping_request.set()
+            if settings.status_use_mqtt:
+                dashboard.mqtt_ping_request.set()
+
+            # Check if it's time to update entries (every DASHBOARD_ENTRIES_UPDATE_ITERATIONS)
+            entries_update_counter += 1
+            if entries_update_counter >= DASHBOARD_ENTRIES_UPDATE_ITERATIONS:
+                entries_update_counter = 0
                 await dashboard.entries.async_request_update_entries()
-                await asyncio.sleep(DASHBOARD_ENTRIES_UPDATE_INTERVAL)
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Error in filesystem polling loop")
-                break
+
+            await asyncio.sleep(DASHBOARD_POLL_INTERVAL)
 
 
 # Global dashboard subscriber instance

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -2,17 +2,30 @@
 
 from __future__ import annotations
 
-from unittest.mock import Mock
+from pathlib import Path
+from unittest.mock import MagicMock, Mock
 
 import pytest
+import pytest_asyncio
 
 from esphome.dashboard.core import ESPHomeDashboard
+from esphome.dashboard.entries import DashboardEntries
 
 
 @pytest.fixture
-def mock_dashboard() -> Mock:
+def mock_settings(tmp_path: Path) -> MagicMock:
+    """Create mock dashboard settings."""
+    settings = MagicMock()
+    settings.config_dir = str(tmp_path)
+    settings.absolute_config_dir = tmp_path
+    return settings
+
+
+@pytest.fixture
+def mock_dashboard(mock_settings: MagicMock) -> Mock:
     """Create a mock dashboard."""
     dashboard = Mock(spec=ESPHomeDashboard)
+    dashboard.settings = mock_settings
     dashboard.entries = Mock()
     dashboard.entries.async_all.return_value = []
     dashboard.stop_event = Mock()
@@ -22,3 +35,9 @@ def mock_dashboard() -> Mock:
     dashboard.bus = Mock()
     dashboard.bus.async_fire = Mock()
     return dashboard
+
+
+@pytest_asyncio.fixture
+async def dashboard_entries(mock_dashboard: Mock) -> DashboardEntries:
+    """Create a DashboardEntries instance for testing."""
+    return DashboardEntries(mock_dashboard)

--- a/tests/dashboard/conftest.py
+++ b/tests/dashboard/conftest.py
@@ -18,4 +18,7 @@ def mock_dashboard() -> Mock:
     dashboard.stop_event = Mock()
     dashboard.stop_event.is_set.return_value = True
     dashboard.ping_request = Mock()
+    dashboard.ignored_devices = set()
+    dashboard.bus = Mock()
+    dashboard.bus.async_fire = Mock()
     return dashboard

--- a/tests/dashboard/test_entries.py
+++ b/tests/dashboard/test_entries.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import tempfile
-from unittest.mock import MagicMock
+from unittest.mock import Mock
 
 import pytest
-import pytest_asyncio
 
 from esphome.core import CORE
+from esphome.dashboard.const import DashboardEvent
 from esphome.dashboard.entries import DashboardEntries, DashboardEntry
 
 
@@ -25,21 +26,6 @@ def setup_core():
         CORE.config_path = Path(tmpdir) / "test.yaml"
         yield
         CORE.reset()
-
-
-@pytest.fixture
-def mock_settings() -> MagicMock:
-    """Create mock dashboard settings."""
-    settings = MagicMock()
-    settings.config_dir = "/test/config"
-    settings.absolute_config_dir = Path("/test/config")
-    return settings
-
-
-@pytest_asyncio.fixture
-async def dashboard_entries(mock_settings: MagicMock) -> DashboardEntries:
-    """Create a DashboardEntries instance for testing."""
-    return DashboardEntries(mock_settings)
 
 
 def test_dashboard_entry_path_initialization() -> None:
@@ -78,15 +64,24 @@ def test_dashboard_entry_path_with_relative_path() -> None:
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_get_by_path(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test getting entry by path."""
-    test_path = Path("/test/config/device.yaml")
-    entry = DashboardEntry(test_path, create_cache_key())
+    # Create a test file
+    test_file = tmp_path / "device.yaml"
+    test_file.write_text("test config")
 
-    dashboard_entries._entries[str(test_path)] = entry
+    # Update entries to load the file
+    await dashboard_entries.async_update_entries()
 
-    result = dashboard_entries.get(str(test_path))
+    # Verify the entry was loaded
+    all_entries = dashboard_entries.async_all()
+    assert len(all_entries) == 1
+    entry = all_entries[0]
+    assert entry.path == test_file
+
+    # Also verify get() works with Path
+    result = dashboard_entries.get(test_file)
     assert result == entry
 
 
@@ -101,45 +96,54 @@ async def test_dashboard_entries_get_nonexistent_path(
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_path_normalization(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test that paths are handled consistently."""
-    path1 = Path("/test/config/device.yaml")
+    # Create a test file
+    test_file = tmp_path / "device.yaml"
+    test_file.write_text("test config")
 
-    entry = DashboardEntry(path1, create_cache_key())
-    dashboard_entries._entries[str(path1)] = entry
+    # Update entries to load the file
+    await dashboard_entries.async_update_entries()
 
-    result = dashboard_entries.get(str(path1))
-    assert result == entry
+    # Get the entry by path
+    result = dashboard_entries.get(test_file)
+    assert result is not None
 
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_path_with_spaces(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test handling paths with spaces."""
-    test_path = Path("/test/config/my device.yaml")
-    entry = DashboardEntry(test_path, create_cache_key())
+    # Create a test file with spaces in name
+    test_file = tmp_path / "my device.yaml"
+    test_file.write_text("test config")
 
-    dashboard_entries._entries[str(test_path)] = entry
+    # Update entries to load the file
+    await dashboard_entries.async_update_entries()
 
-    result = dashboard_entries.get(str(test_path))
-    assert result == entry
-    assert result.path == test_path
+    # Get the entry by path
+    result = dashboard_entries.get(test_file)
+    assert result is not None
+    assert result.path == test_file
 
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_path_with_special_chars(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test handling paths with special characters."""
-    test_path = Path("/test/config/device-01_test.yaml")
-    entry = DashboardEntry(test_path, create_cache_key())
+    # Create a test file with special characters
+    test_file = tmp_path / "device-01_test.yaml"
+    test_file.write_text("test config")
 
-    dashboard_entries._entries[str(test_path)] = entry
+    # Update entries to load the file
+    await dashboard_entries.async_update_entries()
 
-    result = dashboard_entries.get(str(test_path))
-    assert result == entry
+    # Get the entry by path
+    result = dashboard_entries.get(test_file)
+    assert result is not None
 
 
 def test_dashboard_entries_windows_path() -> None:
@@ -154,22 +158,25 @@ def test_dashboard_entries_windows_path() -> None:
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_path_to_cache_key_mapping(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test internal entries storage with paths and cache keys."""
-    path1 = Path("/test/config/device1.yaml")
-    path2 = Path("/test/config/device2.yaml")
+    # Create test files
+    file1 = tmp_path / "device1.yaml"
+    file2 = tmp_path / "device2.yaml"
+    file1.write_text("test config 1")
+    file2.write_text("test config 2")
 
-    entry1 = DashboardEntry(path1, create_cache_key())
-    entry2 = DashboardEntry(path2, (1, 1, 1.0, 1))
+    # Update entries to load the files
+    await dashboard_entries.async_update_entries()
 
-    dashboard_entries._entries[str(path1)] = entry1
-    dashboard_entries._entries[str(path2)] = entry2
+    # Get entries and verify they have different cache keys
+    entry1 = dashboard_entries.get(file1)
+    entry2 = dashboard_entries.get(file2)
 
-    assert str(path1) in dashboard_entries._entries
-    assert str(path2) in dashboard_entries._entries
-    assert dashboard_entries._entries[str(path1)].cache_key == create_cache_key()
-    assert dashboard_entries._entries[str(path2)].cache_key == (1, 1, 1.0, 1)
+    assert entry1 is not None
+    assert entry2 is not None
+    assert entry1.cache_key != entry2.cache_key
 
 
 def test_dashboard_entry_path_property() -> None:
@@ -183,21 +190,99 @@ def test_dashboard_entry_path_property() -> None:
 
 @pytest.mark.asyncio
 async def test_dashboard_entries_all_returns_entries_with_paths(
-    dashboard_entries: DashboardEntries,
+    dashboard_entries: DashboardEntries, tmp_path: Path
 ) -> None:
     """Test that all() returns entries with their paths intact."""
-    paths = [
-        Path("/test/config/device1.yaml"),
-        Path("/test/config/device2.yaml"),
-        Path("/test/config/subfolder/device3.yaml"),
+    # Create test files
+    files = [
+        tmp_path / "device1.yaml",
+        tmp_path / "device2.yaml",
+        tmp_path / "device3.yaml",
     ]
 
-    for path in paths:
-        entry = DashboardEntry(path, create_cache_key())
-        dashboard_entries._entries[str(path)] = entry
+    for file in files:
+        file.write_text("test config")
+
+    # Update entries to load the files
+    await dashboard_entries.async_update_entries()
 
     all_entries = dashboard_entries.async_all()
 
-    assert len(all_entries) == len(paths)
+    assert len(all_entries) == len(files)
     retrieved_paths = [entry.path for entry in all_entries]
-    assert set(retrieved_paths) == set(paths)
+    assert set(retrieved_paths) == set(files)
+
+
+@pytest.mark.asyncio
+async def test_async_update_entries_removed_path(
+    dashboard_entries: DashboardEntries, mock_dashboard: Mock, tmp_path: Path
+) -> None:
+    """Test that removed files trigger ENTRY_REMOVED event."""
+
+    # Create a test file
+    test_file = tmp_path / "device.yaml"
+    test_file.write_text("test config")
+
+    # First update to add the entry
+    await dashboard_entries.async_update_entries()
+
+    # Verify entry was added
+    all_entries = dashboard_entries.async_all()
+    assert len(all_entries) == 1
+    entry = all_entries[0]
+
+    # Delete the file
+    test_file.unlink()
+
+    # Second update to detect removal
+    await dashboard_entries.async_update_entries()
+
+    # Verify entry was removed
+    all_entries = dashboard_entries.async_all()
+    assert len(all_entries) == 0
+
+    # Verify ENTRY_REMOVED event was fired
+    mock_dashboard.bus.async_fire.assert_any_call(
+        DashboardEvent.ENTRY_REMOVED, {"entry": entry}
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_entries_updated_path(
+    dashboard_entries: DashboardEntries, mock_dashboard: Mock, tmp_path: Path
+) -> None:
+    """Test that modified files trigger ENTRY_UPDATED event."""
+
+    # Create a test file
+    test_file = tmp_path / "device.yaml"
+    test_file.write_text("test config")
+
+    # First update to add the entry
+    await dashboard_entries.async_update_entries()
+
+    # Verify entry was added
+    all_entries = dashboard_entries.async_all()
+    assert len(all_entries) == 1
+    entry = all_entries[0]
+    original_cache_key = entry.cache_key
+
+    # Modify the file to change its mtime
+    test_file.write_text("updated config")
+    # Explicitly change the mtime to ensure it's different
+    stat = test_file.stat()
+    os.utime(test_file, (stat.st_atime, stat.st_mtime + 1))
+
+    # Second update to detect modification
+    await dashboard_entries.async_update_entries()
+
+    # Verify entry is still there with updated cache key
+    all_entries = dashboard_entries.async_all()
+    assert len(all_entries) == 1
+    updated_entry = all_entries[0]
+    assert updated_entry == entry  # Same entry object
+    assert updated_entry.cache_key != original_cache_key  # But cache key updated
+
+    # Verify ENTRY_UPDATED event was fired
+    mock_dashboard.bus.async_fire.assert_any_call(
+        DashboardEvent.ENTRY_UPDATED, {"entry": entry}
+    )

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
+from contextlib import asynccontextmanager
 import gzip
 import json
 import os
@@ -24,7 +25,9 @@ from esphome.dashboard.entries import (
     EntryStateSource,
     bool_to_entry_state,
 )
+from esphome.dashboard.models import build_importable_device_dict
 from esphome.dashboard.web_server import DashboardSubscriber
+from esphome.zeroconf import DiscoveredImport
 
 from .common import get_fixture_path
 
@@ -132,6 +135,18 @@ async def dashboard() -> DashboardTestHelper:
     sock.close()
     client.close()
     io_loop.close()
+
+
+@asynccontextmanager
+async def websocket_connection(dashboard: DashboardTestHelper):
+    """Async context manager for WebSocket connections."""
+    url = f"ws://127.0.0.1:{dashboard.port}/events"
+    ws = await websocket_connect(url)
+    try:
+        yield ws
+    finally:
+        if ws:
+            ws.close()
 
 
 @pytest_asyncio.fixture
@@ -836,17 +851,24 @@ def test_build_cache_arguments_name_without_address(mock_dashboard: Mock) -> Non
 
 
 @pytest.mark.asyncio
-async def test_websocket_connection(
-    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+async def test_websocket_connection_initial_state(
+    dashboard: DashboardTestHelper,
 ) -> None:
     """Test WebSocket connection and initial state."""
-    # Initial state already verified in fixture
-    # Just verify we can communicate
-    await websocket_client.write_message(json.dumps({"event": "ping"}))
-    msg = await websocket_client.read_message()
-    assert msg is not None
-    data = json.loads(msg)
-    assert data["event"] == "pong"
+    async with websocket_connection(dashboard) as ws:
+        # Should receive initial state with configured and importable devices
+        msg = await ws.read_message()
+        assert msg is not None
+        data = json.loads(msg)
+        assert data["event"] == "initial_state"
+        assert "devices" in data["data"]
+        assert "configured" in data["data"]["devices"]
+        assert "importable" in data["data"]["devices"]
+
+        # Check configured devices
+        configured = data["data"]["devices"]["configured"]
+        assert len(configured) > 0
+        assert configured[0]["name"] == "pico"  # From test fixtures
 
 
 @pytest.mark.asyncio
@@ -944,20 +966,21 @@ async def test_websocket_entry_removed(
 async def test_websocket_importable_device_added(
     dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
 ) -> None:
-    """Test WebSocket importable device added event."""
-    # Simulate importable device added
+    """Test WebSocket importable device added event with real DiscoveredImport."""
+    # Create a real DiscoveredImport object
+    discovered = DiscoveredImport(
+        device_name="new_import_device",
+        friendly_name="New Import Device",
+        package_import_url="https://example.com/package",
+        project_name="test_project",
+        project_version="1.0.0",
+        network="wifi",
+    )
+
+    # Directly fire the event as the mDNS system would
+    device_dict = build_importable_device_dict(DASHBOARD, discovered)
     DASHBOARD.bus.async_fire(
-        DashboardEvent.IMPORTABLE_DEVICE_ADDED,
-        {
-            "device": {
-                "name": "new_import_device",
-                "friendly_name": "New Import Device",
-                "package_import_url": "https://example.com/package",
-                "project_name": "test_project",
-                "project_version": "1.0.0",
-                "network": "wifi",
-            }
-        },
+        DashboardEvent.IMPORTABLE_DEVICE_ADDED, {"device": device_dict}
     )
 
     # Should receive importable device added event
@@ -966,8 +989,45 @@ async def test_websocket_importable_device_added(
     data = json.loads(msg)
     assert data["event"] == "importable_device_added"
     assert data["data"]["device"]["name"] == "new_import_device"
+    assert data["data"]["device"]["friendly_name"] == "New Import Device"
     assert data["data"]["device"]["project_name"] == "test_project"
     assert data["data"]["device"]["network"] == "wifi"
+    assert data["data"]["device"]["ignored"] is False
+
+
+@pytest.mark.asyncio
+async def test_websocket_importable_device_added_ignored(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket importable device added event for ignored device."""
+    # Add device to ignored list
+    DASHBOARD.ignored_devices.add("ignored_device")
+
+    # Create a real DiscoveredImport object
+    discovered = DiscoveredImport(
+        device_name="ignored_device",
+        friendly_name="Ignored Device",
+        package_import_url="https://example.com/package",
+        project_name="test_project",
+        project_version="1.0.0",
+        network="ethernet",
+    )
+
+    # Directly fire the event as the mDNS system would
+    device_dict = build_importable_device_dict(DASHBOARD, discovered)
+    DASHBOARD.bus.async_fire(
+        DashboardEvent.IMPORTABLE_DEVICE_ADDED, {"device": device_dict}
+    )
+
+    # Should receive importable device added event with ignored=True
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "importable_device_added"
+    assert data["data"]["device"]["name"] == "ignored_device"
+    assert data["data"]["device"]["friendly_name"] == "Ignored Device"
+    assert data["data"]["device"]["network"] == "ethernet"
+    assert data["data"]["device"]["ignored"] is True
 
 
 @pytest.mark.asyncio
@@ -1025,11 +1085,10 @@ async def test_websocket_importable_device_already_configured(
 @pytest.mark.asyncio
 async def test_websocket_multiple_connections(dashboard: DashboardTestHelper) -> None:
     """Test multiple WebSocket connections."""
-    url = f"ws://127.0.0.1:{dashboard.port}/events"
-    ws1 = await websocket_connect(url)
-    ws2 = await websocket_connect(url)
-
-    try:
+    async with (
+        websocket_connection(dashboard) as ws1,
+        websocket_connection(dashboard) as ws2,
+    ):
         # Both should receive initial state
         msg1 = await ws1.read_message()
         assert msg1 is not None
@@ -1057,47 +1116,27 @@ async def test_websocket_multiple_connections(dashboard: DashboardTestHelper) ->
         assert msg2 is not None
         data2 = json.loads(msg2)
         assert data2["event"] == "entry_state_changed"
-    finally:
-        ws1.close()
-        ws2.close()
 
 
 @pytest.mark.asyncio
-async def test_dashboard_subscriber_lifecycle() -> None:
+async def test_dashboard_subscriber_lifecycle(dashboard: DashboardTestHelper) -> None:
     """Test DashboardSubscriber lifecycle."""
-    with (
-        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
-        patch("esphome.dashboard.web_server.settings") as mock_settings,
-    ):
-        mock_dashboard.ping_request = Mock()
-        mock_dashboard.ping_request.set = Mock()
-        mock_dashboard.entries = Mock()
+    subscriber = DashboardSubscriber()
 
-        async def mock_update():
-            await asyncio.sleep(0)
+    # Initially no subscribers
+    assert len(subscriber._subscribers) == 0
+    assert subscriber._event_loop_task is None
 
-        mock_dashboard.entries.async_request_update_entries = Mock(
-            side_effect=mock_update
-        )
-        mock_settings.status_use_mqtt = False
+    # Add a subscriber
+    mock_websocket = Mock()
+    unsubscribe = subscriber.subscribe(mock_websocket)
 
-        subscriber = DashboardSubscriber()
+    # Should have started the event loop task
+    assert len(subscriber._subscribers) == 1
+    assert subscriber._event_loop_task is not None
 
-        # Initially no subscribers
-        assert len(subscriber._subscribers) == 0
-        assert subscriber._event_loop_task is None
+    # Unsubscribe
+    unsubscribe()
 
-        # Add a subscriber
-        mock_websocket = Mock()
-        unsubscribe = subscriber.subscribe(mock_websocket)
-
-        # Should have started the event loop task
-        assert len(subscriber._subscribers) == 1
-        assert subscriber._event_loop_task is not None
-
-        # Unsubscribe
-        unsubscribe()
-
-        # Should have stopped the task (after a small delay)
-        await asyncio.sleep(0.1)
-        assert len(subscriber._subscribers) == 0
+    # Should have stopped the task
+    assert len(subscriber._subscribers) == 0

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -914,6 +914,115 @@ async def test_websocket_entry_added(
 
 
 @pytest.mark.asyncio
+async def test_websocket_entry_removed(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket entry removed event."""
+    # Create a mock entry
+    mock_entry = Mock(spec=DashboardEntry)
+    mock_entry.filename = "removed.yaml"
+    mock_entry.name = "removed_device"
+    mock_entry.to_dict.return_value = {
+        "name": "removed_device",
+        "filename": "removed.yaml",
+        "configuration": "removed.yaml",
+    }
+
+    # Simulate entry removed
+    DASHBOARD.bus.async_fire(DashboardEvent.ENTRY_REMOVED, {"entry": mock_entry})
+
+    # Should receive entry removed event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "entry_removed"
+    assert data["data"]["device"]["name"] == "removed_device"
+    assert data["data"]["device"]["filename"] == "removed.yaml"
+
+
+@pytest.mark.asyncio
+async def test_websocket_importable_device_added(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket importable device added event."""
+    # Simulate importable device added
+    DASHBOARD.bus.async_fire(
+        DashboardEvent.IMPORTABLE_DEVICE_ADDED,
+        {
+            "device": {
+                "name": "new_import_device",
+                "friendly_name": "New Import Device",
+                "package_import_url": "https://example.com/package",
+                "project_name": "test_project",
+                "project_version": "1.0.0",
+                "network": "wifi",
+            }
+        },
+    )
+
+    # Should receive importable device added event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "importable_device_added"
+    assert data["data"]["device"]["name"] == "new_import_device"
+    assert data["data"]["device"]["project_name"] == "test_project"
+    assert data["data"]["device"]["network"] == "wifi"
+
+
+@pytest.mark.asyncio
+async def test_websocket_importable_device_removed(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket importable device removed event."""
+    # Simulate importable device removed
+    DASHBOARD.bus.async_fire(
+        DashboardEvent.IMPORTABLE_DEVICE_REMOVED,
+        {"name": "removed_import_device"},
+    )
+
+    # Should receive importable device removed event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "importable_device_removed"
+    assert data["data"]["name"] == "removed_import_device"
+
+
+@pytest.mark.asyncio
+async def test_websocket_importable_device_already_configured(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test that importable device event is not sent if device is already configured."""
+    # Get an existing configured device name
+    existing_entry = DASHBOARD.entries.async_all()[0]
+
+    # Simulate importable device added with same name as configured device
+    DASHBOARD.bus.async_fire(
+        DashboardEvent.IMPORTABLE_DEVICE_ADDED,
+        {
+            "device": {
+                "name": existing_entry.name,
+                "friendly_name": "Should Not Be Sent",
+                "package_import_url": "https://example.com/package",
+                "project_name": "test_project",
+                "project_version": "1.0.0",
+                "network": "wifi",
+            }
+        },
+    )
+
+    # Send a ping to ensure connection is still alive
+    await websocket_client.write_message(json.dumps({"event": "ping"}))
+
+    # Should only receive pong, not the importable device event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "pong"
+
+
+@pytest.mark.asyncio
 async def test_websocket_multiple_connections(dashboard: DashboardTestHelper) -> None:
     """Test multiple WebSocket connections."""
     url = f"ws://127.0.0.1:{dashboard.port}/events"

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -14,9 +14,17 @@ from tornado.httpclient import AsyncHTTPClient, HTTPClientError, HTTPResponse
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from tornado.testing import bind_unused_port
+from tornado.websocket import WebSocketClientConnection, websocket_connect
 
 from esphome.dashboard import web_server
+from esphome.dashboard.const import DashboardEvent
 from esphome.dashboard.core import DASHBOARD
+from esphome.dashboard.entries import (
+    DashboardEntry,
+    EntryStateSource,
+    bool_to_entry_state,
+)
+from esphome.dashboard.web_server import DashboardSubscriber
 
 from .common import get_fixture_path
 
@@ -124,6 +132,21 @@ async def dashboard() -> DashboardTestHelper:
     sock.close()
     client.close()
     io_loop.close()
+
+
+@pytest_asyncio.fixture
+async def websocket_client(dashboard: DashboardTestHelper) -> WebSocketClientConnection:
+    """Create a WebSocket connection for testing."""
+    url = f"ws://127.0.0.1:{dashboard.port}/events"
+    ws = await websocket_connect(url)
+
+    # Read and discard initial state message
+    await ws.read_message()
+
+    yield ws
+
+    if ws:
+        ws.close()
 
 
 @pytest.mark.asyncio
@@ -810,3 +833,164 @@ def test_build_cache_arguments_name_without_address(mock_dashboard: Mock) -> Non
     mock_dashboard.mdns_status.get_cached_addresses.assert_called_once_with(
         "my-device.local"
     )
+
+
+@pytest.mark.asyncio
+async def test_websocket_connection(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket connection and initial state."""
+    # Initial state already verified in fixture
+    # Just verify we can communicate
+    await websocket_client.write_message(json.dumps({"event": "ping"}))
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "pong"
+
+
+@pytest.mark.asyncio
+async def test_websocket_ping_pong(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket ping/pong mechanism."""
+    # Send ping
+    await websocket_client.write_message(json.dumps({"event": "ping"}))
+
+    # Should receive pong
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "pong"
+
+
+@pytest.mark.asyncio
+async def test_websocket_entry_state_changed(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket entry state changed event."""
+    # Simulate entry state change
+    entry = DASHBOARD.entries.async_all()[0]
+    state = bool_to_entry_state(True, EntryStateSource.MDNS)
+    DASHBOARD.bus.async_fire(
+        DashboardEvent.ENTRY_STATE_CHANGED, {"entry": entry, "state": state}
+    )
+
+    # Should receive state change event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "entry_state_changed"
+    assert data["data"]["filename"] == entry.filename
+    assert data["data"]["name"] == entry.name
+    assert data["data"]["state"] is True
+
+
+@pytest.mark.asyncio
+async def test_websocket_entry_added(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket entry added event."""
+    # Create a mock entry
+    mock_entry = Mock(spec=DashboardEntry)
+    mock_entry.filename = "test.yaml"
+    mock_entry.name = "test_device"
+    mock_entry.to_dict.return_value = {
+        "name": "test_device",
+        "filename": "test.yaml",
+        "configuration": "test.yaml",
+    }
+
+    # Simulate entry added
+    DASHBOARD.bus.async_fire(DashboardEvent.ENTRY_ADDED, {"entry": mock_entry})
+
+    # Should receive entry added event
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "entry_added"
+    assert data["data"]["device"]["name"] == "test_device"
+    assert data["data"]["device"]["filename"] == "test.yaml"
+
+
+@pytest.mark.asyncio
+async def test_websocket_multiple_connections(dashboard: DashboardTestHelper) -> None:
+    """Test multiple WebSocket connections."""
+    url = f"ws://127.0.0.1:{dashboard.port}/events"
+    ws1 = await websocket_connect(url)
+    ws2 = await websocket_connect(url)
+
+    try:
+        # Both should receive initial state
+        msg1 = await ws1.read_message()
+        assert msg1 is not None
+        data1 = json.loads(msg1)
+        assert data1["event"] == "initial_state"
+
+        msg2 = await ws2.read_message()
+        assert msg2 is not None
+        data2 = json.loads(msg2)
+        assert data2["event"] == "initial_state"
+
+        # Fire an event - both should receive it
+        entry = DASHBOARD.entries.async_all()[0]
+        state = bool_to_entry_state(False, EntryStateSource.MDNS)
+        DASHBOARD.bus.async_fire(
+            DashboardEvent.ENTRY_STATE_CHANGED, {"entry": entry, "state": state}
+        )
+
+        msg1 = await ws1.read_message()
+        assert msg1 is not None
+        data1 = json.loads(msg1)
+        assert data1["event"] == "entry_state_changed"
+
+        msg2 = await ws2.read_message()
+        assert msg2 is not None
+        data2 = json.loads(msg2)
+        assert data2["event"] == "entry_state_changed"
+    finally:
+        ws1.close()
+        ws2.close()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_subscriber_lifecycle() -> None:
+    """Test DashboardSubscriber lifecycle."""
+    with (
+        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
+        patch("esphome.dashboard.web_server.settings") as mock_settings,
+    ):
+        mock_dashboard.ping_request = Mock()
+        mock_dashboard.ping_request.set = Mock()
+        mock_dashboard.entries = Mock()
+
+        async def mock_update():
+            await asyncio.sleep(0)
+
+        mock_dashboard.entries.async_request_update_entries = Mock(
+            side_effect=mock_update
+        )
+        mock_settings.status_use_mqtt = False
+
+        subscriber = DashboardSubscriber()
+
+        # Initially no subscribers
+        assert len(subscriber._subscribers) == 0
+        assert subscriber._ping_task is None
+        assert subscriber._filesystem_poll_task is None
+
+        # Add a subscriber
+        mock_websocket = Mock()
+        unsubscribe = subscriber.subscribe(mock_websocket)
+
+        # Should have started tasks
+        assert len(subscriber._subscribers) == 1
+        assert subscriber._ping_task is not None
+        assert subscriber._filesystem_poll_task is not None
+
+        # Unsubscribe
+        unsubscribe()
+
+        # Should have stopped tasks (after a small delay)
+        await asyncio.sleep(0.1)
+        assert len(subscriber._subscribers) == 0

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -905,6 +905,46 @@ async def test_websocket_invalid_json(
 
 
 @pytest.mark.asyncio
+async def test_websocket_authentication_required(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket authentication when auth is required."""
+    with patch(
+        "esphome.dashboard.web_server.is_authenticated"
+    ) as mock_is_authenticated:
+        mock_is_authenticated.return_value = False
+
+        # Try to connect - should be rejected
+        url = f"ws://127.0.0.1:{dashboard.port}/events"
+        try:
+            ws = await websocket_connect(url)
+            # Connection should close immediately
+            msg = await ws.read_message()
+            assert msg is None  # Connection closed
+        except Exception:
+            # Connection may fail immediately, which is also expected
+            pass
+
+
+@pytest.mark.asyncio
+async def test_websocket_authentication_not_required(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket connection when no auth is required."""
+    with patch(
+        "esphome.dashboard.web_server.is_authenticated"
+    ) as mock_is_authenticated:
+        mock_is_authenticated.return_value = True
+
+        # Should be able to connect successfully
+        async with websocket_connection(dashboard) as ws:
+            msg = await ws.read_message()
+            assert msg is not None
+            data = json.loads(msg)
+            assert data["event"] == "initial_state"
+
+
+@pytest.mark.asyncio
 async def test_websocket_entry_state_changed(
     dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
 ) -> None:

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1158,3 +1158,41 @@ async def test_dashboard_subscriber_lifecycle(dashboard: DashboardTestHelper) ->
 
     # Should have stopped the task
     assert len(subscriber._subscribers) == 0
+
+
+@pytest.mark.asyncio
+async def test_dashboard_subscriber_entries_update_interval(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test DashboardSubscriber entries update interval."""
+    # Patch the constants to make the test run faster
+    with (
+        patch("esphome.dashboard.web_server.DASHBOARD_POLL_INTERVAL", 0.01),
+        patch("esphome.dashboard.web_server.DASHBOARD_ENTRIES_UPDATE_ITERATIONS", 2),
+        patch("esphome.dashboard.web_server.settings") as mock_settings,
+        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
+    ):
+        mock_settings.status_use_mqtt = False
+
+        # Mock dashboard dependencies
+        mock_dashboard.ping_request = Mock()
+        mock_dashboard.ping_request.set = Mock()
+        mock_dashboard.entries = Mock()
+        mock_dashboard.entries.async_request_update_entries = Mock()
+
+        subscriber = DashboardSubscriber()
+        mock_websocket = Mock()
+
+        # Subscribe to start the event loop
+        unsubscribe = subscriber.subscribe(mock_websocket)
+
+        # Wait for a few iterations to ensure entries update is called
+        await asyncio.sleep(0.05)  # Should be enough for 2+ iterations
+
+        # Unsubscribe to stop the task
+        unsubscribe()
+
+        # Verify entries update was called
+        assert mock_dashboard.entries.async_request_update_entries.call_count >= 1
+        # Verify ping request was set multiple times
+        assert mock_dashboard.ping_request.set.call_count >= 2

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -887,6 +887,24 @@ async def test_websocket_ping_pong(
 
 
 @pytest.mark.asyncio
+async def test_websocket_invalid_json(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket handling of invalid JSON."""
+    # Send invalid JSON
+    await websocket_client.write_message("not valid json {]")
+
+    # Send a valid ping to verify connection is still alive
+    await websocket_client.write_message(json.dumps({"event": "ping"}))
+
+    # Should receive pong, confirming the connection wasn't closed by invalid JSON
+    msg = await websocket_client.read_message()
+    assert msg is not None
+    data = json.loads(msg)
+    assert data["event"] == "pong"
+
+
+@pytest.mark.asyncio
 async def test_websocket_entry_state_changed(
     dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
 ) -> None:

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -7,7 +7,7 @@ import gzip
 import json
 import os
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import pytest_asyncio
@@ -1232,3 +1232,73 @@ async def test_dashboard_subscriber_entries_update_interval(
         assert mock_dashboard.entries.async_request_update_entries.call_count >= 1
         # Verify ping request was set multiple times
         assert mock_dashboard.ping_request.set.call_count >= 2
+
+
+@pytest.mark.asyncio
+async def test_websocket_refresh_command(
+    dashboard: DashboardTestHelper, websocket_client: WebSocketClientConnection
+) -> None:
+    """Test WebSocket refresh command triggers dashboard update."""
+    with patch("esphome.dashboard.web_server.DASHBOARD_SUBSCRIBER") as mock_subscriber:
+        mock_subscriber.request_refresh = Mock()
+
+        # Send refresh command
+        await websocket_client.write_message(json.dumps({"event": "refresh"}))
+
+        # Give it a moment to process
+        await asyncio.sleep(0.01)
+
+        # Verify request_refresh was called
+        mock_subscriber.request_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_subscriber_refresh_event(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test DashboardSubscriber refresh event triggers immediate update."""
+    # Patch the constants to make the test run faster
+    with (
+        patch(
+            "esphome.dashboard.web_server.DASHBOARD_POLL_INTERVAL", 1.0
+        ),  # Long timeout
+        patch(
+            "esphome.dashboard.web_server.DASHBOARD_ENTRIES_UPDATE_ITERATIONS", 100
+        ),  # Won't reach naturally
+        patch("esphome.dashboard.web_server.settings") as mock_settings,
+        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
+    ):
+        mock_settings.status_use_mqtt = False
+
+        # Mock dashboard dependencies
+        mock_dashboard.ping_request = Mock()
+        mock_dashboard.ping_request.set = Mock()
+        mock_dashboard.entries = Mock()
+        mock_dashboard.entries.async_request_update_entries = AsyncMock()
+
+        subscriber = DashboardSubscriber()
+        mock_websocket = Mock()
+
+        # Subscribe to start the event loop
+        unsubscribe = subscriber.subscribe(mock_websocket)
+
+        # Wait a bit to ensure loop is running
+        await asyncio.sleep(0.01)
+
+        # Verify entries update hasn't been called yet (iterations not reached)
+        assert mock_dashboard.entries.async_request_update_entries.call_count == 0
+
+        # Request refresh
+        subscriber.request_refresh()
+
+        # Wait for the refresh to be processed
+        await asyncio.sleep(0.01)
+
+        # Now entries update should have been called
+        assert mock_dashboard.entries.async_request_update_entries.call_count == 1
+
+        # Unsubscribe to stop the task
+        unsubscribe()
+
+        # Give it a moment to clean up
+        await asyncio.sleep(0.01)

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1085,21 +1085,19 @@ async def test_dashboard_subscriber_lifecycle() -> None:
 
         # Initially no subscribers
         assert len(subscriber._subscribers) == 0
-        assert subscriber._ping_task is None
-        assert subscriber._filesystem_poll_task is None
+        assert subscriber._event_loop_task is None
 
         # Add a subscriber
         mock_websocket = Mock()
         unsubscribe = subscriber.subscribe(mock_websocket)
 
-        # Should have started tasks
+        # Should have started the event loop task
         assert len(subscriber._subscribers) == 1
-        assert subscriber._ping_task is not None
-        assert subscriber._filesystem_poll_task is not None
+        assert subscriber._event_loop_task is not None
 
         # Unsubscribe
         unsubscribe()
 
-        # Should have stopped tasks (after a small delay)
+        # Should have stopped the task (after a small delay)
         await asyncio.sleep(0.1)
         assert len(subscriber._subscribers) == 0

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -914,16 +914,12 @@ async def test_websocket_authentication_required(
     ) as mock_is_authenticated:
         mock_is_authenticated.return_value = False
 
-        # Try to connect - should be rejected
+        # Try to connect - should be rejected with 401
         url = f"ws://127.0.0.1:{dashboard.port}/events"
-        try:
-            ws = await websocket_connect(url)
-            # Connection should close immediately
-            msg = await ws.read_message()
-            assert msg is None  # Connection closed
-        except Exception:
-            # Connection may fail immediately, which is also expected
-            pass
+        with pytest.raises(HTTPClientError) as exc_info:
+            await websocket_connect(url)
+        # Should get HTTP 401 Unauthorized
+        assert exc_info.value.code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
dashboard pr https://github.com/esphome/dashboard/pull/812
# What does this implement/fix?

This PR converts the ESPHome dashboard from a polling-based architecture to a WebSocket-based real-time event system. Previously, the dashboard polled the `/devices` and `/ping` endpoints every 2-5 seconds, creating unnecessary server load and network traffic. The new implementation uses WebSockets to push updates to connected clients only when changes occur.

Key improvements:
- Eliminates periodic polling of `/devices` and `/ping` endpoints
- Provides real-time updates for device state changes, additions, and removals
- Adds real-time discovery of importable devices via mDNS
- Reduces server load by only running background tasks when dashboard clients are connected
- Maintains backward compatibility with existing REST endpoints

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reduces unnecessary network traffic and improves dashboard responsiveness

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable (internal dashboard implementation)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal dashboard improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Implementation Details

### Python (Backend)
- Added `DashboardEventsWebSocket` handler at `/events` endpoint
- Implemented `DashboardSubscriber` class to manage background polling tasks
- Added `DashboardEvent` StrEnum for type-safe event constants
- Modified event bus to support WebSocket event propagation
- Background tasks (ping, filesystem polling) only run when clients are connected

### TypeScript (Frontend)
- Created `DashboardWebSocket` class with automatic reconnection
- Implemented `createWebSocketCollection` utility for managing real-time collections
- Updated device and online status APIs to use WebSocket subscriptions
- Added connection status toast notifications with Material Web Components
- Maintained compatibility with existing REST API fallbacks

### Events
The WebSocket protocol uses the following event types:
- **Internal dashboard events**: `entry_added`, `entry_removed`, `entry_updated`, `entry_state_changed`, `importable_device_added`, `importable_device_removed`
- **Connection level events**: `initial_state`, `ping`, `pong`

### Performance Impact
- Reduces network traffic by ~95% on idle dashboard
- Eliminates 20-30 HTTP requests per minute per client
- Server CPU usage reduced when dashboard is open but idle
- Real-time updates improve perceived responsiveness