### PR TITLE
[usb_uart] Fix flow control on ch34x devices

### DIFF
--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -68,12 +68,9 @@ void USBUartTypeCH34X::enable_channels() {
     value |= channel->data_bits_ - 5;
     value <<= 8;
     value |= 0x8C;
-    uint8_t cmd = 0xA1;
-    if (channel->index_ <= 1) {
-      cmd += channel->index_;
-    } else if (channel->index_ <= 3) {
-      cmd += (0x10 + (channel->index_ - 2));
-    }
+    uint8_t cmd = 0xA1 + channel->index_;
+    if (channel->index_ >= 2)
+      cmd += 0xE;
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd + 3, 0x80, 0, callback);
   }

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -68,10 +68,18 @@ void USBUartTypeCH34X::enable_channels() {
     value |= channel->data_bits_ - 5;
     value <<= 8;
     value |= 0x8C;
-    uint8_t cmd = 0xA1 + channel->index_;
-    if (channel->index_ >= 2)
-      cmd += 0xE;
-    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
+    uint8_t baud_cmd = 0xA1;
+    uint8_t flowctl_cmd = 0xA4;
+    if (channel->index_ <= 1) {
+      baud_cmd += channel->index_;
+      flowctl_cmd += channel->index_;
+    }
+    else if (channel->index_ <= 3) {
+      baud_cmd += (0x10 + (channel->index_ - 2));
+      flowctl_cmd += (0x10 + (channel->index_ - 2));
+    }
+    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, baud_cmd, value, (factor << 8) | divisor, callback);
+    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, flowctl_cmd, 0x80, 0, callback);
   }
   USBUartTypeCdcAcm::enable_channels();
 }

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -68,17 +68,14 @@ void USBUartTypeCH34X::enable_channels() {
     value |= channel->data_bits_ - 5;
     value <<= 8;
     value |= 0x8C;
-    uint8_t baud_cmd = 0xA1;
-    uint8_t flowctl_cmd = 0xA4;
+    uint8_t cmd = 0xA1;
     if (channel->index_ <= 1) {
-      baud_cmd += channel->index_;
-      flowctl_cmd += channel->index_;
+      cmd += channel->index_;
     } else if (channel->index_ <= 3) {
-      baud_cmd += (0x10 + (channel->index_ - 2));
-      flowctl_cmd += (0x10 + (channel->index_ - 2));
+      cmd += (0x10 + (channel->index_ - 2));
     }
-    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, baud_cmd, value, (factor << 8) | divisor, callback);
-    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, flowctl_cmd, 0x80, 0, callback);
+    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
+    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd + 3, 0x80, 0, callback);
   }
   USBUartTypeCdcAcm::enable_channels();
 }

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -73,8 +73,7 @@ void USBUartTypeCH34X::enable_channels() {
     if (channel->index_ <= 1) {
       baud_cmd += channel->index_;
       flowctl_cmd += channel->index_;
-    }
-    else if (channel->index_ <= 3) {
+    } else if (channel->index_ <= 3) {
       baud_cmd += (0x10 + (channel->index_ - 2));
       flowctl_cmd += (0x10 + (channel->index_ - 2));
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fix missing flowcontrol setup when using multichannel & flowctl capable ch34x devices.

Source for fix:
In line 1693 of the linux driver ch343ser, there is a ch343_set_control call, resulting in a cmd-transfer-out, which sets the flowcontrol - this needs to be done in esphome as well, to disable flowcontrol correctly.
Also the previous lines of the mentioned source file show the correct calculation for the cmd for different channels - applied in this fix as well.

See:
https://github.com/WCHSoftGroup/ch343ser_linux/blob/main/driver/ch343.c#1693
and previous lines
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

CH344Q and possibly other flowctl capable usb-uart devices will not work as expected bc of missing flow-control disabling.

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
