### PR TITLE
[haier] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -213,7 +213,7 @@ haier_protocol::HandlerError HonClimate::status_handler_(haier_protocol::FrameTy
                this->real_control_packet_size_);
         this->status_message_callback_.call((const char *) data, data_size);
       } else {
-        ESP_LOGW(TAG, "Status packet too small: %d (should be >= %d)", data_size, this->real_control_packet_size_);
+        ESP_LOGW(TAG, "Status packet too small: %zu (should be >= %zu)", data_size, this->real_control_packet_size_);
       }
       switch (this->protocol_phase_) {
         case ProtocolPhases::SENDING_FIRST_STATUS_REQUEST:
@@ -827,7 +827,7 @@ haier_protocol::HandlerError HonClimate::process_status_message_(const uint8_t *
   size_t expected_size =
       2 + this->status_message_header_size_ + this->real_control_packet_size_ + this->real_sensors_packet_size_;
   if (size < expected_size) {
-    ESP_LOGW(TAG, "Unexpected message size %d (expexted >= %d)", size, expected_size);
+    ESP_LOGW(TAG, "Unexpected message size %u (expexted >= %zu)", size, expected_size);
     return haier_protocol::HandlerError::WRONG_MESSAGE_STRUCTURE;
   }
   uint16_t subtype = (((uint16_t) packet_buffer[0]) << 8) + packet_buffer[1];

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -208,7 +208,7 @@ haier_protocol::HandlerError HonClimate::status_handler_(haier_protocol::FrameTy
         this->last_status_message_.reset();
         this->last_status_message_ = std::unique_ptr<uint8_t[]>(new uint8_t[this->real_control_packet_size_]);
       };
-      if (data_size >= static_cast<size_t>(this->real_control_packet_size_) + 2) {
+      if (data_size >= this->real_control_packet_size_ + 2) {
         memcpy(this->last_status_message_.get(), data + 2 + this->status_message_header_size_,
                this->real_control_packet_size_);
         this->status_message_callback_.call((const char *) data, data_size);

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -208,7 +208,7 @@ haier_protocol::HandlerError HonClimate::status_handler_(haier_protocol::FrameTy
         this->last_status_message_.reset();
         this->last_status_message_ = std::unique_ptr<uint8_t[]>(new uint8_t[this->real_control_packet_size_]);
       };
-      if (data_size >= this->real_control_packet_size_ + 2) {
+      if (data_size >= static_cast<size_t>(this->real_control_packet_size_) + 2) {
         memcpy(this->last_status_message_.get(), data + 2 + this->status_message_header_size_,
                this->real_control_packet_size_);
         this->status_message_callback_.call((const char *) data, data_size);

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -178,7 +178,7 @@ class HonClimate : public HaierClimateBase {
   int extra_control_packet_bytes_{0};
   int extra_sensors_packet_bytes_{4};
   int status_message_header_size_{0};
-  int real_control_packet_size_{sizeof(hon_protocol::HaierPacketControl)};
+  size_t real_control_packet_size_{sizeof(hon_protocol::HaierPacketControl)};
   int real_sensors_packet_size_{sizeof(hon_protocol::HaierPacketSensors) + 4};
   HonControlMethod control_method_;
   std::queue<haier_protocol::HaierMessage> control_messages_queue_;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `haier` component caused by sign comparison warning when comparing unsigned `size_t` with signed `int` type.

**Changes:**
- `haier/hon_climate.h:181`: Changed `real_control_packet_size_` type from `int` to `size_t`
- `haier/hon_climate.cpp:216`: Updated format specifiers from `%d` to `%zu` for `size_t` variables
- `haier/hon_climate.cpp:830`: Updated format specifiers to `%u` for `uint8_t` and `%zu` for `size_t`

The type change is appropriate because `real_control_packet_size_` is calculated from `sizeof(hon_protocol::HaierPacketControl) + extra_control_packet_bytes_`, which is always non-negative and represents a packet size. Using `size_t` is more semantically correct than `int` for this purpose. The format specifier changes ensure correct printf-style formatting for the types.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
