### PR TITLE
2025.10.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.10.0
+PROJECT_NUMBER         = 2025.10.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -606,7 +606,7 @@ def upload_program(
     from esphome import espota2
 
     remote_port = int(ota_conf[CONF_PORT])
-    password = ota_conf.get(CONF_PASSWORD, "")
+    password = ota_conf.get(CONF_PASSWORD)
     if getattr(args, "file", None) is not None:
         binary = Path(args.file)
     else:

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -117,6 +117,17 @@ class Purpose(StrEnum):
     LOGGING = "logging"
 
 
+class PortType(StrEnum):
+    SERIAL = "SERIAL"
+    NETWORK = "NETWORK"
+    MQTT = "MQTT"
+    MQTTIP = "MQTTIP"
+
+
+# Magic MQTT port types that require special handling
+_MQTT_PORT_TYPES = frozenset({PortType.MQTT, PortType.MQTTIP})
+
+
 def _resolve_with_cache(address: str, purpose: Purpose) -> list[str]:
     """Resolve an address using cache if available, otherwise return the address itself."""
     if CORE.address_cache and (cached := CORE.address_cache.get_addresses(address)):
@@ -280,16 +291,67 @@ def mqtt_get_ip(config: ConfigType, username: str, password: str, client_id: str
     return mqtt.get_esphome_device_ip(config, username, password, client_id)
 
 
-_PORT_TO_PORT_TYPE = {
-    "MQTT": "MQTT",
-    "MQTTIP": "MQTTIP",
-}
+def _resolve_network_devices(
+    devices: list[str], config: ConfigType, args: ArgsProtocol
+) -> list[str]:
+    """Resolve device list, converting MQTT magic strings to actual IP addresses.
+
+    This function filters the devices list to:
+    - Replace MQTT/MQTTIP magic strings with actual IP addresses via MQTT lookup
+    - Deduplicate addresses while preserving order
+    - Only resolve MQTT once even if multiple MQTT strings are present
+    - If MQTT resolution fails, log a warning and continue with other devices
+
+    Args:
+        devices: List of device identifiers (IPs, hostnames, or magic strings)
+        config: ESPHome configuration
+        args: Command-line arguments containing MQTT credentials
+
+    Returns:
+        List of network addresses suitable for connection attempts
+    """
+    network_devices: list[str] = []
+    mqtt_resolved: bool = False
+
+    for device in devices:
+        port_type = get_port_type(device)
+        if port_type in _MQTT_PORT_TYPES:
+            # Only resolve MQTT once, even if multiple MQTT entries
+            if not mqtt_resolved:
+                try:
+                    mqtt_ips = mqtt_get_ip(
+                        config, args.username, args.password, args.client_id
+                    )
+                    network_devices.extend(mqtt_ips)
+                except EsphomeError as err:
+                    _LOGGER.warning(
+                        "MQTT IP discovery failed (%s), will try other devices if available",
+                        err,
+                    )
+                mqtt_resolved = True
+        elif device not in network_devices:
+            # Regular network address or IP - add if not already present
+            network_devices.append(device)
+
+    return network_devices
 
 
-def get_port_type(port: str) -> str:
+def get_port_type(port: str) -> PortType:
+    """Determine the type of port/device identifier.
+
+    Returns:
+        PortType.SERIAL for serial ports (/dev/ttyUSB0, COM1, etc.)
+        PortType.MQTT for MQTT logging
+        PortType.MQTTIP for MQTT IP lookup
+        PortType.NETWORK for IP addresses, hostnames, or mDNS names
+    """
     if port.startswith("/") or port.startswith("COM"):
-        return "SERIAL"
-    return _PORT_TO_PORT_TYPE.get(port, "NETWORK")
+        return PortType.SERIAL
+    if port == "MQTT":
+        return PortType.MQTT
+    if port == "MQTTIP":
+        return PortType.MQTTIP
+    return PortType.NETWORK
 
 
 def run_miniterm(config: ConfigType, port: str, args) -> int:
@@ -489,7 +551,7 @@ def upload_using_platformio(config: ConfigType, port: str):
 
 
 def check_permissions(port: str):
-    if os.name == "posix" and get_port_type(port) == "SERIAL":
+    if os.name == "posix" and get_port_type(port) == PortType.SERIAL:
         # Check if we can open selected serial port
         if not os.access(port, os.F_OK):
             raise EsphomeError(
@@ -517,7 +579,7 @@ def upload_program(
     except AttributeError:
         pass
 
-    if get_port_type(host) == "SERIAL":
+    if get_port_type(host) == PortType.SERIAL:
         check_permissions(host)
 
         exit_code = 1
@@ -550,11 +612,10 @@ def upload_program(
     else:
         binary = CORE.firmware_bin
 
-    # MQTT address resolution
-    if get_port_type(host) in ("MQTT", "MQTTIP"):
-        devices = mqtt_get_ip(config, args.username, args.password, args.client_id)
+    # Resolve MQTT magic strings to actual IP addresses
+    network_devices = _resolve_network_devices(devices, config, args)
 
-    return espota2.run_ota(devices, remote_port, password, binary)
+    return espota2.run_ota(network_devices, remote_port, password, binary)
 
 
 def show_logs(config: ConfigType, args: ArgsProtocol, devices: list[str]) -> int | None:
@@ -569,33 +630,22 @@ def show_logs(config: ConfigType, args: ArgsProtocol, devices: list[str]) -> int
         raise EsphomeError("Logger is not configured!")
 
     port = devices[0]
+    port_type = get_port_type(port)
 
-    if get_port_type(port) == "SERIAL":
+    if port_type == PortType.SERIAL:
         check_permissions(port)
         return run_miniterm(config, port, args)
 
-    port_type = get_port_type(port)
-
     # Check if we should use API for logging
-    if has_api():
-        addresses_to_use: list[str] | None = None
+    # Resolve MQTT magic strings to actual IP addresses
+    if has_api() and (
+        network_devices := _resolve_network_devices(devices, config, args)
+    ):
+        from esphome.components.api.client import run_logs
 
-        if port_type == "NETWORK":
-            # Network addresses (IPs, mDNS names, or regular DNS hostnames) can be used
-            # The resolve_ip_address() function in helpers.py handles all types
-            addresses_to_use = devices
-        elif port_type in ("MQTT", "MQTTIP") and has_mqtt_ip_lookup():
-            # Use MQTT IP lookup for MQTT/MQTTIP types
-            addresses_to_use = mqtt_get_ip(
-                config, args.username, args.password, args.client_id
-            )
+        return run_logs(config, network_devices)
 
-        if addresses_to_use is not None:
-            from esphome.components.api.client import run_logs
-
-            return run_logs(config, addresses_to_use)
-
-    if port_type in ("NETWORK", "MQTT") and has_mqtt_logging():
+    if port_type in (PortType.NETWORK, PortType.MQTT) and has_mqtt_logging():
         from esphome import mqtt
 
         return mqtt.show_logs(

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -775,7 +775,7 @@ void Display::test_card() {
     int shift_y = (h - image_h) / 2;
     int line_w = (image_w - 6) / 6;
     int image_c = image_w / 2;
-    for (auto i = 0; i <= image_h; i++) {
+    for (auto i = 0; i != image_h; i++) {
       int c = esp_scale(i, image_h);
       this->horizontal_line(shift_x + 0, shift_y + i, line_w, r.fade_to_white(c));
       this->horizontal_line(shift_x + line_w, shift_y + i, line_w, r.fade_to_black(c));  //
@@ -809,8 +809,11 @@ void Display::test_card() {
       }
     }
   }
-  this->rectangle(0, 0, w, h, Color(127, 0, 127));
   this->filled_rectangle(0, 0, 10, 10, Color(255, 0, 255));
+  this->filled_rectangle(w - 10, 0, 10, 10, Color(255, 0, 255));
+  this->filled_rectangle(0, h - 10, 10, 10, Color(255, 0, 255));
+  this->filled_rectangle(w - 10, h - 10, 10, 10, Color(255, 0, 255));
+  this->rectangle(0, 0, w, h, Color(255, 255, 255));
   this->stop_poller();
 }
 

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -19,6 +19,7 @@ from esphome.const import (
 from esphome.core import CORE, coroutine_with_priority
 from esphome.coroutine import CoroPriority
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,11 +137,12 @@ FINAL_VALIDATE_SCHEMA = ota_esphome_final_validate
 
 
 @coroutine_with_priority(CoroPriority.OTA_UPDATES)
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_port(config[CONF_PORT]))
 
-    if CONF_PASSWORD in config:
+    # Password could be set to an empty string and we can assume that means no password
+    if config.get(CONF_PASSWORD):
         cg.add(var.set_auth_password(config[CONF_PASSWORD]))
         cg.add_define("USE_OTA_PASSWORD")
         # Only include hash algorithms when password is configured

--- a/esphome/components/mipi_spi/models/waveshare.py
+++ b/esphome/components/mipi_spi/models/waveshare.py
@@ -3,6 +3,7 @@ import esphome.config_validation as cv
 
 from .amoled import CO5300
 from .ili import ILI9488_A
+from .jc import AXS15231
 
 DriverChip(
     "WAVESHARE-4-TFT",
@@ -151,4 +152,13 @@ CO5300.extend(
     offset_width=6,
     cs_pin=12,
     reset_pin=39,
+)
+
+AXS15231.extend(
+    "WAVESHARE-ESP32-S3-TOUCH-LCD-3.49",
+    width=172,
+    height=640,
+    data_rate="80MHz",
+    cs_pin=9,
+    reset_pin=21,
 )

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from esphome import core
-from esphome.config_helpers import Extend, Remove, merge_config
+from esphome.config_helpers import Extend, Remove, merge_config, merge_dicts_ordered
 import esphome.config_validation as cv
 from esphome.const import CONF_SUBSTITUTIONS, VALID_SUBSTITUTIONS_CHARACTERS
 from esphome.yaml_util import ESPHomeDataBase, ESPLiteralValue, make_data_base
@@ -170,10 +170,10 @@ def do_substitution_pass(config, command_line_substitutions, ignore_missing=Fals
         return
 
     # Merge substitutions in config, overriding with substitutions coming from command line:
-    substitutions = {
-        **config.get(CONF_SUBSTITUTIONS, {}),
-        **(command_line_substitutions or {}),
-    }
+    # Use merge_dicts_ordered to preserve OrderedDict type for move_to_end()
+    substitutions = merge_dicts_ordered(
+        config.get(CONF_SUBSTITUTIONS, {}), command_line_substitutions or {}
+    )
     with cv.prepend_path("substitutions"):
         if not isinstance(substitutions, dict):
             raise cv.Invalid(

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -402,8 +402,8 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 
     # Disable Enterprise WiFi support if no EAP is configured
-    if CORE.is_esp32 and not has_eap:
-        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT", False)
+    if CORE.is_esp32:
+        add_idf_sdkconfig_option("CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT", has_eap)
 
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
     cg.add(var.set_power_save_mode(config[CONF_POWER_SAVE_MODE]))

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -12,7 +12,7 @@ from typing import Any
 import voluptuous as vol
 
 from esphome import core, loader, pins, yaml_util
-from esphome.config_helpers import Extend, Remove
+from esphome.config_helpers import Extend, Remove, merge_dicts_ordered
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ESPHOME,
@@ -922,10 +922,9 @@ def validate_config(
     if CONF_SUBSTITUTIONS in config or command_line_substitutions:
         from esphome.components import substitutions
 
-        result[CONF_SUBSTITUTIONS] = {
-            **(config.get(CONF_SUBSTITUTIONS) or {}),
-            **command_line_substitutions,
-        }
+        result[CONF_SUBSTITUTIONS] = merge_dicts_ordered(
+            config.get(CONF_SUBSTITUTIONS) or {}, command_line_substitutions
+        )
         result.add_output_path([CONF_SUBSTITUTIONS], CONF_SUBSTITUTIONS)
         try:
             substitutions.do_substitution_pass(config, command_line_substitutions)

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.10.0"
+__version__ = "2025.10.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -242,7 +242,7 @@ def send_check(
 
 
 def perform_ota(
-    sock: socket.socket, password: str, file_handle: io.IOBase, filename: Path
+    sock: socket.socket, password: str | None, file_handle: io.IOBase, filename: Path
 ) -> None:
     file_contents = file_handle.read()
     file_size = len(file_contents)
@@ -278,13 +278,13 @@ def perform_ota(
 
     def perform_auth(
         sock: socket.socket,
-        password: str,
+        password: str | None,
         hash_func: Callable[..., Any],
         nonce_size: int,
         hash_name: str,
     ) -> None:
         """Perform challenge-response authentication using specified hash algorithm."""
-        if not password:
+        if password is None:
             raise OTAError("ESP requests password, but no password given!")
 
         nonce_bytes = receive_exactly(
@@ -385,7 +385,7 @@ def perform_ota(
 
 
 def run_ota_impl_(
-    remote_host: str | list[str], remote_port: int, password: str, filename: Path
+    remote_host: str | list[str], remote_port: int, password: str | None, filename: Path
 ) -> tuple[int, str | None]:
     from esphome.core import CORE
 
@@ -436,7 +436,7 @@ def run_ota_impl_(
 
 
 def run_ota(
-    remote_host: str | list[str], remote_port: int, password: str, filename: Path
+    remote_host: str | list[str], remote_port: int, password: str | None, filename: Path
 ) -> tuple[int, str | None]:
     try:
         return run_ota_impl_(remote_host, remote_port, password, filename)

--- a/tests/component_tests/mipi_spi/test_init.py
+++ b/tests/component_tests/mipi_spi/test_init.py
@@ -69,7 +69,7 @@ def run_schema_validation(config: ConfigType) -> None:
             {
                 "id": "display_id",
                 "model": "custom",
-                "dimensions": {"width": 320, "height": 240},
+                "dimensions": {"width": 260, "height": 260},
                 "draw_rounding": 13,
                 "init_sequence": [[0xA0, 0x01]],
             },
@@ -336,7 +336,7 @@ def test_native_generation(
 
     main_cpp = generate_main(component_fixture_path("native.yaml"))
     assert (
-        "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, display::DISPLAY_ROTATION_0_DEGREES, 1>()"
+        "mipi_spi::MipiSpiBuffer<uint16_t, mipi_spi::PIXEL_MODE_16, true, mipi_spi::PIXEL_MODE_16, mipi_spi::BUS_TYPE_QUAD, 360, 360, 0, 1, display::DISPLAY_ROTATION_0_DEGREES, 1, 1>()"
         in main_cpp
     )
     assert "set_init_sequence({240, 1, 8, 242" in main_cpp

--- a/tests/components/chsc6x/test.esp32-c3-idf.yaml
+++ b/tests/components/chsc6x/test.esp32-c3-idf.yaml
@@ -7,8 +7,8 @@ display:
     id: ili9xxx_display
     model: GC9A01A
     invert_colors: True
-    cs_pin: 10
-    dc_pin: 6
+    cs_pin: 11
+    dc_pin: 7
     pages:
       - id: page1
         lambda: |-

--- a/tests/components/mipi_spi/common.yaml
+++ b/tests/components/mipi_spi/common.yaml
@@ -10,7 +10,7 @@ display:
     invert_colors: true
     show_test_card: true
     spi_mode: mode0
-    draw_rounding: 8
+    draw_rounding: 4
     use_axis_flips: true
     init_sequence:
       - [0xd0, 1, 2, 3]

--- a/tests/components/mipi_spi/test.rp2040-ard.yaml
+++ b/tests/components/mipi_spi/test.rp2040-ard.yaml
@@ -1,7 +1,7 @@
 substitutions:
   dc_pin: GPIO14
   cs_pin: GPIO13
-  enable_pin: GPIO16
+  enable_pin: GPIO17
   reset_pin: GPIO20
 
 packages:

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -287,7 +287,7 @@ def test_perform_ota_no_auth(mock_socket: Mock, mock_file: io.BytesIO) -> None:
 
     mock_socket.recv.side_effect = recv_responses
 
-    espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+    espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # Should not send any auth-related data
     auth_calls = [
@@ -317,7 +317,7 @@ def test_perform_ota_with_compression(mock_socket: Mock) -> None:
 
     mock_socket.recv.side_effect = recv_responses
 
-    espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+    espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # Verify compressed content was sent
     # Get the binary size that was sent (4 bytes after features)
@@ -347,7 +347,7 @@ def test_perform_ota_auth_without_password(mock_socket: Mock) -> None:
     with pytest.raises(
         espota2.OTAError, match="ESP requests password, but no password given"
     ):
-        espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+        espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
 
 @pytest.mark.usefixtures("mock_time")
@@ -413,7 +413,7 @@ def test_perform_ota_sha256_auth_without_password(mock_socket: Mock) -> None:
     with pytest.raises(
         espota2.OTAError, match="ESP requests password, but no password given"
     ):
-        espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+        espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
 
 def test_perform_ota_unexpected_auth_response(mock_socket: Mock) -> None:
@@ -450,7 +450,7 @@ def test_perform_ota_unsupported_version(mock_socket: Mock) -> None:
     mock_socket.recv.side_effect = responses
 
     with pytest.raises(espota2.OTAError, match="Device uses unsupported OTA version"):
-        espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+        espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
 
 @pytest.mark.usefixtures("mock_time")
@@ -471,7 +471,7 @@ def test_perform_ota_upload_error(mock_socket: Mock, mock_file: io.BytesIO) -> N
     mock_socket.recv.side_effect = recv_responses
 
     with pytest.raises(espota2.OTAError, match="Error receiving acknowledge chunk OK"):
-        espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+        espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
 
 @pytest.mark.usefixtures("mock_socket_constructor", "mock_resolve_ip")
@@ -706,7 +706,7 @@ def test_perform_ota_version_differences(
     ]
 
     mock_socket.recv.side_effect = recv_responses
-    espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+    espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # For v1.0, verify that we only get the expected number of recv calls
     # v1.0 doesn't have chunk acknowledgments, so fewer recv calls
@@ -732,7 +732,7 @@ def test_perform_ota_version_differences(
     ]
 
     mock_socket.recv.side_effect = recv_responses_v2
-    espota2.perform_ota(mock_socket, "", mock_file, "test.bin")
+    espota2.perform_ota(mock_socket, None, mock_file, "test.bin")
 
     # For v2.0, verify more recv calls due to chunk acknowledgments
     assert mock_socket.recv.call_count == 9  # v2.0 has 9 recv calls (includes chunk OK)

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1062,7 +1062,7 @@ def test_upload_program_ota_with_file_arg(
     assert exit_code == 0
     assert host == "192.168.1.100"
     mock_run_ota.assert_called_once_with(
-        ["192.168.1.100"], 3232, "", Path("custom.bin")
+        ["192.168.1.100"], 3232, None, Path("custom.bin")
     )
 
 
@@ -1119,7 +1119,9 @@ def test_upload_program_ota_with_mqtt_resolution(
     expected_firmware = (
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
-    mock_run_ota.assert_called_once_with(["192.168.1.100"], 3232, "", expected_firmware)
+    mock_run_ota.assert_called_once_with(
+        ["192.168.1.100"], 3232, None, expected_firmware
+    )
 
 
 @patch("esphome.__main__.importlib.import_module")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -2025,7 +2025,7 @@ def test_upload_program_ota_static_ip_with_mqttip(
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
     mock_run_ota.assert_called_once_with(
-        ["192.168.1.100", "192.168.2.50"], 3232, "", expected_firmware
+        ["192.168.1.100", "192.168.2.50"], 3232, None, expected_firmware
     )
 
 
@@ -2068,7 +2068,7 @@ def test_upload_program_ota_multiple_mqttip_resolves_once(
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
     mock_run_ota.assert_called_once_with(
-        ["192.168.2.50", "192.168.2.51", "192.168.1.100"], 3232, "", expected_firmware
+        ["192.168.2.50", "192.168.2.51", "192.168.1.100"], 3232, None, expected_firmware
     )
 
 
@@ -2230,7 +2230,9 @@ def test_upload_program_ota_mqtt_timeout_fallback(
     expected_firmware = (
         tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
     )
-    mock_run_ota.assert_called_once_with(["192.168.1.100"], 3232, "", expected_firmware)
+    mock_run_ota.assert_called_once_with(
+        ["192.168.1.100"], 3232, None, expected_firmware
+    )
 
 
 @patch("esphome.components.api.client.run_logs")

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -1976,3 +1976,290 @@ def test_command_clean_all_args_used() -> None:
         # Verify the correct configuration paths were passed
         mock_clean_all.assert_any_call(["/path/to/config1"])
         mock_clean_all.assert_any_call(["/path/to/config2", "/path/to/config3"])
+
+
+def test_upload_program_ota_static_ip_with_mqttip(
+    mock_mqtt_get_ip: Mock,
+    mock_run_ota: Mock,
+    tmp_path: Path,
+) -> None:
+    """Test upload_program with static IP and MQTTIP (issue #11260).
+
+    This tests the scenario where a device has manual_ip (static IP) configured
+    and MQTT is also configured. The devices list contains both the static IP
+    and "MQTTIP" magic string. This previously failed because only the first
+    device was checked for MQTT resolution.
+    """
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path)
+
+    mock_mqtt_get_ip.return_value = ["192.168.2.50"]  # Different subnet
+    mock_run_ota.return_value = (0, "192.168.1.100")
+
+    config = {
+        CONF_OTA: [
+            {
+                CONF_PLATFORM: CONF_ESPHOME,
+                CONF_PORT: 3232,
+            }
+        ],
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+    }
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Simulates choose_upload_log_host returning static IP + MQTTIP
+    devices = ["192.168.1.100", "MQTTIP"]
+
+    exit_code, host = upload_program(config, args, devices)
+
+    assert exit_code == 0
+    assert host == "192.168.1.100"
+
+    # Verify MQTT was resolved
+    mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
+
+    # Verify espota2.run_ota was called with both IPs
+    expected_firmware = (
+        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
+    )
+    mock_run_ota.assert_called_once_with(
+        ["192.168.1.100", "192.168.2.50"], 3232, "", expected_firmware
+    )
+
+
+def test_upload_program_ota_multiple_mqttip_resolves_once(
+    mock_mqtt_get_ip: Mock,
+    mock_run_ota: Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that MQTT resolution only happens once even with multiple MQTT magic strings."""
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path)
+
+    mock_mqtt_get_ip.return_value = ["192.168.2.50", "192.168.2.51"]
+    mock_run_ota.return_value = (0, "192.168.2.50")
+
+    config = {
+        CONF_OTA: [
+            {
+                CONF_PLATFORM: CONF_ESPHOME,
+                CONF_PORT: 3232,
+            }
+        ],
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+    }
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Multiple MQTT magic strings in the list
+    devices = ["MQTTIP", "MQTT", "192.168.1.100"]
+
+    exit_code, host = upload_program(config, args, devices)
+
+    assert exit_code == 0
+    assert host == "192.168.2.50"
+
+    # Verify MQTT was only resolved once despite multiple MQTT magic strings
+    mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
+
+    # Verify espota2.run_ota was called with all unique IPs
+    expected_firmware = (
+        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
+    )
+    mock_run_ota.assert_called_once_with(
+        ["192.168.2.50", "192.168.2.51", "192.168.1.100"], 3232, "", expected_firmware
+    )
+
+
+def test_upload_program_ota_mqttip_deduplication(
+    mock_mqtt_get_ip: Mock,
+    mock_run_ota: Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that duplicate IPs are filtered when MQTT returns same IP as static IP."""
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path)
+
+    # MQTT returns the same IP as the static IP
+    mock_mqtt_get_ip.return_value = ["192.168.1.100"]
+    mock_run_ota.return_value = (0, "192.168.1.100")
+
+    config = {
+        CONF_OTA: [
+            {
+                CONF_PLATFORM: CONF_ESPHOME,
+                CONF_PORT: 3232,
+            }
+        ],
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+    }
+    args = MockArgs(username="user", password="pass", client_id="client")
+    devices = ["192.168.1.100", "MQTTIP"]
+
+    exit_code, host = upload_program(config, args, devices)
+
+    assert exit_code == 0
+    assert host == "192.168.1.100"
+
+    # Verify MQTT was resolved
+    mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
+
+    # Verify espota2.run_ota was called with deduplicated IPs (only one instance of 192.168.1.100)
+    # Note: Current implementation doesn't dedupe, so we'll get the IP twice
+    # This test documents current behavior - deduplication could be future enhancement
+    mock_run_ota.assert_called_once()
+    call_args = mock_run_ota.call_args[0]
+    # Should contain both the original IP and MQTT-resolved IP (even if duplicate)
+    assert "192.168.1.100" in call_args[0]
+
+
+@patch("esphome.components.api.client.run_logs")
+def test_show_logs_api_static_ip_with_mqttip(
+    mock_run_logs: Mock,
+    mock_mqtt_get_ip: Mock,
+) -> None:
+    """Test show_logs with static IP and MQTTIP (issue #11260).
+
+    This tests the scenario where a device has manual_ip (static IP) configured
+    and MQTT is also configured. The devices list contains both the static IP
+    and "MQTTIP" magic string.
+    """
+    setup_core(
+        config={
+            "logger": {},
+            CONF_API: {},
+            CONF_MQTT: {CONF_BROKER: "mqtt.local"},
+        },
+        platform=PLATFORM_ESP32,
+    )
+    mock_run_logs.return_value = 0
+    mock_mqtt_get_ip.return_value = ["192.168.2.50"]
+
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Simulates choose_upload_log_host returning static IP + MQTTIP
+    devices = ["192.168.1.100", "MQTTIP"]
+
+    result = show_logs(CORE.config, args, devices)
+
+    assert result == 0
+
+    # Verify MQTT was resolved
+    mock_mqtt_get_ip.assert_called_once_with(CORE.config, "user", "pass", "client")
+
+    # Verify run_logs was called with both IPs
+    mock_run_logs.assert_called_once_with(
+        CORE.config, ["192.168.1.100", "192.168.2.50"]
+    )
+
+
+@patch("esphome.components.api.client.run_logs")
+def test_show_logs_api_multiple_mqttip_resolves_once(
+    mock_run_logs: Mock,
+    mock_mqtt_get_ip: Mock,
+) -> None:
+    """Test that MQTT resolution only happens once for show_logs with multiple MQTT magic strings."""
+    setup_core(
+        config={
+            "logger": {},
+            CONF_API: {},
+            CONF_MQTT: {CONF_BROKER: "mqtt.local"},
+        },
+        platform=PLATFORM_ESP32,
+    )
+    mock_run_logs.return_value = 0
+    mock_mqtt_get_ip.return_value = ["192.168.2.50", "192.168.2.51"]
+
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Multiple MQTT magic strings in the list
+    devices = ["MQTTIP", "192.168.1.100", "MQTT"]
+
+    result = show_logs(CORE.config, args, devices)
+
+    assert result == 0
+
+    # Verify MQTT was only resolved once despite multiple MQTT magic strings
+    mock_mqtt_get_ip.assert_called_once_with(CORE.config, "user", "pass", "client")
+
+    # Verify run_logs was called with all unique IPs (MQTT strings replaced with IPs)
+    # Note: "MQTT" is a different magic string from "MQTTIP", but both trigger MQTT resolution
+    # The _resolve_network_devices helper filters out both after first resolution
+    mock_run_logs.assert_called_once_with(
+        CORE.config, ["192.168.2.50", "192.168.2.51", "192.168.1.100"]
+    )
+
+
+def test_upload_program_ota_mqtt_timeout_fallback(
+    mock_mqtt_get_ip: Mock,
+    mock_run_ota: Mock,
+    tmp_path: Path,
+) -> None:
+    """Test upload_program falls back to other devices when MQTT times out."""
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path)
+
+    # MQTT times out
+    mock_mqtt_get_ip.side_effect = EsphomeError("Failed to find IP via MQTT")
+    mock_run_ota.return_value = (0, "192.168.1.100")
+
+    config = {
+        CONF_OTA: [
+            {
+                CONF_PLATFORM: CONF_ESPHOME,
+                CONF_PORT: 3232,
+            }
+        ],
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+    }
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Static IP first, MQTTIP second
+    devices = ["192.168.1.100", "MQTTIP"]
+
+    exit_code, host = upload_program(config, args, devices)
+
+    # Should succeed using the static IP even though MQTT failed
+    assert exit_code == 0
+    assert host == "192.168.1.100"
+
+    # Verify MQTT was attempted
+    mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
+
+    # Verify espota2.run_ota was called with only the static IP (MQTT failed)
+    expected_firmware = (
+        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
+    )
+    mock_run_ota.assert_called_once_with(["192.168.1.100"], 3232, "", expected_firmware)
+
+
+@patch("esphome.components.api.client.run_logs")
+def test_show_logs_api_mqtt_timeout_fallback(
+    mock_run_logs: Mock,
+    mock_mqtt_get_ip: Mock,
+) -> None:
+    """Test show_logs falls back to other devices when MQTT times out."""
+    setup_core(
+        config={
+            "logger": {},
+            CONF_API: {},
+            CONF_MQTT: {CONF_BROKER: "mqtt.local"},
+        },
+        platform=PLATFORM_ESP32,
+    )
+    mock_run_logs.return_value = 0
+    # MQTT times out
+    mock_mqtt_get_ip.side_effect = EsphomeError("Failed to find IP via MQTT")
+
+    args = MockArgs(username="user", password="pass", client_id="client")
+    # Static IP first, MQTTIP second
+    devices = ["192.168.1.100", "MQTTIP"]
+
+    result = show_logs(CORE.config, args, devices)
+
+    # Should succeed using the static IP even though MQTT failed
+    assert result == 0
+
+    # Verify MQTT was attempted
+    mock_mqtt_get_ip.assert_called_once_with(CORE.config, "user", "pass", "client")
+
+    # Verify run_logs was called with only the static IP (MQTT failed)
+    mock_run_logs.assert_called_once_with(CORE.config, ["192.168.1.100"])


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [mipi_spi] Rotation fixes [esphome#11226](https://github.com/esphome/esphome/pull/11226) (new-feature)
- [ota] Fix MQTT resolution when static IP appears first in device list [esphome#11272](https://github.com/esphome/esphome/pull/11272)
- [ota.esphome] Handle blank password the same as no password defined [esphome#11271](https://github.com/esphome/esphome/pull/11271)
- [tests] Fix OTA password test assertions after merge collision [esphome#11275](https://github.com/esphome/esphome/pull/11275)
- [wifi] Fix enterprise wifi [esphome#11276](https://github.com/esphome/esphome/pull/11276)
- [substitutions] Fix AttributeError when using packages with substitutions [esphome#11274](https://github.com/esphome/esphome/pull/11274)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
