### PR TITLE
[kamstrup_kmp] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -22,7 +22,7 @@ void KamstrupKMPComponent::dump_config() {
   LOG_SENSOR("  ", "Flow", this->flow_sensor_);
   LOG_SENSOR("  ", "Volume", this->volume_sensor_);
 
-  for (int i = 0; i < this->custom_sensors_.size(); i++) {
+  for (size_t i = 0; i < this->custom_sensors_.size(); i++) {
     LOG_SENSOR("  ", "Custom Sensor", this->custom_sensors_[i]);
     ESP_LOGCONFIG(TAG, "    Command: 0x%04X", this->custom_commands_[i]);
   }
@@ -268,7 +268,7 @@ void KamstrupKMPComponent::set_sensor_value_(uint16_t command, float value, uint
   }
 
   // Custom sensors
-  for (int i = 0; i < this->custom_commands_.size(); i++) {
+  for (size_t i = 0; i < this->custom_commands_.size(); i++) {
     if (command == this->custom_commands_[i]) {
       this->custom_sensors_[i]->publish_state(value);
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `kamstrup_kmp` component caused by sign comparison warnings when comparing signed `int` with unsigned `size_t` types.

**Changes:**
- `kamstrup_kmp/kamstrup_kmp.cpp:25`: Changed loop variable from `int` to `size_t` when iterating over `custom_sensors_` vector
- `kamstrup_kmp/kamstrup_kmp.cpp:271`: Changed loop variable from `int` to `size_t` when iterating over `custom_commands_` vector

The type change is safe as the loop variables are used only for indexing into vectors, which expect `size_t` indices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
