### PR TITLE
Migrate from hexencode() to format_hex_pretty() in Kuntze component

### DIFF
--- a/esphome/components/kuntze/kuntze.cpp
+++ b/esphome/components/kuntze/kuntze.cpp
@@ -14,7 +14,7 @@ void Kuntze::on_modbus_data(const std::vector<uint8_t> &data) {
   auto get_16bit = [&](int i) -> uint16_t { return (uint16_t(data[i * 2]) << 8) | uint16_t(data[i * 2 + 1]); };
 
   this->waiting_ = false;
-  ESP_LOGV(TAG, "Data: %s", hexencode(data).c_str());
+  ESP_LOGV(TAG, "Data: %s", format_hex_pretty(data).c_str());
 
   float value = (float) get_16bit(0);
   for (int i = 0; i < data[3]; i++)


### PR DESCRIPTION
# What does this implement/fix?
Migrate component Kuntze from using hexencode() to format_hex_pretty().

Function hexencode() was marked for removal on 2022.01. This was the last bit of code using hexencode().

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
