### PR TITLE
[api] Reduce flash usage in user services by eliminating vector copy

### DIFF
--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -25,8 +25,8 @@ template<typename T> enums::ServiceArgType to_service_arg_type();
 
 template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
  public:
-  UserServiceBase(const std::string &name, const std::array<std::string, sizeof...(Ts)> &arg_names)
-      : name_(name), arg_names_(arg_names) {
+  UserServiceBase(std::string name, const std::array<std::string, sizeof...(Ts)> &arg_names)
+      : name_(std::move(name)), arg_names_(arg_names) {
     this->key_ = fnv1_hash(this->name_);
   }
 

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -25,8 +25,8 @@ template<typename T> enums::ServiceArgType to_service_arg_type();
 
 template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
  public:
-  UserServiceBase(std::string name, const std::array<std::string, sizeof...(Ts)> &arg_names)
-      : name_(std::move(name)), arg_names_(arg_names) {
+  UserServiceBase(const std::string &name, const std::array<std::string, sizeof...(Ts)> &arg_names)
+      : name_(name), arg_names_(arg_names) {
     this->key_ = fnv1_hash(this->name_);
   }
 
@@ -55,7 +55,7 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
 
  protected:
   virtual void execute(Ts... x) = 0;
-  template<int... S> void execute_(std::vector<ExecuteServiceArgument> args, seq<S...> type) {
+  template<int... S> void execute_(const std::vector<ExecuteServiceArgument> &args, seq<S...> type) {
     this->execute((get_execute_arg_value<Ts>(args[S]))...);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Reduces flash usage by 656 bytes by eliminating unnecessary vector copy operations in the API user services implementation.

## Changes

**user_services.h line 58**: Changed `execute_()` parameter from `std::vector<ExecuteServiceArgument> args` (pass-by-value) to `const std::vector<ExecuteServiceArgument> &args` (pass-by-reference). This eliminates a full vector copy on every user service execution across all template instantiations.

This is an internal implementation detail with no API changes - all existing code continues to work without modification.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
