### PR TITLE
[packages] Tighten package validation

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -102,7 +102,7 @@ CONFIG_SCHEMA = cv.Any(
             str: PACKAGE_SCHEMA,
         }
     ),
-    cv.ensure_list(PACKAGE_SCHEMA),
+    [PACKAGE_SCHEMA],
 )
 
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from esphome.components.packages import do_packages_pass
+from esphome.components.packages import CONFIG_SCHEMA, do_packages_pass
 from esphome.config import resolve_extend_remove
 from esphome.config_helpers import Extend, Remove
 import esphome.config_validation as cv
@@ -92,6 +92,50 @@ def test_package_invalid_dict(basic_esphome, basic_wifi):
 
     with pytest.raises(cv.Invalid):
         packages_pass(config)
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        {"package1": "github://esphome/non-existant-repo/file1.yml@main"},
+        {"package2": "github://esphome/non-existant-repo/file1.yml"},
+        {"package3": "github://esphome/non-existant-repo/other-folder/file1.yml"},
+        [
+            "github://esphome/non-existant-repo/file1.yml@main",
+            "github://esphome/non-existant-repo/file1.yml",
+            "github://esphome/non-existant-repo/other-folder/file1.yml",
+        ],
+    ],
+)
+def test_package_shorthand(package):
+    CONFIG_SCHEMA(package)
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        # not github
+        {"package1": "someplace://esphome/non-existant-repo/file1.yml@main"},
+        # missing repo
+        {"package2": "github://esphome/file1.yml"},
+        # missing file
+        {"package3": "github://esphome/non-existant-repo/@main"},
+        {"a": "invalid string, not shorthand"},
+        "some string",
+        3,
+        False,
+        {"a": 8},
+        ["someplace://esphome/non-existant-repo/file1.yml@main"],
+        ["github://esphome/file1.yml"],
+        ["github://esphome/non-existant-repo/@main"],
+        ["some string"],
+        [True],
+        [3],
+    ],
+)
+def test_package_invalid(package):
+    with pytest.raises(cv.Invalid):
+        CONFIG_SCHEMA(package)
 
 
 def test_package_include(basic_wifi, basic_esphome):


### PR DESCRIPTION
# What does this implement/fix?

After [lists were allowed for package definitions](https://github.com/esphome/esphome/pull/8688), certain failed dict-like package definitions may become valid, such as:

```yaml
packages:
  my_package: "github://bad-url"
```
Because the above URL is invalid, validation as dict fails and falls back to `ensure_list`, who happily transforms it to:

```yaml
packages:
  - my_package: "github://bad-url"
```
... which looks like valid package content defining the configuration of a component that happens to be called `my_package` as far as the packages component is concerned.

This PR corrects that. `packages:` must either contain a `dict[package_schema]` or `list[package_schema]`. The PR also adds tests to enforce it and also validate shorthand `github://` form, which I didn't see.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] All (config)
## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
