### PR TITLE
[espnow] Fix compilation error with initializer_list after #11433

### DIFF
--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -14,13 +14,13 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data);
 
  public:
-  void add_on_sent(const std::vector<Action<Ts...> *> &actions) {
+  void add_on_sent(const std::initializer_list<Action<Ts...> *> &actions) {
     this->sent_.add_actions(actions);
     if (this->flags_.wait_for_sent) {
       this->sent_.add_action(new LambdaAction<Ts...>([this](Ts... x) { this->play_next_(x...); }));
     }
   }
-  void add_on_error(const std::vector<Action<Ts...> *> &actions) {
+  void add_on_error(const std::initializer_list<Action<Ts...> *> &actions) {
     this->error_.add_actions(actions);
     if (this->flags_.wait_for_sent) {
       this->error_.add_action(new LambdaAction<Ts...>([this](Ts... x) {


### PR DESCRIPTION

Note that the build target job is expected to fail because this fixes the problem



# What does this implement/fix?

Fixes compilation error in `espnow` component caused by PR #11433 which changed `ActionList::add_actions()` to use `std::initializer_list` instead of `std::vector`.

The `espnow/automation.h` file had two methods (`add_on_sent()` and `add_on_error()`) that were still using the old `std::vector<Action<Ts...> *>` signature, causing a compilation error when the Python code generator tried to pass action lists to these methods.

**Error:**
```
error: cannot convert 'const std::vector<esphome::Action<...>*>' to 'const std::initializer_list<esphome::Action<...>*>&'
```

**Fix:**
Updated both method signatures to accept `std::initializer_list` to match the new `ActionList::add_actions()` signature.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes compilation error introduced by #11433

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal fix only, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing espnow configurations with on_sent/on_error callbacks now compile correctly

espnow:

on_...:
  then:
    - espnow.send:
        address: AA:BB:CC:DD:EE:FF
        data: "test"
        on_sent:
          - logger.log: "Message sent successfully"
        on_error:
          - logger.log: "Failed to send message"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
