### PR TITLE
[voice_assistant] Fix wakeword string being reset while referenced

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -242,7 +242,6 @@ void VoiceAssistant::loop() {
       msg.flags = flags;
       msg.audio_settings = audio_settings;
       msg.set_wake_word_phrase(StringRef(this->wake_word_));
-      this->wake_word_ = "";
 
       // Reset media player state tracking
 #ifdef USE_MEDIA_PLAYER
@@ -256,9 +255,11 @@ void VoiceAssistant::loop() {
         ESP_LOGW(TAG, "Could not request start");
         this->error_trigger_->trigger("not-connected", "Could not request start");
         this->continuous_ = false;
+        this->wake_word_ = "";
         this->set_state_(State::IDLE, State::IDLE);
         break;
       }
+      this->wake_word_ = "";
       this->set_state_(State::STARTING_PIPELINE);
       this->set_timeout("reset-conversation_id", this->conversation_timeout_,
                         [this]() { this->reset_conversation_id(); });

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -255,11 +255,9 @@ void VoiceAssistant::loop() {
         ESP_LOGW(TAG, "Could not request start");
         this->error_trigger_->trigger("not-connected", "Could not request start");
         this->continuous_ = false;
-        this->wake_word_ = "";
         this->set_state_(State::IDLE, State::IDLE);
         break;
       }
-      this->wake_word_ = "";
       this->set_state_(State::STARTING_PIPELINE);
       this->set_timeout("reset-conversation_id", this->conversation_timeout_,
                         [this]() { this->reset_conversation_id(); });


### PR DESCRIPTION
# What does this implement/fix?

https://github.com/esphome/esphome/commit/a614a68f1ad358e9c521ec9b71597539645a8833 changed from copying the string to using a ref, but the string is cleared before being sent. This fixes it by clearing the string after sending.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
