### PR TITLE
[ci] Cache PlatformIO packages in test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,21 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
+
+      - name: Cache platformio
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.platformio
+          key: platformio-test-${{ hashFiles('platformio.ini') }}
+
+      - name: Cache platformio
+        if: github.ref != 'refs/heads/dev'
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.platformio
+          key: platformio-test-${{ hashFiles('platformio.ini') }}
+
       - name: Validate and compile components with intelligent grouping
         run: |
           . venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,19 +433,15 @@ jobs:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
 
-      - name: Cache platformio
-        if: github.ref == 'refs/heads/dev'
+      # Cache PlatformIO packages to speed up test builds
+      # Note: Caches are repository-scoped, PRs from forks cannot restore from the main repo cache
+      - name: Cache PlatformIO
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.platformio
-          key: platformio-test-${{ hashFiles('platformio.ini') }}
-
-      - name: Cache platformio
-        if: github.ref != 'refs/heads/dev'
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.platformio
-          key: platformio-test-${{ hashFiles('platformio.ini') }}
+          key: platformio-test-${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            platformio-test-${{ runner.os }}-${{ env.DEFAULT_PYTHON }}-
 
       - name: Validate and compile components with intelligent grouping
         run: |


### PR DESCRIPTION
# What does this implement/fix?

Adds PlatformIO package caching to CI test workflows to significantly reduce test execution time and bandwidth usage.

Previously, the test suite had to re-download all PlatformIO packages (frameworks, toolchains, libraries) on every CI run, causing:
- Slower test execution (additional minutes per run)
- Increased bandwidth usage
- Potential rate-limiting issues from package servers
- Unnecessary load on PlatformIO infrastructure

This change adds caching of the `~/.platformio` directory using GitHub Actions cache with:
- **Cache key**: `platformio-test-{OS}-{Python version}-{platformio.ini hash}`
- **Restore fallback**: Falls back to any cache with matching OS and Python version when `platformio.ini` changes
- **Scope**: Caches are repository-scoped; PRs from forks cannot restore from the main repo cache but will build their own cache

The cache is automatically saved on every successful test run and restored on subsequent runs, allowing all PRs and branch builds to benefit from cached packages.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI improvement)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - CI infrastructure change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
