### PR TITLE
[http_request] Pass parameters by const reference to reduce flash usage

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -167,8 +167,8 @@ class HttpRequestComponent : public Component {
   }
 
  protected:
-  virtual std::shared_ptr<HttpContainer> perform(std::string url, std::string method, std::string body,
-                                                 std::list<Header> request_headers,
+  virtual std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method,
+                                                 const std::string &body, const std::list<Header> &request_headers,
                                                  std::set<std::string> collect_headers) = 0;
   const char *useragent_{nullptr};
   bool follow_redirects_{};

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -14,8 +14,9 @@ namespace http_request {
 
 static const char *const TAG = "http_request.arduino";
 
-std::shared_ptr<HttpContainer> HttpRequestArduino::perform(std::string url, std::string method, std::string body,
-                                                           std::list<Header> request_headers,
+std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
+                                                           const std::string &body,
+                                                           const std::list<Header> &request_headers,
                                                            std::set<std::string> collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -31,8 +31,8 @@ class HttpContainerArduino : public HttpContainer {
 
 class HttpRequestArduino : public HttpRequestComponent {
  protected:
-  std::shared_ptr<HttpContainer> perform(std::string url, std::string method, std::string body,
-                                         std::list<Header> request_headers,
+  std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
+                                         const std::list<Header> &request_headers,
                                          std::set<std::string> collect_headers) override;
 };
 

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -17,8 +17,9 @@ namespace http_request {
 
 static const char *const TAG = "http_request.host";
 
-std::shared_ptr<HttpContainer> HttpRequestHost::perform(std::string url, std::string method, std::string body,
-                                                        std::list<Header> request_headers,
+std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, const std::string &method,
+                                                        const std::string &body,
+                                                        const std::list<Header> &request_headers,
                                                         std::set<std::string> response_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -18,8 +18,8 @@ class HttpContainerHost : public HttpContainer {
 
 class HttpRequestHost : public HttpRequestComponent {
  public:
-  std::shared_ptr<HttpContainer> perform(std::string url, std::string method, std::string body,
-                                         std::list<Header> request_headers,
+  std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
+                                         const std::list<Header> &request_headers,
                                          std::set<std::string> response_headers) override;
   void set_ca_path(const char *ca_path) { this->ca_path_ = ca_path; }
 

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -52,8 +52,9 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
   return ESP_OK;
 }
 
-std::shared_ptr<HttpContainer> HttpRequestIDF::perform(std::string url, std::string method, std::string body,
-                                                       std::list<Header> request_headers,
+std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, const std::string &method,
+                                                       const std::string &body,
+                                                       const std::list<Header> &request_headers,
                                                        std::set<std::string> collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -37,8 +37,8 @@ class HttpRequestIDF : public HttpRequestComponent {
   void set_buffer_size_tx(uint16_t buffer_size_tx) { this->buffer_size_tx_ = buffer_size_tx; }
 
  protected:
-  std::shared_ptr<HttpContainer> perform(std::string url, std::string method, std::string body,
-                                         std::list<Header> request_headers,
+  std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
+                                         const std::list<Header> &request_headers,
                                          std::set<std::string> collect_headers) override;
   // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
   uint16_t buffer_size_rx_{};


### PR DESCRIPTION
# What does this implement/fix?

Reduces flash usage in the `http_request` component by passing parameters by const reference instead of by value in the internal `perform()` method.

The `HttpRequestComponent::perform()` virtual method was passing `std::string` and container parameters by value, causing unnecessary copy constructor instantiations and template bloat. This change updates the base class and all platform-specific implementations (ESP-IDF, Arduino, Host) to pass most parameters by const reference.

The `perform()` method is `protected` and only called internally by the public `start()` method so this should not be a breaking change. All the functions that pass the strings onward make copies so this is safe.

**Flash savings:**
- ESP32 (ESP-IDF): 340 bytes saved

The `collect_headers` parameter remains pass-by-value as it's intentionally transformed (lowercased) in the `start()` method before being passed to `perform()`.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
http_request:
  timeout: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
