### PR TITLE
[esp32_improv] Fix state not transitioning to PROVISIONED when WiFi configured via captive portal

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -163,9 +163,6 @@ void ESP32ImprovComponent::loop() {
     }
     case improv::STATE_PROVISIONING: {
       this->set_status_indicator_state_((now % 200) < 100);
-      if (wifi::global_wifi_component->is_connected()) {
-        this->on_wifi_connected_();
-      }
       break;
     }
     case improv::STATE_PROVISIONED: {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -40,9 +40,6 @@ void ESP32ImprovComponent::setup() {
 #endif
   global_ble_server->on_disconnect([this](uint16_t conn_id) { this->set_error_(improv::ERROR_NONE); });
 
-  // Listen for WiFi connections to detect when provisioning happens via captive portal or other means
-  wifi::global_wifi_component->get_connect_trigger()->add_callback([this]() { this->on_wifi_connected_(); });
-
   // Start with loop disabled - will be enabled by start() when needed
   this->disable_loop();
 }
@@ -146,6 +143,7 @@ void ESP32ImprovComponent::loop() {
 #else
       this->set_state_(improv::STATE_AUTHORIZED);
 #endif
+      this->check_wifi_connection_();
       break;
     }
     case improv::STATE_AUTHORIZED: {
@@ -159,10 +157,12 @@ void ESP32ImprovComponent::loop() {
       if (!this->check_identify_()) {
         this->set_status_indicator_state_((now % 1000) < 500);
       }
+      this->check_wifi_connection_();
       break;
     }
     case improv::STATE_PROVISIONING: {
       this->set_status_indicator_state_((now % 200) < 100);
+      this->check_wifi_connection_();
       break;
     }
     case improv::STATE_PROVISIONED: {
@@ -372,6 +372,12 @@ void ESP32ImprovComponent::on_wifi_connect_timeout_() {
 #endif
   ESP_LOGW(TAG, "Timed out while connecting to Wi-Fi network");
   wifi::global_wifi_component->clear_sta();
+}
+
+void ESP32ImprovComponent::check_wifi_connection_() {
+  if (wifi::global_wifi_component->is_connected()) {
+    this->on_wifi_connected_();
+  }
 }
 
 void ESP32ImprovComponent::on_wifi_connected_() {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -40,6 +40,9 @@ void ESP32ImprovComponent::setup() {
 #endif
   global_ble_server->on_disconnect([this](uint16_t conn_id) { this->set_error_(improv::ERROR_NONE); });
 
+  // Listen for WiFi connections to detect when provisioning happens via captive portal or other means
+  wifi::global_wifi_component->get_connect_trigger()->add_callback([this]() { this->on_wifi_connected_(); });
+
   // Start with loop disabled - will be enabled by start() when needed
   this->disable_loop();
 }
@@ -161,25 +164,7 @@ void ESP32ImprovComponent::loop() {
     case improv::STATE_PROVISIONING: {
       this->set_status_indicator_state_((now % 200) < 100);
       if (wifi::global_wifi_component->is_connected()) {
-        wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(),
-                                                   this->connecting_sta_.get_password());
-        this->connecting_sta_ = {};
-        this->cancel_timeout("wifi-connect-timeout");
-        this->set_state_(improv::STATE_PROVISIONED);
-
-        std::vector<std::string> urls = {ESPHOME_MY_LINK};
-#ifdef USE_WEBSERVER
-        for (auto &ip : wifi::global_wifi_component->wifi_sta_ip_addresses()) {
-          if (ip.is_ip4()) {
-            std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
-            urls.push_back(webserver_url);
-            break;
-          }
-        }
-#endif
-        std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, urls);
-        this->send_response_(data);
-        this->stop();
+        this->on_wifi_connected_();
       }
       break;
     }
@@ -390,6 +375,36 @@ void ESP32ImprovComponent::on_wifi_connect_timeout_() {
 #endif
   ESP_LOGW(TAG, "Timed out while connecting to Wi-Fi network");
   wifi::global_wifi_component->clear_sta();
+}
+
+void ESP32ImprovComponent::on_wifi_connected_() {
+  // Handle WiFi connection, whether from Improv provisioning or external (e.g., captive portal)
+  if (this->state_ == improv::STATE_PROVISIONING) {
+    // WiFi provisioned via Improv - save credentials and send response
+    wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(), this->connecting_sta_.get_password());
+    this->connecting_sta_ = {};
+    this->cancel_timeout("wifi-connect-timeout");
+
+    std::vector<std::string> urls = {ESPHOME_MY_LINK};
+#ifdef USE_WEBSERVER
+    for (auto &ip : wifi::global_wifi_component->wifi_sta_ip_addresses()) {
+      if (ip.is_ip4()) {
+        std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
+        urls.push_back(webserver_url);
+        break;
+      }
+    }
+#endif
+    std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, urls);
+    this->send_response_(data);
+  } else if (this->is_active() && this->state_ != improv::STATE_PROVISIONED) {
+    // WiFi provisioned externally (e.g., captive portal) - just transition to provisioned
+    ESP_LOGD(TAG, "WiFi provisioned externally, transitioning to provisioned state");
+  }
+
+  // Common actions for both cases
+  this->set_state_(improv::STATE_PROVISIONED);
+  this->stop();
 }
 
 void ESP32ImprovComponent::advertise_service_data_() {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -399,7 +399,7 @@ void ESP32ImprovComponent::on_wifi_connected_() {
     this->send_response_(data);
   } else if (this->is_active() && this->state_ != improv::STATE_PROVISIONED) {
     // WiFi provisioned externally (e.g., captive portal) - just transition to provisioned
-    ESP_LOGD(TAG, "WiFi provisioned externally, transitioning to provisioned state");
+    ESP_LOGD(TAG, "WiFi provisioned externally");
   }
 
   // Common actions for both cases

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -375,15 +375,11 @@ void ESP32ImprovComponent::on_wifi_connect_timeout_() {
 }
 
 void ESP32ImprovComponent::check_wifi_connection_() {
-  if (wifi::global_wifi_component->is_connected()) {
-    this->on_wifi_connected_();
+  if (!wifi::global_wifi_component->is_connected()) {
+    return;
   }
-}
 
-void ESP32ImprovComponent::on_wifi_connected_() {
-  // Handle WiFi connection, whether from Improv provisioning or external (e.g., captive portal)
   if (this->state_ == improv::STATE_PROVISIONING) {
-    // WiFi provisioned via Improv - save credentials and send response
     wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(), this->connecting_sta_.get_password());
     this->connecting_sta_ = {};
     this->cancel_timeout("wifi-connect-timeout");
@@ -401,7 +397,6 @@ void ESP32ImprovComponent::on_wifi_connected_() {
     std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, urls);
     this->send_response_(data);
   } else if (this->is_active() && this->state_ != improv::STATE_PROVISIONED) {
-    // WiFi provisioned externally (e.g., captive portal) - just transition to provisioned
     ESP_LOGD(TAG, "WiFi provisioned externally");
   }
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -402,7 +402,6 @@ void ESP32ImprovComponent::on_wifi_connected_() {
     ESP_LOGD(TAG, "WiFi provisioned externally");
   }
 
-  // Common actions for both cases
   this->set_state_(improv::STATE_PROVISIONED);
   this->stop();
 }

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -112,6 +112,7 @@ class ESP32ImprovComponent : public Component {
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   void on_wifi_connected_();
+  void check_wifi_connection_();
   bool check_identify_();
   void advertise_service_data_();
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -111,7 +111,6 @@ class ESP32ImprovComponent : public Component {
   void send_response_(std::vector<uint8_t> &response);
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
-  void on_wifi_connected_();
   void check_wifi_connection_();
   bool check_identify_();
   void advertise_service_data_();

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -111,6 +111,7 @@ class ESP32ImprovComponent : public Component {
   void send_response_(std::vector<uint8_t> &response);
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
+  void on_wifi_connected_();
   bool check_identify_();
   void advertise_service_data_();
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where esp32_improv does not broadcast the PROVISIONED state (0x04) when WiFi is provisioned via captive portal or other external methods, causing the device to continue appearing as available for provisioning in Home Assistant and other Improv clients.

## Problem

When WiFi gets provisioned through the captive portal (or any method other than Improv BLE), the esp32_improv component never transitions to `STATE_PROVISIONED` and continues advertising itself as available for provisioning. This causes:

1. Home Assistant to continue showing the Improv BLE discovery notification even though WiFi is already configured
2. Improv clients to think the device still needs provisioning
3. Unnecessary BLE advertising and connection attempts

## Solution

Modified the state machine to check for WiFi connection in all active states (AWAITING_AUTHORIZATION, AUTHORIZED, and PROVISIONING). When WiFi is detected as connected, the component transitions to PROVISIONED state regardless of provisioning method. The fix also consolidates duplicate provisioning completion logic into helper methods.

**Key changes:**
- Added `check_wifi_connection_()` helper method called in AWAITING_AUTHORIZATION, AUTHORIZED, and PROVISIONING states
- Created `on_wifi_connected_()` helper method to handle both Improv and external provisioning completion
- Eliminated code duplication in provisioning completion logic
- Uses polling approach consistent with existing state machine pattern

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a bug fix with no user-facing configuration changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - existing esp32_improv configurations work as before

wifi:
  ssid: MySSID
  password: password1

binary_sensor:
  - platform: gpio
    pin: 0
    id: io0_button

output:
  - platform: gpio
    pin: 2
    id: built_in_led

esp32_improv:
  authorizer: io0_button
  status_indicator: built_in_led
```

## Testing

Tested on ESP32-S3 with ESP-IDF framework. Both provisioning methods work correctly:

**Captive Portal Provisioning:**
```
[D][esp32_improv.component:405]: WiFi provisioned externally
[D][esp32_improv.component:231]: State transition: AUTHORIZED (0x02) -> PROVISIONED (0x04)
[D][esp32_improv.component:231]: State transition: PROVISIONED (0x04) -> STOPPED (0x00)
```

**Improv BLE Provisioning:**
```
[D][esp32_improv.component:231]: State transition: PROVISIONING (0x03) -> PROVISIONED (0x04)
[D][esp32_improv.component:231]: State transition: PROVISIONED (0x04) -> STOPPED (0x00)
```

Verified:
- State transitions to PROVISIONED (0x04) for both provisioning methods
- BLE advertising broadcasts correct state
- Improv service stops after 10-second delay
- Home Assistant discovery properly disappears after provisioning
- Resolves issue where captive portal provisioned devices remained in Home Assistant discovery indefinitely

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
