### PR TITLE
[ci] Fix component tests not running when only test files change

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -90,16 +90,18 @@ def get_component_from_path(file_path: str) -> str | None:
     """Extract component name from a file path.
 
     Args:
-        file_path: Path to a file (e.g., "esphome/components/wifi/wifi.cpp")
+        file_path: Path to a file (e.g., "esphome/components/wifi/wifi.cpp"
+                                or "tests/components/uart/test.esp32-idf.yaml")
 
     Returns:
-        Component name if path is in components directory, None otherwise
+        Component name if path is in components or tests directory, None otherwise
     """
-    if not file_path.startswith(ESPHOME_COMPONENTS_PATH):
-        return None
-    parts = file_path.split("/")
-    if len(parts) >= 3:
-        return parts[2]
+    if file_path.startswith(ESPHOME_COMPONENTS_PATH) or file_path.startswith(
+        ESPHOME_TESTS_COMPONENTS_PATH
+    ):
+        parts = file_path.split("/")
+        if len(parts) >= 3 and parts[2]:
+            return parts[2]
     return None
 
 

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1065,3 +1065,39 @@ def test_parse_list_components_output(output: str, expected: list[str]) -> None:
     """Test parse_list_components_output function."""
     result = helpers.parse_list_components_output(output)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("file_path", "expected_component"),
+    [
+        # Component files
+        ("esphome/components/wifi/wifi.cpp", "wifi"),
+        ("esphome/components/uart/uart.h", "uart"),
+        ("esphome/components/api/api_server.cpp", "api"),
+        ("esphome/components/sensor/sensor.cpp", "sensor"),
+        # Test files
+        ("tests/components/uart/test.esp32-idf.yaml", "uart"),
+        ("tests/components/wifi/test.esp8266-ard.yaml", "wifi"),
+        ("tests/components/sensor/test.esp32-idf.yaml", "sensor"),
+        ("tests/components/api/test_api.cpp", "api"),
+        ("tests/components/uart/common.h", "uart"),
+        # Non-component files
+        ("esphome/core/component.cpp", None),
+        ("esphome/core/helpers.h", None),
+        ("tests/integration/test_api.py", None),
+        ("tests/unit_tests/test_helpers.py", None),
+        ("README.md", None),
+        ("script/helpers.py", None),
+        # Edge cases
+        ("esphome/components/", None),  # No component name
+        ("tests/components/", None),  # No component name
+        ("esphome/components", None),  # No trailing slash
+        ("tests/components", None),  # No trailing slash
+    ],
+)
+def test_get_component_from_path(
+    file_path: str, expected_component: str | None
+) -> None:
+    """Test extraction of component names from file paths."""
+    result = helpers.get_component_from_path(file_path)
+    assert result == expected_component


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `determine-jobs` CI script to properly trigger component tests when ONLY test files in `tests/components/<component>/` are modified (without any corresponding component code changes).

Previously, changes to test files (e.g., `tests/components/uart/test.esp32-idf.yaml` or `tests/components/uart/common.h`) would not trigger the corresponding component tests to run in CI. This meant that test file changes could be merged without validation, potentially introducing broken tests.

The root cause was that `get_component_from_path()` only extracted component names from `esphome/components/` paths, not from `tests/components/` paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (internal CI improvement)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a CI/script improvement that affects all platforms equally.

## Example entry for `config.yaml`:

N/A - This change only affects CI infrastructure, not user configurations.
