### PR TITLE
[network] Eliminate runtime string parsing for IP address initialization

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -14,7 +14,7 @@ from esphome.components.esp32.const import (
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
 )
-from esphome.components.network import IPAddress
+from esphome.components.network import ip_address_literal
 from esphome.components.spi import CONF_INTERFACE_INDEX, get_spi_interface
 import esphome.config_validation as cv
 from esphome.const import (
@@ -320,11 +320,11 @@ def _final_validate_spi(config):
 def manual_ip(config):
     return cg.StructInitializer(
         ManualIP,
-        ("static_ip", IPAddress(str(config[CONF_STATIC_IP]))),
-        ("gateway", IPAddress(str(config[CONF_GATEWAY]))),
-        ("subnet", IPAddress(str(config[CONF_SUBNET]))),
-        ("dns1", IPAddress(str(config[CONF_DNS1]))),
-        ("dns2", IPAddress(str(config[CONF_DNS2]))),
+        ("static_ip", ip_address_literal(config[CONF_STATIC_IP])),
+        ("gateway", ip_address_literal(config[CONF_GATEWAY])),
+        ("subnet", ip_address_literal(config[CONF_SUBNET])),
+        ("dns1", ip_address_literal(config[CONF_DNS1])),
+        ("dns2", ip_address_literal(config[CONF_DNS2])),
     )
 
 

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -1,3 +1,5 @@
+import ipaddress
+
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
 import esphome.config_validation as cv
@@ -9,6 +11,41 @@ AUTO_LOAD = ["mdns"]
 
 network_ns = cg.esphome_ns.namespace("network")
 IPAddress = network_ns.class_("IPAddress")
+
+
+def ip_address_literal(ip: str | None) -> cg.MockObj:
+    """Generate an IPAddress with compile-time initialization instead of runtime parsing.
+
+    This function parses the IP address in Python during code generation and generates
+    a call to the 4-octet constructor (IPAddress(192, 168, 1, 1)) instead of the
+    string constructor (IPAddress("192.168.1.1")). This eliminates runtime string
+    parsing overhead and reduces flash usage on embedded systems.
+
+    Args:
+        ip: IP address as string (e.g., "192.168.1.1"), ipaddress.IPv4Address, or None
+
+    Returns:
+        IPAddress expression that uses 4-octet constructor for efficiency
+    """
+    if ip is None:
+        return IPAddress(0, 0, 0, 0)
+
+    try:
+        # Parse using Python's ipaddress module
+        ip_obj = ipaddress.ip_address(str(ip))
+    except (ValueError, TypeError):
+        pass
+    else:
+        # Only support IPv4 for now
+        if isinstance(ip_obj, ipaddress.IPv4Address):
+            # Extract octets from the packed bytes representation
+            octets = ip_obj.packed
+            # Generate call to 4-octet constructor: IPAddress(192, 168, 1, 1)
+            return IPAddress(octets[0], octets[1], octets[2], octets[3])
+
+    # Fallback to string constructor if parsing fails
+    return IPAddress(str(ip))
+
 
 CONFIG_SCHEMA = cv.Schema(
     {

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -13,7 +13,7 @@ network_ns = cg.esphome_ns.namespace("network")
 IPAddress = network_ns.class_("IPAddress")
 
 
-def ip_address_literal(ip: str | None) -> cg.MockObj:
+def ip_address_literal(ip: str | int | None) -> cg.MockObj:
     """Generate an IPAddress with compile-time initialization instead of runtime parsing.
 
     This function parses the IP address in Python during code generation and generates
@@ -32,7 +32,7 @@ def ip_address_literal(ip: str | None) -> cg.MockObj:
 
     try:
         # Parse using Python's ipaddress module
-        ip_obj = ipaddress.ip_address(str(ip))
+        ip_obj = ipaddress.ip_address(ip)
     except (ValueError, TypeError):
         pass
     else:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -3,7 +3,7 @@ from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
-from esphome.components.network import IPAddress
+from esphome.components.network import ip_address_literal
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.config_validation import only_with_esp_idf
@@ -334,9 +334,7 @@ def eap_auth(config):
 
 
 def safe_ip(ip):
-    if ip is None:
-        return IPAddress(0, 0, 0, 0)
-    return IPAddress(str(ip))
+    return ip_address_literal(ip)
 
 
 def manual_ip(config):


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes IP address initialization by eliminating runtime string parsing. Instead of generating code like `IPAddress("192.168.1.100")`, ESPHome now generates `IPAddress(192, 168, 1, 100)` using the existing 4-octet constructor.

**Benefits:**
- **Eliminates runtime string parsing overhead** - IP addresses are now compile-time constants
- **Reduces flash usage** - removes string literals and avoids including parsing code when not needed elsewhere
- **Saves RAM on ESP8266** - critical improvement for resource-constrained devices (~110 bytes per config with multiple manual IPs)
- **Faster initialization** - direct integer assignment instead of string parsing loops

The optimization is implemented purely in Python code generation using a new `ip_address_literal()` helper that parses IP addresses at compile time using Python's `ipaddress` module.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No configuration changes - this is purely an optimization of generated code.

**Example WiFi config with manual IP:**
```yaml
wifi:
  ssid: "MySSID"
  password: "MyPassword"
  manual_ip:
    static_ip: 192.168.1.100
    gateway: 192.168.1.1
    subnet: 255.255.255.0
    dns1: 8.8.8.8
    dns2: 8.8.4.4
```

**Generated code before:**
```cpp
wifi_wifiap.set_manual_ip(wifi::ManualIP{
    .static_ip = network::IPAddress("192.168.1.100"),  // Runtime string parsing
    .gateway = network::IPAddress("192.168.1.1"),
    .subnet = network::IPAddress("255.255.255.0"),
    .dns1 = network::IPAddress("8.8.8.8"),
    .dns2 = network::IPAddress("8.8.4.4"),
});
```

**Generated code after:**
```cpp
wifi_wifiap.set_manual_ip(wifi::ManualIP{
    .static_ip = network::IPAddress(192, 168, 1, 100),  // Compile-time constants
    .gateway = network::IPAddress(192, 168, 1, 1),
    .subnet = network::IPAddress(255, 255, 255, 0),
    .dns1 = network::IPAddress(8, 8, 8, 8),
    .dns2 = network::IPAddress(8, 8, 4, 4),
});
```