### PR TITLE
[ili9xxx] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -325,7 +325,7 @@ void ILI9XXXDisplay::draw_pixels_at(int x_start, int y_start, int w, int h, cons
       // we could deal here with a non-zero y_offset, but if x_offset is zero, y_offset probably will be so don't bother
       this->write_array(ptr, w * h * 2);
     } else {
-      for (size_t y = 0; y != h; y++) {
+      for (size_t y = 0; y != static_cast<size_t>(h); y++) {
         this->write_array(ptr + (y + y_offset) * stride + x_offset, w * 2);
       }
     }
@@ -349,7 +349,7 @@ void ILI9XXXDisplay::draw_pixels_at(int x_start, int y_start, int w, int h, cons
         App.feed_wdt();
       }
       // end of line? Skip to the next.
-      if (++pixel == w) {
+      if (++pixel == static_cast<size_t>(w)) {
         pixel = 0;
         ptr += (x_pad + x_offset) * 2;
       }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `ili9xxx` component caused by sign comparison warnings when comparing unsigned `size_t` with signed `int` types.

**Changes:**
- `ili9xxx/ili9xxx_display.cpp:328`: Cast `h` to `size_t` in loop condition comparing with loop variable `y`
- `ili9xxx/ili9xxx_display.cpp:352`: Cast `w` to `size_t` when comparing with `pixel` counter

The casts are safe since the function has a guard at line 310 (`if (w <= 0 || h <= 0) return;`) ensuring both `w` and `h` are positive before these comparisons are reached.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
