### PR TITLE
[esp32_improv, improv_base] Reduce flash usage by 352 bytes

### DIFF
--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -6,6 +6,21 @@
 namespace esphome {
 namespace improv_base {
 
+static constexpr const char DEVICE_NAME_PLACEHOLDER[] = "{{device_name}}";
+static constexpr size_t DEVICE_NAME_PLACEHOLDER_LEN = sizeof(DEVICE_NAME_PLACEHOLDER) - 1;
+static constexpr const char IP_ADDRESS_PLACEHOLDER[] = "{{ip_address}}";
+static constexpr size_t IP_ADDRESS_PLACEHOLDER_LEN = sizeof(IP_ADDRESS_PLACEHOLDER) - 1;
+
+static void replace_all_in_place(std::string &str, const char *placeholder, size_t placeholder_len,
+                                 const std::string &replacement) {
+  size_t pos = 0;
+  const size_t replacement_len = replacement.length();
+  while ((pos = str.find(placeholder, pos)) != std::string::npos) {
+    str.replace(pos, placeholder_len, replacement);
+    pos += replacement_len;
+  }
+}
+
 std::string ImprovBase::get_formatted_next_url_() {
   if (this->next_url_.empty()) {
     return "";
@@ -14,27 +29,14 @@ std::string ImprovBase::get_formatted_next_url_() {
   std::string formatted_url = this->next_url_;
 
   // Replace all occurrences of {{device_name}}
-  const std::string device_name_placeholder = "{{device_name}}";
-  const std::string &device_name = App.get_name();
-  size_t pos = 0;
-  while ((pos = formatted_url.find(device_name_placeholder, pos)) != std::string::npos) {
-    formatted_url.replace(pos, device_name_placeholder.length(), device_name);
-    pos += device_name.length();
-  }
+  replace_all_in_place(formatted_url, DEVICE_NAME_PLACEHOLDER, DEVICE_NAME_PLACEHOLDER_LEN, App.get_name());
 
   // Replace all occurrences of {{ip_address}}
-  const std::string ip_address_placeholder = "{{ip_address}}";
-  std::string ip_address_str;
   for (auto &ip : network::get_ip_addresses()) {
     if (ip.is_ip4()) {
-      ip_address_str = ip.str();
+      replace_all_in_place(formatted_url, IP_ADDRESS_PLACEHOLDER, IP_ADDRESS_PLACEHOLDER_LEN, ip.str());
       break;
     }
-  }
-  pos = 0;
-  while ((pos = formatted_url.find(ip_address_placeholder, pos)) != std::string::npos) {
-    formatted_url.replace(pos, ip_address_placeholder.length(), ip_address_str);
-    pos += ip_address_str.length();
   }
 
   // Note: {{esphome_version}} is replaced at code generation time in Python


### PR DESCRIPTION
# What does this implement/fix?

Follow-up optimization to #10757 that reduces flash memory usage in the `esp32_improv` and `improv_base` components by eliminating STL container overhead and unnecessary string allocations. This is the first step in optimizing the `next_url` feature - additional optimizations (such as PROGMEM for ESP8266) can be addressed in future PRs.

**Changes:**
1. **esp32_improv**: Replace `std::vector<std::string>` with stack-allocated array for URL building
2. **esp32_improv**: Use `snprintf` instead of string concatenation for webserver URL
3. **improv_base**: Refactor string replacement to eliminate code duplication
4. **improv_base**: Use compile-time `constexpr` for placeholder strings and lengths

**Memory Impact:**
- Flash savings: **-352 bytes** (-0.028%)
- Breakdown: esp32_improv (-76 bytes), improv_base (-276 bytes)
- Reduces #10757's flash increase from +1,620 bytes to +1,268 bytes (21.6% reduction)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up optimization to #10757

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Existing esp32_improv configuration works unchanged:
esp32_improv:
  authorizer: none
  next_url: "https://example.com/setup?device={{device_name}}&ip={{ip_address}}&version={{esphome_version}}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Technical Details

### Before (from PR #10757):
```cpp
std::vector<std::string> urls;
std::string next_url = this->get_formatted_next_url_();
if (!next_url.empty()) {
  urls.push_back(next_url);
}
urls.emplace_back(ESPHOME_MY_LINK);
#ifdef USE_WEBSERVER
for (auto &ip : wifi::global_wifi_component->wifi_sta_ip_addresses()) {
  if (ip.is_ip4()) {
    std::string webserver_url = "http://" + ip.str() + ":" + to_string(USE_WEBSERVER_PORT);
    urls.push_back(webserver_url);
    break;
  }
}
#endif
```

### After:
```cpp
std::string url_strings[3];
size_t url_count = 0;
std::string next_url = this->get_formatted_next_url_();
if (!next_url.empty()) {
  url_strings[url_count++] = std::move(next_url);
}
url_strings[url_count++] = ESPHOME_MY_LINK;
#ifdef USE_WEBSERVER
for (auto &ip : wifi::global_wifi_component->wifi_sta_ip_addresses()) {
  if (ip.is_ip4()) {
    char url_buffer[64];
    snprintf(url_buffer, sizeof(url_buffer), "http://%s:%d", ip.str().c_str(), USE_WEBSERVER_PORT);
    url_strings[url_count++] = url_buffer;
    break;
  }
}
#endif
```

### improv_base optimization:
```cpp
// Before: Duplicated replacement code with magic numbers
std::string formatted_url = this->next_url_;
const std::string device_name_placeholder = "{{device_name}}";
const std::string &device_name = App.get_name();
size_t pos = 0;
while ((pos = formatted_url.find(device_name_placeholder, pos)) != std::string::npos) {
  formatted_url.replace(pos, device_name_placeholder.length(), device_name);
  pos += device_name.length();
}
// ... duplicate code for {{ip_address}}

// After: Reusable helper with constexpr placeholders
static constexpr const char DEVICE_NAME_PLACEHOLDER[] = "{{device_name}}";
static constexpr size_t DEVICE_NAME_PLACEHOLDER_LEN = sizeof(DEVICE_NAME_PLACEHOLDER) - 1;

static void replace_all_in_place(std::string &str, const char *placeholder,
                                  size_t placeholder_len, const std::string &replacement) {
  size_t pos = 0;
  const size_t replacement_len = replacement.length();
  while ((pos = str.find(placeholder, pos)) != std::string::npos) {
    str.replace(pos, placeholder_len, replacement);
    pos += replacement_len;
  }
}

std::string formatted_url = this->next_url_;
replace_all_in_place(formatted_url, DEVICE_NAME_PLACEHOLDER, DEVICE_NAME_PLACEHOLDER_LEN, App.get_name());
```

## Memory Analysis

Tested on ESP32 IDF with `tests/components/esp32_improv/common.yaml`:

| Configuration | Flash (bytes) | Change |
|--------------|---------------|--------|
| Baseline (PR #10757 merged) | 1,249,279 | baseline |
| After esp32_improv optimization | 1,249,203 | -76 bytes |
| After improv_base optimization | 1,248,927 | -352 bytes total |

**RAM:** No change (49,332 bytes)

## Future Optimization Opportunities

### 1. Improv Library API Limitation

The external Improv library (`improv/Improv` v1.2.4) requires `std::vector<std::string>` for its `build_rpc_response()` function. While this PR optimizes URL building with a stack-allocated array, we still incur `std::vector` overhead when passing URLs to the library:

```cpp
// We optimize this part...
std::string url_strings[3];
size_t url_count = 0;
// ... build URLs efficiently ...

// But still need to create a vector here due to Improv library API
std::vector<uint8_t> data = improv::build_rpc_response(
    improv::WIFI_SETTINGS,
    std::vector<std::string>(url_strings, url_strings + url_count)  // <-- temporary vector
);
```

**Potential solution:**

Add a raw pointer + size overload to the Improv library:
```cpp
std::vector<uint8_t> build_rpc_response(Command command, const std::string *datum, size_t datum_size, bool add_checksum = true);
```

The implementation is straightforward - the existing `build_rpc_response()` only uses the vector for iteration and `.size()`, so adding this overload would be a simple copy-paste with `datum_size` replacing `datum.size()`.

**Note:** The Improv library is maintained by ESPHome at https://github.com/improv-wifi/sdk-cpp, so we can add this optimized API directly. This would eliminate the remaining vector construction overhead (~100-200 bytes flash).

### 2. ESP8266 PROGMEM Optimization

The `improv_base` component placeholder strings (`"{{device_name}}"` and `"{{ip_address}}"`) are currently stored in RAM on ESP8266. While `esp32_improv` is ESP32-only, `improv_serial` (which also uses `improv_base`) can run on ESP8266. These strings could be moved to flash memory using PROGMEM in a future PR to save RAM on ESP8266 platforms. With alignment and padding, the actual savings would likely be 40-60 bytes RAM (15 bytes + 14 bytes data + alignment overhead). This was not addressed in this PR as:
1. The primary focus is flash optimization for ESP32
2. PROGMEM requires platform-specific code (`#ifdef USE_ESP8266`) and special string handling
3. ESP8266 users typically don't use the `next_url` feature (it was added for ESP32)
4. Would require testing on actual ESP8266 hardware to measure exact impact
