### PR TITLE
[wifi] Fix missed string literal in flash on ESP8266

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -576,8 +576,9 @@ __attribute__((noinline)) static void log_scan_result(const WiFiScanResult &res)
   format_mac_addr_upper(bssid.data(), bssid_s);
 
   if (res.get_matches()) {
-    ESP_LOGI(TAG, "- '%s' %s" LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(), res.get_is_hidden() ? "(HIDDEN) " : "",
-             bssid_s, LOG_STR_ARG(get_signal_bars(res.get_rssi())));
+    ESP_LOGI(TAG, "- '%s' %s" LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(),
+             res.get_is_hidden() ? LOG_STR_LITERAL("(HIDDEN) ") : LOG_STR_LITERAL(""), bssid_s,
+             LOG_STR_ARG(get_signal_bars(res.get_rssi())));
     ESP_LOGD(TAG,
              "    Channel: %u\n"
              "    RSSI: %d dB",


### PR DESCRIPTION
# What does this implement/fix?

Fixes missed string literal in WiFi scan result logging that should be stored in flash on ESP8266.

**Impact:**
- Reduces ESP8266 RAM usage by 12 bytes

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing ESP8266 memory optimization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
