### PR TITLE
[core] handle mixed IP and DNS addresses correctly in resolve_ip_address

### DIFF
--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -251,8 +251,9 @@ def resolve_ip_address(
             addr_infos = resolver.resolve()
         except EsphomeError as err:
             if not res:
+                # No pre-resolved addresses available, DNS resolution is fatal
                 raise
-            _LOGGER.info("%s (using %d cached IP addresses)", err, len(res))
+            _LOGGER.info("%s (using %d already resolved IP addresses)", err, len(res))
 
         # Convert aioesphomeapi AddrInfo to our format
         for addr_info in addr_infos:

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -241,41 +241,42 @@ def resolve_ip_address(
     # If we have uncached hosts (only non-IP hostnames), resolve them
     if uncached_hosts:
         from esphome.core import EsphomeError
+        from esphome.resolver import AsyncResolver
 
+        resolver = AsyncResolver(uncached_hosts, port)
         try:
-            from esphome.resolver import AsyncResolver
-
-            resolver = AsyncResolver(uncached_hosts, port)
             addr_infos = resolver.resolve()
-            # Convert aioesphomeapi AddrInfo to our format
-            for addr_info in addr_infos:
-                sockaddr = addr_info.sockaddr
-                if addr_info.family == socket.AF_INET6:
-                    # IPv6
-                    sockaddr_tuple = (
-                        sockaddr.address,
-                        sockaddr.port,
-                        sockaddr.flowinfo,
-                        sockaddr.scope_id,
-                    )
-                else:
-                    # IPv4
-                    sockaddr_tuple = (sockaddr.address, sockaddr.port)
-
-                res.append(
-                    (
-                        addr_info.family,
-                        addr_info.type,
-                        addr_info.proto,
-                        "",  # canonname
-                        sockaddr_tuple,
-                    )
-                )
         except EsphomeError as err:
-            if len(res) > 0:
+            if res:
                 _LOGGER.warning(err)
+                addr_infos = []
             else:
-                raise err
+                raise
+
+        # Convert aioesphomeapi AddrInfo to our format
+        for addr_info in addr_infos:
+            sockaddr = addr_info.sockaddr
+            if addr_info.family == socket.AF_INET6:
+                # IPv6
+                sockaddr_tuple = (
+                    sockaddr.address,
+                    sockaddr.port,
+                    sockaddr.flowinfo,
+                    sockaddr.scope_id,
+                )
+            else:
+                # IPv4
+                sockaddr_tuple = (sockaddr.address, sockaddr.port)
+
+            res.append(
+                (
+                    addr_info.family,
+                    addr_info.type,
+                    addr_info.proto,
+                    "",  # canonname
+                    sockaddr_tuple,
+                )
+            )
 
     # Sort by preference
     res.sort(key=addr_preference_)

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -240,16 +240,18 @@ def resolve_ip_address(
 
     # If we have uncached hosts (only non-IP hostnames), resolve them
     if uncached_hosts:
+        from aioesphomeapi.host_resolver import AddrInfo as AioAddrInfo
+
         from esphome.core import EsphomeError
         from esphome.resolver import AsyncResolver
 
         resolver = AsyncResolver(uncached_hosts, port)
+        addr_infos: list[AioAddrInfo] = []
         try:
             addr_infos = resolver.resolve()
         except EsphomeError as err:
             if res:
-                _LOGGER.warning(err)
-                addr_infos = []
+                _LOGGER.info("%s (using %d cached IP addresses)", err, len(res))
             else:
                 raise
 

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -250,34 +250,42 @@ def resolve_ip_address(
 
     # If we have uncached hosts (only non-IP hostnames), resolve them
     if uncached_hosts:
-        from esphome.resolver import AsyncResolver
+        from esphome.core import EsphomeError
 
-        resolver = AsyncResolver(uncached_hosts, port)
-        addr_infos = resolver.resolve()
-        # Convert aioesphomeapi AddrInfo to our format
-        for addr_info in addr_infos:
-            sockaddr = addr_info.sockaddr
-            if addr_info.family == socket.AF_INET6:
-                # IPv6
-                sockaddr_tuple = (
-                    sockaddr.address,
-                    sockaddr.port,
-                    sockaddr.flowinfo,
-                    sockaddr.scope_id,
+        try:
+            from esphome.resolver import AsyncResolver
+
+            resolver = AsyncResolver(uncached_hosts, port)
+            addr_infos = resolver.resolve()
+            # Convert aioesphomeapi AddrInfo to our format
+            for addr_info in addr_infos:
+                sockaddr = addr_info.sockaddr
+                if addr_info.family == socket.AF_INET6:
+                    # IPv6
+                    sockaddr_tuple = (
+                        sockaddr.address,
+                        sockaddr.port,
+                        sockaddr.flowinfo,
+                        sockaddr.scope_id,
+                    )
+                else:
+                    # IPv4
+                    sockaddr_tuple = (sockaddr.address, sockaddr.port)
+
+                res.append(
+                    (
+                        addr_info.family,
+                        addr_info.type,
+                        addr_info.proto,
+                        "",  # canonname
+                        sockaddr_tuple,
+                    )
                 )
+        except EsphomeError as err:
+            if len(res) > 0:
+                _LOGGER.warning(err)
             else:
-                # IPv4
-                sockaddr_tuple = (sockaddr.address, sockaddr.port)
-
-            res.append(
-                (
-                    addr_info.family,
-                    addr_info.type,
-                    addr_info.proto,
-                    "",  # canonname
-                    sockaddr_tuple,
-                )
-            )
+                raise err
 
     # Sort by preference
     res.sort(key=addr_preference_)

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -224,29 +224,19 @@ def resolve_ip_address(
         return res
 
     # Process hosts
-    cached_addresses: list[str] = []
+
     uncached_hosts: list[str] = []
-    has_cache = address_cache is not None
 
     for h in hosts:
         if is_ip_address(h):
-            if has_cache:
-                # If we have a cache, treat IPs as cached
-                cached_addresses.append(h)
-            else:
-                # If no cache, pass IPs through to resolver with hostnames
-                uncached_hosts.append(h)
+            _add_ip_addresses_to_addrinfo([h], port, res)
         elif address_cache and (cached := address_cache.get_addresses(h)):
-            # Found in cache
-            cached_addresses.extend(cached)
+            _add_ip_addresses_to_addrinfo(cached, port, res)
         else:
             # Not cached, need to resolve
             if address_cache and address_cache.has_cache():
                 _LOGGER.info("Host %s not in cache, will need to resolve", h)
             uncached_hosts.append(h)
-
-    # Process cached addresses (includes direct IPs and cached lookups)
-    _add_ip_addresses_to_addrinfo(cached_addresses, port, res)
 
     # If we have uncached hosts (only non-IP hostnames), resolve them
     if uncached_hosts:

--- a/esphome/helpers.py
+++ b/esphome/helpers.py
@@ -250,10 +250,9 @@ def resolve_ip_address(
         try:
             addr_infos = resolver.resolve()
         except EsphomeError as err:
-            if res:
-                _LOGGER.info("%s (using %d cached IP addresses)", err, len(res))
-            else:
+            if not res:
                 raise
+            _LOGGER.info("%s (using %d cached IP addresses)", err, len(res))
 
         # Convert aioesphomeapi AddrInfo to our format
         for addr_info in addr_infos:

--- a/tests/unit_tests/test_helpers.py
+++ b/tests/unit_tests/test_helpers.py
@@ -454,9 +454,27 @@ def test_resolve_ip_address_mixed_list() -> None:
         # Mix of IP and hostname - should use async resolver
         result = helpers.resolve_ip_address(["192.168.1.100", "test.local"], 6053)
 
+        assert len(result) == 2
+        assert result[0][4][0] == "192.168.1.100"
+        assert result[1][4][0] == "192.168.1.200"
+        MockResolver.assert_called_once_with(["test.local"], 6053)
+        mock_resolver.resolve.assert_called_once()
+
+
+def test_resolve_ip_address_mixed_list_fail() -> None:
+    """Test resolving a mix of IPs and hostnames with resolve failed."""
+    with patch("esphome.resolver.AsyncResolver") as MockResolver:
+        mock_resolver = MockResolver.return_value
+        mock_resolver.resolve.side_effect = EsphomeError(
+            "Error resolving IP address: [test.local]"
+        )
+
+        # Mix of IP and hostname - should use async resolver
+        result = helpers.resolve_ip_address(["192.168.1.100", "test.local"], 6053)
+
         assert len(result) == 1
-        assert result[0][4][0] == "192.168.1.200"
-        MockResolver.assert_called_once_with(["192.168.1.100", "test.local"], 6053)
+        assert result[0][4][0] == "192.168.1.100"
+        MockResolver.assert_called_once_with(["test.local"], 6053)
         mock_resolver.resolve.assert_called_once()
 
 


### PR DESCRIPTION
do not raise error if some addresses are IPs and
the mDNS / DNS resolution fails for others

fix: #11501

# What does this implement/fix?

fix case where resolve_ip_address go IPs and DNS but DNS lookup and mDNS failed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11501 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

with fix:
```
INFO Successfully compiled program.
INFO Starting looking for IP in topic esphome/discover/test
INFO Connected to MQTT broker!
INFO Send discover via MQTT broker topic: esphome/ping/test
INFO Found IP: ['10.211.60.20']
WARNING Timeout resolving IP address: Timeout while resolving IP address for ['test.local']
INFO Connecting to 10.211.60.20 port 3232...
INFO Connected to 10.121.60.20
INFO Uploading /workspaces/esphome/config/.esphome/build/test/.pioenvs/test/firmware.bin (1049712 bytes)
```
