### PR TITLE
[esphome.ota] Fix ESP32-S3 OTA authentication with hardware SHA acceleration

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -47,8 +47,6 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   bool handle_auth_send_();
   bool handle_auth_read_();
   bool select_auth_type_();
-  bool prepare_auth_nonce_(HashBase *hasher);
-  bool verify_hash_auth_(HashBase *hasher, size_t hex_size);
   size_t get_auth_hex_size_() const;
   void cleanup_auth_();
   void log_auth_warning_(const LogString *msg);

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -42,8 +42,6 @@ namespace esphome::sha256 {
 //   void helper(HashBase *h) {
 //     h->init();  // WRONG: Will produce truncated/corrupted output
 //   }
-//
-// See s3_hardware_sha.md for complete details on symptoms and debugging.
 
 SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
 

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -10,6 +10,41 @@ namespace esphome::sha256 {
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
 
+// CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION REQUIREMENTS:
+//
+// The ESP32-S3 uses hardware DMA for SHA acceleration. The mbedtls_sha256_context structure contains
+// internal state that the DMA engine references. This imposes two critical constraints:
+//
+// 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
+//    write to incorrect memory locations. This results in null pointer dereferences and crashes.
+//    ALWAYS use fixed-size arrays (e.g., char buf[65], not char buf[size+1]).
+//
+// 2. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
+//    function. NEVER pass the SHA256 object or HashBase pointer to another function. When the stack
+//    frame changes (function call/return), the DMA references become invalid and will produce
+//    truncated hash output (20 bytes instead of 32) or corrupt memory.
+//
+// CORRECT USAGE:
+//   void my_function() {
+//     sha256::SHA256 hasher;  // Created locally
+//     hasher.init();
+//     hasher.add(data, len);  // Any size, no chunking needed
+//     hasher.calculate();
+//     bool ok = hasher.equals_hex(expected);
+//     // hasher destroyed when function returns
+//   }
+//
+// INCORRECT USAGE (WILL FAIL ON ESP32-S3):
+//   void my_function() {
+//     sha256::SHA256 hasher;
+//     helper(&hasher);  // WRONG: Passed to different stack frame
+//   }
+//   void helper(HashBase *h) {
+//     h->init();  // WRONG: Will produce truncated/corrupted output
+//   }
+//
+// See s3_hardware_sha.md for complete details on symptoms and debugging.
+
 SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
 
 void SHA256::init() {

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -39,6 +39,10 @@ class SHA256 : public esphome::HashBase {
 
  protected:
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  // CRITICAL: The mbedtls context MUST be stack-allocated (not a pointer) for ESP32-S3 hardware SHA acceleration.
+  // The ESP32-S3 DMA engine references this structure's memory addresses. If the context is passed to another
+  // function (crossing stack frames) or if VLAs are present, the DMA operations will corrupt memory and produce
+  // truncated/incorrect hash results. See s3_hardware_sha.md for details.
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -42,7 +42,7 @@ class SHA256 : public esphome::HashBase {
   // CRITICAL: The mbedtls context MUST be stack-allocated (not a pointer) for ESP32-S3 hardware SHA acceleration.
   // The ESP32-S3 DMA engine references this structure's memory addresses. If the context is passed to another
   // function (crossing stack frames) or if VLAs are present, the DMA operations will corrupt memory and produce
-  // truncated/incorrect hash results. See s3_hardware_sha.md for details.
+  // truncated/incorrect hash results.
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -39,7 +39,7 @@ class HashBase {
 
   /// Compare the hash against a provided hex-encoded hash
   bool equals_hex(const char *expected) {
-    uint8_t parsed[this->get_size()];
+    uint8_t parsed[32];  // Fixed size for max hash (SHA256 = 32 bytes)
     if (!parse_hex(expected, parsed, this->get_size())) {
       return false;
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes ESP32-S3 OTA authentication failures when using hardware SHA-256 acceleration and consolidates duplicate authentication code.

## Problem

ESP32-S3 OTA authentication was failing with "Password mismatch" errors despite correct passwords. Investigation revealed two critical issues with ESP32-S3 hardware SHA acceleration via DMA:

1. **Variable Length Arrays (VLAs) corrupted the stack**: VLAs caused the DMA engine to write to incorrect memory locations, resulting in null pointer dereferences and crashes.

2. **Hash contexts crossing stack frames broke DMA**: Passing hash objects to helper functions caused the ESP32-S3 DMA engine to produce truncated hash output (20 bytes instead of 32) or corrupt memory.

## Solution

1. **Eliminated all VLAs**: Replaced with fixed-size arrays (`char log_buf[65]` for SHA256, `char log_buf[33]` for MD5).

2. **Inlined all hash operations**: Hash objects are now created and used entirely within the same function. No hash contexts are passed across function boundaries.

3. **Consolidated duplicate code**: Used `HashBase*` pointer to eliminate ~60 lines of duplicate code between SHA256 and MD5 paths while maintaining the critical "same stack frame" requirement. This refactoring reduces flash usage by 36 bytes.

4. **Added comprehensive inline comments**: Documented the ESP32-S3 DMA constraints directly in code to prevent future regressions.

## Memory Impact

The refactoring reduces flash usage while maintaining identical RAM usage:

- **RAM**: 17468 bytes (no change)
- **Flash**: 515038 → 515002 bytes (-36 bytes saved)

The code consolidation eliminates duplicate code paths, resulting in net flash savings despite the virtual function call overhead.

## Changes

### Files Modified

- `esphome/core/hash_base.h` - Fixed VLA in `equals_hex()`
- `esphome/components/sha256/sha256.h` - Added critical constraint comments
- `esphome/components/sha256/sha256.cpp` - Added detailed ESP32-S3 DMA requirements documentation
- `esphome/components/esphome/ota/ota_esphome.cpp` - Inlined hash operations, consolidated code
- `esphome/components/esphome/ota/ota_esphome.h` - Removed helper function declarations

### Key Implementation Details

Both `sha256::SHA256` and `md5::MD5Digest` objects are declared at function scope, with a `HashBase*` pointer selecting between them. This approach:
- Keeps both objects in the same stack frame (required for ESP32-S3 DMA)
- Eliminates duplicate code through polymorphism
- Uses virtual function calls safely (same stack frame, object doesn't move)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- fixes ESP32-S3 OTA authentication with hardware SHA acceleration

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32 (Classic - tested, working)
- [x] ESP32 IDF (S3, C3, C6 - tested, working)
- [x] ESP8266 (tested, working)
- [ ] RP2040 (not tested, uses same BearSSL as ESP8266)
- [x] BK72xx (LibreTiny - tested, working)
- [ ] RTL87xx (not tested, uses mbedtls)
- [ ] nRF52840 (not tested)

### Specific platforms tested:
- ESP32-S3 (primary fix target)
- ESP32 Classic
- ESP32-C3
- ESP32-C6
- ESP8266
- LibreTiny/Beken BK72xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Existing OTA configurations work unchanged

ota:
  - platform: esphome
    password: "my_secure_password"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

The ESP32-S3 hardware SHA DMA constraints are not documented by Espressif. These requirements were discovered through debugging:
- VLAs corrupt stack layout with DMA operations
- Hash contexts cannot cross function boundaries
- Violations cause truncated output or memory corruption

All critical constraints are now documented in inline code comments to prevent future regressions.
