### PR TITLE
[opentherm][ci][tests] Remove redundant ESP32 Arduino tests and simplify conditionals

### DIFF
--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -7,7 +7,7 @@
 
 #include "opentherm.h"
 #include "esphome/core/helpers.h"
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
 #include "driver/timer.h"
 #include "esp_err.h"
 #endif
@@ -31,7 +31,7 @@ OpenTherm *OpenTherm::instance = nullptr;
 OpenTherm::OpenTherm(InternalGPIOPin *in_pin, InternalGPIOPin *out_pin, int32_t device_timeout)
     : in_pin_(in_pin),
       out_pin_(out_pin),
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
       timer_group_(TIMER_GROUP_0),
       timer_idx_(TIMER_0),
 #endif
@@ -57,7 +57,7 @@ bool OpenTherm::initialize() {
   this->out_pin_->setup();
   this->out_pin_->digital_write(true);
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
   return this->init_esp32_timer_();
 #else
   return true;
@@ -238,7 +238,7 @@ void IRAM_ATTR OpenTherm::write_bit_(uint8_t high, uint8_t clock) {
   }
 }
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
 
 bool OpenTherm::init_esp32_timer_() {
   // Search for a free timer. Maybe unstable, we'll see.
@@ -365,7 +365,7 @@ void IRAM_ATTR OpenTherm::stop_timer_() {
   }
 }
 
-#endif  // END ESP32
+#endif  // ESP32
 
 #ifdef ESP8266
 // 5 kHz timer_

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -7,7 +7,7 @@
 
 #include "opentherm.h"
 #include "esphome/core/helpers.h"
-#ifdef ESP32
+#ifdef USE_ESP32
 #include "driver/timer.h"
 #include "esp_err.h"
 #endif
@@ -31,7 +31,7 @@ OpenTherm *OpenTherm::instance = nullptr;
 OpenTherm::OpenTherm(InternalGPIOPin *in_pin, InternalGPIOPin *out_pin, int32_t device_timeout)
     : in_pin_(in_pin),
       out_pin_(out_pin),
-#ifdef ESP32
+#ifdef USE_ESP32
       timer_group_(TIMER_GROUP_0),
       timer_idx_(TIMER_0),
 #endif
@@ -57,7 +57,7 @@ bool OpenTherm::initialize() {
   this->out_pin_->setup();
   this->out_pin_->digital_write(true);
 
-#ifdef ESP32
+#ifdef USE_ESP32
   return this->init_esp32_timer_();
 #else
   return true;
@@ -238,7 +238,7 @@ void IRAM_ATTR OpenTherm::write_bit_(uint8_t high, uint8_t clock) {
   }
 }
 
-#ifdef ESP32
+#ifdef USE_ESP32
 
 bool OpenTherm::init_esp32_timer_() {
   // Search for a free timer. Maybe unstable, we'll see.
@@ -365,7 +365,7 @@ void IRAM_ATTR OpenTherm::stop_timer_() {
   }
 }
 
-#endif  // ESP32
+#endif  // USE_ESP32
 
 #ifdef ESP8266
 // 5 kHz timer_

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -12,7 +12,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
 #include "driver/timer.h"
 #endif
 
@@ -356,7 +356,7 @@ class OpenTherm {
   ISRInternalGPIOPin isr_in_pin_;
   ISRInternalGPIOPin isr_out_pin_;
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
   timer_group_t timer_group_;
   timer_idx_t timer_idx_;
 #endif
@@ -370,7 +370,7 @@ class OpenTherm {
   int32_t timeout_counter_;  // <0 no timeout
   int32_t device_timeout_;
 
-#if defined(ESP32) || defined(USE_ESP_IDF)
+#ifdef ESP32
   esp_err_t timer_error_ = ESP_OK;
   TimerErrorType timer_error_type_ = TimerErrorType::NO_TIMER_ERROR;
 

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -12,7 +12,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef ESP32
+#ifdef USE_ESP32
 #include "driver/timer.h"
 #endif
 
@@ -356,7 +356,7 @@ class OpenTherm {
   ISRInternalGPIOPin isr_in_pin_;
   ISRInternalGPIOPin isr_out_pin_;
 
-#ifdef ESP32
+#ifdef USE_ESP32
   timer_group_t timer_group_;
   timer_idx_t timer_idx_;
 #endif
@@ -370,7 +370,7 @@ class OpenTherm {
   int32_t timeout_counter_;  // <0 no timeout
   int32_t device_timeout_;
 
-#ifdef ESP32
+#ifdef USE_ESP32
   esp_err_t timer_error_ = ESP_OK;
   TimerErrorType timer_error_type_ = TimerErrorType::NO_TIMER_ERROR;
 

--- a/tests/components/opentherm/test.esp32-ard.yaml
+++ b/tests/components/opentherm/test.esp32-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml

--- a/tests/components/opentherm/test.esp32-c3-ard.yaml
+++ b/tests/components/opentherm/test.esp32-c3-ard.yaml
@@ -1,1 +1,0 @@
-<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Removes redundant ESP32 Arduino test files for the `opentherm` component and cleans up redundant preprocessor conditionals. The ESP-IDF tests provide complete coverage since the opentherm component has no framework-specific implementation differences for ESP32.

Also fixes incorrect preprocessor conditionals - changes `#if defined(ESP32) || defined(USE_ESP_IDF)` to `#ifdef USE_ESP32`. The macro `ESP32` is only defined for the original ESP32 variant, while `USE_ESP32` covers all ESP32 variants (C3, S2, S3, etc.). The `|| defined(USE_ESP_IDF)` was unnecessary since ESP-IDF can only run on ESP32 platforms.

## Background

As part of the ongoing effort to reduce Arduino-specific test redundancy (esphome/backlog#66), this PR removes ESP32 Arduino tests that duplicate IDF test coverage.

**Analysis of opentherm component:**
- Previously used `#if defined(ESP32) || defined(USE_ESP_IDF)` to check for ESP32 **platform**
- This was incorrect: `ESP32` is only defined for the original ESP32 variant, not C3/S2/S3
- Changed to `#ifdef USE_ESP32` which covers all ESP32 variants
- The `|| defined(USE_ESP_IDF)` part was unnecessary since ESP-IDF can only run on ESP32 platforms
- ESP32 timer APIs (`timer_init`, `timer_set_counter_value`, `timer_isr_callback_add`) are ESP-IDF APIs
- These timer APIs work identically in both Arduino and ESP-IDF frameworks since Arduino is now built on ESP-IDF
- Only ESP8266 has framework-specific code (using Arduino's `timer1_*` functions)
- ESP32 implementation is identical across frameworks

## Changes

### Code Cleanup

**OpenTherm component:**
- Fixed incorrect `#if defined(ESP32) || defined(USE_ESP_IDF)` to `#ifdef USE_ESP32` in:
  - `esphome/components/opentherm/opentherm.h` (3 locations)
  - `esphome/components/opentherm/opentherm.cpp` (4 locations)
- `ESP32` is only defined for the original ESP32 variant, not C3/S2/S3
- `USE_ESP32` correctly covers all ESP32 variants
- The `|| defined(USE_ESP_IDF)` part was unnecessary since ESP-IDF can only be defined on ESP32 platforms

### Test Files Removed

- `tests/components/opentherm/test.esp32-ard.yaml`
- `tests/components/opentherm/test.esp32-c3-ard.yaml`

### Test Coverage Maintained

ESP-IDF test files remain and cover both frameworks:
- `tests/components/opentherm/test.esp32-idf.yaml`
- `tests/components/opentherm/test.esp32-c3-idf.yaml`

### Platform-Specific Tests Retained

Arduino tests remain for ESP8266 (uses Arduino-specific `timer1_*` functions):
- `tests/components/opentherm/test.esp8266-ard.yaml`

## Benefits

- **Reduces CI test time** - 2 fewer redundant test configurations
- **Simplifies code** - Removes redundant preprocessor conditionals
- **Maintains coverage** - IDF tests cover both frameworks for ESP32

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of esphome/backlog#66 - Remove redundant ESP32 Arduino tests

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
