### PR TITLE
[core] Fix IndexError when OTA devices cannot be resolved

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -185,7 +185,9 @@ def choose_upload_log_host(
             else:
                 resolved.append(device)
         if not resolved:
-            _LOGGER.error("All specified devices: %s could not be resolved.", defaults)
+            raise EsphomeError(
+                f"All specified devices {defaults} could not be resolved. Is the device connected to the network?"
+            )
         return resolved
 
     # No devices specified, show interactive chooser

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -321,12 +321,14 @@ def test_choose_upload_log_host_with_serial_device_no_ports(
 ) -> None:
     """Test SERIAL device when no serial ports are found."""
     setup_core()
-    result = choose_upload_log_host(
-        default="SERIAL",
-        check_default=None,
-        purpose=Purpose.UPLOADING,
-    )
-    assert result == []
+    with pytest.raises(
+        EsphomeError, match="All specified devices .* could not be resolved"
+    ):
+        choose_upload_log_host(
+            default="SERIAL",
+            check_default=None,
+            purpose=Purpose.UPLOADING,
+        )
     assert "No serial ports found, skipping SERIAL device" in caplog.text
 
 
@@ -367,12 +369,14 @@ def test_choose_upload_log_host_with_ota_device_with_api_config() -> None:
     """Test OTA device when API is configured (no upload without OTA in config)."""
     setup_core(config={CONF_API: {}}, address="192.168.1.100")
 
-    result = choose_upload_log_host(
-        default="OTA",
-        check_default=None,
-        purpose=Purpose.UPLOADING,
-    )
-    assert result == []
+    with pytest.raises(
+        EsphomeError, match="All specified devices .* could not be resolved"
+    ):
+        choose_upload_log_host(
+            default="OTA",
+            check_default=None,
+            purpose=Purpose.UPLOADING,
+        )
 
 
 def test_choose_upload_log_host_with_ota_device_with_api_config_logging() -> None:
@@ -405,12 +409,14 @@ def test_choose_upload_log_host_with_ota_device_no_fallback() -> None:
     """Test OTA device with no valid fallback options."""
     setup_core()
 
-    result = choose_upload_log_host(
-        default="OTA",
-        check_default=None,
-        purpose=Purpose.UPLOADING,
-    )
-    assert result == []
+    with pytest.raises(
+        EsphomeError, match="All specified devices .* could not be resolved"
+    ):
+        choose_upload_log_host(
+            default="OTA",
+            check_default=None,
+            purpose=Purpose.UPLOADING,
+        )
 
 
 @pytest.mark.usefixtures("mock_choose_prompt")
@@ -615,21 +621,19 @@ def test_choose_upload_log_host_empty_defaults_list() -> None:
 
 
 @pytest.mark.usefixtures("mock_no_serial_ports", "mock_no_mqtt_logging")
-def test_choose_upload_log_host_all_devices_unresolved(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_choose_upload_log_host_all_devices_unresolved() -> None:
     """Test when all specified devices cannot be resolved."""
     setup_core()
 
-    result = choose_upload_log_host(
-        default=["SERIAL", "OTA"],
-        check_default=None,
-        purpose=Purpose.UPLOADING,
-    )
-    assert result == []
-    assert (
-        "All specified devices: ['SERIAL', 'OTA'] could not be resolved." in caplog.text
-    )
+    with pytest.raises(
+        EsphomeError,
+        match=r"All specified devices \['SERIAL', 'OTA'\] could not be resolved",
+    ):
+        choose_upload_log_host(
+            default=["SERIAL", "OTA"],
+            check_default=None,
+            purpose=Purpose.UPLOADING,
+        )
 
 
 @pytest.mark.usefixtures("mock_no_serial_ports", "mock_no_mqtt_logging")
@@ -762,12 +766,14 @@ def test_choose_upload_log_host_no_address_with_ota_config() -> None:
     """Test OTA device when OTA is configured but no address is set."""
     setup_core(config={CONF_OTA: {}})
 
-    result = choose_upload_log_host(
-        default="OTA",
-        check_default=None,
-        purpose=Purpose.UPLOADING,
-    )
-    assert result == []
+    with pytest.raises(
+        EsphomeError, match="All specified devices .* could not be resolved"
+    ):
+        choose_upload_log_host(
+            default="OTA",
+            check_default=None,
+            purpose=Purpose.UPLOADING,
+        )
 
 
 @dataclass


### PR DESCRIPTION
# What does this implement/fix?

Fixes IndexError crash when `--device OTA` is specified but no devices can be resolved (e.g., Thread-only devices where `CORE.address` is None).

**Before:** When `choose_upload_log_host()` could not resolve any devices, it logged an error but returned an empty list, causing `IndexError: list index out of range` when `upload_program()` or `show_logs()` tried to access `devices[0]`.

**After:** Raises a clear `EsphomeError` with a helpful message showing which devices could not be resolved, allowing graceful exit instead of crashing.

This completes the fix started in PR #10459, which prevented AttributeError but still allowed IndexError to occur.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes partially https://github.com/esphome/esphome/issues/11257 (the IndexError, but doesn't add proper thread OTA support #11095 needed for that)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - bug fix only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Thread-only ESP32-C6 device that triggers the bug
esphome:
  name: test-c6-thread-ota

esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf

openthread:
  tlv: "0e080000000000010000000300001035060004001fffe002083030303030303030030e4f70656e5468726561642d613962390102a9b904103030303030303030303030303030303005100000000000000000000000000000000c0402a0f7f8"

network:
  enable_ipv6: true

logger:
api:
ota:
  platform: esphome
```

**Before this fix:**
```
$ esphome logs test_c6_thread_ota.yaml --device OTA
INFO ESPHome 2025.11.0-dev
INFO Reading configuration test_c6_thread_ota.yaml...
ERROR All specified devices: ['OTA'] could not be resolved.
Traceback (most recent call last):
  ...
  File "/Users/bdraco/esphome/esphome/__main__.py", line 632, in show_logs
    port = devices[0]
           ~~~~~~~^^^
IndexError: list index out of range
```

**After this fix:**
```
$ esphome logs test_c6_thread_ota.yaml --device OTA
INFO ESPHome 2025.11.0-dev
INFO Reading configuration test_c6_thread_ota.yaml...
ERROR All specified devices ['OTA'] could not be resolved. Is the device connected to the network?
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
