### PR TITLE
Fix the LiberTiny bug with UART pin setup

### DIFF
--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -52,15 +52,15 @@ void LibreTinyUARTComponent::setup() {
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
   auto shouldFallbackToSoftwareSerial = [&] bool {
-    hasFlags = []() bool {
+    auto hasFlags = []() bool {
       if (this->rx_pin_ && this->rx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
         return true;
       }
       if (this->tx_pin_ && this->tx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
         return true;
       }
-    }();
-    if (hasFlags) {
+    };
+    if (hasFlags()) {
 #if LT_ARD_HAS_SOFTSERIAL
       ESP_LOGI(TAG, "Pins has flags set. Using Software Serial");
       return true;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -51,27 +51,27 @@ void LibreTinyUARTComponent::setup() {
   bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
-  auto initPinsForHardwareSerial =
-      [&] {
-        auto initPin = [&](InternalGPIOPin *pin) {
-          if (pin->get_flags() != gpio.Flags.FLAG_NONE) {
+  auto initPinsForHardwareSerial = [&] {
+    auto initPin = [&](InternalGPIOPin *pin) {
+      if (pin->get_flags() != gpio.Flags.FLAG_NONE) {
 #if LT_ARD_HAS_SOFTSERIAL
-            ESP_LOGW(TAG, "Pin flags are not supported for hardware serial. Please use Software serial interface if "
-                          "you really need it");
+        ESP_LOGW(TAG, "Pin flags are not supported for hardware serial. Please use Software serial interface if "
+                      "you really need it");
 #else
-            ESP_LOGW(TAG, "Pin flags are not supported for hardware serial");
+        ESP_LOGW(TAG, "Pin flags are not supported for hardware serial");
 #endif
-          }
-        };
-        if (this->rx_pin_) {
-          initPin(this->rx_pin_);
-        }
-        if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-          initPin(this->tx_pin_);
-        }
       }
+    };
+    if (this->rx_pin_) {
+      initPin(this->rx_pin_);
+    }
+    if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
+      initPin(this->tx_pin_);
+    }
+  };
 
-  if (false) return;
+  if (false)
+    return;
 #if LT_HW_UART0
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL0_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL0_RX)) {
     this->serial_ = &Serial0;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -57,7 +57,7 @@ void LibreTinyUARTComponent::setup() {
         return true;
       }
       if (this->tx_pin_ && this->tx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
-        return true
+        return true;
       }
     }();
     if (hasFlags) {

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -51,43 +51,47 @@ void LibreTinyUARTComponent::setup() {
   bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
-  auto initPinsForHardwareSerial = [&] {
-    auto initPin = [&](InternalGPIOPin *pin) {
-      if (pin->get_flags() != gpio.Flags.FLAG_NONE) {
-#if LT_ARD_HAS_SOFTSERIAL
-        ESP_LOGW(TAG, "Pin flags are not supported for hardware serial. Please use Software serial interface if "
-                      "you really need it");
-#else
-        ESP_LOGW(TAG, "Pin flags are not supported for hardware serial");
-#endif
+  auto shouldFallbackToSoftwareSerial = [&] bool {
+    hasFlags = []() bool {
+      if (this->rx_pin_ && this->rx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
+        return true;
       }
-    };
-    if (this->rx_pin_) {
-      initPin(this->rx_pin_);
+      if (this->tx_pin_ && this->tx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
+        return true
+      }
+    }();
+    if (hasFlags) {
+#if LT_ARD_HAS_SOFTSERIAL
+      ESP_LOGI(TAG, "Pins has flags set. Using Software Serial");
+      return true;
+#else
+      ESP_LOGW(TAG, "Pin flags are set but not supported for hardware serial. Ignoring");
+#endif
     }
-    if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-      initPin(this->tx_pin_);
-    }
+    return false;
   };
 
   if (false)
     return;
 #if LT_HW_UART0
-  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL0_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL0_RX)) {
+  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL0_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL0_RX) &&
+           !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial0;
     this->hardware_idx_ = 0;
     initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART1
-  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL1_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL1_RX)) {
+  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL1_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL1_RX) &&
+           !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial1;
     this->hardware_idx_ = 1;
     initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART2
-  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL2_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL2_RX)) {
+  else if ((tx_pin == -1 || tx_pin == PIN_SERIAL2_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL2_RX) &&
+           !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial2;
     this->hardware_idx_ = 2;
     initPinsForHardwareSerial()

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -51,16 +51,12 @@ void LibreTinyUARTComponent::setup() {
   bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
-  auto shouldFallbackToSoftwareSerial = [&]() bool {
-    auto hasFlags = []() bool {
-      if (this->rx_pin_ && this->rx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
-        return true;
-      }
-      if (this->tx_pin_ && this->tx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
-        return true;
-      }
+  auto shouldFallbackToSoftwareSerial = [&]() -> bool {
+    auto hasFlags = [](InternalGPIOPin *pin, const gpio::Flags mask) -> bool {
+      return pin && pin->get_flags() & mask != gpio::Flags::FLAG_NONE;
     };
-    if (hasFlags()) {
+    if (hasFlags(this->tx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN) ||
+        hasFlags(this->rx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {
 #if LT_ARD_HAS_SOFTSERIAL
       ESP_LOGI(TAG, "Pins has flags set. Using Software Serial");
       return true;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -51,7 +51,7 @@ void LibreTinyUARTComponent::setup() {
   bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
-  auto shouldFallbackToSoftwareSerial = [&] bool {
+  auto shouldFallbackToSoftwareSerial = [&]() bool {
     auto hasFlags = []() bool {
       if (this->rx_pin_ && this->rx_pin_->get_flags() != gpio.Flags.FLAG_NONE) {
         return true;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -78,7 +78,6 @@ void LibreTinyUARTComponent::setup() {
            !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial0;
     this->hardware_idx_ = 0;
-    initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART1
@@ -86,7 +85,6 @@ void LibreTinyUARTComponent::setup() {
            !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial1;
     this->hardware_idx_ = 1;
-    initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART2
@@ -94,7 +92,6 @@ void LibreTinyUARTComponent::setup() {
            !shouldFallbackToSoftwareSerial()) {
     this->serial_ = &Serial2;
     this->hardware_idx_ = 2;
-    initPinsForHardwareSerial()
   }
 #endif
   else {

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -46,40 +46,61 @@ uint16_t LibreTinyUARTComponent::get_config() {
 }
 
 void LibreTinyUARTComponent::setup() {
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
-  }
-
   int8_t tx_pin = tx_pin_ == nullptr ? -1 : tx_pin_->get_pin();
   int8_t rx_pin = rx_pin_ == nullptr ? -1 : rx_pin_->get_pin();
   bool tx_inverted = tx_pin_ != nullptr && tx_pin_->is_inverted();
   bool rx_inverted = rx_pin_ != nullptr && rx_pin_->is_inverted();
 
-  if (false)
-    return;
+  auto initPinsForHardwareSerial =
+      [&] {
+        auto initPin = [&](InternalGPIOPin *pin) {
+          if (pin->get_flags() != gpio.Flags.FLAG_NONE) {
+#if LT_ARD_HAS_SOFTSERIAL
+            ESP_LOGW(TAG, "Pin flags are not supported for hardware serial. Please use Software serial interface if "
+                          "you really need it");
+#else
+            ESP_LOGW(TAG, "Pin flags are not supported for hardware serial");
+#endif
+          }
+        };
+        if (this->rx_pin_) {
+          initPin(this->rx_pin_);
+        }
+        if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
+          initPin(this->tx_pin_);
+        }
+      }
+
+  if (false) return;
 #if LT_HW_UART0
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL0_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL0_RX)) {
     this->serial_ = &Serial0;
     this->hardware_idx_ = 0;
+    initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART1
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL1_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL1_RX)) {
     this->serial_ = &Serial1;
     this->hardware_idx_ = 1;
+    initPinsForHardwareSerial()
   }
 #endif
 #if LT_HW_UART2
   else if ((tx_pin == -1 || tx_pin == PIN_SERIAL2_TX) && (rx_pin == -1 || rx_pin == PIN_SERIAL2_RX)) {
     this->serial_ = &Serial2;
     this->hardware_idx_ = 2;
+    initPinsForHardwareSerial()
   }
 #endif
   else {
 #if LT_ARD_HAS_SOFTSERIAL
+    if (this->rx_pin_) {
+      this->rx_pin_->setup();
+    }
+    if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
+      this->tx_pin_->setup();
+    }
     this->serial_ = new SoftwareSerial(rx_pin, tx_pin, rx_inverted || tx_inverted);
 #else
     this->serial_ = &Serial;


### PR DESCRIPTION
# What does this implement/fix?

Problem: once pin->setup() is called pin becomes a GPIO pin. But Hardware UART can't use GPIO pins. It needs pin to be in special UART mode.

So we don't call pin setup initializing the Hardware UART for LiberTiny platform

- If not pin flags set:
  - if hardware UART is using: no pin initialization
  - if software UART is usgin: calling pin->setup()
- If any pin flag set:
  - if hardware UART is using:
    - if we have software UART supported: using software UART with info message
    - if we don't have software UART supported: no pin initialization with Warning message
  - if software UART is usging: calling pin->setup()

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11513

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
