### PR TITLE
template_alarm_control_panel cleanups

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -80,19 +80,12 @@ void TemplateAlarmControlPanel::dump_config() {
 }
 
 void TemplateAlarmControlPanel::setup() {
-  switch (this->restore_mode_) {
-    case ALARM_CONTROL_PANEL_ALWAYS_DISARMED:
-      this->current_state_ = ACP_STATE_DISARMED;
-      break;
-    case ALARM_CONTROL_PANEL_RESTORE_DEFAULT_DISARMED: {
-      uint8_t value;
-      this->pref_ = global_preferences->make_preference<uint8_t>(this->get_preference_hash());
-      if (this->pref_.load(&value)) {
-        this->current_state_ = static_cast<alarm_control_panel::AlarmControlPanelState>(value);
-      } else {
-        this->current_state_ = ACP_STATE_DISARMED;
-      }
-      break;
+  this->current_state_ = ACP_STATE_DISARMED;
+  if (this->restore_mode_ == ALARM_CONTROL_PANEL_RESTORE_DEFAULT_DISARMED) {
+    uint8_t value;
+    this->pref_ = global_preferences->make_preference<uint8_t>(this->get_preference_hash());
+    if (this->pref_.load(&value)) {
+      this->current_state_ = static_cast<alarm_control_panel::AlarmControlPanelState>(value);
     }
   }
   this->desired_state_ = this->current_state_;

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -226,8 +226,6 @@ uint32_t TemplateAlarmControlPanel::get_supported_features() const {
   return features;
 }
 
-bool TemplateAlarmControlPanel::get_requires_code() const { return !this->codes_.empty(); }
-
 void TemplateAlarmControlPanel::arm_(optional<std::string> code, alarm_control_panel::AlarmControlPanelState state,
                                      uint32_t delay) {
   if (this->current_state_ != ACP_STATE_DISARMED) {

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -176,13 +176,13 @@ void TemplateAlarmControlPanel::loop() {
       }
     }
   }
-  // Update all sensors not ready flag
-  this->sensors_ready_ = ((!instant_sensor_not_ready) && (!delayed_sensor_not_ready));
+  // Update all sensors ready flag
+  bool sensors_ready = !(instant_sensor_not_ready || delayed_sensor_not_ready);
 
   // Call the ready state change callback if there was a change
-  if (this->sensors_ready_ != this->sensors_ready_last_) {
+  if (this->sensors_ready_ != sensors_ready) {
+    this->sensors_ready_ = sensors_ready;
     this->ready_callback_.call();
-    this->sensors_ready_last_ = this->sensors_ready_;
   }
 
 #endif

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -156,12 +156,11 @@ void TemplateAlarmControlPanel::loop() {
       }
 
       switch (sensor_info.second.type) {
+        case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
+          future_state = ACP_STATE_TRIGGERED;
+          [[fallthrough]];
         case ALARM_SENSOR_TYPE_INSTANT:
           instant_sensor_not_ready = true;
-          break;
-        case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
-          instant_sensor_not_ready = true;
-          future_state = ACP_STATE_TRIGGERED;
           break;
         case ALARM_SENSOR_TYPE_DELAYED_FOLLOWER:
           // Look to see if we are in the pending state

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -112,11 +112,11 @@ void TemplateAlarmControlPanel::loop() {
     this->publish_state(ACP_STATE_TRIGGERED);
     return;
   }
-  auto future_state = this->current_state_;
+  auto next_state = this->current_state_;
   // reset triggered if all clear
   if (this->current_state_ == ACP_STATE_TRIGGERED && this->trigger_time_ > 0 &&
       (millis() - this->last_update_) > this->trigger_time_) {
-    future_state = this->desired_state_;
+    next_state = this->desired_state_;
   }
 
   bool delayed_sensor_faulted = false;
@@ -157,7 +157,7 @@ void TemplateAlarmControlPanel::loop() {
 
       switch (sensor_info.second.type) {
         case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
-          future_state = ACP_STATE_TRIGGERED;
+          next_state = ACP_STATE_TRIGGERED;
           [[fallthrough]];
         case ALARM_SENSOR_TYPE_INSTANT:
           instant_sensor_faulted = true;
@@ -186,7 +186,7 @@ void TemplateAlarmControlPanel::loop() {
   }
 
 #endif
-  if (this->is_state_armed(future_state) && (!this->sensors_ready_)) {
+  if (this->is_state_armed(next_state) && (!this->sensors_ready_)) {
     // Instant sensors
     if (instant_sensor_faulted) {
       this->publish_state(ACP_STATE_TRIGGERED);
@@ -198,8 +198,8 @@ void TemplateAlarmControlPanel::loop() {
         this->publish_state(ACP_STATE_TRIGGERED);
       }
     }
-  } else if (future_state != this->current_state_) {
-    this->publish_state(future_state);
+  } else if (next_state != this->current_state_) {
+    this->publish_state(next_state);
   }
 }
 

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -119,8 +119,8 @@ void TemplateAlarmControlPanel::loop() {
     future_state = this->desired_state_;
   }
 
-  bool delayed_sensor_not_ready = false;
-  bool instant_sensor_not_ready = false;
+  bool delayed_sensor_faulted = false;
+  bool instant_sensor_faulted = false;
 
 #ifdef USE_BINARY_SENSOR
   // Test all of the sensors in the list regardless of the alarm panel state
@@ -137,7 +137,7 @@ void TemplateAlarmControlPanel::loop() {
       // Record the sensor state change
       this->sensor_data_[sensor_info.second.store_index].last_chime_state = sensor_info.first->state;
     }
-    // Check for triggered sensors
+    // Check for faulted sensors
     if (sensor_info.first->state) {  // Sensor triggered?
       // Skip if auto bypassed
       if (std::count(this->bypassed_sensor_indicies_.begin(), this->bypassed_sensor_indicies_.end(),
@@ -160,24 +160,24 @@ void TemplateAlarmControlPanel::loop() {
           future_state = ACP_STATE_TRIGGERED;
           [[fallthrough]];
         case ALARM_SENSOR_TYPE_INSTANT:
-          instant_sensor_not_ready = true;
+          instant_sensor_faulted = true;
           break;
         case ALARM_SENSOR_TYPE_DELAYED_FOLLOWER:
           // Look to see if we are in the pending state
           if (this->current_state_ == ACP_STATE_PENDING) {
-            delayed_sensor_not_ready = true;
+            delayed_sensor_faulted = true;
           } else {
-            instant_sensor_not_ready = true;
+            instant_sensor_faulted = true;
           }
           break;
         case ALARM_SENSOR_TYPE_DELAYED:
         default:
-          delayed_sensor_not_ready = true;
+          delayed_sensor_faulted = true;
       }
     }
   }
   // Update all sensors ready flag
-  bool sensors_ready = !(instant_sensor_not_ready || delayed_sensor_not_ready);
+  bool sensors_ready = !(instant_sensor_faulted || delayed_sensor_faulted);
 
   // Call the ready state change callback if there was a change
   if (this->sensors_ready_ != sensors_ready) {
@@ -188,9 +188,9 @@ void TemplateAlarmControlPanel::loop() {
 #endif
   if (this->is_state_armed(future_state) && (!this->sensors_ready_)) {
     // Instant sensors
-    if (instant_sensor_not_ready) {
+    if (instant_sensor_faulted) {
       this->publish_state(ACP_STATE_TRIGGERED);
-    } else if (delayed_sensor_not_ready) {
+    } else if (delayed_sensor_faulted) {
       // Delayed sensors
       if ((this->pending_time_ > 0) && (this->current_state_ != ACP_STATE_TRIGGERED)) {
         this->publish_state(ACP_STATE_PENDING);
@@ -248,9 +248,9 @@ void TemplateAlarmControlPanel::arm_(optional<std::string> code, alarm_control_p
 void TemplateAlarmControlPanel::bypass_before_arming() {
 #ifdef USE_BINARY_SENSOR
   for (auto sensor_info : this->sensor_map_) {
-    // Check for sensors left on and set to bypass automatically and remove them from monitoring
+    // Check for faulted bypass_auto sensors and remove them from monitoring
     if ((sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_AUTO) && (sensor_info.first->state)) {
-      ESP_LOGW(TAG, "'%s' is left on and will be automatically bypassed", sensor_info.first->get_name().c_str());
+      ESP_LOGW(TAG, "'%s' is faulted and will be automatically bypassed", sensor_info.first->get_name().c_str());
       this->bypassed_sensor_indicies_.push_back(sensor_info.second.store_index);
     }
   }

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -56,7 +56,7 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   void setup() override;
   void loop() override;
   uint32_t get_supported_features() const override;
-  bool get_requires_code() const override;
+  bool get_requires_code() const override { return !this->codes_.empty(); }
   bool get_requires_code_to_arm() const override { return this->requires_code_to_arm_; }
   bool get_all_sensors_ready() { return this->sensors_ready_; };
   void set_restore_mode(TemplateAlarmControlPanelRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -148,7 +148,6 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   bool supports_arm_home_ = false;
   bool supports_arm_night_ = false;
   bool sensors_ready_ = false;
-  bool sensors_ready_last_ = false;
   uint8_t next_store_index_ = 0;
   // check if the code is valid
   bool is_code_valid_(optional<std::string> code);

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -66,7 +66,8 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   /** Add a binary_sensor to the alarm_panel.
    *
    * @param sensor The BinarySensor instance.
-   * @param ignore_when_home if this should be ignored when armed_home mode
+   * @param flags The OR of BinarySensorFlags for the sensor.
+   * @param type The sensor type which determines its triggering behaviour.
    */
   void add_sensor(binary_sensor::BinarySensor *sensor, uint16_t flags = 0,
                   AlarmSensorType type = ALARM_SENSOR_TYPE_DELAYED);

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -122,7 +122,7 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
  protected:
   void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
 #ifdef USE_BINARY_SENSOR
-  // This maps a binary sensor to its type and attribute bits
+  // This maps a binary sensor to its alarm specific info
   std::map<binary_sensor::BinarySensor *, SensorInfo> sensor_map_;
   // a list of automatically bypassed sensors
   std::vector<uint8_t> bypassed_sensor_indicies_;


### PR DESCRIPTION
# What does this implement/fix?

This PR does some cleaning up and simplification of the template_alarm_control_panel code.

These commits form the first part of #9003, but that hasn't gotten any traction so lets try breaking it into smaller more palatable chunks, starting with some basic code cleanup.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Cover note:

These commits are just code improvements that have no behavioural impact.

Some notes on the commits:

1. Simplify setup() logic

There is only one exceptional case to deal with so replace the switch with an if.

2. Use fallthrough for common ALARM_SENSOR_TYPE_INSTANT_ALWAYS/ALARM_SENSOR_TYPE_INSTANT

Just a minor tidy-up.

3. Move get_requires_code() definition to header

Other minor methods are defined in the header...

4. Fix add_sensor() code doc

Code documentation refers to a non-existent "ignore_when_home" and does not document the actual parameters.

5. Improve sensor_map_ description

Sometimes less is more - especially if things get added to SensorInfo later.

6. Replace sensors_ready_last_ with local var

sensors_ready_last_ is only used in one place, and doesn't actually need to be persisted across calls, so use a local var instead.

7. Use "faulted" for sensors rather than "triggered"/"not ready"/"left on" throughout.

This is for terminology consistency - sensors are either "ready" or "faulted".  It is the alarm that is triggered.

8. Rename future_state to next_state

The standard naming for a series of events is prev/current/next, not "future" which could also be confused with desired_state_.

