### PR TITLE
[wifi] Replace std::vector with std::unique_ptr for WiFi scan buffer

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -776,13 +776,12 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     }
 
     uint16_t number = it.number;
-    std::vector<wifi_ap_record_t> records(number);
-    err = esp_wifi_scan_get_ap_records(&number, records.data());
+    auto records = std::make_unique<wifi_ap_record_t[]>(number);
+    err = esp_wifi_scan_get_ap_records(&number, records.get());
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
       return;
     }
-    records.resize(number);
 
     scan_result_.init(number);
     for (int i = 0; i < number; i++) {


### PR DESCRIPTION
# What does this implement/fix?

This PR reduces flash usage in the ESP32 WiFi component by replacing `std::vector<wifi_ap_record_t>` with `std::unique_ptr<wifi_ap_record_t[]>` for the WiFi scan results buffer.

The WiFi scan results vector is used as a simple buffer to receive data from the ESP-IDF API `esp_wifi_scan_get_ap_records()`. Since:
1. The size is known at runtime (`number` from scan results)
2. The buffer is only used to receive data and iterate once
3. No vector operations (push_back, resize beyond initial allocation, etc.) are needed

Using `std::unique_ptr<T[]>` is more appropriate and eliminates all `std::vector` template overhead including reallocation machinery, capacity management, and iterator infrastructure.

**Flash savings: 328 bytes** on ESP32

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
# Existing WiFi configurations work unchanged

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Technical Details

**Before:**
```cpp
uint16_t number = it.number;
std::vector<wifi_ap_record_t> records(number);
err = esp_wifi_scan_get_ap_records(&number, records.data());
if (err != ESP_OK) {
  ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
  return;
}
records.resize(number);

scan_result_.init(number);
for (int i = 0; i < number; i++) {
  auto &record = records[i];
  // ...
}
```

**After:**
```cpp
uint16_t number = it.number;
auto records = std::make_unique<wifi_ap_record_t[]>(number);
err = esp_wifi_scan_get_ap_records(&number, records.get());
if (err != ESP_OK) {
  ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
  return;
}

scan_result_.init(number);
for (int i = 0; i < number; i++) {
  auto &record = records[i];
  // ...
}
```

**Benefits:**
- Single allocation with exact size known upfront
- No `std::vector` reallocation machinery in generated code
- No capacity management or resize overhead
- Maintains same functionality and readability
- Array access syntax (`records[i]`) unchanged
- Automatic cleanup via RAII

**Why `std::unique_ptr<T[]>` over `std::vector` here:**
- This is a temporary buffer filled by ESP-IDF API, not a dynamic collection
- Size is known at allocation time and never changes
- No need for bounds checking, iterators, or dynamic growth
- Simpler semantics: just a smart pointer to an array
- Follows ESPHome embedded systems guidelines for byte buffers
