### PR TITLE
Add VS1053 audio codec component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -514,6 +514,7 @@ esphome/components/veml3235/* @kbx81
 esphome/components/veml7700/* @latonita
 esphome/components/version/* @esphome/core
 esphome/components/voice_assistant/* @jesserockz @kahrendt
+esphome/components/vs1053/* @mill1000
 esphome/components/wake_on_lan/* @clydebarrow @willwill2will54
 esphome/components/watchdog/* @oarcher
 esphome/components/waveshare_epaper/* @clydebarrow

--- a/esphome/components/vs1053/__init__.py
+++ b/esphome/components/vs1053/__init__.py
@@ -17,8 +17,8 @@ CONF_DREQ_PIN = "dreq_pin"
 vs1053_ns = cg.esphome_ns.namespace("vs1053")
 VS1053Component = vs1053_ns.class_("VS1053Component", cg.Component)
 
-VS1053_SDI_SPI = vs1053_ns.class_("VS1053_SDI_SPIDevice", spi.SPIDevice)
-VS1053_SCI_SPI = vs1053_ns.class_("VS1053_SCI_SPIDevice", spi.SPIDevice)
+VS1053_SDI_SPI = vs1053_ns.class_("VS1053SdiSpiDevice", spi.SPIDevice)
+VS1053_SCI_SPI = vs1053_ns.class_("VS1053SciSpiDevice", spi.SPIDevice)
 
 
 def _spi_schema(cls) -> cv.Schema:

--- a/esphome/components/vs1053/__init__.py
+++ b/esphome/components/vs1053/__init__.py
@@ -1,0 +1,67 @@
+from esphome import pins
+import esphome.codegen as cg
+from esphome.components import spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_RESET_PIN
+
+CODEOWNERS = ["@mill1000"]
+DEPENDENCIES = ["spi"]
+
+MULTI_CONF = True
+CONF_VS1053_ID = "vs1053_id"
+CONF_SDI_SPI = "sdi_spi"
+CONF_SCI_SPI = "sci_spi"
+CONF_DREQ_PIN = "dreq_pin"
+
+
+vs1053_ns = cg.esphome_ns.namespace("vs1053")
+VS1053Component = vs1053_ns.class_("VS1053Component", cg.Component)
+
+VS1053_SDI_SPI = vs1053_ns.class_("VS1053_SDI_SPIDevice", spi.SPIDevice)
+VS1053_SCI_SPI = vs1053_ns.class_("VS1053_SCI_SPIDevice", spi.SPIDevice)
+
+
+def _spi_schema(cls) -> cv.Schema:
+    return cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(cls),
+        }
+    ).extend(spi.spi_device_schema(cs_pin_required=True))
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(VS1053Component),
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_DREQ_PIN): pins.gpio_input_pin_schema,
+        cv.Required(CONF_SCI_SPI): _spi_schema(VS1053_SCI_SPI),
+        cv.Required(CONF_SDI_SPI): _spi_schema(VS1053_SDI_SPI),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def spi_to_code(config):
+    # Construct and register SPI devices
+    var = cg.new_Pvariable(config[CONF_ID])
+    await spi.register_spi_device(var, config)
+    return var
+
+
+async def to_code(config) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    # Set reset pin if present
+    if reset_pin := config.get(CONF_RESET_PIN):
+        cg.add(var.set_reset_pin(await cg.gpio_pin_expression(reset_pin)))
+
+    # Set data request pin
+    dreq_pin = await cg.gpio_pin_expression(config[CONF_DREQ_PIN])
+    cg.add(var.set_dreq_pin(dreq_pin))
+
+    # Register each SPI device
+    sci_spi = await spi_to_code(config[CONF_SCI_SPI])
+    cg.add(var.set_sci_device(sci_spi))
+
+    sdi_spi = await spi_to_code(config[CONF_SDI_SPI])
+    cg.add(var.set_sdi_device(sdi_spi))

--- a/esphome/components/vs1053/vs1053.cpp
+++ b/esphome/components/vs1053/vs1053.cpp
@@ -41,21 +41,6 @@ void VS1053Component::setup() {
 }
 
 void VS1053Component::loop() {
-  // Start playback
-  // Send initial data
-  // Get fill byte
-  //
-  // STOP
-  // Send until end of file
-  // Send fill data
-  // Set cancel bit
-  // Send fill data until cancel cleared -> timeout to fault
-  //
-  // CANCEL
-  // Set cancel bit
-  // Keep sending file data until cancel cleared -> timeout to fault
-  // Send fill data
-
   // Device encountered an error. Attempt recovery with a soft reset
   if (this->state_ == PlaybackState::Error) {
     ESP_LOGI(TAG, "Playback error. Attempting soft reset.");
@@ -86,13 +71,13 @@ void VS1053Component::loop() {
 
     // Send as much fill data as possible
     while (this->data_ready_() && this->fill_remaining_ > 0) {
-      size_t write_length = std::min(this->fill_remaining_, VS1053_TRANSFER_SIZE);
+      size_t write_length = std::min(this->fill_remaining_, MAX_TRANSFER_SIZE);
       this->data_write_(this->fill_buffer_, write_length);
 
       this->fill_remaining_ -= write_length;
 
       // Don't tie up the system for too long
-      if ((micros() - start) > VS1053_LOOP_TIMEOUT_US)
+      if ((micros() - start) > LOOP_TIMEOUT_US)
         break;
     }
 
@@ -113,7 +98,7 @@ void VS1053Component::loop() {
   ESP_LOGD(TAG, "%d bytes of file data remaining.", remaining);
 
   while (this->data_ready_() && remaining > 0) {
-    size_t write_length = std::min(remaining, VS1053_TRANSFER_SIZE);
+    size_t write_length = std::min(remaining, MAX_TRANSFER_SIZE);
     this->data_write_(this->buffer_, write_length);
 
     this->buffer_ += write_length;
@@ -123,7 +108,7 @@ void VS1053Component::loop() {
     uint32_t now = micros();
 
     // Don't tie up the system for too long
-    if ((now - start) > VS1053_LOOP_TIMEOUT_US)
+    if ((now - start) > LOOP_TIMEOUT_US)
       break;
 
     // Handle playback cancellation
@@ -131,9 +116,9 @@ void VS1053Component::loop() {
       if (!this->get_cancel_bit_()) {
         // Start fill if cancel bit is cleared
         ESP_LOGI(TAG, "Playback cancelled. Sending fill data.");
-        this->fill_remaining_ = VS1053_FILL_LENGTH;
+        this->fill_remaining_ = FILL_LENGTH;
         this->state_ = PlaybackState::Cancelled;
-      } else if ((now - this->cancel_start_) > VS1053_CANCEL_TIMEOUT_US) {
+      } else if ((now - this->cancel_start_) > CANCEL_TIMEOUT_US) {
         // Device has failed to cancel after 1 second
         ESP_LOGE(TAG, "Playback cancellation failed.");
         this->state_ = PlaybackState::Error;
@@ -146,7 +131,7 @@ void VS1053Component::loop() {
   // End of file, stop playback
   if (this->buffer_ >= this->buffer_end_) {
     ESP_LOGI(TAG, "Playback complete. Sending fill data.");
-    this->fill_remaining_ = VS1053_FILL_LENGTH;
+    this->fill_remaining_ = FILL_LENGTH;
     this->state_ = PlaybackState::Stop;
   }
 }
@@ -215,9 +200,9 @@ void VS1053Component::play_file(const uint8_t* data, size_t length) {
   this->state_ = PlaybackState::Playing;
 
   // Attempt to fill entire FIFO
-  size_t remaining = std::min(length, VS1053_FIFO_LENGTH);
+  size_t remaining = std::min(length, FIFO_LENGTH);
   while (this->data_ready_() && remaining > 0) {
-    size_t write_length = std::min(remaining, VS1053_TRANSFER_SIZE);
+    size_t write_length = std::min(remaining, MAX_TRANSFER_SIZE);
     this->data_write_(this->buffer_, write_length);
 
     this->buffer_ += write_length;
@@ -302,12 +287,12 @@ void VS1053Component::finish_playback_() {
   // Continue writing fill until cancel bit clears
   size_t fill_sent = 0;
   while (this->get_cancel_bit_()) {
-    this->data_write_(this->fill_buffer_, VS1053_TRANSFER_SIZE);
+    this->data_write_(this->fill_buffer_, MAX_TRANSFER_SIZE);
 
-    fill_sent += VS1053_TRANSFER_SIZE;
+    fill_sent += MAX_TRANSFER_SIZE;
 
     // Cancel bit won't clear, device is in error
-    if (fill_sent >= VS1053_STOP_FILL_LENGTH) {
+    if (fill_sent >= STOP_FILL_LENGTH) {
       ESP_LOGE(TAG, "Playback stop failed.");
       this->state_ = PlaybackState::Error;
       return;

--- a/esphome/components/vs1053/vs1053.cpp
+++ b/esphome/components/vs1053/vs1053.cpp
@@ -4,10 +4,12 @@
 #include "esphome/core/log.h"
 #include "vs1053_reg.h"
 
+#include <algorithm>
+
 namespace esphome {
 namespace vs1053 {
 
-static const char* TAG = "VS1053";
+static const char *const TAG = "VS1053";
 
 void VS1053Component::setup() {
   // Setup pins
@@ -42,7 +44,7 @@ void VS1053Component::setup() {
 
 void VS1053Component::loop() {
   // Device encountered an error. Attempt recovery with a soft reset
-  if (this->state_ == PlaybackState::Error) {
+  if (this->state_ == PlaybackState::ERROR) {
     ESP_LOGI(TAG, "Playback error. Attempting soft reset.");
     if (!this->init_(true)) {
       this->mark_failed();
@@ -50,12 +52,12 @@ void VS1053Component::loop() {
     }
 
     // Device successfully reset
-    this->state_ = PlaybackState::Idle;
+    this->state_ = PlaybackState::IDLE;
     return;
   }
 
   // Nothing to do
-  if (this->state_ == PlaybackState::Idle)
+  if (this->state_ == PlaybackState::IDLE)
     return;
 
   // Not ready for data
@@ -82,16 +84,18 @@ void VS1053Component::loop() {
     }
 
     // Transition to idle if playback was cancelled and all fill is sent
-    if (this->state_ == PlaybackState::Cancelled && this->fill_remaining_ == 0) {
-      this->state_ = PlaybackState::Idle;
+    if (this->state_ == PlaybackState::CANCELLED && this->fill_remaining_ == 0) {
+      this->state_ = PlaybackState::IDLE;
     }
 
     return;
   }
 
   // Handle end of playback
-  if (this->state_ == PlaybackState::Stop)
-    return this->finish_playback_();
+  if (this->state_ == PlaybackState::STOP) {
+    this->finish_playback_();
+    return;
+  }
 
   // Write as much file data as possible
   size_t remaining = this->buffer_end_ - this->buffer_;
@@ -112,16 +116,16 @@ void VS1053Component::loop() {
       break;
 
     // Handle playback cancellation
-    if (this->state_ == PlaybackState::Cancel) {
+    if (this->state_ == PlaybackState::CANCEL) {
       if (!this->get_cancel_bit_()) {
         // Start fill if cancel bit is cleared
         ESP_LOGI(TAG, "Playback cancelled. Sending fill data.");
         this->fill_remaining_ = FILL_LENGTH;
-        this->state_ = PlaybackState::Cancelled;
+        this->state_ = PlaybackState::CANCELLED;
       } else if ((now - this->cancel_start_) > CANCEL_TIMEOUT_US) {
         // Device has failed to cancel after 1 second
         ESP_LOGE(TAG, "Playback cancellation failed.");
-        this->state_ = PlaybackState::Error;
+        this->state_ = PlaybackState::ERROR;
       }
 
       return;
@@ -132,7 +136,7 @@ void VS1053Component::loop() {
   if (this->buffer_ >= this->buffer_end_) {
     ESP_LOGI(TAG, "Playback complete. Sending fill data.");
     this->fill_remaining_ = FILL_LENGTH;
-    this->state_ = PlaybackState::Stop;
+    this->state_ = PlaybackState::STOP;
   }
 }
 
@@ -152,9 +156,7 @@ void VS1053Component::set_volume(uint8_t left, uint8_t right) {
   this->volume_right_ = right;
 
   // Convert incoming volume to attenuation
-  auto convert = [](uint8_t v) {
-    return 0xFF - v;
-  };
+  auto convert = [](uint8_t v) { return 0xFF - v; };
 
   // Register sets attenuation in 0.5 dB steps
   // Maximum volume 0x0000, minimum 0xFEFE, analog powerdown 0xFFFF
@@ -164,7 +166,7 @@ void VS1053Component::set_volume(uint8_t left, uint8_t right) {
 
 void VS1053Component::cancel_playback() {
   // Can't cancel playback if we're not playing
-  if (this->state_ != PlaybackState::Playing)
+  if (this->state_ != PlaybackState::PLAYING)
     return;
 
   ESP_LOGI(TAG, "Cancelling playback.");
@@ -173,14 +175,14 @@ void VS1053Component::cancel_playback() {
   this->set_cancel_bit_();
 
   // Transition to cancel state and save timestamp
-  this->state_ = PlaybackState::Cancel;
+  this->state_ = PlaybackState::CANCEL;
   this->cancel_start_ = micros();
 }
 
-void VS1053Component::play_file(const uint8_t* data, size_t length) {
+void VS1053Component::play_file(const uint8_t *data, size_t length) {
   // Ensure device is idle
-  if (this->state_ != PlaybackState::Idle) {
-    ESP_LOGW(TAG, "State not idle. Current state %d.", this->state_);
+  if (this->state_ != PlaybackState::IDLE) {
+    ESP_LOGW(TAG, "State not idle. Current state %d.", static_cast<int>(this->state_));
     return;
   }
 
@@ -197,7 +199,7 @@ void VS1053Component::play_file(const uint8_t* data, size_t length) {
   this->buffer_end_ = data + length;
 
   // Update state
-  this->state_ = PlaybackState::Playing;
+  this->state_ = PlaybackState::PLAYING;
 
   // Attempt to fill entire FIFO
   size_t remaining = std::min(length, FIFO_LENGTH);
@@ -260,20 +262,14 @@ void VS1053Component::play_test_sine_sdi(uint16_t ms) {
   this->wait_data_ready_(1000);
 
   // Start test with fixed frequency
-  const uint8_t sine_start[16] = {
-      0x53, 0xEF, 0x6E, 0x44,
-      0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00};
+  const uint8_t sine_start[16] = {0x53, 0xEF, 0x6E, 0x44, 0x00, 0x00, 0x00, 0x00,
+                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
   this->data_write_(sine_start, sizeof(sine_start));
 
   // Stop test after duration
   this->set_timeout(ms, [this]() {
-    uint8_t sine_stop[16] = {
-        0x45, 0x78, 0x69, 0x74,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00};
+    uint8_t sine_stop[16] = {0x45, 0x78, 0x69, 0x74, 0x00, 0x00, 0x00, 0x00,
+                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     this->data_write_(sine_stop, sizeof(sine_stop));
   });
 }
@@ -294,13 +290,13 @@ void VS1053Component::finish_playback_() {
     // Cancel bit won't clear, device is in error
     if (fill_sent >= STOP_FILL_LENGTH) {
       ESP_LOGE(TAG, "Playback stop failed.");
-      this->state_ = PlaybackState::Error;
+      this->state_ = PlaybackState::ERROR;
       return;
     }
   }
 
   // Playback complete transition to idle
-  this->state_ = PlaybackState::Idle;
+  this->state_ = PlaybackState::IDLE;
 }
 
 bool VS1053Component::init_(bool soft_reset) {
@@ -342,9 +338,7 @@ bool VS1053Component::init_(bool soft_reset) {
   return true;
 }
 
-bool VS1053Component::get_cancel_bit_() const {
-  return this->command_read_(SCI_REG_MODE) & MODE_SM_CANCEL;
-}
+bool VS1053Component::get_cancel_bit_() const { return this->command_read_(SCI_REG_MODE) & MODE_SM_CANCEL; }
 
 void VS1053Component::set_cancel_bit_() const {
   // Set cancel bit
@@ -352,13 +346,11 @@ void VS1053Component::set_cancel_bit_() const {
   this->command_write_(SCI_REG_MODE, mode | MODE_SM_CANCEL);
 }
 
-uint8_t VS1053Component::get_fill_byte_() const {
-  return get_parameter_(PARAMETER_END_FILL_BYTE_ADDR) & 0xFF;
-}
+uint8_t VS1053Component::get_fill_byte_() const { return get_parameter_(PARAMETER_END_FILL_BYTE_ADDR) & 0xFF; }
 
-uint16_t VS1053Component::get_parameter_(uint16_t addr) const {
+uint16_t VS1053Component::get_parameter_(uint16_t param) const {
   // Read parameter from RAM
-  this->command_write_(SCI_REG_WRAMADDR, addr);
+  this->command_write_(SCI_REG_WRAMADDR, param);
   return this->command_read_(SCI_REG_WRAM);
 }
 
@@ -376,7 +368,7 @@ bool VS1053Component::wait_data_ready_(uint32_t timeout_us) const {
   return true;
 }
 
-void VS1053Component::data_write_(const uint8_t* buffer, size_t length) const {
+void VS1053Component::data_write_(const uint8_t *buffer, size_t length) const {
   // ESP_LOGV(TAG, "SDI write %d bytes: %s", length, format_hex_pretty(buffer, length).c_str());
 
   this->sdi_spi_->enable();

--- a/esphome/components/vs1053/vs1053.cpp
+++ b/esphome/components/vs1053/vs1053.cpp
@@ -219,61 +219,6 @@ void VS1053Component::play_file(const uint8_t *data, size_t length) {
   this->fill_remaining_ = 0;
 }
 
-void VS1053Component::play_test_sine(uint16_t ms, uint32_t freq_hz, uint32_t sample_rate_hz) {
-  // Perform the "new" sine test via SCI
-
-  // Re-init device
-  this->init_();  // TODO check failure? // TODO soft reset instead?
-
-  // New sine test
-  // AICTRLn = Fsin X 65536 / Fs
-  // AICTRLn max value 0x8000
-  // AICTRLn 3 LSB should be zero for best SNR
-
-  // Set sample rate TODO??
-  this->command_write_(SCI_REG_AUDATA, sample_rate_hz & 0xFFFE);
-
-  // Configure sine frequency
-  uint16_t aictrl = std::min((freq_hz * 65536) / sample_rate_hz, 0x8000ul) & ~0x0007;
-  this->command_write_(SCI_REG_AICTRL0, aictrl);  // Left channel
-  this->command_write_(SCI_REG_AICTRL1, aictrl);  // Right channel
-
-  this->command_write_(SCI_REG_AIADDR, 0x4020);  // Start test
-
-  // Stop test after duration
-  this->set_timeout(ms, [this]() {
-    // this->command_write_(SCI_REG_AIADDR, 0);  // TODO Stop tests? Nothing is docs
-    this->init_(true);
-  });
-}
-
-void VS1053Component::play_test_sine_sdi(uint16_t ms) {
-  // Perform the "old" sine test via SDI
-
-  // Re-init device
-  this->init_();  // TODO check failure?
-
-  // Enable test modes
-  uint16_t mode = this->command_read_(SCI_REG_MODE);
-  mode |= MODE_SM_TESTS;
-  this->command_write_(SCI_REG_MODE, mode);
-
-  // Wait for data ready
-  this->wait_data_ready_(1000);
-
-  // Start test with fixed frequency
-  const uint8_t sine_start[16] = {0x53, 0xEF, 0x6E, 0x44, 0x00, 0x00, 0x00, 0x00,
-                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  this->data_write_(sine_start, sizeof(sine_start));
-
-  // Stop test after duration
-  this->set_timeout(ms, [this]() {
-    uint8_t sine_stop[16] = {0x45, 0x78, 0x69, 0x74, 0x00, 0x00, 0x00, 0x00,
-                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    this->data_write_(sine_stop, sizeof(sine_stop));
-  });
-}
-
 void VS1053Component::finish_playback_() {
   ESP_LOGD(TAG, "Finishing playback.");
 

--- a/esphome/components/vs1053/vs1053.cpp
+++ b/esphome/components/vs1053/vs1053.cpp
@@ -1,0 +1,425 @@
+#include "vs1053.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "vs1053_reg.h"
+
+namespace esphome {
+namespace vs1053 {
+
+static const char* TAG = "VS1053";
+
+void VS1053Component::setup() {
+  // Setup pins
+  if (this->reset_pin_)
+    this->reset_pin_->setup();
+  this->dreq_pin_->setup();
+
+  // Initialize SPI devices
+  this->sci_spi_->spi_setup();
+  this->sdi_spi_->spi_setup();
+
+  // Reset and configure device
+  if (!this->init_()) {
+    this->mark_failed();
+    return;
+  }
+
+  // Init appears to be OK
+  // Check status register for device version
+  uint16_t status = this->command_read_(SCI_REG_STATUS);
+  uint8_t version = (status >> 4) & 0x0F;
+
+  ESP_LOGD(TAG, "Status 0x%04X, Version: %d", status, version);
+
+  // Validate device version
+  if (version != VS1053_VERSION) {
+    ESP_LOGE(TAG, "Initialization failed. SS_VER %d != %d", version, VS1053_VERSION);
+    this->mark_failed();
+    return;
+  }
+}
+
+void VS1053Component::loop() {
+  // Start playback
+  // Send initial data
+  // Get fill byte
+  //
+  // STOP
+  // Send until end of file
+  // Send fill data
+  // Set cancel bit
+  // Send fill data until cancel cleared -> timeout to fault
+  //
+  // CANCEL
+  // Set cancel bit
+  // Keep sending file data until cancel cleared -> timeout to fault
+  // Send fill data
+
+  // Device encountered an error. Attempt recovery with a soft reset
+  if (this->state_ == PlaybackState::Error) {
+    ESP_LOGI(TAG, "Playback error. Attempting soft reset.");
+    if (!this->init_(true)) {
+      this->mark_failed();
+      return;
+    }
+
+    // Device successfully reset
+    this->state_ = PlaybackState::Idle;
+    return;
+  }
+
+  // Nothing to do
+  if (this->state_ == PlaybackState::Idle)
+    return;
+
+  // Not ready for data
+  if (!this->data_ready_())
+    return;
+
+  // Get timestamp
+  uint32_t start = micros();
+
+  // Send fill data
+  if (this->fill_remaining_) {
+    ESP_LOGD(TAG, "%d bytes of fill data remaining.", this->fill_remaining_);
+
+    // Send as much fill data as possible
+    while (this->data_ready_() && this->fill_remaining_ > 0) {
+      size_t write_length = std::min(this->fill_remaining_, VS1053_TRANSFER_SIZE);
+      this->data_write_(this->fill_buffer_, write_length);
+
+      this->fill_remaining_ -= write_length;
+
+      // Don't tie up the system for too long
+      if ((micros() - start) > VS1053_LOOP_TIMEOUT_US)
+        break;
+    }
+
+    // Transition to idle if playback was cancelled and all fill is sent
+    if (this->state_ == PlaybackState::Cancelled && this->fill_remaining_ == 0) {
+      this->state_ = PlaybackState::Idle;
+    }
+
+    return;
+  }
+
+  // Handle end of playback
+  if (this->state_ == PlaybackState::Stop)
+    return this->finish_playback_();
+
+  // Write as much file data as possible
+  size_t remaining = this->buffer_end_ - this->buffer_;
+  ESP_LOGD(TAG, "%d bytes of file data remaining.", remaining);
+
+  while (this->data_ready_() && remaining > 0) {
+    size_t write_length = std::min(remaining, VS1053_TRANSFER_SIZE);
+    this->data_write_(this->buffer_, write_length);
+
+    this->buffer_ += write_length;
+    remaining -= write_length;
+
+    // Sample current time
+    uint32_t now = micros();
+
+    // Don't tie up the system for too long
+    if ((now - start) > VS1053_LOOP_TIMEOUT_US)
+      break;
+
+    // Handle playback cancellation
+    if (this->state_ == PlaybackState::Cancel) {
+      if (!this->get_cancel_bit_()) {
+        // Start fill if cancel bit is cleared
+        ESP_LOGI(TAG, "Playback cancelled. Sending fill data.");
+        this->fill_remaining_ = VS1053_FILL_LENGTH;
+        this->state_ = PlaybackState::Cancelled;
+      } else if ((now - this->cancel_start_) > VS1053_CANCEL_TIMEOUT_US) {
+        // Device has failed to cancel after 1 second
+        ESP_LOGE(TAG, "Playback cancellation failed.");
+        this->state_ = PlaybackState::Error;
+      }
+
+      return;
+    }
+  }
+
+  // End of file, stop playback
+  if (this->buffer_ >= this->buffer_end_) {
+    ESP_LOGI(TAG, "Playback complete. Sending fill data.");
+    this->fill_remaining_ = VS1053_FILL_LENGTH;
+    this->state_ = PlaybackState::Stop;
+  }
+}
+
+void VS1053Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "VS1053:");
+  LOG_PIN("  RESET Pin: ", this->reset_pin_);
+  LOG_PIN("  DREQ Pin: ", this->dreq_pin_);
+  // TODO LOG SPI devices?
+  // ESP_LOGCONFIG(TAG, "  SCI SPI ", this->address_);
+}
+
+void VS1053Component::set_volume(uint8_t left, uint8_t right) {
+  ESP_LOGD(TAG, "Set volume L %d, R %d.", left, right);
+
+  // Save volume
+  this->volume_left_ = left;
+  this->volume_right_ = right;
+
+  // Convert incoming volume to attenuation
+  auto convert = [](uint8_t v) {
+    return 0xFF - v;
+  };
+
+  // Register sets attenuation in 0.5 dB steps
+  // Maximum volume 0x0000, minimum 0xFEFE, analog powerdown 0xFFFF
+  uint16_t vol = convert(left) << 8 | convert(right);
+  this->command_write_(SCI_REG_VOLUME, vol);
+}
+
+void VS1053Component::cancel_playback() {
+  // Can't cancel playback if we're not playing
+  if (this->state_ != PlaybackState::Playing)
+    return;
+
+  ESP_LOGI(TAG, "Cancelling playback.");
+
+  // Set cancel bit
+  this->set_cancel_bit_();
+
+  // Transition to cancel state and save timestamp
+  this->state_ = PlaybackState::Cancel;
+  this->cancel_start_ = micros();
+}
+
+void VS1053Component::play_file(const uint8_t* data, size_t length) {
+  // Ensure device is idle
+  if (this->state_ != PlaybackState::Idle) {
+    ESP_LOGW(TAG, "State not idle. Current state %d.", this->state_);
+    return;
+  }
+
+  // Wait for data ready
+  ESP_LOGI(TAG, "Waiting for data ready.");
+  if (!this->wait_data_ready_(1000)) {
+    ESP_LOGE(TAG, "Playback failed. Not ready for data.");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Starting playback.");
+  // Save buffer
+  this->buffer_ = data;
+  this->buffer_end_ = data + length;
+
+  // Update state
+  this->state_ = PlaybackState::Playing;
+
+  // Attempt to fill entire FIFO
+  size_t remaining = std::min(length, VS1053_FIFO_LENGTH);
+  while (this->data_ready_() && remaining > 0) {
+    size_t write_length = std::min(remaining, VS1053_TRANSFER_SIZE);
+    this->data_write_(this->buffer_, write_length);
+
+    this->buffer_ += write_length;
+    remaining -= write_length;
+  }
+
+  // File should be playing now, get fill byte and populate fill buffer
+  uint8_t fill_byte = this->get_fill_byte_();
+  ESP_LOGD(TAG, "End of stream fill byte 0x%02X", fill_byte);
+
+  memset(this->fill_buffer_, fill_byte, sizeof(this->fill_buffer_));
+  this->fill_remaining_ = 0;
+}
+
+void VS1053Component::play_test_sine(uint16_t ms, uint32_t freq_hz, uint32_t sample_rate_hz) {
+  // Perform the "new" sine test via SCI
+
+  // Re-init device
+  this->init_();  // TODO check failure? // TODO soft reset instead?
+
+  // New sine test
+  // AICTRLn = Fsin X 65536 / Fs
+  // AICTRLn max value 0x8000
+  // AICTRLn 3 LSB should be zero for best SNR
+
+  // Set sample rate TODO??
+  this->command_write_(SCI_REG_AUDATA, sample_rate_hz & 0xFFFE);
+
+  // Configure sine frequency
+  uint16_t aictrl = std::min((freq_hz * 65536) / sample_rate_hz, 0x8000ul) & ~0x0007;
+  this->command_write_(SCI_REG_AICTRL0, aictrl);  // Left channel
+  this->command_write_(SCI_REG_AICTRL1, aictrl);  // Right channel
+
+  this->command_write_(SCI_REG_AIADDR, 0x4020);  // Start test
+
+  // Stop test after duration
+  this->set_timeout(ms, [this]() {
+    // this->command_write_(SCI_REG_AIADDR, 0);  // TODO Stop tests? Nothing is docs
+    this->init_(true);
+  });
+}
+
+void VS1053Component::play_test_sine_sdi(uint16_t ms) {
+  // Perform the "old" sine test via SDI
+
+  // Re-init device
+  this->init_();  // TODO check failure?
+
+  // Enable test modes
+  uint16_t mode = this->command_read_(SCI_REG_MODE);
+  mode |= MODE_SM_TESTS;
+  this->command_write_(SCI_REG_MODE, mode);
+
+  // Wait for data ready
+  this->wait_data_ready_(1000);
+
+  // Start test with fixed frequency
+  const uint8_t sine_start[16] = {
+      0x53, 0xEF, 0x6E, 0x44,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00};
+  this->data_write_(sine_start, sizeof(sine_start));
+
+  // Stop test after duration
+  this->set_timeout(ms, [this]() {
+    uint8_t sine_stop[16] = {
+        0x45, 0x78, 0x69, 0x74,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00};
+    this->data_write_(sine_stop, sizeof(sine_stop));
+  });
+}
+
+void VS1053Component::finish_playback_() {
+  ESP_LOGD(TAG, "Finishing playback.");
+
+  // Set cancel bit
+  this->set_cancel_bit_();
+
+  // Continue writing fill until cancel bit clears
+  size_t fill_sent = 0;
+  while (this->get_cancel_bit_()) {
+    this->data_write_(this->fill_buffer_, VS1053_TRANSFER_SIZE);
+
+    fill_sent += VS1053_TRANSFER_SIZE;
+
+    // Cancel bit won't clear, device is in error
+    if (fill_sent >= VS1053_STOP_FILL_LENGTH) {
+      ESP_LOGE(TAG, "Playback stop failed.");
+      this->state_ = PlaybackState::Error;
+      return;
+    }
+  }
+
+  // Playback complete transition to idle
+  this->state_ = PlaybackState::Idle;
+}
+
+bool VS1053Component::init_(bool soft_reset) {
+  ESP_LOGI(TAG, "Starting init.");
+
+  // Soft reset if requested or reset pin is not available
+  if (soft_reset || !this->reset_pin_) {
+    ESP_LOGI(TAG, "Soft reset");
+
+    // Assert soft reset
+    this->command_write_(SCI_REG_MODE, MODE_SM_SDINEW | MODE_SM_RESET);
+
+    // Datasheet says to wait 2 us, then check DREQ
+    delayMicroseconds(10);
+  } else {
+    // Hard reset device via pin
+    ESP_LOGI(TAG, "Hard reset");
+
+    this->reset_pin_->digital_write(false);
+    delayMicroseconds(100);
+    this->reset_pin_->digital_write(true);
+  }
+
+  // Datasheet says DREQ will assert in 1.8 ms @ 12.288 MHz
+  if (!(this->wait_data_ready_(4000))) {
+    ESP_LOGE(TAG, "Initialization failed. DREQ not asserted.");
+    return false;
+  }
+
+  // Configure clocks
+  // CLKI = 3x XTALI, XTALI = 12.288 MHz
+  // TOOD data sheet recommends 3.5x 0x9800
+  ESP_LOGD(TAG, "Configuring clocks.");
+  this->command_write_(SCI_REG_CLOCKF, 0x6000);
+
+  // Set volume
+  this->set_volume(this->volume_left_, this->volume_right_);
+
+  return true;
+}
+
+bool VS1053Component::get_cancel_bit_() const {
+  return this->command_read_(SCI_REG_MODE) & MODE_SM_CANCEL;
+}
+
+void VS1053Component::set_cancel_bit_() const {
+  // Set cancel bit
+  uint16_t mode = this->command_read_(SCI_REG_MODE);
+  this->command_write_(SCI_REG_MODE, mode | MODE_SM_CANCEL);
+}
+
+uint8_t VS1053Component::get_fill_byte_() const {
+  return get_parameter_(PARAMETER_END_FILL_BYTE_ADDR) & 0xFF;
+}
+
+uint16_t VS1053Component::get_parameter_(uint16_t addr) const {
+  // Read parameter from RAM
+  this->command_write_(SCI_REG_WRAMADDR, addr);
+  return this->command_read_(SCI_REG_WRAM);
+}
+
+bool VS1053Component::wait_data_ready_(uint32_t timeout_us) const {
+  ESP_LOGD(TAG, "Waiting %d us for DREQ...", timeout_us);
+
+  uint32_t start = micros();
+
+  // Wait for DREQ to assert
+  while (!this->data_ready_()) {
+    if ((micros() - start) > timeout_us)
+      return false;
+  }
+
+  return true;
+}
+
+void VS1053Component::data_write_(const uint8_t* buffer, size_t length) const {
+  // ESP_LOGV(TAG, "SDI write %d bytes: %s", length, format_hex_pretty(buffer, length).c_str());
+
+  this->sdi_spi_->enable();
+  this->sdi_spi_->write_array(buffer, length);
+  this->sdi_spi_->disable();
+}
+
+uint16_t VS1053Component::command_transfer_(uint8_t instruction, uint8_t addr, uint16_t data) const {
+  ESP_LOGV(TAG, "SCI transfer %02X %02X %04X", instruction, addr, data);
+
+  // Assert XCS
+  this->sci_spi_->enable();
+
+  uint8_t buffer[4] = {
+      instruction,
+      addr,
+      static_cast<uint8_t>(data >> 8),
+      static_cast<uint8_t>(data & 0xFF),
+  };
+  this->sci_spi_->transfer_array(buffer, sizeof(buffer));
+
+  // Deassert XCS
+  this->sci_spi_->disable();
+
+  ESP_LOGV(TAG, "SCI transfer result %02X %02X", buffer[2], buffer[3]);
+
+  return buffer[2] << 8 | buffer[3];
+}
+
+}  // namespace vs1053
+}  // namespace esphome

--- a/esphome/components/vs1053/vs1053.h
+++ b/esphome/components/vs1053/vs1053.h
@@ -26,8 +26,10 @@ static constexpr const uint8_t VS1053_VERSION = 4;  // Per datasheet, VS1053/VS8
 // VS1053 has two SPI interfaces, a command (SCI) and data (SDI) interface
 // XCS is the command select, XDCS is the data select
 // Both interfaces are Mode 0 MSB First
-class VS1053_SCI_SPIDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_200KHZ> {};
-class VS1053_SDI_SPIDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_8MHZ> {};
+class VS1053SciSpiDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                 spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_200KHZ> {};
+class VS1053SdiSpiDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                                 spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_8MHZ> {};
 
 class VS1053Component : public Component {
  public:
@@ -35,39 +37,39 @@ class VS1053Component : public Component {
   void loop() override;
   void dump_config() override;
 
-  void set_reset_pin(GPIOPin* pin) { this->reset_pin_ = pin; }
-  void set_dreq_pin(GPIOPin* pin) { this->dreq_pin_ = pin; }
-  void set_sci_device(VS1053_SCI_SPIDevice* spi) { this->sci_spi_ = spi; }
-  void set_sdi_device(VS1053_SDI_SPIDevice* spi) { this->sdi_spi_ = spi; }
+  void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
+  void set_dreq_pin(GPIOPin *pin) { this->dreq_pin_ = pin; }
+  void set_sci_device(VS1053SciSpiDevice *spi) { this->sci_spi_ = spi; }
+  void set_sdi_device(VS1053SdiSpiDevice *spi) { this->sdi_spi_ = spi; }
 
   void set_volume(uint8_t left, uint8_t right);
   void cancel_playback();
-  void play_file(const uint8_t* data, size_t length);
+  void play_file(const uint8_t *data, size_t length);
 
   void play_test_sine(uint16_t ms, uint32_t freq_hz = 1000, uint32_t sample_rate_hz = 44100);
   void play_test_sine_sdi(uint16_t ms);
 
  protected:
-  GPIOPin* reset_pin_ = nullptr;
-  GPIOPin* dreq_pin_ = nullptr;
-  VS1053_SCI_SPIDevice* sci_spi_ = nullptr;
-  VS1053_SDI_SPIDevice* sdi_spi_ = nullptr;
+  GPIOPin *reset_pin_ = nullptr;
+  GPIOPin *dreq_pin_ = nullptr;
+  VS1053SciSpiDevice *sci_spi_ = nullptr;
+  VS1053SdiSpiDevice *sdi_spi_ = nullptr;
 
   enum class PlaybackState {
-    Idle,
-    Playing,
-    Cancel,
-    Cancelled,
-    Stop,
-    Error,
+    IDLE,
+    PLAYING,
+    CANCEL,
+    CANCELLED,
+    STOP,
+    ERROR,
   };
 
   uint8_t volume_left_ = 200;
   uint8_t volume_right_ = 200;
 
-  PlaybackState state_ = PlaybackState::Idle;
-  const uint8_t* buffer_ = nullptr;
-  const uint8_t* buffer_end_ = nullptr;
+  PlaybackState state_ = PlaybackState::IDLE;
+  const uint8_t *buffer_ = nullptr;
+  const uint8_t *buffer_end_ = nullptr;
   uint8_t fill_buffer_[MAX_TRANSFER_SIZE];
   size_t fill_remaining_ = 0;
   uint32_t cancel_start_ = 0;
@@ -84,7 +86,7 @@ class VS1053Component : public Component {
   bool wait_data_ready_(uint32_t timeout_us) const;
   bool data_ready_() const { return this->dreq_pin_->digital_read(); }
 
-  void data_write_(const uint8_t* buffer, size_t length) const;
+  void data_write_(const uint8_t *buffer, size_t length) const;
   uint16_t command_transfer_(uint8_t instruction, uint8_t addr, uint16_t data) const;
   void command_write_(uint8_t addr, uint16_t data) const { this->command_transfer_(SCI_CMD_WRITE, addr, data); }
   uint16_t command_read_(uint8_t addr) const { return this->command_transfer_(SCI_CMD_READ, addr, 0); }

--- a/esphome/components/vs1053/vs1053.h
+++ b/esphome/components/vs1053/vs1053.h
@@ -46,9 +46,6 @@ class VS1053Component : public Component {
   void cancel_playback();
   void play_file(const uint8_t *data, size_t length);
 
-  void play_test_sine(uint16_t ms, uint32_t freq_hz = 1000, uint32_t sample_rate_hz = 44100);
-  void play_test_sine_sdi(uint16_t ms);
-
  protected:
   GPIOPin *reset_pin_ = nullptr;
   GPIOPin *dreq_pin_ = nullptr;

--- a/esphome/components/vs1053/vs1053.h
+++ b/esphome/components/vs1053/vs1053.h
@@ -78,7 +78,7 @@ class VS1053Component : public Component {
   void set_cancel_bit_() const;
   uint8_t get_fill_byte_() const;
 
-  uint16_t get_parameter_(uint16_t addr) const;
+  uint16_t get_parameter_(uint16_t param) const;
 
   bool wait_data_ready_(uint32_t timeout_us) const;
   bool data_ready_() const { return this->dreq_pin_->digital_read(); }

--- a/esphome/components/vs1053/vs1053.h
+++ b/esphome/components/vs1053/vs1053.h
@@ -12,14 +12,14 @@
 namespace esphome {
 namespace vs1053 {
 
-static constexpr const uint32_t VS1053_CANCEL_TIMEOUT_US = 1000000;  // 1 sec
-static constexpr const uint32_t VS1053_LOOP_TIMEOUT_US = 8000;       // 8 ms
+static constexpr const uint32_t CANCEL_TIMEOUT_US = 1000000;  // 1 sec
+static constexpr const uint32_t LOOP_TIMEOUT_US = 8000;       // 8 ms
 
-static constexpr const size_t VS1053_FIFO_LENGTH = 2048;
-static constexpr const size_t VS1053_TRANSFER_SIZE = 32;  // DREQ must be checked at least every 32 bytes
+static constexpr const size_t FIFO_LENGTH = 2048;
+static constexpr const size_t MAX_TRANSFER_SIZE = 32;  // DREQ must be checked at least every 32 bytes
 
-static constexpr const size_t VS1053_FILL_LENGTH = 2052;
-static constexpr const size_t VS1053_STOP_FILL_LENGTH = 2048;
+static constexpr const size_t FILL_LENGTH = 2052;
+static constexpr const size_t STOP_FILL_LENGTH = 2048;
 
 static constexpr const uint8_t VS1053_VERSION = 4;  // Per datasheet, VS1053/VS8053 SS_VER = 4
 
@@ -68,7 +68,7 @@ class VS1053Component : public Component {
   PlaybackState state_ = PlaybackState::Idle;
   const uint8_t* buffer_ = nullptr;
   const uint8_t* buffer_end_ = nullptr;
-  uint8_t fill_buffer_[VS1053_TRANSFER_SIZE];
+  uint8_t fill_buffer_[MAX_TRANSFER_SIZE];
   size_t fill_remaining_ = 0;
   uint32_t cancel_start_ = 0;
 

--- a/esphome/components/vs1053/vs1053.h
+++ b/esphome/components/vs1053/vs1053.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esphome/components/spi/spi.h"
+#include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
+#include "esphome/core/hal.h"
+#include "vs1053_reg.h"
+
+namespace esphome {
+namespace vs1053 {
+
+static constexpr const uint32_t VS1053_CANCEL_TIMEOUT_US = 1000000;  // 1 sec
+static constexpr const uint32_t VS1053_LOOP_TIMEOUT_US = 8000;       // 8 ms
+
+static constexpr const size_t VS1053_FIFO_LENGTH = 2048;
+static constexpr const size_t VS1053_TRANSFER_SIZE = 32;  // DREQ must be checked at least every 32 bytes
+
+static constexpr const size_t VS1053_FILL_LENGTH = 2052;
+static constexpr const size_t VS1053_STOP_FILL_LENGTH = 2048;
+
+static constexpr const uint8_t VS1053_VERSION = 4;  // Per datasheet, VS1053/VS8053 SS_VER = 4
+
+// VS1053 has two SPI interfaces, a command (SCI) and data (SDI) interface
+// XCS is the command select, XDCS is the data select
+// Both interfaces are Mode 0 MSB First
+class VS1053_SCI_SPIDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_200KHZ> {};
+class VS1053_SDI_SPIDevice : public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_8MHZ> {};
+
+class VS1053Component : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_reset_pin(GPIOPin* pin) { this->reset_pin_ = pin; }
+  void set_dreq_pin(GPIOPin* pin) { this->dreq_pin_ = pin; }
+  void set_sci_device(VS1053_SCI_SPIDevice* spi) { this->sci_spi_ = spi; }
+  void set_sdi_device(VS1053_SDI_SPIDevice* spi) { this->sdi_spi_ = spi; }
+
+  void set_volume(uint8_t left, uint8_t right);
+  void cancel_playback();
+  void play_file(const uint8_t* data, size_t length);
+
+  void play_test_sine(uint16_t ms, uint32_t freq_hz = 1000, uint32_t sample_rate_hz = 44100);
+  void play_test_sine_sdi(uint16_t ms);
+
+ protected:
+  GPIOPin* reset_pin_ = nullptr;
+  GPIOPin* dreq_pin_ = nullptr;
+  VS1053_SCI_SPIDevice* sci_spi_ = nullptr;
+  VS1053_SDI_SPIDevice* sdi_spi_ = nullptr;
+
+  enum class PlaybackState {
+    Idle,
+    Playing,
+    Cancel,
+    Cancelled,
+    Stop,
+    Error,
+  };
+
+  uint8_t volume_left_ = 200;
+  uint8_t volume_right_ = 200;
+
+  PlaybackState state_ = PlaybackState::Idle;
+  const uint8_t* buffer_ = nullptr;
+  const uint8_t* buffer_end_ = nullptr;
+  uint8_t fill_buffer_[VS1053_TRANSFER_SIZE];
+  size_t fill_remaining_ = 0;
+  uint32_t cancel_start_ = 0;
+
+  void finish_playback_();
+
+  bool init_(bool soft_reset = false);
+  bool get_cancel_bit_() const;
+  void set_cancel_bit_() const;
+  uint8_t get_fill_byte_() const;
+
+  uint16_t get_parameter_(uint16_t addr) const;
+
+  bool wait_data_ready_(uint32_t timeout_us) const;
+  bool data_ready_() const { return this->dreq_pin_->digital_read(); }
+
+  void data_write_(const uint8_t* buffer, size_t length) const;
+  uint16_t command_transfer_(uint8_t instruction, uint8_t addr, uint16_t data) const;
+  void command_write_(uint8_t addr, uint16_t data) const { this->command_transfer_(SCI_CMD_WRITE, addr, data); }
+  uint16_t command_read_(uint8_t addr) const { return this->command_transfer_(SCI_CMD_READ, addr, 0); }
+};
+
+}  // namespace vs1053
+}  // namespace esphome

--- a/esphome/components/vs1053/vs1053_reg.h
+++ b/esphome/components/vs1053/vs1053_reg.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace esphome {
+namespace vs1053 {
+
+static constexpr const uint8_t SCI_CMD_READ = 0x03;   // Serial command read
+static constexpr const uint8_t SCI_CMD_WRITE = 0x02;  // Serial command write
+
+static constexpr const uint8_t SCI_REG_MODE = 0x00;        // Mode control
+static constexpr const uint8_t SCI_REG_STATUS = 0x01;      // Status of VS1053b
+static constexpr const uint8_t SCI_REG_BASS = 0x02;        // Built-in bass/treble control
+static constexpr const uint8_t SCI_REG_CLOCKF = 0x03;      // Clock frequency + multiplier
+static constexpr const uint8_t SCI_REG_DECODETIME = 0x04;  // Decode time in seconds
+static constexpr const uint8_t SCI_REG_AUDATA = 0x05;      // Misc. audio data
+static constexpr const uint8_t SCI_REG_WRAM = 0x06;        // RAM write/read
+static constexpr const uint8_t SCI_REG_WRAMADDR = 0x07;    // Base address for RAM write/read
+static constexpr const uint8_t SCI_REG_HDAT0 = 0x08;       // Stream header data 0
+static constexpr const uint8_t SCI_REG_HDAT1 = 0x09;       // Stream header data 1
+static constexpr const uint8_t SCI_REG_AIADDR = 0x0A;      // Start address of application
+static constexpr const uint8_t SCI_REG_VOLUME = 0x0B;      // Volume control
+static constexpr const uint8_t SCI_REG_AICTRL0 = 0x0C;     // Application control register 0
+static constexpr const uint8_t SCI_REG_AICTRL1 = 0x0D;     // Application control register 1
+static constexpr const uint8_t SCI_REG_AICTRL2 = 0x0E;     // Application control register 2
+static constexpr const uint8_t SCI_REG_AICTRL3 = 0x0F;     // Application control register 3
+
+static constexpr const uint16_t GPIO_DDR = 0xC017;    // Direction
+static constexpr const uint16_t GPIO_IDATA = 0xC018;  // Values read from pins
+static constexpr const uint16_t GPIO_ODATA = 0xC019;  // Values set to the pins
+
+static constexpr const uint16_t INT_ENABLE = 0xC01A;  // Interrupt enable
+
+static constexpr const uint16_t MODE_SM_DIFF = 0x0001;      // Differential, 0: normal in-phase audio, 1: left channel inverted
+static constexpr const uint16_t MODE_SM_LAYER12 = 0x0002;   // Allow MPEG layers I & II
+static constexpr const uint16_t MODE_SM_RESET = 0x0004;     // Soft reset
+static constexpr const uint16_t MODE_SM_CANCEL = 0x0008;    // Cancel decoding current file
+static constexpr const uint16_t MODE_SM_EARSPKLO = 0x0010;  // EarSpeaker low setting
+static constexpr const uint16_t MODE_SM_TESTS = 0x0020;     // Allow SDI tests
+static constexpr const uint16_t MODE_SM_STREAM = 0x0040;    // Stream mode
+static constexpr const uint16_t MODE_SM_SDINEW = 0x0800;    // VS1002 native SPI modes
+static constexpr const uint16_t MODE_SM_ADPCM = 0x1000;     // PCM/ADPCM recording active
+static constexpr const uint16_t MODE_SM_LINE1 = 0x4000;     // MIC/LINE1 selector, 0: MICP, 1: LINE1
+static constexpr const uint16_t MODE_SM_CLKRANGE = 0x8000;  // Input clock range, 0: 12..13 MHz, 1: 24..26 MHz
+
+static constexpr const uint16_t EXTRA_PARAMETER_VERSION = 0x0003;
+static constexpr const uint16_t EXTRA_PARAMETER_ADDR = 0x1E02;
+
+static constexpr const uint16_t PARAMETER_END_FILL_BYTE_ADDR = 0x1E06;
+
+typedef struct extra_parameters_t {
+  uint16_t version;         // 0x1E02 - Structure version
+  uint16_t config1;         // 0x1E03 - PPSs RRRR: PS mode, SBR mode, Reverb
+  uint16_t play_speed;      // 0x1E04 - 0,1 = Normal speed; 2 = Twice; 3 = Three times, etc.
+  uint16_t byte_rate;       // 0x1E05 - Average byte rate
+  uint16_t end_fill_byte;   // 0x1E06 - Byte value to send after file sent
+  uint16_t reserved[16];    // 0x1E07–0x1E15 - File byte offsets
+  uint32_t jump_points[8];  // 0x1E16–0x1E25 - File byte offsets
+  uint16_t latest_jump;     // 0x1E26 - Index of the last updated jump point
+  uint32_t position_ms;     // 0x1E27–0x1E28 - Play position, if known (WMA, Ogg Vorbis)
+  int16_t resync;           // 0x1E29 - >0 for automatic M4A, ADIF, WMA resyncs
+  union {
+    struct {
+      uint32_t cur_packet_size;  // 0x1E2A - Current packet size
+      uint32_t packet_size;      // 0x1E2B - Packet size
+    } wma;
+    struct {
+      uint16_t sce_found_mask;     // 0x1E2A - SCEs found since last clear
+      uint16_t cpe_found_mask;     // 0x1E2B - CPEs found since last clear
+      uint16_t lfe_found_mask;     // 0x1E2C - LFEs found since last clear
+      uint16_t play_select;        // 0x1E2D - 0 = First any, initialized at AAC init
+      int16_t dyn_compress;        // 0x1E2E - -8192 = 1.0, initialized at AAC init
+      int16_t dyn_boost;           // 0x1E2F - 8192 = 1.0, initialized at AAC init
+      uint16_t sbr_and_ps_status;  // 0x1E30 - 1 = SBR, 2 = Upsample, 4 = PS, 8 = PS active
+    } aac;
+    struct {
+      uint32_t bytes_left;  // 0x1E2A - Bytes left
+    } midi;
+    struct {
+      int16_t gain;  // 0x1E2A - Proposed gain offset in 0.5 dB steps, default = -12
+    } vorbis;
+  } codec;
+} extra_parameters_t;
+
+}  // namespace vs1053
+}  // namespace esphome

--- a/esphome/components/vs1053/vs1053_reg.h
+++ b/esphome/components/vs1053/vs1053_reg.h
@@ -25,62 +25,15 @@ static constexpr const uint8_t SCI_REG_AICTRL1 = 0x0D;     // Application contro
 static constexpr const uint8_t SCI_REG_AICTRL2 = 0x0E;     // Application control register 2
 static constexpr const uint8_t SCI_REG_AICTRL3 = 0x0F;     // Application control register 3
 
-static constexpr const uint16_t GPIO_DDR = 0xC017;    // Direction
-static constexpr const uint16_t GPIO_IDATA = 0xC018;  // Values read from pins
-static constexpr const uint16_t GPIO_ODATA = 0xC019;  // Values set to the pins
-
-static constexpr const uint16_t INT_ENABLE = 0xC01A;  // Interrupt enable
-
-static constexpr const uint16_t MODE_SM_DIFF = 0x0001;      // Differential, 0: normal in-phase audio, 1: left channel inverted
-static constexpr const uint16_t MODE_SM_LAYER12 = 0x0002;   // Allow MPEG layers I & II
 static constexpr const uint16_t MODE_SM_RESET = 0x0004;     // Soft reset
 static constexpr const uint16_t MODE_SM_CANCEL = 0x0008;    // Cancel decoding current file
-static constexpr const uint16_t MODE_SM_EARSPKLO = 0x0010;  // EarSpeaker low setting
 static constexpr const uint16_t MODE_SM_TESTS = 0x0020;     // Allow SDI tests
-static constexpr const uint16_t MODE_SM_STREAM = 0x0040;    // Stream mode
 static constexpr const uint16_t MODE_SM_SDINEW = 0x0800;    // VS1002 native SPI modes
-static constexpr const uint16_t MODE_SM_ADPCM = 0x1000;     // PCM/ADPCM recording active
-static constexpr const uint16_t MODE_SM_LINE1 = 0x4000;     // MIC/LINE1 selector, 0: MICP, 1: LINE1
-static constexpr const uint16_t MODE_SM_CLKRANGE = 0x8000;  // Input clock range, 0: 12..13 MHz, 1: 24..26 MHz
 
 static constexpr const uint16_t EXTRA_PARAMETER_VERSION = 0x0003;
 static constexpr const uint16_t EXTRA_PARAMETER_ADDR = 0x1E02;
 
 static constexpr const uint16_t PARAMETER_END_FILL_BYTE_ADDR = 0x1E06;
-
-typedef struct extra_parameters_t {
-  uint16_t version;         // 0x1E02 - Structure version
-  uint16_t config1;         // 0x1E03 - PPSs RRRR: PS mode, SBR mode, Reverb
-  uint16_t play_speed;      // 0x1E04 - 0,1 = Normal speed; 2 = Twice; 3 = Three times, etc.
-  uint16_t byte_rate;       // 0x1E05 - Average byte rate
-  uint16_t end_fill_byte;   // 0x1E06 - Byte value to send after file sent
-  uint16_t reserved[16];    // 0x1E07–0x1E15 - File byte offsets
-  uint32_t jump_points[8];  // 0x1E16–0x1E25 - File byte offsets
-  uint16_t latest_jump;     // 0x1E26 - Index of the last updated jump point
-  uint32_t position_ms;     // 0x1E27–0x1E28 - Play position, if known (WMA, Ogg Vorbis)
-  int16_t resync;           // 0x1E29 - >0 for automatic M4A, ADIF, WMA resyncs
-  union {
-    struct {
-      uint32_t cur_packet_size;  // 0x1E2A - Current packet size
-      uint32_t packet_size;      // 0x1E2B - Packet size
-    } wma;
-    struct {
-      uint16_t sce_found_mask;     // 0x1E2A - SCEs found since last clear
-      uint16_t cpe_found_mask;     // 0x1E2B - CPEs found since last clear
-      uint16_t lfe_found_mask;     // 0x1E2C - LFEs found since last clear
-      uint16_t play_select;        // 0x1E2D - 0 = First any, initialized at AAC init
-      int16_t dyn_compress;        // 0x1E2E - -8192 = 1.0, initialized at AAC init
-      int16_t dyn_boost;           // 0x1E2F - 8192 = 1.0, initialized at AAC init
-      uint16_t sbr_and_ps_status;  // 0x1E30 - 1 = SBR, 2 = Upsample, 4 = PS, 8 = PS active
-    } aac;
-    struct {
-      uint32_t bytes_left;  // 0x1E2A - Bytes left
-    } midi;
-    struct {
-      int16_t gain;  // 0x1E2A - Proposed gain offset in 0.5 dB steps, default = -12
-    } vorbis;
-  } codec;
-} extra_parameters_t;
 
 }  // namespace vs1053
 }  // namespace esphome

--- a/esphome/components/vs1053/vs1053_reg.h
+++ b/esphome/components/vs1053/vs1053_reg.h
@@ -25,10 +25,10 @@ static constexpr const uint8_t SCI_REG_AICTRL1 = 0x0D;     // Application contro
 static constexpr const uint8_t SCI_REG_AICTRL2 = 0x0E;     // Application control register 2
 static constexpr const uint8_t SCI_REG_AICTRL3 = 0x0F;     // Application control register 3
 
-static constexpr const uint16_t MODE_SM_RESET = 0x0004;     // Soft reset
-static constexpr const uint16_t MODE_SM_CANCEL = 0x0008;    // Cancel decoding current file
-static constexpr const uint16_t MODE_SM_TESTS = 0x0020;     // Allow SDI tests
-static constexpr const uint16_t MODE_SM_SDINEW = 0x0800;    // VS1002 native SPI modes
+static constexpr const uint16_t MODE_SM_RESET = 0x0004;   // Soft reset
+static constexpr const uint16_t MODE_SM_CANCEL = 0x0008;  // Cancel decoding current file
+static constexpr const uint16_t MODE_SM_TESTS = 0x0020;   // Allow SDI tests
+static constexpr const uint16_t MODE_SM_SDINEW = 0x0800;  // VS1002 native SPI modes
 
 static constexpr const uint16_t EXTRA_PARAMETER_VERSION = 0x0003;
 static constexpr const uint16_t EXTRA_PARAMETER_ADDR = 0x1E02;


### PR DESCRIPTION
# What does this implement/fix?

Adds a component for the VS1053 audio codec. The [VS1053](https://www.vlsi.fi/en/products/vs1053.html) is a multi-format (Ogg/MP3/AAC/WMA/FLAC) audio codec chip. 
The VS1053 is capable of encoding audio data but that functionality has not been implemented.

This chip is commonly found on Adafuit's "Music Maker" series of shields/FeatherWings, and a handful of cheap breakout boards are available.

### I have marked this PR as a draft because I have some open questions regarding best practice.
**1. I am unclear what the proper core component/platform is for this component. Its capabilities fall awkwardly between [Media Player Component](https://esphome.io/components/media_player/) and [Speaker Component](https://esphome.io/components/speaker/).**
Speaker Component's actions align with the chip's capabilities, but the `audio_dac` configuration is not relevant and `speaker.play` expects raw audio data not encoded audio data.

Media Player Component's actions don't align as well (`play_media` expects a URL, announcements, turn_on, turn_off).

### Current status
- [x] Support playback of audio files stored in memory.
- [x] Support cancellation of playback.
- [x] Volume control
- [ ] [Implement patch support](https://www.vlsi.fi/en/support/software/vs10xxpatches.html)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#TBD

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

spi:
  clk_pin: GPIOX
  mosi_pin: GPIOX
  miso_pin: GPIOX

vs1053:
  id: player
  dreq_pin: GPIOX
  sci_spi:
    cs_pin: GPIOX
  sdi_spi:
    cs_pin: GPIOX

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
