### PR TITLE
[json] Add basic compile tests

### DIFF
--- a/tests/components/json/common.yaml
+++ b/tests/components/json/common.yaml
@@ -1,0 +1,33 @@
+json:
+
+interval:
+  - interval: 60s
+    then:
+      - lambda: |-
+          // Test build_json
+          std::string json_str = esphome::json::build_json([](JsonObject root) {
+            root["sensor"] = "temperature";
+            root["value"] = 23.5;
+            root["unit"] = "°C";
+          });
+          ESP_LOGD("test", "Built JSON: %s", json_str.c_str());
+
+          // Test parse_json
+          bool parse_ok = esphome::json::parse_json(json_str, [](JsonObject root) {
+            if (root.containsKey("sensor") && root.containsKey("value")) {
+              const char* sensor = root["sensor"];
+              float value = root["value"];
+              ESP_LOGD("test", "Parsed: sensor=%s, value=%.1f", sensor, value);
+              return true;
+            }
+            return false;
+          });
+          ESP_LOGD("test", "Parse result: %s", parse_ok ? "success" : "failed");
+
+          // Test JsonBuilder class
+          esphome::json::JsonBuilder builder;
+          JsonObject obj = builder.root();
+          obj["test"] = "direct_builder";
+          obj["count"] = 42;
+          std::string result = builder.serialize();
+          ESP_LOGD("test", "JsonBuilder result: %s", result.c_str());

--- a/tests/components/json/common.yaml
+++ b/tests/components/json/common.yaml
@@ -18,11 +18,11 @@ interval:
               const char* sensor = root["sensor"];
               float value = root["value"];
               ESP_LOGD("test", "Parsed: sensor=%s, value=%.1f", sensor, value);
-              return true;
+            } else {
+              ESP_LOGD("test", "Parsed JSON missing required keys");
             }
-            return false;
           });
-          ESP_LOGD("test", "Parse result: %s", parse_ok ? "success" : "failed");
+          ESP_LOGD("test", "Parse result (JSON syntax only): %s", parse_ok ? "success" : "failed");
 
           // Test JsonBuilder class
           esphome::json::JsonBuilder builder;

--- a/tests/components/json/test.esp32-idf.yaml
+++ b/tests/components/json/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/json/test.esp8266-ard.yaml
+++ b/tests/components/json/test.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds basic compile tests for the `json` component that were previously missing. The tests verify that the json component loads correctly and that the ArduinoJson library integration works properly by exercising the core JSON building and parsing functionality.

The tests include lambdas that call:
- `esphome::json::build_json()` - Building JSON objects with strings, numbers, and nested data
- `esphome::json::parse_json()` - Parsing JSON strings and extracting values
- `esphome::json::JsonBuilder` - Direct JsonBuilder class usage for object creation and serialization

This ensures the json component compiles and links correctly across platforms, and catches issues like missing headers, linking problems, or API incompatibilities.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - This is a test coverage improvement

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# The json component is typically auto-loaded by components like web_server, mqtt, etc.
# For standalone testing:
json:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
