### PR TITLE
[pid] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -104,7 +104,7 @@ float PIDController::weighted_average_(std::deque<float> &list, float new_value,
   list.push_front(new_value);
 
   // keep only 'samples' readings, by popping off the back of the list
-  while (list.size() > samples)
+  while (list.size() > static_cast<size_t>(samples))
     list.pop_back();
 
   // calculate and return the average of all values in the list

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -104,7 +104,7 @@ float PIDController::weighted_average_(std::deque<float> &list, float new_value,
   list.push_front(new_value);
 
   // keep only 'samples' readings, by popping off the back of the list
-  while (list.size() > static_cast<size_t>(samples))
+  while (samples > 0 && list.size() > static_cast<size_t>(samples))
     list.pop_back();
 
   // calculate and return the average of all values in the list


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `pid` component caused by sign comparison warning when comparing unsigned `size_t` with signed `int` type.

**Changes:**
- `pid/pid_controller.cpp:107`: Added guard `samples > 0` and cast `samples` to `size_t` when comparing with `list.size()`

The guard ensures that `samples` is positive before casting to `size_t`, preventing unsigned integer wraparound if `samples` were negative. The parameter represents a sample count which is naturally unsigned, but is defined as `int` in the function signature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
