### PR TITLE
[ethernet] Fix Ethernet RMII capable variant validation

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -145,13 +145,6 @@ def _validate(config):
             use_address = CORE.name + config[CONF_DOMAIN]
         config[CONF_USE_ADDRESS] = use_address
 
-    # Validate LAN8670 is only used with ESP32 classic or ESP32-P4
-    if config[CONF_TYPE] == "LAN8670":
-        variant = get_esp32_variant()
-        if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
-            raise cv.Invalid(
-                f"LAN8670 PHY is only supported on ESP32 classic and ESP32-P4, not {variant}"
-            )
     if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
         if _is_framework_spi_polling_mode_supported():
             if CONF_POLLING_INTERVAL in config and CONF_INTERRUPT_PIN in config:
@@ -184,6 +177,12 @@ def _validate(config):
             del config[CONF_CLK_MODE]
         elif CONF_CLK not in config:
             raise cv.Invalid("'clk' is a required option for [ethernet].")
+        variant = get_esp32_variant()
+        if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
+            raise cv.Invalid(
+                f"{config[CONF_TYPE]} PHY requires RMII interface and is only supported "
+                f"on ESP32 classic and ESP32-P4, not {variant}"
+            )
 
     return config
 


### PR DESCRIPTION
# What does this implement/fix?

PR #10874 recently added validation to limit support for the LAN8670 to ESP32 variants that support the RMII interface. However, this check should be extended to all RMII PHYs.

This updates the validator to fail for all RMII PHYs if the variant is not ESP32 classic or ESP32P4.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# This will succeed:
esp32:
  variant: esp32
ethernet:
  type: IP101

# This will fail:
esp32:
  variant: esp32s3
ethernet:
  type: IP101
```
Error message will have the form:
```
IP101 PHY requires RMII interface and is only supported on ESP32 classic and ESP32-P4, not ESP32S3.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
