### PR TITLE
[key_collector] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -86,7 +86,7 @@ void KeyCollector::key_pressed_(uint8_t key) {
     return;
   }
   if (this->end_keys_.find(key) != std::string::npos) {
-    if ((this->min_length_ == 0) || (this->result_.size() >= this->min_length_)) {
+    if ((this->min_length_ == 0) || (this->result_.size() >= static_cast<size_t>(this->min_length_))) {
       this->result_trigger_->trigger(this->result_, this->start_key_, key);
       this->clear();
     }
@@ -94,9 +94,10 @@ void KeyCollector::key_pressed_(uint8_t key) {
   }
   if (!this->allowed_keys_.empty() && (this->allowed_keys_.find(key) == std::string::npos))
     return;
-  if ((this->max_length_ == 0) || (this->result_.size() < this->max_length_))
+  if ((this->max_length_ == 0) || (this->result_.size() < static_cast<size_t>(this->max_length_)))
     this->result_.push_back(key);
-  if ((this->max_length_ > 0) && (this->result_.size() == this->max_length_) && (!this->end_key_required_)) {
+  if ((this->max_length_ > 0) && (this->result_.size() == static_cast<size_t>(this->max_length_)) &&
+      (!this->end_key_required_)) {
     this->result_trigger_->trigger(this->result_, this->start_key_, 0);
     this->clear(false);
   }

--- a/esphome/components/key_collector/key_collector.cpp
+++ b/esphome/components/key_collector/key_collector.cpp
@@ -86,7 +86,7 @@ void KeyCollector::key_pressed_(uint8_t key) {
     return;
   }
   if (this->end_keys_.find(key) != std::string::npos) {
-    if ((this->min_length_ == 0) || (this->result_.size() >= static_cast<size_t>(this->min_length_))) {
+    if ((this->min_length_ == 0) || (this->result_.size() >= this->min_length_)) {
       this->result_trigger_->trigger(this->result_, this->start_key_, key);
       this->clear();
     }
@@ -94,10 +94,9 @@ void KeyCollector::key_pressed_(uint8_t key) {
   }
   if (!this->allowed_keys_.empty() && (this->allowed_keys_.find(key) == std::string::npos))
     return;
-  if ((this->max_length_ == 0) || (this->result_.size() < static_cast<size_t>(this->max_length_)))
+  if ((this->max_length_ == 0) || (this->result_.size() < this->max_length_))
     this->result_.push_back(key);
-  if ((this->max_length_ > 0) && (this->result_.size() == static_cast<size_t>(this->max_length_)) &&
-      (!this->end_key_required_)) {
+  if ((this->max_length_ > 0) && (this->result_.size() == this->max_length_) && (!this->end_key_required_)) {
     this->result_trigger_->trigger(this->result_, this->start_key_, 0);
     this->clear(false);
   }

--- a/esphome/components/key_collector/key_collector.h
+++ b/esphome/components/key_collector/key_collector.h
@@ -13,8 +13,8 @@ class KeyCollector : public Component {
   void loop() override;
   void dump_config() override;
   void set_provider(key_provider::KeyProvider *provider);
-  void set_min_length(int min_length) { this->min_length_ = min_length; };
-  void set_max_length(int max_length) { this->max_length_ = max_length; };
+  void set_min_length(uint32_t min_length) { this->min_length_ = min_length; };
+  void set_max_length(uint32_t max_length) { this->max_length_ = max_length; };
   void set_start_keys(std::string start_keys) { this->start_keys_ = std::move(start_keys); };
   void set_end_keys(std::string end_keys) { this->end_keys_ = std::move(end_keys); };
   void set_end_key_required(bool end_key_required) { this->end_key_required_ = end_key_required; };
@@ -33,8 +33,8 @@ class KeyCollector : public Component {
  protected:
   void key_pressed_(uint8_t key);
 
-  int min_length_{0};
-  int max_length_{0};
+  uint32_t min_length_{0};
+  uint32_t max_length_{0};
   std::string start_keys_;
   std::string end_keys_;
   bool end_key_required_{false};


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `key_collector` component caused by sign comparison warnings when comparing unsigned `size_t` with signed `int` types.

**Changes:**
- `key_collector/key_collector.h:16`: Changed `set_min_length()` parameter type from `int` to `uint32_t`
- `key_collector/key_collector.h:17`: Changed `set_max_length()` parameter type from `int` to `uint32_t`
- `key_collector/key_collector.h:36`: Changed `min_length_` member variable type from `int` to `uint32_t`
- `key_collector/key_collector.h:37`: Changed `max_length_` member variable type from `int` to `uint32_t`

Changing the types from `int` to `uint32_t` eliminates the sign comparison warnings in the .cpp file when comparing with `result_.size()`. These variables represent string length limits and are naturally unsigned.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
