### PR TITLE
[api] Simplify message reading conditional

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -169,11 +169,8 @@ void APIConnection::loop() {
       } else {
         this->last_traffic_ = now;
         // read a packet
-        if (buffer.data_len > 0) {
-          this->read_message(buffer.data_len, buffer.type, &buffer.container[buffer.data_offset]);
-        } else {
-          this->read_message(0, buffer.type, nullptr);
-        }
+        this->read_message(buffer.data_len, buffer.type,
+                           buffer.data_len > 0 ? &buffer.container[buffer.data_offset] : nullptr);
         if (this->flags_.remove)
           return;
       }


### PR DESCRIPTION
# What does this implement/fix?

Simplifies conditional logic in API connection message reading using a ternary operator.

## Changes

Replaced a 5-line if-else block with a single-line ternary expression when calling `read_message()`:

**Before:**
```cpp
if (buffer.data_len > 0) {
  this->read_message(buffer.data_len, buffer.type, &buffer.container[buffer.data_offset]);
} else {
  this->read_message(0, buffer.type, nullptr);
}
```

**After:**
```cpp
this->read_message(buffer.data_len, buffer.type,
                  buffer.data_len > 0 ? &buffer.container[buffer.data_offset] : nullptr);
```

## Impact

- **Flash savings**: 0 bytes (compiler was already optimizing this)
- **Code clarity**: More concise and easier to read
- **Lines of code**: Reduced from 5 lines to 2 lines

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

No configuration changes required - this is an internal refactoring.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
