### PR TITLE
[es7210] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -97,10 +97,10 @@ bool ES7210::set_mic_gain(float mic_gain) {
 }
 
 bool ES7210::configure_sample_rate_() {
-  int mclk_fre = this->sample_rate_ * MCLK_DIV_FRE;
+  uint32_t mclk_fre = this->sample_rate_ * MCLK_DIV_FRE;
   int coeff = -1;
 
-  for (int i = 0; i < (sizeof(ES7210_COEFFICIENTS) / sizeof(ES7210_COEFFICIENTS[0])); ++i) {
+  for (size_t i = 0; i < (sizeof(ES7210_COEFFICIENTS) / sizeof(ES7210_COEFFICIENTS[0])); ++i) {
     if (ES7210_COEFFICIENTS[i].lrclk == this->sample_rate_ && ES7210_COEFFICIENTS[i].mclk == mclk_fre)
       coeff = i;
   }

--- a/esphome/components/es7210/es7210.cpp
+++ b/esphome/components/es7210/es7210.cpp
@@ -102,7 +102,7 @@ bool ES7210::configure_sample_rate_() {
 
   for (size_t i = 0; i < (sizeof(ES7210_COEFFICIENTS) / sizeof(ES7210_COEFFICIENTS[0])); ++i) {
     if (ES7210_COEFFICIENTS[i].lrclk == this->sample_rate_ && ES7210_COEFFICIENTS[i].mclk == mclk_fre)
-      coeff = i;
+      coeff = static_cast<int>(i);
   }
 
   if (coeff >= 0) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `es7210` component caused by sign comparison warnings when comparing signed and unsigned integer types.

**Changes:**
- `es7210.cpp:100`: Changed `mclk_fre` from `int` to `uint32_t` to match the `mclk` field type in `ES7210Coefficient` struct
- `es7210.cpp:103`: Changed loop variable from `int` to `size_t` to match `sizeof()` operator return type
- `es7210.cpp:105`: Added explicit `static_cast<int>(i)` when assigning loop index to `coeff` to make the narrowing conversion explicit and safe (array has ~27 entries, well within `int` range)

All changes ensure type safety and prevent sign comparison warnings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
