### PR TITLE
[esp32] Remove kconfiglib from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,10 +23,6 @@ cairosvg==2.8.2
 freetype-py==2.5.1
 jinja2==3.1.6
 
-# esp-idf requires this, but doesn't bundle it by default
-# https://github.com/espressif/esp-idf/blob/220590d599e134d7a5e7f1e683cc4550349ffbf8/requirements.txt#L24
-kconfiglib==13.7.1
-
 # esp-idf >= 5.0 requires this
 pyparsing >= 3.0
 


### PR DESCRIPTION
As of [esp-idf v5.1](https://github.com/espressif/esp-idf/blob/release/v5.1/tools/requirements/requirements.core.txt#L15 ) esp-idf uses its own kconfiglib: "esp-idf-kconfig" and no longer depends on kconfiglib.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
