### PR TITLE
[mipi_rgb] Add Waveshare 5" 1024x600

### DIFF
--- a/esphome/components/mipi_rgb/models/waveshare.py
+++ b/esphome/components/mipi_rgb/models/waveshare.py
@@ -35,12 +35,12 @@ wave_4_3.extend(
     "WAVESHARE-5-1024X600",
     width=1024,
     height=600,
-    hsync_back_porch=188,
-    hsync_front_porch=88,
-    hsync_pulse_width=8,
-    vsync_back_porch=16,
-    vsync_front_porch=3,
-    vsync_pulse_width=6,
+    hsync_back_porch=145,
+    hsync_front_porch=170,
+    hsync_pulse_width=30,
+    vsync_back_porch=23,
+    vsync_front_porch=12,
+    vsync_pulse_width=2,
 )
 
 wave_4_3.extend(

--- a/esphome/components/mipi_rgb/models/waveshare.py
+++ b/esphome/components/mipi_rgb/models/waveshare.py
@@ -30,6 +30,19 @@ wave_4_3 = DriverChip(
         "blue": [14, 38, 18, 17, 10],
     },
 )
+
+wave_4_3.extend(
+    "WAVESHARE-5-1024X600",
+    width=1024,
+    height=600,
+    hsync_back_porch=188,
+    hsync_front_porch=88,
+    hsync_pulse_width=8,
+    vsync_back_porch=16,
+    vsync_front_porch=3,
+    vsync_pulse_width=6,
+)
+
 wave_4_3.extend(
     "ESP32-S3-TOUCH-LCD-7-800X480",
     enable_pin=[{"ch422g": None, "number": 2}, {"ch422g": None, "number": 6}],


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5476

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: mipi_rgb
    id: rpi_dis
    model: WAVESHARE-5-1024X600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
