### PR TITLE
[datetime] Fix DateTimeStateTrigger compilation when time component is not used

### DIFF
--- a/esphome/components/datetime/datetime_base.h
+++ b/esphome/components/datetime/datetime_base.h
@@ -30,14 +30,12 @@ class DateTimeBase : public EntityBase {
 #endif
 };
 
-#ifdef USE_TIME
 class DateTimeStateTrigger : public Trigger<ESPTime> {
  public:
   explicit DateTimeStateTrigger(DateTimeBase *parent) {
     parent->add_on_state_callback([this, parent]() { this->trigger(parent->state_as_esptime()); });
   }
 };
-#endif
 
 }  // namespace datetime
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation error when using `on_value` triggers with datetime entities in configurations without a time component.

PR #7425 made the time component optional for datetime entities, but incorrectly wrapped `DateTimeStateTrigger` in `#ifdef USE_TIME`. This causes compilation failures when datetime entities with `on_value` triggers are used without a time component, as the trigger class is not defined.

`DateTimeStateTrigger` (used by `on_value`) does not depend on the time component - it simply fires when a datetime entity's state changes. Only the RTC-related functionality (`set_rtc`, `get_rtc`, and the `rtc_` member) require the time component.

This fix removes the incorrect `#ifdef USE_TIME` guard around `DateTimeStateTrigger`, resolving the regression introduced in PR #7425.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes component grouping test failure: `GROUPED[pulse_counter,pulse_meter,pulse_width,template,uptime].nrf52-adafruit`
- Regression from #7425

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml - datetime with on_value trigger, no time component

datetime:
  - platform: template
    name: "Test Date"
    id: test_date
    type: date
    initial_value: "2000-1-2"
    on_value:
      - logger.log:
          format: "Date changed: %04d-%02d-%02d"
          args:
            - x.year
            - x.month
            - x.day_of_month
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
