### PR TITLE
[api] Consolidate fatal error logging to reduce flash usage

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -146,7 +146,7 @@ void APIConnection::loop() {
 
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
-    this->fatal_error_with_socket_log_(err);
+    this->fatal_error_with_log_(LOG_STR("Socket operation failed"), err);
     return;
   }
 
@@ -1577,7 +1577,7 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   delay(0);
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
-    this->fatal_error_with_socket_log_(err);
+    this->fatal_error_with_log_(LOG_STR("Socket operation failed"), err);
     return false;
   }
   if (this->helper_->can_write_without_blocking())

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -116,8 +116,7 @@ void APIConnection::start() {
 
   APIError err = this->helper_->init();
   if (err != APIError::OK) {
-    on_fatal_error();
-    this->log_warning_(LOG_STR("Helper init failed"), err);
+    this->fatal_error_with_log_(LOG_STR("Helper init failed"), err);
     return;
   }
   this->client_info_.peername = helper_->getpeername();
@@ -147,8 +146,7 @@ void APIConnection::loop() {
 
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
-    on_fatal_error();
-    this->log_socket_operation_failed_(err);
+    this->fatal_error_with_socket_log_(err);
     return;
   }
 
@@ -163,8 +161,7 @@ void APIConnection::loop() {
         // No more data available
         break;
       } else if (err != APIError::OK) {
-        on_fatal_error();
-        this->log_warning_(LOG_STR("Reading failed"), err);
+        this->fatal_error_with_log_(LOG_STR("Reading failed"), err);
         return;
       } else {
         this->last_traffic_ = now;
@@ -1580,8 +1577,7 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   delay(0);
   APIError err = this->helper_->loop();
   if (err != APIError::OK) {
-    on_fatal_error();
-    this->log_socket_operation_failed_(err);
+    this->fatal_error_with_socket_log_(err);
     return false;
   }
   if (this->helper_->can_write_without_blocking())
@@ -1600,8 +1596,7 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   if (err == APIError::WOULD_BLOCK)
     return false;
   if (err != APIError::OK) {
-    on_fatal_error();
-    this->log_warning_(LOG_STR("Packet write failed"), err);
+    this->fatal_error_with_log_(LOG_STR("Packet write failed"), err);
     return false;
   }
   // Do not set last_traffic_ on send
@@ -1787,8 +1782,7 @@ void APIConnection::process_batch_() {
   APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&shared_buf},
                                                        std::span<const PacketInfo>(packet_info, packet_count));
   if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
-    on_fatal_error();
-    this->log_warning_(LOG_STR("Batch write failed"), err);
+    this->fatal_error_with_log_(LOG_STR("Batch write failed"), err);
   }
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1869,10 +1863,6 @@ void APIConnection::process_state_subscriptions_() {
 void APIConnection::log_warning_(const LogString *message, APIError err) {
   ESP_LOGW(TAG, "%s (%s): %s %s errno=%d", this->client_info_.name.c_str(), this->client_info_.peername.c_str(),
            LOG_STR_ARG(message), LOG_STR_ARG(api_error_to_logstr(err)), errno);
-}
-
-void APIConnection::log_socket_operation_failed_(APIError err) {
-  this->log_warning_(LOG_STR("Socket operation failed"), err);
 }
 
 }  // namespace esphome::api

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -737,9 +737,6 @@ class APIConnection final : public APIServerConnection {
     this->on_fatal_error();
     this->log_warning_(message, err);
   }
-  inline void fatal_error_with_socket_log_(APIError err) {
-    this->fatal_error_with_log_(LOG_STR("Socket operation failed"), err);
-  }
 };
 
 }  // namespace esphome::api

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -732,8 +732,14 @@ class APIConnection final : public APIServerConnection {
 
   // Helper function to log API errors with errno
   void log_warning_(const LogString *message, APIError err);
-  // Specific helper for duplicated error message
-  void log_socket_operation_failed_(APIError err);
+  // Helper to handle fatal errors with logging
+  inline void fatal_error_with_log_(const LogString *message, APIError err) {
+    this->on_fatal_error();
+    this->log_warning_(message, err);
+  }
+  inline void fatal_error_with_socket_log_(APIError err) {
+    this->fatal_error_with_log_(LOG_STR("Socket operation failed"), err);
+  }
 };
 
 }  // namespace esphome::api


### PR DESCRIPTION
TLDR: I was hoping for more but still a nice cleanup

# What does this implement/fix?

Consolidates repeated error handling patterns in the API connection code to reduce flash usage.

## Changes

Created two inline helper functions to replace a repeated pattern of calling `on_fatal_error()` followed by logging:

1. **`fatal_error_with_log_(message, err)`** - Calls `on_fatal_error()` and logs a custom message
2. **`fatal_error_with_socket_log_(err)`** - Calls `fatal_error_with_log_()` with "Socket operation failed" message

These helpers replace 5 instances of the duplicated pattern:
```cpp
on_fatal_error();
this->log_warning_(LOG_STR("..."), err);
```

Additionally removed the now-unused `log_socket_operation_failed_()` function since it's only called from one place (the new helper).

## Impact

- **Flash savings**: 24 bytes (499074 → 499050 bytes on ESP32)
- **Code clarity**: More consistent error handling pattern
- **Maintainability**: Easier to modify error handling behavior in the future

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

No configuration changes required - this is an internal refactoring.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
