### PR TITLE
[audio, i2s_audio] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/audio/audio.cpp
+++ b/esphome/components/audio/audio.cpp
@@ -57,7 +57,7 @@ const char *audio_file_type_to_string(AudioFileType file_type) {
 void scale_audio_samples(const int16_t *audio_samples, int16_t *output_buffer, int16_t scale_factor,
                          size_t samples_to_scale) {
   // Note the assembly dsps_mulc function has audio glitches if the input and output buffers are the same.
-  for (int i = 0; i < samples_to_scale; i++) {
+  for (size_t i = 0; i < samples_to_scale; i++) {
     int32_t acc = (int32_t) audio_samples[i] * (int32_t) scale_factor;
     output_buffer[i] = (int16_t) (acc >> 15);
   }

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -377,7 +377,7 @@ void I2SAudioSpeaker::speaker_task(void *params) {
             this_speaker->current_stream_info_.get_bits_per_sample() <= 16) {
           size_t len = bytes_read / sizeof(int16_t);
           int16_t *tmp_buf = (int16_t *) new_data;
-          for (int i = 0; i < len; i += 2) {
+          for (size_t i = 0; i < len; i += 2) {
             int16_t tmp = tmp_buf[i];
             tmp_buf[i] = tmp_buf[i + 1];
             tmp_buf[i + 1] = tmp;

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -572,7 +572,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       }
     } else {
       // Determine how many frames to mix
-      for (int i = 0; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
         const uint32_t frames_available_in_buffer =
             speakers_with_data[i]->get_audio_stream_info().bytes_to_frames(transfer_buffers_with_data[i]->available());
         frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
@@ -581,7 +581,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       audio::AudioStreamInfo primary_stream_info = speakers_with_data[0]->get_audio_stream_info();
 
       // Mix two streams together
-      for (int i = 1; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 1; i < transfer_buffers_with_data.size(); ++i) {
         mix_audio_samples(primary_buffer, primary_stream_info,
                           reinterpret_cast<int16_t *>(transfer_buffers_with_data[i]->get_buffer_start()),
                           speakers_with_data[i]->get_audio_stream_info(),
@@ -596,7 +596,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       }
 
       // Update source transfer buffer lengths and add new audio durations to the source speaker pending playbacks
-      for (int i = 0; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
         transfer_buffers_with_data[i]->decrease_buffer_length(
             speakers_with_data[i]->get_audio_stream_info().frames_to_bytes(frames_to_mix));
         speakers_with_data[i]->pending_playback_frames_ += frames_to_mix;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `audio` and`i2s_audio` components caused by sign comparison warnings when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `audio.cpp`: Changed loop variable in `scale_audio_samples()` from `int` to `size_t` to match the `samples_to_scale` parameter type
- `i2s_audio/speaker/i2s_audio_speaker.cpp`: Changed loop variable from `int` to `size_t` to match the `len` variable type

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
