### PR TITLE
[time] Fix clang-tidy sign comparison errors

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -77,7 +77,7 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
              &hour,                                                                                      // NOLINT
              &minute,                                                                                    // NOLINT
              &second, &num) == 6 &&                                                                      // NOLINT
-      num == time_to_parse.size()) {
+      num == static_cast<int>(time_to_parse.size())) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;
@@ -87,7 +87,7 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
                     &hour,                                                                               // NOLINT
                     &minute, &num) == 5 &&                                                               // NOLINT
-             num == time_to_parse.size()) {
+             num == static_cast<int>(time_to_parse.size())) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;
@@ -95,17 +95,17 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
     esp_time.minute = minute;
     esp_time.second = 0;
   } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu:%02hhu %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
-             num == time_to_parse.size()) {
+             num == static_cast<int>(time_to_parse.size())) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
   } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu %n", &hour, &minute, &num) == 2 &&  // NOLINT
-             num == time_to_parse.size()) {
+             num == static_cast<int>(time_to_parse.size())) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
   } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %n", &year, &month, &day, &num) == 3 &&  // NOLINT
-             num == time_to_parse.size()) {
+             num == static_cast<int>(time_to_parse.size())) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failures in the `esphome/core/time.cpp` file caused by sign comparison warnings when comparing signed `int num` with unsigned `size_t` returned by `time_to_parse.size()`.

**Changes:**
- `esphome/core/time.cpp:80`: Cast `time_to_parse.size()` to `int` before comparison with `num`
- `esphome/core/time.cpp:90`: Cast `time_to_parse.size()` to `int` before comparison with `num`
- `esphome/core/time.cpp:98`: Cast `time_to_parse.size()` to `int` before comparison with `num`
- `esphome/core/time.cpp:103`: Cast `time_to_parse.size()` to `int` before comparison with `num`
- `esphome/core/time.cpp:108`: Cast `time_to_parse.size()` to `int` before comparison with `num`

The `num` variable must be `int` because it's populated by `sscanf` with the `%n` format specifier (which requires `int*`). Casting `time_to_parse.size()` to `int` is safe because these are user-provided time strings which should never be huge, and it's more defensive than casting `num` to unsigned.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
