### PR TITLE
[core] Simplify ESPTime::strftime() and save 20 bytes flash

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -46,7 +46,7 @@ struct tm ESPTime::to_c_tm() {
   return c_tm;
 }
 
-std::string ESPTime::strftime(const char *format, size_t format_len) {
+std::string ESPTime::strftime(const char *format) {
   struct tm c_tm = this->to_c_tm();
   char buf[128];
   size_t len = ::strftime(buf, sizeof(buf), format, &c_tm);
@@ -56,7 +56,7 @@ std::string ESPTime::strftime(const char *format, size_t format_len) {
   return "ERROR";
 }
 
-std::string ESPTime::strftime(const std::string &format) { return this->strftime(format.c_str(), format.size()); }
+std::string ESPTime::strftime(const std::string &format) { return this->strftime(format.c_str()); }
 
 bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint16_t year;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -46,23 +46,17 @@ struct tm ESPTime::to_c_tm() {
   return c_tm;
 }
 
-std::string ESPTime::strftime(const std::string &format) {
-  std::string timestr;
-  timestr.resize(format.size() * 4);
+std::string ESPTime::strftime(const char *format, size_t format_len) {
   struct tm c_tm = this->to_c_tm();
-  size_t len = ::strftime(&timestr[0], timestr.size(), format.c_str(), &c_tm);
-  while (len == 0) {
-    if (timestr.size() >= 128) {
-      // strftime has failed for reasons unrelated to the size of the buffer
-      // so return a formatting error
-      return "ERROR";
-    }
-    timestr.resize(timestr.size() * 2);
-    len = ::strftime(&timestr[0], timestr.size(), format.c_str(), &c_tm);
+  char buf[128];
+  size_t len = ::strftime(buf, sizeof(buf), format, &c_tm);
+  if (len > 0) {
+    return std::string(buf, len);
   }
-  timestr.resize(len);
-  return timestr;
+  return "ERROR";
 }
+
+std::string ESPTime::strftime(const std::string &format) { return this->strftime(format.c_str(), format.size()); }
 
 bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint16_t year;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -55,7 +55,7 @@ struct ESPTime {
   std::string strftime(const std::string &format);
 
   /// @copydoc strftime(const std::string &format)
-  std::string strftime(const char *format, size_t format_len = 0);
+  std::string strftime(const char *format);
 
   /// Check if this ESPTime is valid (all fields in range and year is greater than 2018)
   bool is_valid() const { return this->year >= 2019 && this->fields_in_range(); }

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -44,32 +44,14 @@ struct ESPTime {
   size_t strftime(char *buffer, size_t buffer_len, const char *format);
 
   /** Convert this ESPTime struct to a string as specified by the format argument.
-   * @see https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html#index-strftime
+   * @see https://en.cppreference.com/w/c/chrono/strftime
    *
-   * @warning This method uses dynamically allocated strings which can cause heap fragmentation with some
-   * microcontrollers.
-   *
-   * @warning This method can return "ERROR" when the underlying strftime() call fails, e.g. when the
-   * format string contains unsupported specifiers or when the format string doesn't produce any
-   * output.
+   * @warning This method can return "ERROR" when the underlying strftime() call fails or when the
+   * output exceeds 128 bytes.
    */
   std::string strftime(const std::string &format);
 
-  /** Convert this ESPTime struct to a string as specified by the format argument.
-   * @see https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html#index-strftime
-   *
-   * This overload is optimized for string literals and avoids std::string parameter overhead.
-   *
-   * @param format The format string (null-terminated C string)
-   * @param format_len Optional length of the format string. If 0 (default), strlen() will be called.
-   *
-   * @warning This method uses dynamically allocated strings which can cause heap fragmentation with some
-   * microcontrollers.
-   *
-   * @warning This method can return "ERROR" when the underlying strftime() call fails, e.g. when the
-   * format string contains unsupported specifiers or when the format string doesn't produce any
-   * output.
-   */
+  /// @copydoc strftime(const std::string &format)
   std::string strftime(const char *format, size_t format_len = 0);
 
   /// Check if this ESPTime is valid (all fields in range and year is greater than 2018)

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -55,6 +55,23 @@ struct ESPTime {
    */
   std::string strftime(const std::string &format);
 
+  /** Convert this ESPTime struct to a string as specified by the format argument.
+   * @see https://www.gnu.org/software/libc/manual/html_node/Formatting-Calendar-Time.html#index-strftime
+   *
+   * This overload is optimized for string literals and avoids std::string parameter overhead.
+   *
+   * @param format The format string (null-terminated C string)
+   * @param format_len Optional length of the format string. If 0 (default), strlen() will be called.
+   *
+   * @warning This method uses dynamically allocated strings which can cause heap fragmentation with some
+   * microcontrollers.
+   *
+   * @warning This method can return "ERROR" when the underlying strftime() call fails, e.g. when the
+   * format string contains unsupported specifiers or when the format string doesn't produce any
+   * output.
+   */
+  std::string strftime(const char *format, size_t format_len = 0);
+
   /// Check if this ESPTime is valid (all fields in range and year is greater than 2018)
   bool is_valid() const { return this->year >= 2019 && this->fields_in_range(); }
 

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -46,6 +46,9 @@ struct ESPTime {
   /** Convert this ESPTime struct to a string as specified by the format argument.
    * @see https://en.cppreference.com/w/c/chrono/strftime
    *
+   * @warning This method returns a dynamically allocated string which can cause heap fragmentation with some
+   * microcontrollers.
+   *
    * @warning This method can return "ERROR" when the underlying strftime() call fails or when the
    * output exceeds 128 bytes.
    */


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `ESPTime::strftime()` to reduce heap allocations and code size by 20 bytes.

## Changes

1. **Simplified implementation**: Replaced dynamic heap allocation with a fixed 128-byte stack buffer for formatting
2. **Added `const char*` overload**: Avoids `std::string` parameter overhead when called with string literals (common case)
3. **Eliminated resize loop**: The old code would try multiple allocations before failing; new code uses a single stack buffer

## Performance Impact

- **Flash saved**: 20 bytes
- **Heap allocations reduced**: From 2-3 allocations down to 1 (only the return string)
  - **Before**: Heap allocate buffer → format → resize (maybe multiple times) → copy to return string → free buffer
  - **After**: Stack buffer → format → copy to return string
- **Runtime**: Faster (eliminates buffer resize overhead and reduces allocator calls)

## Behavioral Changes

The 128-byte limit was already the hard limit in the old code. The only difference:
- **Old**: Allocate → resize → resize → fail at 128 bytes
- **New**: Single 128-byte stack buffer → fail if output doesn't fit

All datetime formats in the codebase produce outputs < 30 bytes, so this never fails in practice.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A (proactive optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This optimization is transparent to users

# Example usage in lambda (unchanged):
text_sensor:
  - platform: template
    name: "Last Restart"
    lambda: |-
      return id(sntp_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
