### PR TITLE
[tests] Migrate remote_transmitter/receiver to common bus definitions

### DIFF
--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -50,7 +50,14 @@ PACKAGE_DEPENDENCIES = {
 
 # Bus types that can be defined directly in config files
 # Components defining these directly cannot be grouped (they create unique bus IDs)
-DIRECT_BUS_TYPES = ("i2c", "spi", "uart", "modbus")
+DIRECT_BUS_TYPES = (
+    "i2c",
+    "spi",
+    "uart",
+    "modbus",
+    "remote_transmitter",
+    "remote_receiver",
+)
 
 # Signature for components with no bus requirements
 # These components can be merged with any other group
@@ -68,6 +75,8 @@ BASE_BUS_COMPONENTS = {
     "uart",
     "modbus",
     "canbus",
+    "remote_transmitter",
+    "remote_receiver",
 }
 
 # Components that must be tested in isolation (not grouped or batched with others)

--- a/tests/components/ballu/common.yaml
+++ b/tests/components/ballu/common.yaml
@@ -6,3 +6,4 @@ climate:
     name: HeatpumpIR Climate
     min_temperature: 18
     max_temperature: 30
+    transmitter_id: xmitr

--- a/tests/components/ballu/common.yaml
+++ b/tests/components/ballu/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: heatpumpir
     protocol: ballu

--- a/tests/components/ballu/test.esp8266-ard.yaml
+++ b/tests/components/ballu/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/ballu/test.esp8266-ard.yaml
+++ b/tests/components/ballu/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/climate_ir_lg/common.yaml
+++ b/tests/components/climate_ir_lg/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: climate_ir_lg
     name: LG Climate
+    transmitter_id: xmitr

--- a/tests/components/climate_ir_lg/common.yaml
+++ b/tests/components/climate_ir_lg/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: climate_ir_lg
     name: LG Climate

--- a/tests/components/climate_ir_lg/test.esp32-c3-idf.yaml
+++ b/tests/components/climate_ir_lg/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/climate_ir_lg/test.esp32-c3-idf.yaml
+++ b/tests/components/climate_ir_lg/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/climate_ir_lg/test.esp32-idf.yaml
+++ b/tests/components/climate_ir_lg/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/climate_ir_lg/test.esp32-idf.yaml
+++ b/tests/components/climate_ir_lg/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/climate_ir_lg/test.esp8266-ard.yaml
+++ b/tests/components/climate_ir_lg/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/climate_ir_lg/test.esp8266-ard.yaml
+++ b/tests/components/climate_ir_lg/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/coolix/common.yaml
+++ b/tests/components/coolix/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: coolix
     name: Coolix Climate

--- a/tests/components/coolix/common.yaml
+++ b/tests/components/coolix/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: coolix
     name: Coolix Climate
+    transmitter_id: xmitr

--- a/tests/components/coolix/test.esp32-c3-idf.yaml
+++ b/tests/components/coolix/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/coolix/test.esp32-c3-idf.yaml
+++ b/tests/components/coolix/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/coolix/test.esp32-idf.yaml
+++ b/tests/components/coolix/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/coolix/test.esp32-idf.yaml
+++ b/tests/components/coolix/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/coolix/test.esp8266-ard.yaml
+++ b/tests/components/coolix/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/coolix/test.esp8266-ard.yaml
+++ b/tests/components/coolix/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/daikin/common.yaml
+++ b/tests/components/daikin/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: heatpumpir
     protocol: daikin

--- a/tests/components/daikin/common.yaml
+++ b/tests/components/daikin/common.yaml
@@ -6,3 +6,4 @@ climate:
     name: HeatpumpIR Climate
     min_temperature: 18
     max_temperature: 30
+    transmitter_id: xmitr

--- a/tests/components/daikin/test.esp8266-ard.yaml
+++ b/tests/components/daikin/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/daikin/test.esp8266-ard.yaml
+++ b/tests/components/daikin/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/daikin_arc/common.yaml
+++ b/tests/components/daikin_arc/common.yaml
@@ -1,18 +1,3 @@
-remote_transmitter:
-  pin: ${tx_pin}
-  carrier_duty_percent: 50%
-  id: tsvr
-
-remote_receiver:
-  id: rcvr
-  pin:
-    number: ${rx_pin}
-    inverted: true
-    mode:
-      input: true
-      pullup: true
-  tolerance: 40%
-
 climate:
   - platform: daikin_arc
     name: Daikin AC

--- a/tests/components/daikin_arc/test.esp8266-ard.yaml
+++ b/tests/components/daikin_arc/test.esp8266-ard.yaml
@@ -2,4 +2,8 @@ substitutions:
   tx_pin: GPIO0
   rx_pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/daikin_arc/test.esp8266-ard.yaml
+++ b/tests/components/daikin_arc/test.esp8266-ard.yaml
@@ -1,7 +1,3 @@
-substitutions:
-  tx_pin: GPIO0
-  rx_pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
   remote_receiver: !include ../../test_build_components/common/remote_receiver/esp8266-ard.yaml

--- a/tests/components/daikin_brc/common.yaml
+++ b/tests/components/daikin_brc/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: daikin_brc
     name: Daikin_brc Climate

--- a/tests/components/daikin_brc/common.yaml
+++ b/tests/components/daikin_brc/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: daikin_brc
     name: Daikin_brc Climate
+    transmitter_id: xmitr

--- a/tests/components/daikin_brc/test.esp32-c3-idf.yaml
+++ b/tests/components/daikin_brc/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/daikin_brc/test.esp32-c3-idf.yaml
+++ b/tests/components/daikin_brc/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/daikin_brc/test.esp32-idf.yaml
+++ b/tests/components/daikin_brc/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/daikin_brc/test.esp32-idf.yaml
+++ b/tests/components/daikin_brc/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/daikin_brc/test.esp8266-ard.yaml
+++ b/tests/components/daikin_brc/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/daikin_brc/test.esp8266-ard.yaml
+++ b/tests/components/daikin_brc/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/delonghi/common.yaml
+++ b/tests/components/delonghi/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: delonghi
     name: Delonghi Climate

--- a/tests/components/delonghi/common.yaml
+++ b/tests/components/delonghi/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: delonghi
     name: Delonghi Climate
+    transmitter_id: xmitr

--- a/tests/components/delonghi/test.esp32-c3-idf.yaml
+++ b/tests/components/delonghi/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/delonghi/test.esp32-c3-idf.yaml
+++ b/tests/components/delonghi/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/delonghi/test.esp32-idf.yaml
+++ b/tests/components/delonghi/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/delonghi/test.esp32-idf.yaml
+++ b/tests/components/delonghi/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/delonghi/test.esp8266-ard.yaml
+++ b/tests/components/delonghi/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/delonghi/test.esp8266-ard.yaml
+++ b/tests/components/delonghi/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/emmeti/common.yaml
+++ b/tests/components/emmeti/common.yaml
@@ -1,14 +1,5 @@
-remote_transmitter:
-  id: tx
-  pin: ${remote_transmitter_pin}
-  carrier_duty_percent: 100%
-
-remote_receiver:
-  id: rcvr
-  pin: ${remote_receiver_pin}
-
 climate:
   - platform: emmeti
     name: Emmeti
     receiver_id: rcvr
-    transmitter_id: tx
+    transmitter_id: xmitr

--- a/tests/components/emmeti/test.esp32-idf.yaml
+++ b/tests/components/emmeti/test.esp32-idf.yaml
@@ -1,5 +1,5 @@
-substitutions:
-  remote_transmitter_pin: GPIO33
-  remote_receiver_pin: GPIO32
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/emmeti/test.esp8266-ard.yaml
+++ b/tests/components/emmeti/test.esp8266-ard.yaml
@@ -1,5 +1,5 @@
-substitutions:
-  remote_transmitter_pin: GPIO0
-  remote_receiver_pin: GPIO2
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/fujitsu_general/common.yaml
+++ b/tests/components/fujitsu_general/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: fujitsu_general
     name: Fujitsu General Climate

--- a/tests/components/fujitsu_general/common.yaml
+++ b/tests/components/fujitsu_general/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: fujitsu_general
     name: Fujitsu General Climate
+    transmitter_id: xmitr

--- a/tests/components/fujitsu_general/test.esp32-c3-idf.yaml
+++ b/tests/components/fujitsu_general/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/fujitsu_general/test.esp32-c3-idf.yaml
+++ b/tests/components/fujitsu_general/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/fujitsu_general/test.esp32-idf.yaml
+++ b/tests/components/fujitsu_general/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/fujitsu_general/test.esp32-idf.yaml
+++ b/tests/components/fujitsu_general/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/fujitsu_general/test.esp8266-ard.yaml
+++ b/tests/components/fujitsu_general/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/fujitsu_general/test.esp8266-ard.yaml
+++ b/tests/components/fujitsu_general/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/gree/common.yaml
+++ b/tests/components/gree/common.yaml
@@ -2,3 +2,4 @@ climate:
   - platform: gree
     name: GREE
     model: generic
+    transmitter_id: xmitr

--- a/tests/components/gree/common.yaml
+++ b/tests/components/gree/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: gree
     name: GREE

--- a/tests/components/gree/test.esp32-c3-idf.yaml
+++ b/tests/components/gree/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/gree/test.esp32-c3-idf.yaml
+++ b/tests/components/gree/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/gree/test.esp32-idf.yaml
+++ b/tests/components/gree/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/gree/test.esp32-idf.yaml
+++ b/tests/components/gree/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/gree/test.esp8266-ard.yaml
+++ b/tests/components/gree/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/gree/test.esp8266-ard.yaml
+++ b/tests/components/gree/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/heatpumpir/common.yaml
+++ b/tests/components/heatpumpir/common.yaml
@@ -6,6 +6,7 @@ climate:
     name: HeatpumpIR Climate Mitsubishi
     min_temperature: 18
     max_temperature: 30
+    transmitter_id: xmitr
   - platform: heatpumpir
     protocol: daikin
     horizontal_default: mleft
@@ -13,6 +14,7 @@ climate:
     name: HeatpumpIR Climate Daikin
     min_temperature: 18
     max_temperature: 30
+    transmitter_id: xmitr
   - platform: heatpumpir
     protocol: panasonic_altdke
     horizontal_default: mright
@@ -20,3 +22,4 @@ climate:
     name: HeatpumpIR Climate Panasonic
     min_temperature: 18
     max_temperature: 30
+    transmitter_id: xmitr

--- a/tests/components/heatpumpir/common.yaml
+++ b/tests/components/heatpumpir/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: heatpumpir
     protocol: mitsubishi_heavy_zm

--- a/tests/components/heatpumpir/test.bk72xx-ard.yaml
+++ b/tests/components/heatpumpir/test.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO6
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/heatpumpir/test.bk72xx-ard.yaml
+++ b/tests/components/heatpumpir/test.bk72xx-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO6
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
 

--- a/tests/components/heatpumpir/test.esp32-ard.yaml
+++ b/tests/components/heatpumpir/test.esp32-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/heatpumpir/test.esp32-ard.yaml
+++ b/tests/components/heatpumpir/test.esp32-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-ard.yaml
 

--- a/tests/components/heatpumpir/test.esp8266-ard.yaml
+++ b/tests/components/heatpumpir/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/heatpumpir/test.esp8266-ard.yaml
+++ b/tests/components/heatpumpir/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/hitachi_ac344/common.yaml
+++ b/tests/components/hitachi_ac344/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: hitachi_ac344
     name: Hitachi Climate
+    transmitter_id: xmitr

--- a/tests/components/hitachi_ac344/common.yaml
+++ b/tests/components/hitachi_ac344/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: hitachi_ac344
     name: Hitachi Climate

--- a/tests/components/hitachi_ac344/test.bk72xx-ard.yaml
+++ b/tests/components/hitachi_ac344/test.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO6
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac344/test.bk72xx-ard.yaml
+++ b/tests/components/hitachi_ac344/test.bk72xx-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO6
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
 

--- a/tests/components/hitachi_ac344/test.esp32-c3-idf.yaml
+++ b/tests/components/hitachi_ac344/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/hitachi_ac344/test.esp32-c3-idf.yaml
+++ b/tests/components/hitachi_ac344/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac344/test.esp32-idf.yaml
+++ b/tests/components/hitachi_ac344/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac344/test.esp32-idf.yaml
+++ b/tests/components/hitachi_ac344/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/hitachi_ac344/test.esp8266-ard.yaml
+++ b/tests/components/hitachi_ac344/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac344/test.esp8266-ard.yaml
+++ b/tests/components/hitachi_ac344/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/hitachi_ac424/common.yaml
+++ b/tests/components/hitachi_ac424/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: hitachi_ac424
     name: Hitachi Climate
+    transmitter_id: xmitr

--- a/tests/components/hitachi_ac424/common.yaml
+++ b/tests/components/hitachi_ac424/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: hitachi_ac424
     name: Hitachi Climate

--- a/tests/components/hitachi_ac424/test.bk72xx-ard.yaml
+++ b/tests/components/hitachi_ac424/test.bk72xx-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO6
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac424/test.bk72xx-ard.yaml
+++ b/tests/components/hitachi_ac424/test.bk72xx-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO6
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/bk72xx-ard.yaml
 

--- a/tests/components/hitachi_ac424/test.esp32-c3-idf.yaml
+++ b/tests/components/hitachi_ac424/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/hitachi_ac424/test.esp32-c3-idf.yaml
+++ b/tests/components/hitachi_ac424/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac424/test.esp32-idf.yaml
+++ b/tests/components/hitachi_ac424/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac424/test.esp32-idf.yaml
+++ b/tests/components/hitachi_ac424/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/hitachi_ac424/test.esp8266-ard.yaml
+++ b/tests/components/hitachi_ac424/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/hitachi_ac424/test.esp8266-ard.yaml
+++ b/tests/components/hitachi_ac424/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/midea/common.yaml
+++ b/tests/components/midea/common.yaml
@@ -2,10 +2,6 @@ wifi:
   ssid: MySSID
   password: password1
 
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: midea
     id: midea_unit
@@ -16,7 +12,7 @@ climate:
           x.set_mode(CLIMATE_MODE_FAN_ONLY);
     on_state:
       - logger.log: State changed!
-    transmitter_id:
+    transmitter_id: xmitr
     period: 1s
     num_attempts: 5
     timeout: 2s

--- a/tests/components/midea/test.esp32-ard.yaml
+++ b/tests/components/midea/test.esp32-ard.yaml
@@ -2,6 +2,7 @@ substitutions:
   pin: GPIO2
 
 packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-ard.yaml
   uart: !include ../../test_build_components/common/uart/esp32-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/midea/test.esp32-ard.yaml
+++ b/tests/components/midea/test.esp32-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-ard.yaml
   uart: !include ../../test_build_components/common/uart/esp32-ard.yaml

--- a/tests/components/midea/test.esp8266-ard.yaml
+++ b/tests/components/midea/test.esp8266-ard.yaml
@@ -2,6 +2,7 @@ substitutions:
   pin: GPIO15
 
 packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
   uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/midea/test.esp8266-ard.yaml
+++ b/tests/components/midea/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO15
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
   uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml

--- a/tests/components/midea_ir/common.yaml
+++ b/tests/components/midea_ir/common.yaml
@@ -2,3 +2,4 @@ climate:
   - platform: midea_ir
     name: Midea IR
     use_fahrenheit: true
+    transmitter_id: xmitr

--- a/tests/components/midea_ir/common.yaml
+++ b/tests/components/midea_ir/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: 4
-  carrier_duty_percent: 50%
-
 climate:
   - platform: midea_ir
     name: Midea IR

--- a/tests/components/midea_ir/test.esp32-c3-idf.yaml
+++ b/tests/components/midea_ir/test.esp32-c3-idf.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/midea_ir/test.esp32-idf.yaml
+++ b/tests/components/midea_ir/test.esp32-idf.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/midea_ir/test.esp8266-ard.yaml
+++ b/tests/components/midea_ir/test.esp8266-ard.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/mitsubishi/common.yaml
+++ b/tests/components/mitsubishi/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: mitsubishi
     name: Mitsubishi
+    transmitter_id: xmitr

--- a/tests/components/mitsubishi/common.yaml
+++ b/tests/components/mitsubishi/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: 4
-  carrier_duty_percent: 50%
-
 climate:
   - platform: mitsubishi
     name: Mitsubishi

--- a/tests/components/mitsubishi/test.esp32-c3-idf.yaml
+++ b/tests/components/mitsubishi/test.esp32-c3-idf.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/mitsubishi/test.esp32-idf.yaml
+++ b/tests/components/mitsubishi/test.esp32-idf.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/mitsubishi/test.esp8266-ard.yaml
+++ b/tests/components/mitsubishi/test.esp8266-ard.yaml
@@ -1,1 +1,4 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/noblex/common.yaml
+++ b/tests/components/noblex/common.yaml
@@ -1,12 +1,3 @@
-remote_receiver:
-  id: rcvr
-  pin: 4
-  dump: all
-
-remote_transmitter:
-  pin: 2
-  carrier_duty_percent: 50%
-
 sensor:
   - platform: template
     id: noblex_ac_sensor

--- a/tests/components/noblex/test.esp32-c3-idf.yaml
+++ b/tests/components/noblex/test.esp32-c3-idf.yaml
@@ -1,1 +1,5 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/noblex/test.esp32-idf.yaml
+++ b/tests/components/noblex/test.esp32-idf.yaml
@@ -1,1 +1,5 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/noblex/test.esp8266-ard.yaml
+++ b/tests/components/noblex/test.esp8266-ard.yaml
@@ -1,1 +1,5 @@
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+  remote_receiver: !include ../../test_build_components/common/remote_receiver/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -128,10 +128,6 @@ valve:
     optimistic: true
     has_position: true
 
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: climate_ir_lg
     name: LG Climate

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -131,6 +131,7 @@ valve:
 climate:
   - platform: climate_ir_lg
     name: LG Climate
+    transmitter_id: xmitr
 
 prometheus:
   include_internal: true

--- a/tests/components/prometheus/test.esp32-c3-idf.yaml
+++ b/tests/components/prometheus/test.esp32-c3-idf.yaml
@@ -1,6 +1,5 @@
 substitutions:
   verify_ssl: "false"
-  pin: GPIO2
 
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml

--- a/tests/components/prometheus/test.esp32-c3-idf.yaml
+++ b/tests/components/prometheus/test.esp32-c3-idf.yaml
@@ -2,4 +2,7 @@ substitutions:
   verify_ssl: "false"
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/prometheus/test.esp32-idf.yaml
+++ b/tests/components/prometheus/test.esp32-idf.yaml
@@ -3,6 +3,7 @@ substitutions:
   pin: GPIO2
 
 packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
   spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/prometheus/test.esp32-idf.yaml
+++ b/tests/components/prometheus/test.esp32-idf.yaml
@@ -1,6 +1,5 @@
 substitutions:
   verify_ssl: "false"
-  pin: GPIO2
 
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml

--- a/tests/components/prometheus/test.esp8266-ard.yaml
+++ b/tests/components/prometheus/test.esp8266-ard.yaml
@@ -1,6 +1,5 @@
 substitutions:
   verify_ssl: "false"
-  pin: GPIO5
 
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml

--- a/tests/components/prometheus/test.esp8266-ard.yaml
+++ b/tests/components/prometheus/test.esp8266-ard.yaml
@@ -2,4 +2,7 @@ substitutions:
   verify_ssl: "false"
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/tcl112/common.yaml
+++ b/tests/components/tcl112/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 sensor:
   - platform: template
     id: tcl112_sensor

--- a/tests/components/tcl112/common.yaml
+++ b/tests/components/tcl112/common.yaml
@@ -9,3 +9,4 @@ climate:
     supports_heat: true
     supports_cool: true
     sensor: tcl112_sensor
+    transmitter_id: xmitr

--- a/tests/components/tcl112/test.esp32-c3-idf.yaml
+++ b/tests/components/tcl112/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/tcl112/test.esp32-c3-idf.yaml
+++ b/tests/components/tcl112/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/tcl112/test.esp32-idf.yaml
+++ b/tests/components/tcl112/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/tcl112/test.esp32-idf.yaml
+++ b/tests/components/tcl112/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/tcl112/test.esp8266-ard.yaml
+++ b/tests/components/tcl112/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/tcl112/test.esp8266-ard.yaml
+++ b/tests/components/tcl112/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/toshiba/common.yaml
+++ b/tests/components/toshiba/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: toshiba
     name: Toshiba Climate
+    transmitter_id: xmitr

--- a/tests/components/toshiba/common.yaml
+++ b/tests/components/toshiba/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: toshiba
     name: Toshiba Climate

--- a/tests/components/toshiba/test.esp32-c3-idf.yaml
+++ b/tests/components/toshiba/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/toshiba/test.esp32-c3-idf.yaml
+++ b/tests/components/toshiba/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/toshiba/test.esp32-idf.yaml
+++ b/tests/components/toshiba/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/toshiba/test.esp32-idf.yaml
+++ b/tests/components/toshiba/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/toshiba/test.esp8266-ard.yaml
+++ b/tests/components/toshiba/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/toshiba/test.esp8266-ard.yaml
+++ b/tests/components/toshiba/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/whirlpool/common.yaml
+++ b/tests/components/whirlpool/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: whirlpool
     name: Whirlpool Climate

--- a/tests/components/whirlpool/common.yaml
+++ b/tests/components/whirlpool/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: whirlpool
     name: Whirlpool Climate
+    transmitter_id: xmitr

--- a/tests/components/whirlpool/test.esp32-c3-idf.yaml
+++ b/tests/components/whirlpool/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/whirlpool/test.esp32-c3-idf.yaml
+++ b/tests/components/whirlpool/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/whirlpool/test.esp32-idf.yaml
+++ b/tests/components/whirlpool/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/whirlpool/test.esp32-idf.yaml
+++ b/tests/components/whirlpool/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/whirlpool/test.esp8266-ard.yaml
+++ b/tests/components/whirlpool/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/whirlpool/test.esp8266-ard.yaml
+++ b/tests/components/whirlpool/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/whynter/common.yaml
+++ b/tests/components/whynter/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: whynter
     name: Whynter Climate

--- a/tests/components/whynter/common.yaml
+++ b/tests/components/whynter/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: whynter
     name: Whynter Climate
+    transmitter_id: xmitr

--- a/tests/components/whynter/test.esp32-c3-idf.yaml
+++ b/tests/components/whynter/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/whynter/test.esp32-c3-idf.yaml
+++ b/tests/components/whynter/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/whynter/test.esp32-idf.yaml
+++ b/tests/components/whynter/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/whynter/test.esp32-idf.yaml
+++ b/tests/components/whynter/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/whynter/test.esp8266-ard.yaml
+++ b/tests/components/whynter/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/whynter/test.esp8266-ard.yaml
+++ b/tests/components/whynter/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/yashima/common.yaml
+++ b/tests/components/yashima/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: yashima
     name: Yashima Climate
+    transmitter_id: xmitr

--- a/tests/components/yashima/common.yaml
+++ b/tests/components/yashima/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: yashima
     name: Yashima Climate

--- a/tests/components/yashima/test.esp32-c3-idf.yaml
+++ b/tests/components/yashima/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/yashima/test.esp32-c3-idf.yaml
+++ b/tests/components/yashima/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/yashima/test.esp32-idf.yaml
+++ b/tests/components/yashima/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/yashima/test.esp32-idf.yaml
+++ b/tests/components/yashima/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/yashima/test.esp8266-ard.yaml
+++ b/tests/components/yashima/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/yashima/test.esp8266-ard.yaml
+++ b/tests/components/yashima/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/components/zhlt01/common.yaml
+++ b/tests/components/zhlt01/common.yaml
@@ -1,3 +1,4 @@
 climate:
   - platform: zhlt01
     name: ZH/LT-01 Climate
+    transmitter_id: xmitr

--- a/tests/components/zhlt01/common.yaml
+++ b/tests/components/zhlt01/common.yaml
@@ -1,7 +1,3 @@
-remote_transmitter:
-  pin: ${pin}
-  carrier_duty_percent: 50%
-
 climate:
   - platform: zhlt01
     name: ZH/LT-01 Climate

--- a/tests/components/zhlt01/test.esp32-c3-idf.yaml
+++ b/tests/components/zhlt01/test.esp32-c3-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
 

--- a/tests/components/zhlt01/test.esp32-c3-idf.yaml
+++ b/tests/components/zhlt01/test.esp32-c3-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/zhlt01/test.esp32-idf.yaml
+++ b/tests/components/zhlt01/test.esp32-idf.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO2
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
+
 <<: !include common.yaml

--- a/tests/components/zhlt01/test.esp32-idf.yaml
+++ b/tests/components/zhlt01/test.esp32-idf.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO2
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp32-idf.yaml
 

--- a/tests/components/zhlt01/test.esp8266-ard.yaml
+++ b/tests/components/zhlt01/test.esp8266-ard.yaml
@@ -1,4 +1,7 @@
 substitutions:
   pin: GPIO5
 
+packages:
+  remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
+
 <<: !include common.yaml

--- a/tests/components/zhlt01/test.esp8266-ard.yaml
+++ b/tests/components/zhlt01/test.esp8266-ard.yaml
@@ -1,6 +1,3 @@
-substitutions:
-  pin: GPIO5
-
 packages:
   remote_transmitter: !include ../../test_build_components/common/remote_transmitter/esp8266-ard.yaml
 

--- a/tests/test_build_components/common/remote_receiver/esp32-c3-idf.yaml
+++ b/tests/test_build_components/common/remote_receiver/esp32-c3-idf.yaml
@@ -1,0 +1,16 @@
+# Common remote_receiver configuration for ESP32-C3 IDF tests
+# Provides a shared remote receiver that all components can use
+# Components will auto-use this receiver if they don't specify receiver_id
+
+substitutions:
+  remote_receiver_pin: GPIO5
+
+remote_receiver:
+  - id: rcvr
+    pin: ${remote_receiver_pin}
+    dump: all
+    tolerance: 25%
+    clock_resolution: 2000000
+    filter_symbols: 2
+    receive_symbols: 4
+    rmt_symbols: 64

--- a/tests/test_build_components/common/remote_receiver/esp32-idf.yaml
+++ b/tests/test_build_components/common/remote_receiver/esp32-idf.yaml
@@ -1,0 +1,16 @@
+# Common remote_receiver configuration for ESP32 IDF tests
+# Provides a shared remote receiver that all components can use
+# Components will auto-use this receiver if they don't specify receiver_id
+
+substitutions:
+  remote_receiver_pin: GPIO32
+
+remote_receiver:
+  - id: rcvr
+    pin: ${remote_receiver_pin}
+    dump: all
+    tolerance: 25%
+    clock_resolution: 2000000
+    filter_symbols: 2
+    receive_symbols: 4
+    rmt_symbols: 64

--- a/tests/test_build_components/common/remote_receiver/esp8266-ard.yaml
+++ b/tests/test_build_components/common/remote_receiver/esp8266-ard.yaml
@@ -1,0 +1,12 @@
+# Common remote_receiver configuration for ESP8266 Arduino tests
+# Provides a shared remote receiver that all components can use
+# Components will auto-use this receiver if they don't specify receiver_id
+
+substitutions:
+  remote_receiver_pin: GPIO5
+
+remote_receiver:
+  id: rcvr
+  pin: ${remote_receiver_pin}
+  dump: all
+  tolerance: 25%

--- a/tests/test_build_components/common/remote_transmitter/bk72xx-ard.yaml
+++ b/tests/test_build_components/common/remote_transmitter/bk72xx-ard.yaml
@@ -1,0 +1,11 @@
+# Common remote_transmitter configuration for BK72XX Arduino tests
+# Provides a shared remote transmitter that all components can use
+# Components will auto-use this transmitter if they don't specify transmitter_id
+
+substitutions:
+  remote_transmitter_pin: GPIO6
+
+remote_transmitter:
+  id: xmitr
+  pin: ${remote_transmitter_pin}
+  carrier_duty_percent: 50%

--- a/tests/test_build_components/common/remote_transmitter/esp32-ard.yaml
+++ b/tests/test_build_components/common/remote_transmitter/esp32-ard.yaml
@@ -1,0 +1,11 @@
+# Common remote_transmitter configuration for ESP32 Arduino tests
+# Provides a shared remote transmitter that all components can use
+# Components will auto-use this transmitter if they don't specify transmitter_id
+
+substitutions:
+  remote_transmitter_pin: GPIO2
+
+remote_transmitter:
+  id: xmitr
+  pin: ${remote_transmitter_pin}
+  carrier_duty_percent: 50%

--- a/tests/test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
+++ b/tests/test_build_components/common/remote_transmitter/esp32-c3-idf.yaml
@@ -1,0 +1,13 @@
+# Common remote_transmitter configuration for ESP32-C3 IDF tests
+# Provides a shared remote transmitter that all components can use
+# Components will auto-use this transmitter if they don't specify transmitter_id
+
+substitutions:
+  remote_transmitter_pin: GPIO2
+
+remote_transmitter:
+  - id: xmitr
+    pin: ${remote_transmitter_pin}
+    carrier_duty_percent: 50%
+    clock_resolution: 2000000
+    rmt_symbols: 64

--- a/tests/test_build_components/common/remote_transmitter/esp32-idf.yaml
+++ b/tests/test_build_components/common/remote_transmitter/esp32-idf.yaml
@@ -1,0 +1,13 @@
+# Common remote_transmitter configuration for ESP32 IDF tests
+# Provides a shared remote transmitter that all components can use
+# Components will auto-use this transmitter if they don't specify transmitter_id
+
+substitutions:
+  remote_transmitter_pin: GPIO2
+
+remote_transmitter:
+  - id: xmitr
+    pin: ${remote_transmitter_pin}
+    carrier_duty_percent: 50%
+    clock_resolution: 2000000
+    rmt_symbols: 64

--- a/tests/test_build_components/common/remote_transmitter/esp8266-ard.yaml
+++ b/tests/test_build_components/common/remote_transmitter/esp8266-ard.yaml
@@ -1,0 +1,11 @@
+# Common remote_transmitter configuration for ESP8266 Arduino tests
+# Provides a shared remote transmitter that all components can use
+# Components will auto-use this transmitter if they don't specify transmitter_id
+
+substitutions:
+  remote_transmitter_pin: GPIO2
+
+remote_transmitter:
+  id: xmitr
+  pin: ${remote_transmitter_pin}
+  carrier_duty_percent: 50%


### PR DESCRIPTION
# What does this implement/fix?

This PR establishes common bus definitions for `remote_transmitter` and `remote_receiver` components in the test infrastructure, treating them consistently with other bus components (i2c, spi, uart, modbus). This migration eliminates ID conflicts that occur when testing remote-based components together.

## Changes Made

### Infrastructure Changes
1. **Created common bus configurations** for remote_transmitter/receiver across all platforms:
   - `tests/test_build_components/common/remote_transmitter/` (esp32-idf, esp32-c3-idf, esp32-ard, esp8266-ard, bk72xx-ard)
   - `tests/test_build_components/common/remote_receiver/` (esp32-idf, esp32-c3-idf, esp8266-ard)
   - Standard IDs: `xmitr` (transmitter), `rcvr` (receiver)

2. **Updated `script/analyze_component_buses.py`**:
   - Added `remote_transmitter` and `remote_receiver` to `DIRECT_BUS_TYPES`
   - Added both to `BASE_BUS_COMPONENTS` set
   - Ensures remote components are treated as base bus implementations

### Component Migrations (23 IR climate components)
Migrated all IR climate components to use common bus packages instead of defining remotes directly:

**Components migrated:**
- ballu, climate_ir_lg, coolix, daikin, daikin_arc, daikin_brc, delonghi
- fujitsu_general, gree, heatpumpir, hitachi_ac344, hitachi_ac424
- midea, midea_ir, mitsubishi, noblex, prometheus, tcl112, toshiba
- whirlpool, whynter, yashima, zhlt01

**Migration pattern:**
- Removed `remote_transmitter`/`remote_receiver` definitions from `common.yaml`
- Added `packages` section in test files to include common bus configs
- Updated component configs to reference standard IDs (`xmitr`, `rcvr`)


## Benefits

1. **Eliminates ID Conflicts**: Components no longer define conflicting remote_transmitter/receiver IDs when tested together
2. **Consistency**: Remote components now follow the same pattern as i2c, spi, uart, and modbus buses
3. **Maintainability**: Centralized bus configuration makes updates easier across all components
4. **Test Reliability**: Components were already grouped before this change, but now without risk of ID conflicts

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (test infrastructure improvement)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] BK72xx

## Testing Results

**Individual component tests (--no-grouping):**
- ✅ 64 tests passed, 0 failed
- All 23 components validated on all their supported platforms

**Grouped component tests (with intelligent grouping):**
- ✅ 11 builds passed, 0 failed
- Components group correctly by bus configuration
- 85.9% build reduction maintained (9 builds vs 64 without grouping)

**Test command:**
```bash
script/test_build_components.py -c ballu,climate_ir_lg,coolix,daikin,daikin_arc,daikin_brc,delonghi,fujitsu_general,gree,heatpumpir,hitachi_ac344,hitachi_ac424,midea,midea_ir,mitsubishi,noblex,prometheus,tcl112,toshiba,whirlpool,whynter,yashima,zhlt01 -e config
```

## Example entry for `config.yaml`:

No user-facing changes. This is a test infrastructure improvement only.

```yaml
# Components continue to work as before, but tests now use common bus definitions
climate:
  - platform: coolix
    name: Coolix Climate
    # remote_transmitter_id defaults to 'xmitr' from common config
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal test infrastructure only)
