### PR TITLE
[tests] Add i2c_id to mcp47a1 & mcp4725 and remove from isolation

### DIFF
--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -83,8 +83,6 @@ ISOLATED_COMPONENTS = {
     "openthread": "Conflicts with wifi: used by most components",
     "openthread_info": "Conflicts with wifi: used by most components",
     "matrix_keypad": "Needs isolation due to keypad",
-    "mcp4725": "no YAML config to specify i2c bus id",
-    "mcp47a1": "no YAML config to specify i2c bus id",
     "modbus_controller": "Defines multiple modbus buses for testing client/server functionality - conflicts with package modbus bus",
     "neopixelbus": "RMT type conflict with ESP32 Arduino/ESP-IDF headers (enum vs struct rmt_channel_t)",
     "packages": "cannot merge packages",

--- a/tests/components/mcp4725/common.yaml
+++ b/tests/components/mcp4725/common.yaml
@@ -1,3 +1,4 @@
 output:
   - platform: mcp4725
     id: mcp4725_dac_output
+    i2c_id: i2c_bus

--- a/tests/components/mcp47a1/common.yaml
+++ b/tests/components/mcp47a1/common.yaml
@@ -1,3 +1,4 @@
 output:
   - platform: mcp47a1
     id: output_mcp47a1
+    i2c_id: i2c_bus


### PR DESCRIPTION
# What does this implement/fix?

Add i2c_id to mcp47a1 & mcp4725 and remove from isolation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
