### PR TITLE
[esp32_ble] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/esp32_ble/ble_advertising.cpp
+++ b/esphome/components/esp32_ble/ble_advertising.cpp
@@ -152,7 +152,7 @@ void BLEAdvertising::loop() {
   if (now - this->last_advertisement_time_ > this->advertising_cycle_time_) {
     this->stop();
     this->current_adv_index_ += 1;
-    if (this->current_adv_index_ >= this->raw_advertisements_callbacks_.size()) {
+    if (static_cast<size_t>(this->current_adv_index_) >= this->raw_advertisements_callbacks_.size()) {
       this->current_adv_index_ = -1;
     }
     this->start();


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `esp32_ble` component caused by sign comparison warning when comparing signed `int8_t` with unsigned `size_t` type.

**Changes:**
- `esp32_ble/ble_advertising.cpp:155`: Cast `current_adv_index_` (int8_t) to `size_t` when comparing with `raw_advertisements_callbacks_.size()` return value

The cast is safe since we're comparing after incrementing, and the value is checked to be within the valid range of the vector. Kept `int8_t` to minimize memory usage on embedded systems - 127 advertisements is sufficient for practical use.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
