### PR TITLE
[mpr121] remove delay

### DIFF
--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -80,7 +80,8 @@ void MPR121Component::dump_config() {
   }
 }
 void MPR121Component::loop() {
-  if (!this->setup_complete_) return;
+  if (!this->setup_complete_)
+    return;
 
   uint16_t val = 0;
   this->read_byte_16(MPR121_TOUCHSTATUS_L, &val);

--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -51,6 +51,7 @@ void MPR121Component::setup() {
     this->write_byte(MPR121_ECR, 0x80 | (this->max_touch_channel_ + 1));
 
     this->flush_gpio_();
+    this->setup_complete_ = true;
   });
 }
 
@@ -79,6 +80,8 @@ void MPR121Component::dump_config() {
   }
 }
 void MPR121Component::loop() {
+  if (!this->setup_complete_) return;
+
   uint16_t val = 0;
   this->read_byte_16(MPR121_TOUCHSTATUS_L, &val);
 

--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -13,45 +13,45 @@ static const char *const TAG = "mpr121";
 void MPR121Component::setup() {
   // soft reset device
   this->write_byte(MPR121_SOFTRESET, 0x63);
-  delay(100);  // NOLINT
-  if (!this->write_byte(MPR121_ECR, 0x0)) {
-    this->error_code_ = COMMUNICATION_FAILED;
-    this->mark_failed();
-    return;
-  }
+  this->set_timeout(100, [this]() {
+    if (!this->write_byte(MPR121_ECR, 0x0)) {
+      this->error_code_ = COMMUNICATION_FAILED;
+      this->mark_failed();
+      return;
+    }
+    // set touch sensitivity for all 12 channels
+    for (auto *channel : this->channels_) {
+      channel->setup();
+    }
+    this->write_byte(MPR121_MHDR, 0x01);
+    this->write_byte(MPR121_NHDR, 0x01);
+    this->write_byte(MPR121_NCLR, 0x0E);
+    this->write_byte(MPR121_FDLR, 0x00);
 
-  // set touch sensitivity for all 12 channels
-  for (auto *channel : this->channels_) {
-    channel->setup();
-  }
-  this->write_byte(MPR121_MHDR, 0x01);
-  this->write_byte(MPR121_NHDR, 0x01);
-  this->write_byte(MPR121_NCLR, 0x0E);
-  this->write_byte(MPR121_FDLR, 0x00);
+    this->write_byte(MPR121_MHDF, 0x01);
+    this->write_byte(MPR121_NHDF, 0x05);
+    this->write_byte(MPR121_NCLF, 0x01);
+    this->write_byte(MPR121_FDLF, 0x00);
 
-  this->write_byte(MPR121_MHDF, 0x01);
-  this->write_byte(MPR121_NHDF, 0x05);
-  this->write_byte(MPR121_NCLF, 0x01);
-  this->write_byte(MPR121_FDLF, 0x00);
+    this->write_byte(MPR121_NHDT, 0x00);
+    this->write_byte(MPR121_NCLT, 0x00);
+    this->write_byte(MPR121_FDLT, 0x00);
 
-  this->write_byte(MPR121_NHDT, 0x00);
-  this->write_byte(MPR121_NCLT, 0x00);
-  this->write_byte(MPR121_FDLT, 0x00);
+    this->write_byte(MPR121_DEBOUNCE, 0);
+    // default, 16uA charge current
+    this->write_byte(MPR121_CONFIG1, 0x10);
+    // 0.5uS encoding, 1ms period
+    this->write_byte(MPR121_CONFIG2, 0x20);
 
-  this->write_byte(MPR121_DEBOUNCE, 0);
-  // default, 16uA charge current
-  this->write_byte(MPR121_CONFIG1, 0x10);
-  // 0.5uS encoding, 1ms period
-  this->write_byte(MPR121_CONFIG2, 0x20);
+    // Write the Electrode Configuration Register
+    // * Highest 2 bits is "Calibration Lock", which we set to a value corresponding to 5 bits.
+    // * The 2 bits below is "Proximity Enable" and are left at 0.
+    // * The 4 least significant bits control how many electrodes are enabled. Electrodes are enabled
+    //   as a range, starting at 0 up to the highest channel index used.
+    this->write_byte(MPR121_ECR, 0x80 | (this->max_touch_channel_ + 1));
 
-  // Write the Electrode Configuration Register
-  // * Highest 2 bits is "Calibration Lock", which we set to a value corresponding to 5 bits.
-  // * The 2 bits below is "Proximity Enable" and are left at 0.
-  // * The 4 least significant bits control how many electrodes are enabled. Electrodes are enabled
-  //   as a range, starting at 0 up to the highest channel index used.
-  this->write_byte(MPR121_ECR, 0x80 | (this->max_touch_channel_ + 1));
-
-  this->flush_gpio_();
+    this->flush_gpio_();
+  });
 }
 
 void MPR121Component::set_touch_debounce(uint8_t debounce) {
@@ -72,9 +72,6 @@ void MPR121Component::dump_config() {
   switch (this->error_code_) {
     case COMMUNICATION_FAILED:
       ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-      break;
-    case WRONG_CHIP_STATE:
-      ESP_LOGE(TAG, "MPR121 has wrong default value for CONFIG2?");
       break;
     case NONE:
     default:

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -88,7 +88,6 @@ class MPR121Component : public Component, public i2c::I2CDevice {
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,
-    WRONG_CHIP_STATE,
   } error_code_{NONE};
 
   bool flush_gpio_();

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -80,6 +80,7 @@ class MPR121Component : public Component, public i2c::I2CDevice {
   void pin_mode(uint8_t ionum, gpio::Flags flags);
 
  protected:
+  bool setup_complete_{false};
   std::vector<MPR121Channel *> channels_{};
   uint8_t debounce_{0};
   uint8_t touch_threshold_{};


### PR DESCRIPTION
# What does this implement/fix?
Remove delay and replace with set_timeout. Tidy and remove ErrorCode WRONG_CHIP_STATE not used.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
One component in list for issue https://github.com/esphome/backlog/issues/38 "Minimize delay calls as much as possible"
- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
