### PR TITLE
[core] Remove platformio install from setup

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -22,8 +22,6 @@ uv pip install -e ".[dev,test]" --config-settings editable_mode=compat
 
 pre-commit install
 
-script/platformio_install_deps.py platformio.ini --libraries --tools --platforms
-
 mkdir -p .temp
 
 echo

--- a/script/setup.bat
+++ b/script/setup.bat
@@ -19,8 +19,6 @@ pip3 install -e ".[dev,test]" --config-settings editable_mode=compat
 
 pre-commit install
 
-python script/platformio_install_deps.py platformio.ini --libraries --tools --platforms
-
 echo .
 echo .
 echo Virtual environment created. Run 'venv/Scripts/activate' to use it.


### PR DESCRIPTION
# What does this implement/fix?

Can this be removed? 

I don't see a point in downloading platforms you don't need when they will be downloaded in the build automatically. 

Now takes a few seconds to download new requirements instead of minutes. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
