### PR TITLE
[graphical_display_menu] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -116,7 +116,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
   int number_items_fit_to_screen = 0;
   const int max_item_index = this->displayed_item_->items_size() - 1;
 
-  for (size_t i = 0; i <= max_item_index; i++) {
+  for (size_t i = 0; max_item_index >= 0 && i <= static_cast<size_t>(max_item_index); i++) {
     const auto *item = this->displayed_item_->get_item(i);
     const bool selected = i == this->cursor_index_;
     const display::Rect item_dimensions = this->measure_item(display, item, bounds, selected);
@@ -174,7 +174,8 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
 
   display->filled_rectangle(bounds->x, bounds->y, max_width, total_height, this->background_color_);
   auto y_offset = bounds->y;
-  for (size_t i = first_item_index; i <= last_item_index; i++) {
+  for (size_t i = static_cast<size_t>(first_item_index);
+       last_item_index >= 0 && i <= static_cast<size_t>(last_item_index); i++) {
     const auto *item = this->displayed_item_->get_item(i);
     const bool selected = i == this->cursor_index_;
     display::Rect dimensions = menu_dimensions[i];


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `graphical_display_menu` component caused by sign comparison warnings when comparing unsigned `size_t` with signed `int` types.

**Changes:**
- `graphical_display_menu/graphical_display_menu.cpp:119`: Added guard `max_item_index >= 0` and cast to `size_t` in loop condition
- `graphical_display_menu/graphical_display_menu.cpp:177`: Added guard `last_item_index >= 0` and cast `first_item_index` and `last_item_index` to `size_t` in loop condition

The guards prevent undefined behavior when the index values are negative (e.g., when there are no items). The casts are safe since the guards ensure the values are non-negative.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
