### PR TITLE
[ci] Fix clang-tidy split mode for core file changes

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -483,3 +483,4 @@ class WarnIfComponentBlockingGuard {
 void clear_setup_priority_overrides();
 
 }  // namespace esphome
+// Test core file change for split logic

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -483,4 +483,3 @@ class WarnIfComponentBlockingGuard {
 void clear_setup_priority_overrides();
 
 }  // namespace esphome
-// Test core file change for split logic

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -385,7 +385,7 @@ def _filter_changed_ci(files: list[str]) -> list[str]:
     # Action: Check ALL files in each changed component
     # Convert component list to set for O(1) lookups
     component_set = set(components)
-    print(f"Changed components: {', '.join(sorted(components))}")
+    print(f"Changed components: {', '.join(sorted(components))}", file=sys.stderr)
 
     # The 'files' parameter contains ALL files in the codebase that clang-tidy would check.
     # We filter this down to only files in the changed components.

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -8,6 +8,7 @@ import os.path
 from pathlib import Path
 import re
 import subprocess
+import sys
 import time
 from typing import Any
 
@@ -305,7 +306,10 @@ def get_changed_components() -> list[str] | None:
         for f in changed
     )
     if core_cpp_changed:
-        print("Core C++/header files changed - will run full clang-tidy scan")
+        print(
+            "Core C++/header files changed - will run full clang-tidy scan",
+            file=sys.stderr,
+        )
         return None
 
     # Use list-components.py to get changed components
@@ -319,7 +323,10 @@ def get_changed_components() -> list[str] | None:
         return parse_list_components_output(result.stdout)
     except subprocess.CalledProcessError:
         # If the script fails, fall back to full scan
-        print("Could not determine changed components - will run full clang-tidy scan")
+        print(
+            "Could not determine changed components - will run full clang-tidy scan",
+            file=sys.stderr,
+        )
         return None
 
 
@@ -371,7 +378,7 @@ def _filter_changed_ci(files: list[str]) -> list[str]:
             if f in changed and not f.startswith(ESPHOME_COMPONENTS_PATH)
         ]
         if not files:
-            print("No files changed")
+            print("No files changed", file=sys.stderr)
         return files
 
     # Scenario 3: Specific components changed

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -672,18 +672,23 @@ def extract_component_names_from_files(files: list[str]) -> list[str]:
         files: List of file paths
 
     Returns:
-        List of unique component names (unordered)
+        List of unique component names (preserves order)
     """
-    components = []
-    for file in files:
-        component_name = get_component_from_path(file)
-        if component_name and component_name not in components:
-            components.append(component_name)
-    return components
+    return list(
+        dict.fromkeys(comp for file in files if (comp := get_component_from_path(file)))
+    )
 
 
-def add_item_to_components_graph(components_graph, parent, child):
-    """Add a dependency relationship to the components graph."""
+def add_item_to_components_graph(
+    components_graph: dict[str, list[str]], parent: str, child: str
+) -> None:
+    """Add a dependency relationship to the components graph.
+
+    Args:
+        components_graph: Graph mapping parent components to their children
+        parent: Parent component name
+        child: Child component name (dependent)
+    """
     if not parent.startswith("__") and parent != child:
         if parent not in components_graph:
             components_graph[parent] = []
@@ -714,8 +719,12 @@ def resolve_auto_load(
     return auto_load()
 
 
-def create_components_graph():
-    """Create a graph of component dependencies."""
+def create_components_graph() -> dict[str, list[str]]:
+    """Create a graph of component dependencies.
+
+    Returns:
+        Dictionary mapping parent components to their children (dependencies)
+    """
     from pathlib import Path
 
     from esphome import const
@@ -806,8 +815,19 @@ def create_components_graph():
     return components_graph
 
 
-def find_children_of_component(components_graph, component_name, depth=0):
-    """Find all components that depend on the given component (recursively)."""
+def find_children_of_component(
+    components_graph: dict[str, list[str]], component_name: str, depth: int = 0
+) -> list[str]:
+    """Find all components that depend on the given component (recursively).
+
+    Args:
+        components_graph: Graph mapping parent components to their children
+        component_name: Component name to find children for
+        depth: Current recursion depth (max 10)
+
+    Returns:
+        List of all dependent component names (may contain duplicates removed at end)
+    """
     if component_name not in components_graph:
         return []
 

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import cache
 import json
 import os
@@ -648,3 +649,203 @@ def get_components_from_integration_fixtures() -> set[str]:
                     components.add(item["platform"])
 
     return components
+
+
+def filter_component_files(file_path: str) -> bool:
+    """Check if a file path is a component file.
+
+    Args:
+        file_path: Path to check
+
+    Returns:
+        True if the file is in a component directory
+    """
+    return file_path.startswith("esphome/components/") or file_path.startswith(
+        "tests/components/"
+    )
+
+
+def extract_component_names_from_files(files: list[str]) -> list[str]:
+    """Extract unique component names from a list of file paths.
+
+    Args:
+        files: List of file paths
+
+    Returns:
+        List of unique component names (unordered)
+    """
+    components = []
+    for file in files:
+        component_name = get_component_from_path(file)
+        if component_name and component_name not in components:
+            components.append(component_name)
+    return components
+
+
+def add_item_to_components_graph(components_graph, parent, child):
+    """Add a dependency relationship to the components graph."""
+    if not parent.startswith("__") and parent != child:
+        if parent not in components_graph:
+            components_graph[parent] = []
+        if child not in components_graph[parent]:
+            components_graph[parent].append(child)
+
+
+def resolve_auto_load(
+    auto_load: list[str] | Callable[[], list[str]] | Callable[[dict | None], list[str]],
+    config: dict | None = None,
+) -> list[str]:
+    """Resolve AUTO_LOAD to a list, handling callables with or without config parameter.
+
+    Args:
+        auto_load: The AUTO_LOAD value (list or callable)
+        config: Optional config to pass to callable AUTO_LOAD functions
+
+    Returns:
+        List of component names to auto-load
+    """
+    if not callable(auto_load):
+        return auto_load
+
+    import inspect
+
+    if inspect.signature(auto_load).parameters:
+        return auto_load(config)
+    return auto_load()
+
+
+def create_components_graph():
+    """Create a graph of component dependencies."""
+    from pathlib import Path
+
+    from esphome import const
+    from esphome.core import CORE
+    from esphome.loader import ComponentManifest, get_component, get_platform
+
+    # The root directory of the repo
+    root = Path(__file__).parent.parent
+    components_dir = root / "esphome" / "components"
+    # Fake some directory so that get_component works
+    CORE.config_path = root
+    # Various configuration to capture different outcomes used by `AUTO_LOAD` function.
+    KEY_CORE = const.KEY_CORE
+    KEY_TARGET_FRAMEWORK = const.KEY_TARGET_FRAMEWORK
+    KEY_TARGET_PLATFORM = const.KEY_TARGET_PLATFORM
+    PLATFORM_ESP32 = const.PLATFORM_ESP32
+    PLATFORM_ESP8266 = const.PLATFORM_ESP8266
+
+    TARGET_CONFIGURATIONS = [
+        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: None},
+        {KEY_TARGET_FRAMEWORK: "arduino", KEY_TARGET_PLATFORM: None},
+        {KEY_TARGET_FRAMEWORK: "esp-idf", KEY_TARGET_PLATFORM: None},
+        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: PLATFORM_ESP32},
+        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: PLATFORM_ESP8266},
+    ]
+    CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
+
+    components_graph = {}
+    platforms = []
+    components: list[tuple[ComponentManifest, str, Path]] = []
+
+    for path in components_dir.iterdir():
+        if not path.is_dir():
+            continue
+        if not (path / "__init__.py").is_file():
+            continue
+        name = path.name
+        comp = get_component(name)
+        if comp is None:
+            print(
+                f"Cannot find component {name}. Make sure current path is pip installed ESPHome"
+            )
+            import sys
+
+            sys.exit(1)
+
+        components.append((comp, name, path))
+        if comp.is_platform_component:
+            platforms.append(name)
+
+    platforms = set(platforms)
+
+    for comp, name, path in components:
+        for dependency in comp.dependencies:
+            add_item_to_components_graph(
+                components_graph, dependency.split(".")[0], name
+            )
+
+        for target_config in TARGET_CONFIGURATIONS:
+            CORE.data[KEY_CORE] = target_config
+            for item in resolve_auto_load(comp.auto_load, config=None):
+                add_item_to_components_graph(components_graph, item, name)
+        # restore config
+        CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
+
+        for platform_path in path.iterdir():
+            platform_name = platform_path.stem
+            if platform_name == name or platform_name not in platforms:
+                continue
+            platform = get_platform(platform_name, name)
+            if platform is None:
+                continue
+
+            add_item_to_components_graph(components_graph, platform_name, name)
+
+            for dependency in platform.dependencies:
+                add_item_to_components_graph(
+                    components_graph, dependency.split(".")[0], name
+                )
+
+            for target_config in TARGET_CONFIGURATIONS:
+                CORE.data[KEY_CORE] = target_config
+                for item in resolve_auto_load(platform.auto_load, config={}):
+                    add_item_to_components_graph(components_graph, item, name)
+            # restore config
+            CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
+
+    return components_graph
+
+
+def find_children_of_component(components_graph, component_name, depth=0):
+    """Find all components that depend on the given component (recursively)."""
+    if component_name not in components_graph:
+        return []
+
+    children = []
+
+    for child in components_graph[component_name]:
+        children.append(child)
+        if depth < 10:
+            children.extend(
+                find_children_of_component(components_graph, child, depth + 1)
+            )
+    # Remove duplicate values
+    return list(set(children))
+
+
+def get_components_with_dependencies(
+    files: list[str], get_dependencies: bool = False
+) -> list[str]:
+    """Get component names from files, optionally including their dependencies.
+
+    Args:
+        files: List of file paths
+        get_dependencies: If True, include all dependent components
+
+    Returns:
+        Sorted list of component names
+    """
+    components = extract_component_names_from_files(files)
+
+    if get_dependencies:
+        components_graph = create_components_graph()
+
+        all_components = components.copy()
+        for c in components:
+            all_components.extend(find_children_of_component(components_graph, c))
+        # Remove duplicate values
+        all_changed_components = list(set(all_components))
+
+        return sorted(all_changed_components)
+
+    return sorted(components)

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -764,12 +764,9 @@ def create_components_graph() -> dict[str, list[str]]:
         name = path.name
         comp = get_component(name)
         if comp is None:
-            print(
+            raise RuntimeError(
                 f"Cannot find component {name}. Make sure current path is pip installed ESPHome"
             )
-            import sys
-
-            sys.exit(1)
 
         components.append((comp, name, path))
         if comp.is_platform_component:

--- a/script/list-components.py
+++ b/script/list-components.py
@@ -1,180 +1,18 @@
 #!/usr/bin/env python3
 import argparse
-from collections.abc import Callable
-from pathlib import Path
-import sys
 
-from helpers import changed_files, get_component_from_path, git_ls_files
-
-from esphome.const import (
-    KEY_CORE,
-    KEY_TARGET_FRAMEWORK,
-    KEY_TARGET_PLATFORM,
-    PLATFORM_ESP32,
-    PLATFORM_ESP8266,
+from helpers import (
+    changed_files,
+    filter_component_files,
+    get_components_with_dependencies,
+    git_ls_files,
 )
-from esphome.core import CORE
-from esphome.loader import ComponentManifest, get_component, get_platform
-
-
-def filter_component_files(str):
-    return str.startswith("esphome/components/") | str.startswith("tests/components/")
 
 
 def get_all_component_files() -> list[str]:
     """Get all component files from git."""
     files = git_ls_files()
     return list(filter(filter_component_files, files))
-
-
-def extract_component_names_array_from_files_array(files):
-    components = []
-    for file in files:
-        component_name = get_component_from_path(file)
-        if component_name and component_name not in components:
-            components.append(component_name)
-    return components
-
-
-def add_item_to_components_graph(components_graph, parent, child):
-    if not parent.startswith("__") and parent != child:
-        if parent not in components_graph:
-            components_graph[parent] = []
-        if child not in components_graph[parent]:
-            components_graph[parent].append(child)
-
-
-def resolve_auto_load(
-    auto_load: list[str] | Callable[[], list[str]] | Callable[[dict | None], list[str]],
-    config: dict | None = None,
-) -> list[str]:
-    """Resolve AUTO_LOAD to a list, handling callables with or without config parameter.
-
-    Args:
-        auto_load: The AUTO_LOAD value (list or callable)
-        config: Optional config to pass to callable AUTO_LOAD functions
-
-    Returns:
-        List of component names to auto-load
-    """
-    if not callable(auto_load):
-        return auto_load
-
-    import inspect
-
-    if inspect.signature(auto_load).parameters:
-        return auto_load(config)
-    return auto_load()
-
-
-def create_components_graph():
-    # The root directory of the repo
-    root = Path(__file__).parent.parent
-    components_dir = root / "esphome" / "components"
-    # Fake some directory so that get_component works
-    CORE.config_path = root
-    # Various configuration to capture different outcomes used by `AUTO_LOAD` function.
-    TARGET_CONFIGURATIONS = [
-        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: None},
-        {KEY_TARGET_FRAMEWORK: "arduino", KEY_TARGET_PLATFORM: None},
-        {KEY_TARGET_FRAMEWORK: "esp-idf", KEY_TARGET_PLATFORM: None},
-        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: PLATFORM_ESP32},
-        {KEY_TARGET_FRAMEWORK: None, KEY_TARGET_PLATFORM: PLATFORM_ESP8266},
-    ]
-    CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
-
-    components_graph = {}
-    platforms = []
-    components: list[tuple[ComponentManifest, str, Path]] = []
-
-    for path in components_dir.iterdir():
-        if not path.is_dir():
-            continue
-        if not (path / "__init__.py").is_file():
-            continue
-        name = path.name
-        comp = get_component(name)
-        if comp is None:
-            print(
-                f"Cannot find component {name}. Make sure current path is pip installed ESPHome"
-            )
-            sys.exit(1)
-
-        components.append((comp, name, path))
-        if comp.is_platform_component:
-            platforms.append(name)
-
-    platforms = set(platforms)
-
-    for comp, name, path in components:
-        for dependency in comp.dependencies:
-            add_item_to_components_graph(
-                components_graph, dependency.split(".")[0], name
-            )
-
-        for target_config in TARGET_CONFIGURATIONS:
-            CORE.data[KEY_CORE] = target_config
-            for item in resolve_auto_load(comp.auto_load, config=None):
-                add_item_to_components_graph(components_graph, item, name)
-        # restore config
-        CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
-
-        for platform_path in path.iterdir():
-            platform_name = platform_path.stem
-            if platform_name == name or platform_name not in platforms:
-                continue
-            platform = get_platform(platform_name, name)
-            if platform is None:
-                continue
-
-            add_item_to_components_graph(components_graph, platform_name, name)
-
-            for dependency in platform.dependencies:
-                add_item_to_components_graph(
-                    components_graph, dependency.split(".")[0], name
-                )
-
-            for target_config in TARGET_CONFIGURATIONS:
-                CORE.data[KEY_CORE] = target_config
-                for item in resolve_auto_load(platform.auto_load, config={}):
-                    add_item_to_components_graph(components_graph, item, name)
-            # restore config
-            CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
-
-    return components_graph
-
-
-def find_children_of_component(components_graph, component_name, depth=0):
-    if component_name not in components_graph:
-        return []
-
-    children = []
-
-    for child in components_graph[component_name]:
-        children.append(child)
-        if depth < 10:
-            children.extend(
-                find_children_of_component(components_graph, child, depth + 1)
-            )
-    # Remove duplicate values
-    return list(set(children))
-
-
-def get_components(files: list[str], get_dependencies: bool = False):
-    components = extract_component_names_array_from_files_array(files)
-
-    if get_dependencies:
-        components_graph = create_components_graph()
-
-        all_components = components.copy()
-        for c in components:
-            all_components.extend(find_children_of_component(components_graph, c))
-        # Remove duplicate values
-        all_changed_components = list(set(all_components))
-
-        return sorted(all_changed_components)
-
-    return sorted(components)
 
 
 def main():
@@ -251,8 +89,8 @@ def main():
         # Return JSON with both directly changed and all changed components
         import json
 
-        directly_changed = get_components(files, False)
-        all_changed = get_components(files, True)
+        directly_changed = get_components_with_dependencies(files, False)
+        all_changed = get_components_with_dependencies(files, True)
         output = {
             "directly_changed": directly_changed,
             "all_changed": all_changed,
@@ -260,11 +98,11 @@ def main():
         print(json.dumps(output))
     elif args.changed_direct:
         # Return only directly changed components (without dependencies)
-        for c in get_components(files, False):
+        for c in get_components_with_dependencies(files, False):
             print(c)
     else:
         # Return all changed components (with dependencies) - default behavior
-        for c in get_components(files, args.changed):
+        for c in get_components_with_dependencies(files, args.changed):
             print(c)
 
 

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -96,10 +96,11 @@ def test_main_all_tests_should_run(
     mock_should_run_clang_format.return_value = True
     mock_should_run_python_linters.return_value = True
 
-    # Mock changed_files to return component Python files (not C++ to avoid memory impact)
+    # Mock changed_files to return non-component files (to avoid memory impact)
+    # Memory impact only runs when component C++ files change
     mock_changed_files.return_value = [
-        "esphome/components/wifi/__init__.py",
-        "esphome/components/api/__init__.py",
+        "esphome/config.py",
+        "esphome/helpers.py",
     ]
 
     # Run main function with mocked argv
@@ -146,9 +147,9 @@ def test_main_all_tests_should_run(
     # changed_cpp_file_count should be present
     assert "changed_cpp_file_count" in output
     assert isinstance(output["changed_cpp_file_count"], int)
-    # memory_impact should be present
+    # memory_impact should be false (no component C++ files changed)
     assert "memory_impact" in output
-    # Note: memory_impact may be true or false depending on component test availability
+    assert output["memory_impact"]["should_run"] == "false"
 
 
 def test_main_no_tests_should_run(
@@ -247,8 +248,9 @@ def test_main_with_branch_argument(
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = True
 
-    # Mock changed_files to return component Python file (not C++ to avoid memory impact)
-    mock_changed_files.return_value = ["esphome/components/mqtt/__init__.py"]
+    # Mock changed_files to return non-component files (to avoid memory impact)
+    # Memory impact only runs when component C++ files change
+    mock_changed_files.return_value = ["esphome/config.py"]
 
     with (
         patch("sys.argv", ["script.py", "-b", "main"]),
@@ -291,9 +293,9 @@ def test_main_with_branch_argument(
     # changed_cpp_file_count should be present
     assert "changed_cpp_file_count" in output
     assert isinstance(output["changed_cpp_file_count"], int)
-    # memory_impact should be present
+    # memory_impact should be false (no component C++ files changed)
     assert "memory_impact" in output
-    # Note: memory_impact may be true or false depending on component test availability
+    assert output["memory_impact"]["should_run"] == "false"
 
 
 def test_should_run_integration_tests(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -96,17 +96,33 @@ def test_main_all_tests_should_run(
     mock_should_run_clang_format.return_value = True
     mock_should_run_python_linters.return_value = True
 
-    # Mock list-components.py output (now returns JSON with --changed-with-deps)
-    mock_result = Mock()
-    mock_result.stdout = json.dumps(
-        {"directly_changed": ["wifi", "api"], "all_changed": ["wifi", "api", "sensor"]}
-    )
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return component Python files (not C++ to avoid memory impact)
+    mock_changed_files.return_value = [
+        "esphome/components/wifi/__init__.py",
+        "esphome/components/api/__init__.py",
+    ]
 
     # Run main function with mocked argv
     with (
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=False),
+        patch.object(
+            determine_jobs,
+            "get_changed_components",
+            return_value=["wifi", "api", "sensor"],
+        ),
+        patch.object(
+            determine_jobs,
+            "filter_component_files",
+            side_effect=lambda f: f.startswith("esphome/components/"),
+        ),
+        patch.object(
+            determine_jobs,
+            "get_components_with_dependencies",
+            side_effect=lambda files, deps: ["wifi", "api"]
+            if not deps
+            else ["wifi", "api", "sensor"],
+        ),
     ):
         determine_jobs.main()
 
@@ -132,7 +148,7 @@ def test_main_all_tests_should_run(
     assert isinstance(output["changed_cpp_file_count"], int)
     # memory_impact should be present
     assert "memory_impact" in output
-    assert output["memory_impact"]["should_run"] == "false"  # No files changed
+    # Note: memory_impact may be true or false depending on component test availability
 
 
 def test_main_no_tests_should_run(
@@ -154,13 +170,18 @@ def test_main_no_tests_should_run(
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = False
 
-    # Mock empty list-components.py output
-    mock_result = Mock()
-    mock_result.stdout = json.dumps({"directly_changed": [], "all_changed": []})
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return no component files
+    mock_changed_files.return_value = []
 
     # Run main function with mocked argv
-    with patch("sys.argv", ["determine-jobs.py"]):
+    with (
+        patch("sys.argv", ["determine-jobs.py"]),
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(determine_jobs, "filter_component_files", return_value=False),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
+    ):
         determine_jobs.main()
 
     # Check output
@@ -226,16 +247,21 @@ def test_main_with_branch_argument(
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = True
 
-    # Mock list-components.py output
-    mock_result = Mock()
-    mock_result.stdout = json.dumps(
-        {"directly_changed": ["mqtt"], "all_changed": ["mqtt"]}
-    )
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return component Python file (not C++ to avoid memory impact)
+    mock_changed_files.return_value = ["esphome/components/mqtt/__init__.py"]
 
     with (
         patch("sys.argv", ["script.py", "-b", "main"]),
         patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=False),
+        patch.object(determine_jobs, "get_changed_components", return_value=["mqtt"]),
+        patch.object(
+            determine_jobs,
+            "filter_component_files",
+            side_effect=lambda f: f.startswith("esphome/components/"),
+        ),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=["mqtt"]
+        ),
     ):
         determine_jobs.main()
 
@@ -244,13 +270,6 @@ def test_main_with_branch_argument(
     mock_should_run_clang_tidy.assert_called_once_with("main")
     mock_should_run_clang_format.assert_called_once_with("main")
     mock_should_run_python_linters.assert_called_once_with("main")
-
-    # Check that list-components.py was called with branch
-    mock_subprocess_run.assert_called_once()
-    call_args = mock_subprocess_run.call_args[0][0]
-    assert "--changed-with-deps" in call_args
-    assert "-b" in call_args
-    assert "main" in call_args
 
     # Check output
     captured = capsys.readouterr()
@@ -274,7 +293,7 @@ def test_main_with_branch_argument(
     assert isinstance(output["changed_cpp_file_count"], int)
     # memory_impact should be present
     assert "memory_impact" in output
-    assert output["memory_impact"]["should_run"] == "false"
+    # Note: memory_impact may be true or false depending on component test availability
 
 
 def test_should_run_integration_tests(
@@ -500,16 +519,11 @@ def test_main_filters_components_without_tests(
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = False
 
-    # Mock list-components.py output with 3 components
-    # wifi: has tests, sensor: has tests, airthings_ble: no tests
-    mock_result = Mock()
-    mock_result.stdout = json.dumps(
-        {
-            "directly_changed": ["wifi", "sensor"],
-            "all_changed": ["wifi", "sensor", "airthings_ble"],
-        }
-    )
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return component files
+    mock_changed_files.return_value = [
+        "esphome/components/wifi/wifi.cpp",
+        "esphome/components/sensor/sensor.h",
+    ]
 
     # Create test directory structure
     tests_dir = tmp_path / "tests" / "components"
@@ -533,6 +547,23 @@ def test_main_filters_components_without_tests(
         patch.object(determine_jobs, "root_path", str(tmp_path)),
         patch.object(helpers, "root_path", str(tmp_path)),
         patch("sys.argv", ["determine-jobs.py"]),
+        patch.object(
+            determine_jobs,
+            "get_changed_components",
+            return_value=["wifi", "sensor", "airthings_ble"],
+        ),
+        patch.object(
+            determine_jobs,
+            "filter_component_files",
+            side_effect=lambda f: f.startswith("esphome/components/"),
+        ),
+        patch.object(
+            determine_jobs,
+            "get_components_with_dependencies",
+            side_effect=lambda files, deps: ["wifi", "sensor"]
+            if not deps
+            else ["wifi", "sensor", "airthings_ble"],
+        ),
     ):
         # Clear the cache since we're mocking root_path
         determine_jobs._component_has_tests.cache_clear()
@@ -788,15 +819,18 @@ def test_clang_tidy_mode_full_scan(
     mock_should_run_clang_format.return_value = False
     mock_should_run_python_linters.return_value = False
 
-    # Mock list-components.py output
-    mock_result = Mock()
-    mock_result.stdout = json.dumps({"directly_changed": [], "all_changed": []})
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return no component files
+    mock_changed_files.return_value = []
 
     # Mock full scan (hash changed)
     with (
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=True),
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(determine_jobs, "filter_component_files", return_value=False),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
     ):
         determine_jobs.main()
 
@@ -853,12 +887,10 @@ def test_clang_tidy_mode_targeted_scan(
     # Create component names
     components = [f"comp{i}" for i in range(component_count)]
 
-    # Mock list-components.py output
-    mock_result = Mock()
-    mock_result.stdout = json.dumps(
-        {"directly_changed": components, "all_changed": components}
-    )
-    mock_subprocess_run.return_value = mock_result
+    # Mock changed_files to return component files
+    mock_changed_files.return_value = [
+        f"esphome/components/{comp}/file.cpp" for comp in components
+    ]
 
     # Mock git_ls_files to return files for each component
     cpp_files = {
@@ -875,6 +907,15 @@ def test_clang_tidy_mode_targeted_scan(
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=False),
         patch.object(determine_jobs, "git_ls_files", side_effect=mock_git_ls_files),
+        patch.object(determine_jobs, "get_changed_components", return_value=components),
+        patch.object(
+            determine_jobs,
+            "filter_component_files",
+            side_effect=lambda f: f.startswith("esphome/components/"),
+        ),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=components
+        ),
     ):
         determine_jobs.main()
 


### PR DESCRIPTION
# What does this implement/fix?

This PR is a follow-up to #11430 that completes the clang-tidy split mode fix and refactors the codebase for better testability.

## Problems Fixed

1. **Core file changes still weren't triggering split mode**: Even after #11430 fixed component file counting, changes to core C++ files (like `esphome/core/component.h`) would trigger a full clang-tidy scan but incorrectly use nosplit mode.

2. **Difficult to test**: The original implementation used subprocess calls to `list-components.py`, making it hard to write unit tests and verify the logic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Follow-up to #11430

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

*Not applicable - CI infrastructure changes only*

## Example entry for `config.yaml`:

*Not applicable - CI infrastructure changes only*

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

*Not applicable - CI infrastructure changes only*
