### PR TITLE
Add support for proper list parameters to script component

### DIFF
--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -21,6 +21,7 @@ from esphome.cpp_generator import (  # noqa: F401
     Statement,
     StructInitializer,
     TemplateArguments,
+    TypedArrayInitializer,
     add,
     add_build_flag,
     add_build_unflag,

--- a/esphome/components/script/__init__.py
+++ b/esphome/components/script/__init__.py
@@ -170,6 +170,18 @@ async def script_execute_action_to_code(config, action_id, template_arg, args):
                 return cg.RawExpression(str(value).lower())
             return cg.RawExpression(str(value))
 
+        def list_converter(value):
+            if not isinstance(value, list):
+                return converter(value)
+
+            item_type = type[len("std::vector<") : -1]
+            item_converter = convert(item_type)
+            return cg.TypedArrayInitializer(
+                type, *[item_converter(item) for item in value]
+            )
+
+        if type.startswith("std::vector<") and type.endswith(">"):
+            return list_converter
         return converter
 
     async def get_ordered_args(config, script_params):

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -158,6 +158,18 @@ class ArrayInitializer(Expression):
         return cpp
 
 
+class TypedArrayInitializer(ArrayInitializer):
+    __slots__ = ("type",)
+
+    def __init__(self, type_: str, *args: Any, multiline: bool = False):
+        super().__init__(*args, multiline=multiline)
+        self.type = type_
+
+    def __str__(self):
+        base_str = super().__str__()
+        return f"{self.type}{base_str}"
+
+
 class ParameterExpression(Expression):
     __slots__ = ("type", "id")
 

--- a/tests/components/script/common.yaml
+++ b/tests/components/script/common.yaml
@@ -14,6 +14,26 @@ esphome:
             - script.is_running: my_script
           then:
             - logger.log: my_script is running
+      - script.execute:
+          id: my_script_with_array_params
+          bools_param: [true, false, true]
+          numbers_param: [3, 2, 1]
+          strings_param: ["one", "two", "three"]
+      - script.wait: my_script_with_array_params
+      - script.execute:
+          id: my_script_with_array_params
+          bools_param:
+            - true
+            - false
+            - true
+          numbers_param:
+            - 3
+            - 2
+            - 1
+          strings_param:
+            - "one"
+            - "two"
+            - "three"
 
 script:
   - id: my_script
@@ -53,3 +73,14 @@ script:
           count: 5
           then:
             - logger.log: looping!
+  - id: my_script_with_array_params
+    mode: single
+    parameters:
+      bools_param: bool[]
+      numbers_param: int[]
+      strings_param: string[]
+    then:
+      - repeat:
+          count: !lambda 'return bools_param.size();'
+          then:
+            - lambda: 'ESP_LOGD("main", "Hello World! %d %d %s", bools_param[iteration], numbers_param[iteration], strings_param[iteration].c_str());'


### PR DESCRIPTION
# What does this implement/fix?

Implements support for providing yaml lists as input for array parameters in script components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3346

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  on_boot:
    priority: -100
    then:
      - script.execute: 
          id: my_script
          states:
            - true
            - true
            - false
          durations_ms: [200, 300, 0] # this syntax is supported as well.
          colors:
            - "1.0,0.0,0.0"
            - "0.0,1.0,0.0"
            - ""

script:
  - id: my_script
    mode: restart
    parameters: 
      states: bool[]
      durations_ms: int[]
      colors: string[]
    then: 
    - logger.log: "todo"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
