### PR TITLE
[tormatic] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -251,7 +251,7 @@ void Tormatic::stop_at_target_() {
 // Read a GateStatus from the unit. The unit only sends messages in response to
 // status requests or commands, so a message needs to be sent first.
 optional<GateStatus> Tormatic::read_gate_status_() {
-  if (this->available() < sizeof(MessageHeader)) {
+  if (this->available() < static_cast<int>(sizeof(MessageHeader))) {
     return {};
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `tormatic` component caused by sign comparison warning when comparing signed `int` with unsigned `size_t` type.

**Changes:**
- `tormatic/tormatic_cover.cpp:254`: Cast `sizeof(MessageHeader)` to `int` when comparing with `available()` return value

The cast is safe because `sizeof(MessageHeader)` will be a small value representing a message header size, well within `int` range. Casting to `int` rather than casting `available()` to unsigned preserves the ability to detect negative return values from `available()`, which may indicate errors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
