### PR TITLE
[logger] Optimize log formatting performance (35-72% faster)

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -51,9 +51,6 @@ static const char *const LOG_LEVEL_COLORS[] = {
 static constexpr char LOG_LEVEL_LETTER_CHARS[] = {'\0', 'E', 'W', 'I', 'C', 'D', 'V'};
 static constexpr uint8_t ANSI_COLOR_LEN = 7;
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
-static constexpr size_t constexpr_strlen(const char *str) { return *str ? 1 + constexpr_strlen(str + 1) : 0; }
-static_assert(constexpr_strlen(LOG_LEVEL_COLORS[0]) == 0, "Level 0 color must be empty");
-static_assert(constexpr_strlen(LOG_LEVEL_COLORS[1]) == 7, "Color codes must be 7 chars");
 
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
 /** Enum for logging UART selection

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -37,7 +37,7 @@ struct device;
 namespace esphome::logger {
 
 // Color and letter constants for log levels
-static constexpr const char *const LOG_LEVEL_COLORS[] = {
+static const char *const LOG_LEVEL_COLORS[] = {
     "",                                            // NONE
     ESPHOME_LOG_BOLD(ESPHOME_LOG_COLOR_RED),       // ERROR
     ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_YELLOW),   // WARNING

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -48,8 +48,17 @@ static const char *const LOG_LEVEL_COLORS[] = {
     ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_WHITE),    // VERY_VERBOSE
 };
 
-static constexpr char LOG_LEVEL_LETTER_CHARS[] = {'\0', 'E', 'W', 'I', 'C', 'D', 'V'};
+static constexpr char LOG_LEVEL_LETTER_CHARS[] = {
+    '\0',  // NONE
+    'E',   // ERROR
+    'W',   // WARNING
+    'I',   // INFO
+    'C',   // CONFIG
+    'D',   // DEBUG
+    'V',   // VERBOSE (VERY_VERBOSE uses two 'V's)
+};
 static constexpr uint8_t ANSI_COLOR_LEN = 7;
+// Maximum header size: 35 bytes fixed + 32 bytes tag + 16 bytes thread name = 83 bytes (45 byte safety margin)
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
 
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -37,7 +37,7 @@ struct device;
 namespace esphome::logger {
 
 // Color and letter constants for log levels
-static const char *const LOG_LEVEL_COLORS[] = {
+static constexpr const char *const LOG_LEVEL_COLORS[] = {
     "",                                            // NONE
     ESPHOME_LOG_BOLD(ESPHOME_LOG_COLOR_RED),       // ERROR
     ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_YELLOW),   // WARNING
@@ -48,16 +48,21 @@ static const char *const LOG_LEVEL_COLORS[] = {
     ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_WHITE),    // VERY_VERBOSE
 };
 
-static const char *const LOG_LEVEL_LETTERS[] = {
-    "",    // NONE
-    "E",   // ERROR
-    "W",   // WARNING
-    "I",   // INFO
-    "C",   // CONFIG
-    "D",   // DEBUG
-    "V",   // VERBOSE
-    "VV",  // VERY_VERBOSE
-};
+// Single character log level letters (E, W, I, C, D, V)
+static constexpr char LOG_LEVEL_LETTER_CHARS[] = {'\0', 'E', 'W', 'I', 'C', 'D', 'V'};
+
+// ANSI color codes are always 7 characters ("\033[0;32m")
+static constexpr uint8_t ANSI_COLOR_LEN = 7;
+
+// Maximum header size (conservative estimate)
+static constexpr uint16_t MAX_HEADER_SIZE = 128;
+
+// Compile-time string length calculation
+static constexpr size_t constexpr_strlen(const char *str) { return *str ? 1 + constexpr_strlen(str + 1) : 0; }
+
+// Compile-time validation of log level string lengths
+static_assert(constexpr_strlen(LOG_LEVEL_COLORS[0]) == 0, "Level 0 color must be empty");
+static_assert(constexpr_strlen(LOG_LEVEL_COLORS[1]) == 7, "Color codes must be 7 chars");
 
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
 /** Enum for logging UART selection
@@ -215,14 +220,6 @@ class Logger : public Component {
     }
   }
 
-  // Format string to explicit buffer with varargs
-  inline void printf_to_buffer_(char *buffer, uint16_t *buffer_at, uint16_t buffer_size, const char *format, ...) {
-    va_list arg;
-    va_start(arg, format);
-    this->format_body_to_buffer_(buffer, buffer_at, buffer_size, format, arg);
-    va_end(arg);
-  }
-
 #ifndef USE_HOST
   const LogString *get_uart_selection_();
 #endif
@@ -318,26 +315,59 @@ class Logger : public Component {
   }
 #endif
 
+  // Helper: copy fixed-length data to buffer and advance position
+  static inline void copy_and_advance(char *buffer, uint16_t &pos, const char *data, uint8_t len) {
+    memcpy(buffer + pos, data, len);
+    pos += len;
+  }
+
+  // Helper: copy string to buffer and advance position (calculates length with strlen)
+  static inline void copy_string(char *buffer, uint16_t &pos, const char *str) {
+    copy_and_advance(buffer, pos, str, strlen(str));
+  }
+
   inline void HOT write_header_to_buffer_(uint8_t level, const char *tag, int line, const char *thread_name,
                                           char *buffer, uint16_t *buffer_at, uint16_t buffer_size) {
-    // Format header
-    // uint8_t level is already bounded 0-255, just ensure it's <= 7
-    if (level > 7)
-      level = 7;
+    uint16_t pos = *buffer_at;
+    if (pos + MAX_HEADER_SIZE > buffer_size)
+      return;
 
-    const char *color = esphome::logger::LOG_LEVEL_COLORS[level];
-    const char *letter = esphome::logger::LOG_LEVEL_LETTERS[level];
+    const char *color = LOG_LEVEL_COLORS[level];
+    const uint8_t color_len = (level == 0) ? 0 : ANSI_COLOR_LEN;
+
+    // Construct: <color>[LEVEL][tag:line]:
+    copy_and_advance(buffer, pos, color, color_len);
+    buffer[pos++] = '[';
+    if (level != 0) {
+      if (level >= 7) {
+        buffer[pos++] = 'V';  // VERY_VERBOSE = "VV"
+        buffer[pos++] = 'V';
+      } else {
+        buffer[pos++] = LOG_LEVEL_LETTER_CHARS[level];
+      }
+    }
+    buffer[pos++] = ']';
+    buffer[pos++] = '[';
+    copy_string(buffer, pos, tag);
+    buffer[pos++] = ':';
+    buffer[pos++] = '0' + (line / 100) % 10;
+    buffer[pos++] = '0' + (line / 10) % 10;
+    buffer[pos++] = '0' + line % 10;
+    buffer[pos++] = ']';
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
     if (thread_name != nullptr) {
-      // Non-main task with thread name
-      this->printf_to_buffer_(buffer, buffer_at, buffer_size, "%s[%s][%s:%03u]%s[%s]%s: ", color, letter, tag, line,
-                              ESPHOME_LOG_BOLD(ESPHOME_LOG_COLOR_RED), thread_name, color);
-      return;
+      copy_and_advance(buffer, pos, LOG_LEVEL_COLORS[1], ANSI_COLOR_LEN);  // Bold red (error color)
+      buffer[pos++] = '[';
+      copy_string(buffer, pos, thread_name);
+      buffer[pos++] = ']';
+      copy_and_advance(buffer, pos, color, color_len);
     }
 #endif
-    // Main task or non ESP32/LibreTiny platform
-    this->printf_to_buffer_(buffer, buffer_at, buffer_size, "%s[%s][%s:%03u]: ", color, letter, tag, line);
+
+    buffer[pos++] = ':';
+    buffer[pos++] = ' ';
+    *buffer_at = pos;
   }
 
   inline void HOT format_body_to_buffer_(char *buffer, uint16_t *buffer_at, uint16_t buffer_size, const char *format,

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -315,13 +315,11 @@ class Logger : public Component {
   }
 #endif
 
-  // Helper: copy fixed-length data to buffer and advance position
   static inline void copy_and_advance(char *buffer, uint16_t &pos, const char *data, uint8_t len) {
     memcpy(buffer + pos, data, len);
     pos += len;
   }
 
-  // Helper: copy string to buffer and advance position (calculates length with strlen)
   static inline void copy_string(char *buffer, uint16_t &pos, const char *str) {
     copy_and_advance(buffer, pos, str, strlen(str));
   }

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -312,13 +312,10 @@ class Logger : public Component {
   }
 #endif
 
-  static inline void copy_and_advance(char *buffer, uint16_t &pos, const char *data, uint8_t len) {
-    memcpy(buffer + pos, data, len);
-    pos += len;
-  }
-
   static inline void copy_string(char *buffer, uint16_t &pos, const char *str) {
-    copy_and_advance(buffer, pos, str, strlen(str));
+    const size_t len = strlen(str);
+    memcpy(buffer + pos, str, len);
+    pos += len;
   }
 
   static inline void write_ansi_color_for_level(char *buffer, uint16_t &pos, uint8_t level) {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -324,6 +324,7 @@ class Logger : public Component {
   inline void HOT write_header_to_buffer_(uint8_t level, const char *tag, int line, const char *thread_name,
                                           char *buffer, uint16_t *buffer_at, uint16_t buffer_size) {
     uint16_t pos = *buffer_at;
+    // Early return if insufficient space - intentionally don't update buffer_at to prevent partial writes
     if (pos + MAX_HEADER_SIZE > buffer_size)
       return;
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -36,16 +36,16 @@ struct device;
 
 namespace esphome::logger {
 
-// Color and letter constants for log levels
-static const char *const LOG_LEVEL_COLORS[] = {
-    "",                                            // NONE
-    ESPHOME_LOG_BOLD(ESPHOME_LOG_COLOR_RED),       // ERROR
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_YELLOW),   // WARNING
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_GREEN),    // INFO
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_MAGENTA),  // CONFIG
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_CYAN),     // DEBUG
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_GRAY),     // VERBOSE
-    ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_WHITE),    // VERY_VERBOSE
+// ANSI color code last digit (30-38 range, store only last digit to save RAM)
+static constexpr char LOG_LEVEL_COLOR_DIGIT[] = {
+    '\0',  // NONE
+    '1',   // ERROR (31 = red)
+    '3',   // WARNING (33 = yellow)
+    '2',   // INFO (32 = green)
+    '5',   // CONFIG (35 = magenta)
+    '6',   // DEBUG (36 = cyan)
+    '7',   // VERBOSE (37 = gray)
+    '8',   // VERY_VERBOSE (38 = white)
 };
 
 static constexpr char LOG_LEVEL_LETTER_CHARS[] = {
@@ -57,7 +57,7 @@ static constexpr char LOG_LEVEL_LETTER_CHARS[] = {
     'D',   // DEBUG
     'V',   // VERBOSE (VERY_VERBOSE uses two 'V's)
 };
-static constexpr uint8_t ANSI_COLOR_LEN = 7;
+
 // Maximum header size: 35 bytes fixed + 32 bytes tag + 16 bytes thread name = 83 bytes (45 byte safety margin)
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
 
@@ -321,6 +321,20 @@ class Logger : public Component {
     copy_and_advance(buffer, pos, str, strlen(str));
   }
 
+  static inline void write_ansi_color_for_level(char *buffer, uint16_t &pos, uint8_t level) {
+    if (level == 0)
+      return;
+    // Construct ANSI escape sequence: "\033[{bold};3{color}m"
+    // Example: "\033[1;31m" for ERROR (bold red)
+    buffer[pos++] = '\033';
+    buffer[pos++] = '[';
+    buffer[pos++] = (level == 1) ? '1' : '0';  // Only ERROR is bold
+    buffer[pos++] = ';';
+    buffer[pos++] = '3';
+    buffer[pos++] = LOG_LEVEL_COLOR_DIGIT[level];
+    buffer[pos++] = 'm';
+  }
+
   inline void HOT write_header_to_buffer_(uint8_t level, const char *tag, int line, const char *thread_name,
                                           char *buffer, uint16_t *buffer_at, uint16_t buffer_size) {
     uint16_t pos = *buffer_at;
@@ -328,11 +342,8 @@ class Logger : public Component {
     if (pos + MAX_HEADER_SIZE > buffer_size)
       return;
 
-    const char *color = LOG_LEVEL_COLORS[level];
-    const uint8_t color_len = (level == 0) ? 0 : ANSI_COLOR_LEN;
-
     // Construct: <color>[LEVEL][tag:line]:
-    copy_and_advance(buffer, pos, color, color_len);
+    write_ansi_color_for_level(buffer, pos, level);
     buffer[pos++] = '[';
     if (level != 0) {
       if (level >= 7) {
@@ -353,11 +364,11 @@ class Logger : public Component {
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
     if (thread_name != nullptr) {
-      copy_and_advance(buffer, pos, LOG_LEVEL_COLORS[1], ANSI_COLOR_LEN);  // Bold red (error color)
+      write_ansi_color_for_level(buffer, pos, 1);  // Always use bold red for thread name
       buffer[pos++] = '[';
       copy_string(buffer, pos, thread_name);
       buffer[pos++] = ']';
-      copy_and_advance(buffer, pos, color, color_len);
+      write_ansi_color_for_level(buffer, pos, level);  // Restore original color
     }
 #endif
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -314,7 +314,8 @@ class Logger : public Component {
 
   static inline void copy_string(char *buffer, uint16_t &pos, const char *str) {
     const size_t len = strlen(str);
-    memcpy(buffer + pos, str, len);
+    // Intentionally no null terminator, building larger string
+    memcpy(buffer + pos, str, len);  // NOLINT(bugprone-not-null-terminated-result)
     pos += len;
   }
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -48,19 +48,10 @@ static constexpr const char *const LOG_LEVEL_COLORS[] = {
     ESPHOME_LOG_COLOR(ESPHOME_LOG_COLOR_WHITE),    // VERY_VERBOSE
 };
 
-// Single character log level letters (E, W, I, C, D, V)
 static constexpr char LOG_LEVEL_LETTER_CHARS[] = {'\0', 'E', 'W', 'I', 'C', 'D', 'V'};
-
-// ANSI color codes are always 7 characters ("\033[0;32m")
 static constexpr uint8_t ANSI_COLOR_LEN = 7;
-
-// Maximum header size (conservative estimate)
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
-
-// Compile-time string length calculation
 static constexpr size_t constexpr_strlen(const char *str) { return *str ? 1 + constexpr_strlen(str + 1) : 0; }
-
-// Compile-time validation of log level string lengths
 static_assert(constexpr_strlen(LOG_LEVEL_COLORS[0]) == 0, "Level 0 color must be empty");
 static_assert(constexpr_strlen(LOG_LEVEL_COLORS[1]) == 7, "Color codes must be 7 chars");
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes logger header formatting for 13x speedup by replacing `snprintf()` with manual string construction. This improves overall logging performance by 35-72% depending on message complexity.

## Performance Improvements

**Header-only performance (isolated):**
- Simple messages: 82.1 ns → 6.3 ns (**13.0x speedup, 92.3% faster**)
- With thread names: 76.8 ns → 10.8 ns (**7.1x speedup, 85.9% faster**)

**Full logging performance (realistic, including vsnprintf body + footer):**
- Sensor logs with floats: 234.6 ns → 153.4 ns (**1.53x speedup, 34.6% faster**)
- Simple messages: 119.3 ns → 34.0 ns (**3.51x speedup, 71.5% faster**)
- Complex multi-arg logs: 181.2 ns → 103.5 ns (**1.75x speedup, 42.9% faster**)

**Memory impact:**
- ESP32: +228 bytes flash (+0.012%)
- ESP32-C3: +340 bytes flash (+0.019%)
- ESP8266: +112 bytes flash (+0.011%), **-128 bytes RAM (-0.16%)**

The RAM savings on ESP8266 come from storing only ANSI color digit characters instead of full escape sequences, eliminating string array overhead.

## Technical Details

### What Changed

1. Replaced the `snprintf()` call in `write_header_to_buffer_()` with manual buffer construction using direct memory operations and character-by-character assembly
2. Optimized ANSI color code storage by storing only the color digit character (e.g., `'1'` for red) instead of full escape sequences (e.g., `"\033[0;31m"`)
3. Dynamic ANSI sequence construction using `write_ansi_color_for_level()` which builds the escape sequence on-the-fly

### Why This Is Faster

- **No format string parsing** - `snprintf()` must parse `%s`, `%03u`, etc. at runtime
- **Direct memory operations** - Uses simple `memcpy()` and direct character writes
- **Better compiler optimization** - Manual construction allows compiler to optimize with `-Os`
- **Compile-time constants** - Uses `constexpr` for ANSI color digit chars and level letter chars
- **Reduced memory footprint** - Char arrays instead of string arrays save RAM (especially on ESP8266)

## Why This Matters

- Logging is one of the most frequently executed code paths in ESPHome
- When investigating issues, adding logging can trigger loop blocking warnings and alter timing, making bugs harder to track down. Faster logging reduces this "observer effect"

## Real-World Validation

Tested on ESP32-C3 with actual device config dump logging:
- **Console (direct):** 201ms → 143ms (**58ms faster, 29% improvement**)
- **Over network:** 253ms → 240ms (13ms faster, 5% improvement)

The console results closely match the benchmark predictions. The network results show the optimization still provides measurable benefits even when I/O overhead dominates.

## Benchmarks

Comprehensive benchmarks are included in `logger_optimization_benchmarks.zip`:
- `benchmark_logger_noinline.cpp` - Header-only performance measurement
- `benchmark_full_logging.cpp` - Full logging pipeline with realistic sensor messages

Both benchmarks use `-Os` (optimize for size) as ESPHome does in production.

**Note:** Benchmarks were run on a host machine. Actual ESP hardware (especially ESP8266 at 80MHz) will be significantly slower in absolute terms, but the relative speedup ratio (13x for header, 1.5-3.5x for full logging) remains valid.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Performance optimization (non-breaking)

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-visible changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Tested on ESP32-C3 (IDF) and ESP8266. Benchmarks validated on host. The optimization is platform-agnostic and benefits all targets.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# All existing logger configurations work exactly as before

logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
