### PR TITLE
[cap1188] remove delays in setup

### DIFF
--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -25,7 +25,7 @@ void CAP1188Component::setup() {
   }
 } 
 
-void finish_setup() {
+void finish_setup_() {
   // Check if CAP1188 is actually connected
   this->read_byte(CAP1188_PRODUCT_ID, &this->cap1188_product_id_);
   this->read_byte(CAP1188_MANUFACTURE_ID, &this->cap1188_manufacture_id_);

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -10,15 +10,22 @@ static const char *const TAG = "cap1188";
 void CAP1188Component::setup() {
   // Reset device using the reset pin
   if (this->reset_pin_ != nullptr) {
+    this->disable_loop();
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
-    delay(100);  // NOLINT
-    this->reset_pin_->digital_write(true);
-    delay(100);  // NOLINT
-    this->reset_pin_->digital_write(false);
-    delay(100);  // NOLINT
+    this->set_timeout(100, [this]() {
+      this->reset_pin_->digital_write(true);
+      this->set_timeout(100, [this]() {
+        this->reset_pin_->digital_write(false);
+        this->set_timeout(100, [this]() {
+          this->enable_loop();
+        });
+      });
+    });
   }
+} 
 
+void finish_setup() {
   // Check if CAP1188 is actually connected
   this->read_byte(CAP1188_PRODUCT_ID, &this->cap1188_product_id_);
   this->read_byte(CAP1188_MANUFACTURE_ID, &this->cap1188_manufacture_id_);
@@ -67,6 +74,11 @@ void CAP1188Component::dump_config() {
 }
 
 void CAP1188Component::loop() {
+  if (!this->setup_finished_) {
+    this->finish_setup_();
+    this->setup_finished_ = true;
+  }
+
   uint8_t touched = 0;
 
   this->read_register(CAP1188_SENSOR_INPUT_STATUS, &touched, 1);

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -17,13 +17,11 @@ void CAP1188Component::setup() {
       this->reset_pin_->digital_write(true);
       this->set_timeout(100, [this]() {
         this->reset_pin_->digital_write(false);
-        this->set_timeout(100, [this]() {
-          this->enable_loop();
-        });
+        this->set_timeout(100, [this]() { this->enable_loop(); });
       });
     });
   }
-} 
+}
 
 void finish_setup() {
   // Check if CAP1188 is actually connected

--- a/esphome/components/cap1188/cap1188.h
+++ b/esphome/components/cap1188/cap1188.h
@@ -49,6 +49,9 @@ class CAP1188Component : public Component, public i2c::I2CDevice {
   void loop() override;
 
  protected:
+  void finish_setup_();
+  bool setup_finished_{false};
+
   std::vector<CAP1188Channel *> channels_{};
   uint8_t touch_threshold_{0x20};
   uint8_t allow_multiple_touches_{0x80};


### PR DESCRIPTION
# What does this implement/fix?

remove delays in setup by replacing with nested set_timeout and completing remaining setup in first iteration of loop

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
One component in list for issue https://github.com/esphome/backlog/issues/38 "Minimize delay calls as much as possible"
- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
