### PR TITLE
[esp32_ble] Refactor to use CORE.data instead of module-level globals

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -107,8 +107,13 @@ class BTLoggers(Enum):
     """ESP32 WiFi provisioning over Bluetooth"""
 
 
-# Set to track which loggers are needed by components
-_required_loggers: set[BTLoggers] = set()
+# Key for storing required loggers in CORE.data
+ESP32_BLE_REQUIRED_LOGGERS_KEY = "esp32_ble_required_loggers"
+
+
+def _get_required_loggers() -> set[BTLoggers]:
+    """Get the set of required Bluetooth loggers from CORE.data."""
+    return CORE.data.setdefault(ESP32_BLE_REQUIRED_LOGGERS_KEY, set())
 
 
 def register_bt_logger(*loggers: BTLoggers) -> None:
@@ -117,12 +122,13 @@ def register_bt_logger(*loggers: BTLoggers) -> None:
     Args:
         *loggers: One or more BTLoggers enum members
     """
+    required_loggers = _get_required_loggers()
     for logger in loggers:
         if not isinstance(logger, BTLoggers):
             raise TypeError(
                 f"Logger must be a BTLoggers enum member, got {type(logger)}"
             )
-        _required_loggers.add(logger)
+        required_loggers.add(logger)
 
 
 CONF_BLE_ID = "ble_id"
@@ -396,8 +402,9 @@ async def to_code(config):
     # Apply logger settings if log disabling is enabled
     if config.get(CONF_DISABLE_BT_LOGS, False):
         # Disable all Bluetooth loggers that are not required
+        required_loggers = _get_required_loggers()
         for logger in BTLoggers:
-            if logger not in _required_loggers:
+            if logger not in required_loggers:
                 add_idf_sdkconfig_option(f"{logger.value}_NONE", True)
 
     # Set BLE connection establishment timeout to match aioesphomeapi/bleak-retry-connector


### PR DESCRIPTION
# What does this implement/fix?

This PR refactors the `esp32_ble` component to use `CORE.data` for state management instead of module-level mutable globals. This change improves code architecture and prepares the codebase for future improvements where the dashboard may not fork/exec for each compilation.

**Changes:**
- Replaced module-level global `_required_loggers` with `CORE.data` backed storage
- Added typed helper function `_get_required_loggers()` for centralized, type-safe access
- Updated all functions that access or modify this state to use the new helper function
- State now automatically clears between compilation runs via `CORE.data`

**Technical Details:**
The component previously used a module-level mutable global:
- `_required_loggers: set[BTLoggers]` - tracks which Bluetooth logger categories components need

This has been replaced with `CORE.data` storage accessed through a typed helper function, ensuring:
- Proper type hints for IDE support and static analysis
- Automatic state cleanup between runs
- No persistent state across dashboard compilations
- Consistent with ESPHome's architectural patterns

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to eliminate module-level mutable globals in ESPHome
- Follows PR #11205 (wifi) and PR #11220 (esp32_ble_tracker)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal refactoring, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal refactoring with no user-facing changes

esp32_ble:
  io_capability: none
  enable_on_boot: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Testing Performed

- Verified `_get_required_loggers()` returns properly typed `set[BTLoggers]`
- Confirmed state persists within a single compilation run
- Confirmed state clears properly with `CORE.data.clear()`
- Tested logger registration across multiple component registrations
- Verified logger disabling logic works correctly with registered loggers

## Migration Impact

This is a purely internal refactoring with no breaking changes:
- No changes to user configuration
- No changes to component API
- No changes to generated C++ code
- All existing functionality preserved
