### PR TITLE
[tests] Remove superfluous else-blocks from lambdas

### DIFF
--- a/tests/components/absolute_humidity/common.yaml
+++ b/tests/components/absolute_humidity/common.yaml
@@ -8,14 +8,12 @@ sensor:
     lambda: |-
       if (millis() > 10000) {
         return 0.6;
-      } else {
-        return 0.0;
       }
+      return 0.0;
   - platform: template
     id: template_temperature
     lambda: |-
       if (millis() > 10000) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;

--- a/tests/components/analog_threshold/common.yaml
+++ b/tests/components/analog_threshold/common.yaml
@@ -5,9 +5,8 @@ sensor:
     lambda: |-
       if (millis() > 10000) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;
     update_interval: 15s
 
 binary_sensor:

--- a/tests/components/binary_sensor/common.yaml
+++ b/tests/components/binary_sensor/common.yaml
@@ -23,9 +23,8 @@ binary_sensor:
       - lambda: |-
           if (id(some_binary_sensor).state) {
             return x;
-          } else {
-            return {};
           }
+          return {};
       - settle: 100ms
       - timeout: 10s
 

--- a/tests/components/binary_sensor_map/common.yaml
+++ b/tests/components/binary_sensor_map/common.yaml
@@ -4,25 +4,22 @@ binary_sensor:
     lambda: |-
       if (millis() > 10000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
   - platform: template
     id: bin2
     lambda: |-
       if (millis() > 20000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
   - platform: template
     id: bin3
     lambda: |-
       if (millis() > 30000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
 
 sensor:
   - platform: binary_sensor_map

--- a/tests/components/combination/common.yaml
+++ b/tests/components/combination/common.yaml
@@ -4,17 +4,15 @@ sensor:
     lambda: |-
       if (millis() > 10000) {
         return 0.6;
-      } else {
-        return 0.0;
       }
+      return 0.0;
   - platform: template
     id: template_temperature2
     lambda: |-
       if (millis() > 20000) {
         return 0.8;
-      } else {
-        return 0.0;
       }
+      return 0.0;
   - platform: combination
     type: kalman
     name: Kalman-filtered temperature

--- a/tests/components/duty_time/common.yaml
+++ b/tests/components/duty_time/common.yaml
@@ -4,9 +4,8 @@ binary_sensor:
     lambda: |-
       if (millis() > 10000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
 
 sensor:
   - platform: duty_time

--- a/tests/components/endstop/common.yaml
+++ b/tests/components/endstop/common.yaml
@@ -4,9 +4,8 @@ binary_sensor:
     lambda: |-
       if (millis() > 10000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
 
 switch:
   - platform: template

--- a/tests/components/lock/common.yaml
+++ b/tests/components/lock/common.yaml
@@ -17,9 +17,8 @@ lock:
     lambda: |-
       if (millis() > 10000) {
         return LOCK_STATE_LOCKED;
-      } else {
-        return LOCK_STATE_UNLOCKED;
       }
+      return LOCK_STATE_UNLOCKED;
     optimistic: true
     assumed_state: false
     on_unlock:

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -72,10 +72,9 @@ binary_sensor:
       if (id(template_sens).state > 30) {
         // Garage Door is open.
         return true;
-      } else {
-        // Garage Door is closed.
-        return false;
       }
+      // Garage Door is closed.
+      return false;
     on_state:
       - mqtt.publish:
           topic: some/topic/binary_sensor
@@ -217,9 +216,8 @@ cover:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return COVER_OPEN;
-      } else {
-        return COVER_CLOSED;
       }
+      return COVER_CLOSED;
     open_action:
       - logger.log: open_action
     close_action:
@@ -321,9 +319,8 @@ lock:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return LOCK_STATE_LOCKED;
-      } else {
-        return LOCK_STATE_UNLOCKED;
       }
+      return LOCK_STATE_UNLOCKED;
     lock_action:
       - logger.log: lock_action
     unlock_action:
@@ -360,9 +357,8 @@ sensor:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;
     update_interval: 60s
     on_value:
       - mqtt.publish:
@@ -390,9 +386,8 @@ switch:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return true;
-      } else {
-        return false;
       }
+      return false;
     turn_on_action:
       - logger.log: turn_on_action
     turn_off_action:
@@ -436,9 +431,8 @@ valve:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return VALVE_OPEN;
-      } else {
-        return VALVE_CLOSED;
       }
+      return VALVE_CLOSED;
 
 alarm_control_panel:
   - platform: template

--- a/tests/components/pid/common.yaml
+++ b/tests/components/pid/common.yaml
@@ -27,9 +27,8 @@ sensor:
     lambda: |-
       if (millis() > 10000) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;
     update_interval: 60s
 
 climate:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -92,7 +92,6 @@ lock:
         return LOCK_STATE_LOCKED;
       }
       return LOCK_STATE_UNLOCKED;
-
     optimistic: true
 
 select:

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -35,9 +35,8 @@ sensor:
     lambda: |-
       if (millis() > 10000) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;
     update_interval: 60s
 
 text_sensor:
@@ -49,9 +48,8 @@ text_sensor:
     lambda: |-
       if (millis() > 10000) {
         return {"Hello World"};
-      } else {
-        return {"Goodbye (cruel) World"};
       }
+      return {"Goodbye (cruel) World"};
     update_interval: 60s
 
 binary_sensor:
@@ -60,9 +58,8 @@ binary_sensor:
     lambda: |-
       if (millis() > 10000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
 
 switch:
   - platform: template
@@ -70,9 +67,8 @@ switch:
     lambda: |-
       if (millis() > 10000) {
         return true;
-      } else {
-        return false;
       }
+      return false;
     optimistic: true
 
 fan:
@@ -85,9 +81,8 @@ cover:
     lambda: |-
       if (millis() > 10000) {
         return COVER_OPEN;
-      } else {
-        return COVER_CLOSED;
       }
+      return COVER_CLOSED;
 
 lock:
   - platform: template
@@ -95,9 +90,9 @@ lock:
     lambda: |-
       if (millis() > 10000) {
         return LOCK_STATE_LOCKED;
-      } else {
-        return LOCK_STATE_UNLOCKED;
       }
+      return LOCK_STATE_UNLOCKED;
+
     optimistic: true
 
 select:

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -59,9 +59,8 @@ binary_sensor:
       - lambda: |-
           if (id(other_binary_sensor).state) {
             return x;
-          } else {
-            return {};
           }
+          return {};
       - settle: 500ms
       - timeout: 5s
 
@@ -72,9 +71,8 @@ sensor:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return 42.0;
-      } else {
-        return 0.0;
       }
+      return 0.0;
     update_interval: 60s
     filters:
       - calibrate_linear:
@@ -183,9 +181,8 @@ switch:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return true;
-      } else {
-        return false;
       }
+      return false;
     turn_on_action:
       - logger.log: "turn_on_action"
     turn_off_action:
@@ -203,9 +200,8 @@ cover:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return COVER_OPEN;
-      } else {
-        return COVER_CLOSED;
       }
+      return COVER_CLOSED;
     open_action:
       - logger.log: open_action
     close_action:
@@ -238,9 +234,8 @@ lock:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return LOCK_STATE_LOCKED;
-      } else {
-        return LOCK_STATE_UNLOCKED;
       }
+      return LOCK_STATE_UNLOCKED;
     lock_action:
       - logger.log: lock_action
     unlock_action:
@@ -255,9 +250,8 @@ valve:
     lambda: |-
       if (id(some_binary_sensor).state) {
         return VALVE_OPEN;
-      } else {
-        return VALVE_CLOSED;
       }
+      return VALVE_CLOSED;
     open_action:
       - logger.log: open_action
     close_action:

--- a/tests/integration/fixtures/batch_delay_zero_rapid_transitions.yaml
+++ b/tests/integration/fixtures/batch_delay_zero_rapid_transitions.yaml
@@ -34,10 +34,9 @@ binary_sensor:
           ESP_LOGD("test", "Button ON at %u", now);
         }
         return true;
-      } else {
-        // Only log state change
-        if (id(ir_remote_button).state) {
-          ESP_LOGD("test", "Button OFF at %u", now);
-        }
-        return false;
       }
+      // Only log state change
+      if (id(ir_remote_button).state) {
+        ESP_LOGD("test", "Button OFF at %u", now);
+      }
+      return false;


### PR DESCRIPTION
# What does this implement/fix?

Running script/test_build_components  produce many errors such as
```
Compiling .pioenvs/componenttestesp32c3idf/esp_coex/src/coexist_debug.c.o
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml: In lambda function:
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml:946:3: warning: control reaches end of non-void function [-Wreturn-type]
  946 |     name: Binary Sensor Map Group
      |   ^
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml: In lambda function:
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml:949:3: warning: control reaches end of non-void function [-Wreturn-type]
  949 |       - binary_sensor: bin1
      |   ^
Compiling .pioenvs/componenttestesp32c3idf/esp_common/src/esp_err_to_name.c.o
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml: In lambda function:
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml:1657:3: warning: control reaches end of non-void function [-Wreturn-type]
 1657 |     id: bin3
      |   ^
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml: In lambda function:
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml:1660:3: warning: control reaches end of non-void function [-Wreturn-type]
 1660 |     pin: 0
      |   ^
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml: In lambda function:
/home/user/projects/esphome2/tests/test_build_components/build/merged_ags10_ltr501_ltr_als_ps_plus_72.esp32-c3-idf.yaml:1663:3: warning: control reaches end of non-void function [-Wreturn-type]
 1663 |     id: sn74hc165_pin_0
      |   ^
```

caused by lambdas written with a superfluous else statement:
```
if (cond) { return 1; } else { return 0; }
```
and thus,  "are missing" a final return statement.

This commit removes those superfluous else-blocks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840



## Checklist:
  - [x] The code change is tested and works locally.
