### PR TITLE
[esp32_rmt_led_strip] Fix clang-tidy signed/unsigned comparison warning

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -35,7 +35,7 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
     if (symbols_free < RMT_SYMBOLS_PER_BYTE) {
       return 0;
     }
-    for (int32_t i = 0; i < RMT_SYMBOLS_PER_BYTE; i++) {
+    for (size_t i = 0; i < RMT_SYMBOLS_PER_BYTE; i++) {
       if (bytes[index] & (1 << (7 - i))) {
         symbols[i] = params->bit1;
       } else {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a clang-tidy error discovered in PR #11030 CI where a signed/unsigned comparison warning occurs in the `esp32_rmt_led_strip` component.

**Error from CI:**
```
Error: /home/runner/work/esphome/esphome/esphome/components/esp32_rmt_led_strip/led_strip.cpp:38:27: error: comparison of integers of different signs: 'int32_t' (aka 'int') and 'const size_t' (aka 'const unsigned int') [clang-diagnostic-sign-compare,-warnings-as-errors]
   38 |     for (int32_t i = 0; i < RMT_SYMBOLS_PER_BYTE; i++) {
      |                         ~ ^ ~~~~~~~~~~~~~~~~~~~~
```

**Fix:**
Changed the loop variable type from `int32_t` to `size_t` to match the type of `RMT_SYMBOLS_PER_BYTE` constant, eliminating the signed/unsigned comparison.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes clang-tidy failure in https://github.com/esphome/esphome/pull/11030

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - build fix only, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - build fix only
# All existing esp32_rmt_led_strip configurations work exactly as before
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
