### PR TITLE
[substitutions] !extend and !remove now support substitutions and jinja

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -12,7 +12,7 @@ from typing import Any
 import voluptuous as vol
 
 from esphome import core, loader, pins, yaml_util
-from esphome.config_helpers import Extend, Remove, merge_dicts_ordered
+from esphome.config_helpers import Extend, Remove, merge_config, merge_dicts_ordered
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ESPHOME,
@@ -324,13 +324,7 @@ def iter_ids(config, path=None):
             yield from iter_ids(value, path + [key])
 
 
-def recursive_check_replaceme(value):
-    if isinstance(value, list):
-        return cv.Schema([recursive_check_replaceme])(value)
-    if isinstance(value, dict):
-        return cv.Schema({cv.valid: recursive_check_replaceme})(value)
-    if isinstance(value, ESPLiteralValue):
-        pass
+def check_replaceme(value):
     if isinstance(value, str) and value == "REPLACEME":
         raise cv.Invalid(
             "Found 'REPLACEME' in configuration, this is most likely an error. "
@@ -339,7 +333,86 @@ def recursive_check_replaceme(value):
             "If you want to use the literal REPLACEME string, "
             'please use "!literal REPLACEME"'
         )
-    return value
+
+
+def _build_list_index(lst):
+    index = OrderedDict()
+    extensions, removals = [], set()
+    for item in lst:
+        if item is None:
+            removals.add(None)
+            continue
+        item_id = None
+        if isinstance(item, dict) and (item_id := item.get(CONF_ID)):
+            if isinstance(item_id, Extend):
+                extensions.append(item)
+                continue
+            if isinstance(item_id, Remove):
+                removals.add(item_id.value)
+                continue
+        if not item_id or item_id in index:
+            # no id or duplicate -> pass through with identity-based key
+            item_id = id(item)
+        index[item_id] = item
+    return index, extensions, removals
+
+
+def resolve_extend_remove(value, is_key=None):
+    if isinstance(value, ESPLiteralValue):
+        return  # do not check inside literal blocks
+    if isinstance(value, list):
+        index, extensions, removals = _build_list_index(value)
+        if extensions or removals:
+            # Rebuild the original list after
+            # processing all extensions and removals
+            for item in extensions:
+                item_id = item[CONF_ID].value
+                if item_id in removals:
+                    continue
+                old = index.get(item_id)
+                if old is None:
+                    # Failed to find source for extension
+                    # Find index of item to show error at correct position
+                    i = next(
+                        (
+                            i
+                            for i, d in enumerate(value)
+                            if d.get(CONF_ID) == item[CONF_ID]
+                        )
+                    )
+                    with cv.prepend_path(i):
+                        raise cv.Invalid(
+                            f"Source for extension of ID '{item_id}' was not found."
+                        )
+                item[CONF_ID] = item_id
+                index[item_id] = merge_config(old, item)
+            for item_id in removals:
+                index.pop(item_id, None)
+
+            value[:] = index.values()
+
+        for i, item in enumerate(value):
+            with cv.prepend_path(i):
+                resolve_extend_remove(item, False)
+        return
+    if isinstance(value, dict):
+        removals = []
+        for k, v in value.items():
+            with cv.prepend_path(k):
+                if isinstance(v, Remove):
+                    removals.append(k)
+                    continue
+                resolve_extend_remove(k, True)
+                resolve_extend_remove(v, False)
+        for k in removals:
+            value.pop(k, None)
+        return
+    if is_key:
+        return  # do not check keys (yet)
+
+    check_replaceme(value)
+
+    return
 
 
 class ConfigValidationStep(abc.ABC):
@@ -437,19 +510,6 @@ class LoadValidationStep(ConfigValidationStep):
                 continue
             p_name = p_config.get("platform")
             if p_name is None:
-                p_id = p_config.get(CONF_ID)
-                if isinstance(p_id, Extend):
-                    result.add_str_error(
-                        f"Source for extension of ID '{p_id.value}' was not found.",
-                        path + [CONF_ID],
-                    )
-                    continue
-                if isinstance(p_id, Remove):
-                    result.add_str_error(
-                        f"Source for removal of ID '{p_id.value}' was not found.",
-                        path + [CONF_ID],
-                    )
-                    continue
                 result.add_str_error(
                     f"'{self.domain}' requires a 'platform' key but it was not specified.",
                     path,
@@ -934,9 +994,10 @@ def validate_config(
 
     CORE.raw_config = config
 
-    # 1.1. Check for REPLACEME special value
+    # 1.1. Resolve !extend and !remove and check for REPLACEME
+    # After this step, there will not be any Extend or Remove values in the config anymore
     try:
-        recursive_check_replaceme(config)
+        resolve_extend_remove(config)
     except vol.Invalid as err:
         result.add_error(err)
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -24,7 +24,6 @@ import voluptuous as vol
 
 from esphome import core
 import esphome.codegen as cg
-from esphome.config_helpers import Extend, Remove
 from esphome.const import (
     ALLOWED_NAME_CHARS,
     CONF_AVAILABILITY,
@@ -623,12 +622,6 @@ def declare_id(type):
         check_not_templatable(value)
         if value is None:
             return core.ID(None, is_declaration=True, type=type)
-
-        if isinstance(value, Extend):
-            raise Invalid(f"Source for extension of ID '{value.value}' was not found.")
-
-        if isinstance(value, Remove):
-            raise Invalid(f"Source for Removal of ID '{value.value}' was not found.")
 
         return core.ID(validate_id_name(value), is_declaration=True, type=type)
 

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  A: component1
+  B: component2
+  C: component3
+some_component:
+  - id: component1
+    value: 2
+  - id: component2
+    value: 5

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
@@ -1,0 +1,22 @@
+substitutions:
+  A: component1
+  B: component2
+  C: component3
+
+packages:
+  - some_component:
+      - id: component1
+        value: 1
+      - id: !extend ${B}
+        value: 4
+      - id: !extend ${B}
+        value: 5
+      - id: component3
+        value: 6
+
+some_component:
+  - id: !extend ${A}
+    value: 2
+  - id: component2
+    value: 3
+  - id: !remove ${C}

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from esphome import config as config_module, yaml_util
 from esphome.components import substitutions
+from esphome.config import resolve_extend_remove
 from esphome.config_helpers import merge_config
 from esphome.const import CONF_PACKAGES, CONF_SUBSTITUTIONS
 from esphome.core import CORE
@@ -80,6 +81,8 @@ def test_substitutions_fixtures(fixture_path):
                 config = do_packages_pass(config)
 
             substitutions.do_substitution_pass(config, None)
+
+            resolve_extend_remove(config)
 
             # Also load expected using ESPHome's loader, or use {} if missing and DEV_MODE
             if expected_path.is_file():


### PR DESCRIPTION
# What does this implement/fix?

This PR enables `!extend` and `!remove` to accept substitutions or jinja as values of the ids to extend or remove, which allows the user to conditionally modify or remove components altogether.

Other improvements:

* The config merge algorithm is substantially simplified
* Centralized place where `!extend` and `!remove` are resolved (code cleanup). There were a number of places where presence of these tags was checked for in order to detect whether the IDs they pointed to were valid. This is now done in a single place. After that point in the config parse process, the configuration is guaranteed not to have those tags, because they are either fully resolved or an error is raised to indicate the ID is not found.
* Additional tests added

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/5594

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5489

## Test Environment

- [X] All

## Example entry for `config.yaml`:

```yaml
substitutions:
  A: component1
  B: component2
  C: component3

packages:
  - some_component:
      - id: component1
        value: 1
      - id: !extend ${B}
        value: 4
      - id: !extend ${B}
        value: 5
      - id: component3
        value: 6
      

some_component:
  - id: !extend ${A}
    value: 2
  - id: component2
    value: 3
  - id: !remove ${C}
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
