### PR TITLE
[esp32_can] Add advanced bit rate settings to ESP32_CAN

### DIFF
--- a/esphome/components/esp32_can/canbus.py
+++ b/esphome/components/esp32_can/canbus.py
@@ -26,6 +26,10 @@ CODEOWNERS = ["@Sympatron"]
 DEPENDENCIES = ["esp32"]
 
 CONF_TX_ENQUEUE_TIMEOUT = "tx_enqueue_timeout"
+CONF_ADVANCED_BIT_RATE = "advanced_bit_rate"
+CONF_BRP = "prescaler"
+CONF_TSEG1 = "tseg_1"
+CONF_TSEG2 = "tseg_2"
 
 esp32_can_ns = cg.esphome_ns.namespace("esp32_can")
 esp32_can = esp32_can_ns.class_("ESP32Can", CanbusComponent)
@@ -79,6 +83,14 @@ def validate_bit_rate(value):
         raise cv.Invalid(f"Bit rate {value} is not supported on {variant}")
     return cv.enum(CAN_SPEEDS[variant])(value)
 
+def validate_prescaler(value):
+    if value <= 0:
+        raise cv.Invalid(f"Prescaler needs to be a positive integer")
+    if value <= 128 and value % 2 != 0:
+        raise cv.Invalid(f"Prescaler needs to be an even number if less or equal to 128")
+    if value >= 132 and value % 4 != 0:
+        raise cv.Invalid(f"Prescaler needs to be a multiple of 4 if more or equal to 132")
+    return value
 
 CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
     {
@@ -89,18 +101,26 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
         cv.Optional(CONF_RX_QUEUE_LEN): cv.uint32_t,
         cv.Optional(CONF_TX_QUEUE_LEN): cv.uint32_t,
         cv.Optional(CONF_TX_ENQUEUE_TIMEOUT): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_ADVANCED_BIT_RATE):
+            {
+                cv.Required(CONF_BRP): validate_prescaler,
+                cv.Required(CONF_TSEG1): cv.int_range(1,16),
+                cv.Required(CONF_TSEG2): cv.int_range(1,8),
+            },
     }
 )
 
 
-def get_default_tx_enqueue_timeout(bit_rate):
-    bit_rate_numeric = canbus.get_rate(bit_rate)
+def get_default_tx_enqueue_timeout(bit_rate_config):
+    if CONF_BRP in bit_rate_config:
+        bit_rate_numeric = 80_000_000 / (bit_rate_config[CONF_BRP] * (1 + bit_rate_config[CONF_TSEG1] + bit_rate_config[CONF_TSEG2]))
+    else:
+        bit_rate_numeric = canbus.get_rate(bit_rate_config)
     bits_per_packet = 140  # ~max CAN message length
     ms_per_packet = bits_per_packet / bit_rate_numeric * 1000
     return int(
         max(min(math.ceil(10 * ms_per_packet), 1000), 1)
     )  # ~10 packet lengths, min 1ms, max 1000ms
-
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -115,7 +135,13 @@ async def to_code(config):
 
     if CONF_TX_ENQUEUE_TIMEOUT in config:
         tx_enqueue_timeout_ms = config[CONF_TX_ENQUEUE_TIMEOUT].total_milliseconds
+    elif CONF_ADVANCED_BIT_RATE in config:
+        tx_enqueue_timeout_ms = get_default_tx_enqueue_timeout(config[CONF_ADVANCED_BIT_RATE])
     else:
         tx_enqueue_timeout_ms = get_default_tx_enqueue_timeout(config[CONF_BIT_RATE])
 
     cg.add(var.set_tx_enqueue_timeout_ms(tx_enqueue_timeout_ms))
+    if CONF_ADVANCED_BIT_RATE in config:
+        cg.add(var.set_brp(config[CONF_ADVANCED_BIT_RATE][CONF_BRP]))
+        cg.add(var.set_tseg1(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG1]))
+        cg.add(var.set_tseg2(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG2]))

--- a/esphome/components/esp32_can/canbus.py
+++ b/esphome/components/esp32_can/canbus.py
@@ -89,8 +89,11 @@ def validate_prescaler(value):
     if value <= 128 and value % 2 != 0:
         raise cv.Invalid("Prescaler needs to be an even number if less or equal to 128")
     if value >= 132 and value % 4 != 0:
-        raise cv.Invalid("Prescaler needs to be a multiple of 4 if more or equal to 132")
+        raise cv.Invalid(
+            "Prescaler needs to be a multiple of 4 if more or equal to 132"
+        )
     return value
+
 
 CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
     {
@@ -101,19 +104,21 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
         cv.Optional(CONF_RX_QUEUE_LEN): cv.uint32_t,
         cv.Optional(CONF_TX_QUEUE_LEN): cv.uint32_t,
         cv.Optional(CONF_TX_ENQUEUE_TIMEOUT): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_ADVANCED_BIT_RATE):
-            {
-                cv.Required(CONF_PRESCALER): validate_prescaler,
-                cv.Required(CONF_TSEG_1): cv.int_range(1,16),
-                cv.Required(CONF_TSEG_2): cv.int_range(1,8),
-            },
+        cv.Optional(CONF_ADVANCED_BIT_RATE): {
+            cv.Required(CONF_PRESCALER): validate_prescaler,
+            cv.Required(CONF_TSEG_1): cv.int_range(1,16),
+            cv.Required(CONF_TSEG_2): cv.int_range(1,8),
+        },
     }
 )
 
 
 def get_default_tx_enqueue_timeout(bit_rate_config):
     if CONF_PRESCALER in bit_rate_config:
-        bit_rate_numeric = 80_000_000 / (bit_rate_config[CONF_PRESCALER] * (1 + bit_rate_config[CONF_TSEG_1] + bit_rate_config[CONF_TSEG_2]))
+        bit_rate_numeric = 80_000_000 / (
+            bit_rate_config[CONF_PRESCALER]
+            * (1 + bit_rate_config[CONF_TSEG_1] + bit_rate_config[CONF_TSEG_2])
+        )
     else:
         bit_rate_numeric = canbus.get_rate(bit_rate_config)
     bits_per_packet = 140  # ~max CAN message length
@@ -136,7 +141,9 @@ async def to_code(config):
     if CONF_TX_ENQUEUE_TIMEOUT in config:
         tx_enqueue_timeout_ms = config[CONF_TX_ENQUEUE_TIMEOUT].total_milliseconds
     elif CONF_ADVANCED_BIT_RATE in config:
-        tx_enqueue_timeout_ms = get_default_tx_enqueue_timeout(config[CONF_ADVANCED_BIT_RATE])
+        tx_enqueue_timeout_ms = get_default_tx_enqueue_timeout(
+            config[CONF_ADVANCED_BIT_RATE]
+        )
     else:
         tx_enqueue_timeout_ms = get_default_tx_enqueue_timeout(config[CONF_BIT_RATE])
 

--- a/esphome/components/esp32_can/canbus.py
+++ b/esphome/components/esp32_can/canbus.py
@@ -83,6 +83,7 @@ def validate_bit_rate(value):
         raise cv.Invalid(f"Bit rate {value} is not supported on {variant}")
     return cv.enum(CAN_SPEEDS[variant])(value)
 
+
 def validate_prescaler(value):
     if value <= 0:
         raise cv.Invalid("Prescaler needs to be a positive integer")
@@ -106,8 +107,8 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
         cv.Optional(CONF_TX_ENQUEUE_TIMEOUT): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_ADVANCED_BIT_RATE): {
             cv.Required(CONF_PRESCALER): validate_prescaler,
-            cv.Required(CONF_TSEG_1): cv.int_range(1,16),
-            cv.Required(CONF_TSEG_2): cv.int_range(1,8),
+            cv.Required(CONF_TSEG_1): cv.int_range(1, 16),
+            cv.Required(CONF_TSEG_2): cv.int_range(1, 8),
         },
     }
 )
@@ -126,6 +127,7 @@ def get_default_tx_enqueue_timeout(bit_rate_config):
     return int(
         max(min(math.ceil(10 * ms_per_packet), 1000), 1)
     )  # ~10 packet lengths, min 1ms, max 1000ms
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/esphome/components/esp32_can/canbus.py
+++ b/esphome/components/esp32_can/canbus.py
@@ -27,9 +27,9 @@ DEPENDENCIES = ["esp32"]
 
 CONF_TX_ENQUEUE_TIMEOUT = "tx_enqueue_timeout"
 CONF_ADVANCED_BIT_RATE = "advanced_bit_rate"
-CONF_BRP = "prescaler"
-CONF_TSEG1 = "tseg_1"
-CONF_TSEG2 = "tseg_2"
+CONF_PRESCALER = "prescaler"
+CONF_TSEG_1 = "tseg_1"
+CONF_TSEG_2 = "tseg_2"
 
 esp32_can_ns = cg.esphome_ns.namespace("esp32_can")
 esp32_can = esp32_can_ns.class_("ESP32Can", CanbusComponent)
@@ -85,11 +85,11 @@ def validate_bit_rate(value):
 
 def validate_prescaler(value):
     if value <= 0:
-        raise cv.Invalid(f"Prescaler needs to be a positive integer")
+        raise cv.Invalid("Prescaler needs to be a positive integer")
     if value <= 128 and value % 2 != 0:
-        raise cv.Invalid(f"Prescaler needs to be an even number if less or equal to 128")
+        raise cv.Invalid("Prescaler needs to be an even number if less or equal to 128")
     if value >= 132 and value % 4 != 0:
-        raise cv.Invalid(f"Prescaler needs to be a multiple of 4 if more or equal to 132")
+        raise cv.Invalid("Prescaler needs to be a multiple of 4 if more or equal to 132")
     return value
 
 CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
@@ -103,9 +103,9 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
         cv.Optional(CONF_TX_ENQUEUE_TIMEOUT): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_ADVANCED_BIT_RATE):
             {
-                cv.Required(CONF_BRP): validate_prescaler,
-                cv.Required(CONF_TSEG1): cv.int_range(1,16),
-                cv.Required(CONF_TSEG2): cv.int_range(1,8),
+                cv.Required(CONF_PRESCALER): validate_prescaler,
+                cv.Required(CONF_TSEG_1): cv.int_range(1,16),
+                cv.Required(CONF_TSEG_2): cv.int_range(1,8),
             },
     }
 )
@@ -113,7 +113,7 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
 
 def get_default_tx_enqueue_timeout(bit_rate_config):
     if CONF_BRP in bit_rate_config:
-        bit_rate_numeric = 80_000_000 / (bit_rate_config[CONF_BRP] * (1 + bit_rate_config[CONF_TSEG1] + bit_rate_config[CONF_TSEG2]))
+        bit_rate_numeric = 80_000_000 / (bit_rate_config[CONF_PRESCALER] * (1 + bit_rate_config[CONF_TSEG_1] + bit_rate_config[CONF_TSEG_2]))
     else:
         bit_rate_numeric = canbus.get_rate(bit_rate_config)
     bits_per_packet = 140  # ~max CAN message length
@@ -142,6 +142,6 @@ async def to_code(config):
 
     cg.add(var.set_tx_enqueue_timeout_ms(tx_enqueue_timeout_ms))
     if CONF_ADVANCED_BIT_RATE in config:
-        cg.add(var.set_brp(config[CONF_ADVANCED_BIT_RATE][CONF_BRP]))
-        cg.add(var.set_tseg1(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG1]))
-        cg.add(var.set_tseg2(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG2]))
+        cg.add(var.set_brp(config[CONF_ADVANCED_BIT_RATE][CONF_PRESCALER]))
+        cg.add(var.set_tseg1(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG_1]))
+        cg.add(var.set_tseg2(config[CONF_ADVANCED_BIT_RATE][CONF_TSEG_2]))

--- a/esphome/components/esp32_can/canbus.py
+++ b/esphome/components/esp32_can/canbus.py
@@ -112,7 +112,7 @@ CONFIG_SCHEMA = canbus.CANBUS_SCHEMA.extend(
 
 
 def get_default_tx_enqueue_timeout(bit_rate_config):
-    if CONF_BRP in bit_rate_config:
+    if CONF_PRESCALER in bit_rate_config:
         bit_rate_numeric = 80_000_000 / (bit_rate_config[CONF_PRESCALER] * (1 + bit_rate_config[CONF_TSEG_1] + bit_rate_config[CONF_TSEG_2]))
     else:
         bit_rate_numeric = canbus.get_rate(bit_rate_config)

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -91,9 +91,9 @@ bool ESP32Can::setup_internal() {
     // advanced bit rate settings (only one of quanta or brp needs to be provided, and we provide the brp)
     t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT,
                                        .quanta_resolution_hz = 0,
-                                       .brp = (uint32_t)this->brp_,
-                                       .tseg_1 = (uint8_t)this->tseg1_,
-                                       .tseg_2 = (uint8_t)this->tseg2_,
+                                       .brp = (uint32_t) this->brp_,
+                                       .tseg_1 = (uint8_t) this->tseg1_,
+                                       .tseg_2 = (uint8_t) this->tseg2_,
                                        .sjw = 3,
                                        .triple_sampling = false};
   } else if (!get_bitrate(this->bit_rate_, &t_config)) {

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -88,7 +88,7 @@ bool ESP32Can::setup_internal() {
   twai_timing_config_t t_config;
 
   if (this->brp_ != -1 && this->tseg1_ != -1 && this->tseg2_ != -1) {
-    // advanced bit rate settings (only one of quanta or brp needs to be provided, andwe privide the brp)
+    // advanced bit rate settings (only one of quanta or brp needs to be provided, and we provide the brp)
     t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT,
                                        .quanta_resolution_hz = 0,
                                        .brp = (uint32_t)this->brp_,

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -89,9 +89,14 @@ bool ESP32Can::setup_internal() {
 
   if (this->brp_ != -1 && this->tseg1_ != -1 && this->tseg2_ != -1) {
     // advanced bit rate settings (only one of quanta or brp needs to be provided, andwe privide the brp)
-    t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT, .quanta_resolution_hz = 0, .brp = (uint32_t)this->brp_, .tseg_1 = (uint8_t)this->tseg1_, .tseg_2 = (uint8_t)this->tseg2_, .sjw = 3, .triple_sampling = false};
-  }
-  else if (!get_bitrate(this->bit_rate_, &t_config)) {
+    t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT,
+                                       .quanta_resolution_hz = 0,
+                                       .brp = (uint32_t)this->brp_,
+                                       .tseg_1 = (uint8_t)this->tseg1_,
+                                       .tseg_2 = (uint8_t)this->tseg2_,
+                                       .sjw = 3,
+                                       .triple_sampling = false};
+  } else if (!get_bitrate(this->bit_rate_, &t_config)) {
     // invalid bit rate
     this->mark_failed();
     return false;

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -89,13 +89,13 @@ bool ESP32Can::setup_internal() {
 
   if (this->brp_ != -1 && this->tseg1_ != -1 && this->tseg2_ != -1) {
     // advanced bit rate settings (only one of quanta or brp needs to be provided, and we provide the brp)
-    t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT,
-                                       .quanta_resolution_hz = 0,
-                                       .brp = (uint32_t) this->brp_,
-                                       .tseg_1 = (uint8_t) this->tseg1_,
-                                       .tseg_2 = (uint8_t) this->tseg2_,
-                                       .sjw = 3,
-                                       .triple_sampling = false};
+    t_config = (twai_timing_config_t){.clk_src = TWAI_CLK_SRC_DEFAULT,
+                                      .quanta_resolution_hz = 0,
+                                      .brp = (uint32_t) this->brp_,
+                                      .tseg_1 = (uint8_t) this->tseg1_,
+                                      .tseg_2 = (uint8_t) this->tseg2_,
+                                      .sjw = 3,
+                                      .triple_sampling = false};
   } else if (!get_bitrate(this->bit_rate_, &t_config)) {
     // invalid bit rate
     this->mark_failed();

--- a/esphome/components/esp32_can/esp32_can.cpp
+++ b/esphome/components/esp32_can/esp32_can.cpp
@@ -87,7 +87,11 @@ bool ESP32Can::setup_internal() {
   twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
   twai_timing_config_t t_config;
 
-  if (!get_bitrate(this->bit_rate_, &t_config)) {
+  if (this->brp_ != -1 && this->tseg1_ != -1 && this->tseg2_ != -1) {
+    // advanced bit rate settings (only one of quanta or brp needs to be provided, andwe privide the brp)
+    t_config = (twai_timing_config_t) {.clk_src = TWAI_CLK_SRC_DEFAULT, .quanta_resolution_hz = 0, .brp = (uint32_t)this->brp_, .tseg_1 = (uint8_t)this->tseg1_, .tseg_2 = (uint8_t)this->tseg2_, .sjw = 3, .triple_sampling = false};
+  }
+  else if (!get_bitrate(this->bit_rate_, &t_config)) {
     // invalid bit rate
     this->mark_failed();
     return false;

--- a/esphome/components/esp32_can/esp32_can.h
+++ b/esphome/components/esp32_can/esp32_can.h
@@ -14,6 +14,9 @@ class ESP32Can : public canbus::Canbus {
  public:
   void set_rx(int rx) { rx_ = rx; }
   void set_tx(int tx) { tx_ = tx; }
+  void set_brp(int brp) { brp_ = brp; }
+  void set_tseg1(int tseg1) { tseg1_ = tseg1; }
+  void set_tseg2(int tseg2) { tseg2_ = tseg2; }
   void set_tx_queue_len(uint32_t tx_queue_len) { this->tx_queue_len_ = tx_queue_len; }
   void set_rx_queue_len(uint32_t rx_queue_len) { this->rx_queue_len_ = rx_queue_len; }
   void set_tx_enqueue_timeout_ms(uint32_t tx_enqueue_timeout_ms) {
@@ -28,6 +31,9 @@ class ESP32Can : public canbus::Canbus {
 
   int rx_{-1};
   int tx_{-1};
+  int brp_{-1};
+  int tseg1_{-1};
+  int tseg2_{-1};
   TickType_t tx_enqueue_timeout_ticks_{};
   optional<uint32_t> tx_queue_len_{};
   optional<uint32_t> rx_queue_len_{};

--- a/tests/components/esp32_can/common.yaml
+++ b/tests/components/esp32_can/common.yaml
@@ -18,6 +18,10 @@ canbus:
     tx_pin: ${tx_pin}
     can_id: 4
     bit_rate: 50kbps
+    advanced_bit_rate:
+        prescaler: 80
+        tseg_1: 15
+        tseg_2: 4
     on_frame:
       - can_id: 500
         then:

--- a/tests/components/esp32_can/common.yaml
+++ b/tests/components/esp32_can/common.yaml
@@ -19,9 +19,9 @@ canbus:
     can_id: 4
     bit_rate: 50kbps
     advanced_bit_rate:
-        prescaler: 80
-        tseg_1: 15
-        tseg_2: 4
+      prescaler: 80
+      tseg_1: 15
+      tseg_2: 4
     on_frame:
       - can_id: 500
         then:

--- a/tests/components/esp32_can/test.esp32-c6-idf.yaml
+++ b/tests/components/esp32_can/test.esp32-c6-idf.yaml
@@ -31,6 +31,10 @@ canbus:
     tx_pin: GPIO7
     can_id: 4
     bit_rate: 50kbps
+    advanced_bit_rate:
+        prescaler: 80
+        tseg_1: 15
+        tseg_2: 4
     on_frame:
       - can_id: 500
         then:

--- a/tests/components/esp32_can/test.esp32-c6-idf.yaml
+++ b/tests/components/esp32_can/test.esp32-c6-idf.yaml
@@ -32,9 +32,9 @@ canbus:
     can_id: 4
     bit_rate: 50kbps
     advanced_bit_rate:
-        prescaler: 80
-        tseg_1: 15
-        tseg_2: 4
+      prescaler: 80
+      tseg_1: 15
+      tseg_2: 4
     on_frame:
       - can_id: 500
         then:


### PR DESCRIPTION
# What does this implement/fix?

The ESP IDF allows for fine control of the CAN bit rate, by changing individual fields in the config_t structure, in addition to the default macro definitions. There are cases where fine tuning of bit rate is necessary (author's case: 11400 bps as measured on an intercom SW_CAN) 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- none

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5503

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
canbus:
  - platform: esp32_can
    tx_pin: GPIOXX
    rx_pin: GPIOXX
    can_id: 4
    advanced_bit_rate:
        prescaler: 80
        tseg_1: 15
        tseg_2: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
