### PR TITLE
[ci] Reduce component test group size to prevent runner disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           ./script/test_build_components -e compile -c ${{ matrix.file }}
 
   test-build-components-splitter:
-    name: Split components for testing into 20 groups maximum
+    name: Split components for testing into 14 components per group
     runs-on: ubuntu-24.04
     needs:
       - common
@@ -402,10 +402,10 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Split components into 20 groups
+      - name: Split components into groups of 14
         id: split
         run: |
-          components=$(echo '${{ needs.determine-jobs.outputs.changed-components }}' | jq -c '.[]' | shuf | jq -s -c '[_nwise(20) | join(" ")]')
+          components=$(echo '${{ needs.determine-jobs.outputs.changed-components }}' | jq -c '.[]' | shuf | jq -s -c '[_nwise(14) | join(" ")]')
           echo "components=$components" >> $GITHUB_OUTPUT
 
   test-build-components-split:


### PR DESCRIPTION
# What does this implement/fix?

Reduces the component test group size from 20 to 14 components per group to prevent GitHub Actions runners from running out of disk space during CI builds.

## Problem

The release PR #11115 is experiencing CI failures due to disk space exhaustion on GitHub Actions runners. 9 out of 27 component test jobs failed with:
```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251008-084918-utc.log'
```

The current configuration groups components into batches of 20, which creates ~27 test jobs. Each job compiles all components for multiple platforms (esp32-ard, esp32-c3-ard, esp32-idf, esp32-c3-idf, esp8266, etc.), generating large amounts of build artifacts that fill up the runner disk.

## Solution

By reducing the group size from 20 to 14 components per group, we increase the number of jobs from ~27 to ~38 (for 529 components), while reducing disk usage per job by 30%. This provides a better balance between:
- **Disk usage**: Smaller groups compile fewer components, using less disk space
- **Parallelization**: Still maintains reasonable job count (max-parallel: 4)
- **CI time**: Marginal increase in total time due to more jobs, but prevents failures

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes CI failures in #11115 due to runner disk space exhaustion

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a CI infrastructure change

## Test Environment

- [x] All platforms (CI infrastructure change affecting all test runners)

## Example entry for `config.yaml`:

N/A - This is a CI infrastructure change, no user-facing configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).