### PR TITLE
[ci] Reduce component test group size to 10 to prevent runner disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           ./script/test_build_components -e compile -c ${{ matrix.file }}
 
   test-build-components-splitter:
-    name: Split components for testing into 14 components per group
+    name: Split components for testing into 10 components per group
     runs-on: ubuntu-24.04
     needs:
       - common
@@ -402,10 +402,10 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Split components into groups of 14
+      - name: Split components into groups of 10
         id: split
         run: |
-          components=$(echo '${{ needs.determine-jobs.outputs.changed-components }}' | jq -c '.[]' | shuf | jq -s -c '[_nwise(14) | join(" ")]')
+          components=$(echo '${{ needs.determine-jobs.outputs.changed-components }}' | jq -c '.[]' | shuf | jq -s -c '[_nwise(10) | join(" ")]')
           echo "components=$components" >> $GITHUB_OUTPUT
 
   test-build-components-split:


### PR DESCRIPTION
# What does this implement/fix?

Reduces the component test group size from 14 to 10 components per group to prevent CI runner disk exhaustion during parallel component testing.

The previous reduction to 14 components was still causing disk space issues on GitHub runners. This further reduction to 10 components per group should provide more headroom and prevent build failures due to insufficient disk space.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Follows up on the recent commit that reduced it to 14 (82bdb0888)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - CI infrastructure change only

## Test Environment

- N/A - CI infrastructure change only

## Example entry for `config.yaml`:

N/A - CI infrastructure change only

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
