### PR TITLE
[bl0906, bl0942] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -100,7 +100,7 @@ void BL0906::handle_actions_() {
   for (size_t i = 0; i < this->action_queue_.size(); i++) {
     ptr_func = this->action_queue_[i];
     if (ptr_func) {
-      ESP_LOGI(TAG, "HandleActionCallback[%d]", i);
+      ESP_LOGI(TAG, "HandleActionCallback[%zu]", i);
       (this->*ptr_func)();
     }
   }

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -97,7 +97,7 @@ void BL0906::handle_actions_() {
     return;
   }
   ActionCallbackFuncPtr ptr_func = nullptr;
-  for (int i = 0; i < this->action_queue_.size(); i++) {
+  for (size_t i = 0; i < this->action_queue_.size(); i++) {
     ptr_func = this->action_queue_[i];
     if (ptr_func) {
       ESP_LOGI(TAG, "HandleActionCallback[%d]", i);

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -51,7 +51,7 @@ void BL0942::loop() {
   if (!avail) {
     return;
   }
-  if (avail < sizeof(buffer)) {
+  if (static_cast<size_t>(avail) < sizeof(buffer)) {
     if (!this->rx_start_) {
       this->rx_start_ = millis();
     } else if (millis() > this->rx_start_ + PKT_TIMEOUT_MS) {
@@ -148,7 +148,7 @@ void BL0942::setup() {
 
   this->write_reg_(BL0942_REG_USR_WRPROT, 0);
 
-  if (this->read_reg_(BL0942_REG_MODE) != mode)
+  if (static_cast<uint32_t>(this->read_reg_(BL0942_REG_MODE)) != mode)
     this->status_set_warning(LOG_STR("BL0942 setup failed!"));
 
   this->flush();


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `bl0906` and `bl0942` components caused by sign comparison warnings when comparing signed and unsigned integer types.

**Changes:**
- `bl0906.cpp`: Changed loop variable from `int` to `size_t` to match `action_queue_.size()` return type
- `bl0942.cpp`: Cast `avail` to `size_t` when comparing with `sizeof(buffer)`
- `bl0942.cpp`: Cast `read_reg_()` return value to `uint32_t` when comparing with `mode`

All casts are safe since the values are non-negative in their comparison contexts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
