### PR TITLE
[sps30] remove delay

### DIFF
--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -47,11 +47,12 @@ void SPS30Component::setup() {
 
     if (this->fan_interval_.has_value()) {
       // override default value
-      this->result_ = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
+      this->result_ =
+          this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
     } else {
       this->result_ = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
     }
-    
+
     this->set_timeout(20, [this]() {
       if (this->result_) {
         uint16_t secs[2];

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -45,16 +45,15 @@ void SPS30Component::setup() {
     }
     ESP_LOGV(TAG, "  Serial number: %s", this->serial_number_);
 
-    bool result;
     if (this->fan_interval_.has_value()) {
       // override default value
-      result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
+      this->result_ = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
     } else {
-      result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
+      this->result_ = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
     }
-
+    
     this->set_timeout(20, [this]() {
-      if (result) {
+      if (this->result_) {
         uint16_t secs[2];
         if (this->read_data(secs, 2)) {
           this->fan_interval_ = secs[0] << 16 | secs[1];

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -52,17 +52,18 @@ void SPS30Component::setup() {
     } else {
       result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
     }
-    if (result) {
-      delay(20);
-      uint16_t secs[2];
-      if (this->read_data(secs, 2)) {
-        this->fan_interval_ = secs[0] << 16 | secs[1];
+    
+    this->set_timeout(20, [this]() {
+      if (result) {
+        uint16_t secs[2];
+        if (this->read_data(secs, 2)) {
+          this->fan_interval_ = secs[0] << 16 | secs[1];
+        }
       }
-    }
-
-    this->status_clear_warning();
-    this->skipped_data_read_cycles_ = 0;
-    this->start_continuous_measurement_();
+      this->status_clear_warning();
+      this->skipped_data_read_cycles_ = 0;
+      this->start_continuous_measurement_();
+    });
   });
 }
 

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -63,6 +63,7 @@ void SPS30Component::setup() {
       this->status_clear_warning();
       this->skipped_data_read_cycles_ = 0;
       this->start_continuous_measurement_();
+      this->setup_complete_ = true;
     });
   });
 }
@@ -112,6 +113,8 @@ void SPS30Component::dump_config() {
 }
 
 void SPS30Component::update() {
+  if (!this->setup_complete_)
+    return;
   /// Check if warning flag active (sensor reconnected?)
   if (this->status_has_warning()) {
     ESP_LOGD(TAG, "Reconnecting");

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -52,7 +52,7 @@ void SPS30Component::setup() {
     } else {
       result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
     }
-    
+
     this->set_timeout(20, [this]() {
       if (result) {
         uint16_t secs[2];

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -30,11 +30,13 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   bool start_fan_cleaning();
 
  protected:
+  bool result_{0};
   uint16_t raw_firmware_version_;
   char serial_number_[17] = {0};  /// Terminating NULL character
   uint8_t skipped_data_read_cycles_ = 0;
+  
   bool start_continuous_measurement_();
-
+  
   enum ErrorCode : uint8_t {
     COMMUNICATION_FAILED,
     FIRMWARE_VERSION_REQUEST_FAILED,

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -31,6 +31,7 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
 
  protected:
   bool result_{false};
+  bool setup_complete_{false};
   uint16_t raw_firmware_version_;
   char serial_number_[17] = {0};  /// Terminating NULL character
   uint8_t skipped_data_read_cycles_ = 0;

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -30,7 +30,7 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   bool start_fan_cleaning();
 
  protected:
-  bool result_{0};
+  bool result_{false};
   uint16_t raw_firmware_version_;
   char serial_number_[17] = {0};  /// Terminating NULL character
   uint8_t skipped_data_read_cycles_ = 0;

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -34,9 +34,9 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   uint16_t raw_firmware_version_;
   char serial_number_[17] = {0};  /// Terminating NULL character
   uint8_t skipped_data_read_cycles_ = 0;
-  
+
   bool start_continuous_measurement_();
-  
+
   enum ErrorCode : uint8_t {
     COMMUNICATION_FAILED,
     FIRMWARE_VERSION_REQUEST_FAILED,


### PR DESCRIPTION
# What does this implement/fix?

remove delay and replace with set_time. Just a slight change in logic so there is a short 20ms delay regardless of the state of "result" 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
One component in list for issue https://github.com/esphome/backlog/issues/38 "Minimize delay calls as much as possible"

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
