### PR TITLE
[scheduler] Replace defer queue deque with vector to avoid 512-byte upfront allocation

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -344,6 +344,12 @@ void HOT Scheduler::call(uint32_t now) {
     std::unique_ptr<SchedulerItem> item;
     {
       LockGuard lock(this->lock_);
+      // SAFETY: Moving out the unique_ptr leaves a nullptr in the vector at defer_queue_front_.
+      // This is intentional and safe because:
+      // 1. The vector is only cleaned up by cleanup_defer_queue_() at the end of this function
+      // 2. Any code iterating defer_queue_ MUST check for nullptr items (see mark_matching_items_removed_
+      //    and has_cancelled_timeout_in_container_ in scheduler.h)
+      // 3. The lock protects concurrent access, but the nullptr remains until cleanup
       item = std::move(this->defer_queue_[this->defer_queue_front_]);
       this->defer_queue_front_++;
     }
@@ -361,29 +367,7 @@ void HOT Scheduler::call(uint32_t now) {
   // Single consumer (main loop), so no lock needed for this check
   if (this->defer_queue_front_ >= defer_queue_end) {
     LockGuard lock(this->lock_);
-    // Check if new items were added by producers during processing
-    if (this->defer_queue_front_ >= this->defer_queue_.size()) {
-      // Common case: no new items - clear everything
-      this->defer_queue_.clear();
-    } else {
-      // Rare case: new items were added during processing - compact the vector
-      // This only happens when:
-      // 1. A deferred callback calls defer() again, or
-      // 2. Another thread calls defer() while we're processing
-      //
-      // Move unprocessed items (added during this loop) to the front for next iteration
-      //
-      // SAFETY: Compacted items may include cancelled items (marked for removal via
-      // cancel_item_locked_() during execution). This is safe because should_skip_item_()
-      // checks is_item_removed_() before executing, so cancelled items will be skipped
-      // and recycled on the next loop iteration.
-      size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
-      for (size_t i = 0; i < remaining; i++) {
-        this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
-      }
-      this->defer_queue_.resize(remaining);
-    }
-    this->defer_queue_front_ = 0;
+    this->cleanup_defer_queue_locked_();
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -328,17 +328,24 @@ void HOT Scheduler::call(uint32_t now) {
   // Single-core platforms don't use this queue and fall back to the heap-based approach.
   //
   // Note: Items cancelled via cancel_item_locked_() are marked with remove=true but still
-  // processed here. They are removed from the queue normally via pop_front() but skipped
-  // during execution by should_skip_item_(). This is intentional - no memory leak occurs.
-  while (!this->defer_queue_.empty()) {
-    // The outer check is done without a lock for performance. If the queue
-    // appears non-empty, we lock and process an item. We don't need to check
-    // empty() again inside the lock because only this thread can remove items.
+  // processed here. They are skipped during execution by should_skip_item_().
+  // This is intentional - no memory leak occurs.
+  //
+  // We use an index (defer_queue_front_) to track the read position instead of calling
+  // erase() on every pop, which would be O(n). The queue is processed once per loop -
+  // any items added during processing are left for the next loop iteration.
+
+  // Snapshot the queue end point - only process items that existed at loop start
+  // Items added during processing (by callbacks or other threads) run next loop
+  // No lock needed: single consumer (main loop), stale read just means we process less this iteration
+  size_t defer_queue_end = this->defer_queue_.size();
+
+  while (this->defer_queue_front_ < defer_queue_end) {
     std::unique_ptr<SchedulerItem> item;
     {
       LockGuard lock(this->lock_);
-      item = std::move(this->defer_queue_.front());
-      this->defer_queue_.pop_front();
+      item = std::move(this->defer_queue_[this->defer_queue_front_]);
+      this->defer_queue_front_++;
     }
 
     // Execute callback without holding lock to prevent deadlocks
@@ -348,6 +355,35 @@ void HOT Scheduler::call(uint32_t now) {
     }
     // Recycle the defer item after execution
     this->recycle_item_(std::move(item));
+  }
+
+  // If we've consumed all items up to the snapshot point, clean up the dead space
+  // Single consumer (main loop), so no lock needed for this check
+  if (this->defer_queue_front_ >= defer_queue_end) {
+    LockGuard lock(this->lock_);
+    // Check if new items were added by producers during processing
+    if (this->defer_queue_front_ >= this->defer_queue_.size()) {
+      // Common case: no new items - clear everything
+      this->defer_queue_.clear();
+    } else {
+      // Rare case: new items were added during processing - compact the vector
+      // This only happens when:
+      // 1. A deferred callback calls defer() again, or
+      // 2. Another thread calls defer() while we're processing
+      //
+      // Move unprocessed items (added during this loop) to the front for next iteration
+      //
+      // SAFETY: Compacted items may include cancelled items (marked for removal via
+      // cancel_item_locked_() during execution). This is safe because should_skip_item_()
+      // checks is_item_removed_() before executing, so cancelled items will be skipped
+      // and recycled on the next loop iteration.
+      size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
+      for (size_t i = 0; i < remaining; i++) {
+        this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
+      }
+      this->defer_queue_.resize(remaining);
+    }
+    this->defer_queue_front_ = 0;
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -346,7 +346,7 @@ void HOT Scheduler::call(uint32_t now) {
       LockGuard lock(this->lock_);
       // SAFETY: Moving out the unique_ptr leaves a nullptr in the vector at defer_queue_front_.
       // This is intentional and safe because:
-      // 1. The vector is only cleaned up by cleanup_defer_queue_() at the end of this function
+      // 1. The vector is only cleaned up by cleanup_defer_queue_locked_() at the end of this function
       // 2. Any code iterating defer_queue_ MUST check for nullptr items (see mark_matching_items_removed_
       //    and has_cancelled_timeout_in_container_ in scheduler.h)
       // 3. The lock protects concurrent access, but the nullptr remains until cleanup

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -282,8 +282,7 @@ class Scheduler {
 
   // Helper to mark matching items in a container as removed
   // Returns the number of items marked for removal
-  // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this
-  // function.
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
   template<typename Container>
   size_t mark_matching_items_removed_(Container &container, Component *component, const char *name_cstr,
                                       SchedulerItem::Type type, bool match_retry) {
@@ -291,8 +290,8 @@ class Scheduler {
     for (auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)
       // The defer_queue_ uses index-based processing: items are std::moved out but left in the
-      // vector as nullptr until cleanup. If cancel_item_locked_() is called from a callback during
-      // defer queue processing, it will iterate over these nullptr items. This check prevents crashes.
+      // vector as nullptr until cleanup. Even though this function is called with lock held,
+      // the vector can still contain nullptr items from the processing loop. This check prevents crashes.
       if (!item)
         continue;
       if (this->matches_item_(item, component, name_cstr, type, match_retry)) {

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -324,9 +324,12 @@ class Scheduler {
   std::vector<std::unique_ptr<SchedulerItem>> items_;
   std::vector<std::unique_ptr<SchedulerItem>> to_add_;
 #ifndef ESPHOME_THREAD_SINGLE
-  // Single-core platforms don't need the defer queue and save 40 bytes of RAM
-  std::deque<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
-#endif                                                      /* ESPHOME_THREAD_SINGLE */
+  // Single-core platforms don't need the defer queue and save ~32 bytes of RAM
+  // Using std::vector instead of std::deque avoids 512-byte chunked allocations
+  // Index tracking avoids O(n) erase() calls when draining the queue each loop
+  std::vector<std::unique_ptr<SchedulerItem>> defer_queue_;  // FIFO queue for defer() calls
+  size_t defer_queue_front_{0};  // Index of first valid item in defer_queue_ (tracks consumed items)
+#endif                           /* ESPHOME_THREAD_SINGLE */
   uint32_t to_remove_{0};
 
   // Memory pool for recycling SchedulerItem objects to reduce heap churn.

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -289,6 +289,9 @@ class Scheduler {
                                       SchedulerItem::Type type, bool match_retry) {
     size_t count = 0;
     for (auto &item : container) {
+      // Skip nullptr items (can happen in defer_queue_ when items are being processed)
+      if (!item)
+        continue;
       if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
         // Mark item for removal (platform-specific)
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
@@ -311,6 +314,9 @@ class Scheduler {
   bool has_cancelled_timeout_in_container_(const Container &container, Component *component, const char *name_cstr,
                                            bool match_retry) const {
     for (const auto &item : container) {
+      // Skip nullptr items (can happen in defer_queue_ when items are being processed)
+      if (!item)
+        continue;
       if (is_item_removed_(item.get()) &&
           this->matches_item_(item, component, name_cstr, SchedulerItem::TIMEOUT, match_retry,
                               /* skip_removed= */ false)) {

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -290,6 +290,9 @@ class Scheduler {
     size_t count = 0;
     for (auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)
+      // The defer_queue_ uses index-based processing: items are std::moved out but left in the
+      // vector as nullptr until cleanup. If cancel_item_locked_() is called from a callback during
+      // defer queue processing, it will iterate over these nullptr items. This check prevents crashes.
       if (!item)
         continue;
       if (this->matches_item_(item, component, name_cstr, type, match_retry)) {
@@ -315,6 +318,9 @@ class Scheduler {
                                            bool match_retry) const {
     for (const auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)
+      // The defer_queue_ uses index-based processing: items are std::moved out but left in the
+      // vector as nullptr until cleanup. If this function is called during defer queue processing,
+      // it will iterate over these nullptr items. This check prevents crashes.
       if (!item)
         continue;
       if (is_item_removed_(item.get()) &&

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -264,6 +264,36 @@ class Scheduler {
   // Helper to recycle a SchedulerItem
   void recycle_item_(std::unique_ptr<SchedulerItem> item);
 
+#ifndef ESPHOME_THREAD_SINGLE
+  // Helper to cleanup defer_queue_ after processing
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
+  inline void cleanup_defer_queue_locked_() {
+    // Check if new items were added by producers during processing
+    if (this->defer_queue_front_ >= this->defer_queue_.size()) {
+      // Common case: no new items - clear everything
+      this->defer_queue_.clear();
+    } else {
+      // Rare case: new items were added during processing - compact the vector
+      // This only happens when:
+      // 1. A deferred callback calls defer() again, or
+      // 2. Another thread calls defer() while we're processing
+      //
+      // Move unprocessed items (added during this loop) to the front for next iteration
+      //
+      // SAFETY: Compacted items may include cancelled items (marked for removal via
+      // cancel_item_locked_() during execution). This is safe because should_skip_item_()
+      // checks is_item_removed_() before executing, so cancelled items will be skipped
+      // and recycled on the next loop iteration.
+      size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
+      for (size_t i = 0; i < remaining; i++) {
+        this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
+      }
+      this->defer_queue_.resize(remaining);
+    }
+    this->defer_queue_front_ = 0;
+  }
+#endif /* not ESPHOME_THREAD_SINGLE */
+
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization
   // For ESPHOME_THREAD_MULTI_NO_ATOMICS platforms, the caller must hold the scheduler lock before calling this


### PR DESCRIPTION
# What does this implement/fix?

Replaces `std::deque` with `std::vector` for the scheduler's defer queue, avoiding 512-byte upfront allocations for a queue that typically holds 0-2 items. Saves 32 bytes RAM and 508 bytes flash on multi-threaded platforms (ESP32, LibreTiny).

**Key realization:** We were so focused on avoiding expensive `vector.erase()` operations that we overlooked the fact that 99.99% of the time we just `clear()` the entire queue after processing. The deque's O(1) pop-from-front optimization was solving a problem we don't actually have.

## Historical Context

**PR #3951** (Oct 2022) originally implemented a `std::deque`-based queue in `web_server` to fix race conditions when scheduling from the async_tcp thread. The implementation used deque as a FIFO wrapper around scheduler defer calls - it would batch process all queued items then clear the deque each loop.

**PR #9317** (July 2025) generalized this solution to fix scheduler-wide thread-safety issues on multi-core platforms where `defer()` caused race conditions and non-deterministic execution order. The solution:
- Added a dedicated `std::deque` for FIFO execution guarantees directly to the scheduler
- Removed the custom workaround from `web_server` component (now using the scheduler's queue)
- Fixed heap-based scheduling issues under concurrent access

**The Design Mistake:** The choice of `std::deque` was lifted from web_server's workaround without reconsidering whether it made sense for either use case. Turns out `std::deque` was never a good choice - both web_server and the scheduler had the same pattern: batch process everything, then clear.

We were so focused on avoiding expensive `vector.erase()` operations that we completely missed the obvious: 99.99% of the time we just `clear()` the entire queue after processing.

Problems with `std::deque` for this use case:
1. **Allocates 512-byte chunks upfront** - massive overkill for typical usage (0-2 items per loop)
2. **Optimized for O(1) pop-from-front** - but we don't need incremental removal, we batch-clear everything
3. **Complex chunk management code** - 508 bytes of flash for machinery we never use

The deque was solving a problem we don't actually have. The scheduler defer queue just needs: add items, process all items, clear queue. That's exactly what `std::vector` is perfect for.

## Why This Wasn't Caught Earlier

The defer queue was directly ported from the web_server workaround without questioning whether the container choice made sense for the scheduler's actual usage patterns. The lock already provides thread safety - the container just needed to be efficient for the common case (drain everything) and acceptable for the rare case (compact 1-3 items).

## Changes

- **Replaced `std::deque` with `std::vector`** for `defer_queue_`
- **Added index tracking** (`defer_queue_front_`) to avoid O(n) erase operations during processing
- **Optimized for the actual access pattern**:
  - **Common case (99.99%)**: Process all items, then `clear()` the entire vector - O(1) operation
  - **Rare case (0.01%)**: New items added during processing - compact vector with O(n) move for n=1-3 items (negligible cost)
- **Added `cleanup_defer_queue_locked_()`** helper function to encapsulate cleanup logic
- **Added nullptr safety checks** in iteration functions to handle std::moved items during processing

## Memory Impact

Tested on ESP32 (real-world device configuration):

**Before (with std::deque):**
- RAM: 43,636 bytes (13.3% of 327,680 bytes)
- Flash: 1,314,534 bytes (71.6% of 1,835,008 bytes)

**After (with std::vector):**
- RAM: 43,604 bytes (13.3% of 327,680 bytes)
- Flash: 1,314,026 bytes (71.6% of 1,835,008 bytes)

**Savings:**
- **RAM saved: 32 bytes** (0.01% reduction)
- **Flash saved: 508 bytes** (0.04% reduction)

**Key insight:** `std::deque` **immediately allocates a 512-byte chunk** when first used, regardless of actual usage. Since the defer queue typically holds 0-2 items (8-16 bytes of actual data), this is a 96%+ memory waste for the common case.

The RAM savings (32 bytes) come from:
- Reducing container base overhead (~24 bytes for `std::vector` vs ~32+ bytes for `std::deque`)
- More efficient memory layout (vector uses contiguous storage)

Note: The heap allocation savings (512 bytes) aren't visible in the baseline RAM measurement because:
- RAM measurement shows static allocation only
- The 512-byte deque chunk is allocated at runtime on first use
- With `std::vector`, this allocation never happens unless items are actually added

The 508-byte flash savings come from eliminating deque's chunk management and reallocation machinery that was never needed for this use case.

With `std::vector`, memory grows as needed - empty queue uses ~24 bytes, 2 items uses ~40 bytes. No upfront 512-byte allocation.

## Algorithm

```cpp
// Snapshot size at loop start (lock-free read is safe)
size_t defer_queue_end = this->defer_queue_.size();

// Process only items that existed at start
while (this->defer_queue_front_ < defer_queue_end) {
  // Lock-protected access to vector and index increment
  item = std::move(this->defer_queue_[this->defer_queue_front_++]);
  execute(item);
}

// Common case: clear everything
if (this->defer_queue_front_ >= this->defer_queue_.size()) {
  this->defer_queue_.clear();
} else {
  // Rare case: compact (new items added during processing)
  // Move 1-3 items to front - negligible cost
  compact_vector();
}
this->defer_queue_front_ = 0;
```

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (Memory optimization)

**Related issue or feature (if applicable):**

- Follows pattern from #11282 (sensor filter optimization)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266 (not applicable - single-threaded, doesn't use defer queue)
- [ ] RP2040 (not applicable - single-threaded, doesn't use defer queue)
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - Internal scheduler optimization, no user-facing changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

The defer queue is only used on multi-threaded platforms (ESP32, LibreTiny) to guarantee FIFO execution order for `defer()` calls. Single-threaded platforms (ESP8266, RP2040) don't need it and save ~32 bytes by not having it at all.

**Thread Safety**: All vector accesses are protected by the existing `lock_`. The lock-free snapshot read at the start is intentionally benign - stale reads just mean we process fewer items this iteration and catch them next loop.

**Cancelled Items**: Items marked for removal (via `cancel_item_locked_()`) during processing are safe because they're checked by `should_skip_item_()` before execution and will be skipped/recycled on the next loop.
