### PR TITLE
Pass std::initializer_list by const reference

### DIFF
--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -92,7 +92,7 @@ class DoubleClickTrigger : public Trigger<> {
 
 class MultiClickTrigger : public Trigger<>, public Component {
  public:
-  explicit MultiClickTrigger(BinarySensor *parent, std::initializer_list<MultiClickTriggerEvent> timing)
+  explicit MultiClickTrigger(BinarySensor *parent, const std::initializer_list<MultiClickTriggerEvent> &timing)
       : parent_(parent), timing_(timing) {}
 
   void setup() override {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -51,7 +51,7 @@ void BinarySensor::add_filter(Filter *filter) {
     last_filter->next_ = filter;
   }
 }
-void BinarySensor::add_filters(std::initializer_list<Filter *> filters) {
+void BinarySensor::add_filters(const std::initializer_list<Filter *> &filters) {
   for (Filter *filter : filters) {
     this->add_filter(filter);
   }

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -48,7 +48,7 @@ class BinarySensor : public StatefulEntityBase<bool>, public EntityBase_DeviceCl
   void publish_initial_state(bool new_state);
 
   void add_filter(Filter *filter);
-  void add_filters(std::initializer_list<Filter *> filters);
+  void add_filters(const std::initializer_list<Filter *> &filters);
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -67,7 +67,7 @@ float DelayedOffFilter::get_setup_priority() const { return setup_priority::HARD
 
 optional<bool> InvertFilter::new_value(bool value) { return !value; }
 
-AutorepeatFilter::AutorepeatFilter(std::initializer_list<AutorepeatFilterTiming> timings) : timings_(timings) {}
+AutorepeatFilter::AutorepeatFilter(const std::initializer_list<AutorepeatFilterTiming> &timings) : timings_(timings) {}
 
 optional<bool> AutorepeatFilter::new_value(bool value) {
   if (value) {

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -87,7 +87,7 @@ struct AutorepeatFilterTiming {
 
 class AutorepeatFilter : public Filter, public Component {
  public:
-  explicit AutorepeatFilter(std::initializer_list<AutorepeatFilterTiming> timings);
+  explicit AutorepeatFilter(const std::initializer_list<AutorepeatFilterTiming> &timings);
 
   optional<bool> new_value(bool value) override;
 

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -22,7 +22,7 @@ class LightTraits {
   void set_supported_color_modes(ColorModeMask supported_color_modes) {
     this->supported_color_modes_ = supported_color_modes;
   }
-  void set_supported_color_modes(std::initializer_list<ColorMode> modes) {
+  void set_supported_color_modes(const std::initializer_list<ColorMode> &modes) {
     this->supported_color_modes_ = ColorModeMask(modes);
   }
 

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -45,7 +45,7 @@ class LockTraits {
   void set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
   bool supports_state(LockState state) const { return supported_states_mask_ & (1 << state); }
-  void set_supported_states(std::initializer_list<LockState> states) {
+  void set_supported_states(const std::initializer_list<LockState> &states) {
     supported_states_mask_ = 0;
     for (auto state : states) {
       supported_states_mask_ |= (1 << state);

--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -39,7 +39,7 @@ class ABBWelcomeData {
     this->data_[1] = 0xff;
   }
   // Make from initializer_list
-  ABBWelcomeData(std::initializer_list<uint8_t> data) {
+  ABBWelcomeData(const std::initializer_list<uint8_t> &data) {
     std::fill(std::begin(this->data_), std::end(this->data_), 0);
     std::copy_n(data.begin(), std::min(data.size(), this->data_.size()), this->data_.begin());
   }

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -15,7 +15,7 @@ class MideaData {
   // Make default
   MideaData() {}
   // Make from initializer_list
-  MideaData(std::initializer_list<uint8_t> data) {
+  MideaData(const std::initializer_list<uint8_t> &data) {
     std::copy_n(data.begin(), std::min(data.size(), this->data_.size()), this->data_.begin());
   }
   // Make from vector

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -229,7 +229,7 @@ MultiplyFilter::MultiplyFilter(TemplatableValue<float> multiplier) : multiplier_
 optional<float> MultiplyFilter::new_value(float value) { return value * this->multiplier_.value(); }
 
 // ValueListFilter (base class)
-ValueListFilter::ValueListFilter(std::initializer_list<TemplatableValue<float>> values) : values_(values) {}
+ValueListFilter::ValueListFilter(const std::initializer_list<TemplatableValue<float>> &values) : values_(values) {}
 
 bool ValueListFilter::value_matches_any_(float sensor_value) {
   int8_t accuracy = this->parent_->get_accuracy_decimals();
@@ -255,7 +255,7 @@ bool ValueListFilter::value_matches_any_(float sensor_value) {
 }
 
 // FilterOutValueFilter
-FilterOutValueFilter::FilterOutValueFilter(std::initializer_list<TemplatableValue<float>> values_to_filter_out)
+FilterOutValueFilter::FilterOutValueFilter(const std::initializer_list<TemplatableValue<float>> &values_to_filter_out)
     : ValueListFilter(values_to_filter_out) {}
 
 optional<float> FilterOutValueFilter::new_value(float value) {
@@ -277,7 +277,7 @@ optional<float> ThrottleFilter::new_value(float value) {
 
 // ThrottleWithPriorityFilter
 ThrottleWithPriorityFilter::ThrottleWithPriorityFilter(
-    uint32_t min_time_between_inputs, std::initializer_list<TemplatableValue<float>> prioritized_values)
+    uint32_t min_time_between_inputs, const std::initializer_list<TemplatableValue<float>> &prioritized_values)
     : ValueListFilter(prioritized_values), min_time_between_inputs_(min_time_between_inputs) {}
 
 optional<float> ThrottleWithPriorityFilter::new_value(float value) {
@@ -313,7 +313,7 @@ optional<float> DeltaFilter::new_value(float value) {
 }
 
 // OrFilter
-OrFilter::OrFilter(std::initializer_list<Filter *> filters) : filters_(filters), phi_(this) {}
+OrFilter::OrFilter(const std::initializer_list<Filter *> &filters) : filters_(filters), phi_(this) {}
 OrFilter::PhiNode::PhiNode(OrFilter *or_parent) : or_parent_(or_parent) {}
 
 optional<float> OrFilter::PhiNode::new_value(float value) {
@@ -391,7 +391,7 @@ void HeartbeatFilter::setup() {
 
 float HeartbeatFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-CalibrateLinearFilter::CalibrateLinearFilter(std::initializer_list<std::array<float, 3>> linear_functions)
+CalibrateLinearFilter::CalibrateLinearFilter(const std::initializer_list<std::array<float, 3>> &linear_functions)
     : linear_functions_(linear_functions) {}
 
 optional<float> CalibrateLinearFilter::new_value(float value) {
@@ -402,7 +402,7 @@ optional<float> CalibrateLinearFilter::new_value(float value) {
   return NAN;
 }
 
-CalibratePolynomialFilter::CalibratePolynomialFilter(std::initializer_list<float> coefficients)
+CalibratePolynomialFilter::CalibratePolynomialFilter(const std::initializer_list<float> &coefficients)
     : coefficients_(coefficients) {}
 
 optional<float> CalibratePolynomialFilter::new_value(float value) {

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -325,7 +325,7 @@ class MultiplyFilter : public Filter {
  */
 class ValueListFilter : public Filter {
  protected:
-  explicit ValueListFilter(std::initializer_list<TemplatableValue<float>> values);
+  explicit ValueListFilter(const std::initializer_list<TemplatableValue<float>> &values);
 
   /// Check if sensor value matches any configured value (with accuracy rounding)
   bool value_matches_any_(float sensor_value);
@@ -336,7 +336,7 @@ class ValueListFilter : public Filter {
 /// A simple filter that only forwards the filter chain if it doesn't receive `value_to_filter_out`.
 class FilterOutValueFilter : public ValueListFilter {
  public:
-  explicit FilterOutValueFilter(std::initializer_list<TemplatableValue<float>> values_to_filter_out);
+  explicit FilterOutValueFilter(const std::initializer_list<TemplatableValue<float>> &values_to_filter_out);
 
   optional<float> new_value(float value) override;
 };
@@ -356,7 +356,7 @@ class ThrottleFilter : public Filter {
 class ThrottleWithPriorityFilter : public ValueListFilter {
  public:
   explicit ThrottleWithPriorityFilter(uint32_t min_time_between_inputs,
-                                      std::initializer_list<TemplatableValue<float>> prioritized_values);
+                                      const std::initializer_list<TemplatableValue<float>> &prioritized_values);
 
   optional<float> new_value(float value) override;
 
@@ -423,7 +423,7 @@ class DeltaFilter : public Filter {
 
 class OrFilter : public Filter {
  public:
-  explicit OrFilter(std::initializer_list<Filter *> filters);
+  explicit OrFilter(const std::initializer_list<Filter *> &filters);
 
   void initialize(Sensor *parent, Filter *next) override;
 
@@ -446,7 +446,7 @@ class OrFilter : public Filter {
 
 class CalibrateLinearFilter : public Filter {
  public:
-  explicit CalibrateLinearFilter(std::initializer_list<std::array<float, 3>> linear_functions);
+  explicit CalibrateLinearFilter(const std::initializer_list<std::array<float, 3>> &linear_functions);
   optional<float> new_value(float value) override;
 
  protected:
@@ -455,7 +455,7 @@ class CalibrateLinearFilter : public Filter {
 
 class CalibratePolynomialFilter : public Filter {
  public:
-  explicit CalibratePolynomialFilter(std::initializer_list<float> coefficients);
+  explicit CalibratePolynomialFilter(const std::initializer_list<float> &coefficients);
   optional<float> new_value(float value) override;
 
  protected:

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -107,12 +107,12 @@ void Sensor::add_filter(Filter *filter) {
   }
   filter->initialize(this, nullptr);
 }
-void Sensor::add_filters(std::initializer_list<Filter *> filters) {
+void Sensor::add_filters(const std::initializer_list<Filter *> &filters) {
   for (Filter *filter : filters) {
     this->add_filter(filter);
   }
 }
-void Sensor::set_filters(std::initializer_list<Filter *> filters) {
+void Sensor::set_filters(const std::initializer_list<Filter *> &filters) {
   this->clear_filters();
   this->add_filters(filters);
 }

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -77,10 +77,10 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
    *   SlidingWindowMovingAverageFilter(15, 15), // average over last 15 values
    * });
    */
-  void add_filters(std::initializer_list<Filter *> filters);
+  void add_filters(const std::initializer_list<Filter *> &filters);
 
   /// Clear the filters and replace them by filters.
-  void set_filters(std::initializer_list<Filter *> filters);
+  void set_filters(const std::initializer_list<Filter *> &filters);
 
   /// Clear the entire filter chain.
   void clear_filters();

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -51,12 +51,12 @@ void TextSensor::add_filter(Filter *filter) {
   }
   filter->initialize(this, nullptr);
 }
-void TextSensor::add_filters(std::initializer_list<Filter *> filters) {
+void TextSensor::add_filters(const std::initializer_list<Filter *> &filters) {
   for (Filter *filter : filters) {
     this->add_filter(filter);
   }
 }
-void TextSensor::set_filters(std::initializer_list<Filter *> filters) {
+void TextSensor::set_filters(const std::initializer_list<Filter *> &filters) {
   this->clear_filters();
   this->add_filters(filters);
 }

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -37,10 +37,10 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   void add_filter(Filter *filter);
 
   /// Add a list of vectors to the back of the filter chain.
-  void add_filters(std::initializer_list<Filter *> filters);
+  void add_filters(const std::initializer_list<Filter *> &filters);
 
   /// Clear the filters and replace them by filters.
-  void set_filters(std::initializer_list<Filter *> filters);
+  void set_filters(const std::initializer_list<Filter *> &filters);
 
   /// Clear the entire filter chain.
   void clear_filters();

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -15,7 +15,7 @@ namespace esphome {
 
 template<typename... Ts> class AndCondition : public Condition<Ts...> {
  public:
-  explicit AndCondition(std::initializer_list<Condition<Ts...> *> conditions) : conditions_(conditions) {}
+  explicit AndCondition(const std::initializer_list<Condition<Ts...> *> &conditions) : conditions_(conditions) {}
   bool check(Ts... x) override {
     for (auto *condition : this->conditions_) {
       if (!condition->check(x...))
@@ -31,7 +31,7 @@ template<typename... Ts> class AndCondition : public Condition<Ts...> {
 
 template<typename... Ts> class OrCondition : public Condition<Ts...> {
  public:
-  explicit OrCondition(std::initializer_list<Condition<Ts...> *> conditions) : conditions_(conditions) {}
+  explicit OrCondition(const std::initializer_list<Condition<Ts...> *> &conditions) : conditions_(conditions) {}
   bool check(Ts... x) override {
     for (auto *condition : this->conditions_) {
       if (condition->check(x...))
@@ -56,7 +56,7 @@ template<typename... Ts> class NotCondition : public Condition<Ts...> {
 
 template<typename... Ts> class XorCondition : public Condition<Ts...> {
  public:
-  explicit XorCondition(std::initializer_list<Condition<Ts...> *> conditions) : conditions_(conditions) {}
+  explicit XorCondition(const std::initializer_list<Condition<Ts...> *> &conditions) : conditions_(conditions) {}
   bool check(Ts... x) override {
     size_t result = 0;
     for (auto *condition : this->conditions_) {

--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -60,7 +60,7 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
   constexpr FiniteSetMask() = default;
 
   /// Construct from initializer list: {VALUE1, VALUE2, ...}
-  constexpr FiniteSetMask(std::initializer_list<ValueType> values) {
+  constexpr FiniteSetMask(const std::initializer_list<ValueType> &values) {
     for (auto value : values) {
       this->insert(value);
     }
@@ -70,7 +70,7 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
   constexpr void insert(ValueType value) { this->mask_ |= (static_cast<bitmask_t>(1) << BitPolicy::to_bit(value)); }
 
   /// Add multiple values from initializer list
-  constexpr void insert(std::initializer_list<ValueType> values) {
+  constexpr void insert(const std::initializer_list<ValueType> &values) {
     for (auto value : values) {
       this->insert(value);
     }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -195,7 +195,7 @@ template<typename T> class FixedVector {
   }
 
   // Helper to assign from initializer list (shared by constructor and assignment operator)
-  void assign_from_initializer_list_(std::initializer_list<T> init_list) {
+  void assign_from_initializer_list_(const std::initializer_list<T> &init_list) {
     init(init_list.size());
     size_t idx = 0;
     for (const auto &item : init_list) {
@@ -210,7 +210,7 @@ template<typename T> class FixedVector {
 
   /// Constructor from initializer list - allocates exact size needed
   /// This enables brace initialization: FixedVector<int> v = {1, 2, 3};
-  FixedVector(std::initializer_list<T> init_list) { assign_from_initializer_list_(init_list); }
+  FixedVector(const std::initializer_list<T> &init_list) { assign_from_initializer_list_(init_list); }
 
   ~FixedVector() { cleanup_(); }
 
@@ -239,7 +239,7 @@ template<typename T> class FixedVector {
 
   /// Assignment from initializer list - avoids temporary and move overhead
   /// This enables: FixedVector<int> v; v = {1, 2, 3};
-  FixedVector &operator=(std::initializer_list<T> init_list) {
+  FixedVector &operator=(const std::initializer_list<T> &init_list) {
     cleanup_();
     reset_();
     assign_from_initializer_list_(init_list);


### PR DESCRIPTION
# What does this implement/fix?

Pass all `std::initializer_list` parameters by const reference instead of by value to reduce code size.

This changes all function/constructor parameters from `std::initializer_list<T>` to `const std::initializer_list<T> &` throughout the codebase.

**Impact**: Each changed call site saves approximately 20-60 bytes of flash, depending on the platform and usage pattern. With 33 changes across widely-used components (FixedVector, filters, automations, etc.), the cumulative savings can be 500-1500 bytes for typical configurations.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing flash size optimization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# All existing configurations work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
