### PR TITLE
[cm1106] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/cm1106/cm1106.cpp
+++ b/esphome/components/cm1106/cm1106.cpp
@@ -13,7 +13,7 @@ static const uint8_t C_M1106_CMD_SET_CO2_CALIB_RESPONSE[4] = {0x16, 0x01, 0x03, 
 
 uint8_t cm1106_checksum(const uint8_t *response, size_t len) {
   uint8_t crc = 0;
-  for (int i = 0; i < len - 1; i++) {
+  for (size_t i = 0; i < len - 1; i++) {
     crc -= response[i];
   }
   return crc;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `cm1106` component caused by sign comparison warning when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `cm1106.cpp`: Changed loop variable in `cm1106_checksum()` from `int` to `size_t` to match the `len` parameter type

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
