### PR TITLE
[config] !extend / !remove support for LVGL-style configs

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -338,21 +338,33 @@ def check_replaceme(value):
         )
 
 
+def _get_item_id(item):
+    if not isinstance(item, dict):
+        return None
+    item_id = item.get(CONF_ID)
+    if item_id is None and len(item) == 1:
+        item = next(iter(item.values()))
+        if isinstance(item, dict):
+            item_id = item.get(CONF_ID)
+    if isinstance(item_id, Extend):
+        del item[CONF_ID]
+    return item_id
+
+
 def _build_list_index(lst):
     index = OrderedDict()
     extensions, removals = [], set()
-    for item in lst:
+    for pos, item in enumerate(lst):
         if item is None:
             removals.add(None)
             continue
-        item_id = None
-        if isinstance(item, dict) and (item_id := item.get(CONF_ID)):
-            if isinstance(item_id, Extend):
-                extensions.append(item)
-                continue
-            if isinstance(item_id, Remove):
-                removals.add(item_id.value)
-                continue
+        item_id = _get_item_id(item)
+        if isinstance(item_id, Extend):
+            extensions.append((pos, item_id.value, item))
+            continue
+        if isinstance(item_id, Remove):
+            removals.add(item_id.value)
+            continue
         if not item_id or item_id in index:
             # no id or duplicate -> pass through with identity-based key
             item_id = id(item)
@@ -368,26 +380,16 @@ def resolve_extend_remove(value, is_key=None):
         if extensions or removals:
             # Rebuild the original list after
             # processing all extensions and removals
-            for item in extensions:
-                item_id = item[CONF_ID].value
+            for pos, item_id, item in extensions:
                 if item_id in removals:
                     continue
                 old = index.get(item_id)
                 if old is None:
                     # Failed to find source for extension
-                    # Find index of item to show error at correct position
-                    i = next(
-                        (
-                            i
-                            for i, d in enumerate(value)
-                            if d.get(CONF_ID) == item[CONF_ID]
-                        )
-                    )
-                    with cv.prepend_path(i):
+                    with cv.prepend_path(pos):
                         raise cv.Invalid(
                             f"Source for extension of ID '{item_id}' was not found."
                         )
-                item[CONF_ID] = item_id
                 index[item_id] = merge_config(old, item)
             for item_id in removals:
                 index.pop(item_id, None)

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -383,7 +383,7 @@ def _build_list_index(
     return index, extensions, removals
 
 
-def resolve_extend_remove(value: Any, is_key: bool = None):
+def resolve_extend_remove(value: Any, is_key: bool = False) -> None:
     if isinstance(value, ESPLiteralValue):
         return  # do not check inside literal blocks
     if isinstance(value, list):

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -338,20 +338,31 @@ def check_replaceme(value):
         )
 
 
-def _get_item_id(item):
+def _get_item_id(item: Any) -> str | Extend | Remove | None:
+    """Attempts to get a list item's ID"""
     if not isinstance(item, dict):
-        return None
+        return None  # not a dict, can't have ID
+    # 1.- Check regular case:
+    # - id: my_id
     item_id = item.get(CONF_ID)
     if item_id is None and len(item) == 1:
+        # 2.- Check single-key dict case:
+        # - obj:
+        #     id: my_id
         item = next(iter(item.values()))
         if isinstance(item, dict):
             item_id = item.get(CONF_ID)
     if isinstance(item_id, Extend):
+        # Remove instances of Extend so they don't overwrite the original item when merging:
         del item[CONF_ID]
     return item_id
 
 
-def _build_list_index(lst):
+def _build_list_index(
+    lst: list[Any],
+) -> tuple[
+    OrderedDict[str | Extend | Remove, Any], list[tuple[int, str, Any]], set[str]
+]:
     index = OrderedDict()
     extensions, removals = [], set()
     for pos, item in enumerate(lst):
@@ -372,7 +383,7 @@ def _build_list_index(lst):
     return index, extensions, removals
 
 
-def resolve_extend_remove(value, is_key=None):
+def resolve_extend_remove(value: Any, is_key: bool = None):
     if isinstance(value, ESPLiteralValue):
         return  # do not check inside literal blocks
     if isinstance(value, list):

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
@@ -7,3 +7,27 @@ some_component:
     value: 2
   - id: component2
     value: 5
+lvgl:
+  pages:
+    - id: page1
+      widgets:
+        - obj:
+            id: object1
+            x: 3
+            y: 2
+            width: 4
+        - obj:
+            id: object3
+            x: 6
+            y: 12
+            widgets:
+              - obj:
+                  id: object4
+                  x: 14
+                  y: 9
+                  width: 15
+            height: 13
+        - obj:
+            id: object5
+            x: 10
+            y: 11

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
@@ -13,6 +13,30 @@ packages:
         value: 5
       - id: component3
         value: 6
+  - lvgl:
+      pages:
+        - id: page1
+          widgets:
+            - obj:
+                id: object1
+                x: 1
+                y: 2
+            - obj:
+                id: object2
+                x: 5
+            - obj:
+                id: object3
+                x: 6
+                y: 7
+                widgets:
+                  - obj:
+                      id: object4
+                      x: 8
+                      y: 9
+            - obj:
+                id: object5
+                x: 10
+                y: 11
 
 some_component:
   - id: !extend ${A}
@@ -20,3 +44,23 @@ some_component:
   - id: component2
     value: 3
   - id: !remove ${C}
+
+lvgl:
+  pages:
+    - id: !extend page1
+      widgets:
+        - obj:
+            id: !extend object1
+            x: 3
+            width: 4
+        - obj:
+            id: !remove object2
+        - obj:
+            id: !extend object3
+            y: 12
+            height: 13
+            widgets:
+              - obj:
+                  id: !extend object4
+                  x: 14
+                  width: 15


### PR DESCRIPTION
# What does this implement/fix?

This PR improves `!extend` and `!remove` in order to be able to apply it to LVGL-style configurations. The current implementation did not recognize LVGL object structures with their IDs due to the special syntax used there. This PR corrects this, bringing the possibility to structure UIs and override behavior depending on hardware or displays, etc.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [!extend LVGL items](https://discord.com/channels/429907082951524364/1387546367928434920)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5523

## Test Environment

- [x] all

## Example entry for `config.yaml`:

```yaml
# In interface.yaml
lvgl:
  pages:
    - id: main_page
      widgets:
        - label:
            id: title_label
            text: "Main Page"
```
```yaml
packages:
  - !include interface.yaml
lvgl:
  pages:
    - id: !extend main_page
      widgets:
        - label:
            id: !extend title_label
            text: "New Title"
            text_color: red
```


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
