### PR TITLE
[web_server_idf] Optimize parameter storage to reduce flash usage and memory overhead

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -206,7 +206,7 @@ void AsyncWebServerRequest::redirect(const std::string &url) {
 
 void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code, const char *content_type) {
   // Set status code - use constants for common codes to avoid string allocation
-  const char *status;
+  const char *status = nullptr;
   switch (code) {
     case 200:
       status = HTTPD_200;
@@ -218,10 +218,9 @@ void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code
       status = HTTPD_409;
       break;
     default:
-      status = to_string(code).c_str();
       break;
   }
-  httpd_resp_set_status(*this, status);
+  httpd_resp_set_status(*this, status == nullptr ? to_string(code).c_str() : status);
 
   if (content_type && *content_type) {
     httpd_resp_set_type(*this, content_type);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -293,8 +293,8 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const std::string &name) {
     }
   }
 
-  // Don't cache misses to prevent memory exhaustion from malicious requests
-  // with thousands of non-existent parameter lookups
+  // Don't cache misses to avoid wasting memory when handlers check for
+  // optional parameters that don't exist in the request
   if (!val.has_value()) {
     return nullptr;
   }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -164,8 +164,8 @@ esp_err_t AsyncWebServer::request_handler_(AsyncWebServerRequest *request) const
 
 AsyncWebServerRequest::~AsyncWebServerRequest() {
   delete this->rsp_;
-  for (const auto &pair : this->params_) {
-    delete pair.second;  // NOLINT(cppcoreguidelines-owning-memory)
+  for (auto *param : this->params_) {
+    delete param;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }
 
@@ -205,10 +205,23 @@ void AsyncWebServerRequest::redirect(const std::string &url) {
 }
 
 void AsyncWebServerRequest::init_response_(AsyncWebServerResponse *rsp, int code, const char *content_type) {
-  httpd_resp_set_status(*this, code == 200   ? HTTPD_200
-                               : code == 404 ? HTTPD_404
-                               : code == 409 ? HTTPD_409
-                                             : to_string(code).c_str());
+  // Set status code - use constants for common codes to avoid string allocation
+  const char *status;
+  switch (code) {
+    case 200:
+      status = HTTPD_200;
+      break;
+    case 404:
+      status = HTTPD_404;
+      break;
+    case 409:
+      status = HTTPD_409;
+      break;
+    default:
+      status = to_string(code).c_str();
+      break;
+  }
+  httpd_resp_set_status(*this, status);
 
   if (content_type && *content_type) {
     httpd_resp_set_type(*this, content_type);
@@ -265,11 +278,14 @@ void AsyncWebServerRequest::requestAuthentication(const char *realm) const {
 #endif
 
 AsyncWebParameter *AsyncWebServerRequest::getParam(const std::string &name) {
-  auto find = this->params_.find(name);
-  if (find != this->params_.end()) {
-    return find->second;
+  // Check cache first - only successful lookups are cached
+  for (auto *param : this->params_) {
+    if (param->name() == name) {
+      return param;
+    }
   }
 
+  // Look up value from query strings
   optional<std::string> val = query_key_value(this->post_query_, name);
   if (!val.has_value()) {
     auto url_query = request_get_url_query(*this);
@@ -278,11 +294,14 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const std::string &name) {
     }
   }
 
-  AsyncWebParameter *param = nullptr;
-  if (val.has_value()) {
-    param = new AsyncWebParameter(val.value());  // NOLINT(cppcoreguidelines-owning-memory)
+  // Don't cache misses to prevent memory exhaustion from malicious requests
+  // with thousands of non-existent parameter lookups
+  if (!val.has_value()) {
+    return nullptr;
   }
-  this->params_.insert({name, param});
+
+  auto *param = new AsyncWebParameter(name, val.value());  // NOLINT(cppcoreguidelines-owning-memory)
+  this->params_.push_back(param);
   return param;
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -178,7 +178,8 @@ class AsyncWebServerRequest {
   AsyncWebServerResponse *rsp_{};
   // Use vector instead of map/unordered_map: most requests have 0-3 params, so linear search
   // is faster than tree/hash overhead. AsyncWebParameter stores both name and value to avoid
-  // duplicate storage. Only successful lookups are cached to prevent memory exhaustion attacks.
+  // duplicate storage. Only successful lookups are cached to prevent cache pollution when
+  // handlers check for optional parameters that don't exist.
   std::vector<AsyncWebParameter *> params_;
   std::string post_query_;
   AsyncWebServerRequest(httpd_req_t *req) : req_(req) {}

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -30,10 +30,12 @@ using String = std::string;
 
 class AsyncWebParameter {
  public:
-  AsyncWebParameter(std::string value) : value_(std::move(value)) {}
+  AsyncWebParameter(std::string name, std::string value) : name_(std::move(name)), value_(std::move(value)) {}
+  const std::string &name() const { return this->name_; }
   const std::string &value() const { return this->value_; }
 
  protected:
+  std::string name_;
   std::string value_;
 };
 
@@ -174,7 +176,10 @@ class AsyncWebServerRequest {
  protected:
   httpd_req_t *req_;
   AsyncWebServerResponse *rsp_{};
-  std::map<std::string, AsyncWebParameter *> params_;
+  // Use vector instead of map/unordered_map: most requests have 0-3 params, so linear search
+  // is faster than tree/hash overhead. AsyncWebParameter stores both name and value to avoid
+  // duplicate storage. Only successful lookups are cached to prevent memory exhaustion attacks.
+  std::vector<AsyncWebParameter *> params_;
   std::string post_query_;
   AsyncWebServerRequest(httpd_req_t *req) : req_(req) {}
   AsyncWebServerRequest(httpd_req_t *req, std::string post_query) : req_(req), post_query_(std::move(post_query)) {}


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the web_server_idf component to reduce flash usage and improve memory efficiency by refactoring parameter storage and status code handling.

**Changes:**

1. **Refactor AsyncWebParameter storage** - Changed from `std::map<std::string, AsyncWebParameter*>` to `std::vector<AsyncWebParameter*>` with name stored in the parameter object itself
2. **Optimize status code handling** - Replaced nested ternary operators with switch statement in `init_response_`
3. **Improve cache efficiency** - Only cache successful parameter lookups to avoid wasting memory on non-existent parameters

**Benefits:**
- **148 bytes flash savings** on ESP32 (500370 → 500222 bytes)
- **Better performance** - Linear search through vector is faster than map/tree overhead for typical requests with 0-3 parameters
- **Less memory overhead** - Eliminates duplicate name storage and map node overhead (~32 bytes per entry)
- **Better cache locality** - Vector provides contiguous memory vs scattered tree nodes
- **Efficient caching** - Prevents cache pollution when handlers check for optional parameters that don't exist

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal implementation change only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
