### PR TITLE
[esp32] Add advanced options to disable unused VFS features (saves ~8.7 KB flash)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1008,8 +1008,7 @@ async def to_code(config):
     # VFS select is only needed for UART/eventfd file descriptors.
     # Components that need it (e.g., openthread) call require_vfs_select().
     # Saves approximately 2.7KB of flash when disabled (default).
-    vfs_select_required = CORE.data.get(KEY_VFS_SELECT_REQUIRED, False)
-    if vfs_select_required:
+    if CORE.data.get(KEY_VFS_SELECT_REQUIRED, False):
         # Component requires VFS select - force enable regardless of user setting
         add_idf_sdkconfig_option("CONFIG_VFS_SUPPORT_SELECT", True)
     else:
@@ -1023,8 +1022,7 @@ async def to_code(config):
     # ESPHome doesn't use directory functions on ESP32.
     # Components that need it (e.g., storage components) call require_vfs_dir().
     # Saves approximately 0.5KB+ of flash when disabled (default).
-    vfs_dir_required = CORE.data.get(KEY_VFS_DIR_REQUIRED, False)
-    if vfs_dir_required:
+    if CORE.data.get(KEY_VFS_DIR_REQUIRED, False):
         # Component requires VFS directory support - force enable regardless of user setting
         add_idf_sdkconfig_option("CONFIG_VFS_SUPPORT_DIR", True)
     else:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -550,6 +550,8 @@ CONF_ENABLE_LWIP_BRIDGE_INTERFACE = "enable_lwip_bridge_interface"
 CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING = "enable_lwip_tcpip_core_locking"
 CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY = "enable_lwip_check_thread_safety"
 CONF_DISABLE_LIBC_LOCKS_IN_IRAM = "disable_libc_locks_in_iram"
+CONF_DISABLE_VFS_SUPPORT_TERMIOS = "disable_vfs_support_termios"
+CONF_DISABLE_VFS_SUPPORT_SELECT = "disable_vfs_support_select"
 
 
 def _validate_idf_component(config: ConfigType) -> ConfigType:
@@ -614,6 +616,12 @@ FRAMEWORK_SCHEMA = cv.All(
                     ): cv.boolean,
                     cv.Optional(
                         CONF_DISABLE_LIBC_LOCKS_IN_IRAM, default=True
+                    ): cv.boolean,
+                    cv.Optional(
+                        CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True
+                    ): cv.boolean,
+                    cv.Optional(
+                        CONF_DISABLE_VFS_SUPPORT_SELECT, default=True
                     ): cv.boolean,
                     cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
                 }
@@ -961,6 +969,23 @@ async def to_code(config):
     # use libc lock APIs. Saves approximately 1.3KB (1,356 bytes) of IRAM.
     if advanced.get(CONF_DISABLE_LIBC_LOCKS_IN_IRAM, True):
         add_idf_sdkconfig_option("CONFIG_LIBC_LOCKS_PLACE_IN_IRAM", False)
+
+    # Disable VFS support for termios (terminal I/O functions)
+    # ESPHome doesn't use termios functions on ESP32 (only used in host UART driver).
+    # Saves approximately 1.8KB of flash when disabled (default).
+    add_idf_sdkconfig_option(
+        "CONFIG_VFS_SUPPORT_TERMIOS",
+        not advanced.get(CONF_DISABLE_VFS_SUPPORT_TERMIOS, True),
+    )
+
+    # Disable VFS support for select() with file descriptors
+    # ESPHome only uses select() with sockets via lwip_select(), which still works.
+    # VFS select is only needed for UART/eventfd file descriptors, which ESPHome doesn't use.
+    # Saves approximately 2.7KB of flash when disabled (default).
+    add_idf_sdkconfig_option(
+        "CONFIG_VFS_SUPPORT_SELECT",
+        not advanced.get(CONF_DISABLE_VFS_SUPPORT_SELECT, True),
+    )
 
     cg.add_platformio_option("board_build.partitions", "partitions.csv")
     if CONF_PARTITIONS in config:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -552,6 +552,30 @@ CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY = "enable_lwip_check_thread_safety"
 CONF_DISABLE_LIBC_LOCKS_IN_IRAM = "disable_libc_locks_in_iram"
 CONF_DISABLE_VFS_SUPPORT_TERMIOS = "disable_vfs_support_termios"
 CONF_DISABLE_VFS_SUPPORT_SELECT = "disable_vfs_support_select"
+CONF_DISABLE_VFS_SUPPORT_DIR = "disable_vfs_support_dir"
+
+# VFS requirement tracking
+# Components that need VFS features can call require_vfs_select() or require_vfs_dir()
+KEY_VFS_SELECT_REQUIRED = "vfs_select_required"
+KEY_VFS_DIR_REQUIRED = "vfs_dir_required"
+
+
+def require_vfs_select() -> None:
+    """Mark that VFS select support is required by a component.
+
+    Call this from components that use esp_vfs_eventfd or other VFS select features.
+    This prevents CONFIG_VFS_SUPPORT_SELECT from being disabled.
+    """
+    CORE.data[KEY_VFS_SELECT_REQUIRED] = True
+
+
+def require_vfs_dir() -> None:
+    """Mark that VFS directory support is required by a component.
+
+    Call this from components that use directory functions (opendir, readdir, mkdir, etc.).
+    This prevents CONFIG_VFS_SUPPORT_DIR from being disabled.
+    """
+    CORE.data[KEY_VFS_DIR_REQUIRED] = True
 
 
 def _validate_idf_component(config: ConfigType) -> ConfigType:
@@ -623,6 +647,7 @@ FRAMEWORK_SCHEMA = cv.All(
                     cv.Optional(
                         CONF_DISABLE_VFS_SUPPORT_SELECT, default=True
                     ): cv.boolean,
+                    cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
                     cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
                 }
             ),
@@ -980,12 +1005,34 @@ async def to_code(config):
 
     # Disable VFS support for select() with file descriptors
     # ESPHome only uses select() with sockets via lwip_select(), which still works.
-    # VFS select is only needed for UART/eventfd file descriptors, which ESPHome doesn't use.
+    # VFS select is only needed for UART/eventfd file descriptors.
+    # Components that need it (e.g., openthread) call require_vfs_select().
     # Saves approximately 2.7KB of flash when disabled (default).
-    add_idf_sdkconfig_option(
-        "CONFIG_VFS_SUPPORT_SELECT",
-        not advanced.get(CONF_DISABLE_VFS_SUPPORT_SELECT, True),
-    )
+    vfs_select_required = CORE.data.get(KEY_VFS_SELECT_REQUIRED, False)
+    if vfs_select_required:
+        # Component requires VFS select - force enable regardless of user setting
+        add_idf_sdkconfig_option("CONFIG_VFS_SUPPORT_SELECT", True)
+    else:
+        # No component needs it - allow user to control (default: disabled)
+        add_idf_sdkconfig_option(
+            "CONFIG_VFS_SUPPORT_SELECT",
+            not advanced.get(CONF_DISABLE_VFS_SUPPORT_SELECT, True),
+        )
+
+    # Disable VFS support for directory functions (opendir, readdir, mkdir, etc.)
+    # ESPHome doesn't use directory functions on ESP32.
+    # Components that need it (e.g., storage components) call require_vfs_dir().
+    # Saves approximately 0.5KB+ of flash when disabled (default).
+    vfs_dir_required = CORE.data.get(KEY_VFS_DIR_REQUIRED, False)
+    if vfs_dir_required:
+        # Component requires VFS directory support - force enable regardless of user setting
+        add_idf_sdkconfig_option("CONFIG_VFS_SUPPORT_DIR", True)
+    else:
+        # No component needs it - allow user to control (default: disabled)
+        add_idf_sdkconfig_option(
+            "CONFIG_VFS_SUPPORT_DIR",
+            not advanced.get(CONF_DISABLE_VFS_SUPPORT_DIR, True),
+        )
 
     cg.add_platformio_option("board_build.partitions", "partitions.csv")
     if CONF_PARTITIONS in config:

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -107,6 +107,14 @@ _CONNECTION_SCHEMA = cv.Schema(
     }
 )
 
+
+def _require_vfs_select(config):
+    """Register VFS select requirement during config validation."""
+    # OpenThread uses esp_vfs_eventfd which requires VFS select support
+    require_vfs_select()
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -123,6 +131,7 @@ CONFIG_SCHEMA = cv.All(
     cv.has_exactly_one_key(CONF_NETWORK_KEY, CONF_TLV),
     cv.only_with_esp_idf,
     only_on_variant(supported=[VARIANT_ESP32C6, VARIANT_ESP32H2]),
+    _require_vfs_select,
 )
 
 
@@ -141,9 +150,6 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 
 async def to_code(config):
     cg.add_define("USE_OPENTHREAD")
-
-    # OpenThread uses esp_vfs_eventfd which requires VFS select support
-    require_vfs_select()
 
     # OpenThread SRP needs access to mDNS services after setup
     enable_mdns_storage()

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -4,6 +4,7 @@ from esphome.components.esp32 import (
     VARIANT_ESP32H2,
     add_idf_sdkconfig_option,
     only_on_variant,
+    require_vfs_select,
 )
 from esphome.components.mdns import MDNSComponent, enable_mdns_storage
 import esphome.config_validation as cv
@@ -140,6 +141,9 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 
 async def to_code(config):
     cg.add_define("USE_OPENTHREAD")
+
+    # OpenThread uses esp_vfs_eventfd which requires VFS select support
+    require_vfs_select()
 
     # OpenThread SRP needs access to mDNS services after setup
     enable_mdns_storage()


### PR DESCRIPTION
# What does this implement/fix?

Adds advanced ESP-IDF framework options to disable unused VFS (Virtual File System) features, saving approximately **8.7 KB of flash memory** and **316 bytes of heap** by default.

This PR adds three new advanced configuration options under `esp32.framework.advanced`:
- `disable_vfs_support_termios` (default: `true`) - Disables VFS support for termios functions
- `disable_vfs_support_select` (default: `true`) - Disables VFS support for select() with file descriptors
- `disable_vfs_support_dir` (default: `true`) - Disables VFS support for directory functions

## Memory Impact (ESP32-C6 with ESP-IDF)

Measured savings on a configuration with OpenThread:
- **Flash**: -8,740 bytes (-1.24%)
- **Static RAM**: -48 bytes (-0.14%)
- **Heap free (runtime measured)**: +316 bytes

## Component Registration Pattern

Components that require VFS features can call helper functions to register their needs:
- `require_vfs_select()` - For components using esp_vfs_eventfd or other VFS select features (e.g., OpenThread)
- `require_vfs_dir()` - For components using directory functions (e.g., future storage components)

When a component registers its need, the corresponding VFS feature is automatically enabled regardless of the user's configuration setting.

## Why these are safe to disable:

**`CONFIG_VFS_SUPPORT_TERMIOS`**: ESPHome only uses termios functions in the host UART driver (Linux/macOS platform), not on ESP32 devices. The ESP32 UART components don't use termios APIs.

**`CONFIG_VFS_SUPPORT_SELECT`**: ESPHome uses `lwip_select()` for socket operations, which works independently of VFS select support. VFS select is only needed for UART and eventfd file descriptors. Socket operations continue to work normally with this disabled. Components that need it (e.g., OpenThread uses esp_vfs_eventfd) automatically enable it via `require_vfs_select()`.

**`CONFIG_VFS_SUPPORT_DIR`**: ESPHome doesn't use directory operations (opendir, readdir, mkdir, rmdir, etc.) on ESP32. Future components that need directory support can call `require_vfs_dir()` to automatically enable it.

These optimizations are recommended by the ESP-IDF documentation: https://docs.espressif.com/projects/esp-idf/en/v5.5.1/esp32/api-guides/performance/size.html#vfs

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5507

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default behavior - VFS features disabled, saves ~8.7 KB flash + 316 bytes heap
esp32:
  board: esp32dev
  framework:
    type: esp-idf

# To re-enable VFS features if needed (not recommended)
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      disable_vfs_support_termios: false
      disable_vfs_support_select: false
      disable_vfs_support_dir: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
