### PR TITLE
[tests] Fix OTA password test assertions after merge collision

### DIFF
--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -2025,7 +2025,7 @@ def test_upload_program_ota_static_ip_with_mqttip(
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
     mock_run_ota.assert_called_once_with(
-        ["192.168.1.100", "192.168.2.50"], 3232, "", expected_firmware
+        ["192.168.1.100", "192.168.2.50"], 3232, None, expected_firmware
     )
 
 
@@ -2068,7 +2068,7 @@ def test_upload_program_ota_multiple_mqttip_resolves_once(
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
     mock_run_ota.assert_called_once_with(
-        ["192.168.2.50", "192.168.2.51", "192.168.1.100"], 3232, "", expected_firmware
+        ["192.168.2.50", "192.168.2.51", "192.168.1.100"], 3232, None, expected_firmware
     )
 
 
@@ -2230,7 +2230,9 @@ def test_upload_program_ota_mqtt_timeout_fallback(
     expected_firmware = (
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
-    mock_run_ota.assert_called_once_with(["192.168.1.100"], 3232, "", expected_firmware)
+    mock_run_ota.assert_called_once_with(
+        ["192.168.1.100"], 3232, None, expected_firmware
+    )
 
 
 @patch("esphome.components.api.client.run_logs")


### PR DESCRIPTION
# What does this implement/fix?

Fixes failing unit tests after merge collision between PR #11271 (blank password handling) and PR #11272 (MQTT resolution fixes).

PR #11271 changed the OTA password behavior to pass `None` when no password is configured (instead of empty string `""`). PR #11272 added tests that expected the old behavior with empty string. This PR updates the tests to match the current implementation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #11260 (MQTT IP resolution with static IP)
- Fixes merge collision between #11271 and #11272

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Test-only changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - Test-only changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
