### PR TITLE
[ci] Fix component splitter for components with only variant tests

### DIFF
--- a/script/split_components_for_ci.py
+++ b/script/split_components_for_ci.py
@@ -49,9 +49,9 @@ def has_test_files(component_name: str, tests_dir: Path) -> bool:
         tests_dir: Path to tests/components directory (unused, kept for compatibility)
 
     Returns:
-        True if the component has test.*.yaml files
+        True if the component has test.*.yaml or test-*.yaml files
     """
-    return bool(get_component_test_files(component_name))
+    return bool(get_component_test_files(component_name, all_variants=True))
 
 
 def create_intelligent_batches(


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a bug in the CI component splitter where components with only variant test files (`test-*.yaml`) were not being detected, causing the matrix splitter to fail with "Matrix vector 'components' does not contain any values" error.

## Problem

The `script/split_components_for_ci.py` script's `has_test_files()` function was only detecting base test files matching the pattern `test.*.yaml`, but some components only have variant test files matching `test-*.yaml`. This caused the splitter to skip these components when creating test batches.

When the `determine-jobs.py` script (fixed in the companion fix) now correctly returns components with variant tests in `changed-components-with-tests`, the splitter would then try to process them but fail because its own `has_test_files()` check would return `False`.

This caused the CI workflow error:
```
Error when evaluating 'strategy' for job 'test-build-components-split'.
Matrix vector 'components' does not contain any values
```

## Components Affected

5 components have only variant tests and were being filtered out by the splitter:

- **ethernet** (12 variant tests)
- **improv_base** (1 variant test)
- **improv_serial** (10 variant tests)
- **mdns** (6 variant tests)
- **safe_mode** (5 variant tests)

## Solution

Updated the `has_test_files()` function in `script/split_components_for_ci.py` to include `all_variants=True` when calling `get_component_test_files()`. This ensures both base tests (`test.*.yaml`) and variant tests (`test-*.yaml`) are detected.

**Line 54:** Changed from:
```python
return bool(get_component_test_files(component_name))
```

To:
```python
return bool(get_component_test_files(component_name, all_variants=True))
```

Also updated the docstring to reflect that both test patterns are now detected.

## Related Changes

This fix complements the changes in `script/determine-jobs.py` (separate commit) which also needed the same fix for test detection and memory impact analysis.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to PR #11473 where CI was failing for `improv_serial` changes

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal CI improvement

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a CI infrastructure fix

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Note: The splitter script currently has no unit tests. The fix is verified through integration with the existing `determine-jobs.py` tests.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
