### PR TITLE
[core] Add ESP32 ROM functions to reserved ids

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -256,8 +256,6 @@ RESERVED_IDS = [
     "one_bits",
     "recv_packet",
     "send_packet",
-    "sp",
-    "gpio_init",
     "check_pos",
     "software_reset",
 ]

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -244,6 +244,22 @@ RESERVED_IDS = [
     "uart0",
     "uart1",
     "uart2",
+    # ESP32 ROM functions
+    "crc16_be",
+    "crc16_le",
+    "crc32_be",
+    "crc32_le",
+    "crc8_be",
+    "crc8_le",
+    "dbg_state",
+    "debug_timer",
+    "one_bits",
+    "recv_packet",
+    "send_packet",
+    "sp",
+    "gpio_init",
+    "check_pos",
+    "software_reset",
 ]
 
 


### PR DESCRIPTION
# What does this implement/fix?

Add ESP32 ROM functions with simple / common names to the reserved id list. Full list is here: https://github.com/espressif/esp-idf/blob/master/components/esp_rom/esp32/ld/esp32.rom.ld

If a collision does happen it is not caught during the build due to the fact the addresses are provided in an ld file. Strange runtime errors result instead. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10975
- fixes https://github.com/esphome/backlog/issues/68

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
