### PR TITLE
[online_image] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/online_image/bmp_image.cpp
+++ b/esphome/components/online_image/bmp_image.cpp
@@ -117,7 +117,8 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
         this->paint_index_++;
         this->current_index_ += 3;
         index += 3;
-        if (x == static_cast<size_t>(this->width_ - 1) && this->padding_bytes_ > 0) {
+        size_t last_col = static_cast<size_t>(this->width_) - 1;
+        if (x == last_col && this->padding_bytes_ > 0) {
           index += this->padding_bytes_;
           this->current_index_ += this->padding_bytes_;
         }

--- a/esphome/components/online_image/bmp_image.cpp
+++ b/esphome/components/online_image/bmp_image.cpp
@@ -117,7 +117,7 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
         this->paint_index_++;
         this->current_index_ += 3;
         index += 3;
-        if (x == this->width_ - 1 && this->padding_bytes_ > 0) {
+        if (x == static_cast<size_t>(this->width_ - 1) && this->padding_bytes_ > 0) {
           index += this->padding_bytes_;
           this->current_index_ += this->padding_bytes_;
         }

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -25,8 +25,10 @@ static int draw_callback(JPEGDRAW *jpeg) {
   // to avoid crashing.
   App.feed_wdt();
   size_t position = 0;
-  for (size_t y = 0; y < static_cast<size_t>(jpeg->iHeight); y++) {
-    for (size_t x = 0; x < static_cast<size_t>(jpeg->iWidth); x++) {
+  size_t height = static_cast<size_t>(jpeg->iHeight);
+  size_t width = static_cast<size_t>(jpeg->iWidth);
+  for (size_t y = 0; y < height; y++) {
+    for (size_t x = 0; x < width; x++) {
       auto rg = decode_value(jpeg->pPixels[position++]);
       auto ba = decode_value(jpeg->pPixels[position++]);
       Color color(rg[1], rg[0], ba[1], ba[0]);

--- a/esphome/components/online_image/jpeg_image.cpp
+++ b/esphome/components/online_image/jpeg_image.cpp
@@ -25,8 +25,8 @@ static int draw_callback(JPEGDRAW *jpeg) {
   // to avoid crashing.
   App.feed_wdt();
   size_t position = 0;
-  for (size_t y = 0; y < jpeg->iHeight; y++) {
-    for (size_t x = 0; x < jpeg->iWidth; x++) {
+  for (size_t y = 0; y < static_cast<size_t>(jpeg->iHeight); y++) {
+    for (size_t x = 0; x < static_cast<size_t>(jpeg->iWidth); x++) {
       auto rg = decode_value(jpeg->pPixels[position++]);
       auto ba = decode_value(jpeg->pPixels[position++]);
       Color color(rg[1], rg[0], ba[1], ba[0]);


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `online_image` component caused by sign comparison warnings when comparing signed and unsigned integer types.

**Changes:**
- `bmp_image.cpp`: Cast `width_ - 1` to `size_t` when comparing with loop variable `x`
- `jpeg_image.cpp`: Cast JPEG dimensions (`iHeight`, `iWidth`) to `size_t` when comparing with loop variables

The casts are safe since image dimensions are always non-negative values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
