### PR TITLE
[max7219digit] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -90,7 +90,7 @@ void MAX7219Component::loop() {
   }
 
   if (this->scroll_mode_ == ScrollMode::STOP) {
-    if (this->stepsleft_ + get_width_internal() == first_line_size + 1) {
+    if (static_cast<size_t>(this->stepsleft_ + get_width_internal()) == first_line_size + 1) {
       if (millis_since_last_scroll < this->scroll_dwell_) {
         ESP_LOGVV(TAG, "Dwell time at end of string in case of stop at end. Step %d, since last scroll %d, dwell %d.",
                   this->stepsleft_, millis_since_last_scroll, this->scroll_dwell_);


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `max7219digit` component caused by sign comparison warning when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `max7219digit/max7219digit.cpp:93`: Cast `stepsleft_ + get_width_internal()` to `size_t` when comparing with `first_line_size + 1`

The cast is safe since:
- `stepsleft_` is `uint16_t` (always non-negative)
- `get_width_internal()` returns display width (always non-negative in this context)
- The sum represents a position in the scroll buffer, which is naturally unsigned

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
