### PR TITLE
[wifi] Free scan results memory after connection (saves up to 1.2KB RAM)

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -468,6 +468,27 @@ async def wifi_disable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
 
+_FLAGS = {"keep_scan_results": False}
+
+
+def request_wifi_scan_results():
+    """Request that WiFi scan results be kept in memory after connection.
+
+    Components that need access to scan results after WiFi is connected should
+    call this function during their code generation. This prevents the WiFi component from
+    freeing scan result memory after successful connection.
+    """
+    _FLAGS["keep_scan_results"] = True
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
+async def final_step():
+    """Final code generation step to configure scan result retention."""
+    if _FLAGS["keep_scan_results"]:
+        wifi_var = cg.MockObj(id="global_wifi_component", base="wifi::WiFiComponent *")
+        cg.add(wifi_var.set_keep_scan_results(True))
+
+
 @automation.register_action(
     "wifi.configure",
     WiFiConfigureAction,

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -487,8 +487,9 @@ def request_wifi_scan_results():
 async def final_step():
     """Final code generation step to configure scan result retention."""
     if _FLAGS["keep_scan_results"]:
-        wifi_var = cg.MockObj(id="global_wifi_component", base="wifi::WiFiComponent *")
-        cg.add(wifi_var.set_keep_scan_results(True))
+        cg.add(
+            cg.RawExpression("wifi::global_wifi_component->set_keep_scan_results(true)")
+        )
 
 
 @automation.register_action(

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -447,6 +447,8 @@ async def to_code(config):
             var.get_disconnect_trigger(), [], on_disconnect_config
         )
 
+    CORE.add_job(final_step)
+
 
 @automation.register_condition("wifi.connected", WiFiConnectedCondition, cv.Schema({}))
 async def wifi_connected_to_code(config, condition_id, template_arg, args):

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -470,7 +470,7 @@ async def wifi_disable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
 
-_FLAGS = {"keep_scan_results": False}
+KEEP_SCAN_RESULTS_KEY = "wifi_keep_scan_results"
 
 
 def request_wifi_scan_results():
@@ -480,13 +480,13 @@ def request_wifi_scan_results():
     call this function during their code generation. This prevents the WiFi component from
     freeing scan result memory after successful connection.
     """
-    _FLAGS["keep_scan_results"] = True
+    CORE.data[KEEP_SCAN_RESULTS_KEY] = True
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
 async def final_step():
     """Final code generation step to configure scan result retention."""
-    if _FLAGS["keep_scan_results"]:
+    if CORE.data.get(KEEP_SCAN_RESULTS_KEY, False):
         cg.add(
             cg.RawExpression("wifi::global_wifi_component->set_keep_scan_results(true)")
         )

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -716,6 +716,12 @@ void WiFiComponent::check_connecting_finished() {
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
     this->num_retried_ = 0;
 
+    // Free scan results memory unless a component needs them
+    if (!this->keep_scan_results_) {
+      this->scan_result_.clear();
+      this->scan_result_.shrink_to_fit();
+    }
+
     if (this->fast_connect_) {
       this->save_fast_connect_settings_();
     }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -316,6 +316,7 @@ class WiFiComponent : public Component {
   int8_t wifi_rssi();
 
   void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
+  void set_keep_scan_results(bool keep_scan_results) { this->keep_scan_results_ = keep_scan_results; }
 
   Trigger<> *get_connect_trigger() const { return this->connect_trigger_; };
   Trigger<> *get_disconnect_trigger() const { return this->disconnect_trigger_; };
@@ -424,6 +425,7 @@ class WiFiComponent : public Component {
 #endif
   bool enable_on_boot_;
   bool got_ipv4_address_{false};
+  bool keep_scan_results_{false};
 
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};

--- a/esphome/components/wifi_info/text_sensor.py
+++ b/esphome/components/wifi_info/text_sensor.py
@@ -78,8 +78,8 @@ async def to_code(config):
     await setup_conf(config, CONF_BSSID)
     await setup_conf(config, CONF_MAC_ADDRESS)
     if CONF_SCAN_RESULTS in config:
+        await setup_conf(config, CONF_SCAN_RESULTS)
         wifi.request_wifi_scan_results()
-    await setup_conf(config, CONF_SCAN_RESULTS)
     await setup_conf(config, CONF_DNS_ADDRESS)
     if conf := config.get(CONF_IP_ADDRESS):
         wifi_info = await text_sensor.new_text_sensor(config[CONF_IP_ADDRESS])

--- a/esphome/components/wifi_info/text_sensor.py
+++ b/esphome/components/wifi_info/text_sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import text_sensor
+from esphome.components import text_sensor, wifi
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BSSID,
@@ -77,6 +77,8 @@ async def to_code(config):
     await setup_conf(config, CONF_SSID)
     await setup_conf(config, CONF_BSSID)
     await setup_conf(config, CONF_MAC_ADDRESS)
+    if CONF_SCAN_RESULTS in config:
+        wifi.request_wifi_scan_results()
     await setup_conf(config, CONF_SCAN_RESULTS)
     await setup_conf(config, CONF_DNS_ADDRESS)
     if conf := config.get(CONF_IP_ADDRESS):


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes WiFi component memory usage by freeing scan result memory after successful connection when it's no longer needed. WiFi scan results consume RAM that scales with the number of networks detected during scanning. After successful connection, this memory can be freed unless a component explicitly needs access to scan results.

**Changes:**
- WiFi component now frees scan results after successful connection by default
- Added opt-in mechanism for components that need persistent scan results (e.g., `wifi_info` scan results sensor)
- Components call `wifi.request_wifi_scan_results()` during code generation to prevent cleanup
- Updated `wifi_info` component to request scan result retention when scan results sensor is configured

**Memory Impact:**
- ESP8266: **440-1,192 bytes freed** depending on number of networks detected
  - Test environment (fewer networks): 440 bytes
  - Busy location (many networks): 1,192 bytes (~1.5% of ~80KB available RAM)
- Memory savings scale with network density - more networks = more memory saved
- Other platforms benefit proportionally

**Technical Details:**
The implementation uses two key changes:
1. Calls both `.clear()` and `.shrink_to_fit()` on the scan results vector to actually free memory (`.clear()` alone only sets size to 0 but keeps capacity)
2. Adds a `keep_scan_results_` flag that components can set via `wifi.request_wifi_scan_results()` to opt-in to keeping scan results in memory

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Breaking Change Scope:**
This is technically a breaking change for any custom components or external integrations that access `wifi::global_wifi_component->get_scan_result()` after WiFi connection completes. However, the scope is very limited:

- **Core components:** All audited and fixed (`wifi_info`, `captive_portal`, `improv_serial`)
- **Fix for custom components:** Simply call `wifi.request_wifi_scan_results()` in the component's `to_code()` function
- **Runtime detection:** If a custom component tries to access cleared scan results, it will simply get an empty vector (no crash)

**Related issue or feature (if applicable):**

- N/A - Memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing configuration changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required for users
# Works automatically - scan results freed after connection by default

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

# If using wifi_info scan_results sensor, it automatically requests retention
text_sensor:
  - platform: wifi_info
    scan_results:
      name: "WiFi Scan Results"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Testing Performed

**ESP8266 Memory Tests:**

*Test Environment (fewer networks):*
- Before: 22,296 bytes free
- After: 22,736 bytes free
- **Result: 440 bytes saved ✓**

*Busy Location (many networks):*
- **Result: 1,192 bytes saved ✓**

**Functional Tests:**
- WiFi connection with default configuration: ✓ Scan results freed
- WiFi connection with `wifi_info` scan results sensor: ✓ Scan results retained
- Captive portal functionality: ✓ Works correctly (stopped before cleanup)
- Improv serial provisioning: ✓ Works correctly (only uses during provisioning)

**Memory Scaling:**
- Validated that memory savings increase with number of detected networks
- Savings range from 440 bytes (low density) to 1,192 bytes (high density)

## Migration Guide for Custom Components

If you have a custom component that accesses WiFi scan results after connection, add this to your component's Python code:

```python
from esphome.components import wifi

async def to_code(config):
    # If your component needs scan results after WiFi connects
    wifi.request_wifi_scan_results()

    # ... rest of your to_code implementation
```
