### PR TITLE
[substitutions] Fix AttributeError when using packages with substitutions

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from esphome import core
-from esphome.config_helpers import Extend, Remove, merge_config
+from esphome.config_helpers import Extend, Remove, merge_config, merge_dicts_ordered
 import esphome.config_validation as cv
 from esphome.const import CONF_SUBSTITUTIONS, VALID_SUBSTITUTIONS_CHARACTERS
 from esphome.yaml_util import ESPHomeDataBase, ESPLiteralValue, make_data_base
@@ -170,10 +170,10 @@ def do_substitution_pass(config, command_line_substitutions, ignore_missing=Fals
         return
 
     # Merge substitutions in config, overriding with substitutions coming from command line:
-    substitutions = {
-        **config.get(CONF_SUBSTITUTIONS, {}),
-        **(command_line_substitutions or {}),
-    }
+    # Use merge_dicts_ordered to preserve OrderedDict type for move_to_end()
+    substitutions = merge_dicts_ordered(
+        config.get(CONF_SUBSTITUTIONS, {}), command_line_substitutions or {}
+    )
     with cv.prepend_path("substitutions"):
         if not isinstance(substitutions, dict):
             raise cv.Invalid(

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -12,7 +12,7 @@ from typing import Any
 import voluptuous as vol
 
 from esphome import core, loader, pins, yaml_util
-from esphome.config_helpers import Extend, Remove
+from esphome.config_helpers import Extend, Remove, merge_dicts_ordered
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ESPHOME,
@@ -922,10 +922,9 @@ def validate_config(
     if CONF_SUBSTITUTIONS in config or command_line_substitutions:
         from esphome.components import substitutions
 
-        result[CONF_SUBSTITUTIONS] = {
-            **(config.get(CONF_SUBSTITUTIONS) or {}),
-            **command_line_substitutions,
-        }
+        result[CONF_SUBSTITUTIONS] = merge_dicts_ordered(
+            config.get(CONF_SUBSTITUTIONS) or {}, command_line_substitutions
+        )
         result.add_output_path([CONF_SUBSTITUTIONS], CONF_SUBSTITUTIONS)
         try:
             substitutions.do_substitution_pass(config, command_line_substitutions)

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -18,7 +18,7 @@ _PLATFORM_FRAMEWORK_LOOKUP = {
 }
 
 
-def merge_dicts_ordered(*dicts):
+def merge_dicts_ordered(*dicts: dict) -> OrderedDict:
     """Merge multiple dicts into an OrderedDict, preserving key order.
 
     This is a helper to ensure that dictionary merging preserves OrderedDict type,

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -80,7 +80,11 @@ def merge_config(full_old, full_new):
         if isinstance(new, dict):
             if not isinstance(old, dict):
                 return new
-            res = old.copy()
+            # Preserve OrderedDict type by copying to OrderedDict if either input is OrderedDict
+            if isinstance(old, OrderedDict) or isinstance(new, OrderedDict):
+                res = OrderedDict(old)
+            else:
+                res = old.copy()
             for k, v in new.items():
                 if isinstance(v, Remove) and k in old:
                     del res[k]

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -30,11 +30,11 @@ def merge_dicts_ordered(*dicts: dict) -> OrderedDict:
     Returns:
         OrderedDict with merged contents
     """
-    result = {}
+    result = OrderedDict()
     for d in dicts:
         if d:
             result.update(d)
-    return OrderedDict(result)
+    return result
 
 
 class Extend:

--- a/esphome/config_helpers.py
+++ b/esphome/config_helpers.py
@@ -10,11 +10,31 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE
+from esphome.util import OrderedDict
 
 # Pre-build lookup map from (platform, framework) tuples to PlatformFramework enum
 _PLATFORM_FRAMEWORK_LOOKUP = {
     (pf.value[0].value, pf.value[1].value): pf for pf in PlatformFramework
 }
+
+
+def merge_dicts_ordered(*dicts):
+    """Merge multiple dicts into an OrderedDict, preserving key order.
+
+    This is a helper to ensure that dictionary merging preserves OrderedDict type,
+    which is important for operations like move_to_end().
+
+    Args:
+        *dicts: Variable number of dictionaries to merge (later dicts override earlier ones)
+
+    Returns:
+        OrderedDict with merged contents
+    """
+    result = {}
+    for d in dicts:
+        if d:
+            result.update(d)
+    return OrderedDict(result)
 
 
 class Extend:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -124,7 +124,8 @@ def test_substitutions_fixtures(fixture_path):
 
 
 def test_substitutions_with_command_line_maintains_ordered_dict() -> None:
-    """Test that substitutions remain an OrderedDict when command line substitutions are provided.
+    """Test that substitutions remain an OrderedDict when command line substitutions are provided,
+    and that move_to_end() can be called successfully.
 
     This is a regression test for https://github.com/esphome/esphome/issues/11182
     where the config would become a regular dict and fail when move_to_end() was called.

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -277,3 +277,43 @@ def test_validate_config_without_command_line_substitutions_maintains_ordered_di
     # Verify substitutions are unchanged
     assert result[CONF_SUBSTITUTIONS]["var1"] == "value1"
     assert result[CONF_SUBSTITUTIONS]["var2"] == "value2"
+
+
+def test_merge_config_preserves_ordered_dict() -> None:
+    """Test that merge_config preserves OrderedDict type.
+
+    This is a regression test to ensure merge_config doesn't lose OrderedDict type
+    when merging configs, which causes AttributeError on move_to_end().
+    """
+    # Test OrderedDict + dict = OrderedDict
+    od = OrderedDict([("a", 1), ("b", 2)])
+    d = {"b": 20, "c": 3}
+    result = merge_config(od, d)
+    assert isinstance(result, OrderedDict), (
+        "OrderedDict + dict should return OrderedDict"
+    )
+
+    # Test dict + OrderedDict = OrderedDict
+    d = {"a": 1, "b": 2}
+    od = OrderedDict([("b", 20), ("c", 3)])
+    result = merge_config(d, od)
+    assert isinstance(result, OrderedDict), (
+        "dict + OrderedDict should return OrderedDict"
+    )
+
+    # Test OrderedDict + OrderedDict = OrderedDict
+    od1 = OrderedDict([("a", 1), ("b", 2)])
+    od2 = OrderedDict([("b", 20), ("c", 3)])
+    result = merge_config(od1, od2)
+    assert isinstance(result, OrderedDict), (
+        "OrderedDict + OrderedDict should return OrderedDict"
+    )
+
+    # Test that dict + dict still returns regular dict (no unnecessary conversion)
+    d1 = {"a": 1, "b": 2}
+    d2 = {"b": 20, "c": 3}
+    result = merge_config(d1, d2)
+    assert isinstance(result, dict), "dict + dict should return dict"
+    assert not isinstance(result, OrderedDict), (
+        "dict + dict should not return OrderedDict"
+    )

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -4,7 +4,8 @@ from pathlib import Path
 
 from esphome import yaml_util
 from esphome.components import substitutions
-from esphome.const import CONF_PACKAGES
+from esphome.const import CONF_PACKAGES, CONF_SUBSTITUTIONS
+from esphome.util import OrderedDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,3 +119,93 @@ def test_substitutions_fixtures(fixture_path):
     if DEV_MODE:
         _LOGGER.error("Tests passed, but Dev mode is enabled.")
     assert not DEV_MODE  # make sure DEV_MODE is disabled after you are finished.
+
+
+def test_substitutions_with_command_line_maintains_ordered_dict() -> None:
+    """Test that substitutions remain an OrderedDict when command line substitutions are provided.
+
+    This is a regression test for https://github.com/esphome/esphome/issues/11182
+    where the config would become a regular dict and fail when move_to_end() was called.
+    """
+    # Create an OrderedDict config with substitutions
+    config = OrderedDict()
+    config["esphome"] = {"name": "test"}
+    config[CONF_SUBSTITUTIONS] = {"var1": "value1", "var2": "value2"}
+    config["other_key"] = "other_value"
+
+    # Command line substitutions that should override
+    command_line_subs = {"var2": "override", "var3": "new_value"}
+
+    # Call do_substitution_pass with command line substitutions
+    substitutions.do_substitution_pass(config, command_line_subs)
+
+    # Verify that config is still an OrderedDict
+    assert isinstance(config, OrderedDict), "Config should remain an OrderedDict"
+
+    # Verify substitutions are at the beginning (move_to_end with last=False)
+    keys = list(config.keys())
+    assert keys[0] == CONF_SUBSTITUTIONS, "Substitutions should be first key"
+
+    # Verify substitutions were properly merged
+    assert config[CONF_SUBSTITUTIONS]["var1"] == "value1"
+    assert config[CONF_SUBSTITUTIONS]["var2"] == "override"
+    assert config[CONF_SUBSTITUTIONS]["var3"] == "new_value"
+
+    # Verify config[CONF_SUBSTITUTIONS] is also an OrderedDict
+    assert isinstance(config[CONF_SUBSTITUTIONS], OrderedDict), (
+        "Substitutions should be an OrderedDict"
+    )
+
+
+def test_substitutions_without_command_line_maintains_ordered_dict() -> None:
+    """Test that substitutions work correctly without command line substitutions."""
+    config = OrderedDict()
+    config["esphome"] = {"name": "test"}
+    config[CONF_SUBSTITUTIONS] = {"var1": "value1"}
+    config["other_key"] = "other_value"
+
+    # Call without command line substitutions
+    substitutions.do_substitution_pass(config, None)
+
+    # Verify that config is still an OrderedDict
+    assert isinstance(config, OrderedDict), "Config should remain an OrderedDict"
+
+    # Verify substitutions are at the beginning
+    keys = list(config.keys())
+    assert keys[0] == CONF_SUBSTITUTIONS, "Substitutions should be first key"
+
+
+def test_substitutions_after_merge_config_maintains_ordered_dict() -> None:
+    """Test that substitutions work after merge_config (packages scenario).
+
+    This is a regression test for https://github.com/esphome/esphome/issues/11182
+    where using packages would cause config to become a regular dict, breaking move_to_end().
+    """
+    from esphome.config_helpers import merge_config
+
+    # Simulate what happens with packages - merge two OrderedDict configs
+    base_config = OrderedDict()
+    base_config["esphome"] = {"name": "base"}
+    base_config[CONF_SUBSTITUTIONS] = {"var1": "value1"}
+
+    package_config = OrderedDict()
+    package_config["sensor"] = [{"platform": "template"}]
+    package_config[CONF_SUBSTITUTIONS] = {"var2": "value2"}
+
+    # Merge configs (simulating package merge)
+    merged_config = merge_config(base_config, package_config)
+
+    # Verify merged config is still an OrderedDict
+    assert isinstance(merged_config, OrderedDict), (
+        "Merged config should be an OrderedDict"
+    )
+
+    # Now try to run substitution pass on the merged config
+    substitutions.do_substitution_pass(merged_config, None)
+
+    # Should not raise AttributeError
+    assert isinstance(merged_config, OrderedDict), (
+        "Config should still be OrderedDict after substitution pass"
+    )
+    keys = list(merged_config.keys())
+    assert keys[0] == CONF_SUBSTITUTIONS, "Substitutions should be first key"

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -2,9 +2,11 @@ import glob
 import logging
 from pathlib import Path
 
-from esphome import yaml_util
+from esphome import config as config_module, yaml_util
 from esphome.components import substitutions
+from esphome.config_helpers import merge_config
 from esphome.const import CONF_PACKAGES, CONF_SUBSTITUTIONS
+from esphome.core import CORE
 from esphome.util import OrderedDict
 
 _LOGGER = logging.getLogger(__name__)
@@ -181,8 +183,6 @@ def test_substitutions_after_merge_config_maintains_ordered_dict() -> None:
     This is a regression test for https://github.com/esphome/esphome/issues/11182
     where using packages would cause config to become a regular dict, breaking move_to_end().
     """
-    from esphome.config_helpers import merge_config
-
     # Simulate what happens with packages - merge two OrderedDict configs
     base_config = OrderedDict()
     base_config["esphome"] = {"name": "base"}
@@ -209,3 +209,71 @@ def test_substitutions_after_merge_config_maintains_ordered_dict() -> None:
     )
     keys = list(merged_config.keys())
     assert keys[0] == CONF_SUBSTITUTIONS, "Substitutions should be first key"
+
+
+def test_validate_config_with_command_line_substitutions_maintains_ordered_dict(
+    tmp_path,
+) -> None:
+    """Test that validate_config preserves OrderedDict when merging command-line substitutions.
+
+    This tests the code path in config.py where result[CONF_SUBSTITUTIONS] is set
+    using merge_dicts_ordered() with command-line substitutions provided.
+    """
+    # Create a minimal valid config
+    test_config = OrderedDict()
+    test_config["esphome"] = {"name": "test_device", "platform": "ESP32"}
+    test_config[CONF_SUBSTITUTIONS] = {"var1": "value1", "var2": "value2"}
+    test_config["esp32"] = {"board": "esp32dev"}
+
+    # Command line substitutions that should override
+    command_line_subs = {"var2": "override", "var3": "new_value"}
+
+    # Set up CORE for the test with a proper Path object
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("# test config")
+    CORE.config_path = test_yaml
+
+    # Call validate_config with command line substitutions
+    result = config_module.validate_config(test_config, command_line_subs)
+
+    # Verify that result[CONF_SUBSTITUTIONS] is an OrderedDict
+    assert isinstance(result.get(CONF_SUBSTITUTIONS), OrderedDict), (
+        "Result substitutions should be an OrderedDict"
+    )
+
+    # Verify substitutions were properly merged
+    assert result[CONF_SUBSTITUTIONS]["var1"] == "value1"
+    assert result[CONF_SUBSTITUTIONS]["var2"] == "override"
+    assert result[CONF_SUBSTITUTIONS]["var3"] == "new_value"
+
+
+def test_validate_config_without_command_line_substitutions_maintains_ordered_dict(
+    tmp_path,
+) -> None:
+    """Test that validate_config preserves OrderedDict without command-line substitutions.
+
+    This tests the code path in config.py where result[CONF_SUBSTITUTIONS] is set
+    using merge_dicts_ordered() when command_line_substitutions is None.
+    """
+    # Create a minimal valid config
+    test_config = OrderedDict()
+    test_config["esphome"] = {"name": "test_device", "platform": "ESP32"}
+    test_config[CONF_SUBSTITUTIONS] = {"var1": "value1", "var2": "value2"}
+    test_config["esp32"] = {"board": "esp32dev"}
+
+    # Set up CORE for the test with a proper Path object
+    test_yaml = tmp_path / "test.yaml"
+    test_yaml.write_text("# test config")
+    CORE.config_path = test_yaml
+
+    # Call validate_config without command line substitutions
+    result = config_module.validate_config(test_config, None)
+
+    # Verify that result[CONF_SUBSTITUTIONS] is an OrderedDict
+    assert isinstance(result.get(CONF_SUBSTITUTIONS), OrderedDict), (
+        "Result substitutions should be an OrderedDict"
+    )
+
+    # Verify substitutions are unchanged
+    assert result[CONF_SUBSTITUTIONS]["var1"] == "value1"
+    assert result[CONF_SUBSTITUTIONS]["var2"] == "value2"

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -222,7 +222,7 @@ def test_validate_config_with_command_line_substitutions_maintains_ordered_dict(
     # Create a minimal valid config
     test_config = OrderedDict()
     test_config["esphome"] = {"name": "test_device", "platform": "ESP32"}
-    test_config[CONF_SUBSTITUTIONS] = {"var1": "value1", "var2": "value2"}
+    test_config[CONF_SUBSTITUTIONS] = OrderedDict({"var1": "value1", "var2": "value2"})
     test_config["esp32"] = {"board": "esp32dev"}
 
     # Command line substitutions that should override
@@ -258,7 +258,7 @@ def test_validate_config_without_command_line_substitutions_maintains_ordered_di
     # Create a minimal valid config
     test_config = OrderedDict()
     test_config["esphome"] = {"name": "test_device", "platform": "ESP32"}
-    test_config[CONF_SUBSTITUTIONS] = {"var1": "value1", "var2": "value2"}
+    test_config[CONF_SUBSTITUTIONS] = OrderedDict({"var1": "value1", "var2": "value2"})
     test_config["esp32"] = {"board": "esp32dev"}
 
     # Set up CORE for the test with a proper Path object


### PR DESCRIPTION
# What does this implement/fix?

Fixes `AttributeError: 'dict' object has no attribute 'move_to_end'` when processing substitutions after config merging (e.g., when using packages).

## Root Cause

The bug was in `merge_config()` which uses `.copy()` to duplicate dictionaries. The problem occurs when:

1. During package loading/processing, the config becomes a regular `dict` somewhere in the chain (from YAML processing, validation schemas, or dict literals)
2. `merge_config()` does `res = old.copy()` - if `old` is a regular `dict`, the result stays a regular `dict`
3. When merging `merge_config(dict, OrderedDict)`, the result is a `dict` (not `OrderedDict`) because `old.copy()` preserves the type of `old`
4. This "contaminates" the config object - once it becomes a `dict`, it stays a `dict` through all subsequent merges
5. Later, `config.move_to_end(CONF_SUBSTITUTIONS, False)` fails because `config` is a `dict`, not an `OrderedDict`

The key issue: **if the base config becomes a regular `dict` at any point, all future merges preserve that `dict` type, even when merging with `OrderedDict` values.**

## Changes

1. **Fixed `merge_config()` in `config_helpers.py`** (root cause fix):
   - Now preserves `OrderedDict` type when **either** input dict is an `OrderedDict`
   - If `old` OR `new` is `OrderedDict`, result is `OrderedDict` (uses `OrderedDict(old)` instead of `old.copy()`)
   - Regular `dict + dict` merging remains unchanged (no unnecessary conversions)
   - This prevents regular `dict` from "contaminating" the merge chain

2. Added `merge_dicts_ordered()` helper function in `config_helpers.py` to safely merge dicts while preserving `OrderedDict` type (used in substitutions component)

3. Updated substitutions component to use the helper when merging config and command-line substitutions

4. Updated config.py to use the helper when storing merged substitutions in the result object

5. Added comprehensive regression tests:
   - Tests covering the packages + substitutions scenario
   - Direct tests for `merge_config()` behavior with all dict type combinations:
     - `OrderedDict + dict` → `OrderedDict` ✓
     - `dict + OrderedDict` → `OrderedDict` ✓ (this was the bug - used to return `dict`)
     - `OrderedDict + OrderedDict` → `OrderedDict` ✓
     - `dict + dict` → `dict` ✓ (unchanged)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11182

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal bug fix, no user-facing documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

All platforms affected - this is a core config processing bug.

## Example entry for `config.yaml`:

This bug affected any config using packages with substitutions. No config changes needed - the fix is internal.

```yaml
# Example that previously failed:
substitutions:
  device_name: my_device

packages:
  base: !include common/base.yaml

esphome:
  name: ${device_name}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
