### PR TITLE
[waveshare_epaper] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2274,11 +2274,11 @@ void GDEW0154M09::clear_() {
   uint32_t pixsize = this->get_buffer_length_();
   for (uint8_t j = 0; j < 2; j++) {
     this->command(CMD_DTM1_DATA_START_TRANS);
-    for (int count = 0; count < pixsize; count++) {
+    for (uint32_t count = 0; count < pixsize; count++) {
       this->data(0x00);
     }
     this->command(CMD_DTM2_DATA_START_TRANS2);
-    for (int count = 0; count < pixsize; count++) {
+    for (uint32_t count = 0; count < pixsize; count++) {
       this->data(0xff);
     }
     this->command(CMD_DISPLAY_REFRESH);
@@ -2291,11 +2291,11 @@ void HOT GDEW0154M09::display() {
   this->init_internal_();
   // "Mode 0 display" for now
   this->command(CMD_DTM1_DATA_START_TRANS);
-  for (int i = 0; i < this->get_buffer_length_(); i++) {
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
     this->data(0xff);
   }
   this->command(CMD_DTM2_DATA_START_TRANS2);  // write 'new' data to SRAM
-  for (int i = 0; i < this->get_buffer_length_(); i++) {
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
     this->data(this->buffer_[i]);
   }
   this->command(CMD_DISPLAY_REFRESH);


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `waveshare_epaper` component caused by sign comparison warnings when comparing signed `int` loop variables with unsigned `uint32_t` values.

**Changes:**
- `waveshare_epaper/waveshare_epaper.cpp:2277`: Changed loop variable `count` from `int` to `uint32_t`
- `waveshare_epaper/waveshare_epaper.cpp:2281`: Changed loop variable `count` from `int` to `uint32_t`
- `waveshare_epaper/waveshare_epaper.cpp:2294`: Changed loop variable `i` from `int` to `uint32_t`
- `waveshare_epaper/waveshare_epaper.cpp:2298`: Changed loop variable `i` from `int` to `uint32_t`

All loop variables are used for iterating over buffer lengths which are `uint32_t`, making `uint32_t` the appropriate type.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
