### PR TITLE
[core] Merge duplicate loops in mac_address_is_valid()

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -613,8 +613,6 @@ bool mac_address_is_valid(const uint8_t *mac) {
     if (mac[i] != 0) {
       is_all_zeros = false;
     }
-  }
-  for (uint8_t i = 0; i < 6; i++) {
     if (mac[i] != 0xFF) {
       is_all_ones = false;
     }


### PR DESCRIPTION
# What does this implement/fix?

Reduces flash usage by merging two separate loops into one in the `mac_address_is_valid()` function.

## Changes

The `mac_address_is_valid()` function previously used two separate loops to check if a MAC address was all zeros or all ones. This PR merges them into a single loop that performs both checks simultaneously.

**Before:**
```cpp
bool mac_address_is_valid(const uint8_t *mac) {
  bool is_all_zeros = true;
  bool is_all_ones = true;

  for (uint8_t i = 0; i < 6; i++) {
    if (mac[i] != 0) {
      is_all_zeros = false;
    }
  }
  for (uint8_t i = 0; i < 6; i++) {
    if (mac[i] != 0xFF) {
      is_all_ones = false;
    }
  }
  return !(is_all_zeros || is_all_ones);
}
```

**After:**
```cpp
bool mac_address_is_valid(const uint8_t *mac) {
  bool is_all_zeros = true;
  bool is_all_ones = true;

  for (uint8_t i = 0; i < 6; i++) {
    if (mac[i] != 0) {
      is_all_zeros = false;
    }
    if (mac[i] != 0xFF) {
      is_all_ones = false;
    }
  }
  return !(is_all_zeros || is_all_ones);
}
```

## Impact

- **Flash savings**: 20 bytes on ESP32
- **Performance**: Slightly faster (one loop instead of two)
- **Code clarity**: More concise and easier to understand
- **No functional changes**: Behavior is identical

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

No configuration changes required - this is an internal refactoring.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
