### PR TITLE
[esp32_ble_server] Replace HashMap with vector for services - saves 1KB flash, 26x faster

### DIFF
--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -66,7 +66,12 @@ class BLEServer : public Component,
   void ble_before_disabled_event_handler() override;
 
  protected:
-  static std::string get_service_key(ESPBTUUID uuid, uint8_t inst_id);
+  struct ServiceEntry {
+    ESPBTUUID uuid;
+    uint8_t inst_id;
+    BLEService *service;
+  };
+
   void restart_advertising_();
 
   void add_client_(uint16_t conn_id) { this->clients_.insert(conn_id); }
@@ -77,7 +82,7 @@ class BLEServer : public Component,
   bool registered_{false};
 
   std::unordered_set<uint16_t> clients_;
-  std::unordered_map<std::string, BLEService *> services_{};
+  std::vector<ServiceEntry> services_{};
   std::vector<BLEService *> services_to_start_{};
   BLEService *device_information_service_{};
 


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the ESP32 BLE Server component by replacing `std::unordered_map` with `std::vector` for service storage.

**Performance improvements:**
- 26x faster service lookups (typical 3 services case)
- 1KB flash saved
- Reduced RAM usage

The HashMap approach introduced in #5616 used string keys (`uuid.to_string() + std::to_string(inst_id)`) to uniquely identify services. While this worked correctly, the string operations made it significantly slower than a simple vector. Before the UUID formatting optimization in #10714, HashMap was 241x slower (due to sprintf). Even after that optimization, HashMap is still 26x slower. Since BLE servers typically have only 1-3 services, a simple vector with linear search is more efficient.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Existing BLE server configurations work unchanged
esp32_ble_server:
  manufacturer_data:
    manufacturer_id: 0x059F
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-facing changes

## Additional Details

**Impact:**
- Flash: 1,052 bytes saved
- RAM: Reduced (no string allocations)
- Performance (from benchmark):
  - 3 services: 26x faster
  - 15 services: 16x faster
  - 50 services: 10x faster

**Why the massive performance difference?**

Every HashMap lookup performed these operations:
1. Called `uuid.to_string()` - formats 16 bytes into 36-character UUID string
2. Called `std::to_string(inst_id)` - converts uint8_t to string
3. Concatenated these strings (creating a new ~37 byte string)
4. Hashed the resulting string
5. Did the map lookup

The vector approach simply loops through entries and compares 17 bytes directly. Since BLE servers typically have 1-3 services, this is vastly more efficient.

Benchmark included: 
[ble_service_lookup_benchmark.zip](https://github.com/user-attachments/files/22553520/ble_service_lookup_benchmark.zip)

