### PR TITLE
[graph] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -179,7 +179,7 @@ void Graph::draw(Display *buff, uint16_t x_offset, uint16_t y_offset, Color colo
         if (b) {
           int16_t y = (int16_t) roundf((this->height_ - 1) * (1.0 - v)) - thick / 2 + y_offset;
           auto draw_pixel_at = [&buff, c, y_offset, this](int16_t x, int16_t y) {
-            if (y >= y_offset && y < y_offset + this->height_)
+            if (y >= y_offset && static_cast<uint32_t>(y) < y_offset + this->height_)
               buff->draw_pixel_at(x, y, c);
           };
           if (!continuous || !has_prev || !prev_b || (abs(y - prev_y) <= thick)) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `graph` component caused by sign comparison warning when comparing signed `int16_t` with unsigned `uint32_t` type.

**Changes:**
- `graph/graph.cpp:182`: Cast `y` to `uint32_t` when comparing with `y_offset + this->height_`

The cast is safe since the previous condition `y >= y_offset` ensures `y` is non-negative in this context.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
