### PR TITLE
[dashboard] Fix binary download with packages using secrets after Path migration

### DIFF
--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -10,6 +10,10 @@ from esphome.helpers import get_bool_env
 
 from .util.password import password_hash
 
+# Sentinel file name used for CORE.config_path when dashboard initializes.
+# This ensures .parent returns the config directory instead of root.
+_DASHBOARD_SENTINEL_FILE = "___DASHBOARD_SENTINEL___.yaml"
+
 
 class DashboardSettings:
     """Settings for the dashboard."""
@@ -48,7 +52,12 @@ class DashboardSettings:
         self.config_dir = Path(args.configuration)
         self.absolute_config_dir = self.config_dir.resolve()
         self.verbose = args.verbose
-        CORE.config_path = self.config_dir / "."
+        # Set to a sentinel file so .parent gives us the config directory.
+        # Previously this was `os.path.join(self.config_dir, ".")` which worked because
+        # os.path.dirname("/config/.") returns "/config", but Path("/config/.").parent
+        # normalizes to Path("/config") first, then .parent returns Path("/"), breaking
+        # secret resolution. Using a sentinel file ensures .parent gives the correct directory.
+        CORE.config_path = self.config_dir / _DASHBOARD_SENTINEL_FILE
 
     @property
     def relative_url(self) -> str:

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from argparse import Namespace
 from pathlib import Path
 import tempfile
 
 import pytest
 
+from esphome.core import CORE
 from esphome.dashboard.settings import DashboardSettings
 
 
@@ -159,3 +161,60 @@ def test_rel_path_with_numeric_args(dashboard_settings: DashboardSettings) -> No
     result = dashboard_settings.rel_path("123", "456.789")
     expected = dashboard_settings.config_dir / "123" / "456.789"
     assert result == expected
+
+
+def test_config_path_parent_resolves_to_config_dir(tmp_path: Path) -> None:
+    """Test that CORE.config_path.parent resolves to config_dir after parse_args.
+
+    This is a regression test for issue #11280 where binary download failed
+    when using packages with secrets after the Path migration in 2025.10.0.
+
+    The issue was that after switching from os.path to Path:
+    - Before: os.path.dirname("/config/.") → "/config"
+    - After: Path("/config/.").parent → Path("/") (normalized first!)
+
+    The fix uses a sentinel file so .parent returns the correct directory:
+    - Fixed: Path("/config/___DASHBOARD_SENTINEL___.yaml").parent → Path("/config")
+    """
+    # Create test directory structure with secrets and packages
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create secrets.yaml
+    secrets_file = config_dir / "secrets.yaml"
+    secrets_file.write_text("wifi_ssid: TestNetwork\nwifi_password: TestPass123\n")
+
+    # Create package file that uses secrets
+    package_file = config_dir / "common.yaml"
+    package_file.write_text(
+        "wifi:\n  ssid: !secret wifi_ssid\n  password: !secret wifi_password\n"
+    )
+
+    # Create main device config that includes the package
+    device_config = config_dir / "test-device.yaml"
+    device_config.write_text(
+        "esphome:\n  name: test-device\n\npackages:\n  common: !include common.yaml\n"
+    )
+
+    # Set up dashboard settings with our test config directory
+    settings = DashboardSettings()
+    args = Namespace(
+        configuration=str(config_dir),
+        password=None,
+        username=None,
+        ha_addon=False,
+        verbose=False,
+    )
+    settings.parse_args(args)
+
+    # Verify that CORE.config_path.parent correctly points to the config directory
+    # This is critical for secret resolution in yaml_util.py which does:
+    #   main_config_dir = CORE.config_path.parent
+    #   main_secret_yml = main_config_dir / "secrets.yaml"
+    assert CORE.config_path.parent == config_dir.resolve()
+    assert (CORE.config_path.parent / "secrets.yaml").exists()
+    assert (CORE.config_path.parent / "common.yaml").exists()
+
+    # Verify that CORE.config_path itself uses the sentinel file
+    assert CORE.config_path.name == "___DASHBOARD_SENTINEL___.yaml"
+    assert not CORE.config_path.exists()  # Sentinel file doesn't actually exist

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -180,9 +180,12 @@ def test_config_path_parent_resolves_to_config_dir(tmp_path: Path) -> None:
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    # Create secrets.yaml
+    # Create secrets.yaml with obviously fake test values
     secrets_file = config_dir / "secrets.yaml"
-    secrets_file.write_text("wifi_ssid: TestNetwork\nwifi_password: TestPass123\n")
+    secrets_file.write_text(
+        "wifi_ssid: TEST-DUMMY-SSID\n"
+        "wifi_password: not-a-real-password-just-for-testing\n"
+    )
 
     # Create package file that uses secrets
     package_file = config_dir / "common.yaml"

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from argparse import Namespace
 import asyncio
 from collections.abc import Generator
 from contextlib import asynccontextmanager
@@ -17,6 +18,8 @@ from tornado.ioloop import IOLoop
 from tornado.testing import bind_unused_port
 from tornado.websocket import WebSocketClientConnection, websocket_connect
 
+from esphome import yaml_util
+from esphome.core import CORE
 from esphome.dashboard import web_server
 from esphome.dashboard.const import DashboardEvent
 from esphome.dashboard.core import DASHBOARD
@@ -1305,25 +1308,27 @@ async def test_dashboard_subscriber_refresh_event(
 
 
 @pytest.mark.asyncio
-async def test_download_list_handler_with_packages_and_secrets(
-    dashboard: DashboardTestHelper,
+async def test_dashboard_yaml_loading_with_packages_and_secrets(
     tmp_path: Path,
-    mock_storage_json: MagicMock,
-    mock_ext_storage_path: MagicMock,
-    mock_dashboard_settings: MagicMock,
 ) -> None:
-    """Test DownloadListRequestHandler with packages referencing secrets.
+    """Test dashboard YAML loading with packages referencing secrets.
 
     This is a regression test for issue #11280 where binary download failed
     when using packages with secrets after the Path migration in 2025.10.0.
+
+    This test verifies that CORE.config_path initialization in the dashboard
+    allows yaml_util.load_yaml() to correctly resolve secrets from packages.
     """
     # Create test directory structure with secrets and packages
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    # Create secrets.yaml
+    # Create secrets.yaml with obviously fake test values
     secrets_file = config_dir / "secrets.yaml"
-    secrets_file.write_text("wifi_ssid: TestNetwork\nwifi_password: TestPass123\n")
+    secrets_file.write_text(
+        "wifi_ssid: TEST-DUMMY-SSID\n"
+        "wifi_password: not-a-real-password-just-for-testing\n"
+    )
 
     # Create package file that uses secrets
     package_file = config_dir / "common.yaml"
@@ -1338,37 +1343,33 @@ async def test_download_list_handler_with_packages_and_secrets(
         "packages:\n  common: !include common.yaml\n"
     )
 
-    # Mock storage JSON
-    storage_path = tmp_path / "test-download-secrets.json"
-    mock_ext_storage_path.return_value = str(storage_path)
-
-    mock_storage = Mock()
-    mock_storage.name = "test-download-secrets"
-    mock_storage.target_platform = "ESP32"
-    mock_storage_json.load.return_value = mock_storage
-
-    # Configure mock settings to use our temp directory
-    mock_dashboard_settings.rel_path.return_value = device_config
-    mock_dashboard_settings.absolute_config_dir = config_dir.resolve()
-
-    # Make the request - should successfully load YAML with secrets from packages
-    # This would previously fail with "Secret 'wifi_ssid' not defined" due to
-    # CORE.config_path.parent pointing to "/" instead of the config directory
-    response = await dashboard.fetch(
-        "/downloads?configuration=test-download-secrets.yaml",
-        method="GET",
+    # Initialize DASHBOARD settings with our test config directory
+    # This is what sets CORE.config_path - the critical code path for the bug
+    args = Namespace(
+        configuration=str(config_dir),
+        password=None,
+        username=None,
+        ha_addon=False,
+        verbose=False,
     )
-    assert response.code == 200
-    assert response.headers["content-type"] == "application/json"
+    DASHBOARD.settings.parse_args(args)
 
-    # Verify we got a valid response with download options
-    data = json.loads(response.body.decode())
-    assert isinstance(data, list)
-    assert len(data) > 0
+    # With the fix: CORE.config_path should be config_dir / "___DASHBOARD_SENTINEL___.yaml"
+    # so CORE.config_path.parent would be config_dir
+    # Without the fix: CORE.config_path is config_dir / "." which normalizes to config_dir
+    # so CORE.config_path.parent would be tmp_path (the parent of config_dir)
 
-    # Verify the download list contains expected firmware files
-    # The successful response proves that secrets were resolved correctly from
-    # the package file, which means CORE.config_path.parent correctly pointed
-    # to the config directory where secrets.yaml exists
-    assert any("factory" in download.get("file", "") for download in data)
-    assert any("ota" in download.get("file", "") for download in data)
+    # The fix ensures CORE.config_path.parent points to config_dir
+    assert CORE.config_path.parent == config_dir.resolve(), (
+        f"CORE.config_path.parent should point to config_dir. "
+        f"Got {CORE.config_path.parent}, expected {config_dir.resolve()}. "
+        f"CORE.config_path is {CORE.config_path}"
+    )
+
+    # Now load the YAML with packages that reference secrets
+    # This is where the bug would manifest - yaml_util.load_yaml would fail
+    # to find secrets.yaml because CORE.config_path.parent pointed to the wrong place
+    config = yaml_util.load_yaml(device_config)
+    # If we get here, secret resolution worked!
+    assert "esphome" in config
+    assert config["esphome"]["name"] == "test-download-secrets"

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1302,3 +1302,73 @@ async def test_dashboard_subscriber_refresh_event(
 
         # Give it a moment to clean up
         await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_download_list_handler_with_packages_and_secrets(
+    dashboard: DashboardTestHelper,
+    tmp_path: Path,
+    mock_storage_json: MagicMock,
+    mock_ext_storage_path: MagicMock,
+    mock_dashboard_settings: MagicMock,
+) -> None:
+    """Test DownloadListRequestHandler with packages referencing secrets.
+
+    This is a regression test for issue #11280 where binary download failed
+    when using packages with secrets after the Path migration in 2025.10.0.
+    """
+    # Create test directory structure with secrets and packages
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create secrets.yaml
+    secrets_file = config_dir / "secrets.yaml"
+    secrets_file.write_text("wifi_ssid: TestNetwork\nwifi_password: TestPass123\n")
+
+    # Create package file that uses secrets
+    package_file = config_dir / "common.yaml"
+    package_file.write_text(
+        "wifi:\n  ssid: !secret wifi_ssid\n  password: !secret wifi_password\n"
+    )
+
+    # Create main device config that includes the package
+    device_config = config_dir / "test-download-secrets.yaml"
+    device_config.write_text(
+        "esphome:\n  name: test-download-secrets\n  platform: ESP32\n  board: esp32dev\n\n"
+        "packages:\n  common: !include common.yaml\n"
+    )
+
+    # Mock storage JSON
+    storage_path = tmp_path / "test-download-secrets.json"
+    mock_ext_storage_path.return_value = str(storage_path)
+
+    mock_storage = Mock()
+    mock_storage.name = "test-download-secrets"
+    mock_storage.target_platform = "ESP32"
+    mock_storage_json.load.return_value = mock_storage
+
+    # Configure mock settings to use our temp directory
+    mock_dashboard_settings.rel_path.return_value = device_config
+    mock_dashboard_settings.absolute_config_dir = config_dir.resolve()
+
+    # Make the request - should successfully load YAML with secrets from packages
+    # This would previously fail with "Secret 'wifi_ssid' not defined" due to
+    # CORE.config_path.parent pointing to "/" instead of the config directory
+    response = await dashboard.fetch(
+        "/downloads?configuration=test-download-secrets.yaml",
+        method="GET",
+    )
+    assert response.code == 200
+    assert response.headers["content-type"] == "application/json"
+
+    # Verify we got a valid response with download options
+    data = json.loads(response.body.decode())
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+    # Verify the download list contains expected firmware files
+    # The successful response proves that secrets were resolved correctly from
+    # the package file, which means CORE.config_path.parent correctly pointed
+    # to the config directory where secrets.yaml exists
+    assert any("factory" in download.get("file", "") for download in data)
+    assert any("ota" in download.get("file", "") for download in data)


### PR DESCRIPTION
# What does this implement/fix?

Fixes binary download failures when using `packages:` with secrets in ESPHome dashboard after the Path migration in 2025.10.0.

## Problem

After commit 9ea3643b7 (`[core] os.path -> Path (#10654)`), the dashboard initialization changed from:
```python
CORE.config_path = os.path.join(self.config_dir, ".")  # e.g., "/config/."
```
to:
```python
CORE.config_path = self.config_dir / "."  # Path("/config")
```

This broke secret resolution in packaged configurations because:
- **Before**: `os.path.dirname("/config/.")` → `"/config"` ✓
- **After**: `Path("/config/.").parent` normalizes to `Path("/config")` first, then `.parent` → `Path("/")` ✗

When users tried to download compiled binaries for devices using `packages:` that reference secrets, the YAML loader would look for `secrets.yaml` in `/` instead of `/config`, causing "Secret 'xxx' not defined" errors.

## Solution

Set `CORE.config_path` to a sentinel file path (`___DASHBOARD_SENTINEL___.yaml`) instead of a directory path. This ensures that when the YAML loader calls `.parent` to find the secrets directory, it gets the config directory instead of root:
- `Path("/config/___DASHBOARD_SENTINEL___.yaml").parent` → `Path("/config")` ✓

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11280

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no user-facing documentation changes)

## Test Environment

- [x] Dashboard binary download functionality
- [x] Configurations with `packages:` referencing secrets

## Reproduction Script

To reproduce the issue and verify the fix, run this test script:

```bash
#!/bin/bash
# Test script for issue #11280 - Dashboard binary download with packages and secrets

set -e

SCRIPT_DIR=$(mktemp -d)
trap "rm -rf $SCRIPT_DIR" EXIT

cd $SCRIPT_DIR

# Create test structure
mkdir -p config

# Create secrets file
cat > config/secrets.yaml <<EOF
wifi_ssid: "MyNetwork"
wifi_password: "MyPassword123"
EOF

# Create common package
cat > config/common.yaml <<EOF
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

logger:
  level: INFO
EOF

# Create device config that uses the package
cat > config/test-device.yaml <<EOF
esphome:
  name: test-device
  platform: ESP8266
  board: esp01_1m

packages:
  common: !include common.yaml

api:
  encryption:
    key: "base64key=="

ota:
  - platform: esphome
    password: "otapass"
EOF

# Test the Path.parent behavior that causes the bug
python3 <<'PYTHON'
from pathlib import Path
import os

print("=== Demonstrating the bug ===")
print()

# Old behavior (2025.9.3)
old_path = "/config/."
print(f"OLD (2025.9.3): CORE.config_path = '{old_path}'")
print(f"  os.path.dirname('{old_path}') = '{os.path.dirname(old_path)}'")
print(f"  Result: secrets.yaml looked up at '{os.path.join(os.path.dirname(old_path), 'secrets.yaml')}'")
print()

# New behavior that breaks (2025.10.0)
new_path = Path("/config") / "."
print(f"NEW (2025.10.0 broken): CORE.config_path = Path('/config') / '.' = {new_path}")
print(f"  Path('{new_path}').parent = {new_path.parent}")
print(f"  Result: secrets.yaml looked up at '{new_path.parent / 'secrets.yaml'}'")
print(f"  ERROR: Looks in root instead of /config!")
print()

# Fixed behavior (with sentinel)
fixed_path = Path("/config") / "___DASHBOARD_SENTINEL___.yaml"
print(f"FIXED: CORE.config_path = Path('/config') / '___DASHBOARD_SENTINEL___.yaml'")
print(f"  Path('{fixed_path}').parent = {fixed_path.parent}")
print(f"  Result: secrets.yaml looked up at '{fixed_path.parent / 'secrets.yaml'}'")
print(f"  SUCCESS: Looks in /config as expected!")
PYTHON

echo ""
echo "=== Test file structure created at: $SCRIPT_DIR/config ==="
echo "With the bug: Dashboard binary download would fail with 'Secret not defined'"
echo "With the fix: Dashboard binary download succeeds"
```

**Expected output:**
```
=== Demonstrating the bug ===

OLD (2025.9.3): CORE.config_path = '/config/.'
  os.path.dirname('/config/.') = '/config'
  Result: secrets.yaml looked up at '/config/secrets.yaml'

NEW (2025.10.0 broken): CORE.config_path = Path('/config') / '.' = /config
  Path('/config').parent = /
  Result: secrets.yaml looked up at '/secrets.yaml'
  ERROR: Looks in root instead of /config!

FIXED: CORE.config_path = Path('/config') / '___DASHBOARD_SENTINEL___.yaml'
  Path('/config/___DASHBOARD_SENTINEL___.yaml').parent = /config
  Result: secrets.yaml looked up at '/config/secrets.yaml'
  SUCCESS: Looks in /config as expected!
```

## Example entry for `config.yaml`:

This fix applies to any configuration using packages with secrets:

```yaml
# config.yaml
esphome:
  name: my-device
  platform: ESP8266
  board: esp01_1m

packages:
  common: !include common.yaml  # Contains secrets

# common.yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
