### PR TITLE
[waveshare_epaper]:add support for 4.26in B/W epaper.

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -70,6 +70,9 @@ WaveshareEPaper4P2InBV2 = waveshare_epaper_ns.class_(
 WaveshareEPaper4P2InBV2BWR = waveshare_epaper_ns.class_(
     "WaveshareEPaper4P2InBV2BWR", WaveshareEPaperBWR
 )
+WaveshareEPaper4P26In = waveshare_epaper_ns.class_(
+    "WaveshareEPaper4P26In", WaveshareEPaper
+)
 WaveshareEPaper5P65InF = waveshare_epaper_ns.class_(
     "WaveshareEPaper5P65InF", WaveshareEPaper7C
 )
@@ -154,6 +157,7 @@ MODELS = {
     "4.20in": ("b", WaveshareEPaper4P2In),
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),
     "4.20in-bv2-bwr": ("b", WaveshareEPaper4P2InBV2BWR),
+    "4.26in": ("b", WaveshareEPaper4P26In),
     "5.65in-f": ("b", WaveshareEPaper5P65InF),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "5.83inv2": ("b", WaveshareEPaper5P8InV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2760,71 +2760,68 @@ void WaveshareEPaper4P2InBV2BWR::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-
-
 void WaveshareEPaper4P26In::initialize() {
   // https://www.waveshare.net/w/upload/4/46/4.26inch_e-Paper_User_Manual.pdf
-  this->wait_until_idle_();  
-	this->command(0x12);  //SWRESET
-	this->wait_until_idle_();    
-	
-	this->command(0x18); // use the internal temperature sensor
-	this->data(0x80);
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
 
-	this->command(0x0C); //set soft start     
-	this->data(0xAE);
-	this->data(0xC7);
-	this->data(0xC3);
-	this->data(0xC0);
-	this->data(0x80);
+  this->command(0x18);  // use the internal temperature sensor
+  this->data(0x80);
 
-	this->command(0x01);   //      drive output control    
-	this->data((get_height_internal()-1)%256); //  Y  
-	this->data((get_height_internal()-1)/256); //  Y 
-	this->data(0x02);
+  this->command(0x0C);  // set soft start
+  this->data(0xAE);
+  this->data(0xC7);
+  this->data(0xC3);
+  this->data(0xC0);
+  this->data(0x80);
 
-	this->command(0x3C);        // Border       Border setting 
-	this->data(0x01);
+  this->command(0x01);                            //      drive output control
+  this->data((get_height_internal() - 1) % 256);  //  Y
+  this->data((get_height_internal() - 1) / 256);  //  Y
+  this->data(0x02);
 
-	this->command(0x11);        //    data  entry  mode
-	this->data(0x01);           //       X-mode  x+ y-    
+  this->command(0x3C);  // Border       Border setting
+  this->data(0x01);
 
-  this->command(0x44); // SET_RAM_X_ADDRESS_START_END_POSITION
+  this->command(0x11);  //    data  entry  mode
+  this->data(0x01);     //       X-mode  x+ y-
+
+  this->command(0x44);  // SET_RAM_X_ADDRESS_START_END_POSITION
   this->data(0 & 0xFF);
-  this->data((0>>8) & 0x03);
+  this->data((0 >> 8) & 0x03);
   this->data((get_width_internal() - 1) & 0xFF);
-  this->data(((get_width_internal() - 1)>>8) & 0x03);
+  this->data(((get_width_internal() - 1) >> 8) & 0x03);
 
-  this->command(0x45); // SET_RAM_Y_ADDRESS_START_END_POSITION
-  this->data((get_height_internal()- 1) & 0xFF);
-  this->data(((get_height_internal() - 1)>>8) & 0x03);
+  this->command(0x45);  // SET_RAM_Y_ADDRESS_START_END_POSITION
+  this->data((get_height_internal() - 1) & 0xFF);
+  this->data(((get_height_internal() - 1) >> 8) & 0x03);
   this->data(0 & 0xFF);
-  this->data((0>>8) & 0x03);
+  this->data((0 >> 8) & 0x03);
 
-  this->command(0x4E); // SET_RAM_X_ADDRESS_COUNTER
+  this->command(0x4E);  // SET_RAM_X_ADDRESS_COUNTER
   this->data(0 & 0xFF);
-  this->data((0>>8) & 0x03);
+  this->data((0 >> 8) & 0x03);
 
-  this->command(0x4F); // SET_RAM_Y_ADDRESS_COUNTER
+  this->command(0x4F);  // SET_RAM_Y_ADDRESS_COUNTER
   this->data(0 & 0xFF);
-  this->data((0>>8) & 0x03);
+  this->data((0 >> 8) & 0x03);
 
-	this->wait_until_idle_(); 
- 
+  this->wait_until_idle_();
 }
 void HOT WaveshareEPaper4P26In::display() {
-	this->command(0x24);   //write RAM for black(0)/white (1)
-  
+  this->command(0x24);  // write RAM for black(0)/white (1)
+
   delay(2);
   this->start_data_();
   this->write_array(this->buffer_, this->get_buffer_length_());
   this->end_data_();
   delay(2);
-  
-	this->command(0x22); //Display Update Control
-	this->data(0xF7);
-	this->command(0x20); //Activate Display Update Sequence
-	this->wait_until_idle_(); 
+
+  this->command(0x22);  // Display Update Control
+  this->data(0xF7);
+  this->command(0x20);  // Activate Display Update Sequence
+  this->wait_until_idle_();
 }
 int WaveshareEPaper4P26In::get_width_internal() { return 800; }
 int WaveshareEPaper4P26In::get_height_internal() { return 480; }
@@ -2836,7 +2833,6 @@ void WaveshareEPaper4P26In::dump_config() {
   LOG_PIN("  Busy Pin: ", this->busy_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-
 
 void WaveshareEPaper5P8In::initialize() {
   // COMMAND POWER SETTING

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2760,6 +2760,84 @@ void WaveshareEPaper4P2InBV2BWR::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+
+
+void WaveshareEPaper4P26In::initialize() {
+  // https://www.waveshare.net/w/upload/4/46/4.26inch_e-Paper_User_Manual.pdf
+  this->wait_until_idle_();  
+	this->command(0x12);  //SWRESET
+	this->wait_until_idle_();    
+	
+	this->command(0x18); // use the internal temperature sensor
+	this->data(0x80);
+
+	this->command(0x0C); //set soft start     
+	this->data(0xAE);
+	this->data(0xC7);
+	this->data(0xC3);
+	this->data(0xC0);
+	this->data(0x80);
+
+	this->command(0x01);   //      drive output control    
+	this->data((get_height_internal()-1)%256); //  Y  
+	this->data((get_height_internal()-1)/256); //  Y 
+	this->data(0x02);
+
+	this->command(0x3C);        // Border       Border setting 
+	this->data(0x01);
+
+	this->command(0x11);        //    data  entry  mode
+	this->data(0x01);           //       X-mode  x+ y-    
+
+  this->command(0x44); // SET_RAM_X_ADDRESS_START_END_POSITION
+  this->data(0 & 0xFF);
+  this->data((0>>8) & 0x03);
+  this->data((get_width_internal() - 1) & 0xFF);
+  this->data(((get_width_internal() - 1)>>8) & 0x03);
+
+  this->command(0x45); // SET_RAM_Y_ADDRESS_START_END_POSITION
+  this->data((get_height_internal()- 1) & 0xFF);
+  this->data(((get_height_internal() - 1)>>8) & 0x03);
+  this->data(0 & 0xFF);
+  this->data((0>>8) & 0x03);
+
+  this->command(0x4E); // SET_RAM_X_ADDRESS_COUNTER
+  this->data(0 & 0xFF);
+  this->data((0>>8) & 0x03);
+
+  this->command(0x4F); // SET_RAM_Y_ADDRESS_COUNTER
+  this->data(0 & 0xFF);
+  this->data((0>>8) & 0x03);
+
+	this->wait_until_idle_(); 
+ 
+}
+void HOT WaveshareEPaper4P26In::display() {
+	this->command(0x24);   //write RAM for black(0)/white (1)
+  
+  delay(2);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+  delay(2);
+  
+	this->command(0x22); //Display Update Control
+	this->data(0xF7);
+	this->command(0x20); //Activate Display Update Sequence
+	this->wait_until_idle_(); 
+}
+int WaveshareEPaper4P26In::get_width_internal() { return 800; }
+int WaveshareEPaper4P26In::get_height_internal() { return 480; }
+void WaveshareEPaper4P26In::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 4.26in");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+
 void WaveshareEPaper5P8In::initialize() {
   // COMMAND POWER SETTING
   this->command(0x01);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -620,7 +620,6 @@ class WaveshareEPaper4P2InBV2BWR : public WaveshareEPaperBWR {
   int get_height_internal() override;
 };
 
-
 class WaveshareEPaper4P26In : public WaveshareEPaper {
  public:
   void initialize() override;
@@ -630,8 +629,8 @@ class WaveshareEPaper4P26In : public WaveshareEPaper {
   void dump_config() override;
 
   void deep_sleep() override {
-    this->command(0x10); //enter deep sleep
-    this->data(0x01);  
+    this->command(0x10);  // enter deep sleep
+    this->data(0x01);
     delay(100);  // NOLINT
   }
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -620,6 +620,27 @@ class WaveshareEPaper4P2InBV2BWR : public WaveshareEPaperBWR {
   int get_height_internal() override;
 };
 
+
+class WaveshareEPaper4P26In : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10); //enter deep sleep
+    this->data(0x01);  
+    delay(100);  // NOLINT
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper5P8In : public WaveshareEPaper {
  public:
   void initialize() override;


### PR DESCRIPTION
# What does this implement/fix?
Add suppoort for 4.26in B/W waveshare epaper.
![IMG_20251023_114652](https://github.com/user-attachments/assets/3f566ca4-e4c7-4f0b-87bc-fb29215898b6)
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5517

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
font:
  - file: 'fonts/comicbd.ttf'
    id: font1
    size: 20
 
captive_portal:
  
spi:
  clk_pin: GPIO7
  mosi_pin: GPIO9

display:
  - platform: waveshare_epaper
    id: my_display
    model: 4.26in
    cs_pin: GPIO44
    dc_pin: GPIO10
    busy_pin: GPIO4
    reset_pin:  GPIO38
    rotation: 0
    update_interval: 30s
    lambda: |-
      it.rectangle(10, 10, 100, 50);
      it.rectangle(150, 10, 50, 50);
      it.circle(250, 35, 25);
      it.filled_rectangle(10, 80, 100, 50);
      it.filled_rectangle(150, 80, 50, 50);
      it.filled_circle(250, 105, 25);
      it.print(0, 150, id(font1), "Hello World!");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
     in content/components/display/waveshare_epaper.md
```yaml
- `4.26in`
```
