### PR TITLE
[ci] Fix memory impact analysis failing on fork PRs

### DIFF
--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -29,10 +29,8 @@ jobs:
           # Get PR details by searching for PR with matching head SHA
           # The workflow_run.pull_requests field is often empty for forks
           head_sha="${{ github.event.workflow_run.head_sha }}"
-          pr_data=$(gh api --paginate "/repos/${{ github.repository }}/pulls" \
-            --jq ".[] | select(.head.sha == \"$head_sha\") | {number: .number, base_ref: .base.ref}" \
-            | head -1)
-
+          pr_data=$(gh api "/repos/${{ github.repository }}/commits/$head_sha/pulls" \
+            --jq '.[0] | {number: .number, base_ref: .base.ref}')
           if [ -z "$pr_data" ] || [ "$pr_data" == "null" ]; then
             echo "No PR found for SHA $head_sha, skipping"
             echo "skip=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -93,35 +93,13 @@ jobs:
 
       - name: Post or update PR comment
         if: steps.pr.outputs.skip != 'true' && steps.check.outputs.found == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
-          # Extract data from JSON files
-          target_json="./memory-analysis/memory-analysis-target.json"
-          pr_json="./memory-analysis/memory-analysis-pr.json"
-
-          # Parse memory values
-          target_ram=$(jq -r '.ram_bytes' "$target_json")
-          target_flash=$(jq -r '.flash_bytes' "$target_json")
-          pr_ram=$(jq -r '.ram_bytes' "$pr_json")
-          pr_flash=$(jq -r '.flash_bytes' "$pr_json")
-
-          # Get platform and components from target JSON
-          platform=$(jq -r '.platform' "$target_json")
-          components=$(jq -r '.components | @json' "$target_json")
-
-          # Check for target cache hit (assume false if not present)
-          target_cache_hit=""
-          if [ "$(jq -r '.cache_hit // false' "$target_json")" == "true" ]; then
-            target_cache_hit="--target-cache-hit"
-          fi
-
+          # Pass PR number and JSON file paths directly to Python script
+          # Let Python parse the JSON to avoid shell injection risks
+          # The script will validate and sanitize all inputs
           python script/ci_memory_impact_comment.py \
-            --pr-number "${{ steps.pr.outputs.pr_number }}" \
-            --components "$components" \
-            --platform "$platform" \
-            --target-ram "$target_ram" \
-            --target-flash "$target_flash" \
-            --pr-ram "$pr_ram" \
-            --pr-flash "$pr_flash" \
-            --target-json "$target_json" \
-            --pr-json "$pr_json" \
-            $target_cache_hit
+            --pr-number "$PR_NUMBER" \
+            --target-json ./memory-analysis/memory-analysis-target.json \
+            --pr-json ./memory-analysis/memory-analysis-pr.json

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -22,32 +22,37 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Get PR number
+      - name: Get PR details
         id: pr
         run: |
-          # Get PR number by searching for PR with matching head SHA
+          # Get PR details by searching for PR with matching head SHA
           # The workflow_run.pull_requests field is often empty for forks
           head_sha="${{ github.event.workflow_run.head_sha }}"
-          pr_number=$(gh api "/repos/${{ github.repository }}/pulls" \
-            --jq ".[] | select(.head.sha == \"$head_sha\") | .number" \
+          pr_data=$(gh api "/repos/${{ github.repository }}/pulls" \
+            --jq ".[] | select(.head.sha == \"$head_sha\") | {number: .number, base_ref: .base.ref}" \
             | head -1)
 
-          if [ -z "$pr_number" ] || [ "$pr_number" == "null" ]; then
+          if [ -z "$pr_data" ] || [ "$pr_data" == "null" ]; then
             echo "No PR found for SHA $head_sha, skipping"
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
+          pr_number=$(echo "$pr_data" | jq -r '.number')
+          base_ref=$(echo "$pr_data" | jq -r '.base_ref')
+
           echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+          echo "base_ref=$base_ref" >> $GITHUB_OUTPUT
+          echo "Found PR #$pr_number targeting base branch: $base_ref"
 
       - name: Check out code from base repository
         if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # Always check out from the base repository (esphome/esphome), never from forks
-          # This ensures we only run trusted code from the main repo
+          # Use the PR's target branch to ensure we run trusted code from the main repo
           repository: ${{ github.repository }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ steps.pr.outputs.base_ref }}
 
       - name: Set up Python
         if: steps.pr.outputs.skip != 'true'

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -1,0 +1,127 @@
+---
+name: Memory Impact Comment (Forks)
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  memory-impact-comment:
+    name: Post memory impact comment (fork PRs only)
+    runs-on: ubuntu-24.04
+    # Only run for PRs from forks that had successful CI runs
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          # Get PR number by searching for PR with matching head SHA
+          # The workflow_run.pull_requests field is often empty for forks
+          head_sha="${{ github.event.workflow_run.head_sha }}"
+          pr_number=$(gh api "/repos/${{ github.repository }}/pulls" \
+            --jq ".[] | select(.head.sha == \"$head_sha\") | .number" \
+            | head -1)
+
+          if [ -z "$pr_number" ] || [ "$pr_number" == "null" ]; then
+            echo "No PR found for SHA $head_sha, skipping"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+
+      - name: Check out code from base branch
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          pip install jinja2
+
+      - name: Download memory analysis artifacts
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          run_id="${{ github.event.workflow_run.id }}"
+          echo "Downloading artifacts from workflow run $run_id"
+
+          # Download target analysis
+          gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+            --jq '.artifacts[] | select(.name == "memory-analysis-target") | .archive_download_url' \
+            | xargs -I {} gh api {} > memory-analysis-target.zip || true
+
+          # Download PR analysis
+          gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+            --jq '.artifacts[] | select(.name == "memory-analysis-pr") | .archive_download_url' \
+            | xargs -I {} gh api {} > memory-analysis-pr.zip || true
+
+          # Extract artifacts
+          mkdir -p memory-analysis
+          if [ -f memory-analysis-target.zip ]; then
+            unzip -q memory-analysis-target.zip -d memory-analysis/
+          fi
+          if [ -f memory-analysis-pr.zip ]; then
+            unzip -q memory-analysis-pr.zip -d memory-analysis/
+          fi
+
+      - name: Check if artifacts exist
+        id: check
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          if [ -f ./memory-analysis/memory-analysis-target.json ] && [ -f ./memory-analysis/memory-analysis-pr.json ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+            echo "Memory analysis artifacts not found, skipping comment"
+          fi
+
+      - name: Post or update PR comment
+        if: steps.pr.outputs.skip != 'true' && steps.check.outputs.found == 'true'
+        run: |
+          # Extract data from JSON files
+          target_json="./memory-analysis/memory-analysis-target.json"
+          pr_json="./memory-analysis/memory-analysis-pr.json"
+
+          # Parse memory values
+          target_ram=$(jq -r '.ram_bytes' "$target_json")
+          target_flash=$(jq -r '.flash_bytes' "$target_json")
+          pr_ram=$(jq -r '.ram_bytes' "$pr_json")
+          pr_flash=$(jq -r '.flash_bytes' "$pr_json")
+
+          # Get platform and components from target JSON
+          platform=$(jq -r '.platform' "$target_json")
+          components=$(jq -r '.components | @json' "$target_json")
+
+          # Check for target cache hit (assume false if not present)
+          target_cache_hit=""
+          if [ "$(jq -r '.cache_hit // false' "$target_json")" == "true" ]; then
+            target_cache_hit="--target-cache-hit"
+          fi
+
+          python script/ci_memory_impact_comment.py \
+            --pr-number "${{ steps.pr.outputs.pr_number }}" \
+            --components "$components" \
+            --platform "$platform" \
+            --target-ram "$target_ram" \
+            --target-flash "$target_flash" \
+            --pr-ram "$pr_ram" \
+            --pr-flash "$pr_flash" \
+            --target-json "$target_json" \
+            --pr-json "$pr_json" \
+            $target_cache_hit

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  actions: read
 
 jobs:
   memory-impact-comment:
@@ -28,7 +29,7 @@ jobs:
           # Get PR details by searching for PR with matching head SHA
           # The workflow_run.pull_requests field is often empty for forks
           head_sha="${{ github.event.workflow_run.head_sha }}"
-          pr_data=$(gh api "/repos/${{ github.repository }}/pulls" \
+          pr_data=$(gh api --paginate "/repos/${{ github.repository }}/pulls" \
             --jq ".[] | select(.head.sha == \"$head_sha\") | {number: .number, base_ref: .base.ref}" \
             | head -1)
 
@@ -67,23 +68,28 @@ jobs:
           run_id="${{ github.event.workflow_run.id }}"
           echo "Downloading artifacts from workflow run $run_id"
 
+          mkdir -p memory-analysis
+
           # Download target analysis
-          gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
-            --jq '.artifacts[] | select(.name == "memory-analysis-target") | .archive_download_url' \
-            | xargs -I {} gh api {} > memory-analysis-target.zip || true
+          target_url=$(gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+            --jq '.artifacts[] | select(.name == "memory-analysis-target") | .archive_download_url')
+          if [ -n "$target_url" ]; then
+            echo "Found memory-analysis-target artifact, downloading..."
+            gh api "$target_url" > memory-analysis-target.zip
+            unzip -q memory-analysis-target.zip -d memory-analysis/
+          else
+            echo "No memory-analysis-target artifact found."
+          fi
 
           # Download PR analysis
-          gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
-            --jq '.artifacts[] | select(.name == "memory-analysis-pr") | .archive_download_url' \
-            | xargs -I {} gh api {} > memory-analysis-pr.zip || true
-
-          # Extract artifacts
-          mkdir -p memory-analysis
-          if [ -f memory-analysis-target.zip ]; then
-            unzip -q memory-analysis-target.zip -d memory-analysis/
-          fi
-          if [ -f memory-analysis-pr.zip ]; then
+          pr_url=$(gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
+            --jq '.artifacts[] | select(.name == "memory-analysis-pr") | .archive_download_url')
+          if [ -n "$pr_url" ]; then
+            echo "Found memory-analysis-pr artifact, downloading..."
+            gh api "$pr_url" > memory-analysis-pr.zip
             unzip -q memory-analysis-pr.zip -d memory-analysis/
+          else
+            echo "No memory-analysis-pr artifact found."
           fi
 
       - name: Check if artifacts exist

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -40,9 +40,14 @@ jobs:
 
           echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
 
-      - name: Check out code from base branch
+      - name: Check out code from base repository
         if: steps.pr.outputs.skip != 'true'
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # Always check out from the base repository (esphome/esphome), never from forks
+          # This ensures we only run trusted code from the main repo
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Set up Python
         if: steps.pr.outputs.skip != 'true'

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -70,24 +70,16 @@ jobs:
 
           mkdir -p memory-analysis
 
-          # Download target analysis
-          target_url=$(gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
-            --jq '.artifacts[] | select(.name == "memory-analysis-target") | .archive_download_url')
-          if [ -n "$target_url" ]; then
-            echo "Found memory-analysis-target artifact, downloading..."
-            gh api "$target_url" > memory-analysis-target.zip
-            unzip -q memory-analysis-target.zip -d memory-analysis/
+          # Download target analysis artifact
+          if gh run download --name "memory-analysis-target" --dir memory-analysis --repo "${{ github.repository }}" "$run_id"; then
+            echo "Downloaded memory-analysis-target artifact."
           else
             echo "No memory-analysis-target artifact found."
           fi
 
-          # Download PR analysis
-          pr_url=$(gh api "/repos/${{ github.repository }}/actions/runs/${run_id}/artifacts" \
-            --jq '.artifacts[] | select(.name == "memory-analysis-pr") | .archive_download_url')
-          if [ -n "$pr_url" ]; then
-            echo "Found memory-analysis-pr artifact, downloading..."
-            gh api "$pr_url" > memory-analysis-pr.zip
-            unzip -q memory-analysis-pr.zip -d memory-analysis/
+          # Download PR analysis artifact
+          if gh run download --name "memory-analysis-pr" --dir memory-analysis --repo "${{ github.repository }}" "$run_id"; then
+            echo "Downloaded memory-analysis-pr artifact."
           else
             echo "No memory-analysis-pr artifact found."
           fi
@@ -108,6 +100,7 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
         run: |
+          . venv/bin/activate
           # Pass PR number and JSON file paths directly to Python script
           # Let Python parse the JSON to avoid shell injection risks
           # The script will validate and sanitize all inputs

--- a/.github/workflows/ci-memory-impact-comment.yml
+++ b/.github/workflows/ci-memory-impact-comment.yml
@@ -54,16 +54,12 @@ jobs:
           repository: ${{ github.repository }}
           ref: ${{ steps.pr.outputs.base_ref }}
 
-      - name: Set up Python
+      - name: Restore Python
         if: steps.pr.outputs.skip != 'true'
-        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        uses: ./.github/actions/restore-python
         with:
           python-version: "3.11"
-
-      - name: Install dependencies
-        if: steps.pr.outputs.skip != 'true'
-        run: |
-          pip install jinja2
+          cache-key: ${{ hashFiles('.cache-key') }}
 
       - name: Download memory analysis artifacts
         if: steps.pr.outputs.skip != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,7 +600,7 @@ jobs:
           fi
 
       - name: Restore Python
-        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
+        if: steps.check-script.outputs.skip != 'true'
         uses: ./.github/actions/restore-python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
@@ -649,13 +649,13 @@ jobs:
           key: ${{ steps.cache-key.outputs.cache-key }}
 
       - name: Add metadata to JSON
-        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
+        if: steps.check-script.outputs.skip != 'true'
         run: |
           . venv/bin/activate
           components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
           platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
 
-          # Add metadata to newly generated JSON (cache miss means we just built it)
+          # Add metadata to JSON (works for both cache hit and cache miss)
           python script/ci_add_metadata_to_json.py \
             --json-file memory-analysis-target.json \
             --components "$components" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,51 +764,16 @@ jobs:
         continue-on-error: true
       - name: Post or update PR comment
         env:
-          COMPONENTS: ${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}
-          PLATFORM: ${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}
-          TARGET_RAM: ${{ needs.memory-impact-target-branch.outputs.ram_usage }}
-          TARGET_FLASH: ${{ needs.memory-impact-target-branch.outputs.flash_usage }}
-          PR_RAM: ${{ needs.memory-impact-pr-branch.outputs.ram_usage }}
-          PR_FLASH: ${{ needs.memory-impact-pr-branch.outputs.flash_usage }}
-          TARGET_CACHE_HIT: ${{ needs.memory-impact-target-branch.outputs.cache_hit }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           . venv/bin/activate
 
-          # Check if analysis JSON files exist
-          target_json_arg=""
-          pr_json_arg=""
-
-          if [ -f ./memory-analysis/memory-analysis-target.json ]; then
-            echo "Found target analysis JSON"
-            target_json_arg="--target-json ./memory-analysis/memory-analysis-target.json"
-          else
-            echo "No target analysis JSON found"
-          fi
-
-          if [ -f ./memory-analysis/memory-analysis-pr.json ]; then
-            echo "Found PR analysis JSON"
-            pr_json_arg="--pr-json ./memory-analysis/memory-analysis-pr.json"
-          else
-            echo "No PR analysis JSON found"
-          fi
-
-          # Add cache flag if target was cached
-          cache_flag=""
-          if [ "$TARGET_CACHE_HIT" == "true" ]; then
-            cache_flag="--target-cache-hit"
-          fi
-
+          # Pass JSON file paths directly to Python script
+          # All data is extracted from JSON files for security
           python script/ci_memory_impact_comment.py \
-            --pr-number "${{ github.event.pull_request.number }}" \
-            --components "$COMPONENTS" \
-            --platform "$PLATFORM" \
-            --target-ram "$TARGET_RAM" \
-            --target-flash "$TARGET_FLASH" \
-            --pr-ram "$PR_RAM" \
-            --pr-flash "$PR_FLASH" \
-            $target_json_arg \
-            $pr_json_arg \
-            $cache_flag
+            --pr-number "$PR_NUMBER" \
+            --target-json ./memory-analysis/memory-analysis-target.json \
+            --pr-json ./memory-analysis/memory-analysis-pr.json
 
   ci-status:
     name: CI Status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,7 +600,7 @@ jobs:
           fi
 
       - name: Restore Python
-        if: steps.check-script.outputs.skip != 'true'
+        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
         uses: ./.github/actions/restore-python
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
@@ -641,25 +641,25 @@ jobs:
               --output-env \
               --output-json memory-analysis-target.json
 
+      - name: Add metadata to JSON
+        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
+        run: |
+          . venv/bin/activate
+          components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
+          platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
+
+          # Add metadata to JSON before caching
+          python script/ci_add_metadata_to_json.py \
+            --json-file memory-analysis-target.json \
+            --components "$components" \
+            --platform "$platform"
+
       - name: Save memory analysis to cache
         if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true' && steps.build.outcome == 'success'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: memory-analysis-target.json
           key: ${{ steps.cache-key.outputs.cache-key }}
-
-      - name: Add metadata to JSON
-        if: steps.check-script.outputs.skip != 'true'
-        run: |
-          . venv/bin/activate
-          components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
-          platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
-
-          # Add metadata to JSON (works for both cache hit and cache miss)
-          python script/ci_add_metadata_to_json.py \
-            --json-file memory-analysis-target.json \
-            --components "$components" \
-            --platform "$platform"
 
       - name: Extract memory usage for outputs
         id: extract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -649,23 +649,17 @@ jobs:
           key: ${{ steps.cache-key.outputs.cache-key }}
 
       - name: Add metadata to JSON
-        if: steps.check-script.outputs.skip != 'true'
+        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
         run: |
           . venv/bin/activate
           components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
           platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
-          cache_hit="${{ steps.cache-memory-analysis.outputs.cache-hit }}"
 
-          cache_flag=""
-          if [ "$cache_hit" == "true" ]; then
-            cache_flag="--cache-hit"
-          fi
-
+          # Add metadata to newly generated JSON (cache miss means we just built it)
           python script/ci_add_metadata_to_json.py \
             --json-file memory-analysis-target.json \
             --components "$components" \
-            --platform "$platform" \
-            $cache_flag
+            --platform "$platform"
 
       - name: Extract memory usage for outputs
         id: extract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,7 +736,7 @@ jobs:
       - determine-jobs
       - memory-impact-target-branch
       - memory-impact-pr-branch
-    if: github.event_name == 'pull_request' && fromJSON(needs.determine-jobs.outputs.memory_impact).should_run == 'true' && needs.memory-impact-target-branch.outputs.skip != 'true'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && fromJSON(needs.determine-jobs.outputs.memory_impact).should_run == 'true' && needs.memory-impact-target-branch.outputs.skip != 'true'
     permissions:
       contents: read
       pull-requests: write
@@ -764,7 +764,6 @@ jobs:
         continue-on-error: true
       - name: Post or update PR comment
         env:
-          GH_TOKEN: ${{ github.token }}
           COMPONENTS: ${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}
           PLATFORM: ${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}
           TARGET_RAM: ${{ needs.memory-impact-target-branch.outputs.ram_usage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,13 +641,6 @@ jobs:
               --output-env \
               --output-json memory-analysis-target.json
 
-      - name: Add metadata to JSON
-        if: steps.check-script.outputs.skip != 'true' && steps.cache-memory-analysis.outputs.cache-hit != 'true'
-        run: |
-          . venv/bin/activate
-          components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
-          platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
-
           # Add metadata to JSON before caching
           python script/ci_add_metadata_to_json.py \
             --json-file memory-analysis-target.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,25 @@ jobs:
           path: memory-analysis-target.json
           key: ${{ steps.cache-key.outputs.cache-key }}
 
+      - name: Add metadata to JSON
+        if: steps.check-script.outputs.skip != 'true'
+        run: |
+          . venv/bin/activate
+          components='${{ toJSON(fromJSON(needs.determine-jobs.outputs.memory_impact).components) }}'
+          platform="${{ fromJSON(needs.determine-jobs.outputs.memory_impact).platform }}"
+          cache_hit="${{ steps.cache-memory-analysis.outputs.cache-hit }}"
+
+          cache_flag=""
+          if [ "$cache_hit" == "true" ]; then
+            cache_flag="--cache-hit"
+          fi
+
+          python script/ci_add_metadata_to_json.py \
+            --json-file memory-analysis-target.json \
+            --components "$components" \
+            --platform "$platform" \
+            $cache_flag
+
       - name: Extract memory usage for outputs
         id: extract
         if: steps.check-script.outputs.skip != 'true'
@@ -720,6 +739,13 @@ jobs:
             python script/ci_memory_impact_extract.py \
               --output-env \
               --output-json memory-analysis-pr.json
+
+          # Add metadata to JSON (components and platform are in shell variables above)
+          python script/ci_add_metadata_to_json.py \
+            --json-file memory-analysis-pr.json \
+            --components "$components" \
+            --platform "$platform"
+
       - name: Upload memory analysis JSON
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,6 +740,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Check out code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/script/ci_add_metadata_to_json.py
+++ b/script/ci_add_metadata_to_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Add metadata to memory analysis JSON file.
 
-This script adds components, platform, and cache_hit metadata to an existing
+This script adds components and platform metadata to an existing
 memory analysis JSON file. Used by CI to ensure all required fields are present
 for the comment script.
 """

--- a/script/ci_add_metadata_to_json.py
+++ b/script/ci_add_metadata_to_json.py
@@ -34,11 +34,6 @@ def main() -> int:
         required=True,
         help="Platform name",
     )
-    parser.add_argument(
-        "--cache-hit",
-        action="store_true",
-        help="Mark this analysis as loaded from cache",
-    )
 
     args = parser.parse_args()
 
@@ -68,8 +63,6 @@ def main() -> int:
     # Add metadata
     data["components"] = components
     data["platform"] = args.platform
-    if args.cache_hit:
-        data["cache_hit"] = True
 
     # Write back
     try:

--- a/script/ci_add_metadata_to_json.py
+++ b/script/ci_add_metadata_to_json.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Add metadata to memory analysis JSON file.
+
+This script adds components, platform, and cache_hit metadata to an existing
+memory analysis JSON file. Used by CI to ensure all required fields are present
+for the comment script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+def main() -> int:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Add metadata to memory analysis JSON file"
+    )
+    parser.add_argument(
+        "--json-file",
+        required=True,
+        help="Path to JSON file to update",
+    )
+    parser.add_argument(
+        "--components",
+        required=True,
+        help='JSON array of component names (e.g., \'["api", "wifi"]\')',
+    )
+    parser.add_argument(
+        "--platform",
+        required=True,
+        help="Platform name",
+    )
+    parser.add_argument(
+        "--cache-hit",
+        action="store_true",
+        help="Mark this analysis as loaded from cache",
+    )
+
+    args = parser.parse_args()
+
+    # Load existing JSON
+    json_path = Path(args.json_file)
+    if not json_path.exists():
+        print(f"Error: JSON file not found: {args.json_file}", file=sys.stderr)
+        return 1
+
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Error loading JSON: {e}", file=sys.stderr)
+        return 1
+
+    # Parse components
+    try:
+        components = json.loads(args.components)
+        if not isinstance(components, list):
+            print("Error: --components must be a JSON array", file=sys.stderr)
+            return 1
+    except json.JSONDecodeError as e:
+        print(f"Error parsing components: {e}", file=sys.stderr)
+        return 1
+
+    # Add metadata
+    data["components"] = components
+    data["platform"] = args.platform
+    if args.cache_hit:
+        data["cache_hit"] = True
+
+    # Write back
+    try:
+        with open(json_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+        print(f"Added metadata to {args.json_file}", file=sys.stderr)
+    except OSError as e:
+        print(f"Error writing JSON: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/ci_add_metadata_to_json.py
+++ b/script/ci_add_metadata_to_json.py
@@ -56,6 +56,11 @@ def main() -> int:
         if not isinstance(components, list):
             print("Error: --components must be a JSON array", file=sys.stderr)
             return 1
+        # Element-level validation: ensure each component is a non-empty string
+        for idx, comp in enumerate(components):
+            if not isinstance(comp, str) or not comp.strip():
+                print(f"Error: component at index {idx} is not a non-empty string: {comp!r}", file=sys.stderr)
+                return 1
     except json.JSONDecodeError as e:
         print(f"Error parsing components: {e}", file=sys.stderr)
         return 1

--- a/script/ci_add_metadata_to_json.py
+++ b/script/ci_add_metadata_to_json.py
@@ -59,7 +59,10 @@ def main() -> int:
         # Element-level validation: ensure each component is a non-empty string
         for idx, comp in enumerate(components):
             if not isinstance(comp, str) or not comp.strip():
-                print(f"Error: component at index {idx} is not a non-empty string: {comp!r}", file=sys.stderr)
+                print(
+                    f"Error: component at index {idx} is not a non-empty string: {comp!r}",
+                    file=sys.stderr,
+                )
                 return 1
     except json.JSONDecodeError as e:
         print(f"Error parsing components: {e}", file=sys.stderr)

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -269,7 +269,6 @@ def create_comment_body(
     pr_analysis: dict | None = None,
     target_symbols: dict | None = None,
     pr_symbols: dict | None = None,
-    target_cache_hit: bool = False,
 ) -> str:
     """Create the comment body with memory impact analysis using Jinja2 templates.
 
@@ -284,7 +283,6 @@ def create_comment_body(
         pr_analysis: Optional component breakdown for PR branch
         target_symbols: Optional symbol map for target branch
         pr_symbols: Optional symbol map for PR branch
-        target_cache_hit: Whether target branch analysis was loaded from cache
 
     Returns:
         Formatted comment body
@@ -314,7 +312,6 @@ def create_comment_body(
         "flash_change": format_change(
             target_flash, pr_flash, threshold=OVERALL_CHANGE_THRESHOLD
         ),
-        "target_cache_hit": target_cache_hit,
         "component_change_threshold": COMPONENT_CHANGE_THRESHOLD,
     }
 
@@ -556,7 +553,6 @@ def main() -> int:
     target_flash = target_data.get("flash_bytes")
     pr_ram = pr_data.get("ram_bytes")
     pr_flash = pr_data.get("flash_bytes")
-    target_cache_hit = target_data.get("cache_hit", False)
 
     # Validate required fields
     if not all(
@@ -585,7 +581,6 @@ def main() -> int:
         pr_analysis=pr_analysis,
         target_symbols=target_symbols,
         pr_symbols=pr_symbols,
-        target_cache_hit=target_cache_hit,
     )
 
     # Post or update comment

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -571,13 +571,32 @@ def main() -> int:
         type_errors.append(f"platform must be a string, got {type(platform).__name__}")
 
     if target_ram is None:
-        missing_fields.append("target_ram")
+        missing_fields.append("target.ram_bytes")
+    elif not isinstance(target_ram, int):
+        type_errors.append(
+            f"target.ram_bytes must be an integer, got {type(target_ram).__name__}"
+        )
+
     if target_flash is None:
-        missing_fields.append("target_flash")
+        missing_fields.append("target.flash_bytes")
+    elif not isinstance(target_flash, int):
+        type_errors.append(
+            f"target.flash_bytes must be an integer, got {type(target_flash).__name__}"
+        )
+
     if pr_ram is None:
-        missing_fields.append("pr_ram")
+        missing_fields.append("pr.ram_bytes")
+    elif not isinstance(pr_ram, int):
+        type_errors.append(
+            f"pr.ram_bytes must be an integer, got {type(pr_ram).__name__}"
+        )
+
     if pr_flash is None:
-        missing_fields.append("pr_flash")
+        missing_fields.append("pr.flash_bytes")
+    elif not isinstance(pr_flash, int):
+        type_errors.append(
+            f"pr.flash_bytes must be an integer, got {type(pr_flash).__name__}"
+        )
 
     if missing_fields or type_errors:
         if missing_fields:

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -566,9 +566,9 @@ def main() -> int:
         )
     else:
         for idx, comp in enumerate(components):
-            if not isinstance(comp, dict):
+            if not isinstance(comp, str):
                 type_errors.append(
-                    f"components[{idx}] must be a dict, got {type(comp).__name__}"
+                    f"components[{idx}] must be a string, got {type(comp).__name__}"
                 )
     if platform is None:
         missing_fields.append("platform")

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -564,7 +564,12 @@ def main() -> int:
         type_errors.append(
             f"components must be a list, got {type(components).__name__}"
         )
-
+    else:
+        for idx, comp in enumerate(components):
+            if not isinstance(comp, dict):
+                type_errors.append(
+                    f"components[{idx}] must be a dict, got {type(comp).__name__}"
+                )
     if platform is None:
         missing_fields.append("platform")
     elif not isinstance(platform, str):

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -513,27 +513,20 @@ def main() -> int:
     parser.add_argument("--pr-number", required=True, help="PR number")
     parser.add_argument(
         "--components",
-        required=True,
         help='JSON array of component names (e.g., \'["api", "wifi"]\')',
     )
-    parser.add_argument("--platform", required=True, help="Platform name")
-    parser.add_argument(
-        "--target-ram", type=int, required=True, help="Target branch RAM usage"
-    )
-    parser.add_argument(
-        "--target-flash", type=int, required=True, help="Target branch flash usage"
-    )
-    parser.add_argument("--pr-ram", type=int, required=True, help="PR branch RAM usage")
-    parser.add_argument(
-        "--pr-flash", type=int, required=True, help="PR branch flash usage"
-    )
+    parser.add_argument("--platform", help="Platform name")
+    parser.add_argument("--target-ram", type=int, help="Target branch RAM usage")
+    parser.add_argument("--target-flash", type=int, help="Target branch flash usage")
+    parser.add_argument("--pr-ram", type=int, help="PR branch RAM usage")
+    parser.add_argument("--pr-flash", type=int, help="PR branch flash usage")
     parser.add_argument(
         "--target-json",
-        help="Optional path to target branch analysis JSON (for detailed analysis)",
+        help="Path to target branch analysis JSON (required if other args not provided)",
     )
     parser.add_argument(
         "--pr-json",
-        help="Optional path to PR branch analysis JSON (for detailed analysis)",
+        help="Path to PR branch analysis JSON (required if other args not provided)",
     )
     parser.add_argument(
         "--target-cache-hit",
@@ -543,21 +536,13 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    # Parse components from JSON
-    try:
-        components = json.loads(args.components)
-        if not isinstance(components, list):
-            print("Error: --components must be a JSON array", file=sys.stderr)
-            sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"Error parsing --components JSON: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    # Load analysis JSON files
-    target_analysis = None
-    pr_analysis = None
-    target_symbols = None
-    pr_symbols = None
+    # Load analysis JSON files first (safer to parse from base branch JSON than shell args)
+    target_data: dict | None = None
+    pr_data: dict | None = None
+    target_analysis: dict | None = None
+    pr_analysis: dict | None = None
+    target_symbols: dict | None = None
+    pr_symbols: dict | None = None
 
     if args.target_json:
         target_data = load_analysis_json(args.target_json)
@@ -571,20 +556,80 @@ def main() -> int:
             pr_analysis = pr_data["detailed_analysis"].get("components")
             pr_symbols = pr_data["detailed_analysis"].get("symbols")
 
+    # Get values from JSON files or command-line arguments
+    # Prefer JSON files as they're generated from base branch code (safer)
+    if target_data and pr_data:
+        # Extract all values from JSON (prevents shell injection from PR code)
+        components = target_data.get("components")
+        platform = target_data.get("platform")
+        target_ram = target_data.get("ram_bytes")
+        target_flash = target_data.get("flash_bytes")
+        pr_ram = pr_data.get("ram_bytes")
+        pr_flash = pr_data.get("flash_bytes")
+        target_cache_hit = target_data.get("cache_hit", False)
+
+        # Validate required fields
+        if not all(
+            [
+                components,
+                platform,
+                target_ram is not None,
+                target_flash is not None,
+                pr_ram is not None,
+                pr_flash is not None,
+            ]
+        ):
+            print("Error: JSON files missing required fields", file=sys.stderr)
+            sys.exit(1)
+    else:
+        # Fall back to command-line arguments (for backwards compatibility)
+        if not all(
+            [
+                args.components,
+                args.platform,
+                args.target_ram is not None,
+                args.target_flash is not None,
+                args.pr_ram is not None,
+                args.pr_flash is not None,
+            ]
+        ):
+            print(
+                "Error: Must provide either JSON files or all command-line arguments",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # Parse components from JSON string
+        try:
+            components = json.loads(args.components)
+            if not isinstance(components, list):
+                print("Error: --components must be a JSON array", file=sys.stderr)
+                sys.exit(1)
+        except json.JSONDecodeError as e:
+            print(f"Error parsing --components JSON: {e}", file=sys.stderr)
+            sys.exit(1)
+
+        platform = args.platform
+        target_ram = args.target_ram
+        target_flash = args.target_flash
+        pr_ram = args.pr_ram
+        pr_flash = args.pr_flash
+        target_cache_hit = args.target_cache_hit
+
     # Create comment body
     # Note: Memory totals (RAM/Flash) are summed across all builds if multiple were run.
     comment_body = create_comment_body(
         components=components,
-        platform=args.platform,
-        target_ram=args.target_ram,
-        target_flash=args.target_flash,
-        pr_ram=args.pr_ram,
-        pr_flash=args.pr_flash,
+        platform=platform,
+        target_ram=target_ram,
+        target_flash=target_flash,
+        pr_ram=pr_ram,
+        pr_flash=pr_flash,
         target_analysis=target_analysis,
         pr_analysis=pr_analysis,
         target_symbols=target_symbols,
         pr_symbols=pr_symbols,
-        target_cache_hit=args.target_cache_hit,
+        target_cache_hit=target_cache_hit,
     )
 
     # Post or update comment

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -555,17 +555,27 @@ def main() -> int:
     pr_flash = pr_data.get("flash_bytes")
 
     # Validate required fields
-    if not all(
-        [
-            components,
-            platform,
-            target_ram is not None,
-            target_flash is not None,
-            pr_ram is not None,
-            pr_flash is not None,
-        ]
-    ):
-        print("Error: JSON files missing required fields", file=sys.stderr)
+    missing_fields = []
+    if not components:
+        missing_fields.append("components")
+    if not platform:
+        missing_fields.append("platform")
+    if target_ram is None:
+        missing_fields.append("target_ram")
+    if target_flash is None:
+        missing_fields.append("target_flash")
+    if pr_ram is None:
+        missing_fields.append("pr_ram")
+    if pr_flash is None:
+        missing_fields.append("pr_flash")
+
+    if missing_fields:
+        print(
+            f"Error: JSON files missing required fields: {', '.join(missing_fields)}",
+            file=sys.stderr,
+        )
+        print(f"Target JSON keys: {list(target_data.keys())}", file=sys.stderr)
+        print(f"PR JSON keys: {list(pr_data.keys())}", file=sys.stderr)
         sys.exit(1)
 
     # Create comment body

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -512,109 +512,65 @@ def main() -> int:
     )
     parser.add_argument("--pr-number", required=True, help="PR number")
     parser.add_argument(
-        "--components",
-        help='JSON array of component names (e.g., \'["api", "wifi"]\')',
-    )
-    parser.add_argument("--platform", help="Platform name")
-    parser.add_argument("--target-ram", type=int, help="Target branch RAM usage")
-    parser.add_argument("--target-flash", type=int, help="Target branch flash usage")
-    parser.add_argument("--pr-ram", type=int, help="PR branch RAM usage")
-    parser.add_argument("--pr-flash", type=int, help="PR branch flash usage")
-    parser.add_argument(
         "--target-json",
-        help="Path to target branch analysis JSON (required if other args not provided)",
+        required=True,
+        help="Path to target branch analysis JSON file",
     )
     parser.add_argument(
         "--pr-json",
-        help="Path to PR branch analysis JSON (required if other args not provided)",
-    )
-    parser.add_argument(
-        "--target-cache-hit",
-        action="store_true",
-        help="Indicates that target branch analysis was loaded from cache",
+        required=True,
+        help="Path to PR branch analysis JSON file",
     )
 
     args = parser.parse_args()
 
-    # Load analysis JSON files first (safer to parse from base branch JSON than shell args)
-    target_data: dict | None = None
-    pr_data: dict | None = None
+    # Load analysis JSON files (all data comes from JSON for security)
+    target_data: dict | None = load_analysis_json(args.target_json)
+    if not target_data:
+        print("Error: Failed to load target analysis JSON", file=sys.stderr)
+        sys.exit(1)
+
+    pr_data: dict | None = load_analysis_json(args.pr_json)
+    if not pr_data:
+        print("Error: Failed to load PR analysis JSON", file=sys.stderr)
+        sys.exit(1)
+
+    # Extract detailed analysis if available
     target_analysis: dict | None = None
     pr_analysis: dict | None = None
     target_symbols: dict | None = None
     pr_symbols: dict | None = None
 
-    if args.target_json:
-        target_data = load_analysis_json(args.target_json)
-        if target_data and target_data.get("detailed_analysis"):
-            target_analysis = target_data["detailed_analysis"].get("components")
-            target_symbols = target_data["detailed_analysis"].get("symbols")
+    if target_data.get("detailed_analysis"):
+        target_analysis = target_data["detailed_analysis"].get("components")
+        target_symbols = target_data["detailed_analysis"].get("symbols")
 
-    if args.pr_json:
-        pr_data = load_analysis_json(args.pr_json)
-        if pr_data and pr_data.get("detailed_analysis"):
-            pr_analysis = pr_data["detailed_analysis"].get("components")
-            pr_symbols = pr_data["detailed_analysis"].get("symbols")
+    if pr_data.get("detailed_analysis"):
+        pr_analysis = pr_data["detailed_analysis"].get("components")
+        pr_symbols = pr_data["detailed_analysis"].get("symbols")
 
-    # Get values from JSON files or command-line arguments
-    # Prefer JSON files as they're generated from base branch code (safer)
-    if target_data and pr_data:
-        # Extract all values from JSON (prevents shell injection from PR code)
-        components = target_data.get("components")
-        platform = target_data.get("platform")
-        target_ram = target_data.get("ram_bytes")
-        target_flash = target_data.get("flash_bytes")
-        pr_ram = pr_data.get("ram_bytes")
-        pr_flash = pr_data.get("flash_bytes")
-        target_cache_hit = target_data.get("cache_hit", False)
+    # Extract all values from JSON files (prevents shell injection from PR code)
+    components = target_data.get("components")
+    platform = target_data.get("platform")
+    target_ram = target_data.get("ram_bytes")
+    target_flash = target_data.get("flash_bytes")
+    pr_ram = pr_data.get("ram_bytes")
+    pr_flash = pr_data.get("flash_bytes")
+    target_cache_hit = target_data.get("cache_hit", False)
 
-        # Validate required fields
-        if not all(
-            [
-                components,
-                platform,
-                target_ram is not None,
-                target_flash is not None,
-                pr_ram is not None,
-                pr_flash is not None,
-            ]
-        ):
-            print("Error: JSON files missing required fields", file=sys.stderr)
-            sys.exit(1)
-    else:
-        # Fall back to command-line arguments (for backwards compatibility)
-        if not all(
-            [
-                args.components,
-                args.platform,
-                args.target_ram is not None,
-                args.target_flash is not None,
-                args.pr_ram is not None,
-                args.pr_flash is not None,
-            ]
-        ):
-            print(
-                "Error: Must provide either JSON files or all command-line arguments",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        # Parse components from JSON string
-        try:
-            components = json.loads(args.components)
-            if not isinstance(components, list):
-                print("Error: --components must be a JSON array", file=sys.stderr)
-                sys.exit(1)
-        except json.JSONDecodeError as e:
-            print(f"Error parsing --components JSON: {e}", file=sys.stderr)
-            sys.exit(1)
-
-        platform = args.platform
-        target_ram = args.target_ram
-        target_flash = args.target_flash
-        pr_ram = args.pr_ram
-        pr_flash = args.pr_flash
-        target_cache_hit = args.target_cache_hit
+    # Validate required fields
+    if not all(
+        [
+            components,
+            platform,
+            target_ram is not None,
+            target_flash is not None,
+            pr_ram is not None,
+            pr_flash is not None,
+        ]
+    ):
+        print("Error: JSON files missing required fields", file=sys.stderr)
+        sys.exit(1)
 
     # Create comment body
     # Note: Memory totals (RAM/Flash) are summed across all builds if multiple were run.

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -554,12 +554,22 @@ def main() -> int:
     pr_ram = pr_data.get("ram_bytes")
     pr_flash = pr_data.get("flash_bytes")
 
-    # Validate required fields
-    missing_fields = []
-    if not components:
+    # Validate required fields and types
+    missing_fields: list[str] = []
+    type_errors: list[str] = []
+
+    if components is None:
         missing_fields.append("components")
-    if not platform:
+    elif not isinstance(components, list):
+        type_errors.append(
+            f"components must be a list, got {type(components).__name__}"
+        )
+
+    if platform is None:
         missing_fields.append("platform")
+    elif not isinstance(platform, str):
+        type_errors.append(f"platform must be a string, got {type(platform).__name__}")
+
     if target_ram is None:
         missing_fields.append("target_ram")
     if target_flash is None:
@@ -569,11 +579,17 @@ def main() -> int:
     if pr_flash is None:
         missing_fields.append("pr_flash")
 
-    if missing_fields:
-        print(
-            f"Error: JSON files missing required fields: {', '.join(missing_fields)}",
-            file=sys.stderr,
-        )
+    if missing_fields or type_errors:
+        if missing_fields:
+            print(
+                f"Error: JSON files missing required fields: {', '.join(missing_fields)}",
+                file=sys.stderr,
+            )
+        if type_errors:
+            print(
+                f"Error: Type validation failed: {'; '.join(type_errors)}",
+                file=sys.stderr,
+            )
         print(f"Target JSON keys: {list(target_data.keys())}", file=sys.stderr)
         print(f"PR JSON keys: {list(pr_data.keys())}", file=sys.stderr)
         sys.exit(1)

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -24,6 +24,37 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # Comment marker to identify our memory impact comments
 COMMENT_MARKER = "<!-- esphome-memory-impact-analysis -->"
 
+
+def run_gh_command(args: list[str], operation: str) -> subprocess.CompletedProcess:
+    """Run a gh CLI command with error handling.
+
+    Args:
+        args: Command arguments (including 'gh')
+        operation: Description of the operation for error messages
+
+    Returns:
+        CompletedProcess result
+
+    Raises:
+        subprocess.CalledProcessError: If command fails (with detailed error output)
+    """
+    try:
+        return subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(
+            f"ERROR: {operation} failed with exit code {e.returncode}", file=sys.stderr
+        )
+        print(f"ERROR: Command: {' '.join(args)}", file=sys.stderr)
+        print(f"ERROR: stdout: {e.stdout}", file=sys.stderr)
+        print(f"ERROR: stderr: {e.stderr}", file=sys.stderr)
+        raise
+
+
 # Thresholds for emoji significance indicators (percentage)
 OVERALL_CHANGE_THRESHOLD = 1.0  # Overall RAM/Flash changes
 COMPONENT_CHANGE_THRESHOLD = 3.0  # Component breakdown changes
@@ -356,7 +387,7 @@ def find_existing_comment(pr_number: str) -> str | None:
     print(f"DEBUG: Looking for existing comment on PR #{pr_number}", file=sys.stderr)
 
     # Use gh api to get comments directly - this returns the numeric id field
-    result = subprocess.run(
+    result = run_gh_command(
         [
             "gh",
             "api",
@@ -364,9 +395,7 @@ def find_existing_comment(pr_number: str) -> str | None:
             "--jq",
             ".[] | {id, body}",
         ],
-        capture_output=True,
-        text=True,
-        check=True,
+        operation="Get PR comments",
     )
 
     print(
@@ -420,7 +449,8 @@ def update_existing_comment(comment_id: str, comment_body: str) -> None:
         subprocess.CalledProcessError: If gh command fails
     """
     print(f"DEBUG: Updating existing comment {comment_id}", file=sys.stderr)
-    result = subprocess.run(
+    print(f"DEBUG: Comment body length: {len(comment_body)} bytes", file=sys.stderr)
+    result = run_gh_command(
         [
             "gh",
             "api",
@@ -430,9 +460,7 @@ def update_existing_comment(comment_id: str, comment_body: str) -> None:
             "-f",
             f"body={comment_body}",
         ],
-        check=True,
-        capture_output=True,
-        text=True,
+        operation="Update PR comment",
     )
     print(f"DEBUG: Update response: {result.stdout}", file=sys.stderr)
 
@@ -448,11 +476,10 @@ def create_new_comment(pr_number: str, comment_body: str) -> None:
         subprocess.CalledProcessError: If gh command fails
     """
     print(f"DEBUG: Posting new comment on PR #{pr_number}", file=sys.stderr)
-    result = subprocess.run(
+    print(f"DEBUG: Comment body length: {len(comment_body)} bytes", file=sys.stderr)
+    result = run_gh_command(
         ["gh", "pr", "comment", pr_number, "--body", comment_body],
-        check=True,
-        capture_output=True,
-        text=True,
+        operation="Create PR comment",
     )
     print(f"DEBUG: Post response: {result.stdout}", file=sys.stderr)
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes the memory impact analysis comment failing on PRs from forks due to insufficient permissions.

The memory impact analysis feature generates detailed memory usage reports (RAM/Flash) for component changes. However, posting comments on PRs from forks fails because `pull_request` events from forks have read-only `GITHUB_TOKEN` permissions for security reasons, even when `pull-requests: write` is explicitly set.

## Solution

This PR uses a two-workflow approach:

1. **Non-fork PRs** (`.github/workflows/ci.yml` - `memory-impact-comment` job):
   - Works as before - posts comment immediately after analysis completes
   - Has write permissions since PR is from the same repo
   - No changes to user experience

2. **Fork PRs** (`.github/workflows/ci-memory-impact-comment.yml` - new workflow):
   - Runs on `workflow_run` event when CI completes (has write permissions)
   - Automatically triggered when CI workflow finishes successfully
   - Downloads artifacts and posts comment
   - No polling or waiting - runs immediately when CI is done

This follows the same security pattern used by other commenting workflows that need write permissions on fork PRs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (Internal CI infrastructure fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (CI infrastructure change, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

_N/A - This is a GitHub Actions workflow fix that applies to all platforms_

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure change with no user-facing config
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

_N/A - This is a GitHub Actions workflow change that can only be tested in the CI environment. The fix follows the established pattern used in other jobs (determine-jobs, clang-tidy) that successfully handle fork PRs._

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

_N/A - No user-facing changes_

---

## Technical Details

**Root Cause:**
The error was `GraphQL: Resource not accessible by integration (addComment)`. This occurs because GitHub Actions runs `pull_request` events from forks with read-only `GITHUB_TOKEN` permissions, regardless of explicitly set `pull-requests: write` permissions. This is a security feature to prevent malicious PRs from spamming comments or modifying the repository.

**Solution:**
Use different workflows based on PR source:

1. **Non-fork PRs** (`ci.yml` - `memory-impact-comment` job):
   - Condition: `github.event.pull_request.head.repo.full_name == github.repository`
   - Runs in the main CI workflow as before
   - Posts comment immediately after memory analysis completes
   - No change to existing behavior

2. **Fork PRs** (new `ci-memory-impact-comment.yml` workflow):
   - Condition: `github.event.workflow_run.head_repository.full_name != github.repository`
   - Runs on `workflow_run` event when CI completes (has write permissions)
   - Automatically triggered when the CI workflow finishes successfully
   - Finds PR number by matching the workflow's head SHA with open PRs
   - Downloads the memory analysis artifacts from the completed workflow run
   - Posts/updates the PR comment using `pull-requests: write` permission
   - Only checks out base branch code - never PR code
   - Comment appears immediately when CI completes

**Security Considerations:**
- The fork workflow uses `workflow_run` trigger, which runs in the base repository context
- It only checks out the base branch code - never the PR code
- It only downloads artifacts (safe) and doesn't execute PR code
- This prevents malicious PRs from executing arbitrary code with write permissions
- Non-fork PRs continue using the existing secure pattern (runs with repo permissions)

**Precedent:**
- `workflow_run` is the recommended GitHub Actions pattern for workflows that need write permissions on fork PRs
- Used by many projects to safely post comments on fork PRs without security risks
- Standard GitHub Actions security best practices for commenting on fork PRs

**Additional Improvements:**
- **Security hardening**: Removed command-line argument fallback from `ci_memory_impact_comment.py`
  - Script now *requires* JSON files and extracts all data from them
  - Eliminates any possibility of shell injection through component names, platform values, or memory counts
  - Both fork and non-fork workflows now use the same secure JSON-only approach
- **New helper script**: `ci_add_metadata_to_json.py`
  - Python script that adds `components` and `platform` metadata to JSON files
  - Only runs on cache miss (cached files already have metadata)
  - Avoids complex shell `jq` manipulation that would be error-prone and less secure
  - Validates all inputs before adding them to JSON
  - Clean, simple, maintainable approach
- **Removed `cache_hit` flag**: Not worth the complexity of restoring Python on cache hit just for an informational flag
- Added `run_gh_command()` wrapper function to centralize error handling and provide detailed debugging output (stderr, stdout, exit code)
- This helped diagnose the permission issue and will help debug future issues

**Why This Approach:**
- Non-fork PRs maintain fast commenting (immediately after analysis)
- Fork PRs get comments immediately when CI completes (no polling overhead)
- More efficient - no wasted CI minutes on polling loops
- Simpler code - removed ~80 lines of complex waiting logic
- Clear separation of concerns

**Injection Attack Prevention:**
The workflow safely handles potentially malicious data from fork PRs:
- **Trusted code only**: Workflow checks out code from the PR's target branch in the **base repository** (never from forks)
  - Explicitly sets `repository: ${{ github.repository }}` to ensure base repo
  - Uses PR's `base.ref` to check out the exact branch the PR targets
  - Prevents malicious PRs from running arbitrary Python code with write permissions
- **PR details via API**: PR number and base branch obtained via GitHub API (not user-controlled)
- **All other data**: Extracted directly from JSON files by Python (no shell variable expansion at all)
- **JSON files required**: The script no longer accepts any command-line arguments for components, platform, or memory values
- **JSON artifacts**: The memory analysis JSON files are generated by `ci_memory_impact_extract.py`
  - Even though this script runs on PR code, it only parses compiler output
  - Python's JSON parser safely handles all input without shell injection risks
- **Defense in depth**: The script validates all JSON fields before using them
- **No shell interpolation**: Only file paths passed as arguments, no data values

---

## Files Changed

**New Files:**
- `.github/workflows/ci-memory-impact-comment.yml` - New workflow for fork PRs using `workflow_run` trigger
- `script/ci_add_metadata_to_json.py` - Helper script to add metadata to JSON files securely

**Modified Files:**
- `.github/workflows/ci.yml`:
  - Updated `memory-impact-comment` job to use JSON-only interface
  - Added metadata injection step using `ci_add_metadata_to_json.py`
  - Simplified comment posting to only pass PR number and JSON file paths
- `script/ci_memory_impact_comment.py`:
  - Made `--target-json` and `--pr-json` required arguments
  - Removed optional `--components`, `--platform`, and memory value arguments
  - Script now extracts all data from JSON files for security
  - Added proper type hints for new variables

