### PR TITLE
Optimize stateless lambdas to use function pointers

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -102,6 +102,23 @@ StatelessLambdaCondition = cg.esphome_ns.class_("StatelessLambdaCondition", Cond
 ForCondition = cg.esphome_ns.class_("ForCondition", Condition, cg.Component)
 
 
+def use_stateless_lambda_if_applicable(id_obj, lambda_expr, stateless_class):
+    """Replace ID type with stateless lambda class if lambda has no capture.
+
+    Args:
+        id_obj: The ID object (action_id, condition_id, or filter_id)
+        lambda_expr: The lambda expression object
+        stateless_class: The stateless class to use (StatelessLambdaAction, StatelessLambdaCondition, or StatelessLambdaFilter)
+
+    Returns:
+        The original ID or a copy with type replaced to use the stateless class
+    """
+    if lambda_expr.capture == "":
+        id_obj = id_obj.copy()
+        id_obj.type = stateless_class
+    return id_obj
+
+
 def validate_automation(extra_schema=None, extra_validators=None, single=False):
     if extra_schema is None:
         extra_schema = {}
@@ -242,11 +259,9 @@ async def lambda_condition_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=bool)
-    # Use optimized StatelessLambdaCondition for lambdas with no capture
-    if lambda_.capture == "":
-        # Override the condition_id type to use StatelessLambdaCondition
-        condition_id = condition_id.copy()
-        condition_id.type = StatelessLambdaCondition
+    condition_id = use_stateless_lambda_if_applicable(
+        condition_id, lambda_, StatelessLambdaCondition
+    )
     return cg.new_Pvariable(condition_id, template_arg, lambda_)
 
 
@@ -413,11 +428,9 @@ async def lambda_action_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=cg.void)
-    # Use optimized StatelessLambdaAction for lambdas with no capture
-    if lambda_.capture == "":
-        # Override the action_id type to use StatelessLambdaAction
-        action_id = action_id.copy()
-        action_id.type = StatelessLambdaAction
+    action_id = use_stateless_lambda_if_applicable(
+        action_id, lambda_, StatelessLambdaAction
+    )
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -103,7 +103,11 @@ ForCondition = cg.esphome_ns.class_("ForCondition", Condition, cg.Component)
 
 
 def use_stateless_lambda_if_applicable(id_obj, lambda_expr, stateless_class):
-    """Replace ID type with stateless lambda class if lambda has no capture.
+    """Return appropriate ID for lambda based on whether it has capture.
+
+    For stateless lambdas (empty capture), returns a copy of id_obj with type
+    set to stateless_class to use function pointer instead of std::function.
+    Otherwise returns the original ID unchanged.
 
     Args:
         id_obj: The ID object (action_id, condition_id, or filter_id)
@@ -111,7 +115,7 @@ def use_stateless_lambda_if_applicable(id_obj, lambda_expr, stateless_class):
         stateless_class: The stateless class to use (StatelessLambdaAction, StatelessLambdaCondition, or StatelessLambdaFilter)
 
     Returns:
-        The original ID or a copy with type replaced to use the stateless class
+        ID to use with cg.new_Pvariable() - either original or modified copy
     """
     if lambda_expr.capture == "":
         id_obj = id_obj.copy()
@@ -259,10 +263,13 @@ async def lambda_condition_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=bool)
-    condition_id = use_stateless_lambda_if_applicable(
-        condition_id, lambda_, StatelessLambdaCondition
+    return cg.new_Pvariable(
+        use_stateless_lambda_if_applicable(
+            condition_id, lambda_, StatelessLambdaCondition
+        ),
+        template_arg,
+        lambda_,
     )
-    return cg.new_Pvariable(condition_id, template_arg, lambda_)
 
 
 @register_condition(
@@ -428,10 +435,11 @@ async def lambda_action_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=cg.void)
-    action_id = use_stateless_lambda_if_applicable(
-        action_id, lambda_, StatelessLambdaAction
+    return cg.new_Pvariable(
+        use_stateless_lambda_if_applicable(action_id, lambda_, StatelessLambdaAction),
+        template_arg,
+        lambda_,
     )
-    return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 
 @register_action(

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -16,7 +16,12 @@ from esphome.const import (
     CONF_UPDATE_INTERVAL,
 )
 from esphome.core import ID
-from esphome.cpp_generator import MockObj, MockObjClass, TemplateArgsType
+from esphome.cpp_generator import (
+    LambdaExpression,
+    MockObj,
+    MockObjClass,
+    TemplateArgsType,
+)
 from esphome.schema_extractors import SCHEMA_EXTRACT, schema_extractor
 from esphome.types import ConfigType
 from esphome.util import Registry
@@ -102,25 +107,34 @@ StatelessLambdaCondition = cg.esphome_ns.class_("StatelessLambdaCondition", Cond
 ForCondition = cg.esphome_ns.class_("ForCondition", Condition, cg.Component)
 
 
-def use_stateless_lambda_if_applicable(id_obj, lambda_expr, stateless_class):
-    """Return appropriate ID for lambda based on whether it has capture.
+def new_lambda_pvariable(
+    id_obj: ID,
+    lambda_expr: LambdaExpression,
+    stateless_class: MockObjClass,
+    template_arg: cg.TemplateArguments | None = None,
+) -> MockObj:
+    """Create Pvariable for lambda, using stateless class if applicable.
 
-    For stateless lambdas (empty capture), returns a copy of id_obj with type
-    set to stateless_class to use function pointer instead of std::function.
-    Otherwise returns the original ID unchanged.
+    Combines ID selection and Pvariable creation in one call. For stateless
+    lambdas (empty capture), uses function pointer instead of std::function.
 
     Args:
         id_obj: The ID object (action_id, condition_id, or filter_id)
         lambda_expr: The lambda expression object
-        stateless_class: The stateless class to use (StatelessLambdaAction, StatelessLambdaCondition, or StatelessLambdaFilter)
+        stateless_class: The stateless class to use for stateless lambdas
+        template_arg: Optional template arguments (for actions/conditions)
 
     Returns:
-        ID to use with cg.new_Pvariable() - either original or modified copy
+        The created Pvariable
     """
+    # For stateless lambdas, use function pointer instead of std::function
     if lambda_expr.capture == "":
         id_obj = id_obj.copy()
         id_obj.type = stateless_class
-    return id_obj
+
+    if template_arg is not None:
+        return cg.new_Pvariable(id_obj, template_arg, lambda_expr)
+    return cg.new_Pvariable(id_obj, lambda_expr)
 
 
 def validate_automation(extra_schema=None, extra_validators=None, single=False):
@@ -263,12 +277,8 @@ async def lambda_condition_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=bool)
-    return cg.new_Pvariable(
-        use_stateless_lambda_if_applicable(
-            condition_id, lambda_, StatelessLambdaCondition
-        ),
-        template_arg,
-        lambda_,
+    return new_lambda_pvariable(
+        condition_id, lambda_, StatelessLambdaCondition, template_arg
     )
 
 
@@ -435,11 +445,7 @@ async def lambda_action_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=cg.void)
-    return cg.new_Pvariable(
-        use_stateless_lambda_if_applicable(action_id, lambda_, StatelessLambdaAction),
-        template_arg,
-        lambda_,
-    )
+    return new_lambda_pvariable(action_id, lambda_, StatelessLambdaAction, template_arg)
 
 
 @register_action(

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -87,6 +87,7 @@ def validate_potentially_or_condition(value):
 
 DelayAction = cg.esphome_ns.class_("DelayAction", Action, cg.Component)
 LambdaAction = cg.esphome_ns.class_("LambdaAction", Action)
+StatelessLambdaAction = cg.esphome_ns.class_("StatelessLambdaAction", Action)
 IfAction = cg.esphome_ns.class_("IfAction", Action)
 WhileAction = cg.esphome_ns.class_("WhileAction", Action)
 RepeatAction = cg.esphome_ns.class_("RepeatAction", Action)
@@ -97,6 +98,7 @@ ResumeComponentAction = cg.esphome_ns.class_("ResumeComponentAction", Action)
 Automation = cg.esphome_ns.class_("Automation")
 
 LambdaCondition = cg.esphome_ns.class_("LambdaCondition", Condition)
+StatelessLambdaCondition = cg.esphome_ns.class_("StatelessLambdaCondition", Condition)
 ForCondition = cg.esphome_ns.class_("ForCondition", Condition, cg.Component)
 
 
@@ -240,6 +242,11 @@ async def lambda_condition_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=bool)
+    # Use optimized StatelessLambdaCondition for lambdas with no capture
+    if lambda_.capture == "":
+        # Override the condition_id type to use StatelessLambdaCondition
+        condition_id = condition_id.copy()
+        condition_id.type = StatelessLambdaCondition
     return cg.new_Pvariable(condition_id, template_arg, lambda_)
 
 
@@ -406,6 +413,11 @@ async def lambda_action_to_code(
     args: TemplateArgsType,
 ) -> MockObj:
     lambda_ = await cg.process_lambda(config, args, return_type=cg.void)
+    # Use optimized StatelessLambdaAction for lambdas with no capture
+    if lambda_.capture == "":
+        # Override the action_id type to use StatelessLambdaAction
+        action_id = action_id.copy()
+        action_id.type = StatelessLambdaAction
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -155,6 +155,7 @@ DelayedOffFilter = binary_sensor_ns.class_("DelayedOffFilter", Filter, cg.Compon
 InvertFilter = binary_sensor_ns.class_("InvertFilter", Filter)
 AutorepeatFilter = binary_sensor_ns.class_("AutorepeatFilter", Filter, cg.Component)
 LambdaFilter = binary_sensor_ns.class_("LambdaFilter", Filter)
+StatelessLambdaFilter = binary_sensor_ns.class_("StatelessLambdaFilter", Filter)
 SettleFilter = binary_sensor_ns.class_("SettleFilter", Filter, cg.Component)
 
 _LOGGER = getLogger(__name__)
@@ -299,6 +300,10 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(bool, "x")], return_type=cg.optional.template(bool)
     )
+    # Use optimized StatelessLambdaFilter for lambdas with no capture
+    if lambda_.capture == "":
+        filter_id = filter_id.copy()
+        filter_id.type = StatelessLambdaFilter
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -300,10 +300,7 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(bool, "x")], return_type=cg.optional.template(bool)
     )
-    filter_id = automation.use_stateless_lambda_if_applicable(
-        filter_id, lambda_, StatelessLambdaFilter
-    )
-    return cg.new_Pvariable(filter_id, lambda_)
+    return automation.new_lambda_pvariable(filter_id, lambda_, StatelessLambdaFilter)
 
 
 @register_filter(

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -300,10 +300,9 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(bool, "x")], return_type=cg.optional.template(bool)
     )
-    # Use optimized StatelessLambdaFilter for lambdas with no capture
-    if lambda_.capture == "":
-        filter_id = filter_id.copy()
-        filter_id.type = StatelessLambdaFilter
+    filter_id = automation.use_stateless_lambda_if_applicable(
+        filter_id, lambda_, StatelessLambdaFilter
+    )
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -114,7 +114,7 @@ class LambdaFilter : public Filter {
 /** Optimized lambda filter for stateless lambdas (no capture).
  *
  * Uses function pointer instead of std::function to reduce memory overhead.
- * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ * Memory: 4 bytes (function pointer on 32-bit) vs 32 bytes (std::function).
  */
 class StatelessLambdaFilter : public Filter {
  public:

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -111,6 +111,23 @@ class LambdaFilter : public Filter {
   std::function<optional<bool>(bool)> f_;
 };
 
+/** Optimized lambda filter for stateless lambdas (no capture).
+ *
+ * Uses function pointer instead of std::function to reduce memory overhead.
+ * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ */
+class StatelessLambdaFilter : public Filter {
+ public:
+  using stateless_lambda_filter_t = optional<bool> (*)(bool);
+
+  explicit StatelessLambdaFilter(stateless_lambda_filter_t f) : f_(f) {}
+
+  optional<bool> new_value(bool value) override { return this->f_(value); }
+
+ protected:
+  stateless_lambda_filter_t f_;
+};
+
 class SettleFilter : public Filter, public Component {
  public:
   optional<bool> new_value(bool value) override;

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -118,14 +118,12 @@ class LambdaFilter : public Filter {
  */
 class StatelessLambdaFilter : public Filter {
  public:
-  using stateless_lambda_filter_t = optional<bool> (*)(bool);
-
-  explicit StatelessLambdaFilter(stateless_lambda_filter_t f) : f_(f) {}
+  explicit StatelessLambdaFilter(optional<bool> (*f)(bool)) : f_(f) {}
 
   optional<bool> new_value(bool value) override { return this->f_(value); }
 
  protected:
-  stateless_lambda_filter_t f_;
+  optional<bool> (*f_)(bool);
 };
 
 class SettleFilter : public Filter, public Component {

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -430,12 +430,8 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
     text = str(cg.statement(esp_log(config[CONF_TAG], config[CONF_FORMAT], *args_)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    return cg.new_Pvariable(
-        automation.use_stateless_lambda_if_applicable(
-            action_id, lambda_, StatelessLambdaAction
-        ),
-        template_arg,
-        lambda_,
+    return automation.new_lambda_pvariable(
+        action_id, lambda_, StatelessLambdaAction, template_arg
     )
 
 
@@ -461,12 +457,8 @@ async def logger_set_level_to_code(config, action_id, template_arg, args):
         text = str(cg.statement(logger.set_log_level(level)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    return cg.new_Pvariable(
-        automation.use_stateless_lambda_if_applicable(
-            action_id, lambda_, StatelessLambdaAction
-        ),
-        template_arg,
-        lambda_,
+    return automation.new_lambda_pvariable(
+        action_id, lambda_, StatelessLambdaAction, template_arg
     )
 
 

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -430,10 +430,13 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
     text = str(cg.statement(esp_log(config[CONF_TAG], config[CONF_FORMAT], *args_)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    action_id = automation.use_stateless_lambda_if_applicable(
-        action_id, lambda_, StatelessLambdaAction
+    return cg.new_Pvariable(
+        automation.use_stateless_lambda_if_applicable(
+            action_id, lambda_, StatelessLambdaAction
+        ),
+        template_arg,
+        lambda_,
     )
-    return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 
 @automation.register_action(
@@ -458,10 +461,13 @@ async def logger_set_level_to_code(config, action_id, template_arg, args):
         text = str(cg.statement(logger.set_log_level(level)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    action_id = automation.use_stateless_lambda_if_applicable(
-        action_id, lambda_, StatelessLambdaAction
+    return cg.new_Pvariable(
+        automation.use_stateless_lambda_if_applicable(
+            action_id, lambda_, StatelessLambdaAction
+        ),
+        template_arg,
+        lambda_,
     )
-    return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 
 FILTER_SOURCE_FILES = filter_source_files_from_platform(

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -1,7 +1,7 @@
 import re
 
 from esphome import automation
-from esphome.automation import LambdaAction
+from esphome.automation import LambdaAction, StatelessLambdaAction
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
 from esphome.components.esp32.const import (
@@ -430,6 +430,10 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
     text = str(cg.statement(esp_log(config[CONF_TAG], config[CONF_FORMAT], *args_)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
+    # Use optimized StatelessLambdaAction for lambdas with no capture
+    if lambda_.capture == "":
+        action_id = action_id.copy()
+        action_id.type = StatelessLambdaAction
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 
@@ -455,6 +459,10 @@ async def logger_set_level_to_code(config, action_id, template_arg, args):
         text = str(cg.statement(logger.set_log_level(level)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
+    # Use optimized StatelessLambdaAction for lambdas with no capture
+    if lambda_.capture == "":
+        action_id = action_id.copy()
+        action_id.type = StatelessLambdaAction
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -430,10 +430,9 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
     text = str(cg.statement(esp_log(config[CONF_TAG], config[CONF_FORMAT], *args_)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    # Use optimized StatelessLambdaAction for lambdas with no capture
-    if lambda_.capture == "":
-        action_id = action_id.copy()
-        action_id.type = StatelessLambdaAction
+    action_id = automation.use_stateless_lambda_if_applicable(
+        action_id, lambda_, StatelessLambdaAction
+    )
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 
@@ -459,10 +458,9 @@ async def logger_set_level_to_code(config, action_id, template_arg, args):
         text = str(cg.statement(logger.set_log_level(level)))
 
     lambda_ = await cg.process_lambda(Lambda(text), args, return_type=cg.void)
-    # Use optimized StatelessLambdaAction for lambdas with no capture
-    if lambda_.capture == "":
-        action_id = action_id.copy()
-        action_id.type = StatelessLambdaAction
+    action_id = automation.use_stateless_lambda_if_applicable(
+        action_id, lambda_, StatelessLambdaAction
+    )
     return cg.new_Pvariable(action_id, template_arg, lambda_)
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -574,10 +574,7 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(float, "x")], return_type=cg.optional.template(float)
     )
-    filter_id = automation.use_stateless_lambda_if_applicable(
-        filter_id, lambda_, StatelessLambdaFilter
-    )
-    return cg.new_Pvariable(filter_id, lambda_)
+    return automation.new_lambda_pvariable(filter_id, lambda_, StatelessLambdaFilter)
 
 
 DELTA_SCHEMA = cv.Schema(

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -574,10 +574,9 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(float, "x")], return_type=cg.optional.template(float)
     )
-    # Use optimized StatelessLambdaFilter for lambdas with no capture
-    if lambda_.capture == "":
-        filter_id = filter_id.copy()
-        filter_id.type = StatelessLambdaFilter
+    filter_id = automation.use_stateless_lambda_if_applicable(
+        filter_id, lambda_, StatelessLambdaFilter
+    )
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -261,6 +261,7 @@ ExponentialMovingAverageFilter = sensor_ns.class_(
 )
 ThrottleAverageFilter = sensor_ns.class_("ThrottleAverageFilter", Filter, cg.Component)
 LambdaFilter = sensor_ns.class_("LambdaFilter", Filter)
+StatelessLambdaFilter = sensor_ns.class_("StatelessLambdaFilter", Filter)
 OffsetFilter = sensor_ns.class_("OffsetFilter", Filter)
 MultiplyFilter = sensor_ns.class_("MultiplyFilter", Filter)
 ValueListFilter = sensor_ns.class_("ValueListFilter", Filter)
@@ -573,6 +574,10 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(float, "x")], return_type=cg.optional.template(float)
     )
+    # Use optimized StatelessLambdaFilter for lambdas with no capture
+    if lambda_.capture == "":
+        filter_id = filter_id.copy()
+        filter_id.type = StatelessLambdaFilter
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -296,6 +296,23 @@ class LambdaFilter : public Filter {
   lambda_filter_t lambda_filter_;
 };
 
+/** Optimized lambda filter for stateless lambdas (no capture).
+ *
+ * Uses function pointer instead of std::function to reduce memory overhead.
+ * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ */
+class StatelessLambdaFilter : public Filter {
+ public:
+  using stateless_lambda_filter_t = optional<float> (*)(float);
+
+  explicit StatelessLambdaFilter(stateless_lambda_filter_t lambda_filter) : lambda_filter_(lambda_filter) {}
+
+  optional<float> new_value(float value) override { return this->lambda_filter_(value); }
+
+ protected:
+  stateless_lambda_filter_t lambda_filter_;
+};
+
 /// A simple filter that adds `offset` to each value it receives.
 class OffsetFilter : public Filter {
  public:

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -299,7 +299,7 @@ class LambdaFilter : public Filter {
 /** Optimized lambda filter for stateless lambdas (no capture).
  *
  * Uses function pointer instead of std::function to reduce memory overhead.
- * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ * Memory: 4 bytes (function pointer on 32-bit) vs 32 bytes (std::function).
  */
 class StatelessLambdaFilter : public Filter {
  public:

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -303,14 +303,12 @@ class LambdaFilter : public Filter {
  */
 class StatelessLambdaFilter : public Filter {
  public:
-  using stateless_lambda_filter_t = optional<float> (*)(float);
-
-  explicit StatelessLambdaFilter(stateless_lambda_filter_t lambda_filter) : lambda_filter_(lambda_filter) {}
+  explicit StatelessLambdaFilter(optional<float> (*lambda_filter)(float)) : lambda_filter_(lambda_filter) {}
 
   optional<float> new_value(float value) override { return this->lambda_filter_(value); }
 
  protected:
-  stateless_lambda_filter_t lambda_filter_;
+  optional<float> (*lambda_filter_)(float);
 };
 
 /// A simple filter that adds `offset` to each value it receives.

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -57,6 +57,7 @@ validate_filters = cv.validate_registry("filter", FILTER_REGISTRY)
 # Filters
 Filter = text_sensor_ns.class_("Filter")
 LambdaFilter = text_sensor_ns.class_("LambdaFilter", Filter)
+StatelessLambdaFilter = text_sensor_ns.class_("StatelessLambdaFilter", Filter)
 ToUpperFilter = text_sensor_ns.class_("ToUpperFilter", Filter)
 ToLowerFilter = text_sensor_ns.class_("ToLowerFilter", Filter)
 AppendFilter = text_sensor_ns.class_("AppendFilter", Filter)
@@ -70,6 +71,10 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(cg.std_string, "x")], return_type=cg.optional.template(cg.std_string)
     )
+    # Use optimized StatelessLambdaFilter for lambdas with no capture
+    if lambda_.capture == "":
+        filter_id = filter_id.copy()
+        filter_id.type = StatelessLambdaFilter
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -71,10 +71,7 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(cg.std_string, "x")], return_type=cg.optional.template(cg.std_string)
     )
-    filter_id = automation.use_stateless_lambda_if_applicable(
-        filter_id, lambda_, StatelessLambdaFilter
-    )
-    return cg.new_Pvariable(filter_id, lambda_)
+    return automation.new_lambda_pvariable(filter_id, lambda_, StatelessLambdaFilter)
 
 
 @FILTER_REGISTRY.register("to_upper", ToUpperFilter, {})

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -71,10 +71,9 @@ async def lambda_filter_to_code(config, filter_id):
     lambda_ = await cg.process_lambda(
         config, [(cg.std_string, "x")], return_type=cg.optional.template(cg.std_string)
     )
-    # Use optimized StatelessLambdaFilter for lambdas with no capture
-    if lambda_.capture == "":
-        filter_id = filter_id.copy()
-        filter_id.type = StatelessLambdaFilter
+    filter_id = automation.use_stateless_lambda_if_applicable(
+        filter_id, lambda_, StatelessLambdaFilter
+    )
     return cg.new_Pvariable(filter_id, lambda_)
 
 

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -69,14 +69,12 @@ class LambdaFilter : public Filter {
  */
 class StatelessLambdaFilter : public Filter {
  public:
-  using stateless_lambda_filter_t = optional<std::string> (*)(std::string);
-
-  explicit StatelessLambdaFilter(stateless_lambda_filter_t lambda_filter) : lambda_filter_(lambda_filter) {}
+  explicit StatelessLambdaFilter(optional<std::string> (*lambda_filter)(std::string)) : lambda_filter_(lambda_filter) {}
 
   optional<std::string> new_value(std::string value) override { return this->lambda_filter_(value); }
 
  protected:
-  stateless_lambda_filter_t lambda_filter_;
+  optional<std::string> (*lambda_filter_)(std::string);
 };
 
 /// A simple filter that converts all text to uppercase

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -62,6 +62,23 @@ class LambdaFilter : public Filter {
   lambda_filter_t lambda_filter_;
 };
 
+/** Optimized lambda filter for stateless lambdas (no capture).
+ *
+ * Uses function pointer instead of std::function to reduce memory overhead.
+ * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ */
+class StatelessLambdaFilter : public Filter {
+ public:
+  using stateless_lambda_filter_t = optional<std::string> (*)(std::string);
+
+  explicit StatelessLambdaFilter(stateless_lambda_filter_t lambda_filter) : lambda_filter_(lambda_filter) {}
+
+  optional<std::string> new_value(std::string value) override { return this->lambda_filter_(value); }
+
+ protected:
+  stateless_lambda_filter_t lambda_filter_;
+};
+
 /// A simple filter that converts all text to uppercase
 class ToUpperFilter : public Filter {
  public:

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -65,7 +65,7 @@ class LambdaFilter : public Filter {
 /** Optimized lambda filter for stateless lambdas (no capture).
  *
  * Uses function pointer instead of std::function to reduce memory overhead.
- * Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+ * Memory: 4 bytes (function pointer on 32-bit) vs 32 bytes (std::function).
  */
 class StatelessLambdaFilter : public Filter {
  public:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -79,6 +79,18 @@ template<typename... Ts> class LambdaCondition : public Condition<Ts...> {
   std::function<bool(Ts...)> f_;
 };
 
+/// Optimized lambda condition for stateless lambdas (no capture).
+/// Uses function pointer instead of std::function to reduce memory overhead.
+/// Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+template<typename... Ts> class StatelessLambdaCondition : public Condition<Ts...> {
+ public:
+  explicit StatelessLambdaCondition(bool (*f)(Ts...)) : f_(f) {}
+  bool check(Ts... x) override { return this->f_(x...); }
+
+ protected:
+  bool (*f_)(Ts...);
+};
+
 template<typename... Ts> class ForCondition : public Condition<Ts...>, public Component {
  public:
   explicit ForCondition(Condition<> *condition) : condition_(condition) {}
@@ -188,6 +200,19 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
 
  protected:
   std::function<void(Ts...)> f_;
+};
+
+/// Optimized lambda action for stateless lambdas (no capture).
+/// Uses function pointer instead of std::function to reduce memory overhead.
+/// Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
+ public:
+  explicit StatelessLambdaAction(void (*f)(Ts...)) : f_(f) {}
+
+  void play(Ts... x) override { this->f_(x...); }
+
+ protected:
+  void (*f_)(Ts...);
 };
 
 template<typename... Ts> class IfAction : public Action<Ts...> {

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -81,7 +81,7 @@ template<typename... Ts> class LambdaCondition : public Condition<Ts...> {
 
 /// Optimized lambda condition for stateless lambdas (no capture).
 /// Uses function pointer instead of std::function to reduce memory overhead.
-/// Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+/// Memory: 4 bytes (function pointer on 32-bit) vs 32 bytes (std::function).
 template<typename... Ts> class StatelessLambdaCondition : public Condition<Ts...> {
  public:
   explicit StatelessLambdaCondition(bool (*f)(Ts...)) : f_(f) {}
@@ -204,7 +204,7 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
 
 /// Optimized lambda action for stateless lambdas (no capture).
 /// Uses function pointer instead of std::function to reduce memory overhead.
-/// Memory: 8 bytes (function pointer) vs 32 bytes (std::function).
+/// Memory: 4 bytes (function pointer on 32-bit) vs 32 bytes (std::function).
 template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
  public:
   explicit StatelessLambdaAction(void (*f)(Ts...)) : f_(f) {}

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -198,10 +198,9 @@ class LambdaExpression(Expression):
         self.return_type = safe_exp(return_type) if return_type is not None else None
 
     def __str__(self):
-        # Unary + converts stateless lambda to function pointer
-        # This allows implicit conversion to void (*)() or bool (*)()
-        prefix = "+" if self.capture == "" else ""
-        cpp = f"{prefix}[{self.capture}]({self.parameters})"
+        # Stateless lambdas (empty capture) implicitly convert to function pointers
+        # when assigned to function pointer types - no unary + needed
+        cpp = f"[{self.capture}]({self.parameters})"
         if self.return_type is not None:
             cpp += f" -> {self.return_type}"
         cpp += " {\n"

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -198,7 +198,10 @@ class LambdaExpression(Expression):
         self.return_type = safe_exp(return_type) if return_type is not None else None
 
     def __str__(self):
-        cpp = f"[{self.capture}]({self.parameters})"
+        # Unary + converts stateless lambda to function pointer
+        # This allows implicit conversion to void (*)() or bool (*)()
+        prefix = "+" if self.capture == "" else ""
+        cpp = f"{prefix}[{self.capture}]({self.parameters})"
         if self.return_type is not None:
             cpp += f" -> {self.return_type}"
         cpp += " {\n"
@@ -699,6 +702,12 @@ async def process_lambda(
         else:
             parts[i * 3 + 1] = var
         parts[i * 3 + 2] = ""
+
+    # All id() references are global variables in generated C++ code.
+    # Global variables should not be captured - they're accessible everywhere.
+    # Use empty capture instead of capture-by-value.
+    if capture == "=":
+        capture = ""
 
     if isinstance(value, ESPHomeDataBase) and value.esp_range is not None:
         location = value.esp_range.start_mark

--- a/tests/component_tests/text/test_text.py
+++ b/tests/component_tests/text/test_text.py
@@ -58,7 +58,7 @@ def test_text_config_value_mode_set(generate_main):
 
 def test_text_config_lamda_is_set(generate_main):
     """
-    Test if lambda is set for lambda mode
+    Test if lambda is set for lambda mode (optimized with stateless lambda)
     """
     # Given
 
@@ -66,5 +66,5 @@ def test_text_config_lamda_is_set(generate_main):
     main_cpp = generate_main("tests/component_tests/text/test_text.yaml")
 
     # Then
-    assert "it_4->set_template([=]() -> esphome::optional<std::string> {" in main_cpp
+    assert "it_4->set_template(+[]() -> esphome::optional<std::string> {" in main_cpp
     assert 'return std::string{"Hello"};' in main_cpp

--- a/tests/component_tests/text/test_text.py
+++ b/tests/component_tests/text/test_text.py
@@ -66,5 +66,5 @@ def test_text_config_lamda_is_set(generate_main):
     main_cpp = generate_main("tests/component_tests/text/test_text.yaml")
 
     # Then
-    assert "it_4->set_template(+[]() -> esphome::optional<std::string> {" in main_cpp
+    assert "it_4->set_template([]() -> esphome::optional<std::string> {" in main_cpp
     assert 'return std::string{"Hello"};' in main_cpp

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -174,7 +174,7 @@ class TestLambdaExpression:
         )
 
     def test_str__stateless_no_return(self):
-        """Test stateless lambda (empty capture) gets unary + prefix"""
+        """Test stateless lambda (empty capture) generates correctly"""
         target = cg.LambdaExpression(
             ('ESP_LOGD("main", "Test message");',),
             (),  # No parameters
@@ -183,10 +183,10 @@ class TestLambdaExpression:
 
         actual = str(target)
 
-        assert actual == ('+[]() {\n  ESP_LOGD("main", "Test message");\n}')
+        assert actual == ('[]() {\n  ESP_LOGD("main", "Test message");\n}')
 
     def test_str__stateless_with_return(self):
-        """Test stateless lambda with return type gets unary + prefix"""
+        """Test stateless lambda with return type generates correctly"""
         target = cg.LambdaExpression(
             ("return global_value > 0;",),
             (),  # No parameters
@@ -196,10 +196,10 @@ class TestLambdaExpression:
 
         actual = str(target)
 
-        assert actual == ("+[]() -> bool {\n  return global_value > 0;\n}")
+        assert actual == ("[]() -> bool {\n  return global_value > 0;\n}")
 
     def test_str__stateless_with_params(self):
-        """Test stateless lambda with parameters gets unary + prefix"""
+        """Test stateless lambda with parameters generates correctly"""
         target = cg.LambdaExpression(
             ("return foo + bar;",),
             ((int, "foo"), (float, "bar")),
@@ -210,11 +210,11 @@ class TestLambdaExpression:
         actual = str(target)
 
         assert actual == (
-            "+[](int32_t foo, float bar) -> float {\n  return foo + bar;\n}"
+            "[](int32_t foo, float bar) -> float {\n  return foo + bar;\n}"
         )
 
-    def test_str__with_capture_no_prefix(self):
-        """Test lambda with capture (not stateless) does NOT get + prefix"""
+    def test_str__with_capture(self):
+        """Test lambda with capture generates correctly"""
         target = cg.LambdaExpression(
             ("return captured_var + x;",),
             ((int, "x"),),
@@ -224,11 +224,9 @@ class TestLambdaExpression:
 
         actual = str(target)
 
-        # Should NOT have + prefix
         assert actual == (
             "[captured_var](int32_t x) -> int32_t {\n  return captured_var + x;\n}"
         )
-        assert not actual.startswith("+")
 
 
 class TestLiterals:

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -213,6 +213,23 @@ class TestLambdaExpression:
             "+[](int32_t foo, float bar) -> float {\n  return foo + bar;\n}"
         )
 
+    def test_str__with_capture_no_prefix(self):
+        """Test lambda with capture (not stateless) does NOT get + prefix"""
+        target = cg.LambdaExpression(
+            ("return captured_var + x;",),
+            ((int, "x"),),
+            "captured_var",  # Has capture (not stateless)
+            int,
+        )
+
+        actual = str(target)
+
+        # Should NOT have + prefix
+        assert actual == (
+            "[captured_var](int32_t x) -> int32_t {\n  return captured_var + x;\n}"
+        )
+        assert not actual.startswith("+")
+
 
 class TestLiterals:
     @pytest.mark.parametrize(

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -173,6 +173,46 @@ class TestLambdaExpression:
             "}"
         )
 
+    def test_str__stateless_no_return(self):
+        """Test stateless lambda (empty capture) gets unary + prefix"""
+        target = cg.LambdaExpression(
+            ('ESP_LOGD("main", "Test message");',),
+            (),  # No parameters
+            "",  # Empty capture (stateless)
+        )
+
+        actual = str(target)
+
+        assert actual == ('+[]() {\n  ESP_LOGD("main", "Test message");\n}')
+
+    def test_str__stateless_with_return(self):
+        """Test stateless lambda with return type gets unary + prefix"""
+        target = cg.LambdaExpression(
+            ("return global_value > 0;",),
+            (),  # No parameters
+            "",  # Empty capture (stateless)
+            bool,  # Return type
+        )
+
+        actual = str(target)
+
+        assert actual == ("+[]() -> bool {\n  return global_value > 0;\n}")
+
+    def test_str__stateless_with_params(self):
+        """Test stateless lambda with parameters gets unary + prefix"""
+        target = cg.LambdaExpression(
+            ("return foo + bar;",),
+            ((int, "foo"), (float, "bar")),
+            "",  # Empty capture (stateless)
+            float,
+        )
+
+        actual = str(target)
+
+        assert actual == (
+            "+[](int32_t foo, float bar) -> float {\n  return foo + bar;\n}"
+        )
+
 
 class TestLiterals:
     @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this implement/fix?

Eliminates unnecessary `std::function` overhead from YAML-generated lambda actions, conditions, and filters by using function pointers instead, **reducing memory by at least 28 bytes RAM per lambda** (std::function object minus function pointer) and ~48 bytes Flash per lambda on 32-bit platforms.

## Key Insight

**All YAML-generated lambdas are naturally stateless** because all `id()` references become global variables. The previous `[=]` capture-by-value was capturing nothing while paying 28+ bytes overhead per lambda (minimum: std::function object 32 bytes - function pointer 4 bytes). This PR eliminates that waste.

## Overview

ESPHome generates lambdas from YAML for actions, conditions, and filters. Since all `id()` references are globals, none of these YAML-generated lambdas need capture. This PR:

1. **Converts `[=]` to `[]`** - Empty capture (no capture needed)
2. **Uses lightweight classes** - `StatelessLambdaAction`, `StatelessLambdaCondition`, and `StatelessLambdaFilter`
3. **Implicit conversion to function pointers** - C++11 automatically converts stateless lambdas to function pointers
4. **100% optimization rate** - Every YAML action/condition/filter lambda in tested configs uses function pointers

## Changes

### Core Framework

**esphome/cpp_generator.py**
- Changed default capture from `"="` to `""` (empty capture)
- Stateless lambdas implicitly convert to function pointers when passed to function pointer parameters

**esphome/core/base_automation.h**
- Added `StatelessLambdaAction<Ts...>` using `void (*f_)(Ts...)` (4 bytes on 32-bit)
- Added `StatelessLambdaCondition<Ts...>` using `bool (*f_)(Ts...)` (4 bytes on 32-bit)
- Old classes remain for backward compatibility (zero runtime cost)

**esphome/automation.py**
- Added `new_lambda_pvariable()` helper with full type annotations
- Automatically selects stateless class when `lambda_expr.capture == ""`
- Eliminates code duplication across all lambda handlers

### Component Updates

**Filter Classes** (sensor, text_sensor, binary_sensor)
- Added `StatelessLambdaFilter` using function pointers (4 bytes on 32-bit):
  - `optional<float> (*)(float)` for sensors
  - `optional<std::string> (*)(std::string)` for text sensors
  - `optional<bool> (*)(bool)` for binary sensors
- Function pointer types inlined directly (no type aliases)

**Python Code** (sensor, text_sensor, binary_sensor, logger)
- Updated `lambda_filter_to_code()` to use `new_lambda_pvariable()` helper
- Updated `logger_log_action_to_code()` to use `new_lambda_pvariable()` helper
- Updated `logger_set_level_to_code()` to use `new_lambda_pvariable()` helper

### Tests

**tests/unit_tests/test_cpp_generator.py**
- Added 4 tests: 3 for stateless lambda generation (no return, with return, with params) + 1 for capture case

**tests/component_tests/text/test_text.py**
- Updated to expect optimized format: `[]()` instead of `[=]()`

## Memory Savings

**Test Config: apollo-pump-1-5d9bdc.yaml (ESP32-C6)**
- **YAML lambdas optimized:** 20/20 (4 conditions + 16 actions)
- **Flash saved:** 966 bytes
- **Optimization rate:** 100% (all YAML actions/conditions)

**Test Config: athom-smart-plug-v3.yaml (ESP32-C3)**
- **YAML lambdas optimized:** 7/7 (3 filters + 4 actions/conditions)
- **Optimization rate:** 100% (all YAML actions/conditions/filters)

**Per-Lambda Savings:**
- ~48 bytes Flash (measured average from apollo-pump config: 966 bytes / 20 lambdas)
- **At least 28 bytes RAM** (guaranteed minimum: std::function object 32 bytes - function pointer 4 bytes)
  - Actual heap savings vary significantly by configuration, platform, and compiler optimizations
  - Conservative estimate uses theoretical minimum

**Scalability (Conservative Estimate):**
- Based on minimum 28 bytes RAM + 48 bytes Flash per lambda:
- 10 lambdas: ~480 bytes Flash, ~280 bytes RAM
- 20 lambdas: ~966 bytes Flash (measured), ~560 bytes RAM
- 40 lambdas: ~1.9 KB Flash, ~1.1 KB RAM
- 80 lambdas: ~3.8 KB Flash, ~2.2 KB RAM

**Note:** RAM savings are theoretical minimums. Actual heap impact varies by configuration.

## Technical Details

### Why YAML-Generated Lambdas Are Stateless

All `id()` references in YAML become global variables during code generation:
```cpp
// Generated at top of main.cpp
status::StatusBinarySensor *ink_ha_connected;
switch_::Switch *switch_pump;
sensor::Sensor *battery_voltage;

// YAML lambda can access without capture
[]() -> bool {
    return ink_ha_connected->state;  // Global variable - no capture needed!
}
```

**Note:** C++ component code can still use lambdas with capture (e.g., `[this]`) when needed - those correctly use `std::function` and are not optimized by this PR.

### Before/After Comparison

**Before (unnecessary overhead):**
```cpp
lambdaaction_id = new LambdaAction<>([=]() -> void {
    ESP_LOGD("main", "Pump: %s", id(switch_pump)->state ? "ON" : "OFF");
});
// Uses std::function: 32 bytes + type erasure + virtual dispatch
```

**After (optimized):**
```cpp
lambdaaction_id = new StatelessLambdaAction<>([]() -> void {
    ESP_LOGD("main", "Pump: %s", switch_pump->state ? "ON" : "OFF");
});
// Stateless lambda implicitly converts to function pointer: 4 bytes (32-bit) + direct call
```

### Code Quality

**Zero Duplication:**
- All 7 lambda handler call sites use single `new_lambda_pvariable()` helper
- Fully typed with proper annotations for IDE support
- Logic inlined directly (no intermediate helper functions)

**Zero Runtime Cost:**
- Old `LambdaAction`, `LambdaCondition`, `LambdaFilter` classes remain in headers
- Uninstantiated templates generate no code
- Compiler eliminates unused template specializations
- Backward compatible for any custom components

**Clean Implementation:**
- Function pointer types inlined in filter classes (no type aliases)
- Helper function handles both actions/conditions (with template_arg) and filters (without)
- Consistent pattern across all lambda types

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (performance optimization - eliminates unnecessary overhead)

**Related issue or feature (if applicable):**
- N/A (proactive optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

Note: All platforms use C++11 lambda-to-function-pointer conversion (standard feature)

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - optimization is automatic

# Examples of YAML lambdas that get optimized (100% of these use cases):

# 1. Lambda actions - ✅ OPTIMIZED
on_...:
  then:
    - lambda: |-
        ESP_LOGD("main", "State: %d", id(my_sensor).state);

# 2. Lambda conditions - ✅ OPTIMIZED
on_...:
  if:
    condition:
      lambda: 'return id(binary_sensor_id).state;'
    then:
      - logger.log: "Condition met"

# 3. Lambda filters (all three types) - ✅ OPTIMIZED
sensor:
  - platform: template
    filters:
      - lambda: 'return x * 2.0;'

text_sensor:
  - platform: template
    filters:
      - lambda: 'return x + " suffix";'

binary_sensor:
  - platform: template
    filters:
      - lambda: 'return !x;'

# 4. Light effects - ❌ NOT OPTIMIZED (future work)
light:
  - platform: ...
    effects:
      - addressable_lambda:
          name: "Custom Effect"
          update_interval: 16ms
          lambda: |-
            # Uses std::function (different API, not included in this PR)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes

## Additional Notes

### Why This Works

**C++11 Standard Feature:**
- Stateless lambdas (empty capture `[]`) implicitly convert to function pointers
- Conversion happens automatically when assigned to function pointer types
- Supported on all ESPHome platforms (ESP32, ESP8266, RP2040, etc.)

**Compile-Time Safety:**
- If capture were actually needed, compiler would reject the conversion
- Fail-safe design - won't compile if unsafe
- No runtime checks needed

### Impact Analysis

**Tested Configurations:**
- apollo-pump (ESP32-C6): 20/20 YAML lambdas optimized = 100%
- athom-smart-plug (ESP32-C3): 7/7 YAML lambdas optimized = 100%
- **Finding:** No YAML-generated actions/conditions/filters in real configs needed capture

**Why 100% Optimization Rate for YAML Lambdas:**
- All `id()` references are converted to globals during code generation
- Filter parameters come via function args, not capture
- Users write lambda bodies as strings - no capture syntax available

**What Is NOT Optimized:**
- **Light effects** (e.g., `addressable_lambda`) - Use `std::function` (different API, future optimization possible)
- **C++ component code** - Lambdas in component headers can use capture (e.g., `[this]`) when needed

### What Was Being Wasted

**Before this PR:**
```cpp
std::function<void()>  // 32-byte object on 32-bit platforms
- Type erasure overhead
- Virtual function table
- Allocator support (even when unused)
- Copy/move semantics infrastructure
```

**After this PR:**
```cpp
void (*)()  // 4 bytes per lambda (32-bit platforms)
- Direct function pointer
- Direct call (no virtual dispatch)
- No allocator
- Minimal overhead
```

**Bottom Line:** We were paying at least 28 bytes per lambda (32 - 4 bytes) to capture variables that didn't exist.
