### PR TITLE
[esp32] Update migration warning for Arduino-as-IDF-component transition

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -656,6 +656,7 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
         + "Why change? ESP-IDF offers:\n"
         + color(AnsiFore.GREEN, "  ✨ Up to 40% smaller binaries\n")
         + color(AnsiFore.GREEN, "  🚀 Better performance and optimization\n")
+        + color(AnsiFore.GREEN, "  ⚡ 2-3x faster compile times\n")
         + color(AnsiFore.GREEN, "  📦 Custom-built firmware for your exact needs\n")
         + color(
             AnsiFore.GREEN,
@@ -663,7 +664,6 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
         )
         + "\n"
         + "Trade-offs:\n"
-        + color(AnsiFore.YELLOW, "  ⏱️  Compile times are ~25% longer\n")
         + color(AnsiFore.YELLOW, "  🔄 Some components need migration\n")
         + "\n"
         + "What should I do?\n"


### PR DESCRIPTION
# What does this implement/fix?

Updates the ESP32 framework migration warning message to reflect the compile time changes introduced by PR #10647 (Arduino-as-IDF-component transition).

## Background

PR #10647 fundamentally changed how Arduino builds work by migrating from **pre-compiled Arduino libraries** to **compiling Arduino from source as an ESP-IDF component**. This had a significant impact on compile times that wasn't reflected in the migration warning.

**Before PR #10647:**
- Arduino used pre-compiled libraries (fast to link)
- ESP-IDF compiled everything from source
- The migration warning correctly stated "Compile times are ~25% longer" for ESP-IDF

**After PR #10647:**
- Arduino now compiles from source as an IDF component (slower)
- Pure ESP-IDF builds don't have Arduino framework overhead (faster)
- **ESP-IDF is now 2-3x faster** than Arduino builds
- The migration warning was never updated and still claimed ESP-IDF was slower

This outdated message actively **discouraged** users from migrating to the faster framework.

## Changes

1. **Removed misleading compile time warning** from trade-offs section
2. **Added compile time as a benefit** of ESP-IDF:
   - "⚡ 2-3x faster compile times" (in green, alongside other benefits)

### Before:
```
Why change? ESP-IDF offers:
  ✨ Up to 40% smaller binaries
  🚀 Better performance and optimization
  📦 Custom-built firmware for your exact needs
  🔧 Active development and testing by ESPHome developers

Trade-offs:
  ⏱️  Compile times are ~25% longer  ← WRONG!
  🔄 Some components need migration
```

### After:
```
Why change? ESP-IDF offers:
  ✨ Up to 40% smaller binaries
  🚀 Better performance and optimization
  ⚡ 2-3x faster compile times  ← NEW!
  📦 Custom-built firmware for your exact needs
  🔧 Active development and testing by ESPHome developers

Trade-offs:
  🔄 Some components need migration
```

## Benefits

- **Accurate information** - Users now see the true compile time advantage of ESP-IDF
- **Better migration encouragement** - Faster compiles (2-3x) are a compelling reason to migrate from Arduino
- **Removes false barrier** - The old message incorrectly discouraged migration by claiming ESP-IDF was slower
- **Reflects reality** - Since Arduino is now compiled from source as an IDF component (not pre-compiled), it has significant compile time overhead

## Types of changes

- [x] Other (Fix outdated migration help message)

**Related issue or feature (if applicable):**

- Follow-up to #10647 (Arduino-as-IDF-component transition)
- Updates migration warning to reflect new compile time reality

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This only affects the warning message shown when framework is not specified

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
