### PR TITLE
[ci] Fix test detection for components with only variant tests

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -336,7 +336,7 @@ def _component_has_tests(component: str) -> bool:
     Returns:
         True if the component has test YAML files
     """
-    return bool(get_component_test_files(component))
+    return bool(get_component_test_files(component, all_variants=True))
 
 
 def _select_platform_by_preference(
@@ -496,7 +496,7 @@ def detect_memory_impact_config(
 
     for component in sorted(changed_component_set):
         # Look for test files on preferred platforms
-        test_files = get_component_test_files(component)
+        test_files = get_component_test_files(component, all_variants=True)
         if not test_files:
             continue
 


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a bug in the CI test determination logic where components with only variant test files (`test-*.yaml`) were not being detected, causing their tests and memory impact analysis to be skipped.

## Problem

The `script/determine-jobs.py` script was only looking for base test files matching the pattern `test.*.yaml`, but some components only have variant test files matching `test-*.yaml`. This caused the following components to be completely skipped in CI:

- **ethernet** (12 variant tests)
- **improv_base** (1 variant test)
- **improv_serial** (10 variant tests)
- **mdns** (6 variant tests)
- **safe_mode** (5 variant tests)

For example, PR #11473 which modifies `improv_serial` shows:
```json
"changed_components_with_tests": [],
"memory_impact": {"should_run": "false"}
```

Even though `improv_serial` has 10 test files in `tests/components/improv_serial/`.

## Solution

Updated two calls to `get_component_test_files()` to include `all_variants=True`:

1. **Line 339** in `_component_has_tests()` - determines if component tests should run
2. **Line 499** in `detect_memory_impact_config()` - used for memory impact analysis

This ensures both base tests (`test.*.yaml`) and variant tests (`test-*.yaml`) are detected.

## Testing

Added two comprehensive test cases:

1. **`test_main_detects_components_with_variant_tests()`** - Verifies that components with only variant test files (like `improv_serial`, `ethernet`) are properly detected and included in the test matrix
2. **`test_detect_memory_impact_config_with_variant_tests()`** - Verifies that memory impact analysis works correctly for components with only variant tests

All 61 existing tests continue to pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while investigating PR #11473 where `improv_serial` tests weren't running

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal CI improvement

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a CI infrastructure fix

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

