### PR TITLE
[core] Remove deprecated schema constants

### DIFF
--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -172,12 +172,6 @@ def alarm_control_panel_schema(
     return _ALARM_CONTROL_PANEL_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-ALARM_CONTROL_PANEL_SCHEMA = alarm_control_panel_schema(AlarmControlPanel)
-ALARM_CONTROL_PANEL_SCHEMA.add_extra(
-    cv.deprecated_schema_constant("alarm_control_panel")
-)
-
 ALARM_CONTROL_PANEL_ACTION_SCHEMA = maybe_simple_id(
     {
         cv.GenerateID(): cv.use_id(AlarmControlPanel),

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -548,11 +548,6 @@ def binary_sensor_schema(
     return _BINARY_SENSOR_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-BINARY_SENSOR_SCHEMA = binary_sensor_schema()
-BINARY_SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("binary_sensor"))
-
-
 async def setup_binary_sensor_core_(var, config):
     await setup_entity(var, config, "binary_sensor")
 

--- a/esphome/components/button/__init__.py
+++ b/esphome/components/button/__init__.py
@@ -84,11 +84,6 @@ def button_schema(
     return _BUTTON_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-BUTTON_SCHEMA = button_schema(Button)
-BUTTON_SCHEMA.add_extra(cv.deprecated_schema_constant("button"))
-
-
 async def setup_button_core_(var, config):
     await setup_entity(var, config, "button")
 

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -270,11 +270,6 @@ def climate_schema(
     return _CLIMATE_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-CLIMATE_SCHEMA = climate_schema(Climate)
-CLIMATE_SCHEMA.add_extra(cv.deprecated_schema_constant("climate"))
-
-
 async def setup_climate_core_(var, config):
     await setup_entity(var, config, "climate")
 

--- a/esphome/components/climate_ir/__init__.py
+++ b/esphome/components/climate_ir/__init__.py
@@ -1,10 +1,9 @@
 import logging
 
-from esphome import core
 import esphome.codegen as cg
 from esphome.components import climate, remote_base, sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SENSOR, CONF_SUPPORTS_COOL, CONF_SUPPORTS_HEAT
+from esphome.const import CONF_SENSOR, CONF_SUPPORTS_COOL, CONF_SUPPORTS_HEAT
 from esphome.cpp_generator import MockObjClass
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,26 +49,6 @@ def climate_ir_with_receiver_schema(
             ),
         }
     )
-
-
-# Remove before 2025.11.0
-def deprecated_schema_constant(config):
-    type: str = "unknown"
-    if (id := config.get(CONF_ID)) is not None and isinstance(id, core.ID):
-        type = str(id.type).split("::", maxsplit=1)[0]
-    _LOGGER.warning(
-        "Using `climate_ir.CLIMATE_IR_WITH_RECEIVER_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. "
-        "Please use `climate_ir.climate_ir_with_receiver_schema(...)` instead. "
-        "If you are seeing this, report an issue to the external_component author and ask them to update it. "
-        "https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. "
-        "Component using this schema: %s",
-        type,
-    )
-    return config
-
-
-CLIMATE_IR_WITH_RECEIVER_SCHEMA = climate_ir_with_receiver_schema(ClimateIR)
-CLIMATE_IR_WITH_RECEIVER_SCHEMA.add_extra(deprecated_schema_constant)
 
 
 async def register_climate_ir(var, config):

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -151,11 +151,6 @@ def cover_schema(
     return _COVER_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-COVER_SCHEMA = cover_schema(Cover)
-COVER_SCHEMA.add_extra(cv.deprecated_schema_constant("cover"))
-
-
 async def setup_cover_core_(var, config):
     await setup_entity(var, config, "cover")
 

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -85,11 +85,6 @@ def event_schema(
     return _EVENT_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-EVENT_SCHEMA = event_schema()
-EVENT_SCHEMA.add_extra(cv.deprecated_schema_constant("event"))
-
-
 async def setup_event_core_(var, config, *, event_types: list[str]):
     await setup_entity(var, config, "event")
 

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -189,10 +189,6 @@ def fan_schema(
     return _FAN_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-FAN_SCHEMA = fan_schema(Fan)
-FAN_SCHEMA.add_extra(cv.deprecated_schema_constant("fan"))
-
 _PRESET_MODES_SCHEMA = cv.All(
     cv.ensure_list(cv.string_strict),
     cv.Length(min=1),

--- a/esphome/components/lock/__init__.py
+++ b/esphome/components/lock/__init__.py
@@ -91,11 +91,6 @@ def lock_schema(
     return _LOCK_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-LOCK_SCHEMA = lock_schema()
-LOCK_SCHEMA.add_extra(cv.deprecated_schema_constant("lock"))
-
-
 async def _setup_lock_core(var, config):
     await setup_entity(var, config, "lock")
 

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -192,10 +192,6 @@ def media_player_schema(
     return _MEDIA_PLAYER_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-MEDIA_PLAYER_SCHEMA = media_player_schema(MediaPlayer)
-MEDIA_PLAYER_SCHEMA.add_extra(cv.deprecated_schema_constant("media_player"))
-
 MEDIA_PLAYER_ACTION_SCHEMA = automation.maybe_simple_id(
     cv.Schema(
         {

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -238,11 +238,6 @@ def number_schema(
     return _NUMBER_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-NUMBER_SCHEMA = number_schema(Number)
-NUMBER_SCHEMA.add_extra(cv.deprecated_schema_constant("number"))
-
-
 async def setup_number_core_(
     var, config, *, min_value: float, max_value: float, step: float
 ):

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -86,11 +86,6 @@ def select_schema(
     return _SELECT_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-SELECT_SCHEMA = select_schema(Select)
-SELECT_SCHEMA.add_extra(cv.deprecated_schema_constant("select"))
-
-
 async def setup_select_core_(var, config, *, options: list[str]):
     await setup_entity(var, config, "select")
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -369,11 +369,6 @@ def sensor_schema(
     return _SENSOR_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-SENSOR_SCHEMA = sensor_schema()
-SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("sensor"))
-
-
 @FILTER_REGISTRY.register("offset", OffsetFilter, cv.templatable(cv.float_))
 async def offset_filter_to_code(config, filter_id):
     template_ = await cg.templatable(config, [], float)

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -139,11 +139,6 @@ def switch_schema(
     return _SWITCH_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-SWITCH_SCHEMA = switch_schema(Switch)
-SWITCH_SCHEMA.add_extra(cv.deprecated_schema_constant("switch"))
-
-
 async def setup_switch_core_(var, config):
     await setup_entity(var, config, "switch")
 

--- a/esphome/components/text/__init__.py
+++ b/esphome/components/text/__init__.py
@@ -84,11 +84,6 @@ def text_schema(
     return _TEXT_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-TEXT_SCHEMA = text_schema()
-TEXT_SCHEMA.add_extra(cv.deprecated_schema_constant("text"))
-
-
 async def setup_text_core_(
     var,
     config,

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -193,11 +193,6 @@ def text_sensor_schema(
     return _TEXT_SENSOR_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-TEXT_SENSOR_SCHEMA = text_sensor_schema()
-TEXT_SENSOR_SCHEMA.add_extra(cv.deprecated_schema_constant("text_sensor"))
-
-
 async def build_filters(config):
     return await cg.build_registry_list(FILTER_REGISTRY, config)
 

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -84,11 +84,6 @@ def update_schema(
     return _UPDATE_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-UPDATE_SCHEMA = update_schema()
-UPDATE_SCHEMA.add_extra(cv.deprecated_schema_constant("update"))
-
-
 async def setup_update_core_(var, config):
     await setup_entity(var, config, "update")
 

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -129,11 +129,6 @@ def valve_schema(
     return _VALVE_SCHEMA.extend(schema)
 
 
-# Remove before 2025.11.0
-VALVE_SCHEMA = valve_schema()
-VALVE_SCHEMA.add_extra(cv.deprecated_schema_constant("valve"))
-
-
 async def _setup_valve_core(var, config):
     await setup_entity(var, config, "valve")
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -2195,26 +2195,3 @@ def rename_key(old_key, new_key):
         return config
 
     return validator
-
-
-# Remove before 2025.11.0
-def deprecated_schema_constant(entity_type: str):
-    def validator(config):
-        type: str = "unknown"
-        if (id := config.get(CONF_ID)) is not None and isinstance(id, core.ID):
-            type = str(id.type).split("::", maxsplit=1)[0]
-        _LOGGER.warning(
-            "Using `%s.%s_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. "
-            "Please use `%s.%s_schema(...)` instead. "
-            "If you are seeing this, report an issue to the external_component author and ask them to update it. "
-            "https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. "
-            "Component using this schema: %s",
-            entity_type,
-            entity_type.upper(),
-            entity_type,
-            entity_type,
-            type,
-        )
-        return config
-
-    return validator

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -300,7 +300,7 @@ def fix_remote_receiver():
     remote_receiver_schema["CONFIG_SCHEMA"] = {
         "type": "schema",
         "schema": {
-            "extends": ["binary_sensor.BINARY_SENSOR_SCHEMA", "core.COMPONENT_SCHEMA"],
+            "extends": ["binary_sensor._BINARY_SENSOR_SCHEMA", "core.COMPONENT_SCHEMA"],
             "config_vars": output["remote_base"].pop("binary"),
         },
     }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

As per https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
