### PR TITLE
[mipi_spi] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -340,7 +340,7 @@ class MipiSpi : public display::Display,
         this->write_cmd_addr_data(0, 0, 0, 0, ptr, w * h, 8);
       }
     } else {
-      for (size_t y = 0; y != h; y++) {
+      for (size_t y = 0; y != static_cast<size_t>(h); y++) {
         if constexpr (BUS_TYPE == BUS_TYPE_SINGLE || BUS_TYPE == BUS_TYPE_SINGLE_16) {
           this->write_array(ptr, w);
         } else if constexpr (BUS_TYPE == BUS_TYPE_QUAD) {
@@ -372,8 +372,8 @@ class MipiSpi : public display::Display,
       uint8_t dbuffer[DISPLAYPIXEL * 48];
       uint8_t *dptr = dbuffer;
       auto stride = x_offset + w + x_pad;  // stride in pixels
-      for (size_t y = 0; y != h; y++) {
-        for (size_t x = 0; x != w; x++) {
+      for (size_t y = 0; y != static_cast<size_t>(h); y++) {
+        for (size_t x = 0; x != static_cast<size_t>(w); x++) {
           auto color_val = ptr[y * stride + x];
           if constexpr (DISPLAYPIXEL == PIXEL_MODE_18 && BUFFERPIXEL == PIXEL_MODE_16) {
             // 16 to 18 bit conversion


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `mipi_spi` component caused by sign comparison warnings when comparing `size_t` loop variables with `int` parameters.

**Changes:**
- `mipi_spi/mipi_spi.h:343`: Cast `h` to `size_t` in loop condition
- `mipi_spi/mipi_spi.h:375`: Cast `h` to `size_t` in outer loop condition
- `mipi_spi/mipi_spi.h:376`: Cast `w` to `size_t` in inner loop condition

The casts are safe since `w` and `h` represent display width and height, which are always non-negative values in this context.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
