### PR TITLE
[pzemac, pzemdc, sdm_meter] Fix pin conflicts in ESP32-IDF tests

### DIFF
--- a/tests/components/pzemac/test.esp32-idf.yaml
+++ b/tests/components/pzemac/test.esp32-idf.yaml
@@ -1,6 +1,7 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
+  flow_control_pin: GPIO13
 
 packages:
   modbus: !include ../../test_build_components/common/modbus/esp32-idf.yaml

--- a/tests/components/pzemdc/test.esp32-idf.yaml
+++ b/tests/components/pzemdc/test.esp32-idf.yaml
@@ -1,6 +1,7 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
+  flow_control_pin: GPIO13
 
 packages:
   modbus: !include ../../test_build_components/common/modbus/esp32-idf.yaml

--- a/tests/components/sdm_meter/test.esp32-idf.yaml
+++ b/tests/components/sdm_meter/test.esp32-idf.yaml
@@ -1,6 +1,7 @@
 substitutions:
   tx_pin: GPIO4
   rx_pin: GPIO5
+  flow_control_pin: GPIO13
 
 packages:
   modbus: !include ../../test_build_components/common/modbus/esp32-idf.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes pin conflicts in three Modbus component tests (`pzemac`, `pzemdc`, `sdm_meter`) by overriding the `flow_control_pin` substitution to use GPIO13 instead of GPIO4.

## Problem

The modbus package configuration defines `flow_control_pin: GPIO4`, which conflicted with the UART `tx_pin: GPIO4` in these component tests. This caused pin conflict errors when running validation without `--testing-mode`:

```
Pin 4 is used in multiple places.
```

## Solution

Override the `flow_control_pin` substitution in each affected test file to use GPIO13, matching the pattern already established by other modbus components (`growatt_solar`, `havells_solar`, `kuntze`, `modbus`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Found via pin conflict testing tool

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Test configuration change only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing configuration changes - this is a test-only fix.

The fix adds the `flow_control_pin` substitution override:

```yaml
# Before (implicit from modbus package)
substitutions:
  tx_pin: GPIO4
  rx_pin: GPIO5
  # flow_control_pin defaults to GPIO4 - CONFLICT!

# After (explicit override)
substitutions:
  tx_pin: GPIO4
  rx_pin: GPIO5
  flow_control_pin: GPIO13  # No conflict
```

## Verification

Tested with the pin conflict detection tool:

```bash
$ ./script/test_pin_conflicts.py -c pzemac,pzemdc,sdm_meter -t esp32-idf
Testing: pzemac.test.esp32-idf... ✓
Testing: pzemdc.test.esp32-idf... ✓
Testing: sdm_meter.test.esp32-idf... ✓

Tests run:    3
Tests passed: 3
Tests failed: 0
Components with pin conflicts: 0

✓ No pin conflicts found!
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
