### PR TITLE
Use lists inits initialization instead of std::fill

### DIFF
--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -33,19 +33,13 @@ Message Format:
 class ABBWelcomeData {
  public:
   // Make default
-  ABBWelcomeData() {
-    std::fill(std::begin(this->data_), std::end(this->data_), 0);
-    this->data_[0] = 0x55;
-    this->data_[1] = 0xff;
-  }
+  ABBWelcomeData() : data_{0x55, 0xff} {}
   // Make from initializer_list
-  ABBWelcomeData(std::initializer_list<uint8_t> data) {
-    std::fill(std::begin(this->data_), std::end(this->data_), 0);
+  ABBWelcomeData(std::initializer_list<uint8_t> data) : data_{} {
     std::copy_n(data.begin(), std::min(data.size(), this->data_.size()), this->data_.begin());
   }
   // Make from vector
-  ABBWelcomeData(const std::vector<uint8_t> &data) {
-    std::fill(std::begin(this->data_), std::end(this->data_), 0);
+  ABBWelcomeData(const std::vector<uint8_t> &data) : data_{} {
     std::copy_n(data.begin(), std::min(data.size(), this->data_.size()), this->data_.begin());
   }
   // Default copy constructor


### PR DESCRIPTION
# What does this implement/fix?

Refactor ABBWelcomeData constructors to use list/aggregate initialization instead of std::fill. When list-initializations are used, all unspecified elements are default-initialzed, e.g:
 - v{1, 3, 5, 7} -> v[4] = 0;
 - v{} -> all 0;

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840


## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
