### PR TITLE
Added support for tm1638 on QYF board with 16 buttons (and no LEDs)

### DIFF
--- a/esphome/components/tm1638/binary_sensor/__init__.py
+++ b/esphome/components/tm1638/binary_sensor/__init__.py
@@ -10,7 +10,9 @@ TM1638Key = tm1638_ns.class_("TM1638Key", binary_sensor.BinarySensor)
 CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(TM1638Key).extend(
     {
         cv.GenerateID(CONF_TM1638_ID): cv.use_id(TM1638Component),
-        cv.Required(CONF_KEY): cv.int_range(min=0, max=15), # 15 is already OK for qfy board
+        cv.Required(CONF_KEY): cv.int_range(
+            min=0, max=15
+        ),  # 15 is already OK for qfy board
     }
 )
 

--- a/esphome/components/tm1638/binary_sensor/__init__.py
+++ b/esphome/components/tm1638/binary_sensor/__init__.py
@@ -10,7 +10,7 @@ TM1638Key = tm1638_ns.class_("TM1638Key", binary_sensor.BinarySensor)
 CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(TM1638Key).extend(
     {
         cv.GenerateID(CONF_TM1638_ID): cv.use_id(TM1638Component),
-        cv.Required(CONF_KEY): cv.int_range(min=0, max=15),
+        cv.Required(CONF_KEY): cv.int_range(min=0, max=15), # 15 is already OK for qfy board
     }
 )
 

--- a/esphome/components/tm1638/binary_sensor/tm1638_key.cpp
+++ b/esphome/components/tm1638/binary_sensor/tm1638_key.cpp
@@ -3,7 +3,7 @@
 namespace esphome {
 namespace tm1638 {
 
-void TM1638Key::keys_update(uint8_t keys) {
+void TM1638Key::keys_update(uint16_t keys) {
   bool pressed = keys & (1 << key_code_);
   if (pressed != this->state)
     this->publish_state(pressed);

--- a/esphome/components/tm1638/binary_sensor/tm1638_key.h
+++ b/esphome/components/tm1638/binary_sensor/tm1638_key.h
@@ -9,7 +9,7 @@ namespace tm1638 {
 class TM1638Key : public binary_sensor::BinarySensor, public KeyListener {
  public:
   void set_keycode(uint8_t key_code) { key_code_ = key_code; };
-  void keys_update(uint8_t keys) override;
+  void keys_update(uint16_t keys) override;
 
  protected:
   uint8_t key_code_{0};

--- a/esphome/components/tm1638/display.py
+++ b/esphome/components/tm1638/display.py
@@ -3,13 +3,13 @@ import esphome.codegen as cg
 from esphome.components import display
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_BOARD,
     CONF_CLK_PIN,
     CONF_DIO_PIN,
     CONF_ID,
     CONF_INTENSITY,
     CONF_LAMBDA,
     CONF_STB_PIN,
-    CONF_BOARD,
 )
 
 CODEOWNERS = ["@skykingjwc"]
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
         cv.Required(CONF_STB_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_DIO_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_INTENSITY, default=7): cv.int_range(min=0, max=8),
-        cv.Optional(CONF_BOARD, default="led"): cv.string, #led/qyf/lkm
+        cv.Optional(CONF_BOARD, default="led"): cv.string,  # led/qyf/lkm
     }
 ).extend(cv.polling_component_schema("1s"))
 

--- a/esphome/components/tm1638/display.py
+++ b/esphome/components/tm1638/display.py
@@ -9,6 +9,7 @@ from esphome.const import (
     CONF_INTENSITY,
     CONF_LAMBDA,
     CONF_STB_PIN,
+    CONF_BOARD,
 )
 
 CODEOWNERS = ["@skykingjwc"]
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = display.BASIC_DISPLAY_SCHEMA.extend(
         cv.Required(CONF_STB_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_DIO_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_INTENSITY, default=7): cv.int_range(min=0, max=8),
+        cv.Optional(CONF_BOARD, default="led"): cv.string, #led/qyf/lkm
     }
 ).extend(cv.polling_component_schema("1s"))
 
@@ -45,6 +47,8 @@ async def to_code(config):
     cg.add(var.set_stb_pin(stb))
 
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
+
+    cg.add(var.set_board(config[CONF_BOARD]))
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -80,19 +80,18 @@ uint16_t TM1638Component::get_keys() {
 
   delayMicroseconds(10);
 
-  bool isQFY = this->board_ == "qyf"; // once
+  bool isQFY = this->board_ == "qyf";  // once
 
-  for (uint8_t i = 0; i < 4; i++) { // read the 4 button registers
+  for (uint8_t i = 0; i < 4; i++) {  // read the 4 button registers
     uint8_t v = this->shift_in_();
-    if (isQFY) { // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
+    if (isQFY) {  // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
       // turn v ABCDEFGI = 0BC00FG0  into 00CG00BF see matrix below
       v = (((v & 0x40) >> 3 | (v & 0x04)) >> 2) | (v & 0x20) | (v & 0x02) << 3;
       // i = 0 v = 00,10, 9,0021 // i = 1 v = 00,12,11,0043
       // i = 2 v = 00,14,13,0065 // i = 3 v = 00,16,15,0087
       // buttons = 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1
-      buttons |= ((v & 0x000F) << (2*i)) | (((v & 0x00F0) << 4) << (2*i));
-    }
-    else
+      buttons |= ((v & 0x000F) << (2 * i)) | (((v & 0x00F0) << 4) << (2 * i));
+    } else
       buttons |= v << i;  // shift bits to correct slots in the byte
   }
 
@@ -114,12 +113,11 @@ void TM1638Component::update() {  // this is called at the interval specified in
 float TM1638Component::get_setup_priority() const { return setup_priority::PROCESSOR; }
 
 void TM1638Component::display() {
+  uint8_t buffer[8] = {0};
 
-  uint8_t buffer[8] = { 0 };
+  if (this->board_ == "qyf") {  // refactor for differently wired board
 
-  if(this->board_ == "qyf") { // refactor for differently wired board
-
-    uint8_t mask = 0x80; // start on left side (left most 7-segment)
+    uint8_t mask = 0x80;  // start on left side (left most 7-segment)
     for (uint8_t i = 0; i < 8; i++) {
       /*
       if (buffer_[i] & 0x01) buffer[0] |= mask; // A
@@ -131,15 +129,15 @@ void TM1638Component::display() {
       if (buffer_[i] & 0x40) buffer[6] |= mask; // G
       if (buffer_[i] & 0x80) buffer[7] |= mask; // .
       */
-      uint8_t seg = 0x01; // start with A-segment
+      uint8_t seg = 0x01;  // start with A-segment
       for (uint8_t j = 0; j < 8; j++) {
-        if (buffer_[i] & seg) buffer[j] |= mask;
+        if (buffer_[i] & seg)
+          buffer[j] |= mask;
         seg <<= 1;
       }
       mask >>= 1;
     }
-  }
-  else
+  } else
     memcpy(buffer, buffer_, sizeof(buffer));
 
   for (uint8_t i = 0; i < 8; i++) {
@@ -161,7 +159,8 @@ void TM1638Component::reset_() {
 /////////////// LEDs /////////////////
 
 void TM1638Component::set_led(int led_pos, bool led_on_off) {
-  if (this->board_ != "led") return;
+  if (this->board_ != "led")
+    return;
 
   this->send_command_(TM1638_REGISTER_FIXEDADDRESS);
 

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -40,6 +40,10 @@ void TM1638Component::setup() {
 
   this->reset_();  // all LEDs off
 
+  this->clear();
+}
+
+void TM1638Component::clear() {
   for (uint8_t i = 0; i < 8; i++)  // zero fill print buffer
     this->buffer_[i] = 0;
 }
@@ -82,7 +86,7 @@ uint16_t TM1638Component::get_keys() {
     uint8_t v = this->shift_in_();
     if (isQFY) { // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
       // turn v ABCDEFGI = 0BC00FG0  into 00CG00BF see matrix below
-			v = (((v & 0x40) >> 3 | (v & 0x04)) >> 2) | (v & 0x20) | (v & 0x02) << 3;
+      v = (((v & 0x40) >> 3 | (v & 0x04)) >> 2) | (v & 0x20) | (v & 0x02) << 3;
       // i = 0 v = 00,10, 9,0021 // i = 1 v = 00,12,11,0043
       // i = 2 v = 00,14,13,0065 // i = 3 v = 00,16,15,0087
       // buttons = 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -110,8 +110,36 @@ void TM1638Component::update() {  // this is called at the interval specified in
 float TM1638Component::get_setup_priority() const { return setup_priority::PROCESSOR; }
 
 void TM1638Component::display() {
+
+  uint8_t buffer[8] = { 0 };
+
+  if(this->board_ == "qyf") { // refactor for differently wired board
+
+    uint8_t mask = 0x80; // start on left side (left most 7-segment)
+    for (uint8_t i = 0; i < 8; i++) {
+      /*
+      if (buffer_[i] & 0x01) buffer[0] |= mask; // A
+      if (buffer_[i] & 0x02) buffer[1] |= mask; // B
+      if (buffer_[i] & 0x04) buffer[2] |= mask; // C
+      if (buffer_[i] & 0x08) buffer[3] |= mask; // D
+      if (buffer_[i] & 0x10) buffer[4] |= mask; // E
+      if (buffer_[i] & 0x20) buffer[5] |= mask; // F
+      if (buffer_[i] & 0x40) buffer[6] |= mask; // G
+      if (buffer_[i] & 0x80) buffer[7] |= mask; // .
+      */
+      uint8_t seg = 0x01; // start with A-segment
+      for (uint8_t j = 0; j < 8; j++) {
+        if (buffer_[i] & seg) buffer[j] |= mask;
+        seg <<= 1;
+      }
+      mask >>= 1;
+    }
+  }
+  else
+    memcpy(buffer, buffer_, sizeof(buffer));
+
   for (uint8_t i = 0; i < 8; i++) {
-    this->set_7seg_(i, buffer_[i]);
+    this->set_7seg_(i, buffer[i]);
   }
 }
 

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -4,6 +4,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <string>
+
 namespace esphome {
 namespace tm1638 {
 
@@ -34,6 +36,8 @@ void TM1638Component::setup() {
 
   this->set_intensity(intensity_);
 
+  this->set_board(board_);
+
   this->reset_();  // all LEDs off
 
   for (uint8_t i = 0; i < 8; i++)  // zero fill print buffer
@@ -43,8 +47,9 @@ void TM1638Component::setup() {
 void TM1638Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "TM1638:\n"
+                "  Board: %s\n"
                 "  Intensity: %u",
-                this->intensity_);
+                this->board_.c_str(), this->intensity_);
   LOG_PIN("  CLK Pin: ", this->clk_pin_);
   LOG_PIN("  DIO Pin: ", this->dio_pin_);
   LOG_PIN("  STB Pin: ", this->stb_pin_);
@@ -55,13 +60,13 @@ void TM1638Component::loop() {
   if (this->listeners_.empty())
     return;
 
-  uint8_t keys = this->get_keys();
+  uint16_t keys = this->get_keys();
   for (auto &listener : this->listeners_)
     listener->keys_update(keys);
 }
 
-uint8_t TM1638Component::get_keys() {
-  uint8_t buttons = 0;
+uint16_t TM1638Component::get_keys() {
+  uint16_t buttons = 0;
 
   this->stb_pin_->digital_write(false);
 
@@ -71,9 +76,20 @@ uint8_t TM1638Component::get_keys() {
 
   delayMicroseconds(10);
 
-  for (uint8_t i = 0; i < 4; i++) {  // read the 4 button registers
+  bool isQFY = this->board_ == "qyf"; // once
+
+  for (uint8_t i = 0; i < 4; i++) { // read the 4 button registers
     uint8_t v = this->shift_in_();
-    buttons |= v << i;  // shift bits to correct slots in the byte
+    if (isQFY) { // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
+      // turn v ABCDEFGI = 0BC00FG0  into 00CG00BF see matrix below
+			v = (((v & 0x40) >> 3 | (v & 0x04)) >> 2) | (v & 0x20) | (v & 0x02) << 3;
+      // i = 0 v = 00,10, 9,0021 // i = 1 v = 00,12,11,0043
+      // i = 2 v = 00,14,13,0065 // i = 3 v = 00,16,15,0087
+      // buttons = 16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1
+      buttons |= ((v & 0x000F) << (2*i)) | (((v & 0x00F0) << 4) << (2*i));
+    }
+    else
+      buttons |= v << i;  // shift bits to correct slots in the byte
   }
 
   this->dio_pin_->pin_mode(gpio::FLAG_OUTPUT);
@@ -113,6 +129,8 @@ void TM1638Component::reset_() {
 /////////////// LEDs /////////////////
 
 void TM1638Component::set_led(int led_pos, bool led_on_off) {
+  if (this->board_ != "led") return;
+
   this->send_command_(TM1638_REGISTER_FIXEDADDRESS);
 
   uint8_t commands[2];

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -80,11 +80,11 @@ uint16_t TM1638Component::get_keys() {
 
   delayMicroseconds(10);
 
-  bool isQFY = this->board_ == "qyf";  // once
+  bool is_qfy = this->board_ == "qyf";  // once
 
   for (uint8_t i = 0; i < 4; i++) {  // read the 4 button registers
     uint8_t v = this->shift_in_();
-    if (isQFY) {  // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
+    if (is_qfy) {  // 16 buttons - https://github.com/gavinlyonsrepo/TM1638plus/blob/master/src/TM1638plus_Model2.cpp
       // turn v ABCDEFGI = 0BC00FG0  into 00CG00BF see matrix below
       v = (((v & 0x40) >> 3 | (v & 0x04)) >> 2) | (v & 0x20) | (v & 0x02) << 3;
       // i = 0 v = 00,10, 9,0021 // i = 1 v = 00,12,11,0043
@@ -119,20 +119,10 @@ void TM1638Component::display() {
 
     uint8_t mask = 0x80;  // start on left side (left most 7-segment)
     for (uint8_t i = 0; i < 8; i++) {
-      /*
-      if (buffer_[i] & 0x01) buffer[0] |= mask; // A
-      if (buffer_[i] & 0x02) buffer[1] |= mask; // B
-      if (buffer_[i] & 0x04) buffer[2] |= mask; // C
-      if (buffer_[i] & 0x08) buffer[3] |= mask; // D
-      if (buffer_[i] & 0x10) buffer[4] |= mask; // E
-      if (buffer_[i] & 0x20) buffer[5] |= mask; // F
-      if (buffer_[i] & 0x40) buffer[6] |= mask; // G
-      if (buffer_[i] & 0x80) buffer[7] |= mask; // .
-      */
       uint8_t seg = 0x01;  // start with A-segment
-      for (uint8_t j = 0; j < 8; j++) {
+      for (unsigned char & j : buffer) {
         if (buffer_[i] & seg)
-          buffer[j] |= mask;
+          j |= mask;
         seg <<= 1;
       }
       mask >>= 1;

--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -120,7 +120,7 @@ void TM1638Component::display() {
     uint8_t mask = 0x80;  // start on left side (left most 7-segment)
     for (uint8_t i = 0; i < 8; i++) {
       uint8_t seg = 0x01;  // start with A-segment
-      for (unsigned char & j : buffer) {
+      for (unsigned char &j : buffer) {
         if (buffer_[i] & seg)
           j |= mask;
         seg <<= 1;

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -7,13 +7,14 @@
 #include "esphome/core/time.h"
 
 #include <vector>
+#include <string>
 
 namespace esphome {
 namespace tm1638 {
 
 class KeyListener {
  public:
-  virtual void keys_update(uint8_t keys){};
+  virtual void keys_update(uint16_t keys){};
 };
 
 class TM1638Component;
@@ -34,6 +35,13 @@ class TM1638Component : public PollingComponent {
   void set_dio_pin(GPIOPin *pin) { this->dio_pin_ = pin; }
   void set_stb_pin(GPIOPin *pin) { this->stb_pin_ = pin; }
 
+  void set_board(std::string board) {
+    for (char &c : board) {
+      c = std::tolower(static_cast<unsigned char>(c));
+    }
+    this->board_ = board;
+  }
+
   void register_listener(KeyListener *listener) { this->listeners_.push_back(listener); }
 
   /// Evaluate the printf-format and print the result at the given position.
@@ -47,7 +55,7 @@ class TM1638Component : public PollingComponent {
   uint8_t print(const char *str);
 
   void loop() override;
-  uint8_t get_keys();
+  uint16_t get_keys();
 
   /// Evaluate the strftime-format and print the result at the given position.
   uint8_t strftime(uint8_t pos, const char *format, ESPTime time) __attribute__((format(strftime, 3, 0)));
@@ -65,10 +73,11 @@ class TM1638Component : public PollingComponent {
   void shift_out_(uint8_t value);
   void reset_();
   uint8_t shift_in_();
-  uint8_t intensity_{};  /// brghtness of the display  0 through 7
+  uint8_t intensity_{};  /// brightness of the display  0 through 7
   GPIOPin *clk_pin_;
   GPIOPin *stb_pin_;
   GPIOPin *dio_pin_;
+  std::string board_;
   uint8_t *buffer_ = new uint8_t[8];
   optional<tm1638_writer_t> writer_{};
   std::vector<KeyListener *> listeners_{};

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -44,7 +44,7 @@ class TM1638Component : public PollingComponent {
 
   void register_listener(KeyListener *listener) { this->listeners_.push_back(listener); }
 
-  void clear(); // clear display buffer
+  void clear();  // clear display buffer
 
   /// Evaluate the printf-format and print the result at the given position.
   uint8_t printf(uint8_t pos, const char *format, ...) __attribute__((format(printf, 3, 4)));

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -44,6 +44,8 @@ class TM1638Component : public PollingComponent {
 
   void register_listener(KeyListener *listener) { this->listeners_.push_back(listener); }
 
+  void clear(); // clear display buffer
+
   /// Evaluate the printf-format and print the result at the given position.
   uint8_t printf(uint8_t pos, const char *format, ...) __attribute__((format(printf, 3, 4)));
   /// Evaluate the printf-format and print the result at position 0.

--- a/tests/components/tm1638/tm1638-qyf.yaml
+++ b/tests/components/tm1638/tm1638-qyf.yaml
@@ -1,0 +1,21 @@
+display:
+  - platform: tm1638
+    id: tm1638_display
+    stb_pin: 2
+    clk_pin: 5
+    dio_pin: 4
+    update_interval: 5s
+    intensity: 5
+    board: "qyf"
+    lambda: |-
+      it.print("81818181");
+
+binary_sensor:
+  - platform: tm1638
+    id: Button0
+    key: 0
+    filters:
+      - delayed_on: 10ms
+  - platform: tm1638
+    id: Button4
+    key: 15


### PR DESCRIPTION
# What does this implement/fix?

Added a config variable 'board' that defaults to led (LED&KEY board). When qyf is chosen, the 7-segment display on the QYF board is properly addressed

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
Added support for QYF board with 16 buttons

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
done

- esphome/esphome-docs#<esphome-docs PR number goes here>
https://github.com/tropical-ralphie/esphome-docs/pull/1

## Test Environment

- [ x] ESP8266 - D1 mini on 3.3 V

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

# Example configuration entry
display:
    platform: tm1638
    id: tm1638_display
    stb_pin: D5
    clk_pin: D6
    dio_pin: D7
    intensity: 5
    board: "qyf"                       # added
    update_interval: 5s
    lambda: |-
      static int cnt = 0;

      if (cnt == 0)
        it.print("01.2.3456!");
      else
        it.print("Hal 0xCF");

      if (cnt++ > 1)
        cnt = 0;


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
