### PR TITLE
[tests] Fix flaky test_noise_corrupt_encrypted_frame integration test

### DIFF
--- a/tests/integration/test_oversized_payloads.py
+++ b/tests/integration/test_oversized_payloads.py
@@ -281,8 +281,12 @@ async def test_noise_corrupt_encrypted_frame(
         # Check for signs that the process exited/crashed
         if "Segmentation fault" in line or "core dumped" in line:
             process_exited = True
-        # Check for the expected warning about decryption failure
+        # Check for the expected log about decryption failure
+        # This can appear as either a VV-level log from noise or a W-level log from connection
         if (
+            "[VV][api.noise" in line
+            and "noise_cipherstate_decrypt failed: MAC_FAILURE" in line
+        ) or (
             "[W][api.connection" in line
             and "Reading failed CIPHERSTATE_DECRYPT_FAILED" in line
         ):
@@ -322,9 +326,9 @@ async def test_noise_corrupt_encrypted_frame(
         assert not process_exited, (
             "ESPHome process should not crash on corrupt encrypted frames"
         )
-        # Verify we saw the expected warning message
+        # Verify we saw the expected log message about decryption failure
         assert cipherstate_failed, (
-            "Expected to see warning about CIPHERSTATE_DECRYPT_FAILED"
+            "Expected to see log about noise_cipherstate_decrypt failure or CIPHERSTATE_DECRYPT_FAILED"
         )
 
         # Verify we can still reconnect after handling the corrupt frame


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky integration test `test_noise_corrupt_encrypted_frame` that was failing intermittently in CI.

The test was checking for a warning-level log message from `api_connection.cpp` (`[W][api.connection]: ... Reading failed CIPHERSTATE_DECRYPT_FAILED`), but this log message was not consistently appearing in the test output due to timing issues when the connection closes.

The actual log message that is reliably produced is a verbose-level log from the noise frame helper (`[VV][api.noise]: ... noise_cipherstate_decrypt failed: MAC_FAILURE`), which is logged before the error is propagated back to the connection layer.

This PR updates the test to accept either log format, making it more robust while still verifying that corrupt encrypted frames are properly handled without crashing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Fixes flaky CI test

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] nRF52840

(Test runs on host platform but validates behavior across all platforms)

## Example entry for `config.yaml`:

```yaml
# N/A - Test infrastructure change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
