### PR TITLE
[esp32] Hide build warnings

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -74,6 +74,9 @@ FILTER_PLATFORMIO_LINES = [
     r"Creating BIN file .*",
     r"Warning! Could not find file \".*.crt\"",
     r"Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.",
+    r"Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.",
+    r"Warning: esp-idf-size exited with code 2",
+    r"esp_idf_size: error: unrecognized arguments: --ng",
 ]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Hide build warnings that will be fixed in IDF 5.5 and are not fatal. Still leaves the usage print but at least the warnings are gone. 

Before:
```
Building .pioenvs/test/bootloader.bin
Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
Creating ESP32 image...
Successfully created ESP32 image.
Linking .pioenvs/test/firmware.elf
usage: esp_idf_size [-h] [--format {table,text,tree,csv,json2,raw,dot}] [--archives] [--archive-dependencies] [--dep-symbols]
                    [--dep-reverse] [--archive-details ARCHIVE_NAME] [--files] [--diff MAP_FILE] [--no-abbrev] [--unify]
                    [--show-unused] [--show-unchanged] [--use-flash-size] [--lto] [-d] [-o OUTPUT_FILE] [-s COLUMN] [-F PATTERN]
                    [--sort-diff] [--sort-reverse] [-q] [--no-color] [--force-terminal] [--doc]
                    MAP_FILE
esp_idf_size: error: unrecognized arguments: --ng
Warning: esp-idf-size exited with code 2
RAM:   [=         ]  10.3% (used 33900 bytes from 327680 bytes)
Flash: [====      ]  40.6% (used 744382 bytes from 1835008 bytes)
```
after:
```
Building .pioenvs/test/bootloader.bin
Creating ESP32 image...
Successfully created ESP32 image.
Linking .pioenvs/test/firmware.elf
usage: esp_idf_size [-h] [--format {table,text,tree,csv,json2,raw,dot}] [--archives] [--archive-dependencies] [--dep-symbols]
                    [--dep-reverse] [--archive-details ARCHIVE_NAME] [--files] [--diff MAP_FILE] [--no-abbrev] [--unify]
                    [--show-unused] [--show-unchanged] [--use-flash-size] [--lto] [-d] [-o OUTPUT_FILE] [-s COLUMN] [-F PATTERN]
                    [--sort-diff] [--sort-reverse] [-q] [--no-color] [--force-terminal] [--doc]
                    MAP_FILE
RAM:   [=         ]  10.3% (used 33900 bytes from 327680 bytes)
Flash: [====      ]  40.6% (used 744382 bytes from 1835008 bytes)
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
