### PR TITLE
[esp32_improv] Fix crashes from uninitialized pointers and missing null checks

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -15,6 +15,8 @@ using namespace bytebuffer;
 
 static const char *const TAG = "esp32_improv.component";
 static const char *const ESPHOME_MY_LINK = "https://my.home-assistant.io/redirect/config_flow_start?domain=esphome";
+static constexpr uint16_t STOP_ADVERTISING_DELAY =
+    10000;  // Delay (ms) before stopping service to allow BLE clients to read the final state
 
 ESP32ImprovComponent::ESP32ImprovComponent() { global_improv_component = this; }
 
@@ -193,6 +195,23 @@ void ESP32ImprovComponent::set_status_indicator_state_(bool state) {
 #endif
 }
 
+const char *ESP32ImprovComponent::state_to_string_(improv::State state) {
+  switch (state) {
+    case improv::STATE_STOPPED:
+      return "STOPPED";
+    case improv::STATE_AWAITING_AUTHORIZATION:
+      return "AWAITING_AUTHORIZATION";
+    case improv::STATE_AUTHORIZED:
+      return "AUTHORIZED";
+    case improv::STATE_PROVISIONING:
+      return "PROVISIONING";
+    case improv::STATE_PROVISIONED:
+      return "PROVISIONED";
+    default:
+      return "UNKNOWN";
+  }
+}
+
 bool ESP32ImprovComponent::check_identify_() {
   uint32_t now = millis();
 
@@ -206,31 +225,40 @@ bool ESP32ImprovComponent::check_identify_() {
 }
 
 void ESP32ImprovComponent::set_state_(improv::State state) {
-  ESP_LOGV(TAG, "Setting state: %d", state);
+  if (this->state_ != state) {
+    ESP_LOGD(TAG, "State transition: %s (0x%02X) -> %s (0x%02X)", this->state_to_string_(this->state_), this->state_,
+             this->state_to_string_(state), state);
+  }
   this->state_ = state;
-  if (this->status_->get_value().empty() || this->status_->get_value()[0] != state) {
+  if (this->status_ != nullptr && (this->status_->get_value().empty() || this->status_->get_value()[0] != state)) {
     this->status_->set_value(ByteBuffer::wrap(static_cast<uint8_t>(state)));
     if (state != improv::STATE_STOPPED)
       this->status_->notify();
   }
-  std::vector<uint8_t> service_data(8, 0);
-  service_data[0] = 0x77;  // PR
-  service_data[1] = 0x46;  // IM
-  service_data[2] = static_cast<uint8_t>(state);
+  // Only advertise valid Improv states (0x01-0x04).
+  // STATE_STOPPED (0x00) is internal only and not part of the Improv spec.
+  // Advertising 0x00 causes undefined behavior in some clients and makes them
+  // repeatedly connect trying to determine the actual state.
+  if (state != improv::STATE_STOPPED) {
+    std::vector<uint8_t> service_data(8, 0);
+    service_data[0] = 0x77;  // PR
+    service_data[1] = 0x46;  // IM
+    service_data[2] = static_cast<uint8_t>(state);
 
-  uint8_t capabilities = 0x00;
+    uint8_t capabilities = 0x00;
 #ifdef USE_OUTPUT
-  if (this->status_indicator_ != nullptr)
-    capabilities |= improv::CAPABILITY_IDENTIFY;
+    if (this->status_indicator_ != nullptr)
+      capabilities |= improv::CAPABILITY_IDENTIFY;
 #endif
 
-  service_data[3] = capabilities;
-  service_data[4] = 0x00;  // Reserved
-  service_data[5] = 0x00;  // Reserved
-  service_data[6] = 0x00;  // Reserved
-  service_data[7] = 0x00;  // Reserved
+    service_data[3] = capabilities;
+    service_data[4] = 0x00;  // Reserved
+    service_data[5] = 0x00;  // Reserved
+    service_data[6] = 0x00;  // Reserved
+    service_data[7] = 0x00;  // Reserved
 
-  esp32_ble::global_ble->advertising_set_service_data(service_data);
+    esp32_ble::global_ble->advertising_set_service_data(service_data);
+  }
 #ifdef USE_ESP32_IMPROV_STATE_CALLBACK
   this->state_callback_.call(this->state_, this->error_state_);
 #endif
@@ -240,7 +268,12 @@ void ESP32ImprovComponent::set_error_(improv::Error error) {
   if (error != improv::ERROR_NONE) {
     ESP_LOGE(TAG, "Error: %d", error);
   }
-  if (this->error_->get_value().empty() || this->error_->get_value()[0] != error) {
+  // The error_ characteristic is initialized in setup_characteristics() which is called
+  // from the loop, while the BLE disconnect callback is registered in setup().
+  // error_ can be nullptr if:
+  // 1. A client connects/disconnects before setup_characteristics() is called
+  // 2. The device is already provisioned so the service never starts (should_start_ is false)
+  if (this->error_ != nullptr && (this->error_->get_value().empty() || this->error_->get_value()[0] != error)) {
     this->error_->set_value(ByteBuffer::wrap(static_cast<uint8_t>(error)));
     if (this->state_ != improv::STATE_STOPPED)
       this->error_->notify();
@@ -264,7 +297,10 @@ void ESP32ImprovComponent::start() {
 
 void ESP32ImprovComponent::stop() {
   this->should_start_ = false;
-  this->set_timeout("end-service", 1000, [this] {
+  // Wait before stopping the service to ensure all BLE clients see the state change.
+  // This prevents clients from repeatedly reconnecting and wasting resources by allowing
+  // them to observe that the device is provisioned before the service disappears.
+  this->set_timeout("end-service", STOP_ADVERTISING_DELAY, [this] {
     if (this->state_ == improv::STATE_STOPPED || this->service_ == nullptr)
       return;
     this->service_->stop();

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -195,6 +195,7 @@ void ESP32ImprovComponent::set_status_indicator_state_(bool state) {
 #endif
 }
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
 const char *ESP32ImprovComponent::state_to_string_(improv::State state) {
   switch (state) {
     case improv::STATE_STOPPED:
@@ -211,6 +212,7 @@ const char *ESP32ImprovComponent::state_to_string_(improv::State state) {
       return "UNKNOWN";
   }
 }
+#endif
 
 bool ESP32ImprovComponent::check_identify_() {
   uint32_t now = millis();
@@ -225,10 +227,12 @@ bool ESP32ImprovComponent::check_identify_() {
 }
 
 void ESP32ImprovComponent::set_state_(improv::State state) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
   if (this->state_ != state) {
     ESP_LOGD(TAG, "State transition: %s (0x%02X) -> %s (0x%02X)", this->state_to_string_(this->state_), this->state_,
              this->state_to_string_(state), state);
   }
+#endif
   this->state_ = state;
   if (this->status_ != nullptr && (this->status_->get_value().empty() || this->status_->get_value()[0] != state)) {
     this->status_->set_value(ByteBuffer::wrap(static_cast<uint8_t>(state)));

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -108,6 +108,7 @@ class ESP32ImprovComponent : public Component {
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   bool check_identify_();
+  const char *state_to_string_(improv::State state);
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -79,12 +79,12 @@ class ESP32ImprovComponent : public Component {
   std::vector<uint8_t> incoming_data_;
   wifi::WiFiAP connecting_sta_;
 
-  BLEService *service_ = nullptr;
-  BLECharacteristic *status_;
-  BLECharacteristic *error_;
-  BLECharacteristic *rpc_;
-  BLECharacteristic *rpc_response_;
-  BLECharacteristic *capabilities_;
+  BLEService *service_{nullptr};
+  BLECharacteristic *status_{nullptr};
+  BLECharacteristic *error_{nullptr};
+  BLECharacteristic *rpc_{nullptr};
+  BLECharacteristic *rpc_response_{nullptr};
+  BLECharacteristic *capabilities_{nullptr};
 
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *authorizer_{nullptr};

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -108,7 +108,9 @@ class ESP32ImprovComponent : public Component {
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   bool check_identify_();
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
   const char *state_to_string_(improv::State state);
+#endif
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes multiple critical bugs in the ESP32 Improv component that were causing ESP32 crashes and incorrect state advertising:

## Root Causes Fixed

1. **Uninitialized characteristic pointers** - The BLE characteristic pointers (`error_`, `status_`, `rpc_`, etc.) were not explicitly initialized, leaving them with undefined values. This caused null checks to fail unpredictably, leading to crashes when the code tried to dereference invalid pointers.

2. **Missing null check in set_error_()** - The disconnect callback could fire before characteristics were initialized (during early connection) or when the service was never started (device already provisioned). Even with proper initialization, we need to check if `error_` is nullptr before using it.

**Important Note:** This crash was especially likely to occur when `bluetooth_proxy` or any BLE client functionality was enabled alongside ESP32 Improv. Due to an ESP-IDF design limitation, the GATTS (server) event handler receives connect/disconnect events for ALL BLE connections, including outgoing client connections. This means ESP32 Improv's disconnect handler would be called even for connections it didn't handle, significantly increasing the likelihood of hitting the uninitialized pointer bug.

## Issues Resolved

1. **Fixes ESP32 panic/crash when BLE clients disconnect** - The BLE disconnect callback could fire before characteristics are initialized, causing a Guru Meditation Error (Load access fault) when `set_error_()` tried to access `this->error_`. This resulted in the entire ESP32 device rebooting. The crash also occurred when clients connected to already-provisioned devices that never started the Improv service. The root cause was twofold: characteristic pointers were uninitialized (containing garbage values) so null checks didn't work, AND there was no null check before dereferencing the pointer. (regression introduced in PR #7009)

2. **Fixes invalid state advertising** - After provisioning, the component was immediately transitioning from `STATE_PROVISIONED` (0x04) to advertising `STATE_STOPPED` (0x00) which is not a valid Improv protocol state [per specification](https://www.improv-wifi.com/ble/). Valid states are 0x01-0x04. Advertising 0x00 causes undefined behavior in some clients (like Home Assistant) making them repeatedly reconnect trying to determine the actual state.

4. **Ensures clients see state changes** - State changes (particularly `STATE_PROVISIONED`) are now advertised for 10 seconds before stopping the service, allowing BLE clients time to read the final state. Previously the state would change so quickly that clients couldn't observe the transition. This prevents clients from wasting resources repeatedly reconnecting.

5. **Adds state transition logging** - Debug logging now shows all state transitions with human-readable names for easier troubleshooting

## The Fix

- Initialize all BLE characteristic pointers to `nullptr` in the header file using brace initialization
- Add proper null check in `set_error_()` before accessing the characteristic
- The combination of both fixes ensures safe operation in all scenarios

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes "Guru Meditation Error" crashes when ESP32 Improv is used alongside bluetooth_proxy
- Fixes crash when Improv BLE clients repeatedly connect/disconnect
- Fixes Improv clients not seeing provisioned state
- Fixes crashes when BLE clients connect/disconnect before service initialization
- Fixes crashes when clients connect to already-provisioned devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config that previously caused crashes
esp32_improv:
  authorizer: none

# When used alongside bluetooth_proxy
bluetooth_proxy:
  active: true

esp32_ble_tracker:
  scan_parameters:
    active: true

# Optional: Add a factory reset button for testing
button:
  - platform: factory_reset
    name: "Factory Reset"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-exposed functionality changes
