### PR TITLE
[core] Fix MQTT import

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -16,7 +16,7 @@ import argcomplete
 
 # Note: Do not import modules from esphome.components here, as this would
 # cause them to be loaded before external components are processed, resulting
-# in the built-in versions being used instead of the external component ones.
+# in the built-in version being used instead of the external component one.
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
 from esphome.config import iter_component_configs, read_config, strip_default_ids

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -14,6 +14,9 @@ from typing import Protocol
 
 import argcomplete
 
+# Note: Do not import modules from esphome.components here, as this would
+# cause them to be loaded before external components are processed, resulting
+# in the built-in versions being used instead of the external component ones.
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
 from esphome.config import iter_component_configs, read_config, strip_default_ids

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -16,7 +16,6 @@ import argcomplete
 
 from esphome import const, writer, yaml_util
 import esphome.codegen as cg
-from esphome.components.mqtt import CONF_DISCOVER_IP
 from esphome.config import iter_component_configs, read_config, strip_default_ids
 from esphome.const import (
     ALLOWED_NAME_CHARS,
@@ -240,6 +239,8 @@ def has_ota() -> bool:
 
 def has_mqtt_ip_lookup() -> bool:
     """Check if MQTT is available and IP lookup is supported."""
+    from esphome.components.mqtt import CONF_DISCOVER_IP
+
     if CONF_MQTT not in CORE.config:
         return False
     # Default Enabled


### PR DESCRIPTION
# What does this implement/fix?

Seems importing esphome.components.mqtt too early will prevent MQTT being used as an external component. Move the import into the function that uses CONF_DISCOVER_IP

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10980
- related https://github.com/esphome/esphome/pull/10632

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
