### PR TITLE
[remote_transmitter] Remove delays and use RMT instead

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,8 +12,9 @@
 namespace esphome {
 namespace remote_transmitter {
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
-typedef union {
+#if defined(USE_ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+typedef union {  // NOLINT(modernize-use-using)
   struct {
     uint16_t duration : 15;
     uint16_t level : 1;
@@ -25,6 +26,7 @@ struct RemoteTransmitterComponentStore {
   uint32_t times{0};
   uint32_t index{0};
 };
+#endif
 #endif
 
 class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,7 +12,7 @@
 namespace esphome {
 namespace remote_transmitter {
 
-#if defined(USE_ESP32)
+#ifdef USE_ESP32
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
 typedef union {  // NOLINT(modernize-use-using)
   struct {

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -14,6 +14,8 @@ namespace remote_transmitter {
 
 #ifdef USE_ESP32
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+// IDF version 5.5.1 and above is required because of a bug in
+// the RMT encoder: https://github.com/espressif/esp-idf/issues/17244
 typedef union {  // NOLINT(modernize-use-using)
   struct {
     uint16_t duration : 15;

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,6 +12,21 @@
 namespace esphome {
 namespace remote_transmitter {
 
+#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+typedef union {
+  struct {
+    uint16_t duration : 15;
+    uint16_t level : 1;
+  };
+  uint16_t val;
+} rmt_symbol_half_t;
+
+struct RemoteTransmitterComponentStore {
+  uint32_t times{0};
+  uint32_t index{0};
+};
+#endif
+
 class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
                                    public Component
 #ifdef USE_ESP32
@@ -56,9 +71,14 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #ifdef USE_ESP32
   void configure_rmt_();
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+  RemoteTransmitterComponentStore store_{};
+  std::vector<rmt_symbol_half_t> rmt_temp_;
+#else
+  std::vector<rmt_symbol_word_t> rmt_temp_;
+#endif
   uint32_t current_carrier_frequency_{38000};
   bool initialized_{false};
-  std::vector<rmt_symbol_word_t> rmt_temp_;
   bool with_dma_{false};
   bool eot_level_{false};
   rmt_channel_handle_t channel_{NULL};

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -207,7 +207,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->rmt_temp_.clear();
   this->rmt_temp_.reserve(this->temp_.get_data().size() + 1);
 
-  // encode wait time at the start of the buffer to simplify the encoder callback
+  // encode any delay at the start of the buffer to simplify the encoder callback
   // this will be skipped the first time around
   send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
   while (send_wait > 0) {

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -36,11 +36,11 @@ static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size
       store->times--;
       if (store->times == 0) {
         *done = true;
-        symbols[count++].val = (sym_1 << 16) | sym_0;
+        symbols[count++].val = sym_0 | (sym_1 << 16);
         return count;
       }
     }
-    symbols[count++].val = (sym_1 << 16) | sym_0;
+    symbols[count++].val = sym_0 | (sym_1 << 16);
   }
   *done = false;
   return count;

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -10,6 +10,43 @@ namespace remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size_t written, size_t free,
+                                             rmt_symbol_word_t *symbols, bool *done, void *arg) {
+  auto *store = static_cast<RemoteTransmitterComponentStore *>(arg);
+  const auto *encoded = static_cast<const rmt_symbol_half_t *>(data);
+  size_t length = size / sizeof(rmt_symbol_half_t);
+  size_t count = 0;
+
+  // copy symbols
+  for (size_t i = 0; i < free; i++) {
+    uint16_t sym_0 = encoded[store->index++].val;
+    if (store->index >= length) {
+      store->index = 0;
+      store->times--;
+      if (store->times == 0) {
+        *done = true;
+        symbols[count++].val = sym_0;
+        return count;
+      }
+    }
+    uint16_t sym_1 = encoded[store->index++].val;
+    if (store->index >= length) {
+      store->index = 0;
+      store->times--;
+      if (store->times == 0) {
+        *done = true;
+        symbols[count++].val = (sym_1 << 16) | sym_0;
+        return count;
+      }
+    }
+    symbols[count++].val = (sym_1 << 16) | sym_0;
+  }
+  *done = false;
+  return count;
+}
+#endif
+
 void RemoteTransmitterComponent::setup() {
   this->inverted_ = this->pin_->is_inverted();
   this->configure_rmt_();
@@ -34,6 +71,17 @@ void RemoteTransmitterComponent::dump_config() {
 }
 
 void RemoteTransmitterComponent::digital_write(bool value) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+  rmt_symbol_half_t symbol = {
+      .duration = 1,
+      .level = value,
+  };
+  rmt_transmit_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.flags.eot_level = value;
+  this->store_.times = 1;
+  this->store_.index = 0;
+#else
   rmt_symbol_word_t symbol = {
       .duration0 = 1,
       .level0 = value,
@@ -42,8 +90,8 @@ void RemoteTransmitterComponent::digital_write(bool value) {
   };
   rmt_transmit_config_t config;
   memset(&config, 0, sizeof(config));
-  config.loop_count = 0;
   config.flags.eot_level = value;
+#endif
   esp_err_t error = rmt_transmit(this->channel_, this->encoder_, &symbol, sizeof(symbol), &config);
   if (error != ESP_OK) {
     ESP_LOGW(TAG, "rmt_transmit failed: %s", esp_err_to_name(error));
@@ -90,6 +138,20 @@ void RemoteTransmitterComponent::configure_rmt_() {
       gpio_pullup_dis(gpio_num_t(this->pin_->get_pin()));
     }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+    rmt_simple_encoder_config_t encoder;
+    memset(&encoder, 0, sizeof(encoder));
+    encoder.callback = encoder_callback;
+    encoder.arg = &this->store_;
+    encoder.min_chunk_size = 1;
+    error = rmt_new_simple_encoder(&encoder, &this->encoder_);
+    if (error != ESP_OK) {
+      this->error_code_ = error;
+      this->error_string_ = "in rmt_new_simple_encoder";
+      this->mark_failed();
+      return;
+    }
+#else
     rmt_copy_encoder_config_t encoder;
     memset(&encoder, 0, sizeof(encoder));
     error = rmt_new_copy_encoder(&encoder, &this->encoder_);
@@ -99,6 +161,7 @@ void RemoteTransmitterComponent::configure_rmt_() {
       this->mark_failed();
       return;
     }
+#endif
 
     error = rmt_enable(this->channel_);
     if (error != ESP_OK) {
@@ -130,6 +193,79 @@ void RemoteTransmitterComponent::configure_rmt_() {
   }
 }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
+void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
+  if (this->is_failed()) {
+    return;
+  }
+
+  if (this->current_carrier_frequency_ != this->temp_.get_carrier_frequency()) {
+    this->current_carrier_frequency_ = this->temp_.get_carrier_frequency();
+    this->configure_rmt_();
+  }
+
+  this->rmt_temp_.clear();
+  this->rmt_temp_.reserve(this->temp_.get_data().size() + 1);
+
+  // encode wait time at the start of the buffer to simplify the encoder callback
+  // this will be skipped the first time around
+  send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
+  while (send_wait > 0) {
+    int32_t duration = std::min(send_wait, uint32_t(32767));
+    this->rmt_temp_.push_back({
+        .duration = static_cast<uint16_t>(duration),
+        .level = static_cast<uint16_t>(this->eot_level_),
+    });
+    send_wait -= duration;
+  }
+
+  // encode data
+  size_t offset = this->rmt_temp_.size();
+  for (int32_t value : this->temp_.get_data()) {
+    bool level = value >= 0;
+    if (!level) {
+      value = -value;
+    }
+    value = this->from_microseconds_(static_cast<uint32_t>(value));
+    while (value > 0) {
+      int32_t duration = std::min(value, int32_t(32767));
+      this->rmt_temp_.push_back({
+          .duration = static_cast<uint16_t>(duration),
+          .level = static_cast<uint16_t>(level ^ this->inverted_),
+      });
+      value -= duration;
+    }
+  }
+
+  if ((this->rmt_temp_.data() == nullptr) || this->rmt_temp_.size() <= offset) {
+    ESP_LOGE(TAG, "Empty data");
+    return;
+  }
+
+  this->transmit_trigger_->trigger();
+
+  rmt_transmit_config_t config;
+  memset(&config, 0, sizeof(config));
+  config.flags.eot_level = this->eot_level_;
+  this->store_.times = send_times;
+  this->store_.index = offset;
+  esp_err_t error = rmt_transmit(this->channel_, this->encoder_, this->rmt_temp_.data(),
+                                 this->rmt_temp_.size() * sizeof(rmt_symbol_half_t), &config);
+  if (error != ESP_OK) {
+    ESP_LOGW(TAG, "rmt_transmit failed: %s", esp_err_to_name(error));
+    this->status_set_warning();
+  } else {
+    this->status_clear_warning();
+  }
+  error = rmt_tx_wait_all_done(this->channel_, -1);
+  if (error != ESP_OK) {
+    ESP_LOGW(TAG, "rmt_tx_wait_all_done failed: %s", esp_err_to_name(error));
+    this->status_set_warning();
+  }
+
+  this->complete_trigger_->trigger();
+}
+#else
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
   if (this->is_failed())
     return;
@@ -180,7 +316,6 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   for (uint32_t i = 0; i < send_times; i++) {
     rmt_transmit_config_t config;
     memset(&config, 0, sizeof(config));
-    config.loop_count = 0;
     config.flags.eot_level = this->eot_level_;
     esp_err_t error = rmt_transmit(this->channel_, this->encoder_, this->rmt_temp_.data(),
                                    this->rmt_temp_.size() * sizeof(rmt_symbol_word_t), &config);
@@ -200,6 +335,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   }
   this->complete_trigger_->trigger();
 }
+#endif
 
 }  // namespace remote_transmitter
 }  // namespace esphome

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -10,6 +10,9 @@ namespace remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
+// Maximum RMT symbol duration (15-bit field)
+static constexpr uint32_t RMT_SYMBOL_DURATION_MAX = 0x7FFF;
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
 static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size_t written, size_t free,
                                              rmt_symbol_word_t *symbols, bool *done, void *arg) {
@@ -211,7 +214,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   // this will be skipped the first time around
   send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
   while (send_wait > 0) {
-    int32_t duration = std::min(send_wait, uint32_t(32767));
+    int32_t duration = std::min(send_wait, uint32_t(RMT_SYMBOL_DURATION_MAX));
     this->rmt_temp_.push_back({
         .duration = static_cast<uint16_t>(duration),
         .level = static_cast<uint16_t>(this->eot_level_),
@@ -228,7 +231,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     }
     value = this->from_microseconds_(static_cast<uint32_t>(value));
     while (value > 0) {
-      int32_t duration = std::min(value, int32_t(32767));
+      int32_t duration = std::min(value, int32_t(RMT_SYMBOL_DURATION_MAX));
       this->rmt_temp_.push_back({
           .duration = static_cast<uint16_t>(duration),
           .level = static_cast<uint16_t>(level ^ this->inverted_),
@@ -287,7 +290,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     val = this->from_microseconds_(static_cast<uint32_t>(val));
 
     do {
-      int32_t item = std::min(val, int32_t(32767));
+      int32_t item = std::min(val, int32_t(RMT_SYMBOL_DURATION_MAX));
       val -= item;
 
       if (rmt_i % 2 == 0) {


### PR DESCRIPTION
# What does this implement/fix?

Remove software delays and use RMT instead. RMT is more accurate. With only one call to rmt_transmit non-blocking tx is now possible

Will add a non-blocking mode in a followup PR.

Only enabled for 5.5.1 because the simple encoder had a major bug that wasn't fixed until 5.5.1. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/backlog/issues/38

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
