### PR TITLE
[json] Fix missing defines.h include causing PSRAM allocator to be unused

### DIFF
--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 
 #define ARDUINOJSON_ENABLE_STD_STRING 1  // NOLINT


### PR DESCRIPTION
# What does this implement/fix?

Fixes JSON document overflow errors when using PSRAM by adding missing `defines.h` include.

PR #10749 moved `SpiRamAllocator` from `json_util.cpp` to `json_util.h` but forgot to include `esphome/core/defines.h`. This caused the `#ifdef USE_PSRAM` check to always be false, meaning devices with PSRAM configured were incorrectly using the default allocator instead of `SpiRamAllocator`, resulting in JSON document overflow errors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10999

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal bug fix, no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes existing PSRAM configurations

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

psram:
  mode: octal
  speed: 80MHz

web_server:
  version: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Suggested PR Title:

`[json] Fix missing defines.h include causing PSRAM allocator to be unused`
