### PR TITLE
[core] Stop clang-format "fixing" a single line

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -243,8 +243,10 @@
 // Dummy firmware payload for shelly_dimmer
 #define USE_SHD_FIRMWARE_MAJOR_VERSION 56
 #define USE_SHD_FIRMWARE_MINOR_VERSION 5
+// clang-format off
 #define USE_SHD_FIRMWARE_DATA \
   {}
+// clang-format on
 
 #define USE_WEBSERVER
 #define USE_WEBSERVER_AUTH


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Everytime I save this file, clang-format decides to reformat this line, then pre-commit changes it back :facepalm: 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
