### PR TITLE
[esp32_ble_tracker] Refactor to use CORE.data instead of module-level globals

### DIFF
--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -60,11 +60,21 @@ class RegistrationCounts:
     clients: int = 0
 
 
-# Set to track which features are needed by components
-_required_features: set[BLEFeatures] = set()
+# CORE.data keys for state management
+ESP32_BLE_TRACKER_REQUIRED_FEATURES_KEY = "esp32_ble_tracker_required_features"
+ESP32_BLE_TRACKER_REGISTRATION_COUNTS_KEY = "esp32_ble_tracker_registration_counts"
 
-# Track registration counts for StaticVector sizing
-_registration_counts = RegistrationCounts()
+
+def _get_required_features() -> set[BLEFeatures]:
+    """Get the set of required BLE features from CORE.data."""
+    return CORE.data.setdefault(ESP32_BLE_TRACKER_REQUIRED_FEATURES_KEY, set())
+
+
+def _get_registration_counts() -> RegistrationCounts:
+    """Get the registration counts from CORE.data."""
+    return CORE.data.setdefault(
+        ESP32_BLE_TRACKER_REGISTRATION_COUNTS_KEY, RegistrationCounts()
+    )
 
 
 def register_ble_features(features: set[BLEFeatures]) -> None:
@@ -73,7 +83,7 @@ def register_ble_features(features: set[BLEFeatures]) -> None:
     Args:
         features: Set of BLEFeatures enum members
     """
-    _required_features.update(features)
+    _get_required_features().update(features)
 
 
 esp32_ble_tracker_ns = cg.esphome_ns.namespace("esp32_ble_tracker")
@@ -267,15 +277,17 @@ async def to_code(config):
     ):
         register_ble_features({BLEFeatures.ESP_BT_DEVICE})
 
+    registration_counts = _get_registration_counts()
+
     for conf in config.get(CONF_ON_BLE_ADVERTISE, []):
-        _registration_counts.listeners += 1
+        registration_counts.listeners += 1
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         if CONF_MAC_ADDRESS in conf:
             addr_list = [it.as_hex for it in conf[CONF_MAC_ADDRESS]]
             cg.add(trigger.set_addresses(addr_list))
         await automation.build_automation(trigger, [(ESPBTDeviceConstRef, "x")], conf)
     for conf in config.get(CONF_ON_BLE_SERVICE_DATA_ADVERTISE, []):
-        _registration_counts.listeners += 1
+        registration_counts.listeners += 1
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         if len(conf[CONF_SERVICE_UUID]) == len(bt_uuid16_format):
             cg.add(trigger.set_service_uuid16(as_hex(conf[CONF_SERVICE_UUID])))
@@ -288,7 +300,7 @@ async def to_code(config):
             cg.add(trigger.set_address(conf[CONF_MAC_ADDRESS].as_hex))
         await automation.build_automation(trigger, [(adv_data_t_const_ref, "x")], conf)
     for conf in config.get(CONF_ON_BLE_MANUFACTURER_DATA_ADVERTISE, []):
-        _registration_counts.listeners += 1
+        registration_counts.listeners += 1
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         if len(conf[CONF_MANUFACTURER_ID]) == len(bt_uuid16_format):
             cg.add(trigger.set_manufacturer_uuid16(as_hex(conf[CONF_MANUFACTURER_ID])))
@@ -301,7 +313,7 @@ async def to_code(config):
             cg.add(trigger.set_address(conf[CONF_MAC_ADDRESS].as_hex))
         await automation.build_automation(trigger, [(adv_data_t_const_ref, "x")], conf)
     for conf in config.get(CONF_ON_SCAN_END, []):
-        _registration_counts.listeners += 1
+        registration_counts.listeners += 1
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
 
@@ -331,19 +343,21 @@ async def to_code(config):
 @coroutine_with_priority(CoroPriority.FINAL)
 async def _add_ble_features():
     # Add feature-specific defines based on what's needed
-    if BLEFeatures.ESP_BT_DEVICE in _required_features:
+    required_features = _get_required_features()
+    if BLEFeatures.ESP_BT_DEVICE in required_features:
         cg.add_define("USE_ESP32_BLE_DEVICE")
         cg.add_define("USE_ESP32_BLE_UUID")
 
     # Add defines for StaticVector sizing based on registration counts
     # Only define if count > 0 to avoid allocating unnecessary memory
-    if _registration_counts.listeners > 0:
+    registration_counts = _get_registration_counts()
+    if registration_counts.listeners > 0:
         cg.add_define(
-            "ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT", _registration_counts.listeners
+            "ESPHOME_ESP32_BLE_TRACKER_LISTENER_COUNT", registration_counts.listeners
         )
-    if _registration_counts.clients > 0:
+    if registration_counts.clients > 0:
         cg.add_define(
-            "ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT", _registration_counts.clients
+            "ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT", registration_counts.clients
         )
 
 
@@ -395,7 +409,7 @@ async def register_ble_device(
     var: cg.SafeExpType, config: ConfigType
 ) -> cg.SafeExpType:
     register_ble_features({BLEFeatures.ESP_BT_DEVICE})
-    _registration_counts.listeners += 1
+    _get_registration_counts().listeners += 1
     paren = await cg.get_variable(config[CONF_ESP32_BLE_ID])
     cg.add(paren.register_listener(var))
     return var
@@ -403,7 +417,7 @@ async def register_ble_device(
 
 async def register_client(var: cg.SafeExpType, config: ConfigType) -> cg.SafeExpType:
     register_ble_features({BLEFeatures.ESP_BT_DEVICE})
-    _registration_counts.clients += 1
+    _get_registration_counts().clients += 1
     paren = await cg.get_variable(config[CONF_ESP32_BLE_ID])
     cg.add(paren.register_client(var))
     return var
@@ -417,7 +431,7 @@ async def register_raw_ble_device(
     This does NOT register the ESP_BT_DEVICE feature, meaning ESPBTDevice
     will not be compiled in if this is the only registration method used.
     """
-    _registration_counts.listeners += 1
+    _get_registration_counts().listeners += 1
     paren = await cg.get_variable(config[CONF_ESP32_BLE_ID])
     cg.add(paren.register_listener(var))
     return var
@@ -431,7 +445,7 @@ async def register_raw_client(
     This does NOT register the ESP_BT_DEVICE feature, meaning ESPBTDevice
     will not be compiled in if this is the only registration method used.
     """
-    _registration_counts.clients += 1
+    _get_registration_counts().clients += 1
     paren = await cg.get_variable(config[CONF_ESP32_BLE_ID])
     cg.add(paren.register_client(var))
     return var


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the `esp32_ble_tracker` component to use `CORE.data` for state management instead of module-level mutable globals. This change improves code architecture and prepares the codebase for future improvements where the dashboard may not fork/exec for each compilation.

**Changes:**
- Replaced module-level globals `_required_features` and `_registration_counts` with `CORE.data` backed storage
- Added typed helper functions `_get_required_features()` and `_get_registration_counts()` for centralized, type-safe access
- Updated all functions that access or modify this state to use the new helper functions
- State now automatically clears between compilation runs via `CORE.data`

**Technical Details:**
The component previously used two module-level mutable globals:
1. `_required_features: set[BLEFeatures]` - tracks which BLE features components need
2. `_registration_counts: RegistrationCounts` - tracks listener/client counts for StaticVector sizing

These have been replaced with `CORE.data` storage accessed through typed helper functions, ensuring:
- Proper type hints for IDE support and static analysis
- Automatic state cleanup between runs
- No persistent state across dashboard compilations
- Consistent with ESPHome's architectural patterns

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to eliminate module-level mutable globals in ESPHome

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal refactoring, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal refactoring with no user-facing changes

esp32_ble_tracker:
  scan_parameters:
    interval: 320ms
    window: 30ms
    duration: 5min
    active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Testing Performed

- Verified `_get_required_features()` returns properly typed `set[BLEFeatures]`
- Verified `_get_registration_counts()` returns properly typed `RegistrationCounts`
- Confirmed state persists within a single compilation run
- Confirmed state clears properly with `CORE.data.clear()`
- Tested registration counting across multiple component registrations
- Verified BLE feature registration works correctly

## Migration Impact

This is a purely internal refactoring with no breaking changes:
- No changes to user configuration
- No changes to component API
- No changes to generated C++ code
- All existing functionality preserved
