### PR TITLE
[st7567_i2c] Fix clang-tidy sign comparison warning

### DIFF
--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -51,7 +51,9 @@ void HOT I2CST7567::write_display_data() {
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           this->get_width_internal() - x > BLOCK_SIZE ? BLOCK_SIZE : this->get_width_internal() - x);
+                           static_cast<size_t>(this->get_width_internal() - x) > BLOCK_SIZE
+                               ? BLOCK_SIZE
+                               : this->get_width_internal() - x);
     }
   }
 }

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -50,10 +50,10 @@ void HOT I2CST7567::write_display_data() {
 
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
+      size_t remaining = static_cast<size_t>(this->get_width_internal()) - x;
+      size_t chunk = remaining > BLOCK_SIZE ? BLOCK_SIZE : remaining;
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           static_cast<size_t>(this->get_width_internal() - x) > BLOCK_SIZE
-                               ? BLOCK_SIZE
-                               : this->get_width_internal() - x);
+                           chunk);
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `st7567_i2c` component caused by sign comparison warning when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `st7567_i2c/st7567_i2c.cpp:53-56`: Extract `remaining` and `chunk` variables to avoid calling `get_width_internal()` multiple times and ensure all arithmetic is explicitly in `size_t`

The extraction is safe since the loop condition ensures `x < get_width_internal()`, guaranteeing the subtraction result is non-negative. `BLOCK_SIZE` is a `const size_t` representing the block transfer size. This change improves code clarity by avoiding duplicate expressions and mixing explicit casting with implicit promotion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
