### PR TITLE
[binary_sensor] Add compile test for auto repeat

### DIFF
--- a/tests/components/binary_sensor/common.yaml
+++ b/tests/components/binary_sensor/common.yaml
@@ -37,3 +37,36 @@ binary_sensor:
             format: "New state is %s"
             args: ['x.has_value() ? ONOFF(x) : "Unknown"']
         - binary_sensor.invalidate_state: some_binary_sensor
+
+  # Test autorepeat with default configuration (no timings)
+  - platform: template
+    id: autorepeat_default
+    name: "Autorepeat Default"
+    filters:
+      - autorepeat:
+
+  # Test autorepeat with single timing entry
+  - platform: template
+    id: autorepeat_single
+    name: "Autorepeat Single"
+    filters:
+      - autorepeat:
+          - delay: 2s
+            time_off: 200ms
+            time_on: 800ms
+
+  # Test autorepeat with three timing entries
+  - platform: template
+    id: autorepeat_multiple
+    name: "Autorepeat Multiple"
+    filters:
+      - autorepeat:
+          - delay: 500ms
+            time_off: 50ms
+            time_on: 950ms
+          - delay: 2s
+            time_off: 100ms
+            time_on: 900ms
+          - delay: 10s
+            time_off: 200ms
+            time_on: 800ms


### PR DESCRIPTION

# What does this implement/fix?

For baseline ahead of https://github.com/esphome/esphome/pull/11442

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
