### PR TITLE
[mdns] Fix delete/malloc bug and store string constants in flash

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -61,7 +61,7 @@ CONFIG_SCHEMA = cv.All(
 def mdns_txt_record(key: str, value: str):
     return cg.StructInitializer(
         MDNSTXTRecord,
-        ("key", key),
+        ("key", cg.RawExpression(f"MDNS_STR({cg.safe_exp(key)})")),
         ("value", value),
     )
 
@@ -71,8 +71,8 @@ def mdns_service(
 ):
     return cg.StructInitializer(
         MDNSService,
-        ("service_type", service),
-        ("proto", proto),
+        ("service_type", cg.RawExpression(f"MDNS_STR({cg.safe_exp(service)})")),
+        ("proto", cg.RawExpression(f"MDNS_STR({cg.safe_exp(proto)})")),
         ("port", port),
         ("txt_records", txt_records),
     )
@@ -114,7 +114,7 @@ async def to_code(config):
         txt = [
             cg.StructInitializer(
                 MDNSTXTRecord,
-                ("key", txt_key),
+                ("key", cg.RawExpression(f"MDNS_STR({cg.safe_exp(txt_key)})")),
                 ("value", await cg.templatable(txt_value, [], cg.std_string)),
             )
             for txt_key, txt_value in service[CONF_TXT].items()

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -45,24 +45,7 @@ static const char *const TAG = "mdns";
 #define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
-// Define all constant strings using the macro
-MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
-MDNS_STATIC_CONST_CHAR(SERVICE_TCP, "_tcp");
-MDNS_STATIC_CONST_CHAR(SERVICE_PROMETHEUS, "_prometheus-http");
-MDNS_STATIC_CONST_CHAR(SERVICE_HTTP, "_http");
-
-MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
-MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
-MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
-MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
-MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
-MDNS_STATIC_CONST_CHAR(TXT_NETWORK, "network");
-MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION, "api_encryption");
-MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION_SUPPORTED, "api_encryption_supported");
-MDNS_STATIC_CONST_CHAR(TXT_PROJECT_NAME, "project_name");
-MDNS_STATIC_CONST_CHAR(TXT_PROJECT_VERSION, "project_version");
-MDNS_STATIC_CONST_CHAR(TXT_PACKAGE_IMPORT_URL, "package_import_url");
-
+// Define constant strings for values (PROGMEM on ESP8266, regular flash on others)
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP8266, "ESP8266");
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP32, "ESP32");
 MDNS_STATIC_CONST_CHAR(PLATFORM_RP2040, "RP2040");
@@ -80,8 +63,8 @@ void MDNSComponent::compile_records_() {
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
     auto &service = this->services_.emplace_next();
-    service.service_type = MDNS_STR(SERVICE_ESPHOMELIB);
-    service.proto = MDNS_STR(SERVICE_TCP);
+    service.service_type = "_esphomelib";
+    service.proto = "_tcp";
     service.port = api::global_api_server->get_port();
 
     const std::string &friendly_name = App.get_friendly_name();
@@ -112,62 +95,62 @@ void MDNSComponent::compile_records_() {
     txt_records.reserve(txt_count);
 
     if (!friendly_name_empty) {
-      txt_records.push_back({MDNS_STR(TXT_FRIENDLY_NAME), friendly_name});
+      txt_records.push_back({"friendly_name", friendly_name});
     }
-    txt_records.push_back({MDNS_STR(TXT_VERSION), ESPHOME_VERSION});
-    txt_records.push_back({MDNS_STR(TXT_MAC), get_mac_address()});
+    txt_records.push_back({"version", ESPHOME_VERSION});
+    txt_records.push_back({"mac", get_mac_address()});
 
 #ifdef USE_ESP8266
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP8266)});
+    txt_records.push_back({"platform", MDNS_STR(PLATFORM_ESP8266)});
 #elif defined(USE_ESP32)
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP32)});
+    txt_records.push_back({"platform", MDNS_STR(PLATFORM_ESP32)});
 #elif defined(USE_RP2040)
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_RP2040)});
+    txt_records.push_back({"platform", MDNS_STR(PLATFORM_RP2040)});
 #elif defined(USE_LIBRETINY)
     txt_records.emplace_back(MDNSTXTRecord{"platform", lt_cpu_get_model_name()});
 #endif
 
-    txt_records.push_back({MDNS_STR(TXT_BOARD), ESPHOME_BOARD});
+    txt_records.push_back({"board", ESPHOME_BOARD});
 
 #if defined(USE_WIFI)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_WIFI)});
+    txt_records.push_back({"network", MDNS_STR(NETWORK_WIFI)});
 #elif defined(USE_ETHERNET)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_ETHERNET)});
+    txt_records.push_back({"network", MDNS_STR(NETWORK_ETHERNET)});
 #elif defined(USE_OPENTHREAD)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_THREAD)});
+    txt_records.push_back({"network", MDNS_STR(NETWORK_THREAD)});
 #endif
 
 #ifdef USE_API_NOISE
     MDNS_STATIC_CONST_CHAR(NOISE_ENCRYPTION, "Noise_NNpsk0_25519_ChaChaPoly_SHA256");
     if (api::global_api_server->get_noise_ctx()->has_psk()) {
-      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION), MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({"api_encryption", MDNS_STR(NOISE_ENCRYPTION)});
     } else {
-      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION_SUPPORTED), MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({"api_encryption_supported", MDNS_STR(NOISE_ENCRYPTION)});
     }
 #endif
 
 #ifdef ESPHOME_PROJECT_NAME
-    txt_records.push_back({MDNS_STR(TXT_PROJECT_NAME), ESPHOME_PROJECT_NAME});
-    txt_records.push_back({MDNS_STR(TXT_PROJECT_VERSION), ESPHOME_PROJECT_VERSION});
+    txt_records.push_back({"project_name", ESPHOME_PROJECT_NAME});
+    txt_records.push_back({"project_version", ESPHOME_PROJECT_VERSION});
 #endif  // ESPHOME_PROJECT_NAME
 
 #ifdef USE_DASHBOARD_IMPORT
-    txt_records.push_back({MDNS_STR(TXT_PACKAGE_IMPORT_URL), dashboard_import::get_package_import_url()});
+    txt_records.push_back({"package_import_url", dashboard_import::get_package_import_url()});
 #endif
   }
 #endif  // USE_API
 
 #ifdef USE_PROMETHEUS
   auto &prom_service = this->services_.emplace_next();
-  prom_service.service_type = MDNS_STR(SERVICE_PROMETHEUS);
-  prom_service.proto = MDNS_STR(SERVICE_TCP);
+  prom_service.service_type = "_prometheus-http";
+  prom_service.proto = "_tcp";
   prom_service.port = USE_WEBSERVER_PORT;
 #endif
 
 #ifdef USE_WEBSERVER
   auto &web_service = this->services_.emplace_next();
-  web_service.service_type = MDNS_STR(SERVICE_HTTP);
-  web_service.proto = MDNS_STR(SERVICE_TCP);
+  web_service.service_type = "_http";
+  web_service.proto = "_tcp";
   web_service.port = USE_WEBSERVER_PORT;
 #endif
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -9,7 +9,6 @@
 #include <pgmspace.h>
 // Macro to define strings in PROGMEM on ESP8266, regular memory on other platforms
 #define MDNS_STATIC_CONST_CHAR(name, value) static const char name[] PROGMEM = value
-#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
 // Helper to convert PROGMEM string to std::string for TemplatableValue
 // Only define this function if we have services that will use it
 #if defined(USE_API) || defined(USE_PROMETHEUS) || defined(USE_WEBSERVER) || defined(USE_MDNS_EXTRA_SERVICES)
@@ -24,7 +23,6 @@ static std::string mdns_str_value(PGM_P str) {
 #else
 // On non-ESP8266 platforms, use regular const char*
 #define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char name[] = value
-#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
 #define MDNS_STR_VALUE(name) std::string(name)
 #endif
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -45,7 +45,7 @@ static const char *const TAG = "mdns";
 #define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
-// Define constant strings for values (PROGMEM on ESP8266, regular flash on others)
+// Define constant strings for values (PROGMEM on ESP8266, static pointers on others)
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP8266, "ESP8266");
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP32, "ESP32");
 MDNS_STATIC_CONST_CHAR(PLATFORM_RP2040, "RP2040");

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -173,7 +173,7 @@ void MDNSComponent::dump_config() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   ESP_LOGV(TAG, "  Services:");
   for (const auto &service : this->services_) {
-    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(),
+    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type, service.proto,
              const_cast<TemplatableValue<uint16_t> &>(service.port).value());
     for (const auto &record : service.txt_records) {
       ESP_LOGV(TAG, "    TXT: %s = %s", record.key,

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -9,24 +9,20 @@
 #include <pgmspace.h>
 // Macro to define strings in PROGMEM on ESP8266, regular memory on other platforms
 #define MDNS_STATIC_CONST_CHAR(name, value) static const char name[] PROGMEM = value
-// Helper to get string from PROGMEM - returns a temporary std::string
-// Only define this function if we have services that will use it
-#if defined(USE_API) || defined(USE_PROMETHEUS) || defined(USE_WEBSERVER) || defined(USE_MDNS_EXTRA_SERVICES)
-static std::string mdns_string_p(const char *src) {
+#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
+// Helper to convert PROGMEM string to std::string for TemplatableValue
+static std::string mdns_str_value(PGM_P str) {
   char buf[64];
-  strncpy_P(buf, src, sizeof(buf) - 1);
+  strncpy_P(buf, str, sizeof(buf) - 1);
   buf[sizeof(buf) - 1] = '\0';
   return std::string(buf);
 }
-#define MDNS_STR(name) mdns_string_p(name)
-#else
-// If no services are configured, we still need the fallback service but it uses string literals
-#define MDNS_STR(name) std::string(name)
-#endif
+#define MDNS_STR_VALUE(name) mdns_str_value(name)
 #else
 // On non-ESP8266 platforms, use regular const char*
-#define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char *name = value
-#define MDNS_STR(name) name
+#define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char name[] = value
+#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
+#define MDNS_STR_VALUE(name) std::string(name)
 #endif
 
 #ifdef USE_API
@@ -118,11 +114,11 @@ void MDNSComponent::compile_records_() {
     txt_records.push_back({MDNS_STR(TXT_MAC), get_mac_address()});
 
 #ifdef USE_ESP8266
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP8266)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR_VALUE(PLATFORM_ESP8266)});
 #elif defined(USE_ESP32)
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP32)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR_VALUE(PLATFORM_ESP32)});
 #elif defined(USE_RP2040)
-    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_RP2040)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR_VALUE(PLATFORM_RP2040)});
 #elif defined(USE_LIBRETINY)
     txt_records.push_back({MDNS_STR(TXT_PLATFORM), lt_cpu_get_model_name()});
 #endif
@@ -130,19 +126,19 @@ void MDNSComponent::compile_records_() {
     txt_records.push_back({MDNS_STR(TXT_BOARD), ESPHOME_BOARD});
 
 #if defined(USE_WIFI)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_WIFI)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR_VALUE(NETWORK_WIFI)});
 #elif defined(USE_ETHERNET)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_ETHERNET)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR_VALUE(NETWORK_ETHERNET)});
 #elif defined(USE_OPENTHREAD)
-    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_THREAD)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR_VALUE(NETWORK_THREAD)});
 #endif
 
 #ifdef USE_API_NOISE
     MDNS_STATIC_CONST_CHAR(NOISE_ENCRYPTION, "Noise_NNpsk0_25519_ChaChaPoly_SHA256");
     if (api::global_api_server->get_noise_ctx()->has_psk()) {
-      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION), MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION), MDNS_STR_VALUE(NOISE_ENCRYPTION)});
     } else {
-      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION_SUPPORTED), MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION_SUPPORTED), MDNS_STR_VALUE(NOISE_ENCRYPTION)});
     }
 #endif
 
@@ -190,10 +186,10 @@ void MDNSComponent::dump_config() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   ESP_LOGV(TAG, "  Services:");
   for (const auto &service : this->services_) {
-    ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type, service.proto,
+    ESP_LOGV(TAG, "  - %s, %s, %d", MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto),
              const_cast<TemplatableValue<uint16_t> &>(service.port).value());
     for (const auto &record : service.txt_records) {
-      ESP_LOGV(TAG, "    TXT: %s = %s", record.key,
+      ESP_LOGV(TAG, "    TXT: %s = %s", MDNS_STR_ARG(record.key),
                const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -45,7 +45,24 @@ static const char *const TAG = "mdns";
 #define USE_WEBSERVER_PORT 80  // NOLINT
 #endif
 
-// Define constant strings for values (PROGMEM on ESP8266, static pointers on others)
+// Define all constant strings using the macro
+MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
+MDNS_STATIC_CONST_CHAR(SERVICE_TCP, "_tcp");
+MDNS_STATIC_CONST_CHAR(SERVICE_PROMETHEUS, "_prometheus-http");
+MDNS_STATIC_CONST_CHAR(SERVICE_HTTP, "_http");
+
+MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
+MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
+MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
+MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
+MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
+MDNS_STATIC_CONST_CHAR(TXT_NETWORK, "network");
+MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION, "api_encryption");
+MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION_SUPPORTED, "api_encryption_supported");
+MDNS_STATIC_CONST_CHAR(TXT_PROJECT_NAME, "project_name");
+MDNS_STATIC_CONST_CHAR(TXT_PROJECT_VERSION, "project_version");
+MDNS_STATIC_CONST_CHAR(TXT_PACKAGE_IMPORT_URL, "package_import_url");
+
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP8266, "ESP8266");
 MDNS_STATIC_CONST_CHAR(PLATFORM_ESP32, "ESP32");
 MDNS_STATIC_CONST_CHAR(PLATFORM_RP2040, "RP2040");
@@ -63,8 +80,8 @@ void MDNSComponent::compile_records_() {
 #ifdef USE_API
   if (api::global_api_server != nullptr) {
     auto &service = this->services_.emplace_next();
-    service.service_type = "_esphomelib";
-    service.proto = "_tcp";
+    service.service_type = MDNS_STR(SERVICE_ESPHOMELIB);
+    service.proto = MDNS_STR(SERVICE_TCP);
     service.port = api::global_api_server->get_port();
 
     const std::string &friendly_name = App.get_friendly_name();
@@ -95,62 +112,62 @@ void MDNSComponent::compile_records_() {
     txt_records.reserve(txt_count);
 
     if (!friendly_name_empty) {
-      txt_records.push_back({"friendly_name", friendly_name});
+      txt_records.push_back({MDNS_STR(TXT_FRIENDLY_NAME), friendly_name});
     }
-    txt_records.push_back({"version", ESPHOME_VERSION});
-    txt_records.push_back({"mac", get_mac_address()});
+    txt_records.push_back({MDNS_STR(TXT_VERSION), ESPHOME_VERSION});
+    txt_records.push_back({MDNS_STR(TXT_MAC), get_mac_address()});
 
 #ifdef USE_ESP8266
-    txt_records.push_back({"platform", MDNS_STR(PLATFORM_ESP8266)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP8266)});
 #elif defined(USE_ESP32)
-    txt_records.push_back({"platform", MDNS_STR(PLATFORM_ESP32)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_ESP32)});
 #elif defined(USE_RP2040)
-    txt_records.push_back({"platform", MDNS_STR(PLATFORM_RP2040)});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR(PLATFORM_RP2040)});
 #elif defined(USE_LIBRETINY)
-    txt_records.emplace_back(MDNSTXTRecord{"platform", lt_cpu_get_model_name()});
+    txt_records.push_back({MDNS_STR(TXT_PLATFORM), lt_cpu_get_model_name()});
 #endif
 
-    txt_records.push_back({"board", ESPHOME_BOARD});
+    txt_records.push_back({MDNS_STR(TXT_BOARD), ESPHOME_BOARD});
 
 #if defined(USE_WIFI)
-    txt_records.push_back({"network", MDNS_STR(NETWORK_WIFI)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_WIFI)});
 #elif defined(USE_ETHERNET)
-    txt_records.push_back({"network", MDNS_STR(NETWORK_ETHERNET)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_ETHERNET)});
 #elif defined(USE_OPENTHREAD)
-    txt_records.push_back({"network", MDNS_STR(NETWORK_THREAD)});
+    txt_records.push_back({MDNS_STR(TXT_NETWORK), MDNS_STR(NETWORK_THREAD)});
 #endif
 
 #ifdef USE_API_NOISE
     MDNS_STATIC_CONST_CHAR(NOISE_ENCRYPTION, "Noise_NNpsk0_25519_ChaChaPoly_SHA256");
     if (api::global_api_server->get_noise_ctx()->has_psk()) {
-      txt_records.push_back({"api_encryption", MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION), MDNS_STR(NOISE_ENCRYPTION)});
     } else {
-      txt_records.push_back({"api_encryption_supported", MDNS_STR(NOISE_ENCRYPTION)});
+      txt_records.push_back({MDNS_STR(TXT_API_ENCRYPTION_SUPPORTED), MDNS_STR(NOISE_ENCRYPTION)});
     }
 #endif
 
 #ifdef ESPHOME_PROJECT_NAME
-    txt_records.push_back({"project_name", ESPHOME_PROJECT_NAME});
-    txt_records.push_back({"project_version", ESPHOME_PROJECT_VERSION});
+    txt_records.push_back({MDNS_STR(TXT_PROJECT_NAME), ESPHOME_PROJECT_NAME});
+    txt_records.push_back({MDNS_STR(TXT_PROJECT_VERSION), ESPHOME_PROJECT_VERSION});
 #endif  // ESPHOME_PROJECT_NAME
 
 #ifdef USE_DASHBOARD_IMPORT
-    txt_records.push_back({"package_import_url", dashboard_import::get_package_import_url()});
+    txt_records.push_back({MDNS_STR(TXT_PACKAGE_IMPORT_URL), dashboard_import::get_package_import_url()});
 #endif
   }
 #endif  // USE_API
 
 #ifdef USE_PROMETHEUS
   auto &prom_service = this->services_.emplace_next();
-  prom_service.service_type = "_prometheus-http";
-  prom_service.proto = "_tcp";
+  prom_service.service_type = MDNS_STR(SERVICE_PROMETHEUS);
+  prom_service.proto = MDNS_STR(SERVICE_TCP);
   prom_service.port = USE_WEBSERVER_PORT;
 #endif
 
 #ifdef USE_WEBSERVER
   auto &web_service = this->services_.emplace_next();
-  web_service.service_type = "_http";
-  web_service.proto = "_tcp";
+  web_service.service_type = MDNS_STR(SERVICE_HTTP);
+  web_service.proto = MDNS_STR(SERVICE_TCP);
   web_service.port = USE_WEBSERVER_PORT;
 #endif
 
@@ -158,10 +175,10 @@ void MDNSComponent::compile_records_() {
   // Publish "http" service if not using native API or any other services
   // This is just to have *some* mDNS service so that .local resolution works
   auto &fallback_service = this->services_.emplace_next();
-  fallback_service.service_type = "_http";
-  fallback_service.proto = "_tcp";
+  fallback_service.service_type = MDNS_STR(SERVICE_HTTP);
+  fallback_service.proto = MDNS_STR(SERVICE_TCP);
   fallback_service.port = USE_WEBSERVER_PORT;
-  fallback_service.txt_records.emplace_back(MDNSTXTRecord{"version", ESPHOME_VERSION});
+  fallback_service.txt_records.push_back({MDNS_STR(TXT_VERSION), ESPHOME_VERSION});
 #endif
 }
 

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -11,6 +11,8 @@
 #define MDNS_STATIC_CONST_CHAR(name, value) static const char name[] PROGMEM = value
 #define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
 // Helper to convert PROGMEM string to std::string for TemplatableValue
+// Only define this function if we have services that will use it
+#if defined(USE_API) || defined(USE_PROMETHEUS) || defined(USE_WEBSERVER) || defined(USE_MDNS_EXTRA_SERVICES)
 static std::string mdns_str_value(PGM_P str) {
   char buf[64];
   strncpy_P(buf, str, sizeof(buf) - 1);
@@ -18,6 +20,7 @@ static std::string mdns_str_value(PGM_P str) {
   return std::string(buf);
 }
 #define MDNS_STR_VALUE(name) mdns_str_value(name)
+#endif
 #else
 // On non-ESP8266 platforms, use regular const char*
 #define MDNS_STATIC_CONST_CHAR(name, value) static constexpr const char name[] = value

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -193,7 +193,7 @@ void MDNSComponent::dump_config() {
     ESP_LOGV(TAG, "  - %s, %s, %d", service.service_type.c_str(), service.proto.c_str(),
              const_cast<TemplatableValue<uint16_t> &>(service.port).value());
     for (const auto &record : service.txt_records) {
-      ESP_LOGV(TAG, "    TXT: %s = %s", record.key.c_str(),
+      ESP_LOGV(TAG, "    TXT: %s = %s", record.key,
                const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -9,21 +9,31 @@
 namespace esphome {
 namespace mdns {
 
+// Helper struct that identifies strings that may be stored in flash storage (similar to LogString)
+struct MDNSString;
+
+#ifdef USE_ESP8266
+#include <pgmspace.h>
+#define MDNS_STR_ARG(s) ((PGM_P) (s))
+#else
+#define MDNS_STR_ARG(s) (reinterpret_cast<const char *>(s))
+#endif
+
 // Service count is calculated at compile time by Python codegen
 // MDNS_SERVICE_COUNT will always be defined
 
 struct MDNSTXTRecord {
-  const char *key;
+  const MDNSString *key;
   TemplatableValue<std::string> value;
 };
 
 struct MDNSService {
   // service name _including_ underscore character prefix
   // as defined in RFC6763 Section 7
-  const char *service_type;
+  const MDNSString *service_type;
   // second label indicating protocol _including_ underscore character prefix
   // as defined in RFC6763 Section 7, like "_tcp" or "_udp"
-  const char *proto;
+  const MDNSString *proto;
   TemplatableValue<uint16_t> port;
   std::vector<MDNSTXTRecord> txt_records;
 };

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -20,10 +20,10 @@ struct MDNSTXTRecord {
 struct MDNSService {
   // service name _including_ underscore character prefix
   // as defined in RFC6763 Section 7
-  std::string service_type;
+  const char *service_type;
   // second label indicating protocol _including_ underscore character prefix
   // as defined in RFC6763 Section 7, like "_tcp" or "_udp"
-  std::string proto;
+  const char *proto;
   TemplatableValue<uint16_t> port;
   std::vector<MDNSTXTRecord> txt_records;
 };

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -12,6 +12,9 @@ namespace mdns {
 // Helper struct that identifies strings that may be stored in flash storage (similar to LogString)
 struct MDNSString;
 
+// Macro to cast string literals to MDNSString* (works on all platforms)
+#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
+
 #ifdef USE_ESP8266
 #include <pgmspace.h>
 #define MDNS_STR_ARG(s) ((PGM_P) (s))

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -13,7 +13,7 @@ namespace mdns {
 // MDNS_SERVICE_COUNT will always be defined
 
 struct MDNSTXTRecord {
-  std::string key;
+  const char *key;
   TemplatableValue<std::string> value;
 };
 

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -13,7 +13,7 @@ namespace mdns {
 struct MDNSString;
 
 // Macro to cast string literals to MDNSString* (works on all platforms)
-#define MDNS_STR(name) (reinterpret_cast<const MDNSString *>(name))
+#define MDNS_STR(name) (reinterpret_cast<const esphome::mdns::MDNSString *>(name))
 
 #ifdef USE_ESP8266
 #include <pgmspace.h>

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -36,8 +36,7 @@ void MDNSComponent::setup() {
       txt_records.push_back(it);
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port, txt_records.data(),
-                           txt_records.size());
+    err = mdns_service_add(nullptr, service.service_type, service.proto, port, txt_records.data(), txt_records.size());
 
     // free records
     for (const auto &it : txt_records) {
@@ -45,7 +44,7 @@ void MDNSComponent::setup() {
     }
 
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Failed to register service %s: %s", service.service_type.c_str(), esp_err_to_name(err));
+      ESP_LOGW(TAG, "Failed to register service %s: %s", service.service_type, esp_err_to_name(err));
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -45,7 +45,7 @@ void MDNSComponent::setup() {
     }
 
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Failed to register service %s: %s", service.service_type, esp_err_to_name(err));
+      ESP_LOGW(TAG, "Failed to register service %s: %s", MDNS_STR_ARG(service.service_type), esp_err_to_name(err));
     }
   }
 }

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -40,7 +40,9 @@ void MDNSComponent::setup() {
 
     // free records
     for (const auto &it : txt_records) {
-      free((void *) it.value);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-pro-type-cstyle-cast)
+      free(
+          (void *) it
+              .value);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-no-malloc)
     }
 
     if (err != ESP_OK) {

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -29,8 +29,8 @@ void MDNSComponent::setup() {
     std::vector<mdns_txt_item_t> txt_records;
     for (const auto &record : service.txt_records) {
       mdns_txt_item_t it{};
-      // key is a persistent string in services_, no need to strdup
-      it.key = record.key.c_str();
+      // key is a compile-time string literal in flash, no need to strdup
+      it.key = record.key;
       // value is a temporary from TemplatableValue, must strdup to keep it alive
       it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
       txt_records.push_back(it);

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -40,9 +40,7 @@ void MDNSComponent::setup() {
 
     // free records
     for (const auto &it : txt_records) {
-      free(
-          (void *) it
-              .value);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-no-malloc)
+      free((void *) it.value);  // NOLINT(cppcoreguidelines-no-malloc)
     }
 
     if (err != ESP_OK) {

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -26,23 +26,15 @@ void MDNSComponent::setup() {
   mdns_instance_name_set(this->hostname_.c_str());
 
   for (const auto &service : this->services_) {
-    std::vector<mdns_txt_item_t> txt_records;
-    for (const auto &record : service.txt_records) {
-      mdns_txt_item_t it{};
-      // dup strings to ensure the pointer is valid even after the record loop
-      it.key = strdup(record.key.c_str());
-      it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
-      txt_records.push_back(it);
+    std::vector<mdns_txt_item_t> txt_records(service.txt_records.size());
+    for (size_t i = 0; i < service.txt_records.size(); i++) {
+      // mdns_service_add copies the strings internally, no need to strdup
+      txt_records[i].key = service.txt_records[i].key.c_str();
+      txt_records[i].value = const_cast<TemplatableValue<std::string> &>(service.txt_records[i].value).value().c_str();
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port, txt_records.data(),
                            txt_records.size());
-
-    // free records
-    for (const auto &it : txt_records) {
-      delete it.key;    // NOLINT(cppcoreguidelines-owning-memory)
-      delete it.value;  // NOLINT(cppcoreguidelines-owning-memory)
-    }
 
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "Failed to register service %s: %s", service.service_type.c_str(), esp_err_to_name(err));

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -26,15 +26,23 @@ void MDNSComponent::setup() {
   mdns_instance_name_set(this->hostname_.c_str());
 
   for (const auto &service : this->services_) {
-    std::vector<mdns_txt_item_t> txt_records(service.txt_records.size());
-    for (size_t i = 0; i < service.txt_records.size(); i++) {
-      // mdns_service_add copies the strings internally, no need to strdup
-      txt_records[i].key = service.txt_records[i].key.c_str();
-      txt_records[i].value = const_cast<TemplatableValue<std::string> &>(service.txt_records[i].value).value().c_str();
+    std::vector<mdns_txt_item_t> txt_records;
+    for (const auto &record : service.txt_records) {
+      mdns_txt_item_t it{};
+      // key is a persistent string in services_, no need to strdup
+      it.key = record.key.c_str();
+      // value is a temporary from TemplatableValue, must strdup to keep it alive
+      it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
+      txt_records.push_back(it);
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     err = mdns_service_add(nullptr, service.service_type.c_str(), service.proto.c_str(), port, txt_records.data(),
                            txt_records.size());
+
+    // free records
+    for (const auto &it : txt_records) {
+      free((void *) it.value);  // NOLINT(cppcoreguidelines-owning-memory,cppcoreguidelines-pro-type-cstyle-cast)
+    }
 
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "Failed to register service %s: %s", service.service_type.c_str(), esp_err_to_name(err));

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -30,13 +30,14 @@ void MDNSComponent::setup() {
     for (const auto &record : service.txt_records) {
       mdns_txt_item_t it{};
       // key is a compile-time string literal in flash, no need to strdup
-      it.key = record.key;
+      it.key = MDNS_STR_ARG(record.key);
       // value is a temporary from TemplatableValue, must strdup to keep it alive
       it.value = strdup(const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
       txt_records.push_back(it);
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    err = mdns_service_add(nullptr, service.service_type, service.proto, port, txt_records.data(), txt_records.size());
+    err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,
+                           txt_records.data(), txt_records.size());
 
     // free records
     for (const auto &it : txt_records) {

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -21,18 +21,18 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto;
+    auto *proto = MDNS_STR_ARG(service.proto);
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type;
+    auto *service_type = MDNS_STR_ARG(service.service_type);
     while (*service_type == '_') {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key,
+      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -22,11 +22,11 @@ void MDNSComponent::setup() {
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
     auto *proto = MDNS_STR_ARG(service.proto);
-    while (progmem_read_byte(proto) == '_') {
+    while (progmem_read_byte((const uint8_t *) proto) == '_') {
       proto++;
     }
     auto *service_type = MDNS_STR_ARG(service.service_type);
-    while (progmem_read_byte(service_type) == '_') {
+    while (progmem_read_byte((const uint8_t *) service_type) == '_') {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -22,11 +22,11 @@ void MDNSComponent::setup() {
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
     auto *proto = MDNS_STR_ARG(service.proto);
-    while (*proto == '_') {
+    while (pgm_read_byte(proto) == '_') {
       proto++;
     }
     auto *service_type = MDNS_STR_ARG(service.service_type);
-    while (*service_type == '_') {
+    while (pgm_read_byte(service_type) == '_') {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -21,11 +21,11 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto.c_str();
+    auto *proto = service.proto;
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type.c_str();
+    auto *service_type = service.service_type;
     while (*service_type == '_') {
       service_type++;
     }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -30,9 +30,9 @@ void MDNSComponent::setup() {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    MDNS.addService(service_type, proto, port);
+    MDNS.addService(FPSTR(service_type), FPSTR(proto), port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key),
+      MDNS.addServiceTxt(FPSTR(service_type), FPSTR(proto), FPSTR(MDNS_STR_ARG(record.key)),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -32,7 +32,7 @@ void MDNSComponent::setup() {
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+      MDNS.addServiceTxt(service_type, proto, record.key,
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -22,11 +22,11 @@ void MDNSComponent::setup() {
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
     auto *proto = MDNS_STR_ARG(service.proto);
-    while (pgm_read_byte(proto) == '_') {
+    while (progmem_read_byte(proto) == '_') {
       proto++;
     }
     auto *service_type = MDNS_STR_ARG(service.service_type);
-    while (pgm_read_byte(service_type) == '_') {
+    while (progmem_read_byte(service_type) == '_') {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -21,18 +21,18 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto;
+    auto *proto = MDNS_STR_ARG(service.proto);
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type;
+    auto *service_type = MDNS_STR_ARG(service.service_type);
     while (*service_type == '_') {
       service_type++;
     }
     uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port_);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key,
+      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -32,7 +32,7 @@ void MDNSComponent::setup() {
     uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port_);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+      MDNS.addServiceTxt(service_type, proto, record.key,
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -21,11 +21,11 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto.c_str();
+    auto *proto = service.proto;
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type.c_str();
+    auto *service_type = service.service_type;
     while (*service_type == '_') {
       service_type++;
     }

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -21,18 +21,18 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto;
+    auto *proto = MDNS_STR_ARG(service.proto);
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type;
+    auto *service_type = MDNS_STR_ARG(service.service_type);
     while (*service_type == '_') {
       service_type++;
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key,
+      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key),
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -21,11 +21,11 @@ void MDNSComponent::setup() {
     // part of the wire protocol to have an underscore, and for example ESP-IDF
     // expects the underscore to be there, the ESP8266 implementation always adds
     // the underscore itself.
-    auto *proto = service.proto.c_str();
+    auto *proto = service.proto;
     while (*proto == '_') {
       proto++;
     }
-    auto *service_type = service.service_type.c_str();
+    auto *service_type = service.service_type;
     while (*service_type == '_') {
       service_type++;
     }

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -32,7 +32,7 @@ void MDNSComponent::setup() {
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     MDNS.addService(service_type, proto, port);
     for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, record.key.c_str(),
+      MDNS.addServiceTxt(service_type, proto, record.key,
                          const_cast<TemplatableValue<std::string> &>(record.value).value().c_str());
     }
   }

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -155,7 +155,7 @@ void OpenThreadSrpComponent::setup() {
 
     // Set service name
     char *string = otSrpClientBuffersGetServiceEntryServiceNameString(entry, &size);
-    std::string full_service = service.service_type + "." + service.proto;
+    std::string full_service = std::string(MDNS_STR_ARG(service.service_type)) + "." + MDNS_STR_ARG(service.proto);
     if (full_service.size() > size) {
       ESP_LOGW(TAG, "Service name too long: %s", full_service.c_str());
       continue;
@@ -181,7 +181,7 @@ void OpenThreadSrpComponent::setup() {
     for (size_t i = 0; i < service.txt_records.size(); i++) {
       const auto &txt = service.txt_records[i];
       auto value = const_cast<TemplatableValue<std::string> &>(txt.value).value();
-      txt_entries[i].mKey = txt.key;  // Compile-time string literal in flash
+      txt_entries[i].mKey = MDNS_STR_ARG(txt.key);
       txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(strdup(value.c_str()));
       txt_entries[i].mValueLength = value.size();
     }

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -181,7 +181,7 @@ void OpenThreadSrpComponent::setup() {
     for (size_t i = 0; i < service.txt_records.size(); i++) {
       const auto &txt = service.txt_records[i];
       auto value = const_cast<TemplatableValue<std::string> &>(txt.value).value();
-      txt_entries[i].mKey = strdup(txt.key.c_str());
+      txt_entries[i].mKey = txt.key;  // Compile-time string literal in flash
       txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(strdup(value.c_str()));
       txt_entries[i].mValueLength = value.size();
     }


### PR DESCRIPTION
# What does this implement/fix?

Optimizes mDNS by storing compile-time string constants (service names, protocols, and TXT record keys) in flash instead of copying them into RAM via `std::string`. The `this->services_` vector now stores pointers to flash strings instead of duplicating them in heap memory. Additionally fixes undefined behavior in ESP32 where `delete` was used on `malloc()`'d memory.

## The Problem

1. **Unnecessary RAM usage**: Service types ("_esphomelib", "_tcp", etc.) and TXT record keys ("version", "platform", "mac", etc.) are compile-time string literals, but were being stored as `std::string` which copies them from flash to RAM heap:
   ```cpp
   struct MDNSService {
     std::string service_type;  // Copies "_esphomelib" from flash to RAM heap
     std::string proto;         // Copies "_tcp" from flash to RAM heap
   };

   struct MDNSTXTRecord {
     std::string key;  // Copies "version" from flash to RAM heap
   };
   ```

2. **ESP32 undefined behavior**: The code used `delete` on memory allocated by `strdup()` (which uses `malloc()`):
   ```cpp
   it.key = strdup(record.key.c_str());  // allocates with malloc()
   // ...
   delete it.key;  // BUG: should be free(), not delete
   ```

## The Fix

### 1. Store compile-time strings as pointers instead of std::string

Changed structs to use `const MDNSString*` (similar to LogString) for compile-time constants:

```cpp
struct MDNSService {
  const MDNSString *service_type;  // Points to string in flash (PROGMEM on ESP8266)
  const MDNSString *proto;         // Points to string in flash (PROGMEM on ESP8266)
};

struct MDNSTXTRecord {
  const MDNSString *key;  // Points to string in flash (PROGMEM on ESP8266)
};
```

**How it works:**
- `this->services_` now contains **pointers to flash** instead of `std::string` objects that duplicate the data
- **ESP32/RP2040/LibreTiny**: Compile-time strings stored in regular flash, accessed via `const char*` cast
- **ESP8266**: Compile-time strings stored in PROGMEM flash, accessed via helper macros (`MDNS_STR_ARG`, `FPSTR`, `progmem_read_byte`)

**What's optimized:**
- Service types: `"_esphomelib"`, `"_tcp"`, `"_http"`, etc. → stored in flash
- TXT record keys: `"version"`, `"platform"`, `"mac"`, `"board"`, etc. → stored in flash
- TXT record values: Still use `std::string` because they're runtime data (MAC address, board name, user lambdas, etc.) - **future optimization opportunity**

**Benefits**:
- Eliminates `std::string` heap allocations and duplication for every compile-time constant
- Saves `sizeof(std::string)` (12-16 bytes) + string data per field
- Applies to ALL platforms (ESP32, ESP8266, RP2040, LibreTiny)

### 2. Use helper macros for platform abstraction

Uses `MDNS_STR()`, `MDNS_STR_ARG()`, and `MDNS_STR_VALUE()` macros to abstract platform differences:

```cpp
// Keys use MDNS_STR - returns const MDNSString* pointer
txt_records.push_back({MDNS_STR(TXT_VERSION), ESPHOME_VERSION});

// Platform implementations use MDNS_STR_ARG to get usable pointer
const char *key = MDNS_STR_ARG(record.key);  // const char* on ESP32, PGM_P on ESP8266

// Values use MDNS_STR_VALUE - converts to std::string for TemplatableValue
txt_records.push_back({MDNS_STR(TXT_PLATFORM), MDNS_STR_VALUE(PLATFORM_ESP32)});
```

### 3. Fix ESP32 undefined behavior

Changed ESP32 implementation to only strdup values (which are temporary from TemplatableValue), and use `free()` instead of `delete`:

```cpp
it.key = record.key;  // Direct pointer to flash - no strdup needed
it.value = strdup(...);  // Still needed - temporary from TemplatableValue
// ...
free((void *) it.value);  // Use free(), not delete
```

### 4. Remove unnecessary strdup in OpenThread component

The OpenThread component (Thread networking protocol) was also strdup'ing keys unnecessarily:

```cpp
// Before:
txt_entries[i].mKey = strdup(txt.key.c_str());  // Unnecessary allocation

// After:
txt_entries[i].mKey = txt.key;  // Direct pointer to flash
```

## Benefits

- **Fixes undefined behavior**: ESP32 no longer uses `delete` on `malloc()`'d memory (uses `free()` now)
- **Reduces allocations**: ESP32 goes from 2N to N allocations per service (only values need strdup, not keys)
- **Memory optimization**:
  - **ESP32**: Saves **372 bytes flash** (1307216 → 1306844), **RAM unchanged** (43512 → 43512)
  - **ESP8266**: Uses 48 bytes more flash (351291 → 351339) for PROGMEM helpers, but **RAM unchanged** (29756 → 29756)
  - **Both platforms**: `this->services_` now stores pointers to flash instead of duplicating strings in heap
- **RAM savings at runtime**: Eliminates `std::string` overhead (12-16 bytes + string data) for every compile-time constant field
- **Cleaner code**: Uses helper macros to abstract platform differences

**Why ESP8266 uses slightly more flash**: PROGMEM access requires helper functions (`progmem_read_byte()`, `FPSTR()`) which add 48 bytes of code. However, this prevents compile-time strings from being duplicated in RAM - the right trade-off since ESP8266 RAM is more constrained than flash.

**Future optimization**: TXT record values still use `std::string` because they contain runtime data (MAC addresses, board names, user lambdas). These could potentially be optimized in a future change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A (discovered during code review)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation fix, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] LibreTiny

## Example entry for `config.yaml`:

No configuration changes - this is an internal implementation fix. Any existing mDNS configuration will work correctly:

```yaml
mdns:
  services:
    - service: "_esphomelib"
      protocol: "_tcp"
      port: 6053
      txt:
        version: "1.0"
        mac: !lambda 'return get_mac_address();'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Note: Existing tests in `tests/components/mdns/` cover functionality. The changes are internal optimizations and bug fixes.

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal implementation fix only
