### PR TITLE
remove hexencode due 2022.1 deprecation

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1158,18 +1158,4 @@ template<typename T, enable_if_t<std::is_pointer<T *>::value, int> = 0> T &id(T 
 
 ///@}
 
-/// @name Deprecated functions
-///@{
-
-ESPDEPRECATED("hexencode() is deprecated, use format_hex_pretty() instead.", "2022.1")
-inline std::string hexencode(const uint8_t *data, uint32_t len) { return format_hex_pretty(data, len); }
-
-template<typename T>
-ESPDEPRECATED("hexencode() is deprecated, use format_hex_pretty() instead.", "2022.1")
-std::string hexencode(const T &data) {
-  return hexencode(data.data(), data.size());
-}
-
-///@}
-
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Remove hexencode() due 2022.1 deprecation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/backlog/issues/58
- needs: https://github.com/esphome/esphome/pull/11372

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
