### PR TITLE
[esp32_ble_tracker] Reduce gap_scan_result log verbosity to VV

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -295,7 +295,7 @@ void ESP32BLETracker::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_ga
 void ESP32BLETracker::gap_scan_event_handler(const BLEScanResult &scan_result) {
   // Note: This handler is called from the main loop context via esp32_ble's event queue.
   // We process advertisements immediately instead of buffering them.
-  ESP_LOGV(TAG, "gap_scan_result - event %d", scan_result.search_evt);
+  ESP_LOGVV(TAG, "gap_scan_result - event %d", scan_result.search_evt);
 
   if (scan_result.search_evt == ESP_GAP_SEARCH_INQ_RES_EVT) {
     // Process the scan result immediately


### PR DESCRIPTION
# What does this implement/fix?

Reduces log spam by changing the gap_scan_result event logging from verbose (V) to very verbose (VV) level in the ESP32 BLE tracker component.

When verbose logging is enabled, the ESP32 BLE tracker floods the logs with gap_scan_result messages:

```
[10:50:40.596][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.601][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.607][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.609][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.903][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.908][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.914][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.920][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.925][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.931][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.936][V][esp32_ble_tracker:298]: gap_scan_result - event 0
[10:50:40.941][V][esp32_ble_tracker:298]: gap_scan_result - event 0
```

These messages are primarily useful for deep debugging and should be at the VV (very verbose) level to prevent cluttering normal verbose logs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
esp32_ble_tracker:
  # Existing configuration remains the same
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).