### PR TITLE
[ci] Group all PR builds, isolate direct changes for full validation on dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
       python-linters: ${{ steps.determine.outputs.python-linters }}
       changed-components: ${{ steps.determine.outputs.changed-components }}
       changed-components-with-tests: ${{ steps.determine.outputs.changed-components-with-tests }}
+      directly-changed-components-with-tests: ${{ steps.determine.outputs.directly-changed-components-with-tests }}
       component-test-count: ${{ steps.determine.outputs.component-test-count }}
     steps:
       - name: Check out code from GitHub
@@ -206,6 +207,7 @@ jobs:
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
           echo "changed-components=$(echo "$output" | jq -c '.changed_components')" >> $GITHUB_OUTPUT
           echo "changed-components-with-tests=$(echo "$output" | jq -c '.changed_components_with_tests')" >> $GITHUB_OUTPUT
+          echo "directly-changed-components-with-tests=$(echo "$output" | jq -c '.directly_changed_components_with_tests')" >> $GITHUB_OUTPUT
           echo "component-test-count=$(echo "$output" | jq -r '.component_test_count')" >> $GITHUB_OUTPUT
 
   integration-tests:
@@ -358,48 +360,13 @@ jobs:
         # yamllint disable-line rule:line-length
         if: always()
 
-  test-build-components:
-    name: Component test ${{ matrix.file }}
-    runs-on: ubuntu-24.04
-    needs:
-      - common
-      - determine-jobs
-    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) > 0 && fromJSON(needs.determine-jobs.outputs.component-test-count) < 100
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        file: ${{ fromJson(needs.determine-jobs.outputs.changed-components-with-tests) }}
-    steps:
-      - name: Cache apt packages
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.5.3
-        with:
-          packages: libsdl2-dev
-          version: 1.0
-
-      - name: Check out code from GitHub
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Restore Python
-        uses: ./.github/actions/restore-python
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-          cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Validate config for ${{ matrix.file }}
-        run: |
-          . venv/bin/activate
-          python3 script/test_build_components.py -e config -c ${{ matrix.file }}
-      - name: Compile config for ${{ matrix.file }}
-        run: |
-          . venv/bin/activate
-          python3 script/test_build_components.py -e compile -c ${{ matrix.file }}
-
   test-build-components-splitter:
     name: Split components for intelligent grouping (40 weighted per batch)
     runs-on: ubuntu-24.04
     needs:
       - common
       - determine-jobs
-    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) >= 100
+    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) > 0
     outputs:
       matrix: ${{ steps.split.outputs.components }}
     steps:
@@ -430,7 +397,7 @@ jobs:
       - common
       - determine-jobs
       - test-build-components-splitter
-    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) >= 100
+    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.component-test-count) > 0
     strategy:
       fail-fast: false
       max-parallel: 5
@@ -477,18 +444,34 @@ jobs:
           # Convert space-separated components to comma-separated for Python script
           components_csv=$(echo "${{ matrix.components }}" | tr ' ' ',')
 
-          echo "Testing components: $components_csv"
+          # Only isolate directly changed components when targeting dev branch
+          # For beta/release branches, group everything for faster CI
+          #
+          # WHY ISOLATE DIRECTLY CHANGED COMPONENTS?
+          # - Isolated tests run WITHOUT --testing-mode, enabling full validation
+          # - This catches pin conflicts and other issues in directly changed code
+          # - Grouped tests use --testing-mode to allow config merging (disables some checks)
+          # - Dependencies are safe to group since they weren't modified in this PR
+          if [ "${{ github.base_ref }}" = "beta" ] || [ "${{ github.base_ref }}" = "release" ]; then
+            directly_changed_csv=""
+            echo "Testing components: $components_csv"
+            echo "Target branch: ${{ github.base_ref }} - grouping all components"
+          else
+            directly_changed_csv=$(echo '${{ needs.determine-jobs.outputs.directly-changed-components-with-tests }}' | jq -r 'join(",")')
+            echo "Testing components: $components_csv"
+            echo "Target branch: ${{ github.base_ref }} - isolating directly changed components: $directly_changed_csv"
+          fi
           echo ""
 
-          # Run config validation with grouping
-          python3 script/test_build_components.py -e config -c "$components_csv" -f
+          # Run config validation with grouping and isolation
+          python3 script/test_build_components.py -e config -c "$components_csv" -f --isolate "$directly_changed_csv"
 
           echo ""
           echo "Config validation passed! Starting compilation..."
           echo ""
 
-          # Run compilation with grouping
-          python3 script/test_build_components.py -e compile -c "$components_csv" -f
+          # Run compilation with grouping and isolation
+          python3 script/test_build_components.py -e compile -c "$components_csv" -f --isolate "$directly_changed_csv"
 
   pre-commit-ci-lite:
     name: pre-commit.ci lite
@@ -521,7 +504,6 @@ jobs:
       - integration-tests
       - clang-tidy
       - determine-jobs
-      - test-build-components
       - test-build-components-splitter
       - test-build-components-split
       - pre-commit-ci-lite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,9 +384,10 @@ jobs:
 
           # Use intelligent splitter that groups components with same bus configs
           components='${{ needs.determine-jobs.outputs.changed-components-with-tests }}'
+          directly_changed='${{ needs.determine-jobs.outputs.directly-changed-components-with-tests }}'
 
           echo "Splitting components intelligently..."
-          output=$(python3 script/split_components_for_ci.py --components "$components" --batch-size 40 --output github)
+          output=$(python3 script/split_components_for_ci.py --components "$components" --directly-changed "$directly_changed" --batch-size 40 --output github)
 
           echo "$output" >> $GITHUB_OUTPUT
 

--- a/script/split_components_for_ci.py
+++ b/script/split_components_for_ci.py
@@ -56,6 +56,7 @@ def create_intelligent_batches(
     components: list[str],
     tests_dir: Path,
     batch_size: int = 40,
+    directly_changed: set[str] | None = None,
 ) -> list[list[str]]:
     """Create batches optimized for component grouping.
 
@@ -63,6 +64,7 @@ def create_intelligent_batches(
         components: List of component names to batch
         tests_dir: Path to tests/components directory
         batch_size: Target size for each batch
+        directly_changed: Set of directly changed components (for logging only)
 
     Returns:
         List of component batches (lists of component names)
@@ -188,6 +190,10 @@ def main() -> int:
         help="Path to tests/components directory",
     )
     parser.add_argument(
+        "--directly-changed",
+        help="JSON array of directly changed component names (for logging only)",
+    )
+    parser.add_argument(
         "--output",
         "-o",
         choices=["json", "github"],
@@ -208,11 +214,21 @@ def main() -> int:
         print("Components must be a JSON array", file=sys.stderr)
         return 1
 
+    # Parse directly changed components list from JSON (if provided)
+    directly_changed = None
+    if args.directly_changed:
+        try:
+            directly_changed = set(json.loads(args.directly_changed))
+        except json.JSONDecodeError as e:
+            print(f"Error parsing directly-changed JSON: {e}", file=sys.stderr)
+            return 1
+
     # Create intelligent batches
     batches = create_intelligent_batches(
         components=components,
         tests_dir=args.tests_dir,
         batch_size=args.batch_size,
+        directly_changed=directly_changed,
     )
 
     # Convert batches to space-separated strings for CI
@@ -245,6 +261,28 @@ def main() -> int:
     print("\n=== Intelligent Batch Summary ===", file=sys.stderr)
     print(f"Total components requested: {len(components)}", file=sys.stderr)
     print(f"Components with test files: {actual_components}", file=sys.stderr)
+
+    # Show breakdown of directly changed vs dependencies
+    if directly_changed:
+        direct_count = sum(
+            1 for comp in all_batched_components if comp in directly_changed
+        )
+        dep_count = actual_components - direct_count
+        direct_comps = [
+            comp for comp in all_batched_components if comp in directly_changed
+        ]
+        dep_comps = [
+            comp for comp in all_batched_components if comp not in directly_changed
+        ]
+        print(
+            f"  - Direct changes: {direct_count} ({', '.join(sorted(direct_comps))})",
+            file=sys.stderr,
+        )
+        print(
+            f"  - Dependencies: {dep_count} ({', '.join(sorted(dep_comps))})",
+            file=sys.stderr,
+        )
+
     print(f"  - Groupable (weight=1): {groupable_count}", file=sys.stderr)
     print(f"  - Isolated (weight=10): {isolated_count}", file=sys.stderr)
     if actual_components < len(components):

--- a/script/split_components_for_ci.py
+++ b/script/split_components_for_ci.py
@@ -261,7 +261,9 @@ def main() -> int:
     isolated_count = sum(
         1
         for comp in all_batched_components
-        if comp in ISOLATED_COMPONENTS or comp in non_groupable
+        if comp in ISOLATED_COMPONENTS
+        or comp in non_groupable
+        or (directly_changed and comp in directly_changed)
     )
     groupable_count = actual_components - isolated_count
 

--- a/script/split_components_for_ci.py
+++ b/script/split_components_for_ci.py
@@ -96,10 +96,17 @@ def create_intelligent_batches(
 
     for component in components_with_tests:
         # Components that can't be grouped get unique signatures
-        # This includes both manually curated ISOLATED_COMPONENTS and
-        # automatically detected non_groupable components
+        # This includes:
+        # - Manually curated ISOLATED_COMPONENTS
+        # - Automatically detected non_groupable components
+        # - Directly changed components (passed via --isolate in CI)
         # These can share a batch/runner but won't be grouped/merged
-        if component in ISOLATED_COMPONENTS or component in non_groupable:
+        is_isolated = (
+            component in ISOLATED_COMPONENTS
+            or component in non_groupable
+            or (directly_changed and component in directly_changed)
+        )
+        if is_isolated:
             signature_groups[f"isolated_{component}"].append(component)
             continue
 

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -73,9 +73,11 @@ def test_main_all_tests_should_run(
     mock_should_run_clang_format.return_value = True
     mock_should_run_python_linters.return_value = True
 
-    # Mock list-components.py output
+    # Mock list-components.py output (now returns JSON with --changed-with-deps)
     mock_result = Mock()
-    mock_result.stdout = "wifi\napi\nsensor\n"
+    mock_result.stdout = json.dumps(
+        {"directly_changed": ["wifi", "api"], "all_changed": ["wifi", "api", "sensor"]}
+    )
     mock_subprocess_run.return_value = mock_result
 
     # Run main function with mocked argv
@@ -116,7 +118,7 @@ def test_main_no_tests_should_run(
 
     # Mock empty list-components.py output
     mock_result = Mock()
-    mock_result.stdout = ""
+    mock_result.stdout = json.dumps({"directly_changed": [], "all_changed": []})
     mock_subprocess_run.return_value = mock_result
 
     # Run main function with mocked argv
@@ -177,7 +179,9 @@ def test_main_with_branch_argument(
 
     # Mock list-components.py output
     mock_result = Mock()
-    mock_result.stdout = "mqtt\n"
+    mock_result.stdout = json.dumps(
+        {"directly_changed": ["mqtt"], "all_changed": ["mqtt"]}
+    )
     mock_subprocess_run.return_value = mock_result
 
     with patch("sys.argv", ["script.py", "-b", "main"]):
@@ -192,7 +196,7 @@ def test_main_with_branch_argument(
     # Check that list-components.py was called with branch
     mock_subprocess_run.assert_called_once()
     call_args = mock_subprocess_run.call_args[0][0]
-    assert "--changed" in call_args
+    assert "--changed-with-deps" in call_args
     assert "-b" in call_args
     assert "main" in call_args
 
@@ -411,7 +415,12 @@ def test_main_filters_components_without_tests(
     # Mock list-components.py output with 3 components
     # wifi: has tests, sensor: has tests, airthings_ble: no tests
     mock_result = Mock()
-    mock_result.stdout = "wifi\nsensor\nairthings_ble\n"
+    mock_result.stdout = json.dumps(
+        {
+            "directly_changed": ["wifi", "sensor"],
+            "all_changed": ["wifi", "sensor", "airthings_ble"],
+        }
+    )
     mock_subprocess_run.return_value = mock_result
 
     # Create test directory structure

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -445,6 +445,8 @@ def test_main_filters_components_without_tests(
         patch.object(determine_jobs, "root_path", str(tmp_path)),
         patch("sys.argv", ["determine-jobs.py"]),
     ):
+        # Clear the cache since we're mocking root_path
+        determine_jobs._component_has_tests.cache_clear()
         determine_jobs.main()
 
     # Check output


### PR DESCRIPTION
# What does this implement/fix?

Changes the CI to always use grouped component builds for PRs, with directly changed components getting isolated test runners when targeting the `dev` branch.

Previously, the CI would only use grouped builds when 100+ components were changed. Now all PRs use grouped builds, which significantly reduces CI time and resource usage.

**Key behavior change for PRs:**

**Targeting `dev` branch:**
- Components with **direct changes** (files modified in the PR) → **isolated test runners** (tested individually **without** `--testing-mode`)
  - **Why?** We need full validation (pin conflicts, etc.) for directly changed components to catch issues
- Components included only due to **dependencies** → **grouped builds** (tested together with `--testing-mode`)
  - **Why?** Grouping requires `--testing-mode` to disable pin conflict checks and other validations that prevent config merging

**Targeting `beta` or `release` branches:**
- All groupable components are grouped together (no isolation) for maximum CI speed
- Uses `--testing-mode` for all grouped builds

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (CI optimization)

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI change)

## Implementation Details

### Changes Made:

1. **`script/list-components.py`**
   - Added `--changed-with-deps` flag that returns JSON with both directly changed and all changed components in a single call
   - Avoids redundant filesystem operations

2. **`script/determine-jobs.py`**
   - Uses new `--changed-with-deps` flag for efficiency
   - Added `@cache` decorator for component test checking to avoid repeated filesystem operations
   - Outputs `directly_changed_components_with_tests` and `dependency_only_components_with_tests` for CI consumption

3. **`script/split_components_for_ci.py`**
   - Added `--directly-changed` parameter to receive list of directly changed components
   - Weights directly changed components at 10x (same as `ISOLATED_COMPONENTS`) for proper batch distribution
   - Shows breakdown of directly changed vs dependency components in batch summary output

4. **`script/test_build_components.py`**
   - Added `--isolate` parameter accepting a CSV list of components to treat as isolated
   - These components won't be grouped with others and are tested WITHOUT `--testing-mode`
   - This enables full validation (pin conflicts, etc.) for directly changed components
   - Displays them separately in the grouping plan output

5. **`.github/workflows/ci.yml`**
   - Removed the old individual component test job (< 100 components path)
   - All PRs now use the grouped build path (was previously only for 100+ components)
   - For `dev` branch PRs: passes directly changed components via `--isolate` parameter for full validation
   - For `beta`/`release` branch PRs: passes empty `--isolate` to group everything for maximum CI speed
   - Passes directly changed components to the splitter for proper 10x weighting

## Test Environment

- [x] CI workflow changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal CI only)
