### PR TITLE
[animation] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -26,12 +26,12 @@ uint32_t Animation::get_animation_frame_count() const { return this->animation_f
 int Animation::get_current_frame() const { return this->current_frame_; }
 void Animation::next_frame() {
   this->current_frame_++;
-  if (loop_count_ && this->current_frame_ == loop_end_frame_ &&
+  if (loop_count_ && static_cast<uint32_t>(this->current_frame_) == loop_end_frame_ &&
       (this->loop_current_iteration_ < loop_count_ || loop_count_ < 0)) {
     this->current_frame_ = loop_start_frame_;
     this->loop_current_iteration_++;
   }
-  if (this->current_frame_ >= animation_frame_count_) {
+  if (static_cast<uint32_t>(this->current_frame_) >= animation_frame_count_) {
     this->loop_current_iteration_ = 1;
     this->current_frame_ = 0;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `animation` component caused by sign comparison warnings when comparing signed `int` with unsigned `uint32_t` types.

**Changes:**
- `animation.cpp`: Cast `current_frame_` (int) to `uint32_t` when comparing with `loop_end_frame_` and `animation_frame_count_`

The casts are safe since `current_frame_` has just been incremented and is non-negative in both comparison contexts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
