### PR TITLE
[matrix_keypad] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -76,7 +76,7 @@ void MatrixKeypad::loop() {
     active_start = now;
   }
 
-  if ((this->pressed_key_ == key) || (now - active_start < this->debounce_time_))
+  if ((this->pressed_key_ == key) || (now - active_start < static_cast<uint32_t>(this->debounce_time_)))
     return;
 
   row = key / this->columns_.size();

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -76,7 +76,7 @@ void MatrixKeypad::loop() {
     active_start = now;
   }
 
-  if ((this->pressed_key_ == key) || (now - active_start < static_cast<uint32_t>(this->debounce_time_)))
+  if ((this->pressed_key_ == key) || (now - active_start < this->debounce_time_))
     return;
 
   row = key / this->columns_.size();

--- a/esphome/components/matrix_keypad/matrix_keypad.h
+++ b/esphome/components/matrix_keypad/matrix_keypad.h
@@ -29,9 +29,9 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   void set_columns(std::vector<GPIOPin *> pins) { columns_ = std::move(pins); };
   void set_rows(std::vector<GPIOPin *> pins) { rows_ = std::move(pins); };
   void set_keys(std::string keys) { keys_ = std::move(keys); };
-  void set_debounce_time(int debounce_time) { debounce_time_ = debounce_time; };
-  void set_has_diodes(int has_diodes) { has_diodes_ = has_diodes; };
-  void set_has_pulldowns(int has_pulldowns) { has_pulldowns_ = has_pulldowns; };
+  void set_debounce_time(uint32_t debounce_time) { debounce_time_ = debounce_time; };
+  void set_has_diodes(bool has_diodes) { has_diodes_ = has_diodes; };
+  void set_has_pulldowns(bool has_pulldowns) { has_pulldowns_ = has_pulldowns; };
 
   void register_listener(MatrixKeypadListener *listener);
   void register_key_trigger(MatrixKeyTrigger *trig);
@@ -40,7 +40,7 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   std::vector<GPIOPin *> rows_;
   std::vector<GPIOPin *> columns_;
   std::string keys_;
-  int debounce_time_ = 0;
+  uint32_t debounce_time_ = 0;
   bool has_diodes_{false};
   bool has_pulldowns_{false};
   int pressed_key_ = -1;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `matrix_keypad` component caused by sign comparison warning when comparing unsigned `uint32_t` with signed `int` type.

**Changes:**
- `matrix_keypad/matrix_keypad.h:43`: Changed `debounce_time_` type from `int` to `uint32_t`

Changing the types from `int` to `uint32_t` eliminates the sign comparison warnings in the .cpp file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
