### PR TITLE
[esp32] Update IDF 5.5 and Arduino 3.3 to use 55.03.31-1

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -318,6 +318,7 @@ ARDUINO_FRAMEWORK_VERSION_LOOKUP = {
     "dev": cv.Version(3, 3, 1),
 }
 ARDUINO_PLATFORM_VERSION_LOOKUP = {
+    cv.Version(3, 3, 2): cv.Version(55, 3, 31, "1"),
     cv.Version(3, 3, 1): cv.Version(55, 3, 31, "1"),
     cv.Version(3, 3, 0): cv.Version(55, 3, 30, "2"),
     cv.Version(3, 2, 1): cv.Version(54, 3, 21, "2"),
@@ -353,7 +354,7 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
 PLATFORM_VERSION_LOOKUP = {
     "recommended": cv.Version(54, 3, 21, "2"),
     "latest": cv.Version(55, 3, 31, "1"),
-    "dev": "https://github.com/pioarduino/platform-espressif32.git#develop",
+    "dev": cv.Version(55, 3, 31, "1"),
 }
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -318,7 +318,7 @@ ARDUINO_FRAMEWORK_VERSION_LOOKUP = {
     "dev": cv.Version(3, 3, 1),
 }
 ARDUINO_PLATFORM_VERSION_LOOKUP = {
-    cv.Version(3, 3, 1): cv.Version(55, 3, 31),
+    cv.Version(3, 3, 1): cv.Version(55, 3, 31, "1"),
     cv.Version(3, 3, 0): cv.Version(55, 3, 30, "2"),
     cv.Version(3, 2, 1): cv.Version(54, 3, 21, "2"),
     cv.Version(3, 2, 0): cv.Version(54, 3, 20),
@@ -336,8 +336,8 @@ ESP_IDF_FRAMEWORK_VERSION_LOOKUP = {
     "dev": cv.Version(5, 5, 1),
 }
 ESP_IDF_PLATFORM_VERSION_LOOKUP = {
-    cv.Version(5, 5, 1): cv.Version(55, 3, 31),
-    cv.Version(5, 5, 0): cv.Version(55, 3, 31),
+    cv.Version(5, 5, 1): cv.Version(55, 3, 31, "1"),
+    cv.Version(5, 5, 0): cv.Version(55, 3, 31, "1"),
     cv.Version(5, 4, 2): cv.Version(54, 3, 21, "2"),
     cv.Version(5, 4, 1): cv.Version(54, 3, 21, "2"),
     cv.Version(5, 4, 0): cv.Version(54, 3, 21, "2"),
@@ -352,7 +352,7 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
 #  - https://github.com/pioarduino/platform-espressif32/releases
 PLATFORM_VERSION_LOOKUP = {
     "recommended": cv.Version(54, 3, 21, "2"),
-    "latest": cv.Version(55, 3, 31),
+    "latest": cv.Version(55, 3, 31, "1"),
     "dev": "https://github.com/pioarduino/platform-espressif32.git#develop",
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Update to IDF 5.5 and Arduino 3.3 to use 55.03.31-1, required after the pydantic break. 

Change dev to use a fixed platform so it wont randomly break.  

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
