### PR TITLE
[st7789v] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -50,10 +50,8 @@ void HOT I2CST7567::write_display_data() {
 
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
-      size_t remaining = static_cast<size_t>(this->get_width_internal()) - x;
-      size_t chunk = remaining > BLOCK_SIZE ? BLOCK_SIZE : remaining;
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           chunk);
+                           this->get_width_internal() - x > BLOCK_SIZE ? BLOCK_SIZE : this->get_width_internal() - x);
     }
   }
 }

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -51,7 +51,9 @@ void HOT I2CST7567::write_display_data() {
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           this->get_width_internal() - x > BLOCK_SIZE ? BLOCK_SIZE : this->get_width_internal() - x);
+                           static_cast<size_t>(this->get_width_internal() - x) > BLOCK_SIZE
+                               ? BLOCK_SIZE
+                               : this->get_width_internal() - x);
     }
   }
 }

--- a/esphome/components/st7567_i2c/st7567_i2c.cpp
+++ b/esphome/components/st7567_i2c/st7567_i2c.cpp
@@ -50,10 +50,10 @@ void HOT I2CST7567::write_display_data() {
 
     static const size_t BLOCK_SIZE = 64;
     for (uint8_t x = 0; x < (uint8_t) this->get_width_internal(); x += BLOCK_SIZE) {
+      size_t remaining = static_cast<size_t>(this->get_width_internal()) - x;
+      size_t chunk = remaining > BLOCK_SIZE ? BLOCK_SIZE : remaining;
       this->write_register(esphome::st7567_base::ST7567_SET_START_LINE, &buffer_[y * this->get_width_internal() + x],
-                           static_cast<size_t>(this->get_width_internal() - x) > BLOCK_SIZE
-                               ? BLOCK_SIZE
-                               : this->get_width_internal() - x);
+                           chunk);
     }
   }
 }

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -177,7 +177,7 @@ void ST7789V::write_display_data() {
     uint8_t temp_buffer[TEMP_BUFFER_SIZE];
     size_t temp_index = 0;
     for (size_t line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
-      for (size_t index = 0; index < this->get_width_internal(); ++index) {
+      for (size_t index = 0; index < static_cast<size_t>(this->get_width_internal()); ++index) {
         auto color = display::ColorUtil::color_to_565(
             display::ColorUtil::to_color(this->buffer_[index + line], display::ColorOrder::COLOR_ORDER_RGB,
                                          display::ColorBitness::COLOR_BITNESS_332, true));

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -176,8 +176,9 @@ void ST7789V::write_display_data() {
   if (this->eightbitcolor_) {
     uint8_t temp_buffer[TEMP_BUFFER_SIZE];
     size_t temp_index = 0;
-    for (size_t line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
-      for (size_t index = 0; index < static_cast<size_t>(this->get_width_internal()); ++index) {
+    size_t width = static_cast<size_t>(this->get_width_internal());
+    for (size_t line = 0; line < this->get_buffer_length_(); line += width) {
+      for (size_t index = 0; index < width; ++index) {
         auto color = display::ColorUtil::color_to_565(
             display::ColorUtil::to_color(this->buffer_[index + line], display::ColorOrder::COLOR_ORDER_RGB,
                                          display::ColorBitness::COLOR_BITNESS_332, true));

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -176,8 +176,8 @@ void ST7789V::write_display_data() {
   if (this->eightbitcolor_) {
     uint8_t temp_buffer[TEMP_BUFFER_SIZE];
     size_t temp_index = 0;
-    for (int line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
-      for (int index = 0; index < this->get_width_internal(); ++index) {
+    for (size_t line = 0; line < this->get_buffer_length_(); line = line + this->get_width_internal()) {
+      for (size_t index = 0; index < this->get_width_internal(); ++index) {
         auto color = display::ColorUtil::color_to_565(
             display::ColorUtil::to_color(this->buffer_[index + line], display::ColorOrder::COLOR_ORDER_RGB,
                                          display::ColorBitness::COLOR_BITNESS_332, true));


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `st7789v` component caused by sign comparison warnings when comparing signed `int` loop variables with unsigned `size_t` return values.

**Changes:**
- `st7789v/st7789v.cpp:179`: Changed loop variable `line` from `int` to `size_t` when comparing with `get_buffer_length()` return value
- `st7789v/st7789v.cpp:180`: Changed loop variable `index` from `int` to `size_t` and cast `get_width_internal()` to `size_t` in the comparison

Both variables are used for iterating over buffer indices and are always non-negative, making `size_t` the appropriate type. The cast is safe since display width values are always positive.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
