### PR TITLE
[mixer] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -572,7 +572,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       }
     } else {
       // Determine how many frames to mix
-      for (int i = 0; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
         const uint32_t frames_available_in_buffer =
             speakers_with_data[i]->get_audio_stream_info().bytes_to_frames(transfer_buffers_with_data[i]->available());
         frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
@@ -581,7 +581,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       audio::AudioStreamInfo primary_stream_info = speakers_with_data[0]->get_audio_stream_info();
 
       // Mix two streams together
-      for (int i = 1; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 1; i < transfer_buffers_with_data.size(); ++i) {
         mix_audio_samples(primary_buffer, primary_stream_info,
                           reinterpret_cast<int16_t *>(transfer_buffers_with_data[i]->get_buffer_start()),
                           speakers_with_data[i]->get_audio_stream_info(),
@@ -596,7 +596,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
       }
 
       // Update source transfer buffer lengths and add new audio durations to the source speaker pending playbacks
-      for (int i = 0; i < transfer_buffers_with_data.size(); ++i) {
+      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
         transfer_buffers_with_data[i]->decrease_buffer_length(
             speakers_with_data[i]->get_audio_stream_info().frames_to_bytes(frames_to_mix));
         speakers_with_data[i]->pending_playback_frames_ += frames_to_mix;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `mixer` component caused by sign comparison warnings when comparing signed `int` with unsigned `size_t` types.

**Changes:**
- `mixer/speaker/mixer_speaker.cpp:575`: Changed loop variable from `int` to `size_t` when iterating over `transfer_buffers_with_data` vector
- `mixer/speaker/mixer_speaker.cpp:584`: Changed loop variable from `int` to `size_t` when iterating over `transfer_buffers_with_data` vector
- `mixer/speaker/mixer_speaker.cpp:591`: Comparison now uses `size_t i` (no cast needed after loop variable type change)
- `mixer/speaker/mixer_speaker.cpp:599`: Changed loop variable from `int` to `size_t` when iterating over `transfer_buffers_with_data` vector

The type change is safe as the loop variables are used only for indexing into vectors, which expect `size_t` indices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
