### PR TITLE
[ethernet] Add RMII GPIO pin conflict validation

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -434,15 +434,19 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
             component_path = ".".join(str(p) for p in pin_path)
             if is_configurable:
                 error_msg = (
-                    f"GPIO{pin_num} is used by Ethernet RMII ({pin_function}) with the current default configuration. "
-                    f"This conflicts with '{component_path}'. "
-                    f"Please choose a different GPIO pin for '{component_path}'."
+                    f"GPIO{pin_num} is used by Ethernet RMII "
+                    f"({pin_function}) with the current default "
+                    f"configuration. This conflicts with '{component_path}'. "
+                    f"Please choose a different GPIO pin for "
+                    f"'{component_path}'."
                 )
             else:
                 error_msg = (
-                    f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
-                    f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
-                    f"Please choose a different GPIO pin for '{component_path}'."
+                    f"GPIO{pin_num} is reserved for Ethernet RMII "
+                    f"({pin_function}) and cannot be used. This pin is "
+                    f"hardcoded by ESP-IDF and cannot be changed when using "
+                    f"RMII Ethernet PHYs. Please choose a different GPIO pin "
+                    f"for '{component_path}'."
                 )
             raise cv.Invalid(error_msg, path=pin_path)
 

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -286,7 +286,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-def _final_validate(config):
+def _final_validate_spi(config):
     if config[CONF_TYPE] not in SPI_ETHERNET_TYPES:
         return
     if spi_configs := fv.full_config.get().get(CONF_SPI):
@@ -303,9 +303,6 @@ def _final_validate(config):
                         f"`spi` component is using interface '{interface}'. "
                         f"To use {config[CONF_TYPE]}, you must change the `interface` on the `spi` component.",
                     )
-
-
-FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 def manual_ip(config):
@@ -427,6 +424,7 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
 
 def _final_validate(config: ConfigType) -> ConfigType:
     """Final validation for Ethernet component."""
+    _final_validate_spi(config)
     _final_validate_rmii_pins(config)
     return config
 

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -32,6 +32,7 @@ from esphome.const import (
     CONF_MISO_PIN,
     CONF_MODE,
     CONF_MOSI_PIN,
+    CONF_NUMBER,
     CONF_PAGE_ID,
     CONF_PIN,
     CONF_POLLING_INTERVAL,
@@ -52,11 +53,23 @@ from esphome.core import (
     coroutine_with_priority,
 )
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 CONFLICTS_WITH = ["wifi"]
 DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["network"]
 LOGGER = logging.getLogger(__name__)
+
+# RMII pins that are hardcoded on ESP32 and cannot be changed
+# These pins are used by the internal Ethernet MAC when using RMII PHYs
+ESP32_RMII_FIXED_PINS = {
+    19: "EMAC_TXD0",
+    21: "EMAC_TX_EN",
+    22: "EMAC_TXD1",
+    25: "EMAC_RXD0",
+    26: "EMAC_RXD1",
+    27: "EMAC_RX_CRS_DV",
+}
 
 ethernet_ns = cg.esphome_ns.namespace("ethernet")
 PHYRegister = ethernet_ns.struct("PHYRegister")
@@ -383,3 +396,38 @@ async def to_code(config):
 
     if CORE.using_arduino:
         cg.add_library("WiFi", None)
+
+
+def _final_validate_rmii_pins(config: ConfigType) -> None:
+    """Validate that RMII pins are not used by other components."""
+    # Only validate for RMII-based PHYs on ESP32/ESP32P4
+    if config[CONF_TYPE] in SPI_ETHERNET_TYPES or config[CONF_TYPE] == "OPENETH":
+        return  # SPI and OPENETH don't use RMII
+
+    variant = get_esp32_variant()
+    if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
+        return  # Only ESP32 classic and P4 have RMII
+
+    # Check each RMII pin against the pin registry
+    for pin_num, pin_function in ESP32_RMII_FIXED_PINS.items():
+        # Check if this pin is used by any component
+        for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
+            for pin_path, _, pin_config in pin_list:
+                if pin_config.get(CONF_NUMBER) == pin_num:
+                    # Found a conflict - show helpful error message
+                    component_path = ".".join(str(p) for p in pin_path)
+                    raise cv.Invalid(
+                        f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
+                        f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
+                        f"Please choose a different GPIO pin for '{component_path}'.",
+                        path=pin_path,
+                    )
+
+
+def _final_validate(config: ConfigType) -> ConfigType:
+    """Final validation for Ethernet component."""
+    _final_validate_rmii_pins(config)
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -408,20 +408,21 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
     if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
         return  # Only ESP32 classic and P4 have RMII
 
-    # Check each RMII pin against the pin registry
-    for pin_num, pin_function in ESP32_RMII_FIXED_PINS.items():
-        # Check if this pin is used by any component
-        for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
-            for pin_path, _, pin_config in pin_list:
-                if pin_config.get(CONF_NUMBER) == pin_num:
-                    # Found a conflict - show helpful error message
-                    component_path = ".".join(str(p) for p in pin_path)
-                    raise cv.Invalid(
-                        f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
-                        f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
-                        f"Please choose a different GPIO pin for '{component_path}'.",
-                        path=pin_path,
-                    )
+    # Check all used pins against RMII reserved pins
+    for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
+        for pin_path, _, pin_config in pin_list:
+            pin_num = pin_config.get(CONF_NUMBER)
+            if pin_num not in ESP32_RMII_FIXED_PINS:
+                continue
+            # Found a conflict - show helpful error message
+            pin_function = ESP32_RMII_FIXED_PINS[pin_num]
+            component_path = ".".join(str(p) for p in pin_path)
+            raise cv.Invalid(
+                f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
+                f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
+                f"Please choose a different GPIO pin for '{component_path}'.",
+                path=pin_path,
+            )
 
 
 def _final_validate(config: ConfigType) -> ConfigType:

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -60,7 +60,7 @@ DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["network"]
 LOGGER = logging.getLogger(__name__)
 
-# RMII pins that are hardcoded on ESP32 and cannot be changed
+# RMII pins that are hardcoded on ESP32 classic and cannot be changed
 # These pins are used by the internal Ethernet MAC when using RMII PHYs
 ESP32_RMII_FIXED_PINS = {
     19: "EMAC_TXD0",
@@ -69,6 +69,18 @@ ESP32_RMII_FIXED_PINS = {
     25: "EMAC_RXD0",
     26: "EMAC_RXD1",
     27: "EMAC_RX_CRS_DV",
+}
+
+# RMII default pins for ESP32-P4
+# These are the default pins used by ESP-IDF and are configurable in principle,
+# but ESPHome's ethernet component currently has no way to change them
+ESP32P4_RMII_DEFAULT_PINS = {
+    34: "EMAC_TXD0",
+    35: "EMAC_TXD1",
+    28: "EMAC_RX_CRS_DV",
+    29: "EMAC_RXD0",
+    30: "EMAC_RXD1",
+    49: "EMAC_TX_EN",
 }
 
 ethernet_ns = cg.esphome_ns.namespace("ethernet")
@@ -402,24 +414,37 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
         return  # SPI and OPENETH don't use RMII
 
     variant = get_esp32_variant()
-    if variant not in (VARIANT_ESP32, VARIANT_ESP32P4):
-        return  # Only ESP32 classic and P4 have RMII
+    if variant == VARIANT_ESP32:
+        rmii_pins = ESP32_RMII_FIXED_PINS
+        is_configurable = False
+    elif variant == VARIANT_ESP32P4:
+        rmii_pins = ESP32P4_RMII_DEFAULT_PINS
+        is_configurable = True
+    else:
+        return  # No RMII validation needed for other variants
 
     # Check all used pins against RMII reserved pins
     for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
         for pin_path, _, pin_config in pin_list:
             pin_num = pin_config.get(CONF_NUMBER)
-            if pin_num not in ESP32_RMII_FIXED_PINS:
+            if pin_num not in rmii_pins:
                 continue
             # Found a conflict - show helpful error message
-            pin_function = ESP32_RMII_FIXED_PINS[pin_num]
+            pin_function = rmii_pins[pin_num]
             component_path = ".".join(str(p) for p in pin_path)
-            raise cv.Invalid(
-                f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
-                f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
-                f"Please choose a different GPIO pin for '{component_path}'.",
-                path=pin_path,
-            )
+            if is_configurable:
+                error_msg = (
+                    f"GPIO{pin_num} is used by Ethernet RMII ({pin_function}) with the current default configuration. "
+                    f"This conflicts with '{component_path}'. "
+                    f"Please choose a different GPIO pin for '{component_path}'."
+                )
+            else:
+                error_msg = (
+                    f"GPIO{pin_num} is reserved for Ethernet RMII ({pin_function}) and cannot be used. "
+                    f"This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. "
+                    f"Please choose a different GPIO pin for '{component_path}'."
+                )
+            raise cv.Invalid(error_msg, path=pin_path)
 
 
 def _final_validate(config: ConfigType) -> ConfigType:

--- a/tests/components/ethernet/common-dp83848.yaml
+++ b/tests/components/ethernet/common-dp83848.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: DP83848
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-ip101.yaml
+++ b/tests/components/ethernet/common-ip101.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: IP101
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-jl1101.yaml
+++ b/tests/components/ethernet/common-jl1101.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: JL1101
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-ksz8081.yaml
+++ b/tests/components/ethernet/common-ksz8081.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: KSZ8081
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-ksz8081rna.yaml
+++ b/tests/components/ethernet/common-ksz8081rna.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: KSZ8081RNA
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-lan8670.yaml
+++ b/tests/components/ethernet/common-lan8670.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: LAN8670
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-lan8720.yaml
+++ b/tests/components/ethernet/common-lan8720.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: LAN8720
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet/common-rtl8201.yaml
+++ b/tests/components/ethernet/common-rtl8201.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: RTL8201
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1

--- a/tests/components/ethernet_info/common.yaml
+++ b/tests/components/ethernet_info/common.yaml
@@ -1,12 +1,12 @@
 ethernet:
   type: LAN8720
   mdc_pin: 23
-  mdio_pin: 25
+  mdio_pin: 32
   clk:
     pin: 0
     mode: CLK_EXT_IN
   phy_addr: 0
-  power_pin: 26
+  power_pin: 33
   manual_ip:
     static_ip: 192.168.178.56
     gateway: 192.168.178.1


### PR DESCRIPTION
# What does this implement/fix?

This PR adds configuration validation to prevent GPIO conflicts with ESP32 and ESP32-P4 RMII Ethernet pins. The Ethernet component now validates during the configuration phase that no other components are using the RMII pins that are reserved or in use by the Ethernet MAC.

## Backstory

I kept soft-bricking my ESP32 test boards by accidentally configuring dummy components (test LEDs, sensors, etc.) on GPIO pins that are hardcoded by ESP-IDF for RMII Ethernet. The boards would compile and flash successfully, but then fail to boot or connect to the network, requiring tedious serial recovery flashing. This happened repeatedly because it's easy to forget which pins are reserved when adding new test components to a configuration.

This validation catches these conflicts at configuration time, providing clear error messages about which pin is reserved for which Ethernet function and which component is conflicting.

## Implementation Details

The fix adds a `FINAL_VALIDATE_SCHEMA` to the Ethernet component that:

1. **Checks if RMII validation is needed**: Only validates for RMII-based PHYs (LAN8720, RTL8201, DP83848, JL1101, KSZ8081) on ESP32 classic and ESP32-P4. Skips SPI-based Ethernet (W5500, DM9051) and OPENETH.

2. **Uses PIN_SCHEMA_REGISTRY**: Leverages ESPHome's centralized pin tracking system (`pins.PIN_SCHEMA_REGISTRY.pins_used`) to find all GPIO pin assignments across the entire configuration.

3. **Validates RMII pins per variant**:

   **ESP32 Classic** - Hardcoded pins that cannot be changed:
   - GPIO 19 - EMAC_TXD0
   - GPIO 21 - EMAC_TX_EN
   - GPIO 22 - EMAC_TXD1
   - GPIO 25 - EMAC_RXD0
   - GPIO 26 - EMAC_RXD1
   - GPIO 27 - EMAC_RX_CRS_DV

   **ESP32-P4** - Default pins (configurable in ESP-IDF but not exposed in ESPHome):
   - GPIO 34 - EMAC_TXD0
   - GPIO 35 - EMAC_TXD1
   - GPIO 28 - EMAC_RX_CRS_DV
   - GPIO 29 - EMAC_RXD0
   - GPIO 30 - EMAC_RXD1
   - GPIO 49 - EMAC_TX_EN

4. **Provides helpful error messages**: When a conflict is detected, the error message includes:
   - The conflicting GPIO number
   - The Ethernet function using that pin
   - The component path that attempted to use the pin
   - For ESP32 classic: Explanation that the pin is hardcoded and cannot be changed
   - For ESP32-P4: Explanation that the pin is used by the default configuration

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [x] ESP32 (classic)
- [x] ESP32-P4 (validation logic)
- [ ] ESP8266 (not applicable - no RMII support)
- [ ] RP2040 (not applicable - no RMII support)
- [ ] BK72xx (not applicable)
- [ ] RTL87xx (not applicable)
- [ ] nRF52840 (not applicable)

## Example: Before and After

### Before (config accepted, runtime failure):

```yaml
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO12

output:
  - platform: ledc
    pin: GPIO25  # Silently conflicts with EMAC_RXD0
    id: red_led

light:
  - platform: monochromatic
    output: red_led
    name: "Red LED"
```

**Result**: Config validates ✅, compiles ✅, but device fails to connect to network at runtime ❌

### After (validation catches conflict):

```yaml
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO12

output:
  - platform: ledc
    pin: GPIO25  # Now caught during validation!
    id: red_led

light:
  - platform: monochromatic
    output: red_led
    name: "Red LED"
```

**Result**:
```
ERROR ethernet: GPIO25 is reserved for Ethernet RMII (EMAC_RXD0) and cannot be used. This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. Please choose a different GPIO pin for 'output.0'.
```

Config validation fails ❌ - user must fix the conflict before compiling.

### Fixed configuration:

```yaml
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO0_IN
  phy_addr: 1
  power_pin: GPIO12

output:
  - platform: ledc
    pin: GPIO32  # Safe pin, not reserved by Ethernet
    id: red_led

light:
  - platform: monochromatic
    output: red_led
    name: "Red LED"
```

**Result**: Config validates ✅, compiles ✅, device works correctly ✅

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been updated to avoid using reserved RMII pins.
  - [x] Review feedback has been addressed.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
