### PR TITLE
fix: load_cert_chain requires the path, not a file object

### DIFF
--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -120,7 +120,7 @@ def prepare(
                 cert_file.flush()
                 key_file.write(config[CONF_MQTT].get(CONF_CLIENT_CERTIFICATE_KEY))
                 key_file.flush()
-                context.load_cert_chain(cert_file, key_file)
+                context.load_cert_chain(cert_file.name, key_file.name)
         client.tls_set_context(context)
 
     try:


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the problem described in #11416. I believe the error has been introduced in 8cd62c0308e3052321f4e89d09172df14b2812d9. The error is here: https://github.com/esphome/esphome/blob/e212ed024d80bf6b03b0ce5786ca5c294f791e27/esphome/mqtt.py#L123

`load_cert_chain` expects a path, while `tempfile.NamedTemporaryFile` returns a file like object. It should be

```python
context.load_cert_chain(cert_file.name, key_file.name)
``` 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11416

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
