### PR TITLE
[api][time] Refactor timezone update logic for cleaner code

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1081,13 +1081,8 @@ void APIConnection::on_get_time_response(const GetTimeResponse &value) {
     homeassistant::global_homeassistant_time->set_epoch_time(value.epoch_seconds);
 #ifdef USE_TIME_TIMEZONE
     if (value.timezone_len > 0) {
-      const std::string &current_tz = homeassistant::global_homeassistant_time->get_timezone();
-      // Compare without allocating a string
-      if (current_tz.length() != value.timezone_len ||
-          memcmp(current_tz.c_str(), value.timezone, value.timezone_len) != 0) {
-        homeassistant::global_homeassistant_time->set_timezone(
-            std::string(reinterpret_cast<const char *>(value.timezone), value.timezone_len));
-      }
+      homeassistant::global_homeassistant_time->set_timezone(reinterpret_cast<const char *>(value.timezone),
+                                                             value.timezone_len);
     }
 #endif
   }

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -27,6 +27,14 @@ class RealTimeClock : public PollingComponent {
     this->apply_timezone_();
   }
 
+  /// Set the time zone from raw buffer, only if it differs from the current one.
+  void set_timezone(const char *tz, size_t len) {
+    if (this->timezone_.length() != len || memcmp(this->timezone_.c_str(), tz, len) != 0) {
+      this->timezone_.assign(tz, len);
+      this->apply_timezone_();
+    }
+  }
+
   /// Get the time zone currently in use.
   std::string get_timezone() { return this->timezone_; }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

This PR simplifies timezone handling in the API connection by adding a `set_timezone()` overload to `RealTimeClock` that accepts raw buffer data (`const char*`, `size_t`). This reduces complexity in `APIConnection::on_get_time_response()` and provides a cleaner, more idiomatic API.

**Changes:**
- Added `set_timezone(const char*, size_t)` overload to `RealTimeClock` that handles comparison internally
- Simplified `APIConnection::on_get_time_response()` by removing manual timezone comparison logic
- Reduced flash usage by 8 bytes by moving comparison logic into a header-based overload

**Benefits:**
- **Reduced complexity**: API connection code is simpler and more focused
- **Better encapsulation**: Comparison logic lives in the `RealTimeClock` class where it belongs
- **Improved maintainability**: Function overloading is more idiomatic than manual buffer comparisons in caller code
- **Small flash savings**: Header-based implementation allows better compiler optimization

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code quality improvement, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
