### PR TITLE
[ci][improv_serial][tests] Remove redundant ESP32 Arduino test files

### DIFF
--- a/tests/components/improv_serial/test-uart0.esp32-ard.yaml
+++ b/tests/components/improv_serial/test-uart0.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-uart0.yaml

--- a/tests/components/improv_serial/test-uart0.esp32-c3-ard.yaml
+++ b/tests/components/improv_serial/test-uart0.esp32-c3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-uart0.yaml

--- a/tests/components/improv_serial/test-uart0.esp32-s2-ard.yaml
+++ b/tests/components/improv_serial/test-uart0.esp32-s2-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-uart0.yaml

--- a/tests/components/improv_serial/test-uart0.esp32-s3-ard.yaml
+++ b/tests/components/improv_serial/test-uart0.esp32-s3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-uart0.yaml

--- a/tests/components/improv_serial/test-usb_cdc.esp32-c3-ard.yaml
+++ b/tests/components/improv_serial/test-usb_cdc.esp32-c3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-usb_cdc.yaml

--- a/tests/components/improv_serial/test-usb_cdc.esp32-s2-ard.yaml
+++ b/tests/components/improv_serial/test-usb_cdc.esp32-s2-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-usb_cdc.yaml

--- a/tests/components/improv_serial/test-usb_cdc.esp32-s3-ard.yaml
+++ b/tests/components/improv_serial/test-usb_cdc.esp32-s3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common-usb_cdc.yaml


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #11136. Removes redundant ESP32 Arduino test files for `improv_serial` component.

## Background

The `improv_serial` component uses conditional compilation with this pattern:

```cpp
#ifdef USE_ESP32
  // ESP32-specific code (both Arduino and IDF use this path)
#elif defined(USE_ARDUINO)
  // Non-ESP32 Arduino code (ESP8266, RP2040)
#endif
```

On ESP32, both Arduino and ESP-IDF use the same `USE_ESP32` code path. The `USE_ARDUINO` code path is only used by non-ESP32 platforms (ESP8266, RP2040). Therefore, the ESP32 Arduino test files are redundant since the IDF tests already cover the same code.

## Changes

Removes ESP32 Arduino test files for `improv_serial` where:
- Corresponding ESP-IDF test files already exist
- Both Arduino and IDF use the same `USE_ESP32` code path

**Removed (7 files):**
- `test-uart0.esp32-ard.yaml`
- `test-uart0.esp32-c3-ard.yaml`
- `test-uart0.esp32-s2-ard.yaml`
- `test-uart0.esp32-s3-ard.yaml`
- `test-usb_cdc.esp32-c3-ard.yaml`
- `test-usb_cdc.esp32-s2-ard.yaml`
- `test-usb_cdc.esp32-s3-ard.yaml`

**Kept (correctly):**
- `test-uart0.esp8266-ard.yaml` - ESP8266 uses `USE_ARDUINO` code path
- `test-uart0.rp2040-ard.yaml` - RP2040 uses `USE_ARDUINO` code path
- `test-usb_cdc.rp2040-ard.yaml` - RP2040 uses `USE_ARDUINO` code path

All removed tests have corresponding ESP-IDF test files that provide the same coverage for the ESP32 code path.

## Benefits

- **Reduces CI test time** by eliminating redundant test configurations
- **Simplifies maintenance** for improv_serial tests
- **Consistent with #11136** - removes Arduino tests where IDF coverage exists

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (CI/test infrastructure cleanup)

**Related issue or feature (if applicable):**

- Follow-up to #11136

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
