### PR TITLE
[api] Add configurable connection limits

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -59,6 +59,8 @@ CONF_BATCH_DELAY = "batch_delay"
 CONF_CUSTOM_SERVICES = "custom_services"
 CONF_HOMEASSISTANT_SERVICES = "homeassistant_services"
 CONF_HOMEASSISTANT_STATES = "homeassistant_states"
+CONF_LISTEN_BACKLOG = "listen_backlog"
+CONF_MAX_CONNECTIONS = "max_connections"
 
 
 def validate_encryption_key(value):
@@ -158,6 +160,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_CLIENT_DISCONNECTED): automation.validate_automation(
                 single=True
             ),
+            cv.SplitDefault(CONF_LISTEN_BACKLOG, esp8266=1, default=4): cv.int_range(
+                min=1, max=10
+            ),
+            cv.SplitDefault(CONF_MAX_CONNECTIONS, esp8266=4, default=8): cv.int_range(
+                min=1, max=20
+            ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.rename_key(CONF_SERVICES, CONF_ACTIONS),
@@ -176,6 +184,8 @@ async def to_code(config):
         cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_batch_delay(config[CONF_BATCH_DELAY]))
+    cg.add(var.set_listen_backlog(config[CONF_LISTEN_BACKLOG]))
+    cg.add(var.set_max_connections(config[CONF_MAX_CONNECTIONS]))
 
     # Set USE_API_SERVICES if any services are enabled
     if config.get(CONF_ACTIONS) or config[CONF_CUSTOM_SERVICES]:

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -160,12 +160,29 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_CLIENT_DISCONNECTED): automation.validate_automation(
                 single=True
             ),
-            cv.SplitDefault(CONF_LISTEN_BACKLOG, esp8266=1, default=4): cv.int_range(
-                min=1, max=10
-            ),
-            cv.SplitDefault(CONF_MAX_CONNECTIONS, esp8266=4, default=8): cv.int_range(
-                min=1, max=20
-            ),
+            # Connection limits to prevent memory exhaustion on resource-constrained devices
+            # Each connection uses ~500-1000 bytes of RAM plus system resources
+            # Platform defaults based on available RAM and network stack implementation:
+            cv.SplitDefault(
+                CONF_LISTEN_BACKLOG,
+                esp8266=1,  # Limited RAM (~40KB free), LWIP raw sockets
+                esp32=4,  # More RAM (520KB), BSD sockets
+                rp2040=1,  # Limited RAM (264KB), LWIP raw sockets like ESP8266
+                bk72xx=4,  # Moderate RAM, BSD-style sockets
+                rtl87xx=4,  # Moderate RAM, BSD-style sockets
+                host=4,  # Abundant resources
+                ln882x=4,  # Moderate RAM
+            ): cv.int_range(min=1, max=10),
+            cv.SplitDefault(
+                CONF_MAX_CONNECTIONS,
+                esp8266=4,  # ~40KB free RAM, each connection uses ~500-1000 bytes
+                esp32=8,  # 520KB RAM available
+                rp2040=4,  # 264KB RAM but LWIP constraints
+                bk72xx=8,  # Moderate RAM
+                rtl87xx=8,  # Moderate RAM
+                host=8,  # Abundant resources
+                ln882x=8,  # Moderate RAM
+            ): cv.int_range(min=1, max=20),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.rename_key(CONF_SERVICES, CONF_ACTIONS),
@@ -184,8 +201,10 @@ async def to_code(config):
         cg.add(var.set_password(config[CONF_PASSWORD]))
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_batch_delay(config[CONF_BATCH_DELAY]))
-    cg.add(var.set_listen_backlog(config[CONF_LISTEN_BACKLOG]))
-    cg.add(var.set_max_connections(config[CONF_MAX_CONNECTIONS]))
+    if CONF_LISTEN_BACKLOG in config:
+        cg.add(var.set_listen_backlog(config[CONF_LISTEN_BACKLOG]))
+    if CONF_MAX_CONNECTIONS in config:
+        cg.add(var.set_max_connections(config[CONF_MAX_CONNECTIONS]))
 
     # Set USE_API_SERVICES if any services are enabled
     if config.get(CONF_ACTIONS) or config[CONF_CUSTOM_SERVICES]:

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -191,13 +191,10 @@ class APIServer : public Component, public Controller {
   // Group smaller types together
   uint16_t port_{6053};
   uint16_t batch_delay_{100};
-#ifdef USE_ESP8266
-  uint8_t listen_backlog_{1};
-  uint8_t max_connections_{4};
-#else
+  // Connection limits - these defaults will be overridden by config values
+  // from cv.SplitDefault in __init__.py which sets platform-specific defaults
   uint8_t listen_backlog_{4};
   uint8_t max_connections_{8};
-#endif
   bool shutting_down_ = false;
   // 7 bytes used, 1 byte padding
 

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -44,6 +44,8 @@ class APIServer : public Component, public Controller {
   void set_reboot_timeout(uint32_t reboot_timeout);
   void set_batch_delay(uint16_t batch_delay);
   uint16_t get_batch_delay() const { return batch_delay_; }
+  void set_listen_backlog(uint8_t listen_backlog) { this->listen_backlog_ = listen_backlog; }
+  void set_max_connections(uint8_t max_connections) { this->max_connections_ = max_connections; }
 
   // Get reference to shared buffer for API connections
   std::vector<uint8_t> &get_shared_buffer_ref() { return shared_write_buffer_; }
@@ -189,8 +191,15 @@ class APIServer : public Component, public Controller {
   // Group smaller types together
   uint16_t port_{6053};
   uint16_t batch_delay_{100};
+#ifdef USE_ESP8266
+  uint8_t listen_backlog_{1};
+  uint8_t max_connections_{4};
+#else
+  uint8_t listen_backlog_{4};
+  uint8_t max_connections_{8};
+#endif
   bool shutting_down_ = false;
-  // 5 bytes used, 3 bytes padding
+  // 7 bytes used, 1 byte padding
 
 #ifdef USE_API_NOISE
   std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();


### PR DESCRIPTION
# What does this implement/fix?

This PR adds configurable connection limits to the ESPHome API to prevent devices from running out of RAM and crashing.

## Why This Is Needed

Previously, the API would accept connections until the device ran out of resources, which could cause OOM or other failures depending on the platform. Each connection consumes 500-1000 bytes of RAM plus system resources, so multiple connections could easily exhaust available resources:
- ESP8266 can crash with just 4-5 connections when sensors are configured due to limited RAM
- RP2040 uses LWIP raw sockets with similar connection constraints
- Resource exhaustion manifests differently on each platform (OOM, file descriptor limits, etc.)
- Even ESP32 can experience failures with enough connections
- Misbehaving clients or buggy integrations could cause device failures by opening many connections

This PR adds enforced limits with sensible defaults to prevent these resource exhaustion issues while still allowing generous headroom above typical usage.

Users can configure:
- `listen_backlog`: Number of pending connections in the listen queue
- `max_connections`: Maximum number of simultaneous API connections

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Prevents OOM crashes on ESP8266/RP2040 when multiple clients connect
- Allows users to fine-tune connection limits based on their device's memory constraints

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5428

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example configuration with new options
api:
  # Optional: Configure listen backlog (pending connections queue)
  # Default: 1 for ESP8266/RP2040, 4 for other platforms
  listen_backlog: 2

  # Optional: Configure maximum active connections
  # Default: 4 for ESP8266/RP2040, 8 for other platforms
  max_connections: 6
```

## Breaking Changes

### Connection Limits Now Enforced

Previously, the API would accept connections until the device ran out of resources, which could cause OOM or other failures depending on the platform. Now there are enforced defaults:

- **ESP8266**: max 4 connections, backlog of 1 (limited RAM ~40KB free, LWIP raw sockets)
- **RP2040**: max 4 connections, backlog of 1 (LWIP raw sockets with similar constraints)
- **ESP32**: max 8 connections, backlog of 4 (520KB RAM, BSD sockets)
- **Other platforms**: max 8 connections, backlog of 4 (moderate to abundant resources)

Connections exceeding these limits will be rejected with a warning log message.

### Who Is Affected

**Most users won't be affected** - the defaults are set very high for typical use:

**Typical usage:**
- Home Assistant: 1 connection (always connected)
- ESPHome dashboard: 1 connection (only when viewing logs)
- Total typical usage: 1-2 connections

**Default limits:**
- ESP8266/RP2040: 4 connections (2x typical usage)
- ESP32 and other platforms: 8 connections (4x typical usage)

The only users who may need to adjust settings:
- Those running custom integrations that open many simultaneous connections
- Development environments with multiple tools connecting at once
- Users with monitoring systems that open multiple parallel connections

### Migration Guide

If you need more connections than the default, add this to your configuration:

```yaml
api:
  max_connections: 10  # Increase limit (max 20)
  listen_backlog: 5    # Increase queue size (max 10)
```

**Warning for ESP8266/RP2040**: Setting high limits may cause OOM crashes due to limited RAM (ESP8266 has ~40KB free, RP2040 uses LWIP raw sockets with similar constraints).

## Implementation Details

### New Configuration Options

Added two new optional configuration parameters with platform-specific defaults:

```python
cv.SplitDefault(CONF_LISTEN_BACKLOG, esp8266=1, rp2040=1, esp32=4, ...): cv.int_range(min=1, max=10),
cv.SplitDefault(CONF_MAX_CONNECTIONS, esp8266=4, rp2040=4, esp32=8, ...): cv.int_range(min=1, max=20),
```

### Connection Rejection Behavior

When limits are reached:
1. If `max_connections` is exceeded: Connection is accepted then immediately closed with warning
2. If `listen_backlog` queue is full: Connection is rejected at socket layer

### Memory Considerations

On memory-constrained devices:
- ESP8266: ~40KB free RAM
- RP2040: 264KB total but LWIP raw socket constraints
- Each API connection uses approximately 500-1000 bytes
- 4 connections use ~2-4KB RAM
- This leaves sufficient memory for normal operation

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).