### PR TITLE
[gpio] Skip set_inverted() call for default false value

### DIFF
--- a/esphome/components/esp32/gpio.h
+++ b/esphome/components/esp32/gpio.h
@@ -40,13 +40,13 @@ class ESP32InternalGPIOPin : public InternalGPIOPin {
   // - 3 bytes for members below
   // - 1 byte padding for alignment
   // - 4 bytes for vtable pointer
-  uint8_t pin_;        // GPIO pin number (0-255, actual max ~54 on ESP32)
-  gpio::Flags flags_;  // GPIO flags (1 byte)
+  uint8_t pin_{};        // GPIO pin number (0-255, actual max ~54 on ESP32)
+  gpio::Flags flags_{};  // GPIO flags (1 byte)
   struct PinFlags {
     uint8_t inverted : 1;        // Invert pin logic (1 bit)
     uint8_t drive_strength : 2;  // Drive strength 0-3 (2 bits)
     uint8_t reserved : 5;        // Reserved for future use (5 bits)
-  } pin_flags_;                  // Total: 1 byte
+  } pin_flags_{};                // Total: 1 byte
   // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
   static bool isr_service_installed;
 };

--- a/esphome/components/esp32/gpio.h
+++ b/esphome/components/esp32/gpio.h
@@ -40,7 +40,7 @@ class ESP32InternalGPIOPin : public InternalGPIOPin {
   // - 3 bytes for members below
   // - 1 byte padding for alignment
   // - 4 bytes for vtable pointer
-  uint8_t pin_{};        // GPIO pin number (0-255, actual max ~54 on ESP32)
+  uint8_t pin_;          // GPIO pin number (0-255, actual max ~54 on ESP32)
   gpio::Flags flags_{};  // GPIO flags (1 byte)
   struct PinFlags {
     uint8_t inverted : 1;        // Invert pin logic (1 bit)

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -223,7 +223,10 @@ async def esp32_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(getattr(gpio_num_t, f"GPIO_NUM_{num}")))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     if CONF_DRIVE_STRENGTH in config:
         cg.add(var.set_drive_strength(config[CONF_DRIVE_STRENGTH]))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))

--- a/esphome/components/esp8266/gpio.h
+++ b/esphome/components/esp8266/gpio.h
@@ -28,7 +28,7 @@ class ESP8266GPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_{};
+  uint8_t pin_;
   bool inverted_{};
   gpio::Flags flags_{};
 };

--- a/esphome/components/esp8266/gpio.h
+++ b/esphome/components/esp8266/gpio.h
@@ -28,9 +28,9 @@ class ESP8266GPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
+  uint8_t pin_{};
+  bool inverted_{};
+  gpio::Flags flags_{};
 };
 
 }  // namespace esp8266

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -165,7 +165,10 @@ async def esp8266_pin_to_code(config):
     num = config[CONF_NUMBER]
     mode = config[CONF_MODE]
     cg.add(var.set_pin(num))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     cg.add(var.set_flags(pins.gpio_flags_expr(mode)))
     if num < 16:
         initial_state: PinInitialState = CORE.data[KEY_ESP8266][KEY_PIN_INITIAL_STATES][

--- a/esphome/components/host/gpio.h
+++ b/esphome/components/host/gpio.h
@@ -27,7 +27,7 @@ class HostGPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_{};
+  uint8_t pin_;
   bool inverted_{};
   gpio::Flags flags_{};
 };

--- a/esphome/components/host/gpio.h
+++ b/esphome/components/host/gpio.h
@@ -27,9 +27,9 @@ class HostGPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
+  uint8_t pin_{};
+  bool inverted_{};
+  gpio::Flags flags_{};
 };
 
 }  // namespace host

--- a/esphome/components/host/gpio.py
+++ b/esphome/components/host/gpio.py
@@ -57,6 +57,9 @@ async def host_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(num))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var

--- a/esphome/components/libretiny/gpio.py
+++ b/esphome/components/libretiny/gpio.py
@@ -199,6 +199,9 @@ async def component_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(num))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var

--- a/esphome/components/libretiny/gpio_arduino.h
+++ b/esphome/components/libretiny/gpio_arduino.h
@@ -26,9 +26,9 @@ class ArduinoInternalGPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
+  uint8_t pin_{};
+  bool inverted_{};
+  gpio::Flags flags_{};
 };
 
 }  // namespace libretiny

--- a/esphome/components/libretiny/gpio_arduino.h
+++ b/esphome/components/libretiny/gpio_arduino.h
@@ -26,7 +26,7 @@ class ArduinoInternalGPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_{};
+  uint8_t pin_;
   bool inverted_{};
   gpio::Flags flags_{};
 };

--- a/esphome/components/nrf52/gpio.py
+++ b/esphome/components/nrf52/gpio.py
@@ -74,6 +74,9 @@ async def nrf52_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(num))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var

--- a/esphome/components/rp2040/gpio.h
+++ b/esphome/components/rp2040/gpio.h
@@ -28,7 +28,7 @@ class RP2040GPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_{};
+  uint8_t pin_;
   bool inverted_{};
   gpio::Flags flags_{};
 };

--- a/esphome/components/rp2040/gpio.h
+++ b/esphome/components/rp2040/gpio.h
@@ -28,9 +28,9 @@ class RP2040GPIOPin : public InternalGPIOPin {
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
 
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
+  uint8_t pin_{};
+  bool inverted_{};
+  gpio::Flags flags_{};
 };
 
 }  // namespace rp2040

--- a/esphome/components/rp2040/gpio.py
+++ b/esphome/components/rp2040/gpio.py
@@ -94,6 +94,9 @@ async def rp2040_pin_to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     num = config[CONF_NUMBER]
     cg.add(var.set_pin(num))
-    cg.add(var.set_inverted(config[CONF_INVERTED]))
+    # Only set if true to avoid bloating setup() function
+    # (inverted bit in pin_flags_ bitfield is zero-initialized to false)
+    if config[CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
     cg.add(var.set_flags(pins.gpio_flags_expr(config[CONF_MODE])))
     return var

--- a/esphome/components/zephyr/gpio.h
+++ b/esphome/components/zephyr/gpio.h
@@ -25,11 +25,11 @@ class ZephyrGPIOPin : public InternalGPIOPin {
 
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
-  uint8_t pin_;
-  bool inverted_;
-  gpio::Flags flags_;
-  const device *gpio_ = nullptr;
-  bool value_ = false;
+  uint8_t pin_{};
+  bool inverted_{};
+  gpio::Flags flags_{};
+  const device *gpio_{nullptr};
+  bool value_{false};
 };
 
 }  // namespace zephyr

--- a/esphome/components/zephyr/gpio.h
+++ b/esphome/components/zephyr/gpio.h
@@ -25,7 +25,7 @@ class ZephyrGPIOPin : public InternalGPIOPin {
 
  protected:
   void attach_interrupt(void (*func)(void *), void *arg, gpio::InterruptType type) const override;
-  uint8_t pin_{};
+  uint8_t pin_;
   bool inverted_{};
   gpio::Flags flags_{};
   const device *gpio_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes GPIO pin code generation to avoid generating unnecessary setter calls when `inverted` is set to the default value (`false`).

## Changes

**Code generation optimization**: Only generate `set_inverted()` call for non-default values

- `set_inverted()` only called when `inverted: true` is specified
- Reduces flash usage by avoiding unnecessary function calls in `setup()`
- Applied to all main platform GPIO implementations:
  - ESP32
  - ESP8266
  - RP2040
  - Host
  - LibreTiny
  - nRF52

## Analysis

GPIO pin classes use a bitfield for flags where `inverted` is zero-initialized to `false`:

```cpp
struct PinFlags {
    uint8_t inverted : 1;        // Invert pin logic (1 bit)
    uint8_t drive_strength : 2;  // Drive strength 0-3 (2 bits)
    uint8_t reserved : 5;        // Reserved for future use (5 bits)
} pin_flags_;  // Zero-initialized bitfield, inverted defaults to 0 (false)
```

The schema also defaults to `false`:
```python
cv.Optional(CONF_INVERTED, default=False): cv.boolean  // pins.py:338
```

Previously, every GPIO pin would call `set_inverted(false)` even though that's already the C++ default.

**Before this change:**
```cpp
// Always generated, even for default
esp32_esp32internalgpiopin_id_2->set_inverted(false);
```

**After this change:**
```cpp
// Only generated when needed
inverted_pin->set_inverted(true);  // For inverted: true
// Nothing generated for inverted: false - uses C++ bitfield default
```

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (code generation optimization for embedded systems)

**Related issue or feature (if applicable):**

- N/A - proactive optimization for resource-constrained microcontrollers

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a transparent optimization
# Existing configurations continue to work exactly as before

# GPIO binary sensor example
binary_sensor:
  - platform: gpio
    pin: GPIO2  # No inverted specified - no setter call generated
    name: "Door Sensor"

  - platform: gpio
    pin:
      number: GPIO3
      inverted: true  # Setter call generated for non-default
    name: "Inverted Sensor"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing component tests cover the functionality

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - no user-facing changes, backward compatible optimization
