### PR TITLE
[core] Optimize looping_components_ with FixedVector to save flash

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -340,8 +340,8 @@ void Application::calculate_looping_components_() {
     }
   }
 
-  // Pre-reserve vector to avoid reallocations
-  this->looping_components_.reserve(total_looping);
+  // Initialize FixedVector with exact size - no reallocation possible
+  this->looping_components_.init(total_looping);
 
   // Add all components with loop override that aren't already LOOP_DONE
   // Some components (like logger) may call disable_loop() during initialization

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -472,7 +472,7 @@ class Application {
   // - When a component is enabled, it's swapped with the first inactive component
   //   and active_end_ is incremented
   // - This eliminates branch mispredictions from flag checking in the hot loop
-  std::vector<Component *> looping_components_{};
+  FixedVector<Component *> looping_components_{};
 #ifdef USE_SOCKET_SELECT_SUPPORT
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
 #endif

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -159,6 +159,50 @@ template<typename T, size_t N> class StaticVector {
   const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
 };
 
+/// Fixed-capacity vector - allocates once at runtime, never reallocates
+/// This avoids std::vector template overhead (_M_realloc_insert, _M_default_append)
+/// when size is known at initialization but not at compile time
+template<typename T> class FixedVector {
+ private:
+  T *data_{nullptr};
+  size_t size_{0};
+  size_t capacity_{0};
+
+ public:
+  FixedVector() = default;
+
+  ~FixedVector() {
+    if (data_ != nullptr) {
+      delete[] data_;
+    }
+  }
+
+  // Disable copy to avoid accidental copies
+  FixedVector(const FixedVector &) = delete;
+  FixedVector &operator=(const FixedVector &) = delete;
+
+  // Allocate capacity - can only be called once on empty vector
+  void init(size_t n) {
+    if (data_ == nullptr && n > 0) {
+      data_ = new T[n];
+      capacity_ = n;
+      size_ = 0;
+    }
+  }
+
+  // Add element (no reallocation - must have initialized capacity)
+  void push_back(const T &value) {
+    if (size_ < capacity_) {
+      data_[size_++] = value;
+    }
+  }
+
+  size_t size() const { return size_; }
+
+  T &operator[](size_t i) { return data_[i]; }
+  const T &operator[](size_t i) const { return data_[i]; }
+};
+
 ///@}
 
 /// @name Mathematics

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -192,7 +192,7 @@ template<typename T> class FixedVector {
 
   /// Add element without bounds checking
   /// Caller must ensure sufficient capacity was allocated via init()
-  /// Silently ignores pushes beyond capacity to avoid runtime overhead
+  /// Silently ignores pushes beyond capacity (no exception or assertion)
   void push_back(const T &value) {
     if (size_ < capacity_) {
       data_[size_++] = value;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -190,7 +190,9 @@ template<typename T> class FixedVector {
     }
   }
 
-  // Add element (no reallocation - must have initialized capacity)
+  /// Add element without bounds checking
+  /// Caller must ensure sufficient capacity was allocated via init()
+  /// Silently ignores pushes beyond capacity to avoid runtime overhead
   void push_back(const T &value) {
     if (size_ < capacity_) {
       data_[size_++] = value;
@@ -199,6 +201,8 @@ template<typename T> class FixedVector {
 
   size_t size() const { return size_; }
 
+  /// Access element without bounds checking (matches std::vector behavior)
+  /// Caller must ensure index is valid (i < size())
   T &operator[](size_t i) { return data_[i]; }
   const T &operator[](size_t i) const { return data_[i]; }
 };


### PR DESCRIPTION
# What does this implement/fix?

This PR introduces a custom `FixedVector` class to replace `std::vector` for the `looping_components_` member in the Application class, eliminating unnecessary template overhead and reducing flash usage.

## Background

The `looping_components_` vector stores components that need to be called in the main loop. This vector has a unique usage pattern:
- Size is calculated once during `setup()` by counting components with `has_overridden_loop()`
- Allocated once with exact size using `reserve()`
- Never reallocates or grows after initialization
- Only uses basic operations: `push_back()`, `size()`, and `operator[]`

Despite using `reserve()` to prevent reallocation at runtime, the compiler still instantiates `std::vector`'s reallocation template code (`_M_realloc_insert`, `_M_default_append`), contributing ~188-203 bytes of flash overhead per platform.

## Solution

Introduced a minimal `FixedVector<T>` class that:
- Allocates once at runtime via `init(size_t n)` with exact capacity
- Never reallocates (no reallocation template code)
- Provides only the methods actually used: `init()`, `push_back()`, `size()`, `operator[]`
- Uses simple pointer-based storage with manual size tracking
- Deletes copy constructor to prevent accidental expensive copies

## Flash Savings

| Platform | Flash Saved |
|----------|-------------|
| ESP8266  | 332 bytes   |
| ESP32    | 212 bytes   |

## Changes

**esphome/core/helpers.h:**
- Added `FixedVector<T>` template class (lines 165-207)

**esphome/core/application.h:**
- Changed `looping_components_` from `std::vector<Component *>` to `FixedVector<Component *>`

**esphome/core/application.cpp:**
- Changed `looping_components_.reserve()` to `looping_components_.init()` in `calculate_looping_components_()`

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (memory/flash optimization)

**Related issue or feature (if applicable):**

N/A - proactive optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal implementation detail, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No configuration changes required. This is a transparent internal optimization.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

- No functional changes - the behavior of looping components remains identical
- No API changes - this is purely an internal optimization
- The `FixedVector` class could potentially be reused for other fixed-size runtime allocations in the future
- RAM usage unchanged (same allocation pattern, just different container)
