### PR TITLE
[light] Clean up deprecated functions from 1.21

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/core/defines.h"
-#include "esphome/core/color.h"
 #include "esp_color_correction.h"
 #include "esp_color_view.h"
 #include "esp_range_view.h"
+#include "esphome/core/color.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "light_output.h"
 #include "light_state.h"
 #include "transformers.h"
@@ -16,8 +16,6 @@
 
 namespace esphome {
 namespace light {
-
-using ESPColor ESPDEPRECATED("esphome::light::ESPColor is deprecated, use esphome::Color instead.", "v1.21") = Color;
 
 /// Convert the color information from a `LightColorValues` object to a `Color` object (does not apply brightness).
 Color color_from_light_color_values(LightColorValues val);

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "esphome/core/helpers.h"
 #include "color_mode.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 
@@ -29,26 +29,6 @@ class LightTraits {
   bool supports_color_mode(ColorMode color_mode) const { return this->supported_color_modes_.contains(color_mode); }
   bool supports_color_capability(ColorCapability color_capability) const {
     return this->supported_color_modes_.has_capability(color_capability);
-  }
-
-  ESPDEPRECATED("get_supports_brightness() is deprecated, use color modes instead.", "v1.21")
-  bool get_supports_brightness() const { return this->supports_color_capability(ColorCapability::BRIGHTNESS); }
-  ESPDEPRECATED("get_supports_rgb() is deprecated, use color modes instead.", "v1.21")
-  bool get_supports_rgb() const { return this->supports_color_capability(ColorCapability::RGB); }
-  ESPDEPRECATED("get_supports_rgb_white_value() is deprecated, use color modes instead.", "v1.21")
-  bool get_supports_rgb_white_value() const {
-    return this->supports_color_mode(ColorMode::RGB_WHITE) ||
-           this->supports_color_mode(ColorMode::RGB_COLOR_TEMPERATURE);
-  }
-  ESPDEPRECATED("get_supports_color_temperature() is deprecated, use color modes instead.", "v1.21")
-  bool get_supports_color_temperature() const {
-    return this->supports_color_capability(ColorCapability::COLOR_TEMPERATURE);
-  }
-  ESPDEPRECATED("get_supports_color_interlock() is deprecated, use color modes instead.", "v1.21")
-  bool get_supports_color_interlock() const {
-    return this->supports_color_mode(ColorMode::RGB) &&
-           (this->supports_color_mode(ColorMode::WHITE) || this->supports_color_mode(ColorMode::COLD_WARM_WHITE) ||
-            this->supports_color_mode(ColorMode::COLOR_TEMPERATURE));
   }
 
   float get_min_mireds() const { return this->min_mireds_; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Removes functions that were deprecated in 2021.8.0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/backlog/issues/58

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
