### PR TITLE
[json] Fix PSRAM allocator dangling pointer crash

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -11,6 +11,7 @@ static const char *const TAG = "json";
 #ifdef USE_PSRAM
 // Global allocator that outlives all JsonDocuments returned by parse_json()
 // This prevents dangling pointer issues when JsonDocuments are returned from functions
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables) - Must be mutable for ArduinoJson::Allocator
 static SpiRamAllocator global_json_allocator;
 #endif
 

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -8,6 +8,12 @@ namespace json {
 
 static const char *const TAG = "json";
 
+#ifdef USE_PSRAM
+// Global allocator that outlives all JsonDocuments returned by parse_json()
+// This prevents dangling pointer issues when JsonDocuments are returned from functions
+static SpiRamAllocator global_json_allocator;
+#endif
+
 std::string build_json(const json_build_t &f) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   JsonBuilder builder;
@@ -33,8 +39,7 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
     return JsonObject();  // return unbound object
   }
 #ifdef USE_PSRAM
-  auto doc_allocator = SpiRamAllocator();
-  JsonDocument json_document(&doc_allocator);
+  JsonDocument json_document(&global_json_allocator);
 #else
   JsonDocument json_document;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes a crash in `ArduinoJson::StringNode::destroy()` when using PSRAM by ensuring the JSON allocator outlives returned `JsonDocument` objects.

## Problem

When `USE_PSRAM` is defined, the `parse_json()` function created a stack-local `SpiRamAllocator` that was destroyed when the function returned. However, the returned `JsonDocument` held a pointer to this allocator. When the document's destructor later tried to free memory (e.g., in `http_request_update.cpp:85`), it accessed the destroyed allocator, causing a crash:

```
0x420a0a6b: ArduinoJson::V742HB22::detail::StringNode::destroy()
0x4200b599: ArduinoJson::V742HB22::detail::StringPool::clear()
0x4200c63f: ArduinoJson::V742HB22::JsonDocument::~JsonDocument()
0x4200c63f: esphome::json::parse_json() - dangling allocator pointer
```

## Solution

Created a static `global_json_allocator` that lives for the program's lifetime, ensuring all `JsonDocument` objects returned from `parse_json()` can safely use it during destruction.

This matches the pattern already used correctly in `JsonBuilder` where the allocator is a member variable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes crashes in components using `json::parse_json()` with PSRAM enabled (http_request update, etc.)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal bug fix, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Bug only affects ESP32/ESP32 IDF when PSRAM is enabled)

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This fix applies automatically to any component using json::parse_json()
# when PSRAM is enabled, including:

http_request:
  # ...

update:
  - platform: http_request
    source_url: https://example.com/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
