### PR TITLE
[esp32_ble_server] Refactor property setters to reduce code duplication

### DIFF
--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -147,47 +147,27 @@ bool BLECharacteristic::is_failed() {
   return this->state_ == FAILED;
 }
 
-void BLECharacteristic::set_broadcast_property(bool value) {
+void BLECharacteristic::set_property_bit_(esp_gatt_char_prop_t bit, bool value) {
   if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_BROADCAST);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | bit);
   } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_BROADCAST);
+    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~bit);
   }
+}
+
+void BLECharacteristic::set_broadcast_property(bool value) {
+  this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_BROADCAST, value);
 }
 void BLECharacteristic::set_indicate_property(bool value) {
-  if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_INDICATE);
-  } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_INDICATE);
-  }
+  this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_INDICATE, value);
 }
 void BLECharacteristic::set_notify_property(bool value) {
-  if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_NOTIFY);
-  } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_NOTIFY);
-  }
+  this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_NOTIFY, value);
 }
-void BLECharacteristic::set_read_property(bool value) {
-  if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_READ);
-  } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_READ);
-  }
-}
-void BLECharacteristic::set_write_property(bool value) {
-  if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE);
-  } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE);
-  }
-}
+void BLECharacteristic::set_read_property(bool value) { this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_READ, value); }
+void BLECharacteristic::set_write_property(bool value) { this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_WRITE, value); }
 void BLECharacteristic::set_write_no_response_property(bool value) {
-  if (value) {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ | ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
-  } else {
-    this->properties_ = (esp_gatt_char_prop_t) (this->properties_ & ~ESP_GATT_CHAR_PROP_BIT_WRITE_NR);
-  }
+  this->set_property_bit_(ESP_GATT_CHAR_PROP_BIT_WRITE_NR, value);
 }
 
 void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -97,6 +97,8 @@ class BLECharacteristic {
   void remove_client_from_notify_list_(uint16_t conn_id);
   ClientNotificationEntry *find_client_in_notify_list_(uint16_t conn_id);
 
+  void set_property_bit_(esp_gatt_char_prop_t bit, bool value);
+
   std::unique_ptr<std::function<void(std::span<const uint8_t>, uint16_t)>> on_write_callback_;
   std::unique_ptr<std::function<void(uint16_t)>> on_read_callback_;
 


### PR DESCRIPTION
# What does this implement/fix?

Refactors the BLE characteristic property setter methods to reduce code duplication by extracting the common bit manipulation pattern into a single helper method `set_property_bit_()`.

**Before:** Each of the 6 property setter methods (`set_broadcast_property`, `set_indicate_property`, `set_notify_property`, `set_read_property`, `set_write_property`, `set_write_no_response_property`) contained identical if/else logic for setting/clearing property bits.

**After:** All property setters now delegate to a single `set_property_bit_()` helper method that handles the bit manipulation, reducing code duplication and improving maintainability.

This is a code quality improvement with no functional changes - the generated behavior remains identical.

**Impact:** Saves 22 bytes of flash memory with no RAM impact.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal refactoring only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
