### PR TITLE
[speaker/media_player] load `psram` only when needed

### DIFF
--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -29,8 +29,6 @@ from esphome.external_files import download_content
 
 _LOGGER = logging.getLogger(__name__)
 
-AUTO_LOAD = ["audio", "psram"]
-
 CODEOWNERS = ["@kahrendt", "@synesthesiam"]
 DOMAIN = "media_player"
 
@@ -51,6 +49,45 @@ CONF_VOLUME_INCREMENT = "volume_increment"
 CONF_VOLUME_INITIAL = "volume_initial"
 CONF_VOLUME_MIN = "volume_min"
 CONF_VOLUME_MAX = "volume_max"
+
+
+def _get_auto_load():
+    """Conditionally load PSRAM only when needed for speaker media player."""
+    # Check if PSRAM is needed based on configuration
+    raw_config = getattr(CORE, 'raw_config', {})
+    
+    # Look for media_player configurations
+    media_players = raw_config.get('media_player', [])
+    if not isinstance(media_players, list):
+        media_players = [media_players] if media_players else []
+    
+    needs_psram = False
+    for mp_config in media_players:
+        if not isinstance(mp_config, dict):
+            continue
+        # Check if this is a speaker platform
+        platform = mp_config.get('platform')
+        if platform != 'speaker':
+            continue
+            
+        # Check if codec support is enabled (uses PSRAM for WiFi buffers)
+        if mp_config.get(CONF_CODEC_SUPPORT_ENABLED, True):
+            needs_psram = True
+            break
+            
+        # Check if task stack in PSRAM is enabled
+        if mp_config.get(CONF_TASK_STACK_IN_PSRAM, False):
+            needs_psram = True
+            break
+    
+    auto_load = ["audio"]
+    if needs_psram:
+        auto_load.append("psram")
+    
+    return auto_load
+
+
+AUTO_LOAD = _get_auto_load()
 
 
 speaker_ns = cg.esphome_ns.namespace("speaker")

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -54,36 +54,36 @@ CONF_VOLUME_MAX = "volume_max"
 def _get_auto_load():
     """Conditionally load PSRAM only when needed for speaker media player."""
     # Check if PSRAM is needed based on configuration
-    raw_config = getattr(CORE, 'raw_config', {})
-    
+    raw_config = getattr(CORE, "raw_config", {})
+
     # Look for media_player configurations
-    media_players = raw_config.get('media_player', [])
+    media_players = raw_config.get("media_player", [])
     if not isinstance(media_players, list):
         media_players = [media_players] if media_players else []
-    
+
     needs_psram = False
     for mp_config in media_players:
         if not isinstance(mp_config, dict):
             continue
         # Check if this is a speaker platform
-        platform = mp_config.get('platform')
-        if platform != 'speaker':
+        platform = mp_config.get("platform")
+        if platform != "speaker":
             continue
-            
+
         # Check if codec support is enabled (uses PSRAM for WiFi buffers)
         if mp_config.get(CONF_CODEC_SUPPORT_ENABLED, True):
             needs_psram = True
             break
-            
+
         # Check if task stack in PSRAM is enabled
         if mp_config.get(CONF_TASK_STACK_IN_PSRAM, False):
             needs_psram = True
             break
-    
+
     auto_load = ["audio"]
     if needs_psram:
         auto_load.append("psram")
-    
+
     return auto_load
 
 

--- a/tests/component_tests/speaker/media_player/test_conditional_psram.py
+++ b/tests/component_tests/speaker/media_player/test_conditional_psram.py
@@ -9,7 +9,7 @@ from esphome.core import CORE
 @pytest.fixture(autouse=True)
 def reset_core_config():
     """Reset CORE.raw_config before each test."""
-    original_config = getattr(CORE, 'raw_config', None)
+    original_config = getattr(CORE, "raw_config", None)
     CORE.raw_config = {}
     yield
     CORE.raw_config = original_config
@@ -18,147 +18,155 @@ def reset_core_config():
 def test_auto_load_no_media_player():
     """Test that PSRAM is not loaded when no media player is configured."""
     CORE.raw_config = {
-        'esphome': {'name': 'test'},
-        'wifi': {'ssid': 'test'},
+        "esphome": {"name": "test"},
+        "wifi": {"ssid": "test"},
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio']
+    assert result == ["audio"]
 
 
 def test_auto_load_speaker_with_codec_support():
     """Test that PSRAM is loaded when speaker media player has codec support enabled."""
     CORE.raw_config = {
-        'media_player': [{
-            'platform': 'speaker',
-            'announcement_pipeline': {'speaker': 'test_speaker'},
-            'codec_support_enabled': True,
-        }]
+        "media_player": [
+            {
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker"},
+                "codec_support_enabled": True,
+            }
+        ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_speaker_with_task_stack_in_psram():
     """Test that PSRAM is loaded when speaker media player has task stack in PSRAM enabled."""
     CORE.raw_config = {
-        'media_player': [{
-            'platform': 'speaker',
-            'announcement_pipeline': {'speaker': 'test_speaker'},
-            'task_stack_in_psram': True,
-        }]
+        "media_player": [
+            {
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker"},
+                "task_stack_in_psram": True,
+            }
+        ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_speaker_with_both_disabled():
     """Test that PSRAM is not loaded when speaker media player has both features disabled."""
     CORE.raw_config = {
-        'media_player': [{
-            'platform': 'speaker',
-            'announcement_pipeline': {'speaker': 'test_speaker'},
-            'codec_support_enabled': False,
-            'task_stack_in_psram': False,
-        }]
+        "media_player": [
+            {
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker"},
+                "codec_support_enabled": False,
+                "task_stack_in_psram": False,
+            }
+        ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio']
+    assert result == ["audio"]
 
 
 def test_auto_load_speaker_with_defaults():
     """Test that PSRAM is loaded when speaker media player uses default values (codec_support_enabled defaults to True)."""
     CORE.raw_config = {
-        'media_player': [{
-            'platform': 'speaker',
-            'announcement_pipeline': {'speaker': 'test_speaker'},
-            # codec_support_enabled defaults to True, task_stack_in_psram defaults to False
-        }]
+        "media_player": [
+            {
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker"},
+                # codec_support_enabled defaults to True, task_stack_in_psram defaults to False
+            }
+        ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_non_speaker_platform():
     """Test that PSRAM is not loaded for non-speaker media player platforms."""
     CORE.raw_config = {
-        'media_player': [{
-            'platform': 'some_other_platform',
-            'codec_support_enabled': True,
-            'task_stack_in_psram': True,
-        }]
+        "media_player": [
+            {
+                "platform": "some_other_platform",
+                "codec_support_enabled": True,
+                "task_stack_in_psram": True,
+            }
+        ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio']
+    assert result == ["audio"]
 
 
 def test_auto_load_multiple_media_players():
     """Test that PSRAM is loaded if any speaker media player needs it."""
     CORE.raw_config = {
-        'media_player': [
+        "media_player": [
             {
-                'platform': 'speaker',
-                'announcement_pipeline': {'speaker': 'test_speaker1'},
-                'codec_support_enabled': False,
-                'task_stack_in_psram': False,
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker1"},
+                "codec_support_enabled": False,
+                "task_stack_in_psram": False,
             },
             {
-                'platform': 'speaker', 
-                'announcement_pipeline': {'speaker': 'test_speaker2'},
-                'codec_support_enabled': True,  # This should trigger PSRAM loading
-            }
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker2"},
+                "codec_support_enabled": True,  # This should trigger PSRAM loading
+            },
         ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_mixed_platforms():
     """Test PSRAM loading with mixed speaker and non-speaker platforms."""
     CORE.raw_config = {
-        'media_player': [
+        "media_player": [
             {
-                'platform': 'some_other_platform',
-                'codec_support_enabled': True,
+                "platform": "some_other_platform",
+                "codec_support_enabled": True,
             },
             {
-                'platform': 'speaker',
-                'announcement_pipeline': {'speaker': 'test_speaker'},
-                'codec_support_enabled': False,
-                'task_stack_in_psram': True,  # This should trigger PSRAM loading
-            }
+                "platform": "speaker",
+                "announcement_pipeline": {"speaker": "test_speaker"},
+                "codec_support_enabled": False,
+                "task_stack_in_psram": True,  # This should trigger PSRAM loading
+            },
         ]
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_single_config_dict():
     """Test that it works when media_player is a single dict instead of a list."""
     CORE.raw_config = {
-        'media_player': {
-            'platform': 'speaker',
-            'announcement_pipeline': {'speaker': 'test_speaker'},
-            'codec_support_enabled': True,
+        "media_player": {
+            "platform": "speaker",
+            "announcement_pipeline": {"speaker": "test_speaker"},
+            "codec_support_enabled": True,
         }
     }
-    
+
     result = _get_auto_load()
-    assert result == ['audio', 'psram']
+    assert result == ["audio", "psram"]
 
 
 def test_auto_load_empty_media_player_list():
     """Test that it works with an empty media_player list."""
-    CORE.raw_config = {
-        'media_player': []
-    }
-    
+    CORE.raw_config = {"media_player": []}
+
     result = _get_auto_load()
-    assert result == ['audio']
+    assert result == ["audio"]

--- a/tests/component_tests/speaker/media_player/test_conditional_psram.py
+++ b/tests/component_tests/speaker/media_player/test_conditional_psram.py
@@ -1,0 +1,164 @@
+"""Tests for speaker media player conditional PSRAM loading."""
+
+import pytest
+
+from esphome.components.speaker.media_player import _get_auto_load
+from esphome.core import CORE
+
+
+@pytest.fixture(autouse=True)
+def reset_core_config():
+    """Reset CORE.raw_config before each test."""
+    original_config = getattr(CORE, 'raw_config', None)
+    CORE.raw_config = {}
+    yield
+    CORE.raw_config = original_config
+
+
+def test_auto_load_no_media_player():
+    """Test that PSRAM is not loaded when no media player is configured."""
+    CORE.raw_config = {
+        'esphome': {'name': 'test'},
+        'wifi': {'ssid': 'test'},
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio']
+
+
+def test_auto_load_speaker_with_codec_support():
+    """Test that PSRAM is loaded when speaker media player has codec support enabled."""
+    CORE.raw_config = {
+        'media_player': [{
+            'platform': 'speaker',
+            'announcement_pipeline': {'speaker': 'test_speaker'},
+            'codec_support_enabled': True,
+        }]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_speaker_with_task_stack_in_psram():
+    """Test that PSRAM is loaded when speaker media player has task stack in PSRAM enabled."""
+    CORE.raw_config = {
+        'media_player': [{
+            'platform': 'speaker',
+            'announcement_pipeline': {'speaker': 'test_speaker'},
+            'task_stack_in_psram': True,
+        }]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_speaker_with_both_disabled():
+    """Test that PSRAM is not loaded when speaker media player has both features disabled."""
+    CORE.raw_config = {
+        'media_player': [{
+            'platform': 'speaker',
+            'announcement_pipeline': {'speaker': 'test_speaker'},
+            'codec_support_enabled': False,
+            'task_stack_in_psram': False,
+        }]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio']
+
+
+def test_auto_load_speaker_with_defaults():
+    """Test that PSRAM is loaded when speaker media player uses default values (codec_support_enabled defaults to True)."""
+    CORE.raw_config = {
+        'media_player': [{
+            'platform': 'speaker',
+            'announcement_pipeline': {'speaker': 'test_speaker'},
+            # codec_support_enabled defaults to True, task_stack_in_psram defaults to False
+        }]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_non_speaker_platform():
+    """Test that PSRAM is not loaded for non-speaker media player platforms."""
+    CORE.raw_config = {
+        'media_player': [{
+            'platform': 'some_other_platform',
+            'codec_support_enabled': True,
+            'task_stack_in_psram': True,
+        }]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio']
+
+
+def test_auto_load_multiple_media_players():
+    """Test that PSRAM is loaded if any speaker media player needs it."""
+    CORE.raw_config = {
+        'media_player': [
+            {
+                'platform': 'speaker',
+                'announcement_pipeline': {'speaker': 'test_speaker1'},
+                'codec_support_enabled': False,
+                'task_stack_in_psram': False,
+            },
+            {
+                'platform': 'speaker', 
+                'announcement_pipeline': {'speaker': 'test_speaker2'},
+                'codec_support_enabled': True,  # This should trigger PSRAM loading
+            }
+        ]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_mixed_platforms():
+    """Test PSRAM loading with mixed speaker and non-speaker platforms."""
+    CORE.raw_config = {
+        'media_player': [
+            {
+                'platform': 'some_other_platform',
+                'codec_support_enabled': True,
+            },
+            {
+                'platform': 'speaker',
+                'announcement_pipeline': {'speaker': 'test_speaker'},
+                'codec_support_enabled': False,
+                'task_stack_in_psram': True,  # This should trigger PSRAM loading
+            }
+        ]
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_single_config_dict():
+    """Test that it works when media_player is a single dict instead of a list."""
+    CORE.raw_config = {
+        'media_player': {
+            'platform': 'speaker',
+            'announcement_pipeline': {'speaker': 'test_speaker'},
+            'codec_support_enabled': True,
+        }
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio', 'psram']
+
+
+def test_auto_load_empty_media_player_list():
+    """Test that it works with an empty media_player list."""
+    CORE.raw_config = {
+        'media_player': []
+    }
+    
+    result = _get_auto_load()
+    assert result == ['audio']


### PR DESCRIPTION
# What does this implement/fix?

Conditionally load the `psram` component according to configuration. This now allows me to use the `speaker`/`media_player` component on my ESP32C6.

Example video, playing "Radio Paradise Main Mix" via [Radio Browser](https://www.home-assistant.io/integrations/radio_browser/) directly.
https://github.com/user-attachments/assets/cbec774e-39e7-4599-b5c4-b4e21361f315

On;
- ESP32-C6-WROOM-1
- I2S MAX98357A

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Relates to https://github.com/esphome/esphome/issues/10233. The issue raised there is due to poor configuration handling, but also relates to the need for being able to use the `media_player` on a device without PSRAM.

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: assistant
  friendly_name: Assistant
  min_version: 2025.9.2

esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf

external_components:
  - source: github://pr#10954
    components: [psram]
    refresh: 1h
  - source: github://pr#10955
    components: [speaker]
    refresh: 1h
   
i2s_audio:
  - id: i2s_audio_bus
    i2s_lrclk_pin: GPIO15
    i2s_bclk_pin: GPIO19

speaker:
  - platform: i2s_audio
    id: out_speaker
    i2s_dout_pin: GPIO22
    dac_type: external
    sample_rate: 48000

media_player:
  - platform: speaker
    name: None
    id: echo_media_player
    announcement_pipeline:
      speaker: out_speaker
      format: WAV
      sample_rate: 16000
      num_channels: 1
    codec_support_enabled: false
    buffer_size: 6000
    volume_min: 0.4
    files:
      - id: timer_finished_wave_file
        file: https://github.com/esphome/wake-word-voice-assistants/raw/main/sounds/timer_finished.wav
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).