### PR TITLE
[uponor_smatrix] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
+++ b/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
@@ -58,7 +58,7 @@ void UponorSmatrixClimate::control(const climate::ClimateCall &call) {
 }
 
 void UponorSmatrixClimate::on_device_data(const UponorSmatrixData *data, size_t data_len) {
-  for (int i = 0; i < data_len; i++) {
+  for (size_t i = 0; i < data_len; i++) {
     switch (data[i].id) {
       case UPONOR_ID_TARGET_TEMP_MIN:
         this->min_temperature_ = raw_to_celsius(data[i].value);

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
@@ -18,7 +18,7 @@ void UponorSmatrixSensor::dump_config() {
 }
 
 void UponorSmatrixSensor::on_device_data(const UponorSmatrixData *data, size_t data_len) {
-  for (int i = 0; i < data_len; i++) {
+  for (size_t i = 0; i < data_len; i++) {
     switch (data[i].id) {
       case UPONOR_ID_ROOM_TEMP:
         if (this->temperature_sensor_ != nullptr)

--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -122,7 +122,7 @@ bool UponorSmatrixComponent::parse_byte_(uint8_t byte) {
 
   // Decode packet payload data for easy access
   UponorSmatrixData data[data_len];
-  for (int i = 0; i < data_len; i++) {
+  for (size_t i = 0; i < data_len; i++) {
     data[i].id = packet[(i * 3) + 4];
     data[i].value = encode_uint16(packet[(i * 3) + 5], packet[(i * 3) + 6]);
   }
@@ -135,7 +135,7 @@ bool UponorSmatrixComponent::parse_byte_(uint8_t byte) {
     // thermostat sending both room temperature and time information.
     bool found_temperature = false;
     bool found_time = false;
-    for (int i = 0; i < data_len; i++) {
+    for (size_t i = 0; i < data_len; i++) {
       if (data[i].id == UPONOR_ID_ROOM_TEMP)
         found_temperature = true;
       if (data[i].id == UPONOR_ID_DATETIME1)
@@ -181,7 +181,7 @@ bool UponorSmatrixComponent::send(uint16_t device_address, const UponorSmatrixDa
   packet.push_back(device_address >> 8);
   packet.push_back(device_address >> 0);
 
-  for (int i = 0; i < data_len; i++) {
+  for (size_t i = 0; i < data_len; i++) {
     packet.push_back(data[i].id);
     packet.push_back(data[i].value >> 8);
     packet.push_back(data[i].value >> 0);


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `uponor_smatrix` component caused by sign comparison warnings when comparing signed `int` loop variables with unsigned `size_t` parameter.

**Changes:**
- `uponor_smatrix/climate/uponor_smatrix_climate.cpp:61`: Changed loop variable `i` from `int` to `size_t`
- `uponor_smatrix/sensor/uponor_smatrix_sensor.cpp:21`: Changed loop variable `i` from `int` to `size_t`
- `uponor_smatrix/uponor_smatrix.cpp:125`: Changed loop variable `i` from `int` to `size_t`
- `uponor_smatrix/uponor_smatrix.cpp:138`: Changed loop variable `i` from `int` to `size_t`
- `uponor_smatrix/uponor_smatrix.cpp:184`: Changed loop variable `i` from `int` to `size_t`

All loop variables are used for array indexing and iteration over `data_len` which is `size_t`, making `size_t` the appropriate type.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
