### PR TITLE
[mipi_rgb] Fix pin conflicts introduced by shared SPI bus in #11134

### DIFF
--- a/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
+++ b/tests/components/mipi_rgb/test.esp32-s3-idf.yaml
@@ -40,9 +40,7 @@ display:
         - number: 17
       blue:
         - number: 47
-          allow_other_uses: true
-        - number: 41
-          allow_other_uses: true
+        - number: 1
         - number: 0
           ignore_strapping_warning: true
         - number: 42
@@ -53,7 +51,7 @@ display:
       number: 45
       ignore_strapping_warning: true
     hsync_pin:
-      number: 40
+      number: 38
     vsync_pin:
       number: 48
     data_rate: 1000000.0


### PR DESCRIPTION
# What does this implement/fix?

## Problem

PR #11134 refactored component tests to use shared bus configurations for grouped testing. For `mipi_rgb`, this meant switching from a local SPI bus definition to the shared SPI bus package (`../../test_build_components/common/spi/esp32-s3-idf.yaml`). However, this introduced pin conflicts that broke single component testing:

1. **Pin 40 conflict**: The shared SPI config uses GPIO40 for `clk_pin`, but mipi_rgb was also using it for `hsync_pin`
2. **Pin 41 conflict**: The shared SPI config uses GPIO41 for `miso_pin`, but mipi_rgb was also using it as a blue data pin
3. **Leftover `allow_other_uses`**: Pins 47 and 41 still had `allow_other_uses: true` from the old local SPI bus configuration, but weren't actually being shared anymore, causing validation errors

When running `./script/test_build_components -c mipi_rgb -e config`, the test would fail with:
```
Pin 40 is used in multiple places.
Pin 41 is used in multiple places.
Pin 47 incorrectly sets allow_other_uses: true
```

## Solution

Fixed pin assignments to avoid conflicts with the shared SPI bus configuration:

- Changed `hsync_pin` from GPIO40 → GPIO38 (avoids SPI clk conflict)
- Changed blue data pin from GPIO41 → GPIO1 (avoids SPI miso conflict)
- Removed `allow_other_uses: true` from pins 47 and 41 (not needed for single component testing)

This allows the component to work correctly in both:
- **Grouped testing**: Uses shared SPI bus package with multiple components
- **Single component testing**: No pin conflicts or invalid `allow_other_uses` flags

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes single component testing broken by #11134

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Test infrastructure only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (ESP32-S3)
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This is a test infrastructure fix only, no user config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - This is a test infrastructure fix only, no user-facing changes
