### PR TITLE
[rtttl] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -215,7 +215,7 @@ void Rtttl::loop() {
           sample[x].right = 0;
         }
 
-        if (x >= SAMPLE_BUFFER_SIZE || this->samples_sent_ >= this->samples_count_) {
+        if (static_cast<size_t>(x) >= SAMPLE_BUFFER_SIZE || this->samples_sent_ >= this->samples_count_) {
           break;
         }
         this->samples_sent_++;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `rtttl` component caused by sign comparison warning when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `rtttl/rtttl.cpp:218`: Cast `x` to `size_t` when comparing with `SAMPLE_BUFFER_SIZE`

The cast is safe since `x` is initialized to 0 (line 199) and only incremented, ensuring it's always non-negative when reaching this comparison. `SAMPLE_BUFFER_SIZE` is a `const size_t` representing the buffer size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
