### PR TITLE
Add gpio switch interlock compile tests

### DIFF
--- a/tests/components/gpio/common.yaml
+++ b/tests/components/gpio/common.yaml
@@ -12,3 +12,20 @@ switch:
   - platform: gpio
     pin: ${switch_pin}
     id: gpio_switch
+
+  - platform: gpio
+    pin: ${switch_pin_2}
+    id: gpio_switch_interlock_1
+    interlock: [gpio_switch_interlock_2, gpio_switch_interlock_3]
+    interlock_wait_time: 100ms
+
+  - platform: gpio
+    pin: ${switch_pin_3}
+    id: gpio_switch_interlock_2
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_3]
+
+  - platform: gpio
+    pin: ${switch_pin_4}
+    id: gpio_switch_interlock_3
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_2]
+    interlock_wait_time: 50ms

--- a/tests/components/gpio/test.esp32-c3-idf.yaml
+++ b/tests/components/gpio/test.esp32-c3-idf.yaml
@@ -2,5 +2,8 @@ substitutions:
   binary_sensor_pin: GPIO2
   output_pin: GPIO3
   switch_pin: GPIO4
+  switch_pin_2: GPIO5
+  switch_pin_3: GPIO6
+  switch_pin_4: GPIO7
 
 <<: !include common.yaml

--- a/tests/components/gpio/test.esp32-idf.yaml
+++ b/tests/components/gpio/test.esp32-idf.yaml
@@ -2,5 +2,8 @@ substitutions:
   binary_sensor_pin: GPIO12
   output_pin: GPIO13
   switch_pin: GPIO14
+  switch_pin_2: GPIO15
+  switch_pin_3: GPIO16
+  switch_pin_4: GPIO17
 
 <<: !include common.yaml

--- a/tests/components/gpio/test.esp8266-ard.yaml
+++ b/tests/components/gpio/test.esp8266-ard.yaml
@@ -2,5 +2,8 @@ substitutions:
   binary_sensor_pin: GPIO0
   output_pin: GPIO2
   switch_pin: GPIO15
+  switch_pin_2: GPIO12
+  switch_pin_3: GPIO13
+  switch_pin_4: GPIO14
 
 <<: !include common.yaml

--- a/tests/components/gpio/test.nrf52-adafruit.yaml
+++ b/tests/components/gpio/test.nrf52-adafruit.yaml
@@ -12,3 +12,20 @@ switch:
   - platform: gpio
     pin: P1.2
     id: gpio_switch
+
+  - platform: gpio
+    pin: P1.3
+    id: gpio_switch_interlock_1
+    interlock: [gpio_switch_interlock_2, gpio_switch_interlock_3]
+    interlock_wait_time: 100ms
+
+  - platform: gpio
+    pin: P1.4
+    id: gpio_switch_interlock_2
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_3]
+
+  - platform: gpio
+    pin: P1.5
+    id: gpio_switch_interlock_3
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_2]
+    interlock_wait_time: 50ms

--- a/tests/components/gpio/test.nrf52-mcumgr.yaml
+++ b/tests/components/gpio/test.nrf52-mcumgr.yaml
@@ -12,3 +12,20 @@ switch:
   - platform: gpio
     pin: P1.2
     id: gpio_switch
+
+  - platform: gpio
+    pin: P1.3
+    id: gpio_switch_interlock_1
+    interlock: [gpio_switch_interlock_2, gpio_switch_interlock_3]
+    interlock_wait_time: 100ms
+
+  - platform: gpio
+    pin: P1.4
+    id: gpio_switch_interlock_2
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_3]
+
+  - platform: gpio
+    pin: P1.5
+    id: gpio_switch_interlock_3
+    interlock: [gpio_switch_interlock_1, gpio_switch_interlock_2]
+    interlock_wait_time: 50ms

--- a/tests/components/gpio/test.rp2040-ard.yaml
+++ b/tests/components/gpio/test.rp2040-ard.yaml
@@ -2,5 +2,8 @@ substitutions:
   binary_sensor_pin: GPIO2
   output_pin: GPIO3
   switch_pin: GPIO4
+  switch_pin_2: GPIO5
+  switch_pin_3: GPIO6
+  switch_pin_4: GPIO7
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

To get a new baseline ahead of https://github.com/esphome/esphome/pull/11448

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
