### PR TITLE
make types sensors_t and sensor_type_t internal to StatsdComponent

### DIFF
--- a/esphome/components/statsd/statsd.h
+++ b/esphome/components/statsd/statsd.h
@@ -28,21 +28,6 @@
 namespace esphome {
 namespace statsd {
 
-using sensor_type_t = enum { TYPE_SENSOR, TYPE_BINARY_SENSOR };
-
-using sensors_t = struct {
-  const char *name;
-  sensor_type_t type;
-  union {
-#ifdef USE_SENSOR
-    esphome::sensor::Sensor *sensor;
-#endif
-#ifdef USE_BINARY_SENSOR
-    esphome::binary_sensor::BinarySensor *binary_sensor;
-#endif
-  };
-};
-
 class StatsdComponent : public PollingComponent {
  public:
   ~StatsdComponent();
@@ -70,6 +55,20 @@ class StatsdComponent : public PollingComponent {
   const char *host_;
   const char *prefix_;
   uint16_t port_;
+
+  using sensor_type_t = enum { TYPE_SENSOR, TYPE_BINARY_SENSOR };
+  using sensors_t = struct {
+    const char *name;
+    sensor_type_t type;
+    union {
+#ifdef USE_SENSOR
+      esphome::sensor::Sensor *sensor;
+#endif
+#ifdef USE_BINARY_SENSOR
+      esphome::binary_sensor::BinarySensor *binary_sensor;
+#endif
+    };
+  };
 
   std::vector<sensors_t> sensors_;
 


### PR DESCRIPTION

# What does this implement/fix?
This commit moves the sensors_t and sensor_type_t type definitions inside the StatsdComponent class, since they are only used internally.

Having them declared at the namespace level caused the following compile warning:
```
src/esphome/components/statsd/statsd.h:46:7: warning: 'esphome::statsd::StatsdComponent' has a field
'std::vector<esphome::statsd::<unnamed struct> >
 esphome::statsd::StatsdComponent::sensors_'
 whose type has internal linkage [-Wsubobject-linkage]
   46 | class StatsdComponent : public PollingComponent {
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
