### PR TITLE
[cap1188] remove delays in setup

### DIFF
--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "cap1188";
 void CAP1188Component::setup() {
   this->disable_loop();
 
-  // no reset pin 
+  // no reset pin
   if (this->reset_pin_ == nullptr) {
     this->finish_setup_();
     return;

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -8,17 +8,30 @@ namespace cap1188 {
 static const char *const TAG = "cap1188";
 
 void CAP1188Component::setup() {
-  // Reset device using the reset pin
-  if (this->reset_pin_ != nullptr) {
-    this->reset_pin_->setup();
-    this->reset_pin_->digital_write(false);
-    delay(100);  // NOLINT
-    this->reset_pin_->digital_write(true);
-    delay(100);  // NOLINT
-    this->reset_pin_->digital_write(false);
-    delay(100);  // NOLINT
+  this->disable_loop();
+
+  // no reset pin 
+  if (this->reset_pin_ == nullptr) {
+    this->finish_setup_();
+    return;
   }
 
+  // reset pin configured so reset before finishing setup
+  this->reset_pin_->setup();
+  this->reset_pin_->digital_write(false);
+  // delay after reset pin write
+  this->set_timeout(100, [this]() {
+    this->reset_pin_->digital_write(true);
+    // delay after reset pin write
+    this->set_timeout(100, [this]() {
+      this->reset_pin_->digital_write(false);
+      // delay after reset pin write
+      this->set_timeout(100, [this]() { this->finish_setup_(); });
+    });
+  });
+}
+
+void finish_setup_() {
   // Check if CAP1188 is actually connected
   this->read_byte(CAP1188_PRODUCT_ID, &this->cap1188_product_id_);
   this->read_byte(CAP1188_MANUFACTURE_ID, &this->cap1188_manufacture_id_);
@@ -44,6 +57,9 @@ void CAP1188Component::setup() {
 
   // Speed up a bit
   this->write_byte(CAP1188_STAND_BY_CONFIGURATION, 0x30);
+
+  // Setup successful, so enable loop
+  this->enable_loop();
 }
 
 void CAP1188Component::dump_config() {

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -31,7 +31,7 @@ void CAP1188Component::setup() {
   });
 }
 
-void finish_setup_() {
+void CAP1188Component::finish_setup_() {
   // Check if CAP1188 is actually connected
   this->read_byte(CAP1188_PRODUCT_ID, &this->cap1188_product_id_);
   this->read_byte(CAP1188_MANUFACTURE_ID, &this->cap1188_manufacture_id_);

--- a/esphome/components/cap1188/cap1188.h
+++ b/esphome/components/cap1188/cap1188.h
@@ -49,6 +49,8 @@ class CAP1188Component : public Component, public i2c::I2CDevice {
   void loop() override;
 
  protected:
+  void finish_setup_();
+
   std::vector<CAP1188Channel *> channels_{};
   uint8_t touch_threshold_{0x20};
   uint8_t allow_multiple_touches_{0x80};


### PR DESCRIPTION
# What does this implement/fix?

remove delays in setup and replace with set_timeout

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
A component in the list for issue https://github.com/esphome/backlog/issues/38 "Minimize delay calls as much as possible"
- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
