### PR TITLE
[htu21d] Revert register address change

### DIFF
--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -9,8 +9,8 @@ static const char *const TAG = "htu21d";
 
 static const uint8_t HTU21D_ADDRESS = 0x40;
 static const uint8_t HTU21D_REGISTER_RESET = 0xFE;
-static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xE3;
-static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xE5;
+static const uint8_t HTU21D_REGISTER_TEMPERATURE = 0xF3;
+static const uint8_t HTU21D_REGISTER_HUMIDITY = 0xF5;
 static const uint8_t HTU21D_WRITERHT_REG_CMD = 0xE6; /**< Write RH/T User Register 1 */
 static const uint8_t HTU21D_REGISTER_STATUS = 0xE7;
 static const uint8_t HTU21D_WRITEHEATER_REG_CMD = 0x51; /**< Write Heater Control Register */


### PR DESCRIPTION
# What does this implement/fix?

Partial revert of https://github.com/esphome/esphome/pull/10801, use original register addresses. There are multiple versions of this chip and some don't seem to work with those addresses. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11262

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
