### PR TITLE
[sensor] Optimize calibration and Or filters with FixedVector

### DIFF
--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -422,7 +422,7 @@ class DeltaFilter : public Filter {
 
 class OrFilter : public Filter {
  public:
-  explicit OrFilter(std::vector<Filter *> filters);
+  explicit OrFilter(std::initializer_list<Filter *> filters);
 
   void initialize(Sensor *parent, Filter *next) override;
 
@@ -438,28 +438,27 @@ class OrFilter : public Filter {
     OrFilter *or_parent_;
   };
 
-  std::vector<Filter *> filters_;
+  FixedVector<Filter *> filters_;
   PhiNode phi_;
   bool has_value_{false};
 };
 
 class CalibrateLinearFilter : public Filter {
  public:
-  CalibrateLinearFilter(std::vector<std::array<float, 3>> linear_functions)
-      : linear_functions_(std::move(linear_functions)) {}
+  explicit CalibrateLinearFilter(std::initializer_list<std::array<float, 3>> linear_functions);
   optional<float> new_value(float value) override;
 
  protected:
-  std::vector<std::array<float, 3>> linear_functions_;
+  FixedVector<std::array<float, 3>> linear_functions_;
 };
 
 class CalibratePolynomialFilter : public Filter {
  public:
-  CalibratePolynomialFilter(std::vector<float> coefficients) : coefficients_(std::move(coefficients)) {}
+  explicit CalibratePolynomialFilter(std::initializer_list<float> coefficients);
   optional<float> new_value(float value) override;
 
  protected:
-  std::vector<float> coefficients_;
+  FixedVector<float> coefficients_;
 };
 
 class ClampFilter : public Filter {

--- a/tests/components/sensor/common.yaml
+++ b/tests/components/sensor/common.yaml
@@ -173,3 +173,66 @@ sensor:
           timeout: 1000ms
           value: [42.0]
       - multiply: 2.0
+
+  # CalibrateLinearFilter - piecewise linear calibration
+  - platform: copy
+    source_id: source_sensor
+    name: "Calibrate Linear Two Points"
+    filters:
+      - calibrate_linear:
+          - 0.0 -> 0.0
+          - 100.0 -> 100.0
+
+  - platform: copy
+    source_id: source_sensor
+    name: "Calibrate Linear Multiple Segments"
+    filters:
+      - calibrate_linear:
+          - 0.0 -> 0.0
+          - 50.0 -> 55.0
+          - 100.0 -> 102.5
+
+  - platform: copy
+    source_id: source_sensor
+    name: "Calibrate Linear Least Squares"
+    filters:
+      - calibrate_linear:
+          method: least_squares
+          datapoints:
+            - 0.0 -> 0.0
+            - 50.0 -> 55.0
+            - 100.0 -> 102.5
+
+  # CalibratePolynomialFilter - polynomial calibration
+  - platform: copy
+    source_id: source_sensor
+    name: "Calibrate Polynomial Degree 2"
+    filters:
+      - calibrate_polynomial:
+          degree: 2
+          datapoints:
+            - 0.0 -> 0.0
+            - 50.0 -> 55.0
+            - 100.0 -> 102.5
+
+  - platform: copy
+    source_id: source_sensor
+    name: "Calibrate Polynomial Degree 3"
+    filters:
+      - calibrate_polynomial:
+          degree: 3
+          datapoints:
+            - 0.0 -> 0.0
+            - 25.0 -> 26.0
+            - 50.0 -> 55.0
+            - 100.0 -> 102.5
+
+  # OrFilter - filter branching
+  - platform: copy
+    source_id: source_sensor
+    name: "Or Filter with Multiple Branches"
+    filters:
+      - or:
+          - multiply: 2.0
+          - offset: 10.0
+          - lambda: return x * 3.0;


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes three sensor filters (`calibrate_linear`, `calibrate_polynomial`, and `or`) by replacing `std::vector` with `FixedVector` to eliminate STL reallocation overhead and reduce flash usage on embedded systems.

**Flash Savings: ~528 bytes** (3 filters × ~176 bytes each)

## Background

These filters currently use `std::vector` with sizes that are known at compile/config time. This generates unnecessary STL template code for dynamic reallocation (`_M_realloc_insert`, `_M_default_append`) that is never actually used at runtime.

By switching to `FixedVector` with `std::initializer_list` constructors, we eliminate this overhead while maintaining identical runtime behavior.

## Changes

### 1. CalibrateLinearFilter (~176 bytes savings)
- **Before:** `std::vector<std::array<float, 3>> linear_functions_`
- **After:** `FixedVector<std::array<float, 3>> linear_functions_`
- Used for piecewise linear sensor calibration
- **Real-world usage:** esphome-ratgdo voltage sensor calibration

### 2. CalibratePolynomialFilter (~176 bytes savings)
- **Before:** `std::vector<float> coefficients_`
- **After:** `FixedVector<float> coefficients_`
- Used for polynomial sensor calibration

### 3. OrFilter (~176 bytes savings)
- **Before:** `std::vector<Filter *> filters_`
- **After:** `FixedVector<Filter *> filters_`
- Used for parallel filter execution/branching

## Implementation Details

- Uses `std::initializer_list` constructors for efficient initialization
- No Python codegen changes needed (already generates compatible lists)
- Moved constructors to `.cpp` file following best practices
- Uses const references in range-for loops for efficiency
- Added comprehensive component tests for all three filters

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems memory optimization effort
- Related to PR #11407 (ValueListFilter optimization)
- Related to PR #11423 (text_sensor filter optimizations)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - existing configs work as-is
sensor:
  - platform: template
    name: "Calibrated Voltage"
    lambda: return id(adc_sensor).state;
    filters:
      # CalibrateLinearFilter - now uses FixedVector internally
      - calibrate_linear:
          - 1.16 -> 5.0
          - 2.783 -> 12.0

      # CalibratePolynomialFilter - now uses FixedVector internally
      - calibrate_polynomial:
          degree: 2
          datapoints:
            - 0.0 -> 0.0
            - 50.0 -> 55.0
            - 100.0 -> 102.5

      # OrFilter - now uses FixedVector internally
      - or:
          - multiply: 2.0
          - offset: 10.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - Internal optimization only, no user-facing changes
