### PR TITLE
[esp32] Automatically cleanup pydantic issue

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -769,6 +769,41 @@ async def to_code(config):
     for clean_var in ("IDF_PATH", "IDF_TOOLS_PATH"):
         os.environ.pop(clean_var, None)
 
+    if (
+        conf[CONF_TYPE] == FRAMEWORK_ESP_IDF
+        and framework_ver >= cv.Version(5, 4, 0)
+        and framework_ver <= cv.Version(5, 5, 1)
+    ) or (
+        conf[CONF_TYPE] == FRAMEWORK_ARDUINO
+        and framework_ver >= cv.Version(3, 2, 0)
+        and framework_ver <= cv.Version(3, 3, 2)
+    ):
+        try:
+            import shutil
+
+            from platformio.project.config import ProjectConfig
+        except ImportError:
+            pass
+        else:
+            pio_config = ProjectConfig.get_instance()
+            penv_dir = Path(pio_config.get("platformio", "core_dir")) / "penv"
+            platform_dir = Path(pio_config.get("platformio", "platforms_dir"))
+            cleanup = False
+            for root, dirs, files in os.walk(penv_dir):
+                for dir in dirs:
+                    if dir.startswith("pydantic-") and not dir.startswith(
+                        "pydantic-2.11.10"
+                    ):
+                        cleanup = True
+            if cleanup:
+                _LOGGER.warning(
+                    f"Fixing pydantic issue, cleaning {platform_dir} and {penv_dir}"
+                )
+                if platform_dir.exists():
+                    shutil.rmtree(platform_dir)
+                if penv_dir.exists():
+                    shutil.rmtree(penv_dir)
+
     add_extra_script(
         "post",
         "post_build.py",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -769,14 +769,8 @@ async def to_code(config):
     for clean_var in ("IDF_PATH", "IDF_TOOLS_PATH"):
         os.environ.pop(clean_var, None)
 
-    if (
-        conf[CONF_TYPE] == FRAMEWORK_ESP_IDF
-        and framework_ver >= cv.Version(5, 4, 0)
-        and framework_ver <= cv.Version(5, 5, 1)
-    ) or (
-        conf[CONF_TYPE] == FRAMEWORK_ARDUINO
-        and framework_ver >= cv.Version(3, 2, 0)
-        and framework_ver <= cv.Version(3, 3, 2)
+    if (cv.Version(5, 4, 0) <= framework_ver <= cv.Version(5, 5, 1)) or (
+        cv.Version(3, 2, 0) <= framework_ver <= cv.Version(3, 3, 2)
     ):
         try:
             import shutil
@@ -789,7 +783,7 @@ async def to_code(config):
             penv_dir = Path(pio_config.get("platformio", "core_dir")) / "penv"
             platform_dir = Path(pio_config.get("platformio", "platforms_dir"))
             cleanup = False
-            for root, dirs, files in os.walk(penv_dir):
+            for _, dirs, _ in os.walk(penv_dir):
                 for dir in dirs:
                     if dir.startswith("pydantic-") and not dir.startswith(
                         "pydantic-2.11.10"
@@ -797,7 +791,10 @@ async def to_code(config):
                         cleanup = True
             if cleanup:
                 _LOGGER.warning(
-                    f"Fixing pydantic issue, cleaning {platform_dir} and {penv_dir}"
+                    "Fixing pydantic issue, cleaning %s and %s.\n"
+                    "If the issue does not resolve, make sure the recommended platform version is used.",
+                    platform_dir,
+                    penv_dir,
                 )
                 if platform_dir.exists():
                     shutil.rmtree(platform_dir)


### PR DESCRIPTION
# What does this implement/fix?

Automatically fix pydantic issue by auto cleaning if the pydantic version is not 2.11.10

These platforms have pinned pydantic to 2.11.10

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
