### PR TITLE
Use deps for setup ordering

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1,8 +1,11 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
+from collections import defaultdict
+from collections.abc import Callable, Iterable
 from datetime import datetime
 import functools
 import getpass
+import heapq
 import importlib
 import logging
 import os
@@ -10,7 +13,7 @@ from pathlib import Path
 import re
 import sys
 import time
-from typing import Protocol
+from typing import Protocol, cast
 
 import argcomplete
 
@@ -50,8 +53,9 @@ from esphome.const import (
 from esphome.core import CORE, EsphomeError, coroutine
 from esphome.enum import StrEnum
 from esphome.helpers import get_bool_env, indent, is_ip_address
+from esphome.loader import ComponentManifest
 from esphome.log import AnsiFore, color, setup_log
-from esphome.types import ConfigType
+from esphome.types import ConfigFragmentType, ConfigType
 from esphome.util import (
     get_serial_ports,
     list_yaml_files,
@@ -478,12 +482,154 @@ def write_cpp(config: ConfigType) -> int:
 
 
 def generate_cpp_contents(config: ConfigType) -> None:
+    """Generate C++ by scheduling component to_code in a deterministic topological order."""
     _LOGGER.info("Generating C++ source...")
 
-    for name, component, conf in iter_component_configs(CORE.config):
-        if component.to_code is not None:
+    # Collect entries as (name, manifest, conf)
+    entries: list[tuple[str, ComponentManifest | None, ConfigFragmentType]] = list(
+        cast(
+            Iterable[tuple[str, ComponentManifest | None, ConfigFragmentType]],
+            iter_component_configs(config),
+        )
+    )
+
+    name_to_comp_conf: defaultdict[
+        str, list[tuple[ComponentManifest | None, ConfigFragmentType]]
+    ] = defaultdict(list)
+
+    for name, manifest, conf in entries:
+        _LOGGER.debug("Processing component %s", name)
+        name_to_comp_conf[name].append((manifest, conf))
+
+        if manifest is None:
+            continue
+
+    adj: dict[str, set[str]] = defaultdict(set)
+    indegree: dict[str, int] = {nm: 0 for nm in name_to_comp_conf}
+
+    def add_edge(src_name: str, dst_name: str) -> None:
+        _LOGGER.debug("Adding dependency %s -> %s", src_name, dst_name)
+        if dst_name in adj[src_name]:
+            return
+
+        adj[src_name].add(dst_name)
+        indegree[dst_name] += 1
+
+    fixed_deps: list[str] = []
+    # TODO what other fixed components should be included?
+    # I guess this should be a property of the component manifest...?
+    if "logger" in name_to_comp_conf:
+        fixed_deps.append("logger")
+
+    # Build the graph
+
+    # target platform
+    #     ^
+    #     |
+    #  esphome core <-------|
+    #     ^                 |
+    #     |                 |
+    #  fixed deps<----------|
+    #     ^                 |
+    #     |                 |
+    #  components<----------|
+    #     ^                 |
+    #     |-----------------|
+
+    for dep in fixed_deps:
+        add_edge(CONF_ESPHOME, dep)
+
+    for name, manifest, _comp_conf in entries:
+        _LOGGER.debug("Processing dependencies for component %s", name)
+
+        if manifest is None:
+            raise EsphomeError(f"Manifest is None for component {name}")
+
+        _LOGGER.debug("Manifest dependencies for %s: %s", name, manifest.dependencies)
+
+        for dep in manifest.dependencies:
+            if dep not in name_to_comp_conf:
+                _LOGGER.error("Skipping missing dependency %s -> %s", dep, name)
+                raise EsphomeError(
+                    f"Dependency {dep} not found. Known: {sorted(name_to_comp_conf.keys())}"
+                )
+            add_edge(dep, name)
+
+        auto_load: list[str] | Callable[..., list[str]] = manifest.auto_load
+        if callable(auto_load):
+            import inspect
+
+            if inspect.signature(auto_load).parameters:
+                auto_load = auto_load(config)
+            else:
+                auto_load = auto_load()
+
+        for auto_loaded in auto_load:
+            add_edge(name, auto_loaded)
+
+        if manifest.is_target_platform:
+            # the target platform does not depend on anything else, it is the "root",
+            # because the compiler toolchain etc. must be setup first
+            continue
+
+        if name == CONF_ESPHOME:
+            # esphome only depends on the target platform.
+            add_edge(CORE.target_platform, CONF_ESPHOME)
+            continue
+
+        # all components depend on esphome core. This bridges the gap between
+        # missing fixed deps and components.
+        add_edge(CONF_ESPHOME, name)
+
+        # all components depend on fixed deps, to ensure they are initialized first
+        for fixed_dep in fixed_deps:
+            if fixed_dep != name:
+                add_edge(fixed_dep, name)
+
+    zero_indegree: list[str] = list(
+        {nm for nm in name_to_comp_conf if indegree[nm] == 0}
+    )
+
+    heapq.heapify(zero_indegree)
+
+    ordered_names: list[str] = []
+    partial_order: list[list[str]] = [zero_indegree[:]]
+
+    _LOGGER.debug("Adjacency list: %s", adj)
+
+    while True:
+        partial_order.append([])
+        while zero_indegree:
+            name = heapq.heappop(zero_indegree)
+            ordered_names.append(name)
+            for dst in adj[name]:
+                indegree[dst] -= 1
+                if indegree[dst] == 0:
+                    # heapq.heappush(zero_indegree, dst)
+                    heapq.heappush(partial_order[-1], dst)
+        zero_indegree = partial_order[-1][:]
+        if not zero_indegree:
+            _ = partial_order.pop()
+            break
+
+    if len(ordered_names) != len(name_to_comp_conf):
+        cyclic: list[str] = [n for n, deg in indegree.items() if deg > 0]
+        raise EsphomeError(
+            "Circular dependency detected among components: "
+            + ", ".join(sorted(cyclic))
+        )
+
+    _LOGGER.debug("Partial topological order: %s", partial_order)
+    _LOGGER.debug("Total topological names order: %s", ordered_names)
+    _LOGGER.info("Initialization order: %s", ", ".join(ordered_names))
+
+    for name in ordered_names:
+        for component, conf in name_to_comp_conf[name]:
+            if component is None or component.to_code is None:
+                continue
             coro = wrap_to_code(name, component)
             CORE.add_job(coro, conf)
+            _LOGGER.debug("Scheduled %s.to_code()", name)
 
     CORE.flush_tasks()
 
@@ -513,7 +659,7 @@ def compile_program(args: ArgsProtocol, config: ConfigType) -> int:
 
 
 def upload_using_esptool(
-    config: ConfigType, port: str, file: str, speed: int
+    config: ConfigType, port: str, file: str | None, speed: int
 ) -> str | int:
     from esphome import platformio_api
 

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -63,7 +63,7 @@ from esphome.types import ConfigType
 DEPENDENCIES = ["network"]
 
 
-def AUTO_LOAD():
+def AUTO_LOAD() -> list[str]:
     if CORE.is_esp8266 or CORE.is_libretiny:
         return ["async_tcp", "json"]
     return ["json"]

--- a/esphome/components/wake_on_lan/button.py
+++ b/esphome/components/wake_on_lan/button.py
@@ -7,7 +7,7 @@ from esphome.core import CORE
 DEPENDENCIES = ["network"]
 
 
-def AUTO_LOAD():
+def AUTO_LOAD() -> list[str]:
     if CORE.is_esp8266 or CORE.is_rp2040:
         return []
     return ["socket"]

--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -8,7 +8,7 @@ CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["network"]
 
 
-def AUTO_LOAD():
+def AUTO_LOAD() -> list[str]:
     if CORE.is_esp32:
         return ["web_server_idf"]
     if CORE.using_arduino:

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -71,17 +71,14 @@ void Application::register_component_(Component *comp) {
 }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
-  ESP_LOGV(TAG, "Sorting components by setup priority");
-
-  // Sort by setup priority using our helper function
-  insertion_sort_by_priority<decltype(this->components_.begin()), &Component::get_actual_setup_priority>(
-      this->components_.begin(), this->components_.end());
 
   // Initialize looping_components_ early so enable_pending_loops_() works during setup
   this->calculate_looping_components_();
 
   for (uint32_t i = 0; i < this->components_.size(); i++) {
     Component *component = this->components_[i];
+
+    ESP_LOGD(TAG, "Setting up %s", LOG_STR_ARG(component->get_component_log_str()));
 
     // Update loop_component_start_time_ before calling each component during setup
     this->loop_component_start_time_ = millis();

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -95,11 +95,12 @@ class Component {
    *
    * @return The setup priority of this component
    */
-  virtual float get_setup_priority() const;
 
-  float get_actual_setup_priority() const;
+  [[deprecated]] virtual float get_setup_priority() const;
 
-  void set_setup_priority(float priority);
+  [[deprecated]] float get_actual_setup_priority() const;
+
+  [[deprecated]] void set_setup_priority(float priority);
 
   /** priority of loop(). higher -> executed earlier
    *

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -464,6 +464,7 @@ async def _add_platform_defines() -> None:
 
 @coroutine_with_priority(CoroPriority.CORE)
 async def to_code(config: ConfigType) -> None:
+    cg.add_global(cg.RawStatement('#include "esphome.h"'))
     cg.add_global(cg.global_ns.namespace("esphome").using)
     # These can be used by user lambdas, put them to default scope
     cg.add_global(cg.RawExpression("using std::isnan"))

--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -309,6 +309,12 @@ class FakeEventLoop:
         prio = getattr(coro, "priority", 0.0)
         task = _Task(prio, self._task_counter, gen, func)
         self._task_counter += 1
+        _LOGGER.debug(
+            "Scheduling %s in %s (num %s)",
+            func.__qualname__,
+            func.__module__,
+            task.id_number,
+        )
         heapq.heappush(self._pending_tasks, task)
 
     def flush_tasks(self):

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -281,10 +281,8 @@ def write_cpp(code_s):
         code_format = CPP_BASE_FORMAT
 
     copy_src_tree()
-    global_s = '#include "esphome.h"\n'
-    global_s += CORE.cpp_global_section
 
-    full_file = f"{code_format[0] + CPP_INCLUDE_BEGIN}\n{global_s}{CPP_INCLUDE_END}"
+    full_file = f"{code_format[0] + CPP_INCLUDE_BEGIN}\n{CORE.cpp_global_section}{CPP_INCLUDE_END}"
     full_file += (
         f"{code_format[1] + CPP_AUTO_GENERATE_BEGIN}\n{code_s}{CPP_AUTO_GENERATE_END}"
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,6 +38,7 @@ from .types import (
     APIClientConnectedFactory,
     APIClientFactory,
     CompileFunction,
+    CompileOutput,
     ConfigWriter,
     RunCompiledFunction,
 )
@@ -674,3 +675,47 @@ async def run_compiled(
         )
 
     yield _run_compiled
+
+
+@pytest_asyncio.fixture
+async def compile_only(integration_test_dir: Path, shared_platformio_cache: Path):
+    """Compile an ESPHome config and capture stdout/stderr."""
+
+    async def _compile(config_path: Path) -> CompileOutput:
+        env = _get_platformio_env(shared_platformio_cache)
+
+        max_retries = 3
+        last_stdout = ""
+        last_stderr = ""
+        last_rc = 0
+
+        for attempt in range(max_retries):
+            proc = await asyncio.create_subprocess_exec(
+                "esphome",
+                "compile",
+                str(config_path),
+                cwd=integration_test_dir,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                stdin=asyncio.subprocess.DEVNULL,
+                start_new_session=True,
+                env=env,
+                close_fds=False,
+            )
+            out_b, err_b = await proc.communicate()
+            last_stdout = out_b.decode("utf-8", "backslashreplace")
+            last_stderr = err_b.decode("utf-8", "backslashreplace")
+
+            if proc.returncode:
+                last_rc = proc.returncode
+
+            if proc.returncode == 0:
+                break
+            if proc.returncode == -11 and attempt < max_retries - 1:
+                await asyncio.sleep(1)
+                continue
+            break
+
+        return CompileOutput(returncode=last_rc, stdout=last_stdout, stderr=last_stderr)
+
+    return _compile

--- a/tests/integration/fixtures/building_cyclic_dependency.yaml
+++ b/tests/integration/fixtures/building_cyclic_dependency.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: cyclic-dependency
+
+host:
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+    components: [building_cyclic_dependency]
+
+building_cyclic_dependency:

--- a/tests/integration/fixtures/building_missing_auto_load_component.yaml
+++ b/tests/integration/fixtures/building_missing_auto_load_component.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: missing-auto-load-test
+
+host:
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+    components: [building_missing_auto_load_component]
+
+building_missing_auto_load_component:

--- a/tests/integration/fixtures/building_missing_dependency_component.yaml
+++ b/tests/integration/fixtures/building_missing_dependency_component.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: missing-dependency-test
+
+host:
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+    components: [building_missing_dependency_component]
+
+building_missing_dependency_component:

--- a/tests/integration/fixtures/building_topological_component_initialization_order.yaml
+++ b/tests/integration/fixtures/building_topological_component_initialization_order.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: topological-ordering-test
+
+host:
+
+logger:
+
+api:
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+    components: [building_topological_component_ordering]
+
+building_topological_component_ordering:

--- a/tests/integration/fixtures/external_components/building_cyclic_dependency/__init__.py
+++ b/tests/integration/fixtures/external_components/building_cyclic_dependency/__init__.py
@@ -1,0 +1,6 @@
+# Minimal component "cyclic_dep" that depends on itself
+import esphome.config_validation as cv
+
+DEPENDENCIES = ["building_cyclic_dependency"]
+
+CONFIG_SCHEMA = cv.Schema({})

--- a/tests/integration/fixtures/external_components/building_missing_auto_load_component/__init__.py
+++ b/tests/integration/fixtures/external_components/building_missing_auto_load_component/__init__.py
@@ -1,0 +1,8 @@
+import esphome.config_validation as cv
+from esphome.config_validation import Schema
+
+# This external component requests auto-loading a component that is not present
+
+AUTO_LOAD: list[str] = ["absent_component_xyz"]
+
+CONFIG_SCHEMA: Schema = cv.Schema({})

--- a/tests/integration/fixtures/external_components/building_missing_dependency_component/__init__.py
+++ b/tests/integration/fixtures/external_components/building_missing_dependency_component/__init__.py
@@ -1,0 +1,8 @@
+import esphome.config_validation as cv
+from esphome.config_validation import Schema
+
+# This external component declares a dependency on a component that is not present.
+
+DEPENDENCIES: list[str] = ["absent_component_xyz"]
+
+CONFIG_SCHEMA: Schema = cv.Schema({})

--- a/tests/integration/fixtures/external_components/building_topological_component_ordering/__init__.py
+++ b/tests/integration/fixtures/external_components/building_topological_component_ordering/__init__.py
@@ -1,0 +1,3 @@
+import esphome.config_validation as cv
+
+CONFIG_SCHEMA = cv.Schema({})

--- a/tests/integration/test_building_topological_ordering.py
+++ b/tests/integration/test_building_topological_ordering.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .types import CompileOutput, ConfigWriter, OnlyCompileFunction
+
+
+@pytest.mark.asyncio
+async def test_building_missing_dependency_component(
+    yaml_config: str, write_yaml_config: ConfigWriter, compile_only: OnlyCompileFunction
+) -> None:
+    """Compiles a config where a component DEPENDENCIES lists a missing component.
+
+    Expectation: compilation fails with a clear message about the missing dependency.
+    """
+
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    config_path: Path = await write_yaml_config(yaml_config, None)
+    result: CompileOutput = await compile_only(config_path)
+
+    # Should fail because a declared dependency is missing
+    assert result.returncode != 0
+
+    # Expect a clear error about the missing dependency
+    combined = result.stdout + "\n" + result.stderr
+    assert (
+        "Component building_missing_dependency_component requires component absent_component_xyz"
+        in combined
+    ), combined
+
+
+@pytest.mark.asyncio
+async def test_building_missing_auto_load_component(
+    yaml_config: str, write_yaml_config: ConfigWriter, compile_only: OnlyCompileFunction
+) -> None:
+    """Compiles a config where a component AUTO_LOADs a missing target.
+
+    Expectation: compilation fails with a clear message about the missing component.
+    """
+
+    external_components_path = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    config_path: Path = await write_yaml_config(yaml_config, None)
+    result: CompileOutput = await compile_only(config_path)
+
+    # Should fail because AUTO_LOAD points to a missing component
+    assert result.returncode != 0
+
+    combined = result.stdout + "\n" + result.stderr
+    assert "Component not found: absent_component_xyz" in combined, combined
+
+
+@pytest.mark.asyncio
+async def test_building_topological_component_initialization_order(
+    yaml_config: str, write_yaml_config: ConfigWriter, compile_only: OnlyCompileFunction
+) -> None:
+    """Verify that initialization order follows topological order constraints"""
+    external_components_path: str = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    config_path: Path = await write_yaml_config(yaml_config, None)
+    result: CompileOutput = await compile_only(config_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+    # Look for the Initialization order line and check relative positions
+    combined = result.stdout + "\n" + result.stderr
+    # Find the last occurrence to be robust against multiple runs/log blocks
+    marker = "Initialization order: "
+    idx = combined.rfind(marker)
+    assert idx != -1, f"Missing '{marker}' log line.\nLogs:\n{combined}"
+    order_str = combined[idx + len(marker) :].splitlines()[0].strip()
+    names = [s.strip() for s in order_str.split(",")]
+
+    # Helper to get index with assertion
+    def pos(name: str) -> int:
+        assert name in names, f"{name} not found in order: {names}"
+        return names.index(name)
+
+    assert pos("host") < pos("esphome"), order_str
+    assert pos("esphome") < pos("logger"), order_str
+
+    for comp in (
+        "building_topological_component_ordering",
+        "network",
+        "api",
+        "socket",
+        "mdns",
+        "preferences",
+    ):
+        assert pos("esphome") < pos(comp), order_str
+        assert pos("host") < pos(comp), order_str
+        assert pos("logger") < pos(comp), order_str
+
+    assert pos("logger") < pos("building_topological_component_ordering"), order_str
+    assert pos("network") < pos("api"), order_str
+    assert pos("api") < pos("socket"), order_str
+    assert pos("api") < pos("mdns"), order_str
+    assert pos("host") < pos("preferences"), order_str
+
+
+@pytest.mark.asyncio
+async def test_building_cyclic_dependency(
+    yaml_config: str, write_yaml_config: ConfigWriter, compile_only: OnlyCompileFunction
+) -> None:
+    """Compiles the test fixture YAML and asserts cyclic dependency is reported."""
+    external_components_path: str = str(
+        Path(__file__).parent / "fixtures" / "external_components"
+    )
+
+    yaml_config = yaml_config.replace(
+        "EXTERNAL_COMPONENT_PATH", external_components_path
+    )
+
+    config_path: Path = await write_yaml_config(yaml_config, None)
+    result: CompileOutput = await compile_only(config_path)
+
+    assert result.returncode != 0
+    assert (
+        "Circular dependency detected among components: building_cyclic_dependency"
+        in result.stderr
+    )

--- a/tests/integration/types.py
+++ b/tests/integration/types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
@@ -13,6 +14,16 @@ from aioesphomeapi import APIClient
 ConfigWriter = Callable[[str, str | None], Awaitable[Path]]
 CompileFunction = Callable[[Path], Awaitable[Path]]
 RunFunction = Callable[[Path], Awaitable[asyncio.subprocess.Process]]
+
+
+@dataclass
+class CompileOutput:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+OnlyCompileFunction = Callable[[Path], Awaitable[CompileOutput]]
 
 
 class RunCompiledFunction(Protocol):

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -677,7 +677,6 @@ def test_write_cpp_creates_new_file(
     assert written_path == main_cpp
 
     # Check that all necessary parts are in the new file
-    assert '#include "esphome.h"' in written_content
     assert CPP_INCLUDE_BEGIN in written_content
     assert CPP_INCLUDE_END in written_content
     assert CPP_AUTO_GENERATE_BEGIN in written_content


### PR DESCRIPTION
# What does this implement/fix?

Topologically order codegen by dependencies

- Codegen
  - Schedule component to_code calls deterministically via a name-level
    dependency graph (Kahn’s algorithm), with logger-first and lexical
    tie-breaks.
  - Add platform-aware edges (platform component depends on target
    platform; target platform depends on esphome) when applicable.
  - Move #include "esphome.h" into core/config.py global phase; remove
    from writer.py to centralize include handling.
  - Emit USE_REGISTRATION_ORDER_SETUP to align runtime with codegen order.

- Runtime 
  - application.cpp: respect USE_REGISTRATION_ORDER_SETUP to skip priority
    sorting and keep registration order; add detailed DEBUG logs for setup
    order and per-component setup progress.
  - component.h: deprecate get_setup_priority/get_actual_setup_priority.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Relates to: https://github.com/esphome/backlog/issues/56 

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
