### PR TITLE
[network][ci][tests] Remove redundant ESP32 Arduino test files

### DIFF
--- a/tests/components/network/test-ipv6.esp32-ard.yaml
+++ b/tests/components/network/test-ipv6.esp32-ard.yaml
@@ -1,4 +1,0 @@
-substitutions:
-  network_enable_ipv6: "true"
-
-<<: !include common.yaml

--- a/tests/components/network/test-ipv6.esp32-c3-ard.yaml
+++ b/tests/components/network/test-ipv6.esp32-c3-ard.yaml
@@ -1,4 +1,0 @@
-substitutions:
-  network_enable_ipv6: "true"
-
-<<: !include common.yaml

--- a/tests/components/network/test.esp32-ard.yaml
+++ b/tests/components/network/test.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml

--- a/tests/components/network/test.esp32-c3-ard.yaml
+++ b/tests/components/network/test.esp32-c3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Removes redundant ESP32 Arduino test files for the `network` component. The ESP-IDF tests provide complete coverage since the network component has no framework-specific implementation differences.

## Background

As part of the ongoing effort to reduce Arduino-specific test redundancy (esphome/backlog#66), this PR removes ESP32 Arduino network tests that duplicate IDF test coverage.

**Analysis of network component:**
- `esphome/components/network/util.cpp` contains no framework-specific code
- While `esphome/components/network/ip_address.h` has Arduino-specific type conversion operators (lines 67-69, 117-119), these are only type adapters that allow interoperability with Arduino's `IPAddress` type
- The type conversions don't change any logic or behavior - they're just for type compatibility
- The conversion operators are not used anywhere else in the codebase
- Implementation is identical across all frameworks and variants

Since the network implementation behavior is identical for both Arduino and ESP-IDF frameworks, the IDF tests provide complete coverage.

## Changes

### Test Files Removed

- `tests/components/network/test.esp32-ard.yaml`
- `tests/components/network/test.esp32-c3-ard.yaml`
- `tests/components/network/test-ipv6.esp32-ard.yaml`
- `tests/components/network/test-ipv6.esp32-c3-ard.yaml`

### Test Coverage Maintained

ESP-IDF test files remain and cover both frameworks:
- `tests/components/network/test.esp32-idf.yaml`
- `tests/components/network/test.esp32-c3-idf.yaml`
- `tests/components/network/test-ipv6.esp32-idf.yaml`
- `tests/components/network/test-ipv6.esp32-c3-idf.yaml`

### Platform-Specific Tests Retained

Arduino tests remain for other platforms:
- ESP8266 Arduino tests
- RP2040 Arduino tests
- BK72xx tests

## Benefits

- **Reduces CI test time** - 4 fewer redundant test configurations
- **Simplifies maintenance** - Single source of truth for ESP32 network tests
- **Maintains coverage** - IDF tests cover both frameworks for ESP32

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of esphome/backlog#66 - Remove redundant ESP32 Arduino tests

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
