### PR TITLE
[remote_transmitter] Add non-blocking mode

### DIFF
--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import esp32, esp32_rmt, remote_base
@@ -17,6 +19,8 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE
+
+_LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["remote_base"]
 
@@ -66,13 +70,24 @@ CONFIG_SCHEMA = cv.Schema(
             esp32_c6=48,
             esp32_h2=48,
         ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
-        cv.SplitDefault(CONF_NON_BLOCKING, esp32=False): cv.All(
-            cv.only_on_esp32, cv.boolean
-        ),
+        cv.Optional(CONF_NON_BLOCKING): cv.All(cv.only_on_esp32, cv.boolean),
         cv.Optional(CONF_ON_TRANSMIT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
     }
 ).extend(cv.COMPONENT_SCHEMA)
+
+
+def _validate_non_blocking(config):
+    if CORE.is_esp32 and CONF_NON_BLOCKING not in config:
+        _LOGGER.warning(
+            "'non_blocking' is not set for 'remote_transmitter' and will default to 'true'.\n"
+            "The default behavior changed in 2025.11.0; previously blocking mode was used.\n"
+            "To silence this warning, explicitly set 'non_blocking: true' (or 'false')."
+        )
+        config[CONF_NON_BLOCKING] = True
+
+
+FINAL_VALIDATE_SCHEMA = _validate_non_blocking
 
 DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
     {

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -21,6 +21,7 @@ from esphome.core import CORE
 AUTO_LOAD = ["remote_base"]
 
 CONF_EOT_LEVEL = "eot_level"
+CONF_NON_BLOCKING = "non_blocking"
 CONF_ON_TRANSMIT = "on_transmit"
 CONF_ON_COMPLETE = "on_complete"
 CONF_TRANSMITTER_ID = remote_base.CONF_TRANSMITTER_ID
@@ -65,6 +66,9 @@ CONFIG_SCHEMA = cv.Schema(
             esp32_c6=48,
             esp32_h2=48,
         ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
+        cv.SplitDefault(CONF_NON_BLOCKING, esp32=False): cv.All(
+            cv.only_on_esp32, cv.boolean
+        ),
         cv.Optional(CONF_ON_TRANSMIT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
     }
@@ -95,6 +99,7 @@ async def to_code(config):
     if CORE.is_esp32:
         var = cg.new_Pvariable(config[CONF_ID], pin)
         cg.add(var.set_rmt_symbols(config[CONF_RMT_SYMBOLS]))
+        cg.add(var.set_non_blocking(config[CONF_NON_BLOCKING]))
         if CONF_CLOCK_RESOLUTION in config:
             cg.add(var.set_clock_resolution(config[CONF_CLOCK_RESOLUTION]))
         if CONF_USE_DMA in config:

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -54,6 +54,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #if defined(USE_ESP32)
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
+  void set_non_blocking(bool non_blocking) { this->non_blocking_ = non_blocking; }
 #endif
 
   Trigger<> *get_transmit_trigger() const { return this->transmit_trigger_; };
@@ -74,6 +75,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
 #ifdef USE_ESP32
   void configure_rmt_();
+  void wait_for_rmt_();
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
   RemoteTransmitterComponentStore store_{};
@@ -90,6 +92,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   esp_err_t error_code_{ESP_OK};
   std::string error_string_{""};
   bool inverted_{false};
+  bool non_blocking_{false};
 #endif
   uint8_t carrier_duty_percent_;
 

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -215,7 +215,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   }
 
   // if the on_complete timeout is cancelled, block until the tx is complete
-  if (this->non_blocking_ && this->cancel_timeout("on_complete")) {
+  if (this->non_blocking_ && this->cancel_timeout("complete")) {
     this->wait_for_rmt_();
   }
 
@@ -281,7 +281,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   }
 
   if (this->non_blocking_) {
-    set_timeout("on_complete", total_duration / 1000, [this]() { this->wait_for_rmt_(); });
+    set_timeout("complete", total_duration / 1000, [this]() { this->wait_for_rmt_(); });
   } else {
     this->wait_for_rmt_();
   }

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -196,10 +196,27 @@ void RemoteTransmitterComponent::configure_rmt_() {
   }
 }
 
+void RemoteTransmitterComponent::wait_for_rmt_() {
+  esp_err_t error = rmt_tx_wait_all_done(this->channel_, -1);
+  if (error != ESP_OK) {
+    ESP_LOGW(TAG, "rmt_tx_wait_all_done failed: %s", esp_err_to_name(error));
+    this->status_set_warning();
+  }
+
+  this->complete_trigger_->trigger();
+}
+
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {
+  uint64_t total_duration = 0;
+
   if (this->is_failed()) {
     return;
+  }
+
+  // if the on_complete timeout is cancelled, block until the tx is complete
+  if (this->non_blocking_ && this->cancel_timeout("on_complete")) {
+    this->wait_for_rmt_();
   }
 
   if (this->current_carrier_frequency_ != this->temp_.get_carrier_frequency()) {
@@ -213,6 +230,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   // encode any delay at the start of the buffer to simplify the encoder callback
   // this will be skipped the first time around
   send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
+  total_duration += send_wait;
   while (send_wait > 0) {
     int32_t duration = std::min(send_wait, uint32_t(RMT_SYMBOL_DURATION_MAX));
     this->rmt_temp_.push_back({
@@ -230,6 +248,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
       value = -value;
     }
     value = this->from_microseconds_(static_cast<uint32_t>(value));
+    total_duration += value;
     while (value > 0) {
       int32_t duration = std::min(value, int32_t(RMT_SYMBOL_DURATION_MAX));
       this->rmt_temp_.push_back({
@@ -260,13 +279,12 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   } else {
     this->status_clear_warning();
   }
-  error = rmt_tx_wait_all_done(this->channel_, -1);
-  if (error != ESP_OK) {
-    ESP_LOGW(TAG, "rmt_tx_wait_all_done failed: %s", esp_err_to_name(error));
-    this->status_set_warning();
-  }
 
-  this->complete_trigger_->trigger();
+  if (this->non_blocking_) {
+    set_timeout("on_complete", total_duration / 1000, [this]() { this->wait_for_rmt_(); });
+  } else {
+    this->wait_for_rmt_();
+  }
 }
 #else
 void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t send_wait) {

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -229,8 +229,8 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
 
   // encode any delay at the start of the buffer to simplify the encoder callback
   // this will be skipped the first time around
-  send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
   total_duration += send_wait;
+  send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
   while (send_wait > 0) {
     int32_t duration = std::min(send_wait, uint32_t(RMT_SYMBOL_DURATION_MAX));
     this->rmt_temp_.push_back({
@@ -247,8 +247,8 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (!level) {
       value = -value;
     }
-    value = this->from_microseconds_(static_cast<uint32_t>(value));
     total_duration += value;
+    value = this->from_microseconds_(static_cast<uint32_t>(value));
     while (value > 0) {
       int32_t duration = std::min(value, int32_t(RMT_SYMBOL_DURATION_MAX));
       this->rmt_temp_.push_back({

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -214,7 +214,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     return;
   }
 
-  // if the on_complete timeout is cancelled, block until the tx is complete
+  // if the timeout was cancelled, block until the tx is complete
   if (this->non_blocking_ && this->cancel_timeout("complete")) {
     this->wait_for_rmt_();
   }

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -229,7 +229,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
 
   // encode any delay at the start of the buffer to simplify the encoder callback
   // this will be skipped the first time around
-  total_duration += send_wait;
+  total_duration += send_wait * (send_times - 1);
   send_wait = this->from_microseconds_(static_cast<uint32_t>(send_wait));
   while (send_wait > 0) {
     int32_t duration = std::min(send_wait, uint32_t(RMT_SYMBOL_DURATION_MAX));
@@ -247,7 +247,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (!level) {
       value = -value;
     }
-    total_duration += value;
+    total_duration += value * send_times;
     value = this->from_microseconds_(static_cast<uint32_t>(value));
     while (value > 0) {
       int32_t duration = std::min(value, int32_t(RMT_SYMBOL_DURATION_MAX));

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -281,7 +281,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   }
 
   if (this->non_blocking_) {
-    set_timeout("complete", total_duration / 1000, [this]() { this->wait_for_rmt_(); });
+    this->set_timeout("complete", total_duration / 1000, [this]() { this->wait_for_rmt_(); });
   } else {
     this->wait_for_rmt_();
   }

--- a/tests/components/remote_transmitter/esp32-common.yaml
+++ b/tests/components/remote_transmitter/esp32-common.yaml
@@ -2,6 +2,7 @@ remote_transmitter:
   - id: xmitr
     pin: ${pin}
     carrier_duty_percent: 50%
+    non_blocking: true
     clock_resolution: ${clock_resolution}
     rmt_symbols: ${rmt_symbols}
 


### PR DESCRIPTION
# What does this implement/fix?

Remote transmitter can block for a long time:
```
[16:58:18.971][W][component:453]: api took a long time for an operation (146 ms)
[16:58:18.980][W][component:456]: Components should block for at most 30 ms
```

Add a non-blocking mode as followup to https://github.com/esphome/esphome/pull/11505

The default is set to true but print a warning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/backlog/issues/38

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5525

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
