### PR TITLE
[ltr_als_ps] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <limits>
 
 using esphome::i2c::ErrorCode;
 
@@ -14,30 +15,30 @@ static const uint8_t MAX_TRIES = 5;
 
 template<typename T, size_t size> T get_next(const T (&array)[size], const T val) {
   size_t i = 0;
-  size_t idx = -1;
-  while (idx == -1 && i < size) {
+  size_t idx = std::numeric_limits<size_t>::max();
+  while (idx == std::numeric_limits<size_t>::max() && i < size) {
     if (array[i] == val) {
       idx = i;
       break;
     }
     i++;
   }
-  if (idx == -1 || i + 1 >= size)
+  if (idx == std::numeric_limits<size_t>::max() || i + 1 >= size)
     return val;
   return array[i + 1];
 }
 
 template<typename T, size_t size> T get_prev(const T (&array)[size], const T val) {
   size_t i = size - 1;
-  size_t idx = -1;
-  while (idx == -1 && i > 0) {
+  size_t idx = std::numeric_limits<size_t>::max();
+  while (idx == std::numeric_limits<size_t>::max() && i > 0) {
     if (array[i] == val) {
       idx = i;
       break;
     }
     i--;
   }
-  if (idx == -1 || i == 0)
+  if (idx == std::numeric_limits<size_t>::max() || i == 0)
     return val;
   return array[i - 1];
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `ltr_als_ps` component caused by sign comparison warnings when comparing unsigned `size_t` with signed `-1` sentinel value.

**Changes:**
- `ltr_als_ps/ltr_als_ps.cpp:1`: Added `#include <limits>` for std::numeric_limits
- `ltr_als_ps/ltr_als_ps.cpp:18`: Changed sentinel value from `-1` to `std::numeric_limits<size_t>::max()` for `idx` in `get_next()` function
- `ltr_als_ps/ltr_als_ps.cpp:19`: Updated comparison to use `std::numeric_limits<size_t>::max()`
- `ltr_als_ps/ltr_als_ps.cpp:26`: Updated comparison to use `std::numeric_limits<size_t>::max()`
- `ltr_als_ps/ltr_als_ps.cpp:33`: Changed sentinel value from `-1` to `std::numeric_limits<size_t>::max()` for `idx` in `get_prev()` function
- `ltr_als_ps/ltr_als_ps.cpp:34`: Updated comparison to use `std::numeric_limits<size_t>::max()`
- `ltr_als_ps/ltr_als_ps.cpp:41`: Updated comparison to use `std::numeric_limits<size_t>::max()`

Using `std::numeric_limits<size_t>::max()` instead of `-1` is the proper C++ way to represent a sentinel value for unsigned types, avoiding sign comparison issues while maintaining the same logic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
