### PR TITLE
[docs] Add embedded systems optimization best practices to AI instructions

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -252,16 +252,18 @@ This document provides essential context for AI models interacting with this pro
            std::array<uint8_t, 256> buffer;
            ```
 
-        2. **Compile-time-known sizes with dynamic storage:** Use `StaticVector` from `esphome/core/helpers.h` when the maximum size is known at compile time but you need heap allocation.
+        2. **Compile-time-known fixed sizes with vector-like API:** Use `StaticVector` from `esphome/core/helpers.h` for fixed-size stack allocation with `push_back()` interface.
            ```cpp
            // Bad - generates STL realloc code (_M_realloc_insert)
            std::vector<ServiceRecord> services;
            services.reserve(5);  // Still includes reallocation machinery
 
-           // Good - compile-time max size, heap allocated, no reallocation machinery
-           StaticVector<ServiceRecord, MAX_SERVICES> services;  // Max size known at compile time
+           // Good - compile-time fixed size, stack allocated, no reallocation machinery
+           StaticVector<ServiceRecord, MAX_SERVICES> services;  // Allocates all MAX_SERVICES on stack
+           services.push_back(record1);  // Tracks count but all slots allocated
            ```
-           Use `cg.add_define("MAX_SERVICES", count)` to set the maximum from Python configuration.
+           Use `cg.add_define("MAX_SERVICES", count)` to set the size from Python configuration.
+           Like `std::array` but with vector-like API (`push_back()`, `size()`) and no STL reallocation code.
 
         3. **Runtime-known sizes:** Use `FixedVector` from `esphome/core/helpers.h` when the size is only known at runtime initialization.
            ```cpp

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -221,6 +221,70 @@ This document provides essential context for AI models interacting with this pro
     *   **Component Development:** Keep dependencies minimal, provide clear error messages, and write comprehensive docstrings and tests.
     *   **Code Generation:** Generate minimal and efficient C++ code. Validate all user inputs thoroughly. Support multiple platform variations.
     *   **Configuration Design:** Aim for simplicity with sensible defaults, while allowing for advanced customization.
+    *   **Embedded Systems Optimization:** ESPHome targets resource-constrained microcontrollers. Be mindful of flash size and RAM usage.
+
+        **STL Container Guidelines:**
+
+        ESPHome runs on embedded systems with limited resources. Choose containers carefully:
+
+        1. **Compile-time-known sizes:** Use `std::array` instead of `std::vector` when size is known at compile time.
+           ```cpp
+           // Bad - generates STL realloc code
+           std::vector<int> values;
+
+           // Good - no dynamic allocation
+           std::array<int, MAX_VALUES> values;
+           ```
+           Use `cg.add_define("MAX_VALUES", count)` to set the size from Python configuration.
+
+           **For byte buffers:** Avoid `std::vector<uint8_t>` unless the buffer needs to grow. Use `std::unique_ptr<uint8_t[]>` instead.
+           ```cpp
+           // Bad - STL overhead for simple byte buffer
+           std::vector<uint8_t> buffer;
+           buffer.resize(256);
+
+           // Good - minimal overhead, single allocation
+           std::unique_ptr<uint8_t[]> buffer = std::make_unique<uint8_t[]>(256);
+           // Or if size is constant:
+           std::array<uint8_t, 256> buffer;
+           ```
+
+        2. **Small datasets (1-16 elements):** Use `std::vector` or `std::array` with simple structs instead of `std::map`/`std::set`/`std::unordered_map`.
+           ```cpp
+           // Bad - 2KB+ overhead for red-black tree/hash table
+           std::map<std::string, int> small_lookup;
+           std::unordered_map<int, std::string> tiny_map;
+
+           // Good - simple struct with linear search (std::vector is fine)
+           struct LookupEntry {
+             const char *key;
+             int value;
+           };
+           std::vector<LookupEntry> small_lookup = {
+             {"key1", 10},
+             {"key2", 20},
+             {"key3", 30},
+           };
+           // Or std::array if size is compile-time constant:
+           // std::array<LookupEntry, 3> small_lookup = {{ ... }};
+           ```
+           Linear search on small datasets (1-16 elements) is faster than hashing/tree overhead. `std::vector` with simple structs is perfectly fine - it's the heavy containers (`map`, `set`, `unordered_map`) that should be avoided for small datasets.
+
+        3. **Detection:** Look for these patterns in compiler output:
+           - Large code sections with STL symbols (vector, map, set)
+           - `alloc`, `realloc`, `dealloc` in symbol names
+           - Red-black tree code (`rb_tree`, `_Rb_tree`)
+           - Hash table infrastructure (`unordered_map`, `hash`)
+
+        **When to optimize:**
+        - Core components (API, network, logger)
+        - Widely-used components (mdns, wifi, ble)
+        - Components causing flash size complaints
+
+        **When not to optimize:**
+        - Single-use niche components
+        - Code where readability matters more than bytes
+        - Already using appropriate containers
 
 *   **Security:** Be mindful of security when making changes to the API, web server, or any other network-related code. Do not hardcode secrets or keys.
 


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the AI collaboration documentation (CLAUDE.md / `.ai/instructions.md`) to include best practices for embedded systems development in ESPHome. It adds guidelines for choosing appropriate STL containers and introduces ESPHome's custom `StaticVector` and `FixedVector` containers to help AI assistants and developers write more efficient code for resource-constrained microcontrollers.

**Changes:**
- Added **Embedded Systems Optimization** section with comprehensive STL container guidelines:
  - When to use `std::array` vs `std::vector` (compile-time-known sizes)
  - Using `std::unique_ptr<uint8_t[]>` instead of `std::vector<uint8_t>` for fixed-size byte buffers (with caveats about bounds checking)
  - Introduced `StaticVector` for compile-time maximum sizes with heap allocation
  - Introduced `FixedVector` for runtime-known sizes without reallocation machinery
  - Avoiding `std::map`/`std::set`/`std::unordered_map` for small datasets (1-16 elements) with nuanced tradeoffs
  - How to detect STL overhead in compiler output (including `_M_realloc_insert`, `_M_default_append`)
  - When optimization is worthwhile vs when readability matters more

**Context:**
These best practices emerged from extensive optimization work:
- Based on analysis of STL overhead in compiled binaries
- Addresses common patterns that cause unnecessary flash bloat (2KB+ per heavy container, 200-500 bytes per vector reallocation)
- Documents ESPHome's custom containers (`StaticVector`, `FixedVector`) from `esphome/core/helpers.h`
- Documents the practical tradeoffs learned from real-world optimization efforts (mDNS, API, protobuf integration)
- Linear search on 1-16 elements is often faster than hash table/red-black tree overhead on embedded systems (context-dependent)

This documentation will help future contributors and AI assistants write more efficient code for ESPHome's target platforms.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is internal documentation for developers and AI assistants

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - Documentation only

## Example entry for `config.yaml`:

N/A - Documentation only

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).