### PR TITLE
[fingerprint_grow] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -80,7 +80,7 @@ void FingerprintGrowComponent::setup() {
   delay(20);  // This delay guarantees the sensor will in fact be powered power.
 
   if (this->check_password_()) {
-    if (this->new_password_ != -1) {
+    if (this->new_password_ != std::numeric_limits<uint32_t>::max()) {
       if (this->set_password_())
         return;
     } else {

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -6,6 +6,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/uart/uart.h"
 
+#include <limits>
 #include <vector>
 
 namespace esphome {
@@ -177,7 +178,7 @@ class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevic
   uint8_t address_[4] = {0xFF, 0xFF, 0xFF, 0xFF};
   uint16_t capacity_ = 64;
   uint32_t password_ = 0x0;
-  uint32_t new_password_ = -1;
+  uint32_t new_password_ = std::numeric_limits<uint32_t>::max();
   GPIOPin *sensing_pin_{nullptr};
   GPIOPin *sensor_power_pin_{nullptr};
   uint8_t enrollment_image_ = 0;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `fingerprint_grow` component caused by sign comparison warning when comparing unsigned `uint32_t` with signed literal `-1`.

**Changes:**
- `fingerprint_grow/fingerprint_grow.cpp:83`: Changed comparison from `-1` to `std::numeric_limits<uint32_t>::max()` for clarity
- `fingerprint_grow/fingerprint_grow.h:180`: Changed initialization from `-1` to `std::numeric_limits<uint32_t>::max()` for proper unsigned sentinel value
- `fingerprint_grow/fingerprint_grow.h:5`: Added `#include <limits>` for `std::numeric_limits`

Using `std::numeric_limits<uint32_t>::max()` is the proper C++ way to represent the maximum value for unsigned types.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
