### PR TITLE
[core] Fix ComponentIterator alignment for 32-bit platforms

### DIFF
--- a/esphome/core/component_iterator.h
+++ b/esphome/core/component_iterator.h
@@ -168,8 +168,9 @@ class ComponentIterator {
     UPDATE,
 #endif
     MAX,
-  } state_{IteratorState::NONE};
+  };
   uint16_t at_{0};  // Supports up to 65,535 entities per type
+  IteratorState state_{IteratorState::NONE};
   bool include_internal_{false};
 
   template<typename Container>


### PR DESCRIPTION
# What does this implement/fix?

Reorders member variables in `ComponentIterator` to eliminate padding and reduce memory footprint on 32-bit platforms.

The original member layout caused unnecessary padding:
- `state_` (uint8_t, 1 byte) + 1 byte padding
- `at_` (uint16_t, 2 bytes)
- `include_internal_` (bool, 1 byte) + 3 bytes trailing padding
- **Total: 8 bytes**

By reordering to place larger types first:
- `at_` (uint16_t, 2 bytes)
- `state_` (IteratorState/uint8_t, 1 byte)
- `include_internal_` (bool, 1 byte)
- **Total: 4 bytes (50% reduction)**

This change is particularly beneficial for ESP8266 and ESP32 where RAM is constrained.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
