### PR TITLE
[number] Reduce flash usage in NumberCall logging

### DIFF
--- a/esphome/components/number/number_call.cpp
+++ b/esphome/components/number/number_call.cpp
@@ -74,20 +74,20 @@ void NumberCall::perform() {
     target_value = this->value_.value();
   } else if (this->operation_ == NUMBER_OP_TO_MIN) {
     if (std::isnan(min_value)) {
-      this->log_perform_warning_two_strings_(LOG_STR("min"), LOG_STR("value undefined"));
+      this->log_perform_warning_two_strings_(LOG_STR("min"), LOG_STR("undefined"));
     } else {
       target_value = min_value;
     }
   } else if (this->operation_ == NUMBER_OP_TO_MAX) {
     if (std::isnan(max_value)) {
-      this->log_perform_warning_two_strings_(LOG_STR("max"), LOG_STR("value undefined"));
+      this->log_perform_warning_two_strings_(LOG_STR("max"), LOG_STR("undefined"));
     } else {
       target_value = max_value;
     }
   } else if (this->operation_ == NUMBER_OP_INCREMENT) {
-    ESP_LOGD(TAG, "'%s': Increment, with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Increment with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      this->log_perform_warning_two_strings_(LOG_STR("Can't increment,"), LOG_STR("no state"));
+      this->log_perform_warning_two_strings_(LOG_STR("Can't increment"), LOG_STR("no state"));
       return;
     }
     auto step = traits.get_step();
@@ -100,9 +100,9 @@ void NumberCall::perform() {
       }
     }
   } else if (this->operation_ == NUMBER_OP_DECREMENT) {
-    ESP_LOGD(TAG, "'%s': Decrement, with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Decrement with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      this->log_perform_warning_two_strings_(LOG_STR("Can't decrement,"), LOG_STR("no state"));
+      this->log_perform_warning_two_strings_(LOG_STR("Can't decrement"), LOG_STR("no state"));
       return;
     }
     auto step = traits.get_step();

--- a/esphome/components/number/number_call.cpp
+++ b/esphome/components/number/number_call.cpp
@@ -7,6 +7,21 @@ namespace number {
 
 static const char *const TAG = "number";
 
+// Helper functions to reduce code size for logging
+void NumberCall::log_perform_warning_(const LogString *message) {
+  ESP_LOGW(TAG, "'%s': %s", this->parent_->get_name().c_str(), LOG_STR_ARG(message));
+}
+
+void NumberCall::log_perform_warning_value_range_(const LogString *comparison, const LogString *limit_type, float val,
+                                                  float limit) {
+  ESP_LOGW(TAG, "'%s': %f %s %s %f", this->parent_->get_name().c_str(), val, LOG_STR_ARG(comparison),
+           LOG_STR_ARG(limit_type), limit);
+}
+
+void NumberCall::log_perform_warning_two_strings_(const LogString *prefix, const LogString *suffix) {
+  ESP_LOGW(TAG, "'%s': %s %s", this->parent_->get_name().c_str(), LOG_STR_ARG(prefix), LOG_STR_ARG(suffix));
+}
+
 NumberCall &NumberCall::set_value(float value) { return this->with_operation(NUMBER_OP_SET).with_value(value); }
 
 NumberCall &NumberCall::number_increment(bool cycle) {
@@ -42,7 +57,7 @@ void NumberCall::perform() {
   const auto &traits = parent->traits;
 
   if (this->operation_ == NUMBER_OP_NONE) {
-    ESP_LOGW(TAG, "'%s' - NumberCall performed without selecting an operation", name);
+    this->log_perform_warning_(LOG_STR("No operation"));
     return;
   }
 
@@ -51,28 +66,28 @@ void NumberCall::perform() {
   float max_value = traits.get_max_value();
 
   if (this->operation_ == NUMBER_OP_SET) {
-    ESP_LOGD(TAG, "'%s' - Setting number value", name);
+    ESP_LOGD(TAG, "'%s': Setting value", name);
     if (!this->value_.has_value() || std::isnan(*this->value_)) {
-      ESP_LOGW(TAG, "'%s' - No value set for NumberCall", name);
+      this->log_perform_warning_(LOG_STR("No value"));
       return;
     }
     target_value = this->value_.value();
   } else if (this->operation_ == NUMBER_OP_TO_MIN) {
     if (std::isnan(min_value)) {
-      ESP_LOGW(TAG, "'%s' - Can't set to min value through NumberCall: no min_value defined", name);
+      this->log_perform_warning_two_strings_(LOG_STR("min"), LOG_STR("value undefined"));
     } else {
       target_value = min_value;
     }
   } else if (this->operation_ == NUMBER_OP_TO_MAX) {
     if (std::isnan(max_value)) {
-      ESP_LOGW(TAG, "'%s' - Can't set to max value through NumberCall: no max_value defined", name);
+      this->log_perform_warning_two_strings_(LOG_STR("max"), LOG_STR("value undefined"));
     } else {
       target_value = max_value;
     }
   } else if (this->operation_ == NUMBER_OP_INCREMENT) {
-    ESP_LOGD(TAG, "'%s' - Increment number, with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Increment, with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      ESP_LOGW(TAG, "'%s' - Can't increment number through NumberCall: no active state to modify", name);
+      this->log_perform_warning_two_strings_(LOG_STR("Can't increment,"), LOG_STR("no state"));
       return;
     }
     auto step = traits.get_step();
@@ -85,9 +100,9 @@ void NumberCall::perform() {
       }
     }
   } else if (this->operation_ == NUMBER_OP_DECREMENT) {
-    ESP_LOGD(TAG, "'%s' - Decrement number, with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Decrement, with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      ESP_LOGW(TAG, "'%s' - Can't decrement number through NumberCall: no active state to modify", name);
+      this->log_perform_warning_two_strings_(LOG_STR("Can't decrement,"), LOG_STR("no state"));
       return;
     }
     auto step = traits.get_step();
@@ -102,15 +117,15 @@ void NumberCall::perform() {
   }
 
   if (target_value < min_value) {
-    ESP_LOGW(TAG, "'%s' - Value %f must not be less than minimum %f", name, target_value, min_value);
+    this->log_perform_warning_value_range_(LOG_STR("<"), LOG_STR("min"), target_value, min_value);
     return;
   }
   if (target_value > max_value) {
-    ESP_LOGW(TAG, "'%s' - Value %f must not be greater than maximum %f", name, target_value, max_value);
+    this->log_perform_warning_value_range_(LOG_STR(">"), LOG_STR("max"), target_value, max_value);
     return;
   }
 
-  ESP_LOGD(TAG, "  New number value: %f", target_value);
+  ESP_LOGD(TAG, "  New value: %f", target_value);
   this->parent_->control(target_value);
 }
 

--- a/esphome/components/number/number_call.cpp
+++ b/esphome/components/number/number_call.cpp
@@ -18,10 +18,6 @@ void NumberCall::log_perform_warning_value_range_(const LogString *comparison, c
            LOG_STR_ARG(limit_type), limit);
 }
 
-void NumberCall::log_perform_warning_two_strings_(const LogString *prefix, const LogString *suffix) {
-  ESP_LOGW(TAG, "'%s': %s %s", this->parent_->get_name().c_str(), LOG_STR_ARG(prefix), LOG_STR_ARG(suffix));
-}
-
 NumberCall &NumberCall::set_value(float value) { return this->with_operation(NUMBER_OP_SET).with_value(value); }
 
 NumberCall &NumberCall::number_increment(bool cycle) {
@@ -74,20 +70,20 @@ void NumberCall::perform() {
     target_value = this->value_.value();
   } else if (this->operation_ == NUMBER_OP_TO_MIN) {
     if (std::isnan(min_value)) {
-      this->log_perform_warning_two_strings_(LOG_STR("min"), LOG_STR("undefined"));
+      this->log_perform_warning_(LOG_STR("min undefined"));
     } else {
       target_value = min_value;
     }
   } else if (this->operation_ == NUMBER_OP_TO_MAX) {
     if (std::isnan(max_value)) {
-      this->log_perform_warning_two_strings_(LOG_STR("max"), LOG_STR("undefined"));
+      this->log_perform_warning_(LOG_STR("max undefined"));
     } else {
       target_value = max_value;
     }
   } else if (this->operation_ == NUMBER_OP_INCREMENT) {
     ESP_LOGD(TAG, "'%s': Increment with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      this->log_perform_warning_two_strings_(LOG_STR("Can't increment"), LOG_STR("no state"));
+      this->log_perform_warning_(LOG_STR("Can't increment, no state"));
       return;
     }
     auto step = traits.get_step();
@@ -102,7 +98,7 @@ void NumberCall::perform() {
   } else if (this->operation_ == NUMBER_OP_DECREMENT) {
     ESP_LOGD(TAG, "'%s': Decrement with%s cycling", name, this->cycle_ ? "" : "out");
     if (!parent->has_state()) {
-      this->log_perform_warning_two_strings_(LOG_STR("Can't decrement"), LOG_STR("no state"));
+      this->log_perform_warning_(LOG_STR("Can't decrement, no state"));
       return;
     }
     auto step = traits.get_step();

--- a/esphome/components/number/number_call.h
+++ b/esphome/components/number/number_call.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 #include "number_traits.h"
 
 namespace esphome {
@@ -33,6 +34,11 @@ class NumberCall {
   NumberCall &with_cycle(bool cycle);
 
  protected:
+  void log_perform_warning_(const LogString *message);
+  void log_perform_warning_value_range_(const LogString *comparison, const LogString *limit_type, float val,
+                                        float limit);
+  void log_perform_warning_two_strings_(const LogString *prefix, const LogString *suffix);
+
   Number *const parent_;
   NumberOperation operation_{NUMBER_OP_NONE};
   optional<float> value_;

--- a/esphome/components/number/number_call.h
+++ b/esphome/components/number/number_call.h
@@ -37,7 +37,6 @@ class NumberCall {
   void log_perform_warning_(const LogString *message);
   void log_perform_warning_value_range_(const LogString *comparison, const LogString *limit_type, float val,
                                         float limit);
-  void log_perform_warning_two_strings_(const LogString *prefix, const LogString *suffix);
 
   Number *const parent_;
   NumberOperation operation_{NUMBER_OP_NONE};


### PR DESCRIPTION
# What does this implement/fix?

Aligns `NumberCall::perform()` logging with [ESPHome logging guidelines](https://developers.esphome.io/architecture/logging/), reducing flash memory usage by 380 bytes (~56% reduction from original 678-byte function size).

## Flash Savings Breakdown

- **Total saved:** 380 bytes (512585 → 512205)
- **Function reduction:** 56% of original size (678 bytes → ~298 bytes)
- **RAM impact:** 0 bytes

Following the logging guidelines resulted in significant flash savings while maintaining message clarity.

## Before/After Comparison

| # | Before | After | Bytes Saved |
|---|--------|-------|-------------|
| 1 | `'%s' - NumberCall performed without selecting an operation` | `'%s': No operation` | 44 |
| 2 | `'%s' - Setting number value` | `'%s': Setting value` | 7 |
| 3 | `'%s' - No value set for NumberCall` | `'%s': No value` | 23 |
| 4 | `'%s' - Can't set to min value through NumberCall: no min_value defined` | `'%s': min undefined` | 48 |
| 5 | `'%s' - Can't set to max value through NumberCall: no max_value defined` | `'%s': max undefined` | 48 |
| 6 | `'%s' - Increment number, with%s cycling` | `'%s': Increment with%s cycling` | 9 |
| 7 | `'%s' - Can't increment number through NumberCall: no active state to modify` | `'%s': Can't increment, no state` | 46 |
| 8 | `'%s' - Decrement number, with%s cycling` | `'%s': Decrement with%s cycling` | 9 |
| 9 | `'%s' - Can't decrement number through NumberCall: no active state to modify` | `'%s': Can't decrement, no state` | 46 |
| 10 | `'%s' - Value %f must not be less than minimum %f` | `'%s': %f < min %f` | 35 |
| 11 | `'%s' - Value %f must not be greater than maximum %f` | `'%s': %f > max %f` | 35 |
| 12 | `  New number value: %f` | `  New value: %f` | 7 |

## Types of changes

- [x] Code quality improvements to existing code or addition of tests (aligns with logging guidelines)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
# All existing number component configurations work unchanged

number:
  - platform: template
    name: "Test Number"
    optimistic: true
    min_value: 0
    max_value: 100
    step: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
