### PR TITLE
[core] .local addresses are only resolvable if mDNS is enabled

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -207,14 +207,14 @@ def choose_upload_log_host(
                     if has_mqtt_logging():
                         resolved.append("MQTT")
 
-                    if has_api() and has_non_ip_address():
+                    if has_api() and has_non_ip_address() and has_resolvable_address():
                         resolved.extend(_resolve_with_cache(CORE.address, purpose))
 
                 elif purpose == Purpose.UPLOADING:
                     if has_ota() and has_mqtt_ip_lookup():
                         resolved.append("MQTTIP")
 
-                    if has_ota() and has_non_ip_address():
+                    if has_ota() and has_non_ip_address() and has_resolvable_address():
                         resolved.extend(_resolve_with_cache(CORE.address, purpose))
             else:
                 resolved.append(device)
@@ -318,7 +318,17 @@ def has_resolvable_address() -> bool:
     """Check if CORE.address is resolvable (via mDNS, DNS, or is an IP address)."""
     # Any address (IP, mDNS hostname, or regular DNS hostname) is resolvable
     # The resolve_ip_address() function in helpers.py handles all types via AsyncResolver
-    return CORE.address is not None
+    if CORE.address is None:
+        return False
+
+    if has_ip_address():
+        return True
+
+    if has_mdns():
+        return True
+
+    # .local mDNS hostnames are only resolvable if mDNS is enabled
+    return not CORE.address.endswith(".local")
 
 
 def mqtt_get_ip(config: ConfigType, username: str, password: str, client_id: str):

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -744,7 +744,7 @@ def test_choose_upload_log_host_ota_local_all_options() -> None:
         check_default=None,
         purpose=Purpose.UPLOADING,
     )
-    assert result == ["MQTTIP", "test.local"]
+    assert result == ["MQTTIP"]
 
 
 @pytest.mark.usefixtures("mock_serial_ports")
@@ -794,7 +794,7 @@ def test_choose_upload_log_host_ota_local_all_options_logging() -> None:
         check_default=None,
         purpose=Purpose.LOGGING,
     )
-    assert result == ["MQTTIP", "MQTT", "test.local"]
+    assert result == ["MQTTIP", "MQTT"]
 
 
 @pytest.mark.usefixtures("mock_no_mqtt_logging")
@@ -1564,7 +1564,7 @@ def test_has_resolvable_address() -> None:
     setup_core(
         config={CONF_MDNS: {CONF_DISABLED: True}}, address="esphome-device.local"
     )
-    assert has_resolvable_address() is True
+    assert has_resolvable_address() is False
 
     # Test with mDNS disabled and regular DNS hostname (resolvable)
     setup_core(config={CONF_MDNS: {CONF_DISABLED: True}}, address="device.example.com")


### PR DESCRIPTION
# What does this implement/fix?

.local addresses can typically only be resolved with mDNS enabled. 

.local can be resolved via DNS if the user manages a DNS sever with manual entrys that respond to .local, 
not very likely, but marked as Breaking change for this reason.

tring to resolve .local without mDNS adds at minimum 10sec delay to all actions, which will be avoided with the PR. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
