### PR TITLE
[mdns] Restore mdns_txt_record() public API for external components

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -11,7 +11,7 @@ from esphome.const import (
     CONF_SERVICES,
     PlatformFramework,
 )
-from esphome.core import CORE, coroutine_with_priority
+from esphome.core import CORE, Lambda, coroutine_with_priority
 from esphome.coroutine import CoroPriority
 
 CODEOWNERS = ["@esphome/core"]
@@ -58,9 +58,64 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
+def mdns_txt_record(key: str, value: str) -> cg.RawExpression:
+    """Create a mDNS TXT record.
+
+    Public API for external components. Do not remove.
+
+    Args:
+        key: The TXT record key
+        value: The TXT record value (static string only)
+
+    Returns:
+        A RawExpression representing a MDNSTXTRecord struct
+    """
+    return cg.RawExpression(
+        f"{{MDNS_STR({cg.safe_exp(key)}), MDNS_STR({cg.safe_exp(value)})}}"
+    )
+
+
+async def _mdns_txt_record_templated(
+    mdns_comp: cg.Pvariable, key: str, value: Lambda | str
+) -> cg.RawExpression:
+    """Create a mDNS TXT record with support for templated values.
+
+    Internal helper function.
+
+    Args:
+        mdns_comp: The MDNSComponent instance (from cg.get_variable())
+        key: The TXT record key
+        value: The TXT record value (can be a static string or a lambda template)
+
+    Returns:
+        A RawExpression representing a MDNSTXTRecord struct
+    """
+    if not cg.is_template(value):
+        # It's a static string - use directly in flash, no need to store in vector
+        return mdns_txt_record(key, value)
+    # It's a lambda - evaluate and store using helper
+    templated_value = await cg.templatable(value, [], cg.std_string)
+    safe_key = cg.safe_exp(key)
+    dynamic_call = f"{mdns_comp}->add_dynamic_txt_value(({templated_value})())"
+    return cg.RawExpression(f"{{MDNS_STR({safe_key}), MDNS_STR({dynamic_call})}}")
+
+
 def mdns_service(
     service: str, proto: str, port: int, txt_records: list[dict[str, str]]
-):
+) -> cg.StructInitializer:
+    """Create a mDNS service.
+
+    Public API for external components. Do not remove.
+
+    Args:
+        service: Service name (e.g., "_http")
+        proto: Protocol (e.g., "_tcp" or "_udp")
+        port: Port number
+        txt_records: List of MDNSTXTRecord expressions
+
+    Returns:
+        A StructInitializer representing a MDNSService struct
+    """
     return cg.StructInitializer(
         MDNSService,
         ("service_type", cg.RawExpression(f"MDNS_STR({cg.safe_exp(service)})")),
@@ -120,26 +175,10 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     for service in config[CONF_SERVICES]:
-        # Build the txt records list for the service
-        txt_records = []
-        for txt_key, txt_value in service[CONF_TXT].items():
-            if cg.is_template(txt_value):
-                # It's a lambda - evaluate and store using helper
-                templated_value = await cg.templatable(txt_value, [], cg.std_string)
-                safe_key = cg.safe_exp(txt_key)
-                dynamic_call = f"{var}->add_dynamic_txt_value(({templated_value})())"
-                txt_records.append(
-                    cg.RawExpression(
-                        f"{{MDNS_STR({safe_key}), MDNS_STR({dynamic_call})}}"
-                    )
-                )
-            else:
-                # It's a static string - use directly in flash, no need to store in vector
-                txt_records.append(
-                    cg.RawExpression(
-                        f"{{MDNS_STR({cg.safe_exp(txt_key)}), MDNS_STR({cg.safe_exp(txt_value)})}}"
-                    )
-                )
+        txt_records = [
+            await _mdns_txt_record_templated(var, txt_key, txt_value)
+            for txt_key, txt_value in service[CONF_TXT].items()
+        ]
 
         exp = mdns_service(
             service[CONF_SERVICE],

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -101,7 +101,7 @@ async def _mdns_txt_record_templated(
 
 
 def mdns_service(
-    service: str, proto: str, port: int, txt_records: list[dict[str, str]]
+    service: str, proto: str, port: int, txt_records: list[cg.RawExpression]
 ) -> cg.StructInitializer:
     """Create a mDNS service.
 


### PR DESCRIPTION
# What does this implement/fix?

Restores backward compatibility for external components using the mDNS component API after the memory optimization changes in #11114.

## Changes:

1. **Restores `mdns_txt_record()` function** - Public API for external components to create static TXT records
2. **Adds `mdns_service()` documentation** - Documents this function as part of the public API
3. **Refactors internal code** - Uses helper function `_mdns_txt_record_templated()` to reduce code duplication

This ensures external components (like [lvgl-ddp-stream](https://github.com/stuartparmenter/lvgl-ddp-stream)) can continue using the mDNS API without breaking changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11156

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This restores existing API, no documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example for external components using the restored API

esphome:
  name: test-mdns-api

esp32:
  board: esp32dev
  framework:
    type: esp-idf

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

mdns:
  services:
    - service: _myservice
      protocol: _tcp
      port: 8080
      txt:
        txtvers: "1"
        key: "value"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).