### PR TITLE
[total_daily_energy] Fix ID conflicts in component test configuration

### DIFF
--- a/tests/components/total_daily_energy/common.yaml
+++ b/tests/components/total_daily_energy/common.yaml
@@ -17,10 +17,10 @@ sensor:
       name: HLW8012 Voltage
     power:
       name: HLW8012 Power
-      id: hlw8012_power
+      id: total_daily_energy_hlw8012_power
     energy:
       name: HLW8012 Energy
-      id: hlw8012_energy
+      id: total_daily_energy_hlw8012_energy
     update_interval: 15s
     current_resistor: 0.001 ohm
     voltage_divider: 2351
@@ -29,4 +29,4 @@ sensor:
     model: hlw8012
   - platform: total_daily_energy
     name: HLW8012 Total Daily Energy
-    power_id: hlw8012_power
+    power_id: total_daily_energy_hlw8012_power


### PR DESCRIPTION
# What does this implement/fix?

Fixes ID conflicts in `total_daily_energy` component test configuration to allow proper component test grouping.

The `total_daily_energy` component test was using the same IDs (`hlw8012_power` and `hlw8012_energy`) as the `hlw8012` component test. This caused ID conflicts when these components were merged together during grouped component testing, resulting in validation errors.

This change makes the IDs in the `total_daily_energy` test configuration unique by prefixing them with the component name.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Internal test infrastructure improvement

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes - this is a test configuration update only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
