### PR TITLE
template_alarm_control_panel readability improvements

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -25,6 +25,20 @@ void TemplateAlarmControlPanel::add_sensor(binary_sensor::BinarySensor *sensor, 
   this->sensor_data_.push_back(sd);
   this->sensor_map_[sensor].store_index = this->next_store_index_++;
 };
+
+static const LogString *sensor_type_to_string(AlarmSensorType type) {
+  switch (type) {
+    case ALARM_SENSOR_TYPE_INSTANT:
+      return LOG_STR("instant");
+    case ALARM_SENSOR_TYPE_DELAYED_FOLLOWER:
+      return LOG_STR("delayed_follower");
+    case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
+      return LOG_STR("instant_always");
+    case ALARM_SENSOR_TYPE_DELAYED:
+    default:
+      return LOG_STR("delayed");
+  }
+}
 #endif
 
 void TemplateAlarmControlPanel::dump_config() {
@@ -47,33 +61,19 @@ void TemplateAlarmControlPanel::dump_config() {
                 (this->pending_time_ / 1000), (this->trigger_time_ / 1000), this->get_supported_features());
 #ifdef USE_BINARY_SENSOR
   for (auto const &[sensor, info] : this->sensor_map_) {
-    ESP_LOGCONFIG(TAG, "  Binary Sensor:");
     ESP_LOGCONFIG(TAG,
+                  "  Binary Sensor:\n"
                   "    Name: %s\n"
+                  "    Type: %s\n"
                   "    Armed home bypass: %s\n"
                   "    Armed night bypass: %s\n"
                   "    Auto bypass: %s\n"
                   "    Chime mode: %s",
-                  sensor->get_name().c_str(), TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME),
+                  sensor->get_name().c_str(), LOG_STR_ARG(sensor_type_to_string(info.type)),
+                  TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME),
                   TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT),
                   TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_AUTO),
                   TRUEFALSE(info.flags & BINARY_SENSOR_MODE_CHIME));
-    const char *sensor_type;
-    switch (info.type) {
-      case ALARM_SENSOR_TYPE_INSTANT:
-        sensor_type = "instant";
-        break;
-      case ALARM_SENSOR_TYPE_DELAYED_FOLLOWER:
-        sensor_type = "delayed_follower";
-        break;
-      case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
-        sensor_type = "instant_always";
-        break;
-      case ALARM_SENSOR_TYPE_DELAYED:
-      default:
-        sensor_type = "delayed";
-    }
-    ESP_LOGCONFIG(TAG, "    Sensor type: %s", sensor_type);
   }
 #endif
 }

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -46,7 +46,7 @@ void TemplateAlarmControlPanel::dump_config() {
                 "  Supported Features: %" PRIu32,
                 (this->pending_time_ / 1000), (this->trigger_time_ / 1000), this->get_supported_features());
 #ifdef USE_BINARY_SENSOR
-  for (auto sensor_info : this->sensor_map_) {
+  for (auto const &[sensor, info] : this->sensor_map_) {
     ESP_LOGCONFIG(TAG, "  Binary Sensor:");
     ESP_LOGCONFIG(TAG,
                   "    Name: %s\n"
@@ -54,13 +54,12 @@ void TemplateAlarmControlPanel::dump_config() {
                   "    Armed night bypass: %s\n"
                   "    Auto bypass: %s\n"
                   "    Chime mode: %s",
-                  sensor_info.first->get_name().c_str(),
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME),
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT),
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_AUTO),
-                  TRUEFALSE(sensor_info.second.flags & BINARY_SENSOR_MODE_CHIME));
+                  sensor->get_name().c_str(), TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME),
+                  TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT),
+                  TRUEFALSE(info.flags & BINARY_SENSOR_MODE_BYPASS_AUTO),
+                  TRUEFALSE(info.flags & BINARY_SENSOR_MODE_CHIME));
     const char *sensor_type;
-    switch (sensor_info.second.type) {
+    switch (info.type) {
       case ALARM_SENSOR_TYPE_INSTANT:
         sensor_type = "instant";
         break;
@@ -123,39 +122,37 @@ void TemplateAlarmControlPanel::loop() {
   bool instant_sensor_faulted = false;
 
 #ifdef USE_BINARY_SENSOR
-  // Test all of the sensors in the list regardless of the alarm panel state
-  for (auto sensor_info : this->sensor_map_) {
+  // Test all of the sensors regardless of the alarm panel state
+  for (auto const &[sensor, info] : this->sensor_map_) {
     // Check for chime zones
-    if ((sensor_info.second.flags & BINARY_SENSOR_MODE_CHIME)) {
+    if (info.flags & BINARY_SENSOR_MODE_CHIME) {
       // Look for the transition from closed to open
-      if ((!this->sensor_data_[sensor_info.second.store_index].last_chime_state) && (sensor_info.first->state)) {
+      if ((!this->sensor_data_[info.store_index].last_chime_state) && (sensor->state)) {
         // Must be disarmed to chime
         if (this->current_state_ == ACP_STATE_DISARMED) {
           this->chime_callback_.call();
         }
       }
       // Record the sensor state change
-      this->sensor_data_[sensor_info.second.store_index].last_chime_state = sensor_info.first->state;
+      this->sensor_data_[info.store_index].last_chime_state = sensor->state;
     }
     // Check for faulted sensors
-    if (sensor_info.first->state) {  // Sensor triggered?
+    if (sensor->state) {
       // Skip if auto bypassed
       if (std::count(this->bypassed_sensor_indicies_.begin(), this->bypassed_sensor_indicies_.end(),
-                     sensor_info.second.store_index) == 1) {
+                     info.store_index) == 1) {
         continue;
       }
       // Skip if bypass armed home
-      if (this->current_state_ == ACP_STATE_ARMED_HOME &&
-          (sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME)) {
+      if ((this->current_state_ == ACP_STATE_ARMED_HOME) && (info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_HOME)) {
         continue;
       }
       // Skip if bypass armed night
-      if (this->current_state_ == ACP_STATE_ARMED_NIGHT &&
-          (sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT)) {
+      if ((this->current_state_ == ACP_STATE_ARMED_NIGHT) && (info.flags & BINARY_SENSOR_MODE_BYPASS_ARMED_NIGHT)) {
         continue;
       }
 
-      switch (sensor_info.second.type) {
+      switch (info.type) {
         case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
           next_state = ACP_STATE_TRIGGERED;
           [[fallthrough]];
@@ -247,11 +244,11 @@ void TemplateAlarmControlPanel::arm_(optional<std::string> code, alarm_control_p
 
 void TemplateAlarmControlPanel::bypass_before_arming() {
 #ifdef USE_BINARY_SENSOR
-  for (auto sensor_info : this->sensor_map_) {
+  for (auto const &[sensor, info] : this->sensor_map_) {
     // Check for faulted bypass_auto sensors and remove them from monitoring
-    if ((sensor_info.second.flags & BINARY_SENSOR_MODE_BYPASS_AUTO) && (sensor_info.first->state)) {
-      ESP_LOGW(TAG, "'%s' is faulted and will be automatically bypassed", sensor_info.first->get_name().c_str());
-      this->bypassed_sensor_indicies_.push_back(sensor_info.second.store_index);
+    if ((info.flags & BINARY_SENSOR_MODE_BYPASS_AUTO) && (sensor->state)) {
+      ESP_LOGW(TAG, "'%s' is faulted and will be automatically bypassed", sensor->get_name().c_str());
+      this->bypassed_sensor_indicies_.push_back(info.store_index);
     }
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Readability improvements for the template_alarm_control_panel using C++17 range-based loops.

Also continued the reduction of ESP_LOGCONFIG calls in dump_config().  It had been reduced to three, now down to one.

These commits form the second part of a split up of https://github.com/esphome/esphome/pull/9003.
This part contains readability improvements and has no functional changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
