### PR TITLE
[nrf52] fix task names in logs

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -180,7 +180,9 @@ class Logger : public Component {
   inline void HOT format_log_to_buffer_with_terminator_(uint8_t level, const char *tag, int line, const char *format,
                                                         va_list args, char *buffer, uint16_t *buffer_at,
                                                         uint16_t buffer_size) {
-#if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+    this->write_header_to_buffer_(level, tag, line, this->get_thread_name_(), buffer, buffer_at, buffer_size);
+#elif defined(USE_ZEPHYR)
     char buff[MAX_POINTER_REPRESENTATION];
     this->write_header_to_buffer_(level, tag, line, this->get_thread_name_(buff), buffer, buffer_at, buffer_size);
 #else
@@ -281,7 +283,11 @@ class Logger : public Component {
 #endif
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
-  const char *HOT get_thread_name_(char *buff) {
+  const char *HOT get_thread_name_(
+#ifdef USE_ZEPHYR
+      char *buff
+#endif
+  ) {
 #ifdef USE_ZEPHYR
     k_tid_t current_task = k_current_get();
 #else

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -68,6 +68,9 @@ static constexpr char LOG_LEVEL_LETTER_CHARS[] = {
 // Maximum header size: 35 bytes fixed + 32 bytes tag + 16 bytes thread name = 83 bytes (45 byte safety margin)
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
 
+// "0x" + 2 hex digits per byte + '\0'
+static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
+
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
 /** Enum for logging UART selection
  *
@@ -178,7 +181,8 @@ class Logger : public Component {
                                                         va_list args, char *buffer, uint16_t *buffer_at,
                                                         uint16_t buffer_size) {
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
-    this->write_header_to_buffer_(level, tag, line, this->get_thread_name_(), buffer, buffer_at, buffer_size);
+    char buff[MAX_POINTER_REPRESENTATION];
+    this->write_header_to_buffer_(level, tag, line, this->get_thread_name_(buff), buffer, buffer_at, buffer_size);
 #else
     this->write_header_to_buffer_(level, tag, line, nullptr, buffer, buffer_at, buffer_size);
 #endif
@@ -277,7 +281,7 @@ class Logger : public Component {
 #endif
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
-  const char *HOT get_thread_name_() {
+  const char *HOT get_thread_name_(char *buff) {
 #ifdef USE_ZEPHYR
     k_tid_t current_task = k_current_get();
 #else
@@ -291,7 +295,13 @@ class Logger : public Component {
 #elif defined(USE_LIBRETINY)
       return pcTaskGetTaskName(current_task);
 #elif defined(USE_ZEPHYR)
-      return k_thread_name_get(current_task);
+      const char *name = k_thread_name_get(current_task);
+      if (name) {
+        // zephyr print task names only if debug component is present
+        return name;
+      }
+      std::snprintf(buff, MAX_POINTER_REPRESENTATION, "%p", current_task);
+      return buff;
 #endif
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Fix login of thread name on nrf52. Default:
```
[10:42:01.422][I][zephyr_ble_server:039][0x20002c90]: Advertising successfully started
[10:42:01.422][C][component:173]: Setup zephyr_ble_server took 5ms
```
with debug component:
```
[10:43:03.695][I][zephyr_ble_server:039][sysworkq]: Advertising successfully started
[10:43:03.696][C][component:173]: Setup zephyr_ble_server took 5ms
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
