### PR TITLE
[mipi_spi] Fix t-display-amoled

### DIFF
--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -438,7 +438,7 @@ class DriverChip:
             sequence.append((INVOFF,))
         if brightness := config.get(CONF_BRIGHTNESS, self.get_default(CONF_BRIGHTNESS)):
             sequence.append((BRIGHTNESS, brightness))
-        # Add a SLPOUT command if not already the first command.
+        # Add a SLPOUT command if required.
         if not self.skip_command("SLPOUT"):
             sequence.append((SLPOUT,))
         sequence.append((DISPON,))

--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -401,6 +401,12 @@ class DriverChip:
         sequence.append((MADCTL, madctl))
         return madctl
 
+    def skip_command(self, command: str):
+        """
+        Allow suppressing a standard command in the init sequence.
+        """
+        return self.get_default(f"no_{command.lower()}", False)
+
     def get_sequence(self, config) -> tuple[tuple[int, ...], int]:
         """
         Create the init sequence for the display.
@@ -432,7 +438,9 @@ class DriverChip:
             sequence.append((INVOFF,))
         if brightness := config.get(CONF_BRIGHTNESS, self.get_default(CONF_BRIGHTNESS)):
             sequence.append((BRIGHTNESS, brightness))
-        sequence.append((SLPOUT,))
+        # Add a SLPOUT command if not already the first command.
+        if not self.skip_command("SLPOUT"):
+            sequence.append((SLPOUT,))
         sequence.append((DISPON,))
 
         # Flatten the sequence into a list of bytes, with the length of each command

--- a/esphome/components/mipi_spi/models/amoled.py
+++ b/esphome/components/mipi_spi/models/amoled.py
@@ -96,6 +96,7 @@ CO5300 = DriverChip(
     brightness=0xD0,
     color_order=MODE_RGB,
     bus_mode=TYPE_QUAD,
+    no_slpout=True,
     initsequence=(
         (SLPOUT,),  # Requires early SLPOUT
         (PAGESEL, 0x00),

--- a/esphome/components/mipi_spi/models/amoled.py
+++ b/esphome/components/mipi_spi/models/amoled.py
@@ -27,7 +27,8 @@ DriverChip(
     bus_mode=TYPE_QUAD,
     brightness=0xD0,
     color_order=MODE_RGB,
-    initsequence=(SLPOUT,),  # Requires early SLPOUT
+    no_slpout=True,  # SLPOUT is in the init sequence, early
+    initsequence=(SLPOUT,),
 )
 
 DriverChip(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Changes to mipi init sequence construction broke the Lilygo T-Display Amoled which requires the SLPOUT command in a different position in the init sequence.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1420280417822576720

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
