### PR TITLE
[web_server] Consolidate duplicate client connection checks (saves 288 bytes of flash)

### DIFF
--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -19,72 +19,54 @@ ListEntitiesIterator::~ListEntitiesIterator() {}
 
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::binary_sensor_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_COVER
 bool ListEntitiesIterator::on_cover(cover::Cover *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::cover_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_FAN
 bool ListEntitiesIterator::on_fan(fan::Fan *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::fan_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_LIGHT
 bool ListEntitiesIterator::on_light(light::LightState *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::light_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_SENSOR
 bool ListEntitiesIterator::on_sensor(sensor::Sensor *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::sensor_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_SWITCH
 bool ListEntitiesIterator::on_switch(switch_::Switch *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::switch_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_BUTTON
 bool ListEntitiesIterator::on_button(button::Button *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::button_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_TEXT_SENSOR
 bool ListEntitiesIterator::on_text_sensor(text_sensor::TextSensor *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::text_sensor_all_json_generator);
   return true;
 }
 #endif
 #ifdef USE_LOCK
 bool ListEntitiesIterator::on_lock(lock::Lock *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::lock_all_json_generator);
   return true;
 }
@@ -92,8 +74,6 @@ bool ListEntitiesIterator::on_lock(lock::Lock *obj) {
 
 #ifdef USE_VALVE
 bool ListEntitiesIterator::on_valve(valve::Valve *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::valve_all_json_generator);
   return true;
 }
@@ -101,8 +81,6 @@ bool ListEntitiesIterator::on_valve(valve::Valve *obj) {
 
 #ifdef USE_CLIMATE
 bool ListEntitiesIterator::on_climate(climate::Climate *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::climate_all_json_generator);
   return true;
 }
@@ -110,8 +88,6 @@ bool ListEntitiesIterator::on_climate(climate::Climate *obj) {
 
 #ifdef USE_NUMBER
 bool ListEntitiesIterator::on_number(number::Number *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::number_all_json_generator);
   return true;
 }
@@ -119,8 +95,6 @@ bool ListEntitiesIterator::on_number(number::Number *obj) {
 
 #ifdef USE_DATETIME_DATE
 bool ListEntitiesIterator::on_date(datetime::DateEntity *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::date_all_json_generator);
   return true;
 }
@@ -128,8 +102,6 @@ bool ListEntitiesIterator::on_date(datetime::DateEntity *obj) {
 
 #ifdef USE_DATETIME_TIME
 bool ListEntitiesIterator::on_time(datetime::TimeEntity *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::time_all_json_generator);
   return true;
 }
@@ -137,8 +109,6 @@ bool ListEntitiesIterator::on_time(datetime::TimeEntity *obj) {
 
 #ifdef USE_DATETIME_DATETIME
 bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::datetime_all_json_generator);
   return true;
 }
@@ -146,8 +116,6 @@ bool ListEntitiesIterator::on_datetime(datetime::DateTimeEntity *obj) {
 
 #ifdef USE_TEXT
 bool ListEntitiesIterator::on_text(text::Text *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::text_all_json_generator);
   return true;
 }
@@ -155,8 +123,6 @@ bool ListEntitiesIterator::on_text(text::Text *obj) {
 
 #ifdef USE_SELECT
 bool ListEntitiesIterator::on_select(select::Select *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::select_all_json_generator);
   return true;
 }
@@ -164,8 +130,6 @@ bool ListEntitiesIterator::on_select(select::Select *obj) {
 
 #ifdef USE_ALARM_CONTROL_PANEL
 bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::alarm_control_panel_all_json_generator);
   return true;
 }
@@ -173,8 +137,6 @@ bool ListEntitiesIterator::on_alarm_control_panel(alarm_control_panel::AlarmCont
 
 #ifdef USE_EVENT
 bool ListEntitiesIterator::on_event(event::Event *obj) {
-  if (this->events_->count() == 0)
-    return true;
   // Null event type, since we are just iterating over entities
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::event_all_json_generator);
   return true;
@@ -183,8 +145,6 @@ bool ListEntitiesIterator::on_event(event::Event *obj) {
 
 #ifdef USE_UPDATE
 bool ListEntitiesIterator::on_update(update::UpdateEntity *obj) {
-  if (this->events_->count() == 0)
-    return true;
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::update_all_json_generator);
   return true;
 }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -152,6 +152,10 @@ void DeferredUpdateEventSource::loop() {
 
 void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *event_type,
                                                       message_generator_t *message_generator) {
+  // Skip if no connected clients to avoid unnecessary deferred queue processing
+  if (this->count() == 0)
+    return;
+
   // allow all json "details_all" to go through before publishing bare state events, this avoids unnamed entries showing
   // up in the web GUI and reduces event load during initial connect
   if (!entities_iterator_.completed() && 0 != strcmp(event_type, "state_detail_all"))
@@ -197,6 +201,9 @@ void DeferredUpdateEventSourceList::loop() {
 
 void DeferredUpdateEventSourceList::deferrable_send_state(void *source, const char *event_type,
                                                           message_generator_t *message_generator) {
+  // Skip if no event sources (no connected clients) to avoid unnecessary iteration
+  if (this->empty())
+    return;
   for (DeferredUpdateEventSource *dues : *this) {
     dues->deferrable_send_state(source, event_type, message_generator);
   }
@@ -424,8 +431,6 @@ static JsonDetail get_request_detail(AsyncWebServerRequest *request) {
 
 #ifdef USE_SENSOR
 void WebServer::on_sensor_update(sensor::Sensor *obj, float state) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", sensor_state_json_generator);
 }
 void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -473,8 +478,6 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
 
 #ifdef USE_TEXT_SENSOR
 void WebServer::on_text_sensor_update(text_sensor::TextSensor *obj, const std::string &state) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", text_sensor_state_json_generator);
 }
 void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -514,8 +517,6 @@ std::string WebServer::text_sensor_json(text_sensor::TextSensor *obj, const std:
 
 #ifdef USE_SWITCH
 void WebServer::on_switch_update(switch_::Switch *obj, bool state) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", switch_state_json_generator);
 }
 void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -627,8 +628,6 @@ std::string WebServer::button_json(button::Button *obj, JsonDetail start_config)
 
 #ifdef USE_BINARY_SENSOR
 void WebServer::on_binary_sensor_update(binary_sensor::BinarySensor *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", binary_sensor_state_json_generator);
 }
 void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -667,8 +666,6 @@ std::string WebServer::binary_sensor_json(binary_sensor::BinarySensor *obj, bool
 
 #ifdef USE_FAN
 void WebServer::on_fan_update(fan::Fan *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", fan_state_json_generator);
 }
 void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -743,8 +740,6 @@ std::string WebServer::fan_json(fan::Fan *obj, JsonDetail start_config) {
 
 #ifdef USE_LIGHT
 void WebServer::on_light_update(light::LightState *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", light_state_json_generator);
 }
 void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -819,8 +814,6 @@ std::string WebServer::light_json(light::LightState *obj, JsonDetail start_confi
 
 #ifdef USE_COVER
 void WebServer::on_cover_update(cover::Cover *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", cover_state_json_generator);
 }
 void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -906,8 +899,6 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
 
 #ifdef USE_NUMBER
 void WebServer::on_number_update(number::Number *obj, float state) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", number_state_json_generator);
 }
 void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -975,8 +966,6 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
 
 #ifdef USE_DATETIME_DATE
 void WebServer::on_date_update(datetime::DateEntity *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", date_state_json_generator);
 }
 void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1034,8 +1023,6 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
 
 #ifdef USE_DATETIME_TIME
 void WebServer::on_time_update(datetime::TimeEntity *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", time_state_json_generator);
 }
 void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1092,8 +1079,6 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
 
 #ifdef USE_DATETIME_DATETIME
 void WebServer::on_datetime_update(datetime::DateTimeEntity *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", datetime_state_json_generator);
 }
 void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1151,8 +1136,6 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
 
 #ifdef USE_TEXT
 void WebServer::on_text_update(text::Text *obj, const std::string &state) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", text_state_json_generator);
 }
 void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1212,8 +1195,6 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
 
 #ifdef USE_SELECT
 void WebServer::on_select_update(select::Select *obj, const std::string &state, size_t index) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", select_state_json_generator);
 }
 void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1270,8 +1251,6 @@ std::string WebServer::select_json(select::Select *obj, const std::string &value
 
 #ifdef USE_CLIMATE
 void WebServer::on_climate_update(climate::Climate *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", climate_state_json_generator);
 }
 void WebServer::handle_climate_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1412,8 +1391,6 @@ std::string WebServer::climate_json(climate::Climate *obj, JsonDetail start_conf
 
 #ifdef USE_LOCK
 void WebServer::on_lock_update(lock::Lock *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", lock_state_json_generator);
 }
 void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1485,8 +1462,6 @@ std::string WebServer::lock_json(lock::Lock *obj, lock::LockState value, JsonDet
 
 #ifdef USE_VALVE
 void WebServer::on_valve_update(valve::Valve *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", valve_state_json_generator);
 }
 void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1568,8 +1543,6 @@ std::string WebServer::valve_json(valve::Valve *obj, JsonDetail start_config) {
 
 #ifdef USE_ALARM_CONTROL_PANEL
 void WebServer::on_alarm_control_panel_update(alarm_control_panel::AlarmControlPanel *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", alarm_control_panel_state_json_generator);
 }
 void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *request, const UrlMatch &match) {
@@ -1714,8 +1687,6 @@ static const char *update_state_to_string(update::UpdateState state) {
 }
 
 void WebServer::on_update(update::UpdateEntity *obj) {
-  if (this->events_.empty())
-    return;
   this->events_.deferrable_send_state(obj, "state", update_state_json_generator);
 }
 void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlMatch &match) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -412,6 +412,9 @@ void AsyncEventSource::try_send_nodefer(const char *message, const char *event, 
 
 void AsyncEventSource::deferrable_send_state(void *source, const char *event_type,
                                              message_generator_t *message_generator) {
+  // Skip if no connected clients to avoid unnecessary processing
+  if (this->empty())
+    return;
   for (auto *ses : this->sessions_) {
     if (ses->fd_.load() != 0) {  // Skip dead sessions
       ses->deferrable_send_state(source, event_type, message_generator);


### PR DESCRIPTION
# What does this implement/fix?

Consolidates duplicate `empty()` and `count()` checks in the web_server component to reduce flash usage by 288 bytes.

## Changes

This PR eliminates code duplication by moving client connection checks from 38 individual call sites into 3 base `deferrable_send_state()` implementations:

### Before
Every `on_*_update()` method and `ListEntitiesIterator::on_*()` method checked if clients were connected before calling `deferrable_send_state()`:
```cpp
void WebServer::on_sensor_update(sensor::Sensor *obj, float state) {
  if (this->events_.empty())  // Duplicate check
    return;
  this->events_.deferrable_send_state(obj, "state", sensor_state_json_generator);
}
```

### After
The check is consolidated into `deferrable_send_state()` itself:
```cpp
void WebServer::on_sensor_update(sensor::Sensor *obj, float state) {
  this->events_.deferrable_send_state(obj, "state", sensor_state_json_generator);
}

void DeferredUpdateEventSourceList::deferrable_send_state(...) {
  // Skip if no event sources (no connected clients) to avoid unnecessary iteration
  if (this->empty())
    return;
  // ... rest of implementation
}
```

### Files Changed
- **web_server.cpp**: Removed 18 duplicate `empty()` checks, added 2 consolidated checks
- **list_entities.cpp**: Removed 20 duplicate `count()` checks
- **web_server_idf.cpp**: Added 1 consolidated `empty()` check (ESP32)

### Flash Savings
- **Before**: 1,068,954 bytes
- **After**: 1,068,666 bytes
- **Saved**: 288 bytes (38 duplicate checks eliminated)

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
