### PR TITLE
[http_request] Fix HttpContainer resource leak on non-OK status

### DIFF
--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -106,7 +106,12 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
 
   auto container = this->parent_->get(url_with_auth);
 
-  if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
+  if (container == nullptr) {
+    return OTA_CONNECTION_ERROR;
+  }
+  if (container->status_code != HTTP_STATUS_OK) {
+    container->end();
+    container.reset();
     return OTA_CONNECTION_ERROR;
   }
 

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -111,7 +111,6 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
   }
   if (container->status_code != HTTP_STATUS_OK) {
     container->end();
-    container.reset();
     return OTA_CONNECTION_ERROR;
   }
 
@@ -234,8 +233,12 @@ bool OtaHttpRequestComponent::http_get_md5_() {
   ESP_LOGVV(TAG, "url_with_auth: %s", url_with_auth.c_str());
   ESP_LOGI(TAG, "Connecting to: %s", this->md5_url_.c_str());
   auto container = this->parent_->get(url_with_auth);
-  if (container == nullptr) {
+  if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
     ESP_LOGE(TAG, "Failed to connect to MD5 URL");
+    if (container != nullptr && container->status_code != HTTP_STATUS_OK) {
+      container->end();
+      return false;
+    }
     return false;
   }
   size_t length = container->content_length;

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -52,6 +52,11 @@ void HttpRequestUpdate::update_task(void *params) {
     std::string msg = str_sprintf("Failed to fetch manifest from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+
+    if (container->status_code != HTTP_STATUS_OK) {
+      container->end();
+      container.reset();
+    }
     UPDATE_RETURN;
   }
 

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -53,7 +53,7 @@ void HttpRequestUpdate::update_task(void *params) {
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
 
-    if (container->status_code != HTTP_STATUS_OK) {
+    if (container != nullptr && container->status_code != HTTP_STATUS_OK) {
       container->end();
       container.reset();
     }
@@ -67,6 +67,7 @@ void HttpRequestUpdate::update_task(void *params) {
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
     container->end();
+    container.reset();
     UPDATE_RETURN;
   }
 


### PR DESCRIPTION
When HTTP requests return non-OK status codes (e.g., 404, 500), the container's resources (HTTP client handles, connections, and buffers) were not being released. This fix ensures container->end() and container.reset() are called to properly clean up resources before returning error codes.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11578

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
