### PR TITLE
[ci] test_build_components: clean & retry on compile failure

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -36,8 +36,7 @@ def patch_structhash():
         ):
             fs.rmtree(build_dir)
 
-        if not build_dir.is_dir():
-            build_dir.mkdir(parents=True)
+        build_dir.mkdir(parents=True, exist_ok=True)
 
     helpers.clean_build_dir = patched_clean_build_dir
     cli.clean_build_dir = patched_clean_build_dir

--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -313,7 +313,7 @@ def analyze_component(component_dir: Path) -> tuple[dict[str, list[str]], bool, 
 
 
 def analyze_all_components(
-    tests_dir: Path = None,
+    tests_dir: Path | None = None,
 ) -> tuple[dict[str, dict[str, list[str]]], set[str], set[str]]:
     """Analyze all component test directories.
 

--- a/script/test_build_components.py
+++ b/script/test_build_components.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass
 import hashlib
 import os
@@ -24,11 +25,13 @@ from pathlib import Path
 import subprocess
 import sys
 import time
+from typing import ParamSpec
 
 # Add esphome to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # pylint: disable=wrong-import-position
+from esphome.core import EsphomeError
 from script.analyze_component_buses import (
     BASE_BUS_COMPONENTS,
     ISOLATED_COMPONENTS,
@@ -295,6 +298,23 @@ def extract_platform_with_version(base_file: Path) -> str:
     return base_file.stem.replace("build_components_base.", "")
 
 
+Params = ParamSpec("Params")
+
+
+def run_with_clean_retry(
+    func: Callable[Params, TestResult], *args: Params.args, **kwargs: Params.kwargs
+) -> TestResult:
+    try:
+        result: TestResult = func(*args, **kwargs)
+        if not result.success:
+            raise EsphomeError("Test failed")
+        return result
+    except Exception as e:
+        print(f"{func.__name__} failed ({e}), retrying with perform_clean=True...")
+        kwargs["perform_clean"] = True
+        return func(*args, **kwargs)
+
+
 def run_esphome_test(
     component: str,
     test_file: Path,
@@ -305,6 +325,7 @@ def run_esphome_test(
     esphome_command: str,
     continue_on_fail: bool,
     use_testing_mode: bool = False,
+    perform_clean: bool = False,
 ) -> TestResult:
     """Run esphome test for a single component.
 
@@ -364,11 +385,22 @@ def run_esphome_test(
         ]
     )
 
+    cmd_clean = cmd[:]
+
     # Add command and config file
     cmd.extend([esphome_command, str(output_file)])
+    cmd_clean.extend(["clean", str(output_file)])
 
     # Build command string for display/logging
     cmd_str = " ".join(cmd)
+
+    # Clean if requested
+    if perform_clean:
+        print("Cleaning")
+        try:
+            _ = subprocess.run(cmd_clean, check=False)
+        except Exception as e:
+            print(f"Error cleaning: {e}")
 
     # Run command
     print(f"> [{component}] [{test_name}] [{platform_with_version}]")
@@ -429,6 +461,7 @@ def run_grouped_test(
     tests_dir: Path,
     esphome_command: str,
     continue_on_fail: bool,
+    perform_clean: bool = False,
 ) -> TestResult:
     """Run esphome test for a group of components with shared bus configs.
 
@@ -507,9 +540,19 @@ def run_grouped_test(
         "-s",
         "target_platform",
         platform,
-        esphome_command,
-        str(output_file),
     ]
+
+    cmd_clean = cmd[:]
+
+    cmd.extend([esphome_command, str(output_file)])
+    cmd_clean.extend(["clean", str(output_file)])
+
+    if perform_clean:
+        print("Cleaning")
+        try:
+            _ = subprocess.run(cmd_clean, check=False)
+        except Exception as e:
+            print(f"Error cleaning: {e}")
 
     # Build command string for display/logging
     cmd_str = " ".join(cmd)
@@ -860,7 +903,8 @@ def run_grouped_component_tests(
                 continue
 
             # Run grouped test
-            test_result = run_grouped_test(
+            test_result = run_with_clean_retry(
+                run_grouped_test,
                 components=components_to_group,
                 platform=platform,
                 platform_with_version=platform_with_version,
@@ -869,6 +913,7 @@ def run_grouped_component_tests(
                 tests_dir=tests_dir,
                 esphome_command=esphome_command,
                 continue_on_fail=continue_on_fail,
+                perform_clean=True,
             )
 
             # Mark all components as tested
@@ -911,7 +956,8 @@ def run_individual_component_test(
     if (component, platform_with_version) in tested_components:
         return
 
-    test_result = run_esphome_test(
+    test_result: TestResult = run_with_clean_retry(
+        run_esphome_test,
         component=component,
         test_file=test_file,
         platform=platform,
@@ -920,7 +966,9 @@ def run_individual_component_test(
         build_dir=build_dir,
         esphome_command=esphome_command,
         continue_on_fail=continue_on_fail,
+        perform_clean=False,
     )
+
     test_results.append(test_result)
 
 


### PR DESCRIPTION


# What does this implement/fix?

Some tests failed due to missing files required for leftover compilation targets from previous builds. Performing a clean build solves this issue so a clean-and-retry-once strategy has been implemented to mitigate this issue.

```
INFO ESPHome 2025.11.0-dev
INFO Reading configuration esphome/tests/test_build_components/build/canbus.test.esp32-c3-idf.yaml...
INFO Generating C++ source...
INFO Compiling app...
Processing componenttestesp32c3idf (board: lolin_c3_mini; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/55.03.31-1/platform-espressif32.zip)
--------------------------------------------------------------------------------------------------------------------------
INFO Package configuration completed successfully
INFO Package configuration completed successfully
HARDWARE: ESP32C3 160MHz, 320KB RAM, 4MB Flash
 - contrib-piohome @ 3.4.4 
 - framework-espidf @ 3.50501.0 (5.5.1) 
 - tool-cmake @ 4.0.3 
 - tool-esp-rom-elfs @ 2024.10.11 
 - tool-esptoolpy @ 5.1.0 
 - tool-mklittlefs @ 3.2.0 
 - tool-ninja @ 1.13.1 
 - tool-scons @ 4.40801.0 (4.8.1) 
 - toolchain-riscv32-esp @ 14.2.0+20241119
Reading CMake configuration...
No dependencies
*** [.pioenvs/componenttestesp32c3idf/src/esphome/components/animation/animation.cpp.o] Source `src/esphome/components/animation/animation.cpp' not found, needed by target `.pioenvs/componenttestesp32c3idf/src/esphome/components/animation/animation.cpp.o'.
=============================================== [FAILED] Took 2.96 seconds ===============================================
> [esphome] [test] [esp32-c3-idf]


INFO ESPHome 2025.11.0-dev
INFO Reading configuration esphome/tests/test_build_components/build/matrix_keypad.test.esp32-c3-idf.yaml...
WARNING GPIO2 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
INFO Generating C++ source...
INFO Compiling app...
Processing componenttestesp32c3idf (board: lolin_c3_mini; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/55.03.31-1/platform-espressif32.zip)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
INFO Package configuration completed successfully
INFO Package configuration completed successfully
HARDWARE: ESP32C3 160MHz, 320KB RAM, 4MB Flash
 - contrib-piohome @ 3.4.4 
 - framework-espidf @ 3.50501.0 (5.5.1) 
 - tool-cmake @ 4.0.3 
 - tool-esp-rom-elfs @ 2024.10.11 
 - tool-esptoolpy @ 5.1.0 
 - tool-mklittlefs @ 3.2.0 
 - tool-ninja @ 1.13.1 
 - tool-scons @ 4.40801.0 (4.8.1) 
 - toolchain-riscv32-esp @ 14.2.0+20241119
Reading CMake configuration...
No dependencies
*** [.pioenvs/componenttestesp32c3idf/src/esphome/components/display/display.cpp.o] Source `src/esphome/components/display/display.cpp' not found, needed by target `.pioenvs/componenttestesp32c3idf/src/esphome/components/display/display.cpp.o'.
```

After the changes
```
INFO Successfully compiled program.
> [canbus] [test] [esp32-c3-idf]
INFO ESPHome 2025.11.0-dev
INFO Reading configuration esphome/tests/test_build_components/build/canbus.test.esp32-c3-idf.yaml...
INFO Generating C++ source...
INFO Compiling app...
Processing componenttestesp32c3idf (board: lolin_c3_mini; framework: espidf; platform: https://github.com/pioarduino/platform-espressif32/releases/download/55.03.31-1/platform-espressif32.zip)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
INFO Package configuration completed successfully
INFO Package configuration completed successfully
HARDWARE: ESP32C3 160MHz, 320KB RAM, 4MB Flash
 - contrib-piohome @ 3.4.4 
 - framework-espidf @ 3.50501.0 (5.5.1) 
 - tool-cmake @ 4.0.3 
 - tool-esp-rom-elfs @ 2024.10.11 
 - tool-esptoolpy @ 5.1.0 
 - tool-mklittlefs @ 3.2.0 
 - tool-ninja @ 1.13.1 
 - tool-scons @ 4.40801.0 (4.8.1) 
 - toolchain-riscv32-esp @ 14.2.0+20241119
Reading CMake configuration...
No dependencies
*** [.pioenvs/componenttestesp32c3idf/src/esphome/components/animation/animation.cpp.o] Source `src/esphome/components/animation/animation.cpp' not found, needed by target `.pioenvs/componenttestesp32c3idf/src/esphome/components/animation/animation.cpp.o'.
============================================================================ [FAILED] Took 2.70 seconds ============================================================================
run_esphome_test failed (Test failed), retrying with perform_clean=True...
Cleaning
INFO ESPHome 2025.11.0-dev
INFO Reading configuration esphome/tests/test_build_components/build/canbus.test.esp32-c3-idf.yaml...
INFO Deleting esphome/tests/test_build_components/build/.esphome/build/componenttestesp32c3idf/.pioenvs
INFO Deleting esphome/tests/test_build_components/build/.esphome/build/componenttestesp32c3idf/dependencies.lock
INFO Deleting PlatformIO cache /home/juen/.platformio/.cache
INFO Done!
> [canbus] [test] [esp32-c3-idf]
[...]
Wrote 0x4a330 bytes to file 'esphome/tests/test_build_components/build/.esphome/build/componenttestesp32c3idf/.pioenvs/componenttestesp32c3idf/firmware.factory.bin', ready to flash to offset 0x0.
Successfully created esphome/tests/test_build_components/build/.esphome/build/componenttestesp32c3idf/.pioenvs/componenttestesp32c3idf/firmware.factory.bin
esp32_copy_ota_bin([".pioenvs/componenttestesp32c3idf/firmware.bin"], [".pioenvs/componenttestesp32c3idf/firmware.elf"])
Copied firmware to esphome/tests/test_build_components/build/.esphome/build/componenttestesp32c3idf/.pioenvs/componenttestesp32c3idf/firmware.ota.bin
=========================================================================== [SUCCESS] Took 13.93 seconds ===========================================================================
INFO Successfully compiled program.
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
