### PR TITLE
[esp32_ble] Partial revert of #10862 - Fix GATT client notifications

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -332,12 +332,15 @@ def final_validation(config):
 
     # Check if BLE Server is needed
     has_ble_server = "esp32_ble_server" in full_config
-    add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server)
 
     # Check if BLE Client is needed (via esp32_ble_tracker or esp32_ble_client)
     has_ble_client = (
         "esp32_ble_tracker" in full_config or "esp32_ble_client" in full_config
     )
+
+    # ESP-IDF BLE stack requires GATT Server to be enabled when GATT Client is enabled
+    # This is an internal dependency in the Bluedroid stack (tested up to ESP-IDF 5.5.1)
+    add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server or has_ble_client)
     add_idf_sdkconfig_option("CONFIG_BT_GATTC_ENABLE", has_ble_client)
 
     # Handle max_connections: check for deprecated location in esp32_ble_tracker

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -340,6 +340,7 @@ def final_validation(config):
 
     # ESP-IDF BLE stack requires GATT Server to be enabled when GATT Client is enabled
     # This is an internal dependency in the Bluedroid stack (tested ESP-IDF 5.4.2-5.5.1)
+    # See: https://github.com/espressif/esp-idf/issues/17724
     add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server or has_ble_client)
     add_idf_sdkconfig_option("CONFIG_BT_GATTC_ENABLE", has_ble_client)
 

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -339,7 +339,7 @@ def final_validation(config):
     )
 
     # ESP-IDF BLE stack requires GATT Server to be enabled when GATT Client is enabled
-    # This is an internal dependency in the Bluedroid stack (tested up to ESP-IDF 5.5.1)
+    # This is an internal dependency in the Bluedroid stack (tested ESP-IDF 5.4.2-5.5.1)
     add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server or has_ble_client)
     add_idf_sdkconfig_option("CONFIG_BT_GATTC_ENABLE", has_ble_client)
 


### PR DESCRIPTION
# What does this implement/fix?

This PR partially reverts #10862 to fix a critical issue where BLE GATT client connections fail to receive notifications when `CONFIG_BT_GATTS_ENABLE` is disabled.

## Problem

PR #10862 attempted to reduce RAM usage by conditionally disabling GATT Server (`CONFIG_BT_GATTS_ENABLE`) when only GATT Client functionality is needed. However, this breaks BLE client operations because **the ESP-IDF Bluedroid stack requires GATT Server to be enabled even for client-only operations**. This is a limitation/bug in ESP-IDF's BLE stack.

### Symptoms
- BLE devices connect successfully
- GATT operations (descriptor writes, characteristic writes) complete
- **Notifications are never received** (ESP_GATTC_NOTIFY_EVT never fires)
- Devices disconnect with reason 0x13 (GATT_CONN_TERMINATE_PEER_USER)

### Affected Devices
- Yale/August Assure 2 BLE locks (confirmed broken)
- Some BLE device requiring GATT client notifications (not all break)
- bluetooth_proxy connections to devices using notifications

## Root Cause

The ESP-IDF Bluedroid BLE stack has an internal dependency where `CONFIG_BT_GATTC_ENABLE` (GATT Client) cannot function correctly without `CONFIG_BT_GATTS_ENABLE` (GATT Server) being enabled. This has been confirmed across ESP-IDF versions 5.4.x through 5.5.1.

This appears to be an architectural limitation in the Bluedroid stack implementation and will be reported to Espressif as a bug.

## Solution

Enable `CONFIG_BT_GATTS_ENABLE` whenever `CONFIG_BT_GATTC_ENABLE` is needed:

```python
# ESP-IDF BLE stack requires GATT Server to be enabled when GATT Client is enabled
# This is an internal dependency in the Bluedroid stack (tested up to ESP-IDF 5.5.1)
add_idf_sdkconfig_option("CONFIG_BT_GATTS_ENABLE", has_ble_server or has_ble_client)
add_idf_sdkconfig_option("CONFIG_BT_GATTC_ENABLE", has_ble_client)
```

This maintains some RAM savings (GATTS can still be disabled when neither server nor client functionality is used) while ensuring BLE client operations work correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Partially reverts #10862
- Fixes BLE client notification issues (Yale/August locks, bluetooth_proxy)
- https://github.com/espressif/esp-idf/issues/17724

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes required. This fix is transparent to users.

```yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
