### PR TITLE
[api] Prevent API from overriding noise encryption keys set in YAML

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -224,6 +224,7 @@ async def to_code(config):
         if key := encryption_config.get(CONF_KEY):
             decoded = base64.b64decode(key)
             cg.add(var.set_noise_psk(list(decoded)))
+            cg.add_define("USE_API_NOISE_PSK_FROM_YAML")
         else:
             # No key provided, but encryption desired
             # This will allow a plaintext client to provide a noise key,

--- a/tests/integration/fixtures/noise_encryption_key_protection.yaml
+++ b/tests/integration/fixtures/noise_encryption_key_protection.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: noise-key-test
+
+host:
+
+api:
+  encryption:
+    key: "zX9/JHxMKwpP0jUGsF0iESCm1wRvNgR6NkKVOhn7kSs="
+
+logger:

--- a/tests/integration/test_noise_encryption_key_protection.py
+++ b/tests/integration/test_noise_encryption_key_protection.py
@@ -1,0 +1,51 @@
+"""Integration test for noise encryption key protection from YAML."""
+
+from __future__ import annotations
+
+import base64
+
+from aioesphomeapi import InvalidEncryptionKeyAPIError
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_noise_encryption_key_protection(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that noise encryption key set in YAML cannot be changed via API."""
+    # The key that's set in the YAML fixture
+    noise_psk = "zX9/JHxMKwpP0jUGsF0iESCm1wRvNgR6NkKVOhn7kSs="
+
+    # Keep ESPHome process running throughout all tests
+    async with run_compiled(yaml_config):
+        # First connection - test key change attempt
+        async with api_client_connected(noise_psk=noise_psk) as client:
+            # Verify connection is established
+            device_info = await client.device_info()
+            assert device_info is not None
+
+            # Try to set a new encryption key via API
+            new_key = base64.b64encode(
+                b"x" * 32
+            )  # Valid 32-byte key in base64 as bytes
+
+            # This should fail since key was set in YAML
+            success = await client.noise_encryption_set_key(new_key)
+            assert success is False
+
+        # Reconnect with the original key to verify it still works
+        async with api_client_connected(noise_psk=noise_psk) as client:
+            # Verify connection is still successful with original key
+            device_info = await client.device_info()
+            assert device_info is not None
+            assert device_info.name == "noise-key-test"
+
+        # Verify that connecting with a wrong key fails
+        wrong_key = base64.b64encode(b"y" * 32).decode()  # Different key
+        with pytest.raises(InvalidEncryptionKeyAPIError):
+            async with api_client_connected(noise_psk=wrong_key) as client:
+                await client.device_info()


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a critical issue where noise encryption keys set via the API could override keys configured in YAML, leading to authentication failures and hours of user frustration with no clear resolution path.

When a user sets an encryption key in their YAML configuration, they expect that key to be used - always. However, the current implementation allows API-set keys to be saved to preferences and loaded on boot, overriding the YAML configuration. This creates a confusing situation where:
- The YAML shows one key, but a different (hidden) key is actually being used
- Removing and re-adding the YAML key doesn't fix the issue
- There's no clear way for users to understand why their YAML key isn't working

This PR ensures that **YAML configuration always takes precedence** for noise encryption keys, just like it does for all other ESPHome settings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes issues where users report "encryption key in YAML doesn't work" after Home Assistant or other tools have set a key via API

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not needed - this is a bug fix that makes the system work as users already expect

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] Host (integration test)

## Example entry for `config.yaml`:

```yaml
# When this key is set in YAML, it cannot be changed via API
api:
  encryption:
    key: "zX9/JHxMKwpP0jUGsF0iESCm1wRvNgR6NkKVOhn7kSs="
```

## Implementation Details

The fix uses compile-time configuration to achieve zero memory overhead:
1. When an encryption key is set in YAML, a `USE_API_NOISE_PSK_FROM_YAML` define is added
2. This define prevents loading saved keys from preferences
3. API attempts to change the key are rejected with "Key set in YAML" warning
4. No runtime memory cost - everything is handled at compile time

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Added `tests/integration/test_noise_encryption_key_protection.py`
    - Tests verify that API cannot change YAML-configured keys
    - Tests verify reconnection with correct key still works
    - Tests verify connection with wrong key fails

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - Not needed - this is a bug fix that makes existing functionality work as documented