### PR TITLE
[sps30] Clean up

### DIFF
--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -45,16 +45,16 @@ void SPS30Component::setup() {
     }
     ESP_LOGV(TAG, "  Serial number: %s", this->serial_number_);
 
+    bool result;
     if (this->fan_interval_.has_value()) {
       // override default value
-      this->result_ =
-          this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
+      result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS, this->fan_interval_.value());
     } else {
-      this->result_ = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
+      result = this->write_command(SPS30_CMD_SET_AUTOMATIC_CLEANING_INTERVAL_SECONDS);
     }
 
-    this->set_timeout(20, [this]() {
-      if (this->result_) {
+    this->set_timeout(20, [this, result]() {
+      if (result) {
         uint16_t secs[2];
         if (this->read_data(secs, 2)) {
           this->fan_interval_ = secs[0] << 16 | secs[1];

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -30,7 +30,6 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   bool start_fan_cleaning();
 
  protected:
-  bool result_{false};
   bool setup_complete_{false};
   uint16_t raw_firmware_version_;
   char serial_number_[17] = {0};  /// Terminating NULL character


### PR DESCRIPTION
# What does this implement/fix?

I missed this when merging https://github.com/esphome/esphome/pull/10964, should just capture remove instead of making it a member. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
