### PR TITLE
[api] Fix clang-tidy sign comparison error

### DIFF
--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -35,7 +35,7 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
     msg.set_name(StringRef(this->name_));
     msg.key = this->key_;
     std::array<enums::ServiceArgType, sizeof...(Ts)> arg_types = {to_service_arg_type<Ts>()...};
-    for (int i = 0; i < sizeof...(Ts); i++) {
+    for (size_t i = 0; i < sizeof...(Ts); i++) {
       msg.args.emplace_back();
       auto &arg = msg.args.back();
       arg.type = arg_types[i];


### PR DESCRIPTION
# What does this implement/fix?

Fixes clang-tidy CI failure in the `api` component caused by sign comparison warning when comparing signed `int` loop variable with unsigned `sizeof...(Ts)` parameter pack size.

**Changes:**
- `esphome/components/api/user_services.h:38`: Changed loop variable `i` from `int` to `size_t`

The loop variable iterates over a parameter pack using `sizeof...(Ts)`, which returns `size_t`. Using `size_t` for the loop variable matches the type and is semantically correct.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Not applicable - clang-tidy fix only)

## Example entry for `config.yaml`:

```yaml
# No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
