### PR TITLE
2025.9.2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.9.1
+PROJECT_NUMBER         = 2025.9.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -31,6 +31,9 @@ void ESP32ImprovComponent::setup() {
 #endif
   global_ble_server->on(BLEServerEvt::EmptyEvt::ON_DISCONNECT,
                         [this](uint16_t conn_id) { this->set_error_(improv::ERROR_NONE); });
+
+  // Start with loop disabled - will be enabled by start() when needed
+  this->disable_loop();
 }
 
 void ESP32ImprovComponent::setup_characteristics() {

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -79,12 +79,12 @@ class ESP32ImprovComponent : public Component {
   std::vector<uint8_t> incoming_data_;
   wifi::WiFiAP connecting_sta_;
 
-  BLEService *service_ = nullptr;
-  BLECharacteristic *status_;
-  BLECharacteristic *error_;
-  BLECharacteristic *rpc_;
-  BLECharacteristic *rpc_response_;
-  BLECharacteristic *capabilities_;
+  BLEService *service_{nullptr};
+  BLECharacteristic *status_{nullptr};
+  BLECharacteristic *error_{nullptr};
+  BLECharacteristic *rpc_{nullptr};
+  BLECharacteristic *rpc_response_{nullptr};
+  BLECharacteristic *capabilities_{nullptr};
 
 #ifdef USE_BINARY_SENSOR
   binary_sensor::BinarySensor *authorizer_{nullptr};
@@ -108,6 +108,9 @@ class ESP32ImprovComponent : public Component {
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   bool check_identify_();
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+  const char *state_to_string_(improv::State state);
+#endif
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -128,4 +128,4 @@ async def to_code(config):
 
     cg.add_library("tonia/HeatpumpIR", "1.0.37")
     if CORE.is_libretiny or CORE.is_esp32:
-        CORE.add_platformio_option("lib_ignore", "IRremoteESP8266")
+        CORE.add_platformio_option("lib_ignore", ["IRremoteESP8266"])

--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -401,6 +401,12 @@ class DriverChip:
         sequence.append((MADCTL, madctl))
         return madctl
 
+    def skip_command(self, command: str):
+        """
+        Allow suppressing a standard command in the init sequence.
+        """
+        return self.get_default(f"no_{command.lower()}", False)
+
     def get_sequence(self, config) -> tuple[tuple[int, ...], int]:
         """
         Create the init sequence for the display.
@@ -432,7 +438,9 @@ class DriverChip:
             sequence.append((INVOFF,))
         if brightness := config.get(CONF_BRIGHTNESS, self.get_default(CONF_BRIGHTNESS)):
             sequence.append((BRIGHTNESS, brightness))
-        sequence.append((SLPOUT,))
+        # Add a SLPOUT command if required.
+        if not self.skip_command("SLPOUT"):
+            sequence.append((SLPOUT,))
         sequence.append((DISPON,))
 
         # Flatten the sequence into a list of bytes, with the length of each command

--- a/esphome/components/mipi_rgb/models/waveshare.py
+++ b/esphome/components/mipi_rgb/models/waveshare.py
@@ -7,6 +7,7 @@ wave_4_3 = DriverChip(
     "ESP32-S3-TOUCH-LCD-4.3",
     swap_xy=UNDEFINED,
     initsequence=(),
+    color_order="RGB",
     width=800,
     height=480,
     pclk_frequency="16MHz",

--- a/esphome/components/mipi_spi/models/amoled.py
+++ b/esphome/components/mipi_spi/models/amoled.py
@@ -27,7 +27,8 @@ DriverChip(
     bus_mode=TYPE_QUAD,
     brightness=0xD0,
     color_order=MODE_RGB,
-    initsequence=(SLPOUT,),  # Requires early SLPOUT
+    no_slpout=True,  # SLPOUT is in the init sequence, early
+    initsequence=(SLPOUT,),
 )
 
 DriverChip(
@@ -95,6 +96,7 @@ CO5300 = DriverChip(
     brightness=0xD0,
     color_order=MODE_RGB,
     bus_mode=TYPE_QUAD,
+    no_slpout=True,
     initsequence=(
         (SLPOUT,),  # Requires early SLPOUT
         (PAGESEL, 0x00),

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -72,6 +72,7 @@ void USBUartTypeCH34X::enable_channels() {
     if (channel->index_ >= 2)
       cmd += 0xE;
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
+    this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd + 3, 0x80, 0, callback);
   }
   USBUartTypeCdcAcm::enable_channels();
 }

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -40,5 +40,7 @@ async def to_code(config):
             cg.add_library("Update", None)
         if CORE.is_esp8266:
             cg.add_library("ESP8266WiFi", None)
+        if CORE.is_libretiny:
+            CORE.add_platformio_option("lib_ignore", ["ESPAsyncTCP", "RPAsyncTCP"])
         # https://github.com/ESP32Async/ESPAsyncWebServer/blob/main/library.json
         cg.add_library("ESP32Async/ESPAsyncWebServer", "3.7.10")

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.9.1"
+__version__ = "2025.9.2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -396,7 +396,7 @@ async def add_includes(includes):
 async def _add_platformio_options(pio_options):
     # Add includes at the very end, so that they override everything
     for key, val in pio_options.items():
-        if key == "build_flags" and not isinstance(val, list):
+        if key in ["build_flags", "lib_ignore"] and not isinstance(val, list):
             val = [val]
         cg.add_platformio_option(key, val)
 


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32_improv] Disable loop by default until provisioning needed [esphome#10764](https://github.com/esphome/esphome/pull/10764)
- [libretiny] Fix lib_ignore handling and ignore incompatible libraries [esphome#10846](https://github.com/esphome/esphome/pull/10846)
- Set color_order to RGB for the Waveshare ESP32-S3-TOUCH-LCD-4.3 and ESP32-S3-TOUCH-LCD-7-800X480 [esphome#10835](https://github.com/esphome/esphome/pull/10835)
- [esp32_improv] Fix crashes from uninitialized pointers and missing null checks [esphome#10902](https://github.com/esphome/esphome/pull/10902)
- [sx126x] Fix issues with variable length FSK packets [esphome#10911](https://github.com/esphome/esphome/pull/10911)
- [mipi_spi] Fix t-display-amoled [esphome#10922](https://github.com/esphome/esphome/pull/10922)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
