### PR TITLE
[mdns] Use std::unique_ptr for TXT records to reduce ESP32 flash usage

### DIFF
--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -31,19 +31,17 @@ void MDNSComponent::setup() {
   mdns_instance_name_set(this->hostname_.c_str());
 
   for (const auto &service : services) {
-    FixedVector<mdns_txt_item_t> txt_records;
-    txt_records.init(service.txt_records.size());
-    for (const auto &record : service.txt_records) {
-      mdns_txt_item_t it{};
+    auto txt_records = std::make_unique<mdns_txt_item_t[]>(service.txt_records.size());
+    for (size_t i = 0; i < service.txt_records.size(); i++) {
+      const auto &record = service.txt_records[i];
       // key and value are either compile-time string literals in flash or pointers to dynamic_txt_values_
       // Both remain valid for the lifetime of this function, and ESP-IDF makes internal copies
-      it.key = MDNS_STR_ARG(record.key);
-      it.value = MDNS_STR_ARG(record.value);
-      txt_records.push_back(it);
+      txt_records[i].key = MDNS_STR_ARG(record.key);
+      txt_records[i].value = MDNS_STR_ARG(record.value);
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,
-                           txt_records.begin(), txt_records.size());
+                           txt_records.get(), service.txt_records.size());
 
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "Failed to register service %s: %s", MDNS_STR_ARG(service.service_type), esp_err_to_name(err));

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -31,7 +31,8 @@ void MDNSComponent::setup() {
   mdns_instance_name_set(this->hostname_.c_str());
 
   for (const auto &service : services) {
-    std::vector<mdns_txt_item_t> txt_records;
+    FixedVector<mdns_txt_item_t> txt_records;
+    txt_records.init(service.txt_records.size());
     for (const auto &record : service.txt_records) {
       mdns_txt_item_t it{};
       // key and value are either compile-time string literals in flash or pointers to dynamic_txt_values_
@@ -42,7 +43,7 @@ void MDNSComponent::setup() {
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,
-                           txt_records.data(), txt_records.size());
+                           txt_records.begin(), txt_records.size());
 
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "Failed to register service %s: %s", MDNS_STR_ARG(service.service_type), esp_err_to_name(err));


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the ESP32 mDNS component by replacing `std::vector<mdns_txt_item_t>` with `std::unique_ptr<mdns_txt_item_t[]>` for TXT record handling.

The TXT records vector is used as a temporary buffer to pass data to the ESP-IDF mDNS API. Since:
1. The size is known at runtime (`service.txt_records.size()`)
2. The buffer is only used to build and pass data to the API
3. No vector operations (dynamic growth, capacity management) are needed

Using `std::unique_ptr<T[]>` is more appropriate and eliminates all `std::vector` template overhead including reallocation machinery, iterator infrastructure, and capacity tracking.

**Flash savings: 212 bytes** on ESP32

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
# Existing mDNS configurations work unchanged

mdns:
  # All existing functionality remains the same
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Technical Details

**Before:**
```cpp
for (const auto &service : services) {
  std::vector<mdns_txt_item_t> txt_records;
  for (const auto &record : service.txt_records) {
    mdns_txt_item_t it{};
    // key and value are either compile-time string literals in flash or pointers to dynamic_txt_values_
    // Both remain valid for the lifetime of this function, and ESP-IDF makes internal copies
    it.key = MDNS_STR_ARG(record.key);
    it.value = MDNS_STR_ARG(record.value);
    txt_records.push_back(it);
  }
  uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
  err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,
                         txt_records.data(), txt_records.size());
}
```

**After:**
```cpp
for (const auto &service : services) {
  auto txt_records = std::make_unique<mdns_txt_item_t[]>(service.txt_records.size());
  for (size_t i = 0; i < service.txt_records.size(); i++) {
    const auto &record = service.txt_records[i];
    // key and value are either compile-time string literals in flash or pointers to dynamic_txt_values_
    // Both remain valid for the lifetime of this function, and ESP-IDF makes internal copies
    txt_records[i].key = MDNS_STR_ARG(record.key);
    txt_records[i].value = MDNS_STR_ARG(record.value);
  }
  uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
  err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,
                         txt_records.get(), service.txt_records.size());
}
```

**Benefits:**
- Single allocation with exact size known upfront
- No `std::vector` reallocation machinery in generated code
- No capacity management or push_back overhead
- Maintains same functionality and readability
- Array access syntax (`txt_records[i]`) unchanged
- Automatic cleanup via RAII

**Why `std::unique_ptr<T[]>` over `std::vector` here:**
- This is a temporary buffer to pass to ESP-IDF API, not a dynamic collection
- Size is known at allocation time from `service.txt_records.size()`
- No need for bounds checking, iterators, or dynamic growth
- Simpler semantics: just a smart pointer to an array
- Follows ESPHome embedded systems guidelines for byte buffers
