### PR TITLE
[esp32_can] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -68,7 +68,7 @@ static bool get_bitrate(canbus::CanSpeed bitrate, twai_timing_config_t *t_config
 
 bool ESP32Can::setup_internal() {
   static int next_twai_ctrl_num = 0;
-  if (next_twai_ctrl_num >= SOC_TWAI_CONTROLLER_NUM) {
+  if (static_cast<unsigned>(next_twai_ctrl_num) >= SOC_TWAI_CONTROLLER_NUM) {
     ESP_LOGW(TAG, "Maximum number of esp32_can components created already");
     this->mark_failed();
     return false;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `esp32_can` component caused by sign comparison warning when comparing signed `int` with unsigned `unsigned long` type.

**Changes:**
- `esp32_can/esp32_can.cpp:71`: Cast `next_twai_ctrl_num` to `unsigned` when comparing with `SOC_TWAI_CONTROLLER_NUM` macro

The cast is safe since `next_twai_ctrl_num` is a static counter that starts at 0 and only increments, so it's always non-negative.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
