### PR TITLE
Change LDO-channel max value to 3.3V

### DIFF
--- a/esphome/components/esp_ldo/__init__.py
+++ b/esphome/components/esp_ldo/__init__.py
@@ -24,7 +24,7 @@ CONFIG_SCHEMA = cv.All(
             {
                 cv.GenerateID(): cv.declare_id(EspLdo),
                 cv.Required(CONF_VOLTAGE): cv.All(
-                    cv.voltage, cv.float_range(min=0.5, max=2.7)
+                    cv.voltage, cv.float_range(min=0.5, max=3.3)
                 ),
                 cv.Required(CONF_CHANNEL): cv.one_of(*CHANNELS, int=True),
                 cv.Optional(CONF_ADJUSTABLE, default=False): cv.boolean,


### PR DESCRIPTION
# What does this implement/fix?
As the LDO is used for supplying power to the sd-card slot on some boards - and it is capable of it as well - allow the ldo-channel to be set to 3.3V max.
Default can/should stay @2.7V.

Users need to verify the LDO channel usage on their specific boards. Also the LDO can be used to switch on/off/reset attached devices.
In case of my specific P4 dev board, an additional GPIO (GPIO45 in my case) is linked to the base of a PWM-capable transistor (A03401) implemented in that sd-card power line -> allowing for runtime PWM of the resulting voltage between 0 and the LDO maximum value.
This could (afaik) be used to switch sd-card power from 3.3V to 1.8V for specific cards.
3.3V should be the value used for typical sd cards though.

All tested and verified with Fluke multimeter here.

<!-- Quick description and explanation of changes -->

set max. value of voltage in init.py to 3.3V

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5440

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp_ldo:
  - channel: 3
    voltage: 2.5V
  - channel: 4
    voltage: 3.3V
    adjustable: True
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
