### PR TITLE
[speaker] Further optimize WiFi driver settings when PSRAM is available

### DIFF
--- a/esphome/components/const/__init__.py
+++ b/esphome/components/const/__init__.py
@@ -8,6 +8,7 @@ BYTE_ORDER_BIG = "big_endian"
 
 CONF_COLOR_DEPTH = "color_depth"
 CONF_DRAW_ROUNDING = "draw_rounding"
+CONF_IGNORE_NOT_FOUND = "ignore_not_found"
 CONF_ON_RECEIVE = "on_receive"
 CONF_ON_STATE_CHANGE = "on_state_change"
 CONF_REQUEST_HEADERS = "request_headers"

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -45,6 +45,7 @@ TYPE_HEX = "hex"
 SDK_MODES = {TYPE_QUAD: "QUAD", TYPE_OCTAL: "OCT", TYPE_HEX: "HEX"}
 
 CONF_ENABLE_ECC = "enable_ecc"
+CONF_IGNORE_NOT_FOUND = "ignore_not_found"
 
 SPIRAM_MODES = {
     VARIANT_ESP32: (TYPE_QUAD,),
@@ -111,6 +112,7 @@ def get_config_schema(config):
             cv.Optional(CONF_ENABLE_ECC, default=False): cv.boolean,
             cv.Optional(CONF_SPEED, default=speeds[0]): cv.one_of(*speeds, upper=True),
             cv.Optional(CONF_DISABLED, default=False): cv.boolean,
+            cv.Optional(CONF_IGNORE_NOT_FOUND, default=True): cv.boolean,
         }
     )(config)
 
@@ -135,7 +137,9 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_SPIRAM", True)
     add_idf_sdkconfig_option("CONFIG_SPIRAM_USE", True)
     add_idf_sdkconfig_option("CONFIG_SPIRAM_USE_CAPS_ALLOC", True)
-    add_idf_sdkconfig_option("CONFIG_SPIRAM_IGNORE_NOTFOUND", True)
+    add_idf_sdkconfig_option(
+        "CONFIG_SPIRAM_IGNORE_NOTFOUND", config[CONF_IGNORE_NOT_FOUND]
+    )
 
     add_idf_sdkconfig_option(f"CONFIG_SPIRAM_MODE_{SDK_MODES[config[CONF_MODE]]}", True)
 

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -1,6 +1,7 @@
 import logging
 
 import esphome.codegen as cg
+from esphome.components.const import CONF_IGNORE_NOT_FOUND
 from esphome.components.esp32 import (
     CONF_CPU_FREQUENCY,
     CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES,
@@ -45,7 +46,6 @@ TYPE_HEX = "hex"
 SDK_MODES = {TYPE_QUAD: "QUAD", TYPE_OCTAL: "OCT", TYPE_HEX: "HEX"}
 
 CONF_ENABLE_ECC = "enable_ecc"
-CONF_IGNORE_NOT_FOUND = "ignore_not_found"
 
 SPIRAM_MODES = {
     VARIANT_ESP32: (TYPE_QUAD,),

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -7,9 +7,11 @@ from pathlib import Path
 from esphome import automation, external_files
 import esphome.codegen as cg
 from esphome.components import audio, esp32, media_player, psram, speaker
+from esphome.components.const import CONF_IGNORE_NOT_FOUND
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BUFFER_SIZE,
+    CONF_DISABLED,
     CONF_FILE,
     CONF_FILES,
     CONF_FORMAT,
@@ -26,6 +28,7 @@ from esphome.const import (
 from esphome.core import CORE, HexInt
 from esphome.core.entity_helpers import inherit_property_from
 from esphome.external_files import download_content
+import esphome.final_validate as fv
 from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
@@ -242,6 +245,29 @@ def _validate_supported_local_file(config):
     return config
 
 
+PSRAM_GUARANTEED_KEY = "speaker_media_player_psram_guaranteed"
+
+
+def _check_psram_available(config):
+    """Check if PSRAM is guaranteed during final validation and store in CORE.data."""
+    full_config = fv.full_config.get()
+
+    # Check if psram component is configured
+    psram_guaranteed = False
+    if "psram" in full_config:
+        psram_config = full_config["psram"]
+        # PSRAM is guaranteed if both CONF_DISABLED is False and CONF_IGNORE_NOT_FOUND is False
+        if not psram_config.get(CONF_DISABLED, False) and not psram_config.get(
+            CONF_IGNORE_NOT_FOUND, True
+        ):
+            psram_guaranteed = True
+
+    # Store in CORE.data for access during to_code()
+    CORE.data[PSRAM_GUARANTEED_KEY] = psram_guaranteed
+
+    return config
+
+
 LOCAL_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_PATH): cv.file_,
@@ -318,6 +344,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
         extra=cv.ALLOW_EXTRA,
     ),
     _validate_supported_local_file,
+    _check_psram_available,
 )
 
 
@@ -328,22 +355,59 @@ async def to_code(config):
         cg.add_define("USE_AUDIO_FLAC_SUPPORT", True)
         cg.add_define("USE_AUDIO_MP3_SUPPORT", True)
 
-        # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM", 16)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM", 64)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM", 64)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_TX_ENABLED", True)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BA_WIN", 32)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
-        esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
+        if CORE.data.get(PSRAM_GUARANTEED_KEY, False):
+            # PSRAM is guaranteed, higher buffer counts are allowed
+            # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
 
-        esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
-        esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 65534)
-        esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
-        esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
+            # These two are necessary to allow much higher counts
+            esp32.add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_WND_SCALE", True)
 
-        # Allocate wifi buffers in PSRAM
-        esp32.add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM", 16)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM", 512)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_TX_BUFFER", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BUFFER_TYPE", 0)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_CACHE_TX_BUFFER_NUM", 32)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_TX_BUFFER_NUM", 8)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_TX_ENABLED", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BA_WIN", 16)
+
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_MAX_ACTIVE_TCP", 16)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_MAX_LISTENING_TCP", 16)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 512)
+
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MAXRTX", 12)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MSS", 1436)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MSL", 60000)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_OVERSIZE_MSS", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_QUEUE_OOSEQ", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 512)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RCV_SCALE", 3)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SYNMAXRTX", 6)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 512000)
+        else:
+            # PSRAM is not guaranteed, which require lower buffer counts
+            # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
+
+            # Allocate wifi buffers in PSRAM - harmless if PSRAM isn't available
+            esp32.add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
+
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM", 16)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM", 64)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM", 64)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_TX_ENABLED", True)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
+            esp32.add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BA_WIN", 32)
+
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
+
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
+            esp32.add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 65534)
 
     var = await media_player.new_media_player(config)
     await cg.register_component(var, config)

--- a/tests/components/psram/test.esp32-s3-idf.yaml
+++ b/tests/components/psram/test.esp32-s3-idf.yaml
@@ -9,3 +9,4 @@ psram:
   mode: octal
   speed: 120MHz
   enable_ecc: true
+  ignore_not_found: false


### PR DESCRIPTION
# What does this implement/fix?

This is built on top of #11411, merge that first!

This PR checks if PSRAM is guaranteed to be available based on how the psram component is configured. If so, it increases the buffer counts dramatically to reduce stuttering. These buffers are set at compilation via **sdk_config** options, so this needs to be determined at the codegen stage. It uses the previous settings that were modified in #10088 that worked well for streaming audio. I modified the settings in that PR because the upgrade to IDF 5.4 apparently made the checks on them more strict and it was using worse default values. This will hopefully fix the stuttering issues [reported on recent firmware versions of the VPE](https://github.com/esphome/home-assistant-voice-pe/issues/455).

See Espressif's [esp_wifi Kconfig](https://github.com/espressif/esp-idf/blob/release/v5.4/components/esp_wifi/Kconfig) and [lwip Kconfig](https://github.com/espressif/esp-idf/blob/release/v5.4/components/lwip/Kconfig) for the different maximums allowed when ``SPIRAM_IGNORE_NOTFOUND`` is set and not set.

I don't particularly like this approach, where the logic for determining if PSRAM is available is done here, so I am leaving this PR as a draft for now pending further discussion.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

psram:
  mode: octal
  speed: 80MHz
  ignore_not_found: false

  - platform: speaker
    name: Media Player
    announcement_pipeline:
      speaker: OUTPUT_SPEAKER_ID
      format: FLAC
      num_channels: 1
      sample_rate: 48000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
