### PR TITLE
[ota] Increase handshake timeout to 20s now that auth is non-blocking

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -29,7 +29,7 @@ namespace esphome {
 static const char *const TAG = "esphome.ota";
 static constexpr uint16_t OTA_BLOCK_SIZE = 8192;
 static constexpr size_t OTA_BUFFER_SIZE = 1024;                  // buffer size for OTA data transfer
-static constexpr uint32_t OTA_SOCKET_TIMEOUT_HANDSHAKE = 10000;  // milliseconds for initial handshake
+static constexpr uint32_t OTA_SOCKET_TIMEOUT_HANDSHAKE = 20000;  // milliseconds for initial handshake
 static constexpr uint32_t OTA_SOCKET_TIMEOUT_DATA = 90000;       // milliseconds for data transfer
 
 #ifdef USE_OTA_PASSWORD

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -410,7 +410,7 @@ def run_ota_impl_(
         af, socktype, _, _, sa = r
         _LOGGER.info("Connecting to %s port %s...", sa[0], sa[1])
         sock = socket.socket(af, socktype)
-        sock.settimeout(10.0)
+        sock.settimeout(20.0)
         try:
             sock.connect(sa)
         except OSError as err:

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -493,7 +493,7 @@ def test_run_ota_impl_successful(
     assert result_host == "192.168.1.100"
 
     # Verify socket was configured correctly
-    mock_socket.settimeout.assert_called_with(10.0)
+    mock_socket.settimeout.assert_called_with(20.0)
     mock_socket.connect.assert_called_once_with(("192.168.1.100", 3232))
     mock_socket.close.assert_called_once()
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes OTA authentication timeouts on poor WiFi connections by increasing the handshake timeout from 10 to 20 seconds.

The 10-second timeout was always insufficient for devices with poor connectivity, frequently causing OTA uploads to fail with "Error receiving acknowledge auth: timed out". However, we couldn't safely increase it before because authentication was blocking - a longer timeout would freeze the entire device during the handshake phase.

Now that #10912 has made OTA authentication non-blocking, we can safely extend the timeout to 20 seconds to accommodate slower network connections without impacting device responsiveness.

This change updates both the Python client timeout (`espota2.py`) and the firmware handshake timeout (`ota_esphome.cpp`) to maintain consistency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #10912 (non-blocking OTA authentication)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal timeout change, no user-facing documentation needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal timeout adjustment
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
