### PR TITLE
[esp32_ble_server] Use early returns in is_created() and is_failed() methods

### DIFF
--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -129,6 +129,7 @@ bool BLECharacteristic::is_created() {
     if (!descriptor->is_created())
       return false;
   }
+  // All descriptors are created if we reach here
   this->state_ = CREATED;
   return true;
 }

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -125,26 +125,25 @@ bool BLECharacteristic::is_created() {
   if (this->state_ != CREATING_DEPENDENTS)
     return false;
 
-  bool created = true;
   for (auto *descriptor : this->descriptors_) {
-    created &= descriptor->is_created();
+    if (!descriptor->is_created())
+      return false;
   }
-  if (created)
-    this->state_ = CREATED;
-  return this->state_ == CREATED;
+  this->state_ = CREATED;
+  return true;
 }
 
 bool BLECharacteristic::is_failed() {
   if (this->state_ == FAILED)
     return true;
 
-  bool failed = false;
   for (auto *descriptor : this->descriptors_) {
-    failed |= descriptor->is_failed();
+    if (descriptor->is_failed()) {
+      this->state_ = FAILED;
+      return true;
+    }
   }
-  if (failed)
-    this->state_ = FAILED;
-  return this->state_ == FAILED;
+  return false;
 }
 
 void BLECharacteristic::set_broadcast_property(bool value) {


### PR DESCRIPTION
# What does this implement/fix?

Refactors the `is_created()` and `is_failed()` methods in `BLECharacteristic` to use early return logic instead of accumulating results with boolean variables and bitwise operations.

**Before:**
- `is_created()` used `created &= descriptor->is_created()` to accumulate all descriptor states
- `is_failed()` used `failed |= descriptor->is_failed()` to accumulate all descriptor states
- Both methods checked all descriptors even after finding a definitive result

**After:**
- Both methods return immediately upon finding a descriptor in the relevant state
- `is_created()` returns `false` as soon as any uncreated descriptor is found
- `is_failed()` returns `true` as soon as any failed descriptor is found

This improves readability and efficiency by avoiding unnecessary iterations when the result is already determined.

**Impact:** Saves 12 bytes of flash memory with no RAM impact.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal refactoring only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
