### PR TITLE
[zwave_proxy] Send HomeID upon client connect

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1389,6 +1389,11 @@ void APIConnection::complete_authentication_() {
     this->send_time_request();
   }
 #endif
+#ifdef USE_ZWAVE_PROXY
+  if (zwave_proxy::global_zwave_proxy != nullptr) {
+    zwave_proxy::global_zwave_proxy->api_connection_authenticated(this);
+  }
+#endif
 }
 
 bool APIConnection::send_hello_response(const HelloRequest &msg) {

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -127,6 +127,11 @@ void ZWaveProxy::dump_config() {
                 format_hex_pretty(this->home_id_.data(), this->home_id_.size(), ':', false).c_str());
 }
 
+void ZWaveProxy::api_connection_authenticated(api::APIConnection *conn) {
+  // If a client just authenticated, send the current home ID
+  this->send_homeid_changed_msg_(conn);
+}
+
 void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::enums::ZWaveProxyRequestType type) {
   switch (type) {
     case api::enums::ZWAVE_PROXY_REQUEST_TYPE_SUBSCRIBE:
@@ -136,7 +141,6 @@ void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::en
       }
       this->api_connection_ = api_connection;
       ESP_LOGV(TAG, "API connection is now subscribed");
-      this->send_homeid_changed_msg_();  // Send current home ID to new subscription
       break;
     case api::enums::ZWAVE_PROXY_REQUEST_TYPE_UNSUBSCRIBE:
       if (this->api_connection_ != api_connection) {
@@ -171,12 +175,15 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
   this->write_array(data, length);
 }
 
-void ZWaveProxy::send_homeid_changed_msg_() {
+void ZWaveProxy::send_homeid_changed_msg_(api::APIConnection *conn) {
   api::ZWaveProxyRequest msg;
   msg.type = api::enums::ZWAVE_PROXY_REQUEST_TYPE_HOME_ID_CHANGE;
   msg.data = this->home_id_.data();
   msg.data_len = this->home_id_.size();
-  if (api::global_api_server != nullptr) {
+  if (conn != nullptr) {
+    // Send to specific connection
+    conn->send_message(msg, api::ZWaveProxyRequest::MESSAGE_TYPE);
+  } else if (api::global_api_server != nullptr) {
     // We could add code to manage a second subscription type, but, since this message is
     //  very infrequent and small, we simply send it to all clients
     api::global_api_server->on_zwave_proxy_request(msg);

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -101,15 +101,7 @@ void ZWaveProxy::process_uart_() {
         // Store the 4-byte Home ID, which starts at offset 4, and notify connected clients if it changed
         // The frame parser has already validated the checksum and ensured all bytes are present
         if (this->set_home_id(&this->buffer_[4])) {
-          api::ZWaveProxyRequest msg;
-          msg.type = api::enums::ZWAVE_PROXY_REQUEST_TYPE_HOME_ID_CHANGE;
-          msg.data = this->home_id_.data();
-          msg.data_len = this->home_id_.size();
-          if (api::global_api_server != nullptr) {
-            // We could add code to manage a second subscription type, but, since this message is
-            //  very infrequent and small, we simply send it to all clients
-            api::global_api_server->on_zwave_proxy_request(msg);
-          }
+          this->send_homeid_changed_msg_();
         }
       }
       ESP_LOGV(TAG, "Sending to client: %s", YESNO(this->api_connection_ != nullptr));
@@ -144,6 +136,7 @@ void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::en
       }
       this->api_connection_ = api_connection;
       ESP_LOGV(TAG, "API connection is now subscribed");
+      this->send_homeid_changed_msg_();  // Send current home ID to new subscription
       break;
     case api::enums::ZWAVE_PROXY_REQUEST_TYPE_UNSUBSCRIBE:
       if (this->api_connection_ != api_connection) {
@@ -176,6 +169,18 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
   }
   ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty(data, length).c_str());
   this->write_array(data, length);
+}
+
+void ZWaveProxy::send_homeid_changed_msg_() {
+  api::ZWaveProxyRequest msg;
+  msg.type = api::enums::ZWAVE_PROXY_REQUEST_TYPE_HOME_ID_CHANGE;
+  msg.data = this->home_id_.data();
+  msg.data_len = this->home_id_.size();
+  if (api::global_api_server != nullptr) {
+    // We could add code to manage a second subscription type, but, since this message is
+    //  very infrequent and small, we simply send it to all clients
+    api::global_api_server->on_zwave_proxy_request(msg);
+  }
 }
 
 void ZWaveProxy::send_simple_command_(const uint8_t command_id) {

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -128,8 +128,10 @@ void ZWaveProxy::dump_config() {
 }
 
 void ZWaveProxy::api_connection_authenticated(api::APIConnection *conn) {
-  // If a client just authenticated, send the current home ID
-  this->send_homeid_changed_msg_(conn);
+  if (this->home_id_ready_) {
+    // If a client just authenticated & HomeID is ready, send the current HomeID
+    this->send_homeid_changed_msg_(conn);
+  }
 }
 
 void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::enums::ZWaveProxyRequestType type) {

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -61,6 +61,7 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   void send_frame(const uint8_t *data, size_t length);
 
  protected:
+  void send_homeid_changed_msg_();
   void send_simple_command_(uint8_t command_id);
   bool parse_byte_(uint8_t byte);  // Returns true if frame parsing was completed (a frame is ready in the buffer)
   void parse_start_(uint8_t byte);

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -49,6 +49,7 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   float get_setup_priority() const override;
   bool can_proceed() override;
 
+  void api_connection_authenticated(api::APIConnection *conn);
   void zwave_proxy_request(api::APIConnection *api_connection, api::enums::ZWaveProxyRequestType type);
   api::APIConnection *get_api_connection() { return this->api_connection_; }
 
@@ -61,7 +62,7 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   void send_frame(const uint8_t *data, size_t length);
 
  protected:
-  void send_homeid_changed_msg_();
+  void send_homeid_changed_msg_(api::APIConnection *conn = nullptr);
   void send_simple_command_(uint8_t command_id);
   bool parse_byte_(uint8_t byte);  // Returns true if frame parsing was completed (a frame is ready in the buffer)
   void parse_start_(uint8_t byte);


### PR DESCRIPTION
# What does this implement/fix?

Quick change to send HomeID to newly connected clients.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
