### PR TITLE
[daikin_arc] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -26,7 +26,7 @@ void DaikinArcClimate::transmit_query_() {
   uint8_t remote_header[8] = {0x11, 0xDA, 0x27, 0x00, 0x84, 0x87, 0x20, 0x00};
 
   // Calculate checksum
-  for (int i = 0; i < sizeof(remote_header) - 1; i++) {
+  for (size_t i = 0; i < sizeof(remote_header) - 1; i++) {
     remote_header[sizeof(remote_header) - 1] += remote_header[i];
   }
 
@@ -102,7 +102,7 @@ void DaikinArcClimate::transmit_state() {
   remote_state[9] = fan_speed & 0xff;
 
   // Calculate checksum
-  for (int i = 0; i < sizeof(remote_header) - 1; i++) {
+  for (size_t i = 0; i < sizeof(remote_header) - 1; i++) {
     remote_header[sizeof(remote_header) - 1] += remote_header[i];
   }
 
@@ -353,7 +353,7 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
     int bytes_count = data.size() / 2 / 8;
     std::unique_ptr<char[]> buf(new char[bytes_count * 3 + 1]);
     buf[0] = '\0';
-    for (size_t i = 0; i < bytes_count; i++) {
+    for (size_t i = 0; i < static_cast<size_t>(bytes_count); i++) {
       uint8_t byte = 0;
       for (int8_t bit = 0; bit < 8; bit++) {
         if (data.expect_item(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE)) {
@@ -370,7 +370,7 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (!valid_daikin_frame) {
     char sbuf[16 * 10 + 1];
     sbuf[0] = '\0';
-    for (size_t j = 0; j < data.size(); j++) {
+    for (size_t j = 0; j < static_cast<size_t>(data.size()); j++) {
       if ((j - 2) % 16 == 0) {
         if (j > 0) {
           ESP_LOGD(TAG, "DATA %04x: %s", (j - 16 > 0xffff ? 0 : j - 16), sbuf);
@@ -380,19 +380,26 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
       char type_ch = ' ';
       // debug_tolerance = 25%
 
-      if (DAIKIN_DBG_LOWER(DAIKIN_ARC_PRE_MARK) <= data[j] && data[j] <= DAIKIN_DBG_UPPER(DAIKIN_ARC_PRE_MARK))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_ARC_PRE_MARK)) <= data[j] &&
+          data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_ARC_PRE_MARK)))
         type_ch = 'P';
-      if (DAIKIN_DBG_LOWER(DAIKIN_ARC_PRE_SPACE) <= -data[j] && -data[j] <= DAIKIN_DBG_UPPER(DAIKIN_ARC_PRE_SPACE))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_ARC_PRE_SPACE)) <= -data[j] &&
+          -data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_ARC_PRE_SPACE)))
         type_ch = 'a';
-      if (DAIKIN_DBG_LOWER(DAIKIN_HEADER_MARK) <= data[j] && data[j] <= DAIKIN_DBG_UPPER(DAIKIN_HEADER_MARK))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_HEADER_MARK)) <= data[j] &&
+          data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_HEADER_MARK)))
         type_ch = 'H';
-      if (DAIKIN_DBG_LOWER(DAIKIN_HEADER_SPACE) <= -data[j] && -data[j] <= DAIKIN_DBG_UPPER(DAIKIN_HEADER_SPACE))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_HEADER_SPACE)) <= -data[j] &&
+          -data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_HEADER_SPACE)))
         type_ch = 'h';
-      if (DAIKIN_DBG_LOWER(DAIKIN_BIT_MARK) <= data[j] && data[j] <= DAIKIN_DBG_UPPER(DAIKIN_BIT_MARK))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_BIT_MARK)) <= data[j] &&
+          data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_BIT_MARK)))
         type_ch = 'B';
-      if (DAIKIN_DBG_LOWER(DAIKIN_ONE_SPACE) <= -data[j] && -data[j] <= DAIKIN_DBG_UPPER(DAIKIN_ONE_SPACE))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_ONE_SPACE)) <= -data[j] &&
+          -data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_ONE_SPACE)))
         type_ch = '1';
-      if (DAIKIN_DBG_LOWER(DAIKIN_ZERO_SPACE) <= -data[j] && -data[j] <= DAIKIN_DBG_UPPER(DAIKIN_ZERO_SPACE))
+      if (static_cast<int32_t>(DAIKIN_DBG_LOWER(DAIKIN_ZERO_SPACE)) <= -data[j] &&
+          -data[j] <= static_cast<int32_t>(DAIKIN_DBG_UPPER(DAIKIN_ZERO_SPACE)))
         type_ch = '0';
 
       if (abs(data[j]) > 100000) {
@@ -400,7 +407,7 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else {
         sprintf(sbuf, "%s%-5d[%c] ", sbuf, (int) (round(data[j] / 10.) * 10), type_ch);
       }
-      if (j == data.size() - 1) {
+      if (j == static_cast<size_t>(data.size()) - 1) {
         ESP_LOGD(TAG, "DATA %04x: %s", (j - 8 > 0xffff ? 0 : j - 8), sbuf);
       }
     }

--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -350,10 +350,10 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   bool valid_daikin_frame = false;
   if (data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     valid_daikin_frame = true;
-    int bytes_count = data.size() / 2 / 8;
+    size_t bytes_count = data.size() / 2 / 8;
     std::unique_ptr<char[]> buf(new char[bytes_count * 3 + 1]);
     buf[0] = '\0';
-    for (size_t i = 0; i < static_cast<size_t>(bytes_count); i++) {
+    for (size_t i = 0; i < bytes_count; i++) {
       uint8_t byte = 0;
       for (int8_t bit = 0; bit < 8; bit++) {
         if (data.expect_item(DAIKIN_BIT_MARK, DAIKIN_ONE_SPACE)) {
@@ -407,7 +407,7 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
       } else {
         sprintf(sbuf, "%s%-5d[%c] ", sbuf, (int) (round(data[j] / 10.) * 10), type_ch);
       }
-      if (j == static_cast<size_t>(data.size()) - 1) {
+      if (j + 1 == static_cast<size_t>(data.size())) {
         ESP_LOGD(TAG, "DATA %04x: %s", (j - 8 > 0xffff ? 0 : j - 8), sbuf);
       }
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `daikin_arc` component caused by sign comparison warnings when comparing signed and unsigned integer types.

**Changes:**
- `daikin_arc.cpp:29, 105`: Changed loop variable from `int` to `size_t` when comparing with `sizeof(remote_header) - 1`
- `daikin_arc.cpp:353`: Changed `bytes_count` from `int` to `size_t` to eliminate need for casting in loop condition
- `daikin_arc.cpp:373`: Cast `data.size()` to `size_t` in loop condition
- `daikin_arc.cpp:383-395`: Cast macro results to `int32_t` to match `data[j]` type in comparisons (12 comparisons)
- `daikin_arc.cpp:410`: Rewrote comparison from `j == data.size() - 1` to `j + 1 == data.size()` to avoid potential underflow

All changes ensure type safety and prevent sign comparison warnings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
