### PR TITLE
[ci] Dynamic runner allocation: 8 for releases, 4 for dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,7 +433,7 @@ jobs:
     if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) >= 100
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: ${{ (github.base_ref == 'beta' || github.base_ref == 'release') && 8 || 4 }}
       matrix:
         components: ${{ fromJson(needs.test-build-components-splitter.outputs.matrix) }}
     steps:


### PR DESCRIPTION
# What does this implement/fix?

This PR adjusts the CI runner allocation to prioritize faster builds for release branches while maintaining efficient resource usage for regular development.

**Changes:**
- Increase parallel runners from 5 to **8** for PRs targeting `beta` and `release` branches
- Reduce parallel runners to **4** for PRs targeting `dev` and other branches as it was before #11134

**Rationale:**
Following PR #11134 which reduced CI time to 1h47m through component grouping, releases are still too slow for the release process. This change prioritizes release velocity:
- **Beta/Release branches** (8 runners): Expected ~50-65 minute CI time - critical for release cadence
- **Dev/other branches** (4 runners): Acceptable longer CI times while conserving GitHub Actions resources for regular development

The dynamic allocation uses `github.base_ref` to detect the target branch and adjust `max-parallel` accordingly.

## Types of changes

- [x] Other (CI/CD infrastructure improvement)

**Related issue or feature (if applicable):**

- Follows up on #11134 (Component test grouping optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (CI-only change)

## Test Environment

- [x] All platforms (CI infrastructure change affects all platforms equally)

## Example entry for `config.yaml`:

```yaml
# No config changes - CI workflow only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
