### PR TITLE
[tests] Fix ESP32-C3 component test binary size by using larger partition table

### DIFF
--- a/tests/test_build_components/build_components_base.esp32-c3-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c3-idf.yaml
@@ -6,6 +6,9 @@ esp32:
   board: lolin_c3_mini
   framework:
     type: esp-idf
+  # Use custom partition table with larger app partition (3MB)
+  # Default IDF partitions only allow 1.75MB which is too small for grouped tests
+  partitions: ../partitions_testing.csv
 
 logger:
   level: VERY_VERBOSE


### PR DESCRIPTION
# What does this implement/fix?

Fixes ESP32-C3 (IDF) component test failures caused by binary size exceeding the default partition table limits.

The ESP32-C3 component tests were failing with "program size (2252918 bytes) is greater than maximum allowed (1835008 bytes)" errors when testing large component groups. This was because the C3 test configuration was using the default partition table which only allocates ~1.75MB for the app partition, while the ESP32 classic tests already used a custom partition table with 3MB app partitions.

This change applies the same custom partition table (`partitions_testing.csv`) to ESP32-C3 tests that was already being used for ESP32 classic tests, allowing the 2.25MB test binary to fit comfortably.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes CI test failures for ESP32-C3 component batches

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This change only affects test infrastructure, no user config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

**Before this change:**
- Flash usage: 122.8% (2,252,918 / 1,835,008 bytes) - FAILED ❌
- Using default IDF partition table (~1.75MB app partition)

**After this change:**
- Flash usage: 53.7% (2,252,918 / 4,194,304 bytes) - SUCCESS ✅
- Using custom partition table with 3MB factory partition

This aligns ESP32-C3 test configuration with ESP32 classic, which was already using the larger partition table successfully.
