### PR TITLE
[usb_host] Fix double-free crash with lock-free atomic pool allocation

### DIFF
--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -9,10 +9,30 @@
 #include <freertos/task.h>
 #include "esphome/core/lock_free_queue.h"
 #include "esphome/core/event_pool.h"
-#include <list>
+#include <atomic>
 
 namespace esphome {
 namespace usb_host {
+
+// THREADING MODEL:
+// This component uses a dedicated USB task for event processing to prevent data loss.
+// - USB Task (high priority): Handles USB events, executes transfer callbacks
+// - Main Loop Task: Initiates transfers, processes completion events
+//
+// Thread-safe communication:
+// - Lock-free queues for USB task -> main loop events (SPSC pattern)
+// - Lock-free TransferRequest pool using atomic bitmask (MCSP pattern)
+//
+// TransferRequest pool access pattern:
+// - get_trq_() [allocate]: Called from BOTH USB task and main loop threads
+//   * USB task: via USB UART input callbacks that restart transfers immediately
+//   * Main loop: for output transfers and flow-controlled input restarts
+// - release_trq() [deallocate]: Called from main loop thread only
+//
+// The multi-threaded allocation is intentional for performance:
+// - USB task can immediately restart input transfers without context switching
+// - Main loop controls backpressure by deciding when to restart after consuming data
+// The atomic bitmask ensures thread-safe allocation without mutex blocking.
 
 static const char *const TAG = "usb_host";
 
@@ -98,13 +118,7 @@ class USBClient : public Component {
   friend class USBHost;
 
  public:
-  USBClient(uint16_t vid, uint16_t pid) : vid_(vid), pid_(pid) { init_pool(); }
-
-  void init_pool() {
-    this->trq_pool_.clear();
-    for (size_t i = 0; i != MAX_REQUESTS; i++)
-      this->trq_pool_.push_back(&this->requests_[i]);
-  }
+  USBClient(uint16_t vid, uint16_t pid) : vid_(vid), pid_(pid), trq_in_use_(0) {}
   void setup() override;
   void loop() override;
   // setup must happen after the host bus has been setup
@@ -126,10 +140,13 @@ class USBClient : public Component {
 
  protected:
   bool register_();
-  TransferRequest *get_trq_();
+  TransferRequest *get_trq_();  // Lock-free allocation using atomic bitmask (multi-consumer safe)
   virtual void disconnect();
   virtual void on_connected() {}
-  virtual void on_disconnected() { this->init_pool(); }
+  virtual void on_disconnected() {
+    // Reset all requests to available (all bits to 0)
+    this->trq_in_use_.store(0);
+  }
 
   // USB task management
   static void usb_task_fn(void *arg);
@@ -143,7 +160,11 @@ class USBClient : public Component {
   int state_{USB_CLIENT_INIT};
   uint16_t vid_{};
   uint16_t pid_{};
-  std::list<TransferRequest *> trq_pool_{};
+  // Lock-free pool management using atomic bitmask (no dynamic allocation)
+  // Bit i = 1: requests_[i] is in use, Bit i = 0: requests_[i] is available
+  // Supports multiple concurrent consumers (both threads can allocate)
+  // Single producer for deallocation (main loop only)
+  std::atomic<uint16_t> trq_in_use_;
   TransferRequest requests_[MAX_REQUESTS]{};
 };
 class USBHost : public Component {

--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -52,7 +52,8 @@ static const uint8_t USB_DIR_IN = 1 << 7;
 static const uint8_t USB_DIR_OUT = 0;
 static const size_t SETUP_PACKET_SIZE = 8;
 
-static const size_t MAX_REQUESTS = 16;               // maximum number of outstanding requests possible.
+static const size_t MAX_REQUESTS = 16;  // maximum number of outstanding requests possible.
+static_assert(MAX_REQUESTS <= 16, "MAX_REQUESTS must be <= 16 to fit in uint16_t bitmask");
 static constexpr size_t USB_EVENT_QUEUE_SIZE = 32;   // Size of event queue between USB task and main loop
 static constexpr size_t USB_TASK_STACK_SIZE = 4096;  // Stack size for USB task (same as ESP-IDF USB examples)
 static constexpr UBaseType_t USB_TASK_PRIORITY = 5;  // Higher priority than main loop (tskIDLE_PRIORITY + 5)
@@ -164,6 +165,7 @@ class USBClient : public Component {
   // Bit i = 1: requests_[i] is in use, Bit i = 0: requests_[i] is available
   // Supports multiple concurrent consumers (both threads can allocate)
   // Single producer for deallocation (main loop only)
+  // Limited to 16 slots by uint16_t size (enforced by static_assert)
   std::atomic<uint16_t> trq_in_use_;
   TransferRequest requests_[MAX_REQUESTS]{};
 };

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -382,9 +382,10 @@ TransferRequest *USBClient::get_trq_() {
       trq->transfer->device_handle = this->device_handle_;
       return trq;
     }
-    // Another thread claimed this slot, retry with updated mask
-    // Don't increment i - retry the same slot with the updated mask
-    mask = expected;
+    // CAS failed - another thread modified the bitmask
+    // Restart search from the beginning with the updated mask
+    mask = this->trq_in_use_.load(std::memory_order_relaxed);
+    i = 0;
   }
 
   ESP_LOGE(TAG, "All %d transfer slots in use", MAX_REQUESTS);

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -363,7 +363,7 @@ TransferRequest *USBClient::get_trq_() {
   // Find first available slot (bit = 0) and try to claim it atomically
   // We use a while loop to allow retrying the same slot after CAS failure
   size_t i = 0;
-  while (i < MAX_REQUESTS) {
+  while (i != MAX_REQUESTS) {
     if (mask & (1U << i)) {
       // Slot is in use, move to next slot
       i++;

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -7,6 +7,7 @@
 
 #include <cinttypes>
 #include <cstring>
+#include <atomic>
 namespace esphome {
 namespace usb_host {
 
@@ -185,9 +186,11 @@ void USBClient::setup() {
     this->mark_failed();
     return;
   }
-  for (auto *trq : this->trq_pool_) {
-    usb_host_transfer_alloc(64, 0, &trq->transfer);
-    trq->client = this;
+  // Pre-allocate USB transfer buffers for all slots at startup
+  // This avoids any dynamic allocation during runtime
+  for (size_t i = 0; i < MAX_REQUESTS; i++) {
+    usb_host_transfer_alloc(64, 0, &this->requests_[i].transfer);
+    this->requests_[i].client = this;  // Set once, never changes
   }
 
   // Create and start USB task
@@ -347,17 +350,39 @@ static void control_callback(const usb_transfer_t *xfer) {
   queue_transfer_cleanup(trq, EVENT_CONTROL_COMPLETE);
 }
 
+// THREAD CONTEXT: Called from both USB task and main loop threads (multi-consumer)
+// - USB task: USB UART input callbacks restart transfers for immediate data reception
+// - Main loop: Output transfers and flow-controlled input restarts after consuming data
+//
+// THREAD SAFETY: Lock-free using atomic compare-and-swap on bitmask
+// This multi-threaded access is intentional for performance - USB task can
+// immediately restart transfers without waiting for main loop scheduling.
 TransferRequest *USBClient::get_trq_() {
-  if (this->trq_pool_.empty()) {
-    ESP_LOGE(TAG, "Too many requests queued");
-    return nullptr;
+  uint16_t mask = this->trq_in_use_.load(std::memory_order_relaxed);
+
+  // Find first available slot (bit = 0) and try to claim it atomically
+  for (size_t i = 0; i < MAX_REQUESTS; i++) {
+    if (!(mask & (1U << i))) {
+      // Slot i appears available, try to claim it atomically
+      uint16_t expected = mask;
+      uint16_t desired = mask | (1U << i);  // Set bit i to mark as in-use
+
+      if (this->trq_in_use_.compare_exchange_weak(expected, desired, std::memory_order_acquire,
+                                                  std::memory_order_relaxed)) {
+        // Successfully claimed slot i - prepare the TransferRequest
+        auto *trq = &this->requests_[i];
+        trq->transfer->context = trq;
+        trq->transfer->device_handle = this->device_handle_;
+        return trq;
+      }
+      // Another thread claimed this slot, retry with updated mask
+      mask = expected;
+      i--;  // Retry the same index with new mask value
+    }
   }
-  auto *trq = this->trq_pool_.front();
-  this->trq_pool_.pop_front();
-  trq->client = this;
-  trq->transfer->context = trq;
-  trq->transfer->device_handle = this->device_handle_;
-  return trq;
+
+  ESP_LOGE(TAG, "Too many requests queued (all %d slots in use)", MAX_REQUESTS);
+  return nullptr;
 }
 void USBClient::disconnect() {
   this->on_disconnected();
@@ -370,6 +395,8 @@ void USBClient::disconnect() {
   this->device_addr_ = -1;
 }
 
+// THREAD CONTEXT: Called from main loop thread only
+// - Used for device configuration and control operations
 bool USBClient::control_transfer(uint8_t type, uint8_t request, uint16_t value, uint16_t index,
                                  const transfer_cb_t &callback, const std::vector<uint8_t> &data) {
   auto *trq = this->get_trq_();
@@ -425,6 +452,9 @@ static void transfer_callback(usb_transfer_t *xfer) {
 }
 /**
  * Performs a transfer input operation.
+ * THREAD CONTEXT: Called from both USB task and main loop threads!
+ * - USB task: USB UART input callbacks call start_input() which calls this
+ * - Main loop: Initial setup and other components
  *
  * @param ep_address The endpoint address.
  * @param callback The callback function to be called when the transfer is complete.
@@ -451,6 +481,9 @@ void USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
 
 /**
  * Performs an output transfer operation.
+ * THREAD CONTEXT: Called from main loop thread only
+ * - USB UART output uses defer() to ensure main loop context
+ * - Modbus and other components call from loop()
  *
  * @param ep_address The endpoint address.
  * @param callback The callback function to be called when the transfer is complete.
@@ -483,7 +516,28 @@ void USBClient::dump_config() {
                 "  Product id %04X",
                 this->vid_, this->pid_);
 }
-void USBClient::release_trq(TransferRequest *trq) { this->trq_pool_.push_back(trq); }
+// THREAD CONTEXT: Only called from main loop thread (single producer for deallocation)
+// - Via event processing when handling EVENT_TRANSFER_COMPLETE/EVENT_CONTROL_COMPLETE
+// - Directly when transfer submission fails
+//
+// THREAD SAFETY: Lock-free using atomic AND to clear bit
+// Single-producer pattern makes this simpler than allocation
+void USBClient::release_trq(TransferRequest *trq) {
+  if (trq == nullptr)
+    return;
+
+  // Calculate index from pointer arithmetic
+  size_t index = trq - this->requests_;
+  if (index >= MAX_REQUESTS) {
+    ESP_LOGE(TAG, "Invalid TransferRequest pointer");
+    return;
+  }
+
+  // Atomically clear bit i to mark slot as available
+  // fetch_and with inverted bitmask clears the bit atomically
+  uint16_t bit = 1U << index;
+  this->trq_in_use_.fetch_and(~bit, std::memory_order_release);
+}
 
 }  // namespace usb_host
 }  // namespace esphome

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -371,11 +371,9 @@ TransferRequest *USBClient::get_trq_() {
     }
 
     // Slot i appears available, try to claim it atomically
-    uint16_t expected = mask;
     uint16_t desired = mask | (1U << i);  // Set bit i to mark as in-use
 
-    if (this->trq_in_use_.compare_exchange_weak(expected, desired, std::memory_order_acquire,
-                                                std::memory_order_relaxed)) {
+    if (this->trq_in_use_.compare_exchange_weak(mask, desired, std::memory_order_acquire, std::memory_order_relaxed)) {
       // Successfully claimed slot i - prepare the TransferRequest
       auto *trq = &this->requests_[i];
       trq->transfer->context = trq;
@@ -383,8 +381,8 @@ TransferRequest *USBClient::get_trq_() {
       return trq;
     }
     // CAS failed - another thread modified the bitmask
-    // Restart search from the beginning with the updated mask
-    mask = this->trq_in_use_.load(std::memory_order_relaxed);
+    // mask was already updated by compare_exchange_weak with the current value
+    // No need to reload - the CAS already did that for us
     i = 0;
   }
 

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -387,7 +387,7 @@ TransferRequest *USBClient::get_trq_() {
     mask = expected;
   }
 
-  ESP_LOGE(TAG, "Too many requests queued (all %d slots in use)", MAX_REQUESTS);
+  ESP_LOGE(TAG, "All %d transfer slots in use", MAX_REQUESTS);
   return nullptr;
 }
 void USBClient::disconnect() {

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -543,7 +543,7 @@ void USBClient::release_trq(TransferRequest *trq) {
   // Atomically clear bit i to mark slot as available
   // fetch_and with inverted bitmask clears the bit atomically
   uint16_t bit = 1U << index;
-  this->trq_in_use_.fetch_and(~bit, std::memory_order_release);
+  this->trq_in_use_.fetch_and(static_cast<uint16_t>(~bit), std::memory_order_release);
 }
 
 }  // namespace usb_host

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -361,24 +361,30 @@ TransferRequest *USBClient::get_trq_() {
   uint16_t mask = this->trq_in_use_.load(std::memory_order_relaxed);
 
   // Find first available slot (bit = 0) and try to claim it atomically
-  for (size_t i = 0; i < MAX_REQUESTS; i++) {
-    if (!(mask & (1U << i))) {
-      // Slot i appears available, try to claim it atomically
-      uint16_t expected = mask;
-      uint16_t desired = mask | (1U << i);  // Set bit i to mark as in-use
-
-      if (this->trq_in_use_.compare_exchange_weak(expected, desired, std::memory_order_acquire,
-                                                  std::memory_order_relaxed)) {
-        // Successfully claimed slot i - prepare the TransferRequest
-        auto *trq = &this->requests_[i];
-        trq->transfer->context = trq;
-        trq->transfer->device_handle = this->device_handle_;
-        return trq;
-      }
-      // Another thread claimed this slot, retry with updated mask
-      mask = expected;
-      i--;  // Retry the same index with new mask value
+  // We use a while loop to allow retrying the same slot after CAS failure
+  size_t i = 0;
+  while (i < MAX_REQUESTS) {
+    if (mask & (1U << i)) {
+      // Slot is in use, move to next slot
+      i++;
+      continue;
     }
+
+    // Slot i appears available, try to claim it atomically
+    uint16_t expected = mask;
+    uint16_t desired = mask | (1U << i);  // Set bit i to mark as in-use
+
+    if (this->trq_in_use_.compare_exchange_weak(expected, desired, std::memory_order_acquire,
+                                                std::memory_order_relaxed)) {
+      // Successfully claimed slot i - prepare the TransferRequest
+      auto *trq = &this->requests_[i];
+      trq->transfer->context = trq;
+      trq->transfer->device_handle = this->device_handle_;
+      return trq;
+    }
+    // Another thread claimed this slot, retry with updated mask
+    // Don't increment i - retry the same slot with the updated mask
+    mask = expected;
   }
 
   ESP_LOGE(TAG, "Too many requests queued (all %d slots in use)", MAX_REQUESTS);


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a critical double-free crash in the USB host component by replacing the thread-unsafe `std::list` pool with a lock-free atomic bitmask implementation. The crash occurs when USB UART transfers are initiated from both the USB task and main loop threads concurrently.

The root cause is that `get_trq_()` is called from multiple threads:
- USB task: When USB UART input callbacks restart transfers immediately for performance
- Main loop: When initiating output transfers or flow-controlled input restarts

The previous `std::list` implementation with no synchronization led to memory corruption and crashes with the error: `assert failed: tlsf_free tlsf.c:630 (!block_is_free(block) && "block already marked as free")`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10925

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation change only

## Additional Notes

The multi-threaded access to the TransferRequest pool is intentional for performance:
- USB task can immediately restart input transfers without context switching
- Main loop provides flow control by deciding when to restart after consuming data
- The atomic bitmask ensures this is done safely without race conditions

This fix resolves the crash reported in #10925 while also improving performance and reducing memory fragmentation.