### PR TITLE
[ci][ethernet][tests] Remove redundant Arduino tests for ethernet PHYs

### DIFF
--- a/tests/components/ethernet/test-dm9051.esp32-ard.yaml
+++ b/tests/components/ethernet/test-dm9051.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-dm9051.yaml

--- a/tests/components/ethernet/test-dp83848.esp32-ard.yaml
+++ b/tests/components/ethernet/test-dp83848.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-dp83848.yaml

--- a/tests/components/ethernet/test-ip101.esp32-ard.yaml
+++ b/tests/components/ethernet/test-ip101.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-ip101.yaml

--- a/tests/components/ethernet/test-ksz8081.esp32-ard.yaml
+++ b/tests/components/ethernet/test-ksz8081.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-ksz8081.yaml

--- a/tests/components/ethernet/test-ksz8081rna.esp32-ard.yaml
+++ b/tests/components/ethernet/test-ksz8081rna.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-ksz8081rna.yaml

--- a/tests/components/ethernet/test-lan8670.esp32-ard.yaml
+++ b/tests/components/ethernet/test-lan8670.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-lan8670.yaml

--- a/tests/components/ethernet/test-lan8720.esp32-ard.yaml
+++ b/tests/components/ethernet/test-lan8720.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-lan8720.yaml

--- a/tests/components/ethernet/test-rtl8201.esp32-ard.yaml
+++ b/tests/components/ethernet/test-rtl8201.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-rtl8201.yaml

--- a/tests/components/ethernet/test-w5500.esp32-ard.yaml
+++ b/tests/components/ethernet/test-w5500.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-w5500.yaml


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #11136. Removes redundant ESP32 Arduino test files for ethernet PHYs that don't have framework-specific code.

## Background

After the initial cleanup in #11136, the ethernet component still had Arduino test files for PHYs that don't use `USE_ARDUINO` defines. Only the JL1101 PHY has conditional Arduino code - all other PHYs use common code that works on both Arduino and ESP-IDF frameworks.

## Changes

Removes ethernet PHY Arduino test files where:
- Corresponding ESP-IDF test files already exist
- No framework-specific code in the PHY implementation

**Removed:**
- `test-dm9051.esp32-ard.yaml`
- `test-dp83848.esp32-ard.yaml`
- `test-ip101.esp32-ard.yaml`
- `test-ksz8081.esp32-ard.yaml`
- `test-ksz8081rna.esp32-ard.yaml`
- `test-lan8670.esp32-ard.yaml`
- `test-lan8720.esp32-ard.yaml`
- `test-rtl8201.esp32-ard.yaml`
- `test-w5500.esp32-ard.yaml`

**Kept:**
- `test-jl1101.esp32-ard.yaml` (has `USE_ARDUINO` conditional code in `esp_eth_phy_jl1101.c`)

All removed tests have corresponding `-idf.yaml` versions that provide the same coverage.

## Benefits

- **Reduces CI test time** by eliminating redundant ethernet test configurations
- **Simplifies maintenance** for ethernet PHY tests
- **Consistent with #11136** - removes Arduino tests where IDF coverage exists

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (CI/test infrastructure cleanup)

**Related issue or feature (if applicable):**

- Follow-up to #11136

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
