### PR TITLE
[light] Reduce code duplication in LightCall setters

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -539,15 +539,28 @@ LightCall &LightCall::from_light_color_values(const LightColorValues &values) {
 ColorMode LightCall::get_active_color_mode_() {
   return this->has_color_mode() ? this->color_mode_ : this->parent_->remote_values.get_color_mode();
 }
-LightCall &LightCall::set_transition_length_if_supported(uint32_t transition_length) {
-  if (this->get_active_color_mode_() & ColorCapability::BRIGHTNESS)
-    this->set_transition_length(transition_length);
+
+// Helper methods to reduce code duplication for *_if_supported methods
+inline LightCall &LightCall::set_if_capability_supported_(ColorCapability capability,
+                                                          LightCall &(LightCall::*setter)(float), float value) {
+  if (this->get_active_color_mode_() & capability)
+    (this->*setter)(value);
   return *this;
 }
-LightCall &LightCall::set_brightness_if_supported(float brightness) {
-  if (this->get_active_color_mode_() & ColorCapability::BRIGHTNESS)
-    this->set_brightness(brightness);
+
+inline LightCall &LightCall::set_if_capability_supported_(ColorCapability capability,
+                                                          LightCall &(LightCall::*setter)(uint32_t), uint32_t value) {
+  if (this->get_active_color_mode_() & capability)
+    (this->*setter)(value);
   return *this;
+}
+
+LightCall &LightCall::set_transition_length_if_supported(uint32_t transition_length) {
+  return this->set_if_capability_supported_(ColorCapability::BRIGHTNESS, &LightCall::set_transition_length,
+                                            transition_length);
+}
+LightCall &LightCall::set_brightness_if_supported(float brightness) {
+  return this->set_if_capability_supported_(ColorCapability::BRIGHTNESS, &LightCall::set_brightness, brightness);
 }
 LightCall &LightCall::set_color_mode_if_supported(ColorMode color_mode) {
   if (this->parent_->get_traits().supports_color_mode(color_mode))
@@ -555,29 +568,19 @@ LightCall &LightCall::set_color_mode_if_supported(ColorMode color_mode) {
   return *this;
 }
 LightCall &LightCall::set_color_brightness_if_supported(float brightness) {
-  if (this->get_active_color_mode_() & ColorCapability::RGB)
-    this->set_color_brightness(brightness);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::RGB, &LightCall::set_color_brightness, brightness);
 }
 LightCall &LightCall::set_red_if_supported(float red) {
-  if (this->get_active_color_mode_() & ColorCapability::RGB)
-    this->set_red(red);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::RGB, &LightCall::set_red, red);
 }
 LightCall &LightCall::set_green_if_supported(float green) {
-  if (this->get_active_color_mode_() & ColorCapability::RGB)
-    this->set_green(green);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::RGB, &LightCall::set_green, green);
 }
 LightCall &LightCall::set_blue_if_supported(float blue) {
-  if (this->get_active_color_mode_() & ColorCapability::RGB)
-    this->set_blue(blue);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::RGB, &LightCall::set_blue, blue);
 }
 LightCall &LightCall::set_white_if_supported(float white) {
-  if (this->get_active_color_mode_() & ColorCapability::WHITE)
-    this->set_white(white);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::WHITE, &LightCall::set_white, white);
 }
 LightCall &LightCall::set_color_temperature_if_supported(float color_temperature) {
   if (this->get_active_color_mode_() & ColorCapability::COLOR_TEMPERATURE ||
@@ -586,14 +589,10 @@ LightCall &LightCall::set_color_temperature_if_supported(float color_temperature
   return *this;
 }
 LightCall &LightCall::set_cold_white_if_supported(float cold_white) {
-  if (this->get_active_color_mode_() & ColorCapability::COLD_WARM_WHITE)
-    this->set_cold_white(cold_white);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::COLD_WARM_WHITE, &LightCall::set_cold_white, cold_white);
 }
 LightCall &LightCall::set_warm_white_if_supported(float warm_white) {
-  if (this->get_active_color_mode_() & ColorCapability::COLD_WARM_WHITE)
-    this->set_warm_white(warm_white);
-  return *this;
+  return this->set_if_capability_supported_(ColorCapability::COLD_WARM_WHITE, &LightCall::set_warm_white, warm_white);
 }
 IMPLEMENT_LIGHT_CALL_SETTER(state, bool, FLAG_HAS_STATE)
 IMPLEMENT_LIGHT_CALL_SETTER(transition_length, uint32_t, FLAG_HAS_TRANSITION)

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -539,22 +539,6 @@ LightCall &LightCall::from_light_color_values(const LightColorValues &values) {
 ColorMode LightCall::get_active_color_mode_() {
   return this->has_color_mode() ? this->color_mode_ : this->parent_->remote_values.get_color_mode();
 }
-
-// Helper methods to reduce code duplication for *_if_supported methods
-inline LightCall &LightCall::set_if_capability_supported_(ColorCapability capability,
-                                                          LightCall &(LightCall::*setter)(float), float value) {
-  if (this->get_active_color_mode_() & capability)
-    (this->*setter)(value);
-  return *this;
-}
-
-inline LightCall &LightCall::set_if_capability_supported_(ColorCapability capability,
-                                                          LightCall &(LightCall::*setter)(uint32_t), uint32_t value) {
-  if (this->get_active_color_mode_() & capability)
-    (this->*setter)(value);
-  return *this;
-}
-
 LightCall &LightCall::set_transition_length_if_supported(uint32_t transition_length) {
   return this->set_if_capability_supported_(ColorCapability::BRIGHTNESS, &LightCall::set_transition_length,
                                             transition_length);

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -182,9 +182,17 @@ class LightCall {
 
   // Helper methods to reduce code duplication for *_if_supported methods
   inline LightCall &set_if_capability_supported_(ColorCapability capability, LightCall &(LightCall::*setter)(float),
-                                                 float value);
+                                                 float value) {
+    if (this->get_active_color_mode_() & capability)
+      (this->*setter)(value);
+    return *this;
+  }
   inline LightCall &set_if_capability_supported_(ColorCapability capability, LightCall &(LightCall::*setter)(uint32_t),
-                                                 uint32_t value);
+                                                 uint32_t value) {
+    if (this->get_active_color_mode_() & capability)
+      (this->*setter)(value);
+    return *this;
+  }
 
   /// Validate all properties and return the target light color values.
   LightColorValues validate_();

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -180,6 +180,12 @@ class LightCall {
   /// Get the currently targeted, or active if none set, color mode.
   ColorMode get_active_color_mode_();
 
+  // Helper methods to reduce code duplication for *_if_supported methods
+  inline LightCall &set_if_capability_supported_(ColorCapability capability, LightCall &(LightCall::*setter)(float),
+                                                 float value);
+  inline LightCall &set_if_capability_supported_(ColorCapability capability, LightCall &(LightCall::*setter)(uint32_t),
+                                                 uint32_t value);
+
   /// Validate all properties and return the target light color values.
   LightColorValues validate_();
 


### PR DESCRIPTION
# What does this implement/fix?

Reduces code duplication in `light_call.cpp` by introducing helper methods for the `*_if_supported` setter family. This refactoring consolidates ~40 lines of repetitive conditional setter code into two reusable inline helper methods.

**Benefits:**
- Improved code maintainability and readability
- 128 bytes flash size reduction
- No RAM impact
- No functional changes

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactoring only)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - No user-facing changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
