### PR TITLE
[climate] Add basic compile tests for climate component

### DIFF
--- a/tests/components/climate/common.yaml
+++ b/tests/components/climate/common.yaml
@@ -1,0 +1,31 @@
+switch:
+  - platform: template
+    id: climate_heater_switch
+    optimistic: true
+  - platform: template
+    id: climate_cooler_switch
+    optimistic: true
+
+sensor:
+  - platform: template
+    id: climate_temperature_sensor
+    lambda: |-
+      return 21.5;
+    update_interval: 60s
+
+climate:
+  - platform: bang_bang
+    id: climate_test_climate
+    name: Test Climate
+    sensor: climate_temperature_sensor
+    default_target_temperature_low: 18°C
+    default_target_temperature_high: 24°C
+    idle_action:
+      - switch.turn_off: climate_heater_switch
+      - switch.turn_off: climate_cooler_switch
+    cool_action:
+      - switch.turn_on: climate_cooler_switch
+      - switch.turn_off: climate_heater_switch
+    heat_action:
+      - switch.turn_on: climate_heater_switch
+      - switch.turn_off: climate_cooler_switch

--- a/tests/components/climate/test.esp8266-ard.yaml
+++ b/tests/components/climate/test.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR adds basic compile tests for the climate component on ESP8266 with Arduino framework.

Currently, changes to the core climate component (in `esphome/components/climate/`) do not trigger any impact analysis in CI because there are no basic climate tests. This means changes to the climate base classes could potentially break compilation without being caught by the test suite.

This adds a minimal test configuration that:
- Uses the `bang_bang` climate platform (simple, lightweight)
- Tests basic climate functionality (heating, cooling, idle actions)
- Provides a foundation for catching compilation issues in climate core changes
- Follows the same pattern as other component tests (thermostat, bang_bang, pid)

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Infrastructure improvement

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Test infrastructure only

## Test Environment

- [x] ESP8266
- [ ] ESP32
- [ ] ESP32 IDF
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This is a test configuration, not for end-user use
# See tests/components/climate/common.yaml for the test setup

switch:
  - platform: template
    id: climate_heater_switch
    optimistic: true
  - platform: template
    id: climate_cooler_switch
    optimistic: true

sensor:
  - platform: template
    id: climate_temperature_sensor
    lambda: |-
      return 21.5;
    update_interval: 60s

climate:
  - platform: bang_bang
    id: climate_test_climate
    name: Test Climate
    sensor: climate_temperature_sensor
    default_target_temperature_low: 18°C
    default_target_temperature_high: 24°C
    idle_action:
      - switch.turn_off: climate_heater_switch
      - switch.turn_off: climate_cooler_switch
    cool_action:
      - switch.turn_on: climate_cooler_switch
      - switch.turn_off: climate_heater_switch
    heat_action:
      - switch.turn_on: climate_heater_switch
      - switch.turn_off: climate_cooler_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
