### PR TITLE
[script] Reduce RAM usage by storing names in flash

### DIFF
--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -12,6 +12,7 @@ from esphome.cpp_generator import (  # noqa: F401
     ArrayInitializer,
     Expression,
     LineComment,
+    LogStringLiteral,
     MockObj,
     MockObjClass,
     Pvariable,

--- a/esphome/components/script/__init__.py
+++ b/esphome/components/script/__init__.py
@@ -124,7 +124,7 @@ async def to_code(config):
         template, func_args = parameters_to_template(conf[CONF_PARAMETERS])
         trigger = cg.new_Pvariable(conf[CONF_ID], template)
         # Add a human-readable name to the script
-        cg.add(trigger.set_name(conf[CONF_ID].id))
+        cg.add(trigger.set_name(cg.LogStringLiteral(conf[CONF_ID].id)))
 
         if CONF_MAX_RUNS in conf:
             cg.add(trigger.set_max_runs(conf[CONF_MAX_RUNS]))


### PR DESCRIPTION
# What does this implement/fix?

Optimizes script component memory usage by storing script names in flash memory instead of RAM.

Previously, each script stored its name as a `std::string name_` member variable, wasting 12-24 bytes per script plus heap allocation for the string data. Since `std::string` dynamically allocates, the string data was stored in heap RAM even though it's set once at compile time. Since script names are only used for internal logging, this changes the storage to use `const LogString*` instead, following the same pattern used for component sources in commit 8d90f13e97.

**Memory savings per script:**
- **ESP8266/ESP32**: 8 bytes (12 byte std::string → 4 byte pointer) + string data moved from heap RAM to flash

Both platforms are 32-bit, so savings are identical.

**Example savings (5-10 scripts with 10-char names):**
- **Object size**: 40-80 bytes
- **String data**: 50-100 bytes (moved to flash)
- **Total RAM saved**: 90-180 bytes

This is a non-breaking internal optimization with no user-visible changes.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Internal memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - existing script configs work identically

script:
  - id: my_script
    mode: single
    then:
      - logger.log: "Script running"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
