### PR TITLE
[esp32] Add pydantic compatibility fix for ESP-IDF 5.4.x

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -776,6 +776,12 @@ async def to_code(config):
     )
 
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+        # Add pydantic compatibility fix for ESP-IDF 5.4.x
+        add_extra_script(
+            "pre",
+            "fix_pydantic_compatibility.py",
+            Path(__file__).parent / "fix_pydantic_compatibility.py.script",
+        )
         cg.add_platformio_option("framework", "espidf")
         cg.add_build_flag("-DUSE_ESP_IDF")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")

--- a/esphome/components/esp32/fix_pydantic_compatibility.py.script
+++ b/esphome/components/esp32/fix_pydantic_compatibility.py.script
@@ -53,34 +53,48 @@ def fix_pydantic_compatibility():
         else:
             print("ESP-IDF 5.4.x detected, applying pydantic compatibility fix...")
 
-        # Get the PlatformIO environment's Python executable
-        # This is the Python environment that ESP-IDF will use
-        pio_python = env.subst("$PYTHONEXE")  # noqa: F821
-        if not pio_python or not os.path.exists(pio_python):
-            print("PlatformIO Python executable not found, skipping pydantic fix")
+        # Get the ESP-IDF Python environment
+        # The error occurs in the ESP-IDF environment, not the PlatformIO environment
+        espidf_python = None
+
+        # Try to find the ESP-IDF Python executable
+        if idf_path:
+            # If IDF_PATH is set, look for Python in the ESP-IDF environment
+            espidf_python = os.path.join(idf_path, "tools", "python_env", "idf5.4_py3.13_env", "Scripts", "python.exe")
+            if not os.path.exists(espidf_python):
+                espidf_python = os.path.join(idf_path, "tools", "python_env", "idf5.4_py3.13_env", "bin", "python")
+        else:
+            # If IDF_PATH is not set, try to find it in the PlatformIO ESP-IDF environment
+            platformio_home = os.path.expanduser("~/.platformio")
+            espidf_python = os.path.join(platformio_home, "penv", ".espidf-5.4.2", "bin", "python")
+            if not os.path.exists(espidf_python):
+                espidf_python = os.path.join(platformio_home, "penv", ".espidf-5.4.2", "Scripts", "python.exe")
+
+        if not espidf_python or not os.path.exists(espidf_python):
+            print("ESP-IDF Python executable not found, skipping pydantic fix")
             return
 
-        print(f"Using Python executable: {pio_python}")
+        print(f"Using ESP-IDF Python executable: {espidf_python}")
 
-        # Try to install compatible pydantic version in the PlatformIO environment
+        # Try to install compatible pydantic version in the ESP-IDF environment
         try:
             # Check if uv is available (ESP-IDF 5.5+ uses uv instead of pip)
             uv_available = subprocess.run([
-                pio_python, "-m", "uv", "--version"
+                espidf_python, "-m", "uv", "--version"
             ], check=False, capture_output=True, text=True, timeout=10).returncode == 0
 
             if uv_available:
                 print("Using uv package manager")
                 # Use uv to install pydantic 2.11.10 (the version ESP-IDF expects)
                 result = subprocess.run([
-                    pio_python, "-m", "uv", "pip", "install",
+                    espidf_python, "-m", "uv", "pip", "install",
                     "pydantic==2.11.10", "--force-reinstall"
                 ], check=False, capture_output=True, text=True, timeout=120)
             else:
                 print("Using pip package manager")
                 # Use pip to install pydantic 2.11.10
                 result = subprocess.run([
-                    pio_python, "-m", "pip", "install",
+                    espidf_python, "-m", "pip", "install",
                     "pydantic==2.11.10", "--force-reinstall"
                 ], check=False, capture_output=True, text=True, timeout=120)
 

--- a/esphome/components/esp32/fix_pydantic_compatibility.py.script
+++ b/esphome/components/esp32/fix_pydantic_compatibility.py.script
@@ -1,0 +1,74 @@
+Import("env")  # noqa: F821
+
+import subprocess  # noqa: E402
+import sys  # noqa: E402
+import os  # noqa: E402
+import platformio  # noqa: E402
+
+
+def fix_pydantic_compatibility():
+    """
+    Fix pydantic compatibility issue with ESP-IDF 5.4.x.
+    
+    ESP-IDF 5.4.x component manager expects pydantic 1.x, but ESPHome 2025.9.3
+    uses pydantic 2.x. This script downgrades pydantic in the ESP-IDF environment
+    to resolve the AttributeError: 'NoneType' object has no attribute 'validation_alias'
+    """
+    try:
+        # Check if we're using ESP-IDF framework
+        framework = env.get("PIOFRAMEWORK", [])
+        if "espidf" not in framework:
+            print("Not using ESP-IDF framework, skipping pydantic fix")
+            return
+            
+        print("ESP-IDF framework detected, checking pydantic compatibility...")
+        
+        # Get the ESP-IDF Python environment
+        idf_path = env.get("IDF_PATH")
+        if not idf_path:
+            print("IDF_PATH not found, skipping pydantic fix")
+            return
+            
+        # Check if we're using ESP-IDF 5.4.x (which has the pydantic issue)
+        idf_version = env.get("IDF_VER", "")
+        if not idf_version.startswith("5.4"):
+            print(f"ESP-IDF version {idf_version} detected, pydantic fix not needed")
+            return
+            
+        print(f"ESP-IDF {idf_version} detected, applying pydantic compatibility fix...")
+        
+        # Get the PlatformIO environment's Python executable
+        # This is the Python environment that ESP-IDF will use
+        pio_python = env.subst("$PYTHONEXE")
+        if not pio_python or not os.path.exists(pio_python):
+            print("PlatformIO Python executable not found, skipping pydantic fix")
+            return
+            
+        print(f"Using Python executable: {pio_python}")
+        
+        # Try to downgrade pydantic in the PlatformIO environment
+        try:
+            # Use the PlatformIO Python environment to install pydantic 1.x
+                   result = subprocess.run([
+                       pio_python, "-m", "pip", "install", 
+                       "pydantic==1.10.15", "--force-reinstall"
+                   ], capture_output=True, text=True, timeout=120)
+            
+            if result.returncode == 0:
+                print("Successfully downgraded pydantic to 1.10.15 for ESP-IDF compatibility")
+                print("This should resolve the 'validation_alias' AttributeError")
+            else:
+                print(f"Warning: Failed to downgrade pydantic: {result.stderr}")
+                print("You may need to manually run: pip install 'pydantic==1.10.15' 'pydantic-settings==1.2.0'")
+                
+        except subprocess.TimeoutExpired:
+            print("Warning: Timeout while downgrading pydantic")
+        except Exception as e:
+            print(f"Warning: Error downgrading pydantic: {e}")
+            
+    except Exception as e:
+        print(f"Warning: Error in pydantic compatibility fix: {e}")
+
+
+# Run the fix before the build
+fix_pydantic_compatibility()

--- a/esphome/components/esp32/fix_pydantic_compatibility.py.script
+++ b/esphome/components/esp32/fix_pydantic_compatibility.py.script
@@ -9,7 +9,7 @@ import platformio  # noqa: E402
 def fix_pydantic_compatibility():
     """
     Fix pydantic compatibility issue with ESP-IDF 5.4.x.
-    
+
     ESP-IDF 5.4.x component manager expects pydantic 1.x, but ESPHome 2025.9.3
     uses pydantic 2.x. This script downgrades pydantic in the ESP-IDF environment
     to resolve the AttributeError: 'NoneType' object has no attribute 'validation_alias'
@@ -20,52 +20,52 @@ def fix_pydantic_compatibility():
         if "espidf" not in framework:
             print("Not using ESP-IDF framework, skipping pydantic fix")
             return
-            
+
         print("ESP-IDF framework detected, checking pydantic compatibility...")
-        
+
         # Get the ESP-IDF Python environment
         idf_path = env.get("IDF_PATH")
         if not idf_path:
             print("IDF_PATH not found, skipping pydantic fix")
             return
-            
+
         # Check if we're using ESP-IDF 5.4.x (which has the pydantic issue)
         idf_version = env.get("IDF_VER", "")
         if not idf_version.startswith("5.4"):
             print(f"ESP-IDF version {idf_version} detected, pydantic fix not needed")
             return
-            
+
         print(f"ESP-IDF {idf_version} detected, applying pydantic compatibility fix...")
-        
+
         # Get the PlatformIO environment's Python executable
         # This is the Python environment that ESP-IDF will use
         pio_python = env.subst("$PYTHONEXE")
         if not pio_python or not os.path.exists(pio_python):
             print("PlatformIO Python executable not found, skipping pydantic fix")
             return
-            
+
         print(f"Using Python executable: {pio_python}")
-        
+
         # Try to downgrade pydantic in the PlatformIO environment
         try:
             # Use the PlatformIO Python environment to install pydantic 1.x
                    result = subprocess.run([
-                       pio_python, "-m", "pip", "install", 
+                       pio_python, "-m", "pip", "install",
                        "pydantic==1.10.15", "--force-reinstall"
                    ], capture_output=True, text=True, timeout=120)
-            
+
             if result.returncode == 0:
                 print("Successfully downgraded pydantic to 1.10.15 for ESP-IDF compatibility")
                 print("This should resolve the 'validation_alias' AttributeError")
             else:
                 print(f"Warning: Failed to downgrade pydantic: {result.stderr}")
                 print("You may need to manually run: pip install 'pydantic==1.10.15' 'pydantic-settings==1.2.0'")
-                
+
         except subprocess.TimeoutExpired:
             print("Warning: Timeout while downgrading pydantic")
         except Exception as e:
             print(f"Warning: Error downgrading pydantic: {e}")
-            
+
     except Exception as e:
         print(f"Warning: Error in pydantic compatibility fix: {e}")
 

--- a/esphome/components/esp32/fix_pydantic_compatibility.py.script
+++ b/esphome/components/esp32/fix_pydantic_compatibility.py.script
@@ -24,16 +24,34 @@ def fix_pydantic_compatibility():
         # Get the ESP-IDF Python environment
         idf_path = env.get("IDF_PATH")  # noqa: F821
         if not idf_path:
-            print("IDF_PATH not found, skipping pydantic fix")
-            return
+            # In CI environments, IDF_PATH might not be set even when using ESP-IDF
+            # Check if we're actually using ESP-IDF by looking at the framework
+            print("IDF_PATH not found, but ESP-IDF framework detected - proceeding with pydantic fix")
 
         # Check if we're using ESP-IDF 5.4.x (which has the pydantic issue)
         idf_version = env.get("IDF_VER", "")  # noqa: F821
-        if not idf_version.startswith("5.4"):
+        if not idf_version:
+            # If IDF_VER is not set, check the framework version from PlatformIO
+            # The framework version format is like "3.50402.0" for ESP-IDF 5.4.2
+            framework_version = env.get("PIOFRAMEWORK_VERSION", "")  # noqa: F821
+            if not framework_version:
+                # Try alternative environment variables
+                framework_version = env.get("FRAMEWORK_VERSION", "")  # noqa: F821
+
+            if framework_version and framework_version.startswith("3.50402"):  # ESP-IDF 5.4.2
+                print(f"ESP-IDF framework version {framework_version} detected (ESP-IDF 5.4.x), applying pydantic fix")
+            else:
+                # If we can't determine the version, but we're using ESP-IDF framework,
+                # assume it might be 5.4.x and apply the fix (it's safe to do so)
+                print(f"ESP-IDF framework detected (version unknown: {framework_version}), applying pydantic fix as precaution")
+        elif not idf_version.startswith("5.4"):
             print(f"ESP-IDF version {idf_version} detected, pydantic fix not needed")
             return
 
-        print(f"ESP-IDF {idf_version} detected, applying pydantic compatibility fix...")
+        if idf_version:
+            print(f"ESP-IDF {idf_version} detected, applying pydantic compatibility fix...")
+        else:
+            print("ESP-IDF 5.4.x detected, applying pydantic compatibility fix...")
 
         # Get the PlatformIO environment's Python executable
         # This is the Python environment that ESP-IDF will use

--- a/esphome/components/esp32/fix_pydantic_compatibility.py.script
+++ b/esphome/components/esp32/fix_pydantic_compatibility.py.script
@@ -1,22 +1,20 @@
 Import("env")  # noqa: F821
 
-import subprocess  # noqa: E402
-import sys  # noqa: E402
 import os  # noqa: E402
-import platformio  # noqa: E402
+import subprocess  # noqa: E402
 
 
 def fix_pydantic_compatibility():
     """
     Fix pydantic compatibility issue with ESP-IDF 5.4.x.
 
-    ESP-IDF 5.4.x component manager expects pydantic 1.x, but ESPHome 2025.9.3
-    uses pydantic 2.x. This script downgrades pydantic in the ESP-IDF environment
+    ESP-IDF 5.4.x component manager has compatibility issues with newer pydantic versions.
+    This script ensures the correct pydantic version is installed in the ESP-IDF environment
     to resolve the AttributeError: 'NoneType' object has no attribute 'validation_alias'
     """
     try:
-        # Check if we're using ESP-IDF framework
-        framework = env.get("PIOFRAMEWORK", [])
+        # Check if we're using ESP-IDF framework (either standalone or with Arduino)
+        framework = env.get("PIOFRAMEWORK", [])  # noqa: F821
         if "espidf" not in framework:
             print("Not using ESP-IDF framework, skipping pydantic fix")
             return
@@ -24,13 +22,13 @@ def fix_pydantic_compatibility():
         print("ESP-IDF framework detected, checking pydantic compatibility...")
 
         # Get the ESP-IDF Python environment
-        idf_path = env.get("IDF_PATH")
+        idf_path = env.get("IDF_PATH")  # noqa: F821
         if not idf_path:
             print("IDF_PATH not found, skipping pydantic fix")
             return
 
         # Check if we're using ESP-IDF 5.4.x (which has the pydantic issue)
-        idf_version = env.get("IDF_VER", "")
+        idf_version = env.get("IDF_VER", "")  # noqa: F821
         if not idf_version.startswith("5.4"):
             print(f"ESP-IDF version {idf_version} detected, pydantic fix not needed")
             return
@@ -39,32 +37,46 @@ def fix_pydantic_compatibility():
 
         # Get the PlatformIO environment's Python executable
         # This is the Python environment that ESP-IDF will use
-        pio_python = env.subst("$PYTHONEXE")
+        pio_python = env.subst("$PYTHONEXE")  # noqa: F821
         if not pio_python or not os.path.exists(pio_python):
             print("PlatformIO Python executable not found, skipping pydantic fix")
             return
 
         print(f"Using Python executable: {pio_python}")
 
-        # Try to downgrade pydantic in the PlatformIO environment
+        # Try to install compatible pydantic version in the PlatformIO environment
         try:
-            # Use the PlatformIO Python environment to install pydantic 1.x
-                   result = subprocess.run([
-                       pio_python, "-m", "pip", "install",
-                       "pydantic==1.10.15", "--force-reinstall"
-                   ], capture_output=True, text=True, timeout=120)
+            # Check if uv is available (ESP-IDF 5.5+ uses uv instead of pip)
+            uv_available = subprocess.run([
+                pio_python, "-m", "uv", "--version"
+            ], check=False, capture_output=True, text=True, timeout=10).returncode == 0
+
+            if uv_available:
+                print("Using uv package manager")
+                # Use uv to install pydantic 2.11.10 (the version ESP-IDF expects)
+                result = subprocess.run([
+                    pio_python, "-m", "uv", "pip", "install",
+                    "pydantic==2.11.10", "--force-reinstall"
+                ], check=False, capture_output=True, text=True, timeout=120)
+            else:
+                print("Using pip package manager")
+                # Use pip to install pydantic 2.11.10
+                result = subprocess.run([
+                    pio_python, "-m", "pip", "install",
+                    "pydantic==2.11.10", "--force-reinstall"
+                ], check=False, capture_output=True, text=True, timeout=120)
 
             if result.returncode == 0:
-                print("Successfully downgraded pydantic to 1.10.15 for ESP-IDF compatibility")
+                print("Successfully installed pydantic 2.11.10 for ESP-IDF compatibility")
                 print("This should resolve the 'validation_alias' AttributeError")
             else:
-                print(f"Warning: Failed to downgrade pydantic: {result.stderr}")
-                print("You may need to manually run: pip install 'pydantic==1.10.15' 'pydantic-settings==1.2.0'")
+                print(f"Warning: Failed to install pydantic: {result.stderr}")
+                print("You may need to manually run: pip install 'pydantic==2.11.10'")
 
         except subprocess.TimeoutExpired:
-            print("Warning: Timeout while downgrading pydantic")
+            print("Warning: Timeout while installing pydantic")
         except Exception as e:
-            print(f"Warning: Error downgrading pydantic: {e}")
+            print(f"Warning: Error installing pydantic: {e}")
 
     except Exception as e:
         print(f"Warning: Error in pydantic compatibility fix: {e}")


### PR DESCRIPTION
# What does this implement/fix?

Works around the recently introduced pydantic validator version mismatch

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11162

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
