### PR TITLE
[api] Convert HomeassistantActionRequest vectors to FixedVector for flash savings

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -776,9 +776,9 @@ message HomeassistantActionRequest {
   option (ifdef) = "USE_API_HOMEASSISTANT_SERVICES";
 
   string service = 1;
-  repeated HomeassistantServiceMap data = 2;
-  repeated HomeassistantServiceMap data_template = 3;
-  repeated HomeassistantServiceMap variables = 4;
+  repeated HomeassistantServiceMap data = 2 [(fixed_vector) = true];
+  repeated HomeassistantServiceMap data_template = 3 [(fixed_vector) = true];
+  repeated HomeassistantServiceMap variables = 4 [(fixed_vector) = true];
   bool is_event = 5;
   uint32 call_id = 6 [(field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES"];
   bool wants_response = 7 [(field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON"];

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1110,9 +1110,9 @@ class HomeassistantActionRequest final : public ProtoMessage {
 #endif
   StringRef service_ref_{};
   void set_service(const StringRef &ref) { this->service_ref_ = ref; }
-  std::vector<HomeassistantServiceMap> data{};
-  std::vector<HomeassistantServiceMap> data_template{};
-  std::vector<HomeassistantServiceMap> variables{};
+  FixedVector<HomeassistantServiceMap> data{};
+  FixedVector<HomeassistantServiceMap> data_template{};
+  FixedVector<HomeassistantServiceMap> variables{};
   bool is_event{false};
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
   uint32_t call_id{0};

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -201,9 +201,9 @@ class CustomAPIDevice {
   void call_homeassistant_service(const std::string &service_name, const std::map<std::string, std::string> &data) {
     HomeassistantActionRequest resp;
     resp.set_service(StringRef(service_name));
+    resp.data.init(data.size());
     for (auto &it : data) {
-      resp.data.emplace_back();
-      auto &kv = resp.data.back();
+      auto &kv = resp.data.emplace_back();
       kv.set_key(StringRef(it.first));
       kv.value = it.second;
     }
@@ -244,9 +244,9 @@ class CustomAPIDevice {
     HomeassistantActionRequest resp;
     resp.set_service(StringRef(service_name));
     resp.is_event = true;
+    resp.data.init(data.size());
     for (auto &it : data) {
-      resp.data.emplace_back();
-      auto &kv = resp.data.back();
+      auto &kv = resp.data.emplace_back();
       kv.set_key(StringRef(it.first));
       kv.value = it.second;
     }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -122,24 +122,14 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   Trigger<std::string, Ts...> *get_error_trigger() const { return this->error_trigger_; }
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
-  template<typename VectorType, typename SourceType>
-  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
-    dest.init(source.size());
-    for (auto &it : source) {
-      auto &kv = dest.emplace_back();
-      kv.set_key(StringRef(it.key));
-      kv.value = it.value.value(x...);
-    }
-  }
-
   void play(Ts... x) override {
     HomeassistantActionRequest resp;
     std::string service_value = this->service_.value(x...);
     resp.set_service(StringRef(service_value));
     resp.is_event = this->flags_.is_event;
-    populate_service_map(resp.data, this->data_, x...);
-    populate_service_map(resp.data_template, this->data_template_, x...);
-    populate_service_map(resp.variables, this->variables_, x...);
+    this->populate_service_map_(resp.data, this->data_, x...);
+    this->populate_service_map_(resp.data_template, this->data_template_, x...);
+    this->populate_service_map_(resp.variables, this->variables_, x...);
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
     if (this->flags_.wants_status) {
@@ -184,6 +174,16 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   }
 
  protected:
+  template<typename VectorType, typename SourceType>
+  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
+    dest.init(source.size());
+    for (auto &it : source) {
+      auto &kv = dest.emplace_back();
+      kv.set_key(StringRef(it.key));
+      kv.value = it.value.value(x...);
+    }
+  }
+
   APIServer *parent_;
   TemplatableStringValue<Ts...> service_{};
   std::vector<TemplatableKeyValuePair<Ts...>> data_;

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -122,29 +122,24 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   Trigger<std::string, Ts...> *get_error_trigger() const { return this->error_trigger_; }
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
+  template<typename VectorType, typename SourceType>
+  static void populate_service_map_(VectorType &dest, SourceType &source, Ts... x) {
+    dest.init(source.size());
+    for (auto &it : source) {
+      auto &kv = dest.emplace_back();
+      kv.set_key(StringRef(it.key));
+      kv.value = it.value.value(x...);
+    }
+  }
+
   void play(Ts... x) override {
     HomeassistantActionRequest resp;
     std::string service_value = this->service_.value(x...);
     resp.set_service(StringRef(service_value));
     resp.is_event = this->flags_.is_event;
-    for (auto &it : this->data_) {
-      resp.data.emplace_back();
-      auto &kv = resp.data.back();
-      kv.set_key(StringRef(it.key));
-      kv.value = it.value.value(x...);
-    }
-    for (auto &it : this->data_template_) {
-      resp.data_template.emplace_back();
-      auto &kv = resp.data_template.back();
-      kv.set_key(StringRef(it.key));
-      kv.value = it.value.value(x...);
-    }
-    for (auto &it : this->variables_) {
-      resp.variables.emplace_back();
-      auto &kv = resp.variables.back();
-      kv.set_key(StringRef(it.key));
-      kv.value = it.value.value(x...);
-    }
+    populate_service_map_(resp.data, this->data_, x...);
+    populate_service_map_(resp.data_template, this->data_template_, x...);
+    populate_service_map_(resp.variables, this->variables_, x...);
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
     if (this->flags_.wants_status) {

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -127,9 +127,9 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
     std::string service_value = this->service_.value(x...);
     resp.set_service(StringRef(service_value));
     resp.is_event = this->flags_.is_event;
-    this->populate_service_map_(resp.data, this->data_, x...);
-    this->populate_service_map_(resp.data_template, this->data_template_, x...);
-    this->populate_service_map_(resp.variables, this->variables_, x...);
+    this->populate_service_map(resp.data, this->data_, x...);
+    this->populate_service_map(resp.data_template, this->data_template_, x...);
+    this->populate_service_map(resp.variables, this->variables_, x...);
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
     if (this->flags_.wants_status) {
@@ -175,7 +175,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
  protected:
   template<typename VectorType, typename SourceType>
-  static void populate_service_map_(VectorType &dest, SourceType &source, Ts... x) {
+  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
     dest.init(source.size());
     for (auto &it : source) {
       auto &kv = dest.emplace_back();

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -175,7 +175,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
  protected:
   template<typename VectorType, typename SourceType>
-  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
+  static void populate_service_map_(VectorType &dest, SourceType &source, Ts... x) {
     dest.init(source.size());
     for (auto &it : source) {
       auto &kv = dest.emplace_back();

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -123,7 +123,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
   template<typename VectorType, typename SourceType>
-  static void populate_service_map_(VectorType &dest, SourceType &source, Ts... x) {
+  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
     dest.init(source.size());
     for (auto &it : source) {
       auto &kv = dest.emplace_back();
@@ -137,9 +137,9 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
     std::string service_value = this->service_.value(x...);
     resp.set_service(StringRef(service_value));
     resp.is_event = this->flags_.is_event;
-    populate_service_map_(resp.data, this->data_, x...);
-    populate_service_map_(resp.data_template, this->data_template_, x...);
-    populate_service_map_(resp.variables, this->variables_, x...);
+    populate_service_map(resp.data, this->data_, x...);
+    populate_service_map(resp.data_template, this->data_template_, x...);
+    populate_service_map(resp.variables, this->variables_, x...);
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
     if (this->flags_.wants_status) {

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -90,13 +90,12 @@ void HomeassistantNumber::control(float value) {
   api::HomeassistantActionRequest resp;
   resp.set_service(SERVICE_NAME);
 
-  resp.data.emplace_back();
-  auto &entity_id = resp.data.back();
+  resp.data.init(2);
+  auto &entity_id = resp.data.emplace_back();
   entity_id.set_key(ENTITY_ID_KEY);
   entity_id.value = this->entity_id_;
 
-  resp.data.emplace_back();
-  auto &entity_value = resp.data.back();
+  auto &entity_value = resp.data.emplace_back();
   entity_value.set_key(VALUE_KEY);
   entity_value.value = to_string(value);
 

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -51,8 +51,8 @@ void HomeassistantSwitch::write_state(bool state) {
     resp.set_service(SERVICE_OFF);
   }
 
-  resp.data.emplace_back();
-  auto &entity_id_kv = resp.data.back();
+  resp.data.init(1);
+  auto &entity_id_kv = resp.data.emplace_back();
   entity_id_kv.set_key(ENTITY_ID_KEY);
   entity_id_kv.value = this->entity_id_;
 


### PR DESCRIPTION
needs:
- [x] https://github.com/esphome/esphome/pull/11231

# What does this implement/fix?

This PR converts `HomeassistantActionRequest` message vectors from `std::vector` to `FixedVector` to reduce flash usage by eliminating STL template bloat. This follows the same optimization pattern successfully used for mDNS TXT records.

## Changes

The `HomeassistantActionRequest` protobuf message contains three repeated fields that are populated with known sizes at runtime:
- `data` - service call data parameters
- `data_template` - templated service call data
- `variables` - service call variables

By converting these to `FixedVector` and calling `init()` with the exact size before populating, we eliminate `_M_realloc_insert` and `_M_default_append` template instantiations that add flash overhead.

### Implementation Details

1. **api.proto** - Added `[(fixed_vector) = true]` option to three repeated fields
2. **homeassistant_service.h** - Created `populate_service_map_()` template helper function to eliminate code duplication and call `init()` before populating vectors
3. **homeassistant_switch.cpp** - Uses `init(1)` for single-element vector
4. **homeassistant_number.cpp** - Uses `init(2)` for two-element vector
5. **custom_api_device.h** - Uses `init(data.size())` for runtime-sized vectors in two methods

## Flash Savings

**ESP8266**: 280 bytes saved (506,173 → 505,893 bytes)
**RAM**: No change

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (flash optimization)

**Related issue or feature (if applicable):**

- Part of ongoing flash optimization effort for memory-constrained platforms

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-visible changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is an internal optimization
# Existing configurations continue to work unchanged

api:
  services:
    - service: example_service
      variables:
        my_var: string
      then:
        - homeassistant.service:
            service: light.turn_on
            data:
              entity_id: light.example
              brightness: "{{ my_var }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-visible changes)
