### PR TITLE
[api] Use FixedVector for HomeAssistantServiceCallAction to reduce flash usage and avoid realloc

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -380,12 +380,19 @@ async def homeassistant_service_to_code(
     var = cg.new_Pvariable(action_id, template_arg, serv, False)
     templ = await cg.templatable(config[CONF_ACTION], args, None)
     cg.add(var.set_service(templ))
+
+    # Initialize FixedVectors with exact sizes from config
+    cg.add(var.init_data(len(config[CONF_DATA])))
     for key, value in config[CONF_DATA].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_data(key, templ))
+
+    cg.add(var.init_data_template(len(config[CONF_DATA_TEMPLATE])))
     for key, value in config[CONF_DATA_TEMPLATE].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_data_template(key, templ))
+
+    cg.add(var.init_variables(len(config[CONF_VARIABLES])))
     for key, value in config[CONF_VARIABLES].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_variable(key, templ))
@@ -458,15 +465,23 @@ async def homeassistant_event_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg, serv, True)
     templ = await cg.templatable(config[CONF_EVENT], args, None)
     cg.add(var.set_service(templ))
+
+    # Initialize FixedVectors with exact sizes from config
+    cg.add(var.init_data(len(config[CONF_DATA])))
     for key, value in config[CONF_DATA].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_data(key, templ))
+
+    cg.add(var.init_data_template(len(config[CONF_DATA_TEMPLATE])))
     for key, value in config[CONF_DATA_TEMPLATE].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_data_template(key, templ))
+
+    cg.add(var.init_variables(len(config[CONF_VARIABLES])))
     for key, value in config[CONF_VARIABLES].items():
         templ = await cg.templatable(value, args, None)
         cg.add(var.add_variable(key, templ))
+
     return var
 
 
@@ -489,6 +504,8 @@ async def homeassistant_tag_scanned_to_code(config, action_id, template_arg, arg
     serv = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, serv, True)
     cg.add(var.set_service("esphome.tag_scanned"))
+    # Initialize FixedVector with exact size (1 data field)
+    cg.add(var.init_data(1))
     templ = await cg.templatable(config[CONF_TAG], args, cg.std_string)
     cg.add(var.add_data("tag_id", templ))
     return var

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -186,7 +186,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
  protected:
   // Helper to add key-value pairs to FixedVectors with perfect forwarding to avoid copies
-  template<typename K, typename V> void add_kv(FixedVector<TemplatableKeyValuePair<Ts...>> &vec, K &&key, V &&value) {
+  template<typename K, typename V> void add_kv_(FixedVector<TemplatableKeyValuePair<Ts...>> &vec, K &&key, V &&value) {
     auto &kv = vec.emplace_back();
     kv.key = std::forward<K>(key);
     kv.value = std::forward<V>(value);

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -41,10 +41,14 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
 
 template<typename... Ts> class TemplatableKeyValuePair {
  public:
+  // Default constructor needed for FixedVector::emplace_back()
+  TemplatableKeyValuePair() = default;
+
   // Keys are always string literals from YAML dictionary keys (e.g., "code", "event")
   // and never templatable values or lambdas. Only the value parameter can be a lambda/template.
   // Using pass-by-value with std::move allows optimal performance for both lvalues and rvalues.
   template<typename T> TemplatableKeyValuePair(std::string key, T value) : key(std::move(key)), value(value) {}
+
   std::string key;
   TemplatableStringValue<Ts...> value;
 };
@@ -93,15 +97,28 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
+  // Initialize FixedVector members - called from Python codegen with compile-time known sizes
+  void init_data(size_t count) { this->data_.init(count); }
+  void init_data_template(size_t count) { this->data_template_.init(count); }
+  void init_variables(size_t count) { this->variables_.init(count); }
+
   // Keys are always string literals from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
   // The value parameter can be a lambda/template, but keys are never templatable.
   // Using pass-by-value allows the compiler to optimize for both lvalues and rvalues.
-  template<typename T> void add_data(std::string key, T value) { this->data_.emplace_back(std::move(key), value); }
+  template<typename T> void add_data(std::string key, T value) {
+    auto &kv = this->data_.emplace_back();
+    kv.key = std::move(key);
+    kv.value = value;
+  }
   template<typename T> void add_data_template(std::string key, T value) {
-    this->data_template_.emplace_back(std::move(key), value);
+    auto &kv = this->data_template_.emplace_back();
+    kv.key = std::move(key);
+    kv.value = value;
   }
   template<typename T> void add_variable(std::string key, T value) {
-    this->variables_.emplace_back(std::move(key), value);
+    auto &kv = this->variables_.emplace_back();
+    kv.key = std::move(key);
+    kv.value = value;
   }
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
@@ -186,9 +203,9 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   APIServer *parent_;
   TemplatableStringValue<Ts...> service_{};
-  std::vector<TemplatableKeyValuePair<Ts...>> data_;
-  std::vector<TemplatableKeyValuePair<Ts...>> data_template_;
-  std::vector<TemplatableKeyValuePair<Ts...>> variables_;
+  FixedVector<TemplatableKeyValuePair<Ts...>> data_;
+  FixedVector<TemplatableKeyValuePair<Ts...>> data_template_;
+  FixedVector<TemplatableKeyValuePair<Ts...>> variables_;
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   TemplatableStringValue<Ts...> response_template_{""};

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -97,28 +97,22 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 
   template<typename T> void set_service(T service) { this->service_ = service; }
 
-  // Initialize FixedVector members - called from Python codegen with compile-time known sizes
+  // Initialize FixedVector members - called from Python codegen with compile-time known sizes.
+  // Must be called before any add_* methods; capacity must match the number of subsequent add_* calls.
   void init_data(size_t count) { this->data_.init(count); }
   void init_data_template(size_t count) { this->data_template_.init(count); }
   void init_variables(size_t count) { this->variables_.init(count); }
 
   // Keys are always string literals from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
   // The value parameter can be a lambda/template, but keys are never templatable.
-  // Using pass-by-value allows the compiler to optimize for both lvalues and rvalues.
-  template<typename T> void add_data(std::string key, T value) {
-    auto &kv = this->data_.emplace_back();
-    kv.key = std::move(key);
-    kv.value = value;
+  template<typename K, typename V> void add_data(K &&key, V &&value) {
+    this->add_kv(this->data_, std::forward<K>(key), std::forward<V>(value));
   }
-  template<typename T> void add_data_template(std::string key, T value) {
-    auto &kv = this->data_template_.emplace_back();
-    kv.key = std::move(key);
-    kv.value = value;
+  template<typename K, typename V> void add_data_template(K &&key, V &&value) {
+    this->add_kv(this->data_template_, std::forward<K>(key), std::forward<V>(value));
   }
-  template<typename T> void add_variable(std::string key, T value) {
-    auto &kv = this->variables_.emplace_back();
-    kv.key = std::move(key);
-    kv.value = value;
+  template<typename K, typename V> void add_variable(K &&key, V &&value) {
+    this->add_kv(this->variables_, std::forward<K>(key), std::forward<V>(value));
   }
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
@@ -191,6 +185,13 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   }
 
  protected:
+  // Helper to add key-value pairs to FixedVectors with perfect forwarding to avoid copies
+  template<typename K, typename V> void add_kv(FixedVector<TemplatableKeyValuePair<Ts...>> &vec, K &&key, V &&value) {
+    auto &kv = vec.emplace_back();
+    kv.key = std::forward<K>(key);
+    kv.value = std::forward<V>(value);
+  }
+
   template<typename VectorType, typename SourceType>
   static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
     dest.init(source.size());

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -106,13 +106,13 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   // Keys are always string literals from the Python code generation (e.g., cg.add(var.add_data("tag_id", templ))).
   // The value parameter can be a lambda/template, but keys are never templatable.
   template<typename K, typename V> void add_data(K &&key, V &&value) {
-    this->add_kv(this->data_, std::forward<K>(key), std::forward<V>(value));
+    this->add_kv_(this->data_, std::forward<K>(key), std::forward<V>(value));
   }
   template<typename K, typename V> void add_data_template(K &&key, V &&value) {
-    this->add_kv(this->data_template_, std::forward<K>(key), std::forward<V>(value));
+    this->add_kv_(this->data_template_, std::forward<K>(key), std::forward<V>(value));
   }
   template<typename K, typename V> void add_variable(K &&key, V &&value) {
-    this->add_kv(this->variables_, std::forward<K>(key), std::forward<V>(value));
+    this->add_kv_(this->variables_, std::forward<K>(key), std::forward<V>(value));
   }
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES


### PR DESCRIPTION
# What does this implement/fix?

Converts `HomeAssistantServiceCallAction` internal storage from `std::vector<TemplatableKeyValuePair>` to `FixedVector` to reduce flash usage and eliminate runtime heap reallocations.

## Changes

### C++ (`homeassistant_service.h`)
- Added default constructor to `TemplatableKeyValuePair` (required for `FixedVector::emplace_back()`)
- Converted three member variables from `std::vector` to `FixedVector`:
  - `data_` (for `homeassistant.action`/`homeassistant.service` data)
  - `data_template_` (for templated data fields)
  - `variables_` (for lambda variables)
- Added `init_data()`, `init_data_template()`, `init_variables()` methods called from Python codegen
- Updated `add_data()`, `add_data_template()`, `add_variable()` to use FixedVector's emplace_back pattern

### Python (`__init__.py`)
- Added `init_*()` calls in `homeassistant_service_to_code()` before loops (3 calls)
- Added `init_*()` calls in `homeassistant_event_to_code()` before loops (3 calls)
- Added `init_data(1)` call in `homeassistant_tag_scanned_to_code()` (1 call)

Python codegen provides exact sizes from YAML config dictionaries (`len(config[CONF_DATA])`, etc.) to pre-allocate FixedVectors.

## Benefits

### Flash Savings
- **ESP8266**: 148 bytes saved (503,853 → 503,705 bytes)
- Eliminates `std::vector<TemplatableKeyValuePair>::_M_realloc_insert` template instantiation
- Removes STL reallocation machinery from binary

### Runtime Benefits
- **Zero heap reallocations**: All allocations happen once during construction with exact size
- **No heap fragmentation**: Single allocation per vector, no incremental growth
- **Deterministic memory usage**: Size known from YAML configuration at compile-time
- **Predictable performance**: No dynamic resizing during action execution

## Why This Works

The number of data/data_template/variables fields is **compile-time constant** - determined from the YAML configuration:

```yaml
homeassistant.action:
  action: light.turn_on
  data:
    entity_id: light.kitchen  # 1 item
    brightness: 255            # 2 items
  data_template:
    color_name: "{{ color }}"  # 1 item
  # Total: 2 data, 1 data_template, 0 variables
```

Python codegen knows these counts and calls:
```cpp
var.init_data(2);          // Allocates exactly 2 slots
var.init_data_template(1); // Allocates exactly 1 slot
var.init_variables(0);     // Allocates 0 slots (no allocation)
```

Then the loops populate pre-allocated storage with no reallocations.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (memory optimization)

**Related issue or feature (if applicable):**

- Part of ongoing FixedVector optimization effort to reduce flash usage on resource-constrained platforms

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-visible changes)

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:

No configuration changes required. This is a transparent optimization that works with existing configurations:

```yaml
api:
  homeassistant_services: true

# All existing homeassistant.action/service/event configurations work unchanged
on_...:
  then:
    - homeassistant.action:
        action: light.turn_on
        data:
          entity_id: light.kitchen
          brightness: 255
        data_template:
          color_name: "{{ state }}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal optimization only)
