### PR TITLE
[tuya] Fix clang-tidy signed/unsigned comparison warning

### DIFF
--- a/esphome/components/tuya/select/tuya_select.cpp
+++ b/esphome/components/tuya/select/tuya_select.cpp
@@ -50,7 +50,7 @@ void TuyaSelect::dump_config() {
                 "  Options are:",
                 this->select_id_, this->is_int_ ? "int" : "enum");
   auto options = this->traits.get_options();
-  for (auto i = 0; i < this->mappings_.size(); i++) {
+  for (size_t i = 0; i < this->mappings_.size(); i++) {
     ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i).c_str());
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a clang-tidy error discovered in PR #11030 CI where a signed/unsigned comparison warning occurs in the `tuya` component's select platform.

**Error from CI:**
```
Error: /home/runner/work/esphome/esphome/esphome/components/tuya/select/tuya_select.cpp:53:22: error: comparison of integers of different signs: 'int' and 'size_type' (aka 'unsigned int') [clang-diagnostic-sign-compare,-warnings-as-errors]
   53 |   for (auto i = 0; i < this->mappings_.size(); i++) {
      |                    ~ ^ ~~~~~~~~~~~~~~~~~~~~~~
```

**Fix:**
Changed the loop variable type from `auto` (which deduced to `int`) to `size_t` in `dump_config()` to match the type returned by `this->mappings_.size()`, eliminating the signed/unsigned comparison.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes clang-tidy failure discovered in https://github.com/esphome/esphome/pull/11030

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - build fix only, no user-facing changes

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - build fix only
# All existing tuya select configurations work exactly as before
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
