### PR TITLE
[ci] Fix pre-commit action to comply with pinned SHA security policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+      - uses: esphome/action@43cd1109c09c544d97196f7730ee5b2e0cc6d81e # v3.0.1 fork with pinned actions/cache
         env:
           SKIP: pylint,clang-tidy-hash
       - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0


### PR DESCRIPTION
# What does this implement/fix?

Fixes GitHub Actions CI failures caused by security policy requiring all actions to be pinned to full-length commit SHAs.

The `pre-commit/action@v3.0.1` internally uses `actions/cache@v4` with a tag reference instead of a pinned SHA, which violates the repository's security policy that mandates all actions must be pinned to full-length commit SHAs.

**Solution:**
- Forked `pre-commit/action` to `esphome/action`
- Updated the forked action to pin `actions/cache` to commit SHA `0057852bfaa89a56745cba8c7296529d2fc39830` (v4.3.0)
- Updated CI workflow to use the forked action at commit `43cd1109c09c544d97196f7730ee5b2e0cc6d81e`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes GitHub Actions CI failures on all PRs

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (CI infrastructure change only)

## Test Environment

- N/A (CI workflow change only)

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
