### PR TITLE
[web_server_idf] Use std::vector instead of std::set for SSE sessions

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <list>
 #include <map>
-#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -315,7 +314,10 @@ class AsyncEventSource : public AsyncWebHandler {
 
  protected:
   std::string url_;
-  std::set<AsyncEventSourceResponse *> sessions_;
+  // Use vector instead of set: SSE sessions are typically 1-5 connections (browsers, dashboards).
+  // Linear search is faster than red-black tree overhead for this small dataset.
+  // Only operations needed: add session, remove session, iterate sessions - no need for sorted order.
+  std::vector<AsyncEventSourceResponse *> sessions_;
   connect_handler_t on_connect_{};
   esphome::web_server::WebServer *web_server_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Replaces `std::set` with `std::vector` for AsyncEventSource session storage in the ESP-IDF web server implementation to eliminate red-black tree overhead for small session counts. Saves 952 bytes of flash and ~24 bytes of RAM at runtime.

**Changes:**
- Replace `std::set<AsyncEventSourceResponse*>` with `std::vector` in `web_server_idf.h`
- Update insert operation: `sessions_.insert(rsp)` → `sessions_.push_back(rsp)`
- Optimize removal loop: Use swap-with-last-element pattern for O(1) removal instead of iterator-based erase
- Remove `#include <set>` (no longer needed)

**Rationale:**
The AsyncEventSource manages Server-Sent Events (SSE) connections for the web server's `/events` endpoint, which provides real-time state updates to the built-in web interface. Each browser tab viewing the device's web UI creates one SSE connection. Typical usage is a single connection - it's rare to have two users trying to control the same device at the same time (even rarer to have more than 2-3). For this small dataset, linear search is faster than red-black tree overhead. The only operations needed are: add session, remove session, iterate sessions - no need for sorted order or fast lookup by pointer value.

**Impact:**
- **Flash savings: 952 bytes** (eliminates red-black tree instantiation)
  - Before: 554558 bytes (30.2%)
  - After: 553606 bytes (30.2%)
- **RAM savings: ~24 bytes** at runtime for typical single browser tab with active `/events` connection (24 bytes per connection saved from red-black tree node overhead)
- No functional changes - iteration order doesn't matter for SSE sessions
- Swap-based removal maintains O(1) performance without preserving order

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing flash size optimization effort for ESP32

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation change, no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
# Existing web_server configurations work unchanged

web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.a
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
