### PR TITLE
[tuya] allow enum for eco id

### DIFF
--- a/esphome/components/tuya/climate/tuya_climate.h
+++ b/esphome/components/tuya/climate/tuya_climate.h
@@ -104,6 +104,7 @@ class TuyaClimate : public climate::Climate, public Component {
   optional<uint8_t> eco_id_{};
   optional<uint8_t> sleep_id_{};
   optional<float> eco_temperature_{};
+  TuyaDatapointType eco_type_{};
   uint8_t active_state_;
   uint8_t fan_state_;
   optional<uint8_t> swing_vertical_id_{};


### PR DESCRIPTION
# What does this implement/fix?

Some devices use an enum instead of a boolean for the eco setting.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/2461

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
