### PR TITLE
fatfs_esp32

### DIFF
--- a/esphome/components/fatfs_esp32/__init__.py
+++ b/esphome/components/fatfs_esp32/__init__.py
@@ -1,0 +1,32 @@
+import esphome.codegen as cg
+from esphome.components import fatfs
+import esphome.config_validation as cv
+from esphome.const import PLATFORM_ESP32
+from esphome.core import CORE
+from esphome.cpp_generator import MockObjClass
+
+IS_PLATFORM_COMPONENT = True
+CODEOWNERS = ["@abel-msk"]
+
+FatESP32_ns = cg.esphome_ns.namespace("fatfs_esp32")
+FatESP32 = FatESP32_ns.class_("FatESP32", fatfs.FatFS)
+
+
+def fatfs_esp32_schema(
+    class_: MockObjClass,
+) -> cv.Schema:
+    return fatfs.fatfs_schema(class_)
+
+
+async def new_esp32_driver(config, *args):
+    if CORE.target_platform != PLATFORM_ESP32:
+        raise NotImplementedError(
+            "This component can be used only on ESP32 platform any variants."
+        )
+    return await fatfs.new_fatfs(config, *args)
+
+
+async def to_code(config):
+    raise NotImplementedError(
+        "This component if only FATFS API for ESP32 platform. You need fatfs component with device driver."
+    )

--- a/esphome/components/fatfs_esp32/fatfs_esp32.cpp
+++ b/esphome/components/fatfs_esp32/fatfs_esp32.cpp
@@ -1,0 +1,252 @@
+#include "fatfs_esp32.h"
+#ifdef USE_ESP32
+#include "esphome/core/log.h"
+extern "C" {
+#include "ff.h"
+#include "diskio.h"
+#if ESP_IDF_VERSION_MAJOR > 3
+#include "diskio_impl.h"
+#endif
+#include "esp_vfs_fat.h"
+}
+
+namespace esphome {
+namespace fatfs_esp32 {
+using namespace esphome::fatfs;
+static const char *const TAG = "fatfs_esp32";
+std::map<std::uint8_t, StorageIO *> db;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+using enum fatfs::StorageState;
+
+DSTATUS ff_sd_initialize(uint8_t pdrv) {
+  StorageIO *io_class = nullptr;
+  if (db.find(pdrv) != db.end()) {
+    io_class = db.at(pdrv);
+  } else {
+    ESP_LOGE(TAG, "IO driver not initilized, drv=%d", pdrv);
+    return RES_ERROR;
+  }
+  if (io_class == NULL) {
+    ESP_LOGE(TAG, "Cannot obtain driver drv=%d", pdrv);
+    return RES_ERROR;
+  }
+  io_class->storage_init();
+  ESP_LOGVV(TAG, "ff_sd_initialize, drv=%d, rc=%d", pdrv, io_class->storage_error());
+  return io_class->storage_status();
+}
+
+DSTATUS ff_sd_status(uint8_t pdrv) {
+  StorageIO *io_class;
+  if (db.find(pdrv) != db.end()) {
+    io_class = db.at(pdrv);
+  } else {
+    ESP_LOGE(TAG, "IO driver not initilized, drv=%d", pdrv);
+    return RES_ERROR;
+  }
+  ESP_LOGVV(TAG, "ff_sd_status, drv=%d, rc=%d", pdrv, io_class->storage_error());
+
+  return io_class->storage_status();
+}
+
+DRESULT ff_sd_read(uint8_t pdrv, uint8_t *buffer, DWORD sector, UINT count) {
+  StorageIO *io_class;
+  if (db.find(pdrv) != db.end()) {
+    io_class = db.at(pdrv);
+  } else {
+    ESP_LOGE(TAG, "ff_sd_read. IO driver not initilized, drv=%d", pdrv);
+    return RES_ERROR;
+  }
+  DRESULT res = static_cast<DRESULT>(io_class->storage_read_sectors(buffer, sector, count));
+  if (res != 0) {
+    ESP_LOGE(TAG, "ff_sd_read. Read error, drv=%d, res=%d, rc=%d", pdrv, res, io_class->storage_error());
+  } else {
+    ESP_LOGVV(TAG, "ff_sd_read. Read OK, drv=%d, sector=%d, count=%d", pdrv, sector, count);
+  }
+  return res;
+}
+
+DRESULT ff_sd_write(uint8_t pdrv, const uint8_t *buffer, DWORD sector, UINT count) {
+  StorageIO *io_class;
+  if (db.find(pdrv) != db.end()) {
+    io_class = db.at(pdrv);
+  } else {
+    ESP_LOGE(TAG, "ff_sd_write. IO driver not initilized, drv=%d", pdrv);
+    return RES_ERROR;
+  }
+
+  DRESULT res = static_cast<DRESULT>(io_class->storage_write_sectors(buffer, sector, count));
+  if (res != 0) {
+    ESP_LOGE(TAG, "ff_sd_write. Read error, drv=%d, rc=%d", pdrv, io_class->storage_error());
+  } else {
+    ESP_LOGVV(TAG, "ff_sd_write. Read OK, drv=%d, sector=%d, count=%d", pdrv, sector, count);
+  }
+
+  return res;
+}
+
+DRESULT ff_sd_ioctl(uint8_t pdrv, uint8_t cmd, void *buff) {
+  StorageIO *io_class;
+  if (db.find(pdrv) != db.end()) {
+    io_class = db.at(pdrv);
+  } else {
+    ESP_LOGE(TAG, "ff_sd_ioctl. IO driver not initilized, drv=%d", pdrv);
+    return RES_ERROR;
+  }
+  DRESULT res = static_cast<DRESULT>(io_class->storage_ioctl(cmd, buff));
+  ESP_LOGVV(TAG, "ff_sd_ioctl, drv=%d, cmd=%d, res=%d, rc=%d", pdrv, cmd, res, io_class->storage_error());
+  return res;
+}
+
+bool FatESP32::set_io_driver(StorageIO *io_class) {
+  io_ = io_class;
+
+  if (this->get_grive_id() == 0xFF) {
+    for (uint8_t i = 0; i < 11; i++) {
+      if (db.find(i) == db.end()) {
+        this->set_drive_id(i);
+        break;
+      }
+    }
+  } else {
+    //  Check is driver_id unique
+    if (db.find(this->get_grive_id()) != db.end()) {
+      ESP_LOGE(TAG, "Init driver id fail. Duplicate id x%02x", this->get_grive_id());
+      return false;
+    }
+  }
+  //  Check is IO driver registered
+  if (io_ == NULL) {
+    ESP_LOGE(TAG, "Init IO driver failed. Driver not set.");
+    return false;
+  }
+  //  Register IO Driver
+  db.insert_or_assign(this->get_grive_id(), io_);
+  return true;
+}
+
+void FatESP32::init_driver() {
+  sd_impl_.init = &ff_sd_initialize;
+  sd_impl_.status = &ff_sd_status;
+  sd_impl_.read = &ff_sd_read;
+  sd_impl_.write = &ff_sd_write;
+  sd_impl_.ioctl = &ff_sd_ioctl;
+  ff_diskio_register(this->get_grive_id(), &sd_impl_);
+  ESP_LOGD(TAG, "init drv=%s", this->get_drive_name().c_str());
+}
+
+void FatESP32::relese_driver() {
+  ff_diskio_register(this->get_grive_id(), NULL);
+  ESP_LOGV(TAG, "Release driver. drv=%s", this->get_drive_name().c_str());
+}
+
+bool FatESP32::mount() {
+  FATFS *local_fs;
+  // char *ldrv = strdup(this->get_drive_name().c_str());
+
+  esp_err_t err = esp_vfs_fat_register(path_.c_str(), this->get_drive_name().c_str(), FAT_MAX_FILES, &local_fs);
+  if (err == ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "esp_vfs_fat_register failed (0x%x)%s: SD is registered.", err, esp_err_to_name(err));
+    return false;
+  } else if (err != ESP_OK) {
+    ESP_LOGE(TAG, "esp_vfs_fat_register failed (0x%x)%s", err, esp_err_to_name(err));
+    return false;
+  }
+
+  FRESULT res = f_mount(local_fs, this->get_drive_name().c_str(), 1);
+  if (res != FR_OK) {
+    ESP_LOGE(TAG, "f_mount failed: (0x%x)%s", res, fs_errstr(res));
+    esp_vfs_fat_unregister_path(path_.c_str());
+    return false;
+  }
+  ESP_LOGD(TAG, "mount drv=%s, mount point=%s", this->get_drive_name().c_str(), path_.c_str());
+  fs_ = local_fs;
+  return true;
+}
+
+void FatESP32::unmount() {
+  if (fs_ != NULL) {
+    FRESULT res = f_mount(NULL, this->get_drive_name().c_str(), 0);
+    if (res != FR_OK)
+      ESP_LOGE(TAG, "unmount problem: (0x%x)%s", res, fs_errstr(res));
+    esp_err_t err = esp_vfs_fat_unregister_path(path_.c_str());
+    if (err != ESP_OK)
+      ESP_LOGE(TAG, "esp_vfs_fat_unregister_path problem (0x%x)%s", err, esp_err_to_name(err));
+    fs_ = NULL;
+    ESP_LOGV(TAG, "unmount drv=%s", this->get_drive_name().c_str());
+  }
+}
+
+bool FatESP32::is_exist(std::string &path) {
+  auto fs = FatESP32Info(path);
+  return fs.is_exist();
+}
+
+fatfs::FileObject *FatESP32::open_file(std::string &path, uint8_t mode) {
+  FatESP32File *fl = new FatESP32File(path);
+  fl->open(mode);
+  error_ = fl->file_error();
+  return fl;
+}
+
+fatfs::FileObject *FatESP32::open_file(fatfs::FatInfo *obj, uint8_t mode) {
+  FatESP32File *fl = new FatESP32File(*obj);
+  // ESP_LOGV(TAG,"Create file object for file.");
+  fl->open(mode);
+  error_ = fl->file_error();
+  return fl;
+}
+
+fatfs::DirObject *FatESP32::open_dir(std::string &path) {
+  ESP_LOGV(TAG, "Open dir from path %s", path.c_str());
+  FatESP32Dir *d_obj = new FatESP32Dir(path);
+  d_obj->open();
+  error_ = d_obj->file_error();
+  return d_obj;
+}
+
+fatfs::DirObject *FatESP32::open_dir(fatfs::FatInfo *obj) {
+  ESP_LOGV(TAG, "Open dir from FatInfo %s", obj->get_full_path().c_str());
+  FatESP32Dir *d_obj = new FatESP32Dir(*obj);
+  d_obj->open();
+  error_ = d_obj->file_error();
+  return d_obj;
+}
+
+fatfs::DirObject *FatESP32::mk_dir(std::string &path) {
+  error_ = static_cast<fatfs::FatError>(f_mkdir(path.c_str()));
+  if (error_ != fatfs::FatError::FR_OK) {
+    ESP_LOGE(TAG, "f_mkdir  %s failled (0x%x) %s", path.c_str(), static_cast<int>(error_),
+             fs_errstr(static_cast<int>(error_)));
+    return NULL;
+  }
+  FatESP32Dir *dptr = new FatESP32Dir(path);
+  error_ = dptr->file_error();
+  return dptr;
+}
+
+fatfs::DirObject *FatESP32::mk_dir(fatfs::FatInfo *obj, std::string &name) {
+  std::string dir = obj->get_full_path() + "/" + name;
+  return this->mk_dir(dir);
+}
+
+bool FatESP32::del(std::string &path) {
+  error_ = static_cast<fatfs::FatError>(f_unlink(path.c_str()));
+  if (error_ != fatfs::FatError::FR_OK) {
+    ESP_LOGE(TAG, "f_unlink  %s failled (0x%x) %s", path.c_str(), static_cast<int>(error_),
+             fs_errstr(static_cast<int>(error_)));
+    return false;
+  }
+  return true;
+}
+
+bool FatESP32::rename(std::string &path_from, std::string &path_to) {
+  error_ = static_cast<fatfs::FatError>(f_rename(path_from.c_str(), path_to.c_str()));
+  if (error_ != fatfs::FatError::FR_OK) {
+    ESP_LOGE(TAG, "f_rename %s - %s failled (0x%x) %s", path_from.c_str(), path_to.c_str(), static_cast<int>(error_),
+             fs_errstr(static_cast<int>(error_)));
+    return false;
+  }
+  return true;
+}
+}  // namespace fatfs_esp32
+}  // namespace esphome
+#endif

--- a/esphome/components/fatfs_esp32/fatfs_esp32.h
+++ b/esphome/components/fatfs_esp32/fatfs_esp32.h
@@ -1,0 +1,234 @@
+#pragma once
+#include "esphome/core/defines.h"
+#ifdef USE_ESP32
+#include "esphome/core/gpio.h"
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include <map>
+#include "esphome/core/log.h"
+#include "esphome/components/fatfs/fatfs.h"
+#include "esphome/core/time.h"
+#include "fatfs_esp32_file.h"
+
+namespace esphome {
+namespace fatfs_esp32 {
+#ifndef FAT_MAX_FILES
+#define FAT_MAX_FILES 5  // NOLINT
+#endif
+
+using DSTATUS = BYTE;
+
+DSTATUS ff_sd_initialize(uint8_t pdrv);
+DSTATUS ff_sd_status(uint8_t pdrv);
+
+/** --------------------------------------------------------------------------------
+ * @brief The disk_read function is called to read data from the storage device.
+ *
+ * @param pdrv [IN] Physical drive number to identify the target device.
+ * @param buffer [OUT] Pointer to the first item of the byte array
+ *      to store read data. Size of read data will be the sector size * count bytes.
+ * @param sector [IN] Start sector number in LBA. The data type LBA_t is an alias of
+ *      DWORD or QWORD depends on the configuration option.
+ * @param count [IN] Number of sectors to read.
+ * @return DRESULT
+ * RES_OK (0) The function succeeded.
+ * RES_ERROR An unrecoverable hard error occured during the read operation.
+ * RES_PARERR Invalid parameter.
+ * RES_NOTRDY The device has not been initialized.
+ */
+DRESULT ff_sd_read(uint8_t pdrv, uint8_t *buffer, DWORD sector, UINT count);
+
+/** --------------------------------------------------------------------------------
+ * @brief
+ *
+ * @param pdrv Physical drive number to identify the target device.
+ * @param buffer Pointer to the first item of the byte array to be written.
+ *      The size of data to be written is sector size * count bytes.
+ * @param sector
+ *      Start sector number in LBA. The data type LBA_t is an
+ *      alias of DWORD or QWORD depends on the configuration option.
+ * @param count
+ *      Number of sectors to write.
+ * @return DRESULT
+ * RES_OK (0) The function succeeded.
+ * RES_ERROR An unrecoverable hard error occured during the write operation.
+ * RES_WRPRT The medium is write protected.
+ * RES_PARERR Invalid parameter.
+ * RES_NOTRDY The device has not been initialized.
+ */
+DRESULT ff_sd_write(uint8_t pdrv, const uint8_t *buffer, DWORD sector, UINT count);
+
+DRESULT ff_sd_ioctl(uint8_t pdrv, uint8_t cmd, void *buff);
+
+/** ****************************************************************************************
+ * @brief  Diskio operation wrapper api, required  as low level for FatFS lib and esp_idf vfat
+ *         need to be implemented for IO driver implementation
+ *
+ *   Method return statueses:
+ * RES_OK  0 - Successful
+ * RES_ERROR  1 - R//W Error
+ * RES_WRPRT 2 - Write Protected
+ * RES_NOTRDY 3 - Not Ready
+ * RES_PARERR 4 - Invalid Parameter
+ */
+class StorageIO {
+ public:
+  /**
+   * @brief init driver
+   *
+   * @return true
+   * @return false
+   */
+  virtual bool storage_init() = 0;
+
+  /**
+   * @brief reset driver initialization
+   */
+  virtual void storage_uninit() = 0;
+
+  /**
+   * @brief provide writing one or more sectors
+   *
+   * @param buffer buffer with data need wreite
+   * @param sector start sector
+   * @param count total sectors need to write
+   * @return uint8_t
+   */
+  virtual uint8_t storage_write_sectors(const uint8_t *buffer, DWORD sector, UINT count) = 0;
+
+  /**
+   * @brief provide reading one or more sectors
+   *
+   * @param buffer buffer for save read data
+   * @param sector start sector for read
+   * @param count nom of sectors to read
+   * @return uint8_t
+   */
+  virtual uint8_t storage_read_sectors(uint8_t *buffer, DWORD sector, UINT count) = 0;
+
+  /**
+   * @brief Used for special data requests for FAT lib
+   *
+   * @param cmd
+   *    CTRL_SYNC
+   *    GET_SECTOR_COUNT
+   *    GET_SECTOR_SIZE
+   *    GET_BLOCK_SIZE
+   *
+   * @param buff buffer for store result
+   * @return uint8_t  operation status
+   */
+  virtual uint8_t storage_ioctl(uint8_t cmd, void *buff) = 0;
+
+  /**
+   * @brief The current drive status is returned in combination of status flags described below.
+   *        FatFs refers only STA_NOINIT and STA_PROTECT.
+   * @return uint8_t  - status flag.  Can bee one of following:
+   *
+   * STA_READY  (0x00) - Ready for operation
+   * STA_NOINIT (0x01) - Indicates that the device has not been initialized and not ready to work.
+   *    This flag is set on system reset, media removal or failure of disk_initialize function.
+   *    It is cleared on disk_initialize function succeeded. Any media change that occurs
+   *    asynchronously must be captured and reflect it to the status flags, or auto-mount
+   *    function will not work correctly. If the system does not support media change detection,
+   *    application program needs to explicitly re-mount the volume with f_mount function
+   *    after each media change.
+   * STA_NODISK (0x02)-  Indicates that no medium in the drive. This is always cleared when the drive
+   *    is non-removable class. Note that FatFs does not refer this flag.
+   * STA_PROTECT (0x04) - Indicates that the medium is write protected.
+   *    This is always cleared when the drive has no write protect function.
+   *    Not valid if STA_NODISK is set.
+   */
+  virtual uint8_t storage_status() = 0;
+
+  /**
+   * @brief  Compare storage status returned by @ref storage_status "storage_status"
+   * with exact status
+   *
+   * @param st_const  status tocompare with
+   * @return true   if pointed status set
+   * @return false  if pointed status not set
+   */
+  virtual bool is_storage_status(uint8_t st_const) { return (this->storage_status() & st_const) > 0; };
+
+  /**
+   * @brief  Return last IO operation error (if any)
+   *
+   * @return uint8_t
+   */
+  virtual uint8_t storage_error() = 0;
+};
+
+/** ****************************************************************************************
+ * @brief  Provide implementation of fatfs  API. See @ref fatfs::FatFs component.
+ * Cover FATFS lib from  esp_idf sdk.  FATFS lib also accessible under Arduino framework.
+ * Implementation controll fat mount/unmount, check if media exist
+ * and of course  provide access to fs objects (files and dirs)
+ *
+ * It does not provide storage media access, so this implementation
+ * need to be extended with storage media driver  StorageIO @ref fatfs_esp32::StorageIO.
+ * Injects driver class with "set_io_driver" method
+ */
+class FatESP32 : public fatfs::FatFs {
+ public:
+  bool set_io_driver(StorageIO *io_class);
+  void set_mount_point(std::string &path) { path_ = std::move(path); };
+  std::string get_mount_point() { return path_; };
+
+  /**
+   * @brief   Save pointers for read/write call and send it to ff_diskio_register (from fatfs)
+   */
+  virtual void init_driver();
+
+  /**
+   * @brief  Reset driver state
+   */
+  virtual void relese_driver();
+
+  /**
+   * @brief   Mount Fat filesystems if media available
+   *
+   * @return true  mout success
+   * @return false  mount failed
+   */
+  virtual bool mount();
+
+  /**
+   * @brief  Remove mount registrations
+   */
+  virtual void unmount();
+
+  /**
+   * @brief  Check is FS is mounted
+   *
+   * @return true   FS available
+   * @return false  FS not mounted
+   */
+  bool is_mount() override { return fs_ != NULL; };
+
+  fatfs::FatInfo *get_info(std::string &path) override;
+  bool is_exist(std::string &path) override;
+  fatfs::FileObject *open_file(std::string &path, uint8_t mode) override;
+  fatfs::FileObject *open_file(fatfs::FatInfo *obj, uint8_t mode) override;
+  fatfs::DirObject *open_dir(std::string &path) override;
+  fatfs::DirObject *open_dir(fatfs::FatInfo *obj) override;
+  fatfs::DirObject *mk_dir(std::string &path) override;
+  fatfs::DirObject *mk_dir(fatfs::FatInfo *obj, std::string &name) override;
+  bool del(std::string &path) override;
+  bool rename(std::string &path_from, std::string &path_to) override;
+  fatfs::FatError file_error() override { return error_; };
+  const char *print_file_error() override { return fs_errstr(static_cast<int>(error_)); };
+
+ private:
+  StorageIO *io_{NULL};
+  ff_diskio_impl_t sd_impl_;
+  std::string path_ = "/sdcard";
+  FATFS *fs_{NULL};
+  fatfs::FatError error_ = fatfs::FatError::FR_OK;
+};
+
+extern std::map<std::uint8_t, StorageIO *> db;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+}  // namespace fatfs_esp32
+}  // namespace esphome
+#endif

--- a/esphome/components/fatfs_esp32/fatfs_esp32_file.cpp
+++ b/esphome/components/fatfs_esp32/fatfs_esp32_file.cpp
@@ -1,0 +1,309 @@
+// #include "fatfs_esp32.h"
+#include "fatfs_esp32_file.h"
+#ifdef USE_ESP32
+#include "esphome/core/log.h"
+#include "esphome/core/time.h"
+#include <utility>
+extern "C" {
+#include "ff.h"
+#include "diskio.h"
+#if ESP_IDF_VERSION_MAJOR > 3
+#include "diskio_impl.h"
+#endif
+#include "esp_vfs_fat.h"
+}
+namespace esphome {
+namespace fatfs_esp32 {
+
+static const char *const TAG = "fatfs_esp32_file";
+
+FatESP32Info::FatESP32Info(std::string path) {
+  ESP_LOGV(TAG, "Init fatInfo. Path=%s ", path.c_str());
+  exist_ = false;
+
+  // Cut off drive part
+  if ((path.length() > 2) && (path[1] == ':')) {
+    drive_ = path.substr(0, 2);
+    path_ = path.substr(2, path.length() - 1);
+  } else {
+    path_ = path;
+    drive_ = std::string("0:");
+    // TODO:  get first inserted drive
+  }
+
+  // Cut off trailing  '/'  if path non root
+  if ((path_.length() > 1) && (path_[path_.length() - 1] == '/')) {
+    path_ = path_.substr(0, path_.length() - 2);
+    ESP_LOGV(TAG, "Subst trail space |%s|", path_.c_str());
+  }
+
+  //  Divide for path and name
+  size_t pos = path_.rfind('/');
+  if (pos == std::string::npos) {
+    name_ = path_;
+    path_ = std::string("");
+  } else {
+    //  Divide for path and name
+    name_ = path_.substr(pos + 1);
+    path_ = path_.substr(0, pos + 1);
+  }
+
+  ESP_LOGV(TAG, "Parse input path. %s (drv=%s, path=%s, name=%s)", path.c_str(), drive_.c_str(), path_.c_str(),
+           name_.c_str());
+
+  // Check for root object
+  if (path_.empty() && name_.empty()) {
+    return;
+  }
+  std::string fpath = drive_ + path_ + name_;
+
+  FILINFO finfo;
+  FRESULT res = f_stat(fpath.c_str(), &finfo);
+  ESP_LOGV(TAG, "f_stat for  %s, rc=%d", fpath.c_str(), res);
+  if (res == FR_NO_FILE || res == FR_NO_PATH) {
+    return;
+  } else if ((res == FR_INVALID_NAME) && (path_ == "/")) {
+    // res = FR_OK;
+    exist_ = true;
+    is_dir_ = true;
+    return;
+  } else if (res != FR_OK) {
+    ESP_LOGE(TAG, "f_stat %s error: (0x%x) %s", fpath.c_str(), res, fs_errstr(res));
+    return;
+  }
+
+  exist_ = true;
+  size_ = finfo.fsize;
+  name_ = std::string(finfo.fname);
+  is_dir_ = finfo.fattrib & AM_DIR;
+  is_hidden_ = finfo.fattrib & AM_HID;
+  is_system_ = finfo.fattrib & AM_SYS;
+  is_ro_ = finfo.fattrib & AM_RDO;
+  create_date_.year = (finfo.fdate >> 9) + 1980;
+  create_date_.month = finfo.fdate >> 5 & 15;
+  create_date_.day_of_month = finfo.fdate & 31;
+  create_date_.hour = finfo.ftime >> 11;
+  create_date_.minute = finfo.ftime >> 5 & 63;
+  create_date_.second = 0;
+  ESP_LOGV(TAG, "Load %s info %s", is_dir_ ? "DIR" : "FILE", name_.c_str());
+}
+
+FatESP32Info::FatESP32Info(fatfs::FatInfo &source) {
+  // *this = source;
+  drive_ = source.get_drive();
+  path_ = source.get_path();
+  name_ = source.get_name();
+  ESP_LOGVV(TAG, "Get FatInfo Object. d=%s, p=%s, n=%s", drive_.c_str(), path_.c_str(), name_.c_str());
+
+  if (source.is_exist()) {
+    exist_ = true;
+    size_ = source.size();
+    is_dir_ = source.is_dir();
+    is_hidden_ = source.is_hidden();
+    is_system_ = source.is_sys();
+    is_ro_ = source.is_readonly();
+    create_date_ = *(source.get_cr_date());
+  }
+}
+
+FatESP32Info &FatESP32Info::operator=(const FatESP32Info &source) {
+  if (this == &source)
+    return *this;
+  drive_ = source.drive_;
+  path_ = source.path_;
+  name_ = source.name_;
+
+  if (source.exist_) {
+    exist_ = true;
+    size_ = source.size_;
+    is_dir_ = source.is_dir_;
+    is_hidden_ = source.is_hidden_;
+    is_system_ = source.is_system_;
+    is_ro_ = source.is_ro_;
+    create_date_ = source.create_date_;
+  }
+  return *this;
+}
+
+std::string FatESP32Info::get_full_path() { return drive_ + path_ + name_; };
+
+FatESP32File::FatESP32File(std::string path) : FatESP32Info{std::move(path)} {}
+
+FatESP32File::FatESP32File(fatfs::FatInfo &finfo) : FatESP32Info{finfo} {}
+
+FatESP32File::~FatESP32File() {
+  if (is_open_) {
+    f_close(&fptr_);
+    ESP_LOGV(TAG, "Close file %s. Delete object.", this->FatESP32Info::get_full_path().c_str());
+  }
+}
+
+bool FatESP32File::open(uint16_t mode) {
+  bool ret = false;
+  ESP_LOGV(TAG, "Open file %s open mode= 0b " BYTE_TO_BINARY_PATTERN " " BYTE_TO_BINARY_PATTERN,
+           this->get_full_path().c_str(), BYTE_TO_BINARY((uint8_t) (mode >> 8)), BYTE_TO_BINARY((uint8_t) (mode)));
+  if (this->is_open_) {
+    ret = true;
+  } else if (this->FatESP32Info::is_exist() || mode & FAT_F_CREATE_ALWAYS) {
+    error_ = f_open(&fptr_, this->FatESP32Info::get_full_path().c_str(), mode);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "File %s open error (0x%x) %s", this->FatESP32Info::get_full_path().c_str(), error_,
+               fs_errstr(error_));
+    } else {
+      ESP_LOGVV(TAG, "File  %s open OK", this->FatESP32Info::get_full_path().c_str());
+      is_open_ = true;
+      ret = true;
+    }
+  } else {
+    error_ = FR_NO_FILE;
+  }
+  return ret;
+}
+
+void FatESP32File::close() {
+  if (is_open_) {
+    error_ = f_close(&fptr_);
+    if (error_ != FR_OK)
+      ESP_LOGE(TAG, "File close error (0x%x) %s", error_, fs_errstr(error_));
+    is_open_ = false;
+    ESP_LOGVV(TAG, "File close file %s, OK", this->FatESP32Info::get_full_path().c_str());
+  }
+}
+
+int32_t FatESP32File::read(void *buf, size_t size) {
+  UINT real_rd = 0;
+  if (is_open_) {
+    error_ = f_read(&fptr_, buf, size, &real_rd);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Read error (0x%x) %s", error_, fs_errstr(error_));
+      return -1;
+    }
+    // else  if(f_eof(&fptr_)) real_rd = 0;   // (fp)->obj.objsize
+  }
+  return real_rd;
+}
+
+int32_t FatESP32File::write(void *buf, size_t size) {
+  UINT real_wr = 0;
+  if (is_open_) {
+    error_ = f_write(&fptr_, buf, size, &real_wr);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Write error (0x%x) %s", error_, fs_errstr(error_));
+      return -1;
+    }
+  }
+  return real_wr;
+}
+
+bool FatESP32File::lseek(size_t pos) {
+  if (is_open_) {
+    error_ = f_lseek(&fptr_, pos);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Lseek error (0x%x) %s", error_, fs_errstr(error_));
+      return false;
+    }
+  }
+  return true;
+}
+
+bool FatESP32File::truncate() {
+  if (is_open_) {
+    error_ = f_truncate(&fptr_);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Truncate error (0x%x) %s", error_, fs_errstr(error_));
+      return false;
+    }
+  }
+  return true;
+}
+
+void FatESP32File::flush() {
+  if (is_open_) {
+    error_ = f_truncate(&fptr_);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Flush error (0x%x) %s", error_, fs_errstr(error_));
+    }
+  }
+}
+
+uint32_t FatESP32File::get_pos() {
+  if (is_open_) {
+    return f_tell(&fptr_);
+  }
+  return 0;
+}
+
+bool FatESP32File::is_eof() { return f_eof(&fptr_); }
+
+FatESP32Dir::FatESP32Dir(std::string path) : FatESP32Info{std::move(path)} {}
+
+FatESP32Dir::FatESP32Dir(fatfs::FatInfo &finfo) : FatESP32Info{finfo} {}
+
+FatESP32Dir::~FatESP32Dir() {
+  if (is_open_) {
+    f_closedir(&dptr_);
+  }
+}
+
+bool FatESP32Dir::open() {
+  ESP_LOGVV(TAG, "Open dir %s", this->FatESP32Info::get_full_path().c_str());
+  if (is_open_) {
+    return true;
+  }
+  if (!this->is_dir()) {
+    ESP_LOGVV(TAG, "Trying open file as directory. %s", this->FatESP32Info::get_full_path().c_str());
+    error_ = FR_INVALID_NAME;
+    return false;
+  }
+  if (this->FatESP32Info::is_exist()) {
+    error_ = f_opendir(&dptr_, this->FatESP32Info::get_full_path().c_str());
+  } else {
+    error_ = FR_NO_PATH;
+  }
+  is_open_ = error_ == FR_OK;
+  return is_open_;
+}
+
+fatfs::FatInfo *FatESP32Dir::get_next() {
+  ESP_LOGVV(TAG, "Get next dir %s object", this->FatESP32Info::get_full_path().c_str());
+  FILINFO fptr;
+  if (is_open_) {
+    error_ = f_readdir(&dptr_, &fptr);
+    if (error_ != FR_OK) {
+      ESP_LOGE(TAG, "Read dir entry error %s", fs_errstr(error_));
+      return NULL;
+    }
+    if (fptr.fname[0] == 0) {
+      return NULL;  //  Mean end of list
+    }
+    // return new FatESP32Info(this->get_full_path() + "/" + std::string(fptr.fname));
+    ESP_LOGV(TAG, "Read next object %s from directory %s (d=%s,p=%s,n=%s)", fptr.fname, this->get_full_path().c_str(),
+             this->FatESP32Info::get_drive().c_str(), this->FatESP32Info::get_path().c_str(),
+             this->FatESP32Info::get_name().c_str());
+
+    if (this->FatESP32Info::get_name().empty()) {
+      return new FatESP32Info(this->FatESP32Info::get_full_path() + std::string(fptr.fname));
+    } else {
+      return new FatESP32Info(this->FatESP32Info::get_full_path() + "/" + std::string(fptr.fname));
+    }
+  }
+  return NULL;
+}
+
+bool FatESP32Dir::reset() {
+  if (is_open_) {
+    error_ = f_closedir(&dptr_);
+    is_open_ = false;
+    if (error_ != FR_OK) {
+      return false;
+    }
+  }
+
+  error_ = f_opendir(&dptr_, this->FatESP32Info::get_full_path().c_str());
+  is_open_ = error_ == FR_OK;
+  return is_open_;
+}
+
+}  // namespace fatfs_esp32
+}  // namespace esphome
+#endif

--- a/esphome/components/fatfs_esp32/fatfs_esp32_file.h
+++ b/esphome/components/fatfs_esp32/fatfs_esp32_file.h
@@ -1,0 +1,104 @@
+#pragma once
+#include "esphome/core/defines.h"
+#ifdef USE_ESP32
+#include "esphome/core/gpio.h"
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include <map>
+#include "esphome/core/log.h"
+#include "esphome/components/fatfs/fatfs.h"
+#include "esphome/core/time.h"
+extern "C" {
+#include "ff.h"
+#include "diskio.h"
+#if ESP_IDF_VERSION_MAJOR > 3
+#include "diskio_impl.h"
+#endif
+#include "esp_vfs_fat.h"
+}
+
+namespace esphome {
+namespace fatfs_esp32 {
+
+using fatfs::fs_errstr;
+
+/** --------------------------------------------------------------------------------
+ * @brief Provide implementation for @ref fatfs::FatInfo API
+ */
+class FatESP32Info : public fatfs::FatInfo {
+ public:
+  FatESP32Info(fatfs::FatInfo &source);
+  FatESP32Info(std::string path);
+  FatESP32Info &operator=(const FatESP32Info &source);
+  bool is_exist() override { return exist_; };
+  bool is_dir() override { return is_dir_; };
+  bool is_readonly() override { return is_ro_; };
+  bool is_sys() override { return is_system_; };
+  bool is_hidden() override { return is_hidden_; };
+  size_t size() override { return size_; };
+  ESPTime *get_cr_date() override { return &create_date_; };
+  std::string get_name() override { return name_; };
+  std::string get_path() override { return path_; };
+  std::string get_drive() override { return drive_; };
+  std::string get_full_path() override;
+
+ private:
+  std::string name_{""};
+  std::string path_{""};
+  std::string drive_{""};
+  size_t size_;
+  bool exist_ = false;
+  bool is_dir_ = false;
+  bool is_hidden_ = false;
+  bool is_system_ = false;
+  bool is_ro_ = false;
+  ESPTime create_date_;
+};
+
+/** --------------------------------------------------------------------------------
+ * @brief Provide implementation for @ref fatfs::FileObject API
+ */
+class FatESP32File : public fatfs::FileObject, public FatESP32Info {
+ public:
+  FatESP32File(std::string path);
+  FatESP32File(fatfs::FatInfo &finfo);
+  ~FatESP32File();
+  bool open(uint16_t mode) override;
+  void close() override;
+  int32_t read(void *buf, size_t size) override;
+  int32_t write(void *buf, size_t size) override;
+  bool lseek(size_t pos) override;
+  bool truncate() override;
+  void flush() override;
+  bool is_eof() override;
+  uint32_t get_pos() override;
+  fatfs::FatError file_error() override { return static_cast<fatfs::FatError>(error_); };
+
+ private:
+  uint8_t error_ = FR_OK;
+  FIL fptr_;
+  bool is_open_ = false;
+};
+
+/** --------------------------------------------------------------------------------
+ * @brief Provide implementation for @ref fatfs::DirObject API
+ */
+class FatESP32Dir : public fatfs::DirObject, public FatESP32Info {
+ public:
+  FatESP32Dir(std::string path);
+  FatESP32Dir(fatfs::FatInfo &finfo);
+  ~FatESP32Dir();
+  bool open() override;
+  fatfs::FatInfo *get_next() override;
+  bool reset() override;
+  fatfs::FatError file_error() override { return static_cast<fatfs::FatError>(error_); };
+
+ private:
+  uint8_t error_ = {FR_OK};
+  FF_DIR dptr_;
+  bool is_open_ = false;
+};
+
+}  // namespace fatfs_esp32
+}  // namespace esphome
+#endif


### PR DESCRIPTION
# What does this implement/fix?
Fatfs_esp32 itself provide methods for accessing files and directory on FAT filesystems thought esp32 implementation of fatfs library.  Fatfs library support FAT16, FAT32 and ExFat.
It is platform component under FATFS platform (Required Fatfs #11093)
<!-- Quick description and explanation of changes -->


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5467

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
fatfs:
  - platform: ...    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
