### PR TITLE
[number] Skip set_mode call when using default AUTO mode

### DIFF
--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -252,7 +252,10 @@ async def setup_number_core_(
     cg.add(var.traits.set_max_value(max_value))
     cg.add(var.traits.set_step(step))
 
-    cg.add(var.traits.set_mode(config[CONF_MODE]))
+    # Only set if non-default to avoid bloating setup() function
+    # (mode_ is initialized to NUMBER_MODE_AUTO in the header)
+    if config[CONF_MODE] != NumberMode.NUMBER_MODE_AUTO:
+        cg.add(var.traits.set_mode(config[CONF_MODE]))
 
     for conf in config.get(CONF_ON_VALUE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes the `number` component to avoid generating unnecessary setter calls when the mode is set to the default value (`AUTO`).

## Changes

**Code generation optimization**: Only generate `set_mode()` call for non-default values
- `traits.set_mode()` only called when mode is not `NUMBER_MODE_AUTO` (default)
- Reduces flash usage by avoiding unnecessary function calls in `setup()`

## Analysis

The `NumberTraits` class initializes `mode_` to `NUMBER_MODE_AUTO` in the header:
```cpp
NumberMode mode_{NUMBER_MODE_AUTO};  // number_traits.h:35
```

The schema also defaults to `"AUTO"`:
```python
cv.Optional(CONF_MODE, default="AUTO")  // __init__.py:209
```

Previously, every number entity would call `set_mode(NUMBER_MODE_AUTO)` even though that's already the C++ default.

**Before this change:**
```cpp
// Always generated, even for default
ld2450_zone1_y1->traits.set_mode(number::NUMBER_MODE_AUTO);
```

**After this change:**
```cpp
// Only generated when needed
number_slider->traits.set_mode(number::NUMBER_MODE_SLIDER);  // For mode: slider
// Nothing generated for mode: auto - uses C++ default
```

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (code generation optimization for embedded systems)

**Related issue or feature (if applicable):**

- N/A - proactive optimization for resource-constrained microcontrollers

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a transparent optimization
# Existing configurations continue to work exactly as before

number:
  - platform: template
    name: "Number with Auto Mode"
    optimistic: true
    min_value: 0
    max_value: 100
    step: 1
    mode: auto  # No setter call generated - uses C++ default

  - platform: template
    name: "Number with Slider Mode"
    optimistic: true
    min_value: 0
    max_value: 100
    step: 1
    mode: slider  # Setter call generated for non-default
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing component tests cover the functionality

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - no user-facing changes, backward compatible optimization
