### PR TITLE
[sonoff_d1] Fix clang-tidy signed/unsigned comparison warning

### DIFF
--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -50,7 +50,7 @@ static const char *const TAG = "sonoff_d1";
 
 uint8_t SonoffD1Output::calc_checksum_(const uint8_t *cmd, const size_t len) {
   uint8_t crc = 0;
-  for (int i = 2; i < len - 1; i++) {
+  for (size_t i = 2; i < len - 1; i++) {
     crc += cmd[i];
   }
   return crc;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a clang-tidy error discovered in PR #11030 CI where a signed/unsigned comparison warning occurs in the `sonoff_d1` component.

**Error from CI:**
```
Error: /home/runner/work/esphome/esphome/esphome/components/sonoff_d1/sonoff_d1.cpp:53:21: error: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned int') [clang-diagnostic-sign-compare,-warnings-as-errors]
   53 |   for (int i = 2; i < len - 1; i++) {
      |                   ~ ^ ~~~~~~~
```

**Fix:**
Changed the loop variable type from `int` to `size_t` in `calc_checksum_()` to match the type of the `len` parameter, eliminating the signed/unsigned comparison.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes clang-tidy failure discovered in https://github.com/esphome/esphome/pull/11030

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - build fix only, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - build fix only
# All existing sonoff_d1 configurations work exactly as before
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
