### PR TITLE
[ci] Add Python 3.14 testing and streamline version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,7 @@ jobs:
       matrix:
         python-version:
           - "3.11"
-          - "3.12"
-          - "3.13"
+          - "3.14"
         os:
           - ubuntu-latest
           - macOS-latest
@@ -124,13 +123,9 @@ jobs:
           # Minimize CI resource usage
           # by only running the Python version
           # version used for docker images on Windows and macOS
-          - python-version: "3.13"
+          - python-version: "3.14"
             os: windows-latest
-          - python-version: "3.12"
-            os: windows-latest
-          - python-version: "3.13"
-            os: macOS-latest
-          - python-version: "3.12"
+          - python-version: "3.14"
             os: macOS-latest
     runs-on: ${{ matrix.os }}
     needs:


### PR DESCRIPTION
# What does this implement/fix?

Updates CI Python version testing strategy to:
- Add Python 3.14 testing (on Linux only)
- Remove Python 3.12 and 3.13 from the test matrix
- Keep Python 3.11 (oldest supported) and 3.14 (newest) to ensure compatibility across the supported range while reducing CI resource usage

This change tests the boundaries of our Python version support (oldest and newest) rather than testing every intermediate version, which provides sufficient coverage with better CI efficiency.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (CI-only change)

## Test Environment

- N/A (CI configuration change only)

## Example entry for `config.yaml`:

```yaml
# N/A - CI configuration change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
