### PR TITLE
[ci][debug][tests] Remove redundant ESP32 variant Arduino test files

### DIFF
--- a/tests/components/debug/test.esp32-c3-ard.yaml
+++ b/tests/components/debug/test.esp32-c3-ard.yaml
@@ -1,4 +1,0 @@
-<<: !include common.yaml
-
-esp32:
-  cpu_frequency: 80MHz

--- a/tests/components/debug/test.esp32-s2-ard.yaml
+++ b/tests/components/debug/test.esp32-s2-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml

--- a/tests/components/debug/test.esp32-s3-ard.yaml
+++ b/tests/components/debug/test.esp32-s3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Removes redundant ESP32 variant Arduino test files for the `debug` component. A single Arduino test is sufficient to verify framework-specific code since the Arduino-specific functionality is not variant-specific.

## Background

As part of the ongoing effort to reduce Arduino-specific test redundancy (esphome/backlog#66), this PR removes redundant ESP32 variant Arduino debug tests.

**Analysis of ESP32 debug component:**
- The debug component **does have Arduino-specific code** for ESP32:
  - Flash chip information via `ESP.getFlashChipMode()`, `ESP.getFlashChipSize()`, `ESP.getFlashChipSpeed()`
  - Framework detection (`#ifdef USE_ARDUINO` vs `#ifdef USE_ESP_IDF`)

- However, this Arduino-specific code is **identical across all ESP32 variants**
- The flash chip API calls and framework detection logic don't differ between ESP32, ESP32-C3, ESP32-S2, and ESP32-S3

Since the Arduino-specific code is the same for all variants, we only need **one** Arduino test to verify the Arduino code paths work correctly.

## Changes

### Test Files Removed

- `tests/components/debug/test.esp32-c3-ard.yaml` (redundant - same code as ESP32)
- `tests/components/debug/test.esp32-s2-ard.yaml` (redundant - same code as ESP32)
- `tests/components/debug/test.esp32-s3-ard.yaml` (redundant - same code as ESP32)

### Test Files Retained

- `tests/components/debug/test.esp32-ard.yaml` (kept to test Arduino-specific flash chip APIs and framework detection)
- IDF tests for all variants (test non-Arduino code paths)

## Benefits

- **Reduces CI test time** - 3 fewer redundant test configurations
- **Maintains Arduino coverage** - Still tests Arduino-specific code with ESP32 test
- **Simplifies maintenance** - One Arduino test instead of four identical ones

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of esphome/backlog#66 - Remove redundant ESP32 Arduino tests

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
