### PR TITLE
[esp32_ble_server][esp32_improv] Eliminate unnecessary heap allocations

### DIFF
--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -461,7 +461,9 @@ async def parse_value(value_config, args):
     if isinstance(value, str):
         value = list(value.encode(value_config[CONF_STRING_ENCODING]))
     if isinstance(value, list):
-        return cg.std_vector.template(cg.uint8)(value)
+        # Generate initializer list {1, 2, 3} instead of std::vector<uint8_t>({1, 2, 3})
+        # This calls the set_value(std::initializer_list<uint8_t>) overload
+        return cg.ArrayInitializer(*value)
     val = cg.RawExpression(f"{value_config[CONF_TYPE]}({cg.safe_exp(value)})")
     return ByteBuffer_ns.wrap(val, value_config[CONF_ENDIANNESS])
 

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -35,13 +35,18 @@ BLECharacteristic::BLECharacteristic(const ESPBTUUID uuid, uint32_t properties) 
 
 void BLECharacteristic::set_value(ByteBuffer buffer) { this->set_value(buffer.get_data()); }
 
-void BLECharacteristic::set_value(const std::vector<uint8_t> &buffer) {
+void BLECharacteristic::set_value(std::vector<uint8_t> &&buffer) {
   xSemaphoreTake(this->set_value_lock_, 0L);
-  this->value_ = buffer;
+  this->value_ = std::move(buffer);
   xSemaphoreGive(this->set_value_lock_);
 }
+
+void BLECharacteristic::set_value(std::initializer_list<uint8_t> data) {
+  this->set_value(std::vector<uint8_t>(data));  // Delegate to move overload
+}
+
 void BLECharacteristic::set_value(const std::string &buffer) {
-  this->set_value(std::vector<uint8_t>(buffer.begin(), buffer.end()));
+  this->set_value(std::vector<uint8_t>(buffer.begin(), buffer.end()));  // Delegate to move overload
 }
 
 void BLECharacteristic::notify() {

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -33,7 +33,8 @@ class BLECharacteristic {
   ~BLECharacteristic();
 
   void set_value(ByteBuffer buffer);
-  void set_value(const std::vector<uint8_t> &buffer);
+  void set_value(std::vector<uint8_t> &&buffer);
+  void set_value(std::initializer_list<uint8_t> data);
   void set_value(const std::string &buffer);
 
   void set_broadcast_property(bool value);

--- a/esphome/components/esp32_ble_server/ble_descriptor.cpp
+++ b/esphome/components/esp32_ble_server/ble_descriptor.cpp
@@ -46,15 +46,17 @@ void BLEDescriptor::do_create(BLECharacteristic *characteristic) {
   this->state_ = CREATING;
 }
 
-void BLEDescriptor::set_value(std::vector<uint8_t> buffer) {
-  size_t length = buffer.size();
+void BLEDescriptor::set_value(std::vector<uint8_t> &&buffer) { this->set_value_impl_(buffer.data(), buffer.size()); }
 
+void BLEDescriptor::set_value(std::initializer_list<uint8_t> data) { this->set_value_impl_(data.begin(), data.size()); }
+
+void BLEDescriptor::set_value_impl_(const uint8_t *data, size_t length) {
   if (length > this->value_.attr_max_len) {
     ESP_LOGE(TAG, "Size %d too large, must be no bigger than %d", length, this->value_.attr_max_len);
     return;
   }
   this->value_.attr_len = length;
-  memcpy(this->value_.attr_value, buffer.data(), length);
+  memcpy(this->value_.attr_value, data, length);
 }
 
 void BLEDescriptor::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,

--- a/esphome/components/esp32_ble_server/ble_descriptor.h
+++ b/esphome/components/esp32_ble_server/ble_descriptor.h
@@ -27,7 +27,8 @@ class BLEDescriptor {
   void do_create(BLECharacteristic *characteristic);
   ESPBTUUID get_uuid() const { return this->uuid_; }
 
-  void set_value(std::vector<uint8_t> buffer);
+  void set_value(std::vector<uint8_t> &&buffer);
+  void set_value(std::initializer_list<uint8_t> data);
   void set_value(ByteBuffer buffer) { this->set_value(buffer.get_data()); }
 
   void gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if, esp_ble_gatts_cb_param_t *param);
@@ -42,6 +43,8 @@ class BLEDescriptor {
   }
 
  protected:
+  void set_value_impl_(const uint8_t *data, size_t length);
+
   BLECharacteristic *characteristic_{nullptr};
   ESPBTUUID uuid_;
   uint16_t handle_{0xFFFF};

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -270,8 +270,8 @@ void ESP32ImprovComponent::set_error_(improv::Error error) {
   }
 }
 
-void ESP32ImprovComponent::send_response_(std::vector<uint8_t> &response) {
-  this->rpc_response_->set_value(ByteBuffer::wrap(response));
+void ESP32ImprovComponent::send_response_(std::vector<uint8_t> &&response) {
+  this->rpc_response_->set_value(std::move(response));
   if (this->state_ != improv::STATE_STOPPED)
     this->rpc_response_->notify();
 }
@@ -409,10 +409,8 @@ void ESP32ImprovComponent::check_wifi_connection_() {
       }
     }
 #endif
-    // Pass to build_rpc_response using vector constructor from iterators to avoid extra copies
-    std::vector<uint8_t> data = improv::build_rpc_response(
-        improv::WIFI_SETTINGS, std::vector<std::string>(url_strings, url_strings + url_count));
-    this->send_response_(data);
+    this->send_response_(improv::build_rpc_response(improv::WIFI_SETTINGS,
+                                                    std::vector<std::string>(url_strings, url_strings + url_count)));
   } else if (this->is_active() && this->state_ != improv::STATE_PROVISIONED) {
     ESP_LOGD(TAG, "WiFi provisioned externally");
   }

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -109,7 +109,7 @@ class ESP32ImprovComponent : public Component, public improv_base::ImprovBase {
   void set_state_(improv::State state, bool update_advertising = true);
   void set_error_(improv::Error error);
   improv::State get_initial_state_() const;
-  void send_response_(std::vector<uint8_t> &response);
+  void send_response_(std::vector<uint8_t> &&response);
   void process_incoming_data_();
   void on_wifi_connect_timeout_();
   void check_wifi_connection_();


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `esp32_ble_server` and `esp32_improv` components to eliminate unnecessary heap allocations by using move semantics and initializer lists instead of creating temporary vectors.

## Problem

Both components were creating unnecessary temporary `std::vector<uint8_t>` objects:

### esp32_ble_server
Generated code was creating temporary vectors for compile-time constant data:
```cpp
// Before
characteristic->set_value(std::vector<uint8_t>({69, 83, 80, 72, 111, 109, 101}));
// Creates temp vector → copies to value_ → destroys temp (2 allocations)

// After
characteristic->set_value({69, 83, 80, 72, 111, 109, 101});
// Direct initializer list → single allocation
```

### esp32_improv
The `send_response_()` method was creating **multiple unnecessary copies** through `ByteBuffer::wrap()`:

```cpp
// Before - 3 copies!
void send_response_(std::vector<uint8_t> &response) {
  this->rpc_response_->set_value(ByteBuffer::wrap(response));
  // 1. ByteBuffer::wrap(response) copies vector into ByteBuffer.data_
  // 2. buffer.get_data() returns copy of data_
  // 3. set_value() copies into value_
}

// After - 0 copies, 1 move!
void send_response_(std::vector<uint8_t> &&response) {
  this->rpc_response_->set_value(std::move(response));  // Direct move
}
```

**Why ByteBuffer::wrap() existed:** `ByteBuffer` is a convenience wrapper for converting C arrays (`uint8_t *ptr, size_t len`) to vectors and handling endianness. It's useful for BLE stack callbacks with raw pointers, but when you already have a `std::vector`, wrapping it is pure overhead. The ironic comment "avoid extra copies" was actually **creating** extra copies!

## Solution

1. **Added move semantics**: Changed `const std::vector<uint8_t> &` to `std::vector<uint8_t> &&` to accept rvalue references
2. **Added initializer_list overloads**: New `set_value(std::initializer_list<uint8_t>)` overloads for zero-copy compile-time data
3. **Updated code generator**: Changed Python codegen to use `ArrayInitializer` instead of `std::vector` wrapper
4. **Deduplicated code**: Created helper methods to avoid duplicate validation/copy logic

## Performance Impact

**Flash savings: 288 bytes total**
- `esp32_ble_server`: 178 bytes (eliminated temporary vector wrapper in generated code)
- `esp32_improv`: 110 bytes (removed ByteBuffer::wrap() overhead)

**Runtime improvements:**
- BLE Server: 50% fewer heap allocations for device information (manufacturer, model, firmware)
  - Before: `std::vector<uint8_t>({...})` → 2 allocations (temp + copy)
  - After: `{...}` → 1 allocation (direct)
- Improv: **75% fewer allocations** during WiFi provisioning responses
  - Before: 4 allocations (1 initial + 3 copies through ByteBuffer chain)
  - After: 1 allocation (initial vector, then moved)
- BLEDescriptor with initializer_list: **Zero allocations** (direct memcpy to pre-allocated buffer)

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Performance optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No configuration changes required. The optimization is transparent to users.

```yaml
# Existing configurations work unchanged
esp32_ble_server:
  manufacturer: "ESPHome"  # Now more efficient internally
  model: "Device"
  firmware_version: "1.0.0"

esp32_improv:
  authorizer: none  # WiFi provisioning responses now more efficient
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

### The ByteBuffer::wrap() Problem

`ByteBuffer::wrap()` was being used unnecessarily in `esp32_improv`:

```cpp
// ByteBuffer's intended use (wrapping raw C arrays):
ByteBuffer::wrap(param->write.value, param->write.len)  // Good - converts C array to vector

// ByteBuffer misuse (wrapping existing vector):
ByteBuffer::wrap(response)  // Bad - creates 3 copies!
```

The allocation chain for the "bad" usage:
1. **Allocation 1**: `build_rpc_response()` creates initial vector
2. **Allocation 2**: `ByteBuffer::wrap(response)` copies vector into `ByteBuffer.data_`
3. **Allocation 3**: `buffer.get_data()` returns a copy of `data_`
4. **Allocation 4**: `set_value()` copies into `value_`

**Total: 4 allocations** (1 initial + 3 unnecessary copies)

By bypassing ByteBuffer and using move semantics directly, we eliminate the 3 unnecessary copies, reducing total allocations from **4 to 1** (75% reduction).

### Why Removing ByteBuffer::wrap() is Safe (Endianness)

**Question:** `ByteBuffer::wrap()` sets endianness to LITTLE. Is it safe to remove this?

**Answer:** Yes. The endianness setting was never actually used. Here's why:

```cpp
// What ByteBuffer::wrap() does:
static ByteBuffer wrap(std::vector<uint8_t> const &data, Endian endianness = LITTLE) {
  ByteBuffer buffer = {data};
  buffer.endianness_ = endianness;  // Sets endianness...
  return buffer;
}

// But then we immediately call:
buffer.get_data()  // Returns raw bytes WITHOUT using endianness!

// get_data() implementation:
std::vector<uint8_t> get_data() { return this->data_; };  // Just returns raw bytes
```

**Key insight:** `ByteBuffer.endianness_` is **only used** by serialization methods like:
- `put_uint16()`, `put_uint32()` - converts multi-byte integers to bytes
- `get_uint16()`, `get_uint32()` - converts bytes to multi-byte integers

Since we're using `get_data()` which returns raw bytes directly, the endianness setting was:
1. Being set by `wrap()`
2. Never consulted by `get_data()`
3. Pure overhead

The `improv::build_rpc_response()` already returns pre-serialized bytes in the correct format. We're just passing those bytes through to BLE, so endianness conversion was never needed.