### PR TITLE
[usb_host] Fix atomic memory ordering in transfer slot allocation

### DIFF
--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -82,6 +82,12 @@ struct TransferStatus {
 
 using transfer_cb_t = std::function<void(const TransferStatus &)>;
 
+enum TransferResult : uint8_t {
+  TRANSFER_OK = 0,
+  TRANSFER_ERROR_NO_SLOTS,
+  TRANSFER_ERROR_SUBMIT_FAILED,
+};
+
 class USBClient;
 
 // struct used to capture all data needed for a transfer
@@ -134,7 +140,7 @@ class USBClient : public Component {
   void on_opened(uint8_t addr);
   void on_removed(usb_device_handle_t handle);
   void control_transfer_callback(const usb_transfer_t *xfer) const;
-  void transfer_in(uint8_t ep_address, const transfer_cb_t &callback, uint16_t length);
+  TransferResult transfer_in(uint8_t ep_address, const transfer_cb_t &callback, uint16_t length);
   void transfer_out(uint8_t ep_address, const transfer_cb_t &callback, const uint8_t *data, uint16_t length);
   void dump_config() override;
   void release_trq(TransferRequest *trq);

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -334,7 +334,7 @@ static void control_callback(const usb_transfer_t *xfer) {
 // This multi-threaded access is intentional for performance - USB task can
 // immediately restart transfers without waiting for main loop scheduling.
 TransferRequest *USBClient::get_trq_() {
-  trq_bitmask_t mask = this->trq_in_use_.load(std::memory_order_relaxed);
+  trq_bitmask_t mask = this->trq_in_use_.load(std::memory_order_acquire);
 
   // Find first available slot (bit = 0) and try to claim it atomically
   // We use a while loop to allow retrying the same slot after CAS failure
@@ -443,14 +443,15 @@ static void transfer_callback(usb_transfer_t *xfer) {
  * @param ep_address The endpoint address.
  * @param callback The callback function to be called when the transfer is complete.
  * @param length The length of the data to be transferred.
+ * @return TransferResult indicating success or specific failure reason
  *
  * @throws None.
  */
-void USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, uint16_t length) {
+TransferResult USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, uint16_t length) {
   auto *trq = this->get_trq_();
   if (trq == nullptr) {
     ESP_LOGE(TAG, "Too many requests queued");
-    return;
+    return TRANSFER_ERROR_NO_SLOTS;
   }
   trq->callback = callback;
   trq->transfer->callback = transfer_callback;
@@ -460,7 +461,9 @@ void USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to submit transfer, address=%x, length=%d, err=%x", ep_address, length, err);
     this->release_trq(trq);
+    return TRANSFER_ERROR_SUBMIT_FAILED;
   }
+  return TRANSFER_OK;
 }
 
 /**

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -229,13 +229,12 @@ void USBUartComponent::do_start_input_(USBUartChannel *channel) {
   // Caller must ensure input_started_ is already set to true
   const auto *ep = channel->cdc_dev_.in_ep;
 
-  // Set up callback using a lambda that captures channel and forwards to the named function
-  auto callback = [this, channel](const usb_host::TransferStatus &status) {
-    this->input_transfer_callback_(channel, status);
-  };
-
   // input_started_ already set to true by caller
-  auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
+  auto result = this->transfer_in(
+      ep->bEndpointAddress,
+      [this, channel](const usb_host::TransferStatus &status) { this->input_transfer_callback_(channel, status); },
+      ep->wMaxPacketSize);
+
   if (result == usb_host::TRANSFER_ERROR_NO_SLOTS) {
     // No slots available - defer retry to main loop
     this->defer_input_retry_(channel);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -256,7 +256,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-      // Transfer failed, slot already released - just clear flag, let read_array() restart later
+      // Transfer failed, slot already released
+      // Mark input as not started so normal operations can restart later
       channel->input_started_.store(false);
       return;
     }
@@ -267,6 +268,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       if (chunk == nullptr) {
         // No chunks available - queue is full, data dropped, slot already released
         this->usb_data_queue_.increment_dropped_count();
+        // Mark input as not started so normal operations can restart later
         channel->input_started_.store(false);
         return;
       }

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -169,6 +169,25 @@ bool USBUartChannel::read_array(uint8_t *data, size_t len) {
   this->parent_->start_input(this);
   return status;
 }
+void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
+  static constexpr uint8_t MAX_INPUT_RETRIES = 10;
+
+  // Atomically increment and get previous value
+  uint8_t retry_count = channel->input_retry_count_.fetch_add(1);
+  if (retry_count >= MAX_INPUT_RETRIES) {
+    ESP_LOGE(TAG, "Input retry limit reached for channel %d, stopping retries", channel->index_);
+    channel->input_started_.store(false);
+    return;
+  }
+
+  // Keep input_started_ as true during defer to prevent multiple retries from queueing
+  // The deferred lambda will clear it before calling start_input()
+  this->defer([this, channel] {
+    channel->input_started_.store(false);
+    this->start_input(channel);
+  });
+}
+
 void USBUartComponent::setup() { USBClient::setup(); }
 void USBUartComponent::loop() {
   USBClient::loop();
@@ -214,8 +233,13 @@ void USBUartComponent::dump_config() {
   }
 }
 void USBUartComponent::start_input(USBUartChannel *channel) {
-  if (!channel->initialised_.load() || channel->input_started_.load())
+  if (!channel->initialised_.load())
     return;
+
+  // Atomically check if not started and set to started in one operation
+  bool expected = false;
+  if (!channel->input_started_.compare_exchange_strong(expected, true))
+    return;  // Already started, another thread won the race
   // THREAD CONTEXT: Called from both USB task and main loop threads
   // - USB task: Immediate restart after successful transfer for continuous data flow
   // - Main loop: Controlled restart after consuming data (backpressure mechanism)
@@ -232,8 +256,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-      // On failure, don't restart - let next read_array() trigger it
-      channel->input_started_.store(false);
+      // On failure, defer retry to main loop
+      this->defer_input_retry_(channel);
       return;
     }
 
@@ -241,10 +265,9 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       // Allocate a chunk from the pool
       UsbDataChunk *chunk = this->chunk_pool_.allocate();
       if (chunk == nullptr) {
-        // No chunks available - queue is full or we're out of memory
+        // No chunks available - defer retry to main loop for backpressure
         this->usb_data_queue_.increment_dropped_count();
-        // Mark input as not started so we can retry
-        channel->input_started_.store(false);
+        this->defer_input_retry_(channel);
         return;
       }
 
@@ -258,13 +281,22 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       this->usb_data_queue_.push(chunk);
     }
 
-    // On success, restart input immediately from USB task for performance
+    // On success, reset retry count and restart input immediately from USB task for performance
     // The lock-free queue will handle backpressure
+    channel->input_retry_count_.store(0);
     channel->input_started_.store(false);
     this->start_input(channel);
   };
-  channel->input_started_.store(true);
-  this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
+  // input_started_ already set to true by compare_exchange_strong above
+  auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
+  if (result == usb_host::TRANSFER_ERROR_NO_SLOTS) {
+    // No slots available - defer retry to main loop
+    this->defer_input_retry_(channel);
+  } else if (result != usb_host::TRANSFER_OK) {
+    // Other error (submit failed) - don't retry, just clear flag
+    // Error already logged by transfer_in()
+    channel->input_started_.store(false);
+  }
 }
 
 void USBUartComponent::start_output(USBUartChannel *channel) {
@@ -370,6 +402,7 @@ void USBUartTypeCdcAcm::enable_channels() {
   for (auto *channel : this->channels_) {
     if (!channel->initialised_.load())
       continue;
+    channel->input_retry_count_.store(0);
     channel->input_started_.store(false);
     channel->output_started_.store(false);
     this->start_input(channel);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -297,7 +297,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     // On success, reset retry count and restart input immediately from USB task for performance
     // The lock-free queue will handle backpressure
     channel->input_retry_count_.store(0);
-    this->restart_input_(channel);
+    channel->input_started_.store(false);
+    this->start_input(channel);
   };
   // input_started_ already set to true by compare_exchange_strong above
   auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -169,6 +169,11 @@ bool USBUartChannel::read_array(uint8_t *data, size_t len) {
   this->parent_->start_input(this);
   return status;
 }
+void USBUartComponent::reset_input_state_(USBUartChannel *channel) {
+  channel->input_retry_count_.store(0);
+  channel->input_started_.store(false);
+}
+
 void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
   static constexpr uint8_t MAX_INPUT_RETRIES = 10;
 
@@ -176,7 +181,7 @@ void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
   uint8_t retry_count = channel->input_retry_count_.fetch_add(1);
   if (retry_count >= MAX_INPUT_RETRIES) {
     ESP_LOGE(TAG, "Input retry limit reached for channel %d, stopping retries", channel->index_);
-    channel->input_started_.store(false);
+    this->reset_input_state_(channel);
     return;
   }
 
@@ -257,8 +262,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
       // Transfer failed, slot already released
-      // Mark input as not started so normal operations can restart later
-      channel->input_started_.store(false);
+      // Reset state so normal operations can restart later
+      this->reset_input_state_(channel);
       return;
     }
 
@@ -268,8 +273,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       if (chunk == nullptr) {
         // No chunks available - queue is full, data dropped, slot already released
         this->usb_data_queue_.increment_dropped_count();
-        // Mark input as not started so normal operations can restart later
-        channel->input_started_.store(false);
+        // Reset state so normal operations can restart later
+        this->reset_input_state_(channel);
         return;
       }
 
@@ -295,9 +300,9 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     // No slots available - defer retry to main loop
     this->defer_input_retry_(channel);
   } else if (result != usb_host::TRANSFER_OK) {
-    // Other error (submit failed) - don't retry, just clear flag
+    // Other error (submit failed) - don't retry, just reset state
     // Error already logged by transfer_in()
-    channel->input_started_.store(false);
+    this->reset_input_state_(channel);
   }
 }
 
@@ -404,8 +409,7 @@ void USBUartTypeCdcAcm::enable_channels() {
   for (auto *channel : this->channels_) {
     if (!channel->initialised_.load())
       continue;
-    channel->input_retry_count_.store(0);
-    channel->input_started_.store(false);
+    this->reset_input_state_(channel);
     channel->output_started_.store(false);
     this->start_input(channel);
   }

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -184,48 +184,56 @@ void USBUartComponent::restart_input_(USBUartChannel *channel) {
   }
 }
 
-void USBUartComponent::do_start_input_(USBUartChannel *channel) {
-  // This function does the actual work of starting input
-  // Caller must ensure input_started_ is already set to true
-  const auto *ep = channel->cdc_dev_.in_ep;
-  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
-  auto callback = [this, channel](const usb_host::TransferStatus &status) {
-    ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
-    if (!status.success) {
-      ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-      // Transfer failed, slot already released
+void USBUartComponent::input_transfer_callback_(USBUartChannel *channel, const usb_host::TransferStatus &status) {
+  // CALLBACK CONTEXT: This function is executed in USB task via transfer_callback
+  ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
+
+  if (!status.success) {
+    ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
+    // Transfer failed, slot already released
+    // Reset state so normal operations can restart later
+    this->reset_input_state_(channel);
+    return;
+  }
+
+  if (!channel->dummy_receiver_ && status.data_len > 0) {
+    // Allocate a chunk from the pool
+    UsbDataChunk *chunk = this->chunk_pool_.allocate();
+    if (chunk == nullptr) {
+      // No chunks available - queue is full, data dropped, slot already released
+      this->usb_data_queue_.increment_dropped_count();
       // Reset state so normal operations can restart later
       this->reset_input_state_(channel);
       return;
     }
 
-    if (!channel->dummy_receiver_ && status.data_len > 0) {
-      // Allocate a chunk from the pool
-      UsbDataChunk *chunk = this->chunk_pool_.allocate();
-      if (chunk == nullptr) {
-        // No chunks available - queue is full, data dropped, slot already released
-        this->usb_data_queue_.increment_dropped_count();
-        // Reset state so normal operations can restart later
-        this->reset_input_state_(channel);
-        return;
-      }
+    // Copy data to chunk (this is fast, happens in USB task)
+    memcpy(chunk->data, status.data, status.data_len);
+    chunk->length = status.data_len;
+    chunk->channel = channel;
 
-      // Copy data to chunk (this is fast, happens in USB task)
-      memcpy(chunk->data, status.data, status.data_len);
-      chunk->length = status.data_len;
-      chunk->channel = channel;
+    // Push to lock-free queue for main loop processing
+    // Push always succeeds because pool size == queue size
+    this->usb_data_queue_.push(chunk);
+  }
 
-      // Push to lock-free queue for main loop processing
-      // Push always succeeds because pool size == queue size
-      this->usb_data_queue_.push(chunk);
-    }
+  // On success, reset retry count and restart input immediately from USB task for performance
+  // The lock-free queue will handle backpressure
+  channel->input_retry_count_.store(0);
+  channel->input_started_.store(false);
+  this->start_input(channel);
+}
 
-    // On success, reset retry count and restart input immediately from USB task for performance
-    // The lock-free queue will handle backpressure
-    channel->input_retry_count_.store(0);
-    channel->input_started_.store(false);
-    this->start_input(channel);
+void USBUartComponent::do_start_input_(USBUartChannel *channel) {
+  // This function does the actual work of starting input
+  // Caller must ensure input_started_ is already set to true
+  const auto *ep = channel->cdc_dev_.in_ep;
+
+  // Set up callback using a lambda that captures channel and forwards to the named function
+  auto callback = [this, channel](const usb_host::TransferStatus &status) {
+    this->input_transfer_callback_(channel, status);
   };
+
   // input_started_ already set to true by caller
   auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
   if (result == usb_host::TRANSFER_ERROR_NO_SLOTS) {

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -186,9 +186,9 @@ void USBUartComponent::restart_input_(USBUartChannel *channel) {
 void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
   static constexpr uint8_t MAX_INPUT_RETRIES = 10;
 
-  // Atomically increment and get previous value
-  uint8_t retry_count = channel->input_retry_count_.fetch_add(1);
-  if (retry_count >= MAX_INPUT_RETRIES) {
+  // Atomically increment and get the NEW value (previous + 1)
+  uint8_t new_retry_count = channel->input_retry_count_.fetch_add(1) + 1;
+  if (new_retry_count > MAX_INPUT_RETRIES) {
     ESP_LOGE(TAG, "Input retry limit reached for channel %d, stopping retries", channel->index_);
     this->reset_input_state_(channel);
     return;
@@ -250,7 +250,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
   // Atomically check if not started and set to started in one operation
   bool expected = false;
   if (!channel->input_started_.compare_exchange_strong(expected, true))
-    return;  // Already started, another thread won the race
+    return;  // Already started - prevents duplicate transfers from concurrent threads
   // THREAD CONTEXT: Called from both USB task and main loop threads
   // - USB task: Immediate restart after successful transfer for continuous data flow
   // - Main loop: Controlled restart after consuming data (backpressure mechanism)

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -175,11 +175,66 @@ void USBUartComponent::reset_input_state_(USBUartChannel *channel) {
 }
 
 void USBUartComponent::restart_input_(USBUartChannel *channel) {
-  // Atomically check if still started and clear it before calling start_input
-  // This prevents race with concurrent restart attempts from different threads
+  // Atomically verify it's still started (true) and keep it started
+  // This prevents the race window of toggling true->false->true
   bool expected = true;
-  if (channel->input_started_.compare_exchange_strong(expected, false)) {
+  if (channel->input_started_.compare_exchange_strong(expected, true)) {
+    // Still started - do the actual restart work without toggling the flag
+    this->do_start_input_(channel);
+  }
+}
+
+void USBUartComponent::do_start_input_(USBUartChannel *channel) {
+  // This function does the actual work of starting input
+  // Caller must ensure input_started_ is already set to true
+  const auto *ep = channel->cdc_dev_.in_ep;
+  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
+  auto callback = [this, channel](const usb_host::TransferStatus &status) {
+    ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
+    if (!status.success) {
+      ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
+      // Transfer failed, slot already released
+      // Reset state so normal operations can restart later
+      this->reset_input_state_(channel);
+      return;
+    }
+
+    if (!channel->dummy_receiver_ && status.data_len > 0) {
+      // Allocate a chunk from the pool
+      UsbDataChunk *chunk = this->chunk_pool_.allocate();
+      if (chunk == nullptr) {
+        // No chunks available - queue is full, data dropped, slot already released
+        this->usb_data_queue_.increment_dropped_count();
+        // Reset state so normal operations can restart later
+        this->reset_input_state_(channel);
+        return;
+      }
+
+      // Copy data to chunk (this is fast, happens in USB task)
+      memcpy(chunk->data, status.data, status.data_len);
+      chunk->length = status.data_len;
+      chunk->channel = channel;
+
+      // Push to lock-free queue for main loop processing
+      // Push always succeeds because pool size == queue size
+      this->usb_data_queue_.push(chunk);
+    }
+
+    // On success, reset retry count and restart input immediately from USB task for performance
+    // The lock-free queue will handle backpressure
+    channel->input_retry_count_.store(0);
+    channel->input_started_.store(false);
     this->start_input(channel);
+  };
+  // input_started_ already set to true by caller
+  auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
+  if (result == usb_host::TRANSFER_ERROR_NO_SLOTS) {
+    // No slots available - defer retry to main loop
+    this->defer_input_retry_(channel);
+  } else if (result != usb_host::TRANSFER_OK) {
+    // Other error (submit failed) - don't retry, just reset state
+    // Error already logged by transfer_in()
+    this->reset_input_state_(channel);
   }
 }
 
@@ -251,6 +306,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
   bool expected = false;
   if (!channel->input_started_.compare_exchange_strong(expected, true))
     return;  // Already started - prevents duplicate transfers from concurrent threads
+
   // THREAD CONTEXT: Called from both USB task and main loop threads
   // - USB task: Immediate restart after successful transfer for continuous data flow
   // - Main loop: Controlled restart after consuming data (backpressure mechanism)
@@ -261,55 +317,9 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
   //
   // The underlying transfer_in() uses lock-free atomic allocation from the
   // TransferRequest pool, making this multi-threaded access safe
-  const auto *ep = channel->cdc_dev_.in_ep;
-  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
-  auto callback = [this, channel](const usb_host::TransferStatus &status) {
-    ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
-    if (!status.success) {
-      ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-      // Transfer failed, slot already released
-      // Reset state so normal operations can restart later
-      this->reset_input_state_(channel);
-      return;
-    }
 
-    if (!channel->dummy_receiver_ && status.data_len > 0) {
-      // Allocate a chunk from the pool
-      UsbDataChunk *chunk = this->chunk_pool_.allocate();
-      if (chunk == nullptr) {
-        // No chunks available - queue is full, data dropped, slot already released
-        this->usb_data_queue_.increment_dropped_count();
-        // Reset state so normal operations can restart later
-        this->reset_input_state_(channel);
-        return;
-      }
-
-      // Copy data to chunk (this is fast, happens in USB task)
-      memcpy(chunk->data, status.data, status.data_len);
-      chunk->length = status.data_len;
-      chunk->channel = channel;
-
-      // Push to lock-free queue for main loop processing
-      // Push always succeeds because pool size == queue size
-      this->usb_data_queue_.push(chunk);
-    }
-
-    // On success, reset retry count and restart input immediately from USB task for performance
-    // The lock-free queue will handle backpressure
-    channel->input_retry_count_.store(0);
-    channel->input_started_.store(false);
-    this->start_input(channel);
-  };
-  // input_started_ already set to true by compare_exchange_strong above
-  auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);
-  if (result == usb_host::TRANSFER_ERROR_NO_SLOTS) {
-    // No slots available - defer retry to main loop
-    this->defer_input_retry_(channel);
-  } else if (result != usb_host::TRANSFER_OK) {
-    // Other error (submit failed) - don't retry, just reset state
-    // Error already logged by transfer_in()
-    this->reset_input_state_(channel);
-  }
+  // Do the actual work (input_started_ already set to true by CAS above)
+  this->do_start_input_(channel);
 }
 
 void USBUartComponent::start_output(USBUartChannel *channel) {

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -256,8 +256,8 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     ESP_LOGV(TAG, "Transfer result: length: %u; status %X", status.data_len, status.error_code);
     if (!status.success) {
       ESP_LOGE(TAG, "Control transfer failed, status=%s", esp_err_to_name(status.error_code));
-      // On failure, defer retry to main loop
-      this->defer_input_retry_(channel);
+      // Transfer failed, slot already released - just clear flag, let read_array() restart later
+      channel->input_started_.store(false);
       return;
     }
 
@@ -265,9 +265,9 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       // Allocate a chunk from the pool
       UsbDataChunk *chunk = this->chunk_pool_.allocate();
       if (chunk == nullptr) {
-        // No chunks available - defer retry to main loop for backpressure
+        // No chunks available - queue is full, data dropped, slot already released
         this->usb_data_queue_.increment_dropped_count();
-        this->defer_input_retry_(channel);
+        channel->input_started_.store(false);
         return;
       }
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -174,6 +174,15 @@ void USBUartComponent::reset_input_state_(USBUartChannel *channel) {
   channel->input_started_.store(false);
 }
 
+void USBUartComponent::restart_input_(USBUartChannel *channel) {
+  // Atomically check if still started and clear it before calling start_input
+  // This prevents race with concurrent restart attempts from different threads
+  bool expected = true;
+  if (channel->input_started_.compare_exchange_strong(expected, false)) {
+    this->start_input(channel);
+  }
+}
+
 void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
   static constexpr uint8_t MAX_INPUT_RETRIES = 10;
 
@@ -186,11 +195,8 @@ void USBUartComponent::defer_input_retry_(USBUartChannel *channel) {
   }
 
   // Keep input_started_ as true during defer to prevent multiple retries from queueing
-  // The deferred lambda will clear it before calling start_input()
-  this->defer([this, channel] {
-    channel->input_started_.store(false);
-    this->start_input(channel);
-  });
+  // The deferred lambda will atomically restart
+  this->defer([this, channel] { this->restart_input_(channel); });
 }
 
 void USBUartComponent::setup() { USBClient::setup(); }
@@ -291,8 +297,7 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     // On success, reset retry count and restart input immediately from USB task for performance
     // The lock-free queue will handle backpressure
     channel->input_retry_count_.store(0);
-    channel->input_started_.store(false);
-    this->start_input(channel);
+    this->restart_input_(channel);
   };
   // input_started_ already set to true by compare_exchange_strong above
   auto result = this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize);

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -144,6 +144,7 @@ class USBUartComponent : public usb_host::USBClient {
   void defer_input_retry_(USBUartChannel *channel);
   void reset_input_state_(USBUartChannel *channel);
   void restart_input_(USBUartChannel *channel);
+  void do_start_input_(USBUartChannel *channel);
   std::vector<USBUartChannel *> channels_{};
 };
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -111,10 +111,11 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   CdcEps cdc_dev_{};
   // Enum (likely 4 bytes)
   UARTParityOptions parity_{UART_CONFIG_PARITY_NONE};
-  // Group atomics together (each 1 byte)
+  // Group atomics together
   std::atomic<bool> input_started_{true};
   std::atomic<bool> output_started_{true};
   std::atomic<bool> initialised_{false};
+  std::atomic<uint8_t> input_retry_count_{0};
   // Group regular bytes together to minimize padding
   const uint8_t index_;
   bool debug_{};
@@ -140,6 +141,7 @@ class USBUartComponent : public usb_host::USBClient {
   EventPool<UsbDataChunk, USB_DATA_QUEUE_SIZE> chunk_pool_;
 
  protected:
+  void defer_input_retry_(USBUartChannel *channel);
   std::vector<USBUartChannel *> channels_{};
 };
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -145,6 +145,7 @@ class USBUartComponent : public usb_host::USBClient {
   void reset_input_state_(USBUartChannel *channel);
   void restart_input_(USBUartChannel *channel);
   void do_start_input_(USBUartChannel *channel);
+  void input_transfer_callback_(USBUartChannel *channel, const usb_host::TransferStatus &status);
   std::vector<USBUartChannel *> channels_{};
 };
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -142,6 +142,7 @@ class USBUartComponent : public usb_host::USBClient {
 
  protected:
   void defer_input_retry_(USBUartChannel *channel);
+  void reset_input_state_(USBUartChannel *channel);
   std::vector<USBUartChannel *> channels_{};
 };
 

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -143,6 +143,7 @@ class USBUartComponent : public usb_host::USBClient {
  protected:
   void defer_input_retry_(USBUartChannel *channel);
   void reset_input_state_(USBUartChannel *channel);
+  void restart_input_(USBUartChannel *channel);
   std::vector<USBUartChannel *> channels_{};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a critical memory ordering bug in the USB host component that caused transfer slots to appear permanently in use after extended runtime (observed after ~8 days), leading to "All 16 transfer slots in use" errors and component failure.

## Root Cause

The `get_trq_()` function in `usb_host_client.cpp` used `memory_order_relaxed` when loading the transfer slot bitmask:

```cpp
trq_bitmask_t mask = this->trq_in_use_.load(std::memory_order_relaxed);
```

However, `release_trq()` uses `memory_order_release` when freeing slots.

**The problem:** `memory_order_relaxed` does not synchronize with `memory_order_release`. To establish proper cross-thread visibility, you need an acquire-release pair: stores must use `memory_order_release` and corresponding loads must use `memory_order_acquire`.

**Without proper synchronization:**
- USB task thread frees a slot using `fetch_and()` with `memory_order_release` (sets bit to 0)
- Main loop thread loads the bitmask with `memory_order_relaxed`
- The C++ memory model does **not guarantee** the main loop will see the freed slot
- On ESP32 dual-core systems, each core has separate caches - without memory barriers, stale cached values can persist indefinitely
- Over extended runtime (8 days observed), freed slots probabilistically fail to become visible to the allocating thread
- Eventually all 16 slots appear "stuck" as in-use, causing permanent failure

## Changes

### 1. **Fixed Memory Ordering** (Primary Fix)
- Changed initial load from `memory_order_relaxed` to `memory_order_acquire`
- Properly pairs with `memory_order_release` in `release_trq()`
- Ensures released slots are visible across threads

### 2. **Added Transfer Result Enum**
- Changed `transfer_in()` to return `TransferResult` enum instead of `bool`
- Distinguishes between "no slots available" vs "submit failed"
- Allows intelligent retry only when appropriate

### 3. **Added Resilient Retry Logic for Slot Exhaustion**
https://ptb.discord.com/channels/429907082951524364/1426535751952236695/1426632234298900510
- Added `defer_input_retry_()` helper with atomic retry counter (max 10 retries)
- **Only retries on `TRANSFER_ERROR_NO_SLOTS`** - when transfer submission fails due to all slots in use
- Does **not** retry on:
  - Transfer failures (`!status.success`) - slot already released, normal operations will restart
  - Chunk allocation failures - slot already released, data dropped, normal operations will restart
- Defers retry to main loop instead of immediately failing, allowing main loop to catch up
- Main loop can be temporarily blocked by NVS writes, flash operations, or other synchronous tasks
- During blocking, transfer slots fill up because callbacks can't execute to release them
- Retry mechanism allows main loop to catch up and release slots
- This approach may result in some USB data drops but prevents complete channel failure
- Uses `fetch_add()` for thread-safe retry counting
- Prevents duplicate retry deferrals with atomic compare-exchange

### 4. **Thread-Safe start_input()**
- Used `compare_exchange_strong()` for atomic check-and-set of `input_started_` flag
- Prevents race where USB task and main loop both start transfers simultaneously
- Eliminates potential for duplicate transfers queued for same channel

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes transfer slot exhaustion after extended runtime (8 days observed)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal bugfix, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Existing usb_uart configurations will benefit from the fix

uart:
  - platform: usb_uart
    id: uart_bus
    vid: 0x10C4
    pid: 0xEA60
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
