### PR TITLE
[modbus_controller] Optimize lambdas to use function pointers instead of std::function

### DIFF
--- a/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
+++ b/esphome/components/modbus_controller/binary_sensor/modbus_binarysensor.h
@@ -33,8 +33,8 @@ class ModbusBinarySensor : public Component, public binary_sensor::BinarySensor,
 
   void dump_config() override;
 
-  using transform_func_t = std::function<optional<bool>(ModbusBinarySensor *, bool, const std::vector<uint8_t> &)>;
-  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
+  using transform_func_t = optional<bool> (*)(ModbusBinarySensor *, bool, const std::vector<uint8_t> &);
+  void set_template(transform_func_t f) { this->transform_func_ = f; }
 
  protected:
   optional<transform_func_t> transform_func_{nullopt};

--- a/esphome/components/modbus_controller/number/modbus_number.h
+++ b/esphome/components/modbus_controller/number/modbus_number.h
@@ -31,10 +31,10 @@ class ModbusNumber : public number::Number, public Component, public SensorItem 
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
   void set_write_multiply(float factor) { this->multiply_by_ = factor; }
 
-  using transform_func_t = std::function<optional<float>(ModbusNumber *, float, const std::vector<uint8_t> &)>;
-  using write_transform_func_t = std::function<optional<float>(ModbusNumber *, float, std::vector<uint16_t> &)>;
-  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
-  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  using transform_func_t = optional<float> (*)(ModbusNumber *, float, const std::vector<uint8_t> &);
+  using write_transform_func_t = optional<float> (*)(ModbusNumber *, float, std::vector<uint16_t> &);
+  void set_template(transform_func_t f) { this->transform_func_ = f; }
+  void set_write_template(write_transform_func_t f) { this->write_transform_func_ = f; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -29,8 +29,8 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
   // Do nothing
   void parse_and_publish(const std::vector<uint8_t> &data) override{};
 
-  using write_transform_func_t = std::function<optional<float>(ModbusFloatOutput *, float, std::vector<uint16_t> &)>;
-  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  using write_transform_func_t = optional<float> (*)(ModbusFloatOutput *, float, std::vector<uint16_t> &);
+  void set_write_template(write_transform_func_t f) { this->write_transform_func_ = f; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:
@@ -60,8 +60,8 @@ class ModbusBinaryOutput : public output::BinaryOutput, public Component, public
   // Do nothing
   void parse_and_publish(const std::vector<uint8_t> &data) override{};
 
-  using write_transform_func_t = std::function<optional<bool>(ModbusBinaryOutput *, bool, std::vector<uint8_t> &)>;
-  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  using write_transform_func_t = optional<bool> (*)(ModbusBinaryOutput *, bool, std::vector<uint8_t> &);
+  void set_write_template(write_transform_func_t f) { this->write_transform_func_ = f; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:

--- a/esphome/components/modbus_controller/select/modbus_select.h
+++ b/esphome/components/modbus_controller/select/modbus_select.h
@@ -26,16 +26,15 @@ class ModbusSelect : public Component, public select::Select, public SensorItem 
     this->mapping_ = std::move(mapping);
   }
 
-  using transform_func_t =
-      std::function<optional<std::string>(ModbusSelect *const, int64_t, const std::vector<uint8_t> &)>;
-  using write_transform_func_t =
-      std::function<optional<int64_t>(ModbusSelect *const, const std::string &, int64_t, std::vector<uint16_t> &)>;
+  using transform_func_t = optional<std::string> (*)(ModbusSelect *const, int64_t, const std::vector<uint8_t> &);
+  using write_transform_func_t = optional<int64_t> (*)(ModbusSelect *const, const std::string &, int64_t,
+                                                       std::vector<uint16_t> &);
 
   void set_parent(ModbusController *const parent) { this->parent_ = parent; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
-  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  void set_template(transform_func_t f) { this->transform_func_ = f; }
+  void set_write_template(write_transform_func_t f) { this->write_transform_func_ = f; }
 
   void dump_config() override;
   void parse_and_publish(const std::vector<uint8_t> &data) override;

--- a/esphome/components/modbus_controller/sensor/modbus_sensor.h
+++ b/esphome/components/modbus_controller/sensor/modbus_sensor.h
@@ -25,9 +25,9 @@ class ModbusSensor : public Component, public sensor::Sensor, public SensorItem 
 
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   void dump_config() override;
-  using transform_func_t = std::function<optional<float>(ModbusSensor *, float, const std::vector<uint8_t> &)>;
+  using transform_func_t = optional<float> (*)(ModbusSensor *, float, const std::vector<uint8_t> &);
 
-  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
+  void set_template(transform_func_t f) { this->transform_func_ = f; }
 
  protected:
   optional<transform_func_t> transform_func_{nullopt};

--- a/esphome/components/modbus_controller/switch/modbus_switch.h
+++ b/esphome/components/modbus_controller/switch/modbus_switch.h
@@ -34,10 +34,10 @@ class ModbusSwitch : public Component, public switch_::Switch, public SensorItem
   void parse_and_publish(const std::vector<uint8_t> &data) override;
   void set_parent(ModbusController *parent) { this->parent_ = parent; }
 
-  using transform_func_t = std::function<optional<bool>(ModbusSwitch *, bool, const std::vector<uint8_t> &)>;
-  using write_transform_func_t = std::function<optional<bool>(ModbusSwitch *, bool, std::vector<uint8_t> &)>;
-  void set_template(transform_func_t &&f) { this->publish_transform_func_ = f; }
-  void set_write_template(write_transform_func_t &&f) { this->write_transform_func_ = f; }
+  using transform_func_t = optional<bool> (*)(ModbusSwitch *, bool, const std::vector<uint8_t> &);
+  using write_transform_func_t = optional<bool> (*)(ModbusSwitch *, bool, std::vector<uint8_t> &);
+  void set_template(transform_func_t f) { this->publish_transform_func_ = f; }
+  void set_write_template(write_transform_func_t f) { this->write_transform_func_ = f; }
   void set_use_write_mutiple(bool use_write_multiple) { this->use_write_multiple_ = use_write_multiple; }
 
  protected:

--- a/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
+++ b/esphome/components/modbus_controller/text_sensor/modbus_textsensor.h
@@ -30,9 +30,8 @@ class ModbusTextSensor : public Component, public text_sensor::TextSensor, publi
   void dump_config() override;
 
   void parse_and_publish(const std::vector<uint8_t> &data) override;
-  using transform_func_t =
-      std::function<optional<std::string>(ModbusTextSensor *, std::string, const std::vector<uint8_t> &)>;
-  void set_template(transform_func_t &&f) { this->transform_func_ = f; }
+  using transform_func_t = optional<std::string> (*)(ModbusTextSensor *, std::string, const std::vector<uint8_t> &);
+  void set_template(transform_func_t f) { this->transform_func_ = f; }
 
  protected:
   optional<transform_func_t> transform_func_{nullopt};

--- a/tests/components/modbus_controller/common.yaml
+++ b/tests/components/modbus_controller/common.yaml
@@ -56,6 +56,14 @@ binary_sensor:
     register_type: read
     address: 0x3200
     bitmask: 0x80
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_binary_sensor2
+    name: Test Binary Sensor with Lambda
+    register_type: read
+    address: 0x3201
+    lambda: |-
+      return x;
 
 number:
   - platform: modbus_controller
@@ -65,6 +73,16 @@ number:
     address: 0x9001
     value_type: U_WORD
     multiply: 1.0
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_number2
+    name: Test Number with Lambda
+    address: 0x9002
+    value_type: U_WORD
+    lambda: |-
+      return x * 2.0;
+    write_lambda: |-
+      return x / 2.0;
 
 output:
   - platform: modbus_controller
@@ -74,6 +92,14 @@ output:
     register_type: holding
     value_type: U_WORD
     multiply: 1000
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_output2
+    address: 2049
+    register_type: holding
+    value_type: U_WORD
+    write_lambda: |-
+      return x * 100.0;
 
 select:
   - platform: modbus_controller
@@ -87,6 +113,34 @@ select:
       "One": 1
       "Two": 2
       "Three": 3
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_select2
+    name: Test Select with Lambda
+    address: 1001
+    value_type: U_WORD
+    optionsmap:
+      "Off": 0
+      "On": 1
+      "Two": 2
+    lambda: |-
+      ESP_LOGD("Reg1001", "Received value %lld", x);
+      if (x > 1) {
+        return std::string("Two");
+      } else if (x == 1) {
+        return std::string("On");
+      }
+      return std::string("Off");
+    write_lambda: |-
+      ESP_LOGD("Reg1001", "Set option to %s (%lld)", x.c_str(), value);
+      if (x == "On") {
+        return 1;
+      }
+      if (x == "Two") {
+        payload.push_back(0x0002);
+        return 0;
+      }
+      return value;
 
 sensor:
   - platform: modbus_controller
@@ -97,6 +151,15 @@ sensor:
     address: 0x9001
     unit_of_measurement: "AH"
     value_type: U_WORD
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_sensor2
+    name: Test Sensor with Lambda
+    register_type: holding
+    address: 0x9002
+    value_type: U_WORD
+    lambda: |-
+      return x / 10.0;
 
 switch:
   - platform: modbus_controller
@@ -106,6 +169,16 @@ switch:
     register_type: coil
     address: 0x15
     bitmask: 1
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_switch2
+    name: Test Switch with Lambda
+    register_type: coil
+    address: 0x16
+    lambda: |-
+      return !x;
+    write_lambda: |-
+      return !x;
 
 text_sensor:
   - platform: modbus_controller
@@ -117,3 +190,13 @@ text_sensor:
     register_count: 3
     raw_encode: HEXBYTES
     response_size: 6
+  - platform: modbus_controller
+    modbus_controller_id: modbus_controller1
+    id: modbus_text_sensor2
+    name: Test Text Sensor with Lambda
+    register_type: holding
+    address: 0x9014
+    register_count: 2
+    response_size: 4
+    lambda: |-
+      return "Modified: " + x;


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `modbus_controller` components to use function pointers instead of `std::function` for lambda transforms, reducing memory overhead for configurations that use lambdas.

## Background

ESPHome YAML lambdas are stateless (they don't capture variables), making them candidates for function pointers instead of the heavier `std::function`. This PR replaces `optional<std::function<...>>` with `optional<FunctionPointer>` for all modbus_controller transform lambdas.

## Changes

Updated 8 modbus_controller component types with 11 transform functions total:

- **ModbusSensor** - read transform
- **ModbusBinarySensor** - read transform
- **ModbusNumber** - read + write transforms
- **ModbusSwitch** - read + write transforms
- **ModbusTextSensor** - read transform
- **ModbusSelect** - read + write transforms
- **ModbusFloatOutput** - write transform
- **ModbusBinaryOutput** - write transform

## Memory Impact

- **std::function**: 32 bytes (function pointer + type erasure overhead + allocator)
- **Function pointer**: 4 bytes
- **Savings**: 28 bytes per lambda transform

For configurations using modbus lambdas, this reduces flash size by ~28 bytes per transform function used.

## Technical Details

Pattern used:

```cpp
// Before
using transform_func_t = std::function<optional<float>(Component*, float, const std::vector<uint8_t>&)>;
void set_template(transform_func_t &&f) { this->transform_func_ = f; }
optional<transform_func_t> transform_func_{nullopt};

// After
using transform_func_t = optional<float> (*)(Component*, float, const std::vector<uint8_t>&);
void set_template(transform_func_t f) { this->transform_func_ = f; }
optional<transform_func_t> transform_func_{nullopt};
```

The optimization keeps the `optional<>` wrapper (simplest approach) and just changes the contained type from `std::function` to a function pointer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing std::function optimization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Lambda usage remains unchanged - this is a transparent optimization

modbus_controller:
  - id: modbus1
    address: 0x1

sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Battery Capacity"
    address: 0x9001
    register_type: holding
    value_type: U_WORD
    # Read lambda - transform parsed value
    lambda: |-
      ESP_LOGI("","Incoming value=%f", x);
      return x / 10.0;

number:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Battery Cap Number"
    address: 0x9002
    value_type: U_WORD
    # Read lambda
    lambda: |-
      return x * 1.0;
    # Write lambda - can modify payload
    write_lambda: |-
      ESP_LOGD("main","Modbus Number incoming value = %f", x);
      uint16_t capacity = x;
      payload.push_back(capacity);
      return x * 1.0;

select:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Mode Select"
    address: 1000
    value_type: U_WORD
    optionsmap:
      "Off": 0
      "On": 1
      "Auto": 2
    # Read lambda - return string based on register value
    lambda: |-
      if (x > 1) {
        return std::string("Auto");
      }
      return x == 1 ? std::string("On") : std::string("Off");
    # Write lambda - can use optionsmap value or custom payload
    write_lambda: |-
      ESP_LOGD("main", "Set option to %s (%lld)", x.c_str(), value);
      if (x == "Auto") {
        payload.push_back(0x0002);
        return 0;
      }
      return value;

switch:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Enable Switch"
    register_type: coil
    address: 2
    # Read lambda - invert value
    lambda: |-
      return !x;
    # Write lambda - can send custom modbus command
    write_lambda: |-
      ESP_LOGD("main","Switch state = %f", x);
      return !x;

text_sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Status"
    address: 1002
    register_count: 2
    response_size: 4
    raw_encode: HEXBYTES
    # Lambda processes encoded string
    lambda: |-
      uint16_t value = modbus_controller::word_from_hex_str(x, 0);
      switch (value) {
        case 1: return std::string("ready");
        case 2: return std::string("charging");
        default: return std::string("unknown");
      }

binary_sensor:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    name: "Error Status"
    register_type: read
    address: 0x3200
    bitmask: 0x80
    # Lambda transforms bool value
    lambda: |-
      return x;

output:
  - platform: modbus_controller
    modbus_controller_id: modbus1
    address: 2048
    value_type: U_WORD
    # Write lambda for output
    write_lambda: |-
      ESP_LOGD("main","Output value = %f", x);
      payload.push_back(x * 1000);
      return x;
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
