### PR TITLE
[lock] Replace std::set with bitmask (saves 388B flash + 23B RAM per lock)

### DIFF
--- a/esphome/components/copy/lock/copy_lock.cpp
+++ b/esphome/components/copy/lock/copy_lock.cpp
@@ -11,7 +11,7 @@ void CopyLock::setup() {
 
   traits.set_assumed_state(source_->traits.get_assumed_state());
   traits.set_requires_code(source_->traits.get_requires_code());
-  traits.set_supported_states(source_->traits.get_supported_states());
+  traits.set_supported_states_mask(source_->traits.get_supported_states_mask());
   traits.set_supports_open(source_->traits.get_supports_open());
 
   this->publish_state(source_->state);

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -5,6 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
+#include <span>
 
 namespace esphome {
 namespace lock {
@@ -44,6 +45,12 @@ class LockTraits {
   void set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
   bool supports_state(LockState state) const { return supported_states_mask_ & (1 << state); }
+  void set_supported_states(std::span<const LockState> states) {
+    supported_states_mask_ = 0;
+    for (auto state : states) {
+      supported_states_mask_ |= (1 << state);
+    }
+  }
   uint8_t get_supported_states_mask() const { return supported_states_mask_; }
   void set_supported_states_mask(uint8_t mask) { supported_states_mask_ = mask; }
   void add_supported_state(LockState state) { supported_states_mask_ |= (1 << state); }

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -5,7 +5,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
-#include <set>
 
 namespace esphome {
 namespace lock {
@@ -44,16 +43,16 @@ class LockTraits {
   bool get_assumed_state() const { return this->assumed_state_; }
   void set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
-  bool supports_state(LockState state) const { return supported_states_.count(state); }
-  std::set<LockState> get_supported_states() const { return supported_states_; }
-  void set_supported_states(std::set<LockState> states) { supported_states_ = std::move(states); }
-  void add_supported_state(LockState state) { supported_states_.insert(state); }
+  bool supports_state(LockState state) const { return supported_states_mask_ & (1 << state); }
+  uint8_t get_supported_states_mask() const { return supported_states_mask_; }
+  void set_supported_states_mask(uint8_t mask) { supported_states_mask_ = mask; }
+  void add_supported_state(LockState state) { supported_states_mask_ |= (1 << state); }
 
  protected:
   bool supports_open_{false};
   bool requires_code_{false};
   bool assumed_state_{false};
-  std::set<LockState> supported_states_ = {LOCK_STATE_NONE, LOCK_STATE_LOCKED, LOCK_STATE_UNLOCKED};
+  uint8_t supported_states_mask_{(1 << LOCK_STATE_NONE) | (1 << LOCK_STATE_LOCKED) | (1 << LOCK_STATE_UNLOCKED)};
 };
 
 /** This class is used to encode all control actions on a lock device.

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -5,7 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
-#include <span>
+#include <initializer_list>
 
 namespace esphome {
 namespace lock {
@@ -45,7 +45,7 @@ class LockTraits {
   void set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
   bool supports_state(LockState state) const { return supported_states_mask_ & (1 << state); }
-  void set_supported_states(std::span<const LockState> states) {
+  void set_supported_states(std::initializer_list<LockState> states) {
     supported_states_mask_ = 0;
     for (auto state : states) {
       supported_states_mask_ |= (1 << state);


### PR DESCRIPTION
# What does this implement/fix?

Replaces `std::set<LockState>` with a `uint8_t` bitmask in `LockTraits` to reduce memory overhead and eliminate unnecessary red-black tree code.

## Motivation

`LockState` is a simple enum with only 6 possible values (0-5), but `LockTraits` was using `std::set` to track supported states. This pulled in 150+ bytes of red-black tree code for set insertion, node allocation, and tree balancing - massive overkill for a 6-value enum.

## Changes

- Replaced `std::set<LockState> supported_states_` with `uint8_t supported_states_mask_` internally
- Changed API methods:
  - `set_supported_states(std::set<LockState>)` → `set_supported_states(std::initializer_list<LockState>)`
    - Accepts initializer lists: `{LOCK_STATE_LOCKED, LOCK_STATE_UNLOCKED}`
  - `get_supported_states()` removed (use `supports_state()` to check individual states)
  - Added `get_supported_states_mask()` for internal use (returns `uint8_t`)
  - Added `set_supported_states_mask(uint8_t)` for efficient copying between traits
  - `supports_state()` now uses bit check instead of `set::count()`
  - `add_supported_state()` unchanged (still uses bit-or internally)
- Updated `copy_lock.cpp` to use `get/set_supported_states_mask()`
- Removed `#include <set>`, added `#include <initializer_list>`

## Why uint8_t is sufficient

`LockState` currently has 6 defined states (NONE, LOCKED, UNLOCKED, JAMMED, LOCKING, UNLOCKING). A `uint8_t` bitmask supports up to 8 states, providing headroom for 2 additional states.

Physical locks have inherently limited state models - they can be locked, unlocked, transitioning between states, or in an error state. Even advanced smart locks don't exceed this complexity. It's **extremely unlikely** locks would ever need >8 states.

We're not pre-emptively using `uint16_t` because:
1. This breaking change has minimal impact (only C++ custom components affected)
2. If >8 states are ever needed, another breaking change is acceptable given the low impact
3. `uint16_t` would waste 1 byte per lock instance for no current benefit
4. The alternative (keeping `std::set`) wastes 388 bytes flash + 23 bytes RAM per lock to avoid a hypothetical future break

## Memory Savings

**Flash:** 388 bytes saved, consisting of:
- 150B red-black tree insertion logic (`_M_get_insert_hint_unique_pos`)
- ~100B tree node allocation/deallocation
- ~100B `std::set<LockState>` template instantiation
- ~38B tree balancing and other operations

**RAM:** ~23 bytes saved per lock instance (eliminates `std::set` per-instance overhead)

**Heap:** Eliminates 0-3 small allocations during setup, reducing heap fragmentation

Note: RAM savings are per lock instance and may not show in static measurements as `std::set` allocates on the heap at runtime.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing ESP8266 memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal API change only

## Breaking Change Details

**Who is affected:** Only C++ custom components that directly call:
- `LockTraits::get_supported_states()` (removed)
- `LockTraits::set_supported_states()` (signature changed)

**What breaks:**
- `get_supported_states()` removed - use `supports_state()` to check individual states
- `set_supported_states()` now takes `std::initializer_list<LockState>` instead of `std::set<LockState>`

**Migration path:**
```cpp
// Old:
std::set<LockState> states = traits.get_supported_states();  // REMOVED
traits.set_supported_states({LOCK_STATE_LOCKED, LOCK_STATE_UNLOCKED});

// New (setting states - works with same syntax!):
traits.set_supported_states({LOCK_STATE_LOCKED, LOCK_STATE_UNLOCKED});  // Now uses std::initializer_list

// New (getting states - check individually):
if (traits.supports_state(LOCK_STATE_LOCKED)) { ... }

// New (internal copying - for library code like copy_lock):
traits.set_supported_states_mask(source_traits.get_supported_states_mask());

// Unchanged methods still work:
traits.add_supported_state(LOCK_STATE_LOCKED);  // Still works
traits.supports_state(LOCK_STATE_JAMMED);        // Still works
```

**Most code won't break:** The common pattern `set_supported_states({...})` works unchanged - only accepts braced-init syntax now (not std::set/std::vector variables).

**Internal ESPHome impact:** Only one file affected (`copy_lock.cpp`), already updated.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Tested on ESP8266 with lock component, verified 388 byte flash reduction.

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing lock configurations work unchanged:

lock:
  - platform: template
    name: "Test Lock"
    id: test_lock
    lambda: |-
      return LOCK_STATE_UNLOCKED;
    lock_action:
      - logger.log: "Lock!"
    unlock_action:
      - logger.log: "Unlock!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
