### PR TITLE
[web_server] Reduce flash and RAM usage by optimizing string construction

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -366,7 +366,9 @@ std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
 
 std::string value_accuracy_with_uom_to_string(float value, int8_t accuracy_decimals, StringRef unit_of_measurement) {
   normalize_accuracy_decimals(value, accuracy_decimals);
-  char tmp[64];  // Increased to accommodate unit of measurement
+  // Buffer sized for float (up to ~15 chars) + space + typical UOM (usually <20 chars like "μS/cm")
+  // snprintf truncates safely if exceeded, though ESPHome UOMs are typically short
+  char tmp[64];
   if (unit_of_measurement.empty()) {
     snprintf(tmp, sizeof(tmp), "%.*f", accuracy_decimals, value);
   } else {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/string_ref.h"
 
 #include <strings.h>
 #include <algorithm>
@@ -348,14 +349,29 @@ ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
   return PARSE_NONE;
 }
 
-std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
+static inline void normalize_accuracy_decimals(float &value, int8_t &accuracy_decimals) {
   if (accuracy_decimals < 0) {
     auto multiplier = powf(10.0f, accuracy_decimals);
     value = roundf(value * multiplier) / multiplier;
     accuracy_decimals = 0;
   }
+}
+
+std::string value_accuracy_to_string(float value, int8_t accuracy_decimals) {
+  normalize_accuracy_decimals(value, accuracy_decimals);
   char tmp[32];  // should be enough, but we should maybe improve this at some point.
   snprintf(tmp, sizeof(tmp), "%.*f", accuracy_decimals, value);
+  return std::string(tmp);
+}
+
+std::string value_accuracy_with_uom_to_string(float value, int8_t accuracy_decimals, StringRef unit_of_measurement) {
+  normalize_accuracy_decimals(value, accuracy_decimals);
+  char tmp[64];  // Increased to accommodate unit of measurement
+  if (unit_of_measurement.empty()) {
+    snprintf(tmp, sizeof(tmp), "%.*f", accuracy_decimals, value);
+  } else {
+    snprintf(tmp, sizeof(tmp), "%.*f %s", accuracy_decimals, value, unit_of_measurement.c_str());
+  }
   return std::string(tmp);
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -14,10 +14,6 @@
 
 #include "esphome/core/optional.h"
 
-namespace esphome {
-class StringRef;
-}
-
 #ifdef USE_ESP8266
 #include <Esp.h>
 #endif
@@ -48,6 +44,9 @@ class StringRef;
 #define PACKED __attribute__((packed))
 
 namespace esphome {
+
+// Forward declaration to avoid circular dependency with string_ref.h
+class StringRef;
 
 /// @name STL backports
 ///@{

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -14,6 +14,10 @@
 
 #include "esphome/core/optional.h"
 
+namespace esphome {
+class StringRef;
+}
+
 #ifdef USE_ESP8266
 #include <Esp.h>
 #endif
@@ -600,6 +604,8 @@ ParseOnOffState parse_on_off(const char *str, const char *on = nullptr, const ch
 
 /// Create a string from a value and an accuracy in decimals.
 std::string value_accuracy_to_string(float value, int8_t accuracy_decimals);
+/// Create a string from a value, an accuracy in decimals, and a unit of measurement.
+std::string value_accuracy_with_uom_to_string(float value, int8_t accuracy_decimals, StringRef unit_of_measurement);
 
 /// Derive accuracy in decimals from an increment step.
 int8_t step_to_accuracy_decimals(float step);


### PR DESCRIPTION
# What does this implement/fix?

Optimizes web server JSON generation to reduce flash usage and runtime memory allocations by:

1. **Eliminates redundant `get_unit_of_measurement()` calls**: Changed from 4 calls per sensor/number update to 1 `get_unit_of_measurement_ref()` call, avoiding temporary string allocations.

2. **Adds `value_accuracy_with_uom_to_string()` helper**: Formats value and unit of measurement in a single `snprintf()` call instead of string concatenation, eliminating an allocation per sensor/number state update.

3. **Centralizes entity ID construction**: Moved `"prefix-" + obj->get_object_id()` logic from 19 call sites into `set_json_id()` using a stack buffer and `snprintf()`, enabling string literal deduplication.

4. **Uses `StringRef` accessors**: Changed to `get_icon_ref()`, `get_device_class_ref()`, and `get_unit_of_measurement_ref()` where available. ArduinoJson can consume `StringRef` directly, avoiding temporary `std::string` conversions.

## Results

**Flash savings:**
- ESP32-C3 (27.2% flash): -460 bytes
- ESP32-C3 (58.4% flash): -776 bytes
- ESP8266 (48.9% flash): -420 bytes

**RAM savings:**
- ESP8266: -48 bytes (string literal deduplication from separating entity type names)

**Runtime improvements:**
- Eliminates 3-4 string allocations per sensor/number state update
- Reduces heap fragmentation from frequent temporary string creation

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - optimization is transparent to users

web_server:
  port: 80

sensor:
  - platform: homeassistant
    id: temperature_sensor
    entity_id: sensor.outdoor_temperature
    unit_of_measurement: "°C"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
