### PR TITLE
[tests] Fix millis() ambiguity in component tests with gps component

### DIFF
--- a/tests/components/absolute_humidity/common.yaml
+++ b/tests/components/absolute_humidity/common.yaml
@@ -6,14 +6,14 @@ sensor:
   - platform: template
     id: template_humidity
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 0.6;
       }
       return 0.0;
   - platform: template
     id: template_temperature
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 42.0;
       }
       return 0.0;

--- a/tests/components/analog_threshold/common.yaml
+++ b/tests/components/analog_threshold/common.yaml
@@ -3,7 +3,7 @@ sensor:
     id: template_sensor
     name: Template Sensor
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 42.0;
       }
       return 0.0;

--- a/tests/components/bang_bang/common.yaml
+++ b/tests/components/bang_bang/common.yaml
@@ -10,7 +10,7 @@ sensor:
   - platform: template
     id: template_sensor1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 42.0;
       } else {
         return 0.0;

--- a/tests/components/binary_sensor_map/common.yaml
+++ b/tests/components/binary_sensor_map/common.yaml
@@ -2,21 +2,21 @@ binary_sensor:
   - platform: template
     id: bin1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return true;
       }
       return false;
   - platform: template
     id: bin2
     lambda: |-
-      if (millis() > 20000) {
+      if (esphome::millis() > 20000) {
         return true;
       }
       return false;
   - platform: template
     id: bin3
     lambda: |-
-      if (millis() > 30000) {
+      if (esphome::millis() > 30000) {
         return true;
       }
       return false;

--- a/tests/components/combination/common.yaml
+++ b/tests/components/combination/common.yaml
@@ -2,14 +2,14 @@ sensor:
   - platform: template
     id: template_temperature1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 0.6;
       }
       return 0.0;
   - platform: template
     id: template_temperature2
     lambda: |-
-      if (millis() > 20000) {
+      if (esphome::millis() > 20000) {
         return 0.8;
       }
       return 0.0;

--- a/tests/components/duty_time/common.yaml
+++ b/tests/components/duty_time/common.yaml
@@ -2,7 +2,7 @@ binary_sensor:
   - platform: template
     id: bin1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return true;
       }
       return false;

--- a/tests/components/endstop/common.yaml
+++ b/tests/components/endstop/common.yaml
@@ -2,7 +2,7 @@ binary_sensor:
   - platform: template
     id: bin1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return true;
       }
       return false;

--- a/tests/components/lock/common.yaml
+++ b/tests/components/lock/common.yaml
@@ -15,7 +15,7 @@ lock:
     id: test_lock1
     name: Template Lock
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return LOCK_STATE_LOCKED;
       }
       return LOCK_STATE_UNLOCKED;

--- a/tests/components/pid/common.yaml
+++ b/tests/components/pid/common.yaml
@@ -25,7 +25,7 @@ sensor:
   - platform: template
     id: template_sensor1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 42.0;
       }
       return 0.0;

--- a/tests/components/prometheus/common.yaml
+++ b/tests/components/prometheus/common.yaml
@@ -33,7 +33,7 @@ sensor:
   - platform: template
     id: template_sensor1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return 42.0;
       }
       return 0.0;
@@ -46,7 +46,7 @@ text_sensor:
   - platform: template
     id: template_text_sensor1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return {"Hello World"};
       }
       return {"Goodbye (cruel) World"};
@@ -56,7 +56,7 @@ binary_sensor:
   - platform: template
     id: template_binary_sensor1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return true;
       }
       return false;
@@ -65,7 +65,7 @@ switch:
   - platform: template
     id: template_switch1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return true;
       }
       return false;
@@ -79,7 +79,7 @@ cover:
   - platform: template
     id: template_cover1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return COVER_OPEN;
       }
       return COVER_CLOSED;
@@ -88,7 +88,7 @@ lock:
   - platform: template
     id: template_lock1
     lambda: |-
-      if (millis() > 10000) {
+      if (esphome::millis() > 10000) {
         return LOCK_STATE_LOCKED;
       }
       return LOCK_STATE_UNLOCKED;


### PR DESCRIPTION
needs https://github.com/esphome/esphome/pull/11498

# What does this implement/fix?

Fixes compile failures in component tests when merged with the `gps` component by qualifying all `millis()` calls with `esphome::` namespace.

When component tests are merged together for compilation (as done in the "Check compile failure on defaults" CI job), lambdas using `millis()` become ambiguous when tested alongside the `gps` component. The `gps` component uses the TinyGPSPlus library which declares its own `millis()` function (in TinyGPS++.h:38), causing a conflict with ESPHome's `millis()` function (in esphome/core/hal.h:42).

This PR qualifies all `millis()` calls in component test common.yaml files with `esphome::millis()` to explicitly use ESPHome's version and avoid ambiguity.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes CI failure seen in https://github.com/esphome/esphome/pull/11495

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a test infrastructure fix only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This PR only affects test files, not user-facing configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Technical Details

### Example Change

```yaml
# Before
lambda: |-
  if (millis() > 10000) {
    return 42.0;
  }
  return 0.0;

# After
lambda: |-
  if (esphome::millis() > 10000) {
    return 42.0;
  }
  return 0.0;
```

### Error Fixed

```
error: call of overloaded 'millis()' is ambiguous
.piolibdeps/componenttestesp32c3idf/TinyGPSPlus/src/TinyGPS++.h:38:15: note: candidate: 'long unsigned int millis()'
src/esphome/core/hal.h:42:10: note: candidate: 'uint32_t esphome::millis()'
```
