### PR TITLE
[mpr121] cleaner setup

### DIFF
--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -11,6 +11,7 @@ namespace mpr121 {
 static const char *const TAG = "mpr121";
 
 void MPR121Component::setup() {
+  this->disable_loop();
   // soft reset device
   this->write_byte(MPR121_SOFTRESET, 0x63);
   this->set_timeout(100, [this]() {
@@ -51,7 +52,7 @@ void MPR121Component::setup() {
     this->write_byte(MPR121_ECR, 0x80 | (this->max_touch_channel_ + 1));
 
     this->flush_gpio_();
-    this->setup_complete_ = true;
+    this->enable_loop();
   });
 }
 
@@ -80,9 +81,6 @@ void MPR121Component::dump_config() {
   }
 }
 void MPR121Component::loop() {
-  if (!this->setup_complete_)
-    return;
-
   uint16_t val = 0;
   this->read_byte_16(MPR121_TOUCHSTATUS_L, &val);
 

--- a/esphome/components/mpr121/mpr121.h
+++ b/esphome/components/mpr121/mpr121.h
@@ -80,7 +80,6 @@ class MPR121Component : public Component, public i2c::I2CDevice {
   void pin_mode(uint8_t ionum, gpio::Flags flags);
 
  protected:
-  bool setup_complete_{false};
   std::vector<MPR121Channel *> channels_{};
   uint8_t debounce_{0};
   uint8_t touch_threshold_{};


### PR DESCRIPTION
# What does this implement/fix?
improve pr[#10963](https://github.com/esphome/esphome/pull/10963) by using disable_loop() and enable_loop() in setup to prevent loop running before setup completes instead of set_complete flag

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
https://github.com/esphome/esphome/pull/10963

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
