### PR TITLE
[web_server] Reduce code duplication in JSON generation with helper functions

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -453,9 +453,9 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
 
   const auto uom_ref = obj->get_unit_of_measurement_ref();
 
-  set_json_value(root, obj, "sensor", value, start_config);
-  root["state"] =
+  std::string state =
       std::isnan(value) ? "NA" : value_accuracy_with_uom_to_string(value, obj->get_accuracy_decimals(), uom_ref);
+  set_json_icon_state_value(root, obj, "sensor", state, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
     if (!uom_ref.empty())
@@ -942,13 +942,13 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
 
   const auto uom_ref = obj->traits.get_unit_of_measurement_ref();
 
-  set_json_id(root, obj, "number", start_config);
-  root["value"] = std::isnan(value)
-                      ? "\"NaN\""
-                      : value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
-  root["state"] = std::isnan(value) ? "NA"
-                                    : value_accuracy_with_uom_to_string(
-                                          value, step_to_accuracy_decimals(obj->traits.get_step()), uom_ref);
+  std::string val_str = std::isnan(value)
+                            ? "\"NaN\""
+                            : value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
+  std::string state_str = std::isnan(value) ? "NA"
+                                            : value_accuracy_with_uom_to_string(
+                                                  value, step_to_accuracy_decimals(obj->traits.get_step()), uom_ref);
+  set_json_icon_state_value(root, obj, "number", state_str, val_str, start_config);
   if (start_config == DETAIL_ALL) {
     root["min_value"] =
         value_accuracy_to_string(obj->traits.get_min_value(), step_to_accuracy_decimals(obj->traits.get_step()));

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1177,11 +1177,11 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_value(root, obj, "text", value, start_config);
+  std::string state = obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD ? "********" : value;
+  set_json_icon_state_value(root, obj, "text", state, value, start_config);
   root["min_length"] = obj->traits.get_min_length();
   root["max_length"] = obj->traits.get_max_length();
   root["pattern"] = obj->traits.get_pattern();
-  root["state"] = obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD ? "********" : value;
   if (start_config == DETAIL_ALL) {
     root["mode"] = (int) obj->traits.get_mode();
     this->add_sorting_info_(root, obj);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -453,10 +453,9 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
 
   const auto uom_ref = obj->get_unit_of_measurement_ref();
 
-  // Build JSON directly inline
-  std::string state =
+  set_json_value(root, obj, "sensor", value, start_config);
+  root["state"] =
       std::isnan(value) ? "NA" : value_accuracy_with_uom_to_string(value, obj->get_accuracy_decimals(), uom_ref);
-  set_json_icon_state_value(root, obj, "sensor", state, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
     if (!uom_ref.empty())
@@ -796,8 +795,7 @@ std::string WebServer::light_json(light::LightState *obj, JsonDetail start_confi
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "light", start_config);
-  root["state"] = obj->remote_values.is_on() ? "ON" : "OFF";
+  set_json_value(root, obj, "light", obj->remote_values.is_on() ? "ON" : "OFF", start_config);
 
   light::LightJSONSchema::dump_json(*obj, root);
   if (start_config == DETAIL_ALL) {
@@ -945,6 +943,12 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
   const auto uom_ref = obj->traits.get_unit_of_measurement_ref();
 
   set_json_id(root, obj, "number", start_config);
+  root["value"] = std::isnan(value)
+                      ? "\"NaN\""
+                      : value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
+  root["state"] = std::isnan(value) ? "NA"
+                                    : value_accuracy_with_uom_to_string(
+                                          value, step_to_accuracy_decimals(obj->traits.get_step()), uom_ref);
   if (start_config == DETAIL_ALL) {
     root["min_value"] =
         value_accuracy_to_string(obj->traits.get_min_value(), step_to_accuracy_decimals(obj->traits.get_step()));
@@ -955,14 +959,6 @@ std::string WebServer::number_json(number::Number *obj, float value, JsonDetail 
     if (!uom_ref.empty())
       root["uom"] = uom_ref;
     this->add_sorting_info_(root, obj);
-  }
-  if (std::isnan(value)) {
-    root["value"] = "\"NaN\"";
-    root["state"] = "NA";
-  } else {
-    root["value"] = value_accuracy_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()));
-    root["state"] =
-        value_accuracy_with_uom_to_string(value, step_to_accuracy_decimals(obj->traits.get_step()), uom_ref);
   }
 
   return builder.serialize();
@@ -1739,8 +1735,8 @@ std::string WebServer::update_json(update::UpdateEntity *obj, JsonDetail start_c
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_value(root, obj, "update", obj->update_info.latest_version, start_config);
-  root["state"] = update_state_to_string(obj->state);
+  set_json_icon_state_value(root, obj, "update", update_state_to_string(obj->state), obj->update_info.latest_version,
+                            start_config);
   if (start_config == DETAIL_ALL) {
     root["current_version"] = obj->update_info.current_version;
     root["title"] = obj->update_info.title;

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -454,12 +454,8 @@ std::string WebServer::sensor_json(sensor::Sensor *obj, float value, JsonDetail 
   const auto uom_ref = obj->get_unit_of_measurement_ref();
 
   // Build JSON directly inline
-  std::string state;
-  if (std::isnan(value)) {
-    state = "NA";
-  } else {
-    state = value_accuracy_with_uom_to_string(value, obj->get_accuracy_decimals(), uom_ref);
-  }
+  std::string state =
+      std::isnan(value) ? "NA" : value_accuracy_with_uom_to_string(value, obj->get_accuracy_decimals(), uom_ref);
   set_json_icon_state_value(root, obj, "sensor", state, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
@@ -1020,10 +1016,8 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "date", start_config);
   std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
-  root["value"] = value;
-  root["state"] = value;
+  set_json_icon_state_value(root, obj, "date", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
   }
@@ -1078,10 +1072,8 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "time", start_config);
   std::string value = str_sprintf("%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
-  root["value"] = value;
-  root["state"] = value;
+  set_json_icon_state_value(root, obj, "time", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
   }
@@ -1136,11 +1128,9 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "datetime", start_config);
   std::string value =
       str_sprintf("%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour, obj->minute, obj->second);
-  root["value"] = value;
-  root["state"] = value;
+  set_json_icon_state_value(root, obj, "datetime", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
   }
@@ -1191,16 +1181,11 @@ std::string WebServer::text_json(text::Text *obj, const std::string &value, Json
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "text", start_config);
+  set_json_value(root, obj, "text", value, start_config);
   root["min_length"] = obj->traits.get_min_length();
   root["max_length"] = obj->traits.get_max_length();
   root["pattern"] = obj->traits.get_pattern();
-  if (obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD) {
-    root["state"] = "********";
-  } else {
-    root["state"] = value;
-  }
-  root["value"] = value;
+  root["state"] = obj->traits.get_mode() == text::TextMode::TEXT_MODE_PASSWORD ? "********" : value;
   if (start_config == DETAIL_ALL) {
     root["mode"] = (int) obj->traits.get_mode();
     this->add_sorting_info_(root, obj);
@@ -1754,8 +1739,7 @@ std::string WebServer::update_json(update::UpdateEntity *obj, JsonDetail start_c
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  set_json_id(root, obj, "update", start_config);
-  root["value"] = obj->update_info.latest_version;
+  set_json_value(root, obj, "update", obj->update_info.latest_version, start_config);
   root["state"] = update_state_to_string(obj->state);
   if (start_config == DETAIL_ALL) {
     root["current_version"] = obj->update_info.current_version;


### PR DESCRIPTION
# What does this implement/fix?

Refactors entity JSON generation in the web_server component to consistently use existing helper functions with ternary operators, reducing code duplication and flash usage by 524 bytes.

## Changes

This PR improves code consistency by using the existing `set_json_value` and `set_json_icon_state_value` helper functions instead of manually calling `set_json_id` and setting individual fields. Ternary operators are used with intermediate string variables for conditional value generation.

### Refactored Methods

**Using `set_json_icon_state_value`** (combines set_json_id + icon + state + value):
- `date_json()` - with intermediate string for formatted date
- `time_json()` - with intermediate string for formatted time
- `datetime_json()` - with intermediate string for formatted datetime
- `sensor_json()` - with ternary for NaN handling
- `number_json()` - with ternary for NaN handling (both value and state)
- `text_json()` - with ternary for password masking
- `update_json()` - with state string conversion

**Using `set_json_value`** (combines set_json_id + value):
- `light_json()` - with ternary for ON/OFF state

### Before
```cpp
std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_config) {
  json::JsonBuilder builder;
  JsonObject root = builder.root();

  set_json_id(root, obj, "date", start_config);
  std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
  root["value"] = value;
  root["state"] = value;
  // ...
}
```

### After
```cpp
std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_config) {
  json::JsonBuilder builder;
  JsonObject root = builder.root();

  std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
  set_json_icon_state_value(root, obj, "date", value, value, start_config);
  // ...
}
```

### Benefits
- **Code consistency**: All entity types now use consistent helper patterns
- **Reduced duplication**: Eliminates repetitive field assignment code across 8 JSON generation methods
- **Flash savings**: 524 bytes saved
- **Maintainability**: Single source of truth for JSON structure in helper functions

### Additional Examples

**sensor_json - Ternary with intermediate string:**
```cpp
// Before
set_json_id(root, obj, "sensor", start_config);
if (std::isnan(value)) {
  root["state"] = "NA";
} else {
  root["state"] = value_accuracy_with_uom_to_string(...);
}
root["value"] = value;

// After
std::string state = std::isnan(value) ? "NA" : value_accuracy_with_uom_to_string(...);
set_json_icon_state_value(root, obj, "sensor", state, value, start_config);
```

**number_json - Ternary with intermediate strings:**
```cpp
// Before
set_json_id(root, obj, "number", start_config);
if (std::isnan(value)) {
  root["value"] = "\"NaN\"";
  root["state"] = "NA";
} else {
  root["value"] = value_accuracy_to_string(...);
  root["state"] = value_accuracy_with_uom_to_string(...);
}

// After
std::string val_str = std::isnan(value) ? "\"NaN\"" : value_accuracy_to_string(...);
std::string state_str = std::isnan(value) ? "NA" : value_accuracy_with_uom_to_string(...);
set_json_icon_state_value(root, obj, "number", state_str, val_str, start_config);
```

### Flash Savings
- **Before**: 1,068,954 bytes
- **After**: 1,068,430 bytes
- **Saved**: 524 bytes

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
