### PR TITLE
[core] Don't remove storage in clean-all

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1155,7 +1155,9 @@ def parse_args(argv):
         "configuration", help="Your YAML configuration file(s).", nargs="+"
     )
 
-    parser_clean_all = subparsers.add_parser("clean-all", help="Clean all files.")
+    parser_clean_all = subparsers.add_parser(
+        "clean-all", help="Clean all build and platform files."
+    )
     parser_clean_all.add_argument(
         "configuration", help="Your YAML configuration directory.", nargs="*"
     )

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -343,7 +343,13 @@ def clean_all(configuration: list[str]):
         buid_dir = Path(dir) / ".esphome"
         if buid_dir.is_dir():
             _LOGGER.info("Deleting %s", buid_dir)
-            shutil.rmtree(buid_dir)
+            # Don't remove storage as it will cause the dashboard to regenerate all
+            # config files and that could cause issues
+            for item in buid_dir.iterdir():
+                if item.is_file():
+                    item.unlink()
+                elif item.name != "storage" and item.is_dir():
+                    shutil.rmtree(item)
 
     # Clean PlatformIO project files
     try:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -342,7 +342,7 @@ def clean_all(configuration: list[str]):
     for dir in configuration:
         buid_dir = Path(dir) / ".esphome"
         if buid_dir.is_dir():
-            _LOGGER.info("Deleting %s", buid_dir)
+            _LOGGER.info("Cleaning %s", buid_dir)
             # Don't remove storage as it will cause the dashboard to regenerate all configs
             for item in buid_dir.iterdir():
                 if item.is_file():

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -343,8 +343,7 @@ def clean_all(configuration: list[str]):
         buid_dir = Path(dir) / ".esphome"
         if buid_dir.is_dir():
             _LOGGER.info("Deleting %s", buid_dir)
-            # Don't remove storage as it will cause the dashboard to regenerate all
-            # config files and that could cause issues
+            # Don't remove storage as it will cause the dashboard to regenerate all configs
             for item in buid_dir.iterdir():
                 if item.is_file():
                     item.unlink()

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -340,11 +340,11 @@ def clean_all(configuration: list[str]):
 
     # Clean entire build dir
     for dir in configuration:
-        buid_dir = Path(dir) / ".esphome"
-        if buid_dir.is_dir():
-            _LOGGER.info("Cleaning %s", buid_dir)
+        build_dir = Path(dir) / ".esphome"
+        if build_dir.is_dir():
+            _LOGGER.info("Cleaning %s", build_dir)
             # Don't remove storage as it will cause the dashboard to regenerate all configs
-            for item in buid_dir.iterdir():
+            for item in build_dir.iterdir():
                 if item.is_file():
                     item.unlink()
                 elif item.name != "storage" and item.is_dir():

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -921,3 +921,67 @@ def test_clean_all_partial_exists(
         clean_all([str(config_dir)])
 
         assert build_dir.exists()
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_removes_non_storage_directories(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all removes directories other than storage."""
+    # Create build directory with various subdirectories
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+
+    # Create files
+    (build_dir / "file1.txt").write_text("content1")
+    (build_dir / "file2.txt").write_text("content2")
+
+    # Create storage directory (should be preserved)
+    storage_dir = build_dir / "storage"
+    storage_dir.mkdir()
+    (storage_dir / "storage.json").write_text('{"test": "data"}')
+
+    # Create other directories (should be removed)
+    cache_dir = build_dir / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "cache_file.txt").write_text("cache content")
+
+    logs_dir = build_dir / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "log1.txt").write_text("log content")
+
+    temp_dir = build_dir / "temp"
+    temp_dir.mkdir()
+    (temp_dir / "temp_file.txt").write_text("temp content")
+
+    # Call clean_all
+    from esphome.writer import clean_all
+
+    with caplog.at_level("INFO"):
+        clean_all([str(config_dir)])
+
+    # Verify .esphome directory still exists
+    assert build_dir.exists()
+
+    # Verify storage directory and its contents are preserved
+    assert storage_dir.exists()
+    assert (storage_dir / "storage.json").exists()
+    assert (storage_dir / "storage.json").read_text() == '{"test": "data"}'
+
+    # Verify files were removed
+    assert not (build_dir / "file1.txt").exists()
+    assert not (build_dir / "file2.txt").exists()
+
+    # Verify non-storage directories were removed
+    assert not cache_dir.exists()
+    assert not logs_dir.exists()
+    assert not temp_dir.exists()
+
+    # Verify logging mentions cleaning
+    assert "Cleaning" in caplog.text
+    assert str(build_dir) in caplog.text

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -804,7 +804,7 @@ def test_clean_all(
     assert not pio_core.exists()
 
     # Verify logging mentions each
-    assert "Deleting" in caplog.text
+    assert "Cleaning" in caplog.text
     assert str(build_dir1) in caplog.text
     assert str(build_dir2) in caplog.text
     assert "PlatformIO cache" in caplog.text
@@ -858,7 +858,7 @@ def test_clean_all_preserves_storage(
     assert not (build_dir / "other_file.txt").exists()
 
     # Verify logging mentions deletion
-    assert "Deleting" in caplog.text
+    assert "Cleaning" in caplog.text
     assert str(build_dir) in caplog.text
 
 

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -790,9 +790,14 @@ def test_clean_all(
         with caplog.at_level("INFO"):
             clean_all([str(config1_dir), str(config2_dir)])
 
-    # Verify deletions
-    assert not build_dir1.exists()
-    assert not build_dir2.exists()
+    # Verify deletions - .esphome directories remain but contents are cleaned
+    # The .esphome directory itself is not removed because it may contain storage
+    assert build_dir1.exists()
+    assert build_dir2.exists()
+
+    # Verify that files in .esphome were removed
+    assert not (build_dir1 / "dummy.txt").exists()
+    assert not (build_dir2 / "dummy.txt").exists()
     assert not pio_cache.exists()
     assert not pio_packages.exists()
     assert not pio_platforms.exists()
@@ -806,6 +811,55 @@ def test_clean_all(
     assert "PlatformIO packages" in caplog.text
     assert "PlatformIO platforms" in caplog.text
     assert "PlatformIO core" in caplog.text
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_preserves_storage(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all preserves storage directory."""
+    # Create build directory with storage subdirectory
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+    (build_dir / "dummy.txt").write_text("x")
+    (build_dir / "other_file.txt").write_text("y")
+
+    # Create storage directory with content
+    storage_dir = build_dir / "storage"
+    storage_dir.mkdir()
+    (storage_dir / "storage.json").write_text('{"test": "data"}')
+    (storage_dir / "other_storage.txt").write_text("storage content")
+
+    # Call clean_all
+    from esphome.writer import clean_all
+
+    with caplog.at_level("INFO"):
+        clean_all([str(config_dir)])
+
+    # Verify .esphome directory still exists
+    assert build_dir.exists()
+
+    # Verify storage directory still exists with its contents
+    assert storage_dir.exists()
+    assert (storage_dir / "storage.json").exists()
+    assert (storage_dir / "other_storage.txt").exists()
+
+    # Verify storage contents are intact
+    assert (storage_dir / "storage.json").read_text() == '{"test": "data"}'
+    assert (storage_dir / "other_storage.txt").read_text() == "storage content"
+
+    # Verify other files were removed
+    assert not (build_dir / "dummy.txt").exists()
+    assert not (build_dir / "other_file.txt").exists()
+
+    # Verify logging mentions deletion
+    assert "Deleting" in caplog.text
+    assert str(build_dir) in caplog.text
 
 
 @patch("esphome.writer.CORE")
@@ -833,8 +887,8 @@ def test_clean_all_platformio_not_available(
     ):
         clean_all([str(config_dir)])
 
-    # Build dir removed, PlatformIO dirs remain
-    assert not build_dir.exists()
+        # Build dir contents cleaned, PlatformIO dirs remain
+        assert build_dir.exists()
     assert pio_cache.exists()
 
     # No PlatformIO-specific logs
@@ -866,4 +920,4 @@ def test_clean_all_partial_exists(
 
         clean_all([str(config_dir)])
 
-    assert not build_dir.exists()
+        assert build_dir.exists()


### PR DESCRIPTION
# What does this implement/fix?

Don't remove storage as it will cause the dashboard to regenerate all configs. Regenerating all configs causes issues if there is a large number of them. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
