### PR TITLE
[statsd] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/statsd/statsd.cpp
+++ b/esphome/components/statsd/statsd.cpp
@@ -151,7 +151,7 @@ void StatsdComponent::send_(std::string *out) {
 
   int n_bytes = this->sock_->sendto(out->c_str(), out->length(), 0, reinterpret_cast<sockaddr *>(&this->destination_),
                                     sizeof(this->destination_));
-  if (n_bytes != out->length()) {
+  if (n_bytes != static_cast<int>(out->length())) {
     ESP_LOGE(TAG, "Failed to send UDP packed (%d of %d)", n_bytes, out->length());
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `statsd` component caused by sign comparison warning when comparing signed `int` with unsigned `size_type`.

**Changes:**
- `statsd/statsd.cpp:154`: Cast `out->length()` to `int` when comparing with `n_bytes`

The cast is safe because `out->length()` is bounded by `SEND_THRESHOLD` (1024 bytes), well within `int` range. Casting to `int` rather than casting `n_bytes` to unsigned preserves the ability to detect negative return values from `sendto()`, which indicate errors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
