### PR TITLE
[scheduler] Remove unused deque include after defer queue optimization

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <memory>
 #include <cstring>
-#include <deque>
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
 #include <atomic>
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Remove unused `<deque>` include from scheduler.h that was left behind after PR #11305 replaced `std::deque` with `std::vector` for the defer queue.

This is a minor cleanup that removes the now-unused header include.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Follow-up to #11305

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a header cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
