### PR TITLE
Add basic text_sensor tests

### DIFF
--- a/tests/components/text_sensor/common.yaml
+++ b/tests/components/text_sensor/common.yaml
@@ -1,0 +1,66 @@
+text_sensor:
+  - platform: template
+    name: "Test Substitute Single"
+    id: test_substitute_single
+    filters:
+      - substitute:
+          - ERROR -> Error
+
+  - platform: template
+    name: "Test Substitute Multiple"
+    id: test_substitute_multiple
+    filters:
+      - substitute:
+          - ERROR -> Error
+          - WARN -> Warning
+          - INFO -> Information
+          - DEBUG -> Debug
+
+  - platform: template
+    name: "Test Substitute Chained"
+    id: test_substitute_chained
+    filters:
+      - substitute:
+          - foo -> bar
+      - to_upper
+      - substitute:
+          - BAR -> baz
+
+  - platform: template
+    name: "Test Map Single"
+    id: test_map_single
+    filters:
+      - map:
+          - ON -> Active
+
+  - platform: template
+    name: "Test Map Multiple"
+    id: test_map_multiple
+    filters:
+      - map:
+          - ON -> Active
+          - OFF -> Inactive
+          - UNKNOWN -> Error
+          - IDLE -> Standby
+
+  - platform: template
+    name: "Test Map Passthrough"
+    id: test_map_passthrough
+    filters:
+      - map:
+          - Good -> Excellent
+          - Bad -> Poor
+
+  - platform: template
+    name: "Test All Filters"
+    id: test_all_filters
+    filters:
+      - to_upper
+      - to_lower
+      - append: " suffix"
+      - prepend: "prefix "
+      - substitute:
+          - prefix -> PREFIX
+          - suffix -> SUFFIX
+      - map:
+          - PREFIX text SUFFIX -> mapped

--- a/tests/components/text_sensor/test.esp8266-ard.yaml
+++ b/tests/components/text_sensor/test.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add basic text_sensor tests

To establish baseline for https://github.com/esphome/esphome/pull/11423

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
