### PR TITLE
[core] Fix crash when config keys contain periods during platform detection

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -318,7 +318,8 @@ def preload_core_config(config, result) -> str:
     target_platforms = []
 
     for domain in config:
-        if domain.startswith("."):
+        # Skip package keys which may contain periods (e.g., "ratgdo.esphome")
+        if "." in domain:
             continue
         if _is_target_platform(domain):
             target_platforms += [domain]

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -476,6 +476,55 @@ def test_preload_core_config_multiple_platforms(setup_core: Path) -> None:
             preload_core_config(config, result)
 
 
+def test_preload_core_config_skips_package_keys_with_periods(setup_core: Path) -> None:
+    """Test preload_core_config skips package keys containing periods.
+
+    Package keys can contain periods (e.g., "ratgdo.esphome") and should be
+    skipped when searching for target platforms to avoid triggering the
+    assertion in get_component() that component names cannot contain periods.
+
+    Regression test for: https://github.com/esphome/esphome/issues/11182
+    """
+    config = {
+        CONF_ESPHOME: {
+            CONF_NAME: "test_device",
+        },
+        "esp32": {},
+        # Package key with period should be ignored
+        "ratgdo.esphome": "github://ratgdo/esphome-ratgdo/v32disco_secplusv1.yaml",
+    }
+    result = {}
+
+    # Should not raise AssertionError from get_component()
+    platform = preload_core_config(config, result)
+
+    assert platform == "esp32"
+    assert CORE.name == "test_device"
+
+
+def test_preload_core_config_skips_keys_starting_with_period(setup_core: Path) -> None:
+    """Test preload_core_config skips keys starting with period.
+
+    Keys starting with "." are special ESPHome internal keys and should be
+    skipped when searching for target platforms.
+    """
+    config = {
+        CONF_ESPHOME: {
+            CONF_NAME: "test_device",
+        },
+        "esp8266": {},
+        # Internal key starting with period should be ignored
+        ".platformio_options": {"board_build.flash_mode": "dout"},
+    }
+    result = {}
+
+    # Should not raise any errors
+    platform = preload_core_config(config, result)
+
+    assert platform == "esp8266"
+    assert CORE.name == "test_device"
+
+
 def test_include_file_header(tmp_path: Path, mock_copy_file_if_changed: Mock) -> None:
     """Test include_file adds include statement for header files."""
     src_file = tmp_path / "source.h"


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression causing `AssertionError` crashes during config validation when top-level config keys contain periods.

The `preload_core_config()` function iterates through all top-level config keys to identify the target platform (e.g., `esp32`, `esp8266`). It calls `get_component()` on each key to check if it's a platform component. However, `get_component()` has an assertion that component names cannot contain periods, causing a crash when encountering any top-level key with a period.

This regression surfaced in 2025.10.x due to changes in config processing order. Users reported crashes in #11182 when using configs with package keys like `ratgdo.esphome`, even when correctly placed under `packages:`.

**The fix:** Skip any config key containing a period when searching for target platforms, since:
- Component/platform names cannot contain periods by design (enforced by `get_component()` assertion)
- This single check replaces the previous `startswith(".")` check and handles more cases
- Prevents crashes while maintaining correct platform detection behavior

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11182

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (bugfix, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config would previously crash with AssertionError
# (though this is not a recommended pattern, it shouldn't crash)

packages:
  ratgdo.esphome: github://ratgdo/esphome-ratgdo/v32disco_secplusv1.yaml

esphome:
  name: my-device

esp32:
  board: esp32dev
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
