### PR TITLE
[lvgl] Make animimg work with an animation

### DIFF
--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -90,7 +90,26 @@ async def to_code(config):
         image_type,
         trans_value,
         frame_count,
+        frame_durations,
     ) = await espImage.write_image(config, all_frames=True)
+
+    # Generate frame durations array if we have timing data
+    durations_arr = cg.nullptr
+    if frame_durations:
+        # Validate that frame durations matches frame count
+        if len(frame_durations) != frame_count:
+            raise cv.Invalid(
+                f"Frame durations length ({len(frame_durations)}) does not match frame count ({frame_count})"
+            )
+        # Create static constexpr array for frame durations (stored in flash)
+        durations_name = f"{config[CONF_ID]}_durations"
+        durations_str = ", ".join(str(d) for d in frame_durations)
+        cg.add(
+            cg.RawExpression(
+                f"static constexpr uint32_t {durations_name}[{len(frame_durations)}] = {{{durations_str}}}"
+            )
+        )
+        durations_arr = cg.RawExpression(durations_name)
 
     var = cg.new_Pvariable(
         config[CONF_ID],
@@ -100,6 +119,7 @@ async def to_code(config):
         frame_count,
         image_type,
         trans_value,
+        durations_arr,
     )
     if loop_config := config.get(CONF_LOOP):
         start = loop_config[CONF_START_FRAME]

--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -6,7 +6,8 @@ namespace esphome {
 namespace animation {
 
 Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count,
-                     image::ImageType type, image::Transparency transparent)
+                     image::ImageType type, image::Transparency transparent, const uint32_t *frame_durations,
+                     uint32_t default_duration_ms)
     : Image(data_start, width, height, type, transparent),
       animation_data_start_(data_start),
       current_frame_(0),
@@ -14,7 +15,9 @@ Animation::Animation(const uint8_t *data_start, int width, int height, uint32_t 
       loop_start_frame_(0),
       loop_end_frame_(animation_frame_count_),
       loop_count_(0),
-      loop_current_iteration_(1) {}
+      loop_current_iteration_(1),
+      frame_durations_(frame_durations),
+      default_frame_duration_(default_duration_ms) {}
 void Animation::set_loop(uint32_t start_frame, uint32_t end_frame, int count) {
   loop_start_frame_ = std::min(start_frame, animation_frame_count_);
   loop_end_frame_ = std::min(end_frame, animation_frame_count_);
@@ -65,6 +68,44 @@ void Animation::update_data_start_() {
   const uint32_t image_size = this->get_width_stride() * this->height_;
   this->data_start_ = this->animation_data_start_ + image_size * this->current_frame_;
 }
+
+uint32_t Animation::get_frame_duration(int frame) const {
+  if (this->frame_durations_ != nullptr && frame >= 0 && static_cast<uint32_t>(frame) < this->animation_frame_count_) {
+    return this->frame_durations_[frame];
+  }
+  return this->default_frame_duration_;
+}
+
+uint32_t Animation::get_average_duration() const {
+  if (this->frame_durations_ == nullptr) {
+    return this->default_frame_duration_;
+  }
+  if (this->animation_frame_count_ == 0) {
+    return this->default_frame_duration_;
+  }
+
+  uint64_t sum = 0;
+  for (uint32_t i = 0; i < this->animation_frame_count_; i++) {
+    sum += this->frame_durations_[i];
+  }
+  return static_cast<uint32_t>(sum / this->animation_frame_count_);
+}
+
+uint32_t Animation::get_total_duration() const {
+  if (this->frame_durations_ == nullptr) {
+    return this->animation_frame_count_ * this->default_frame_duration_;
+  }
+
+  uint32_t total = 0;
+  for (uint32_t i = 0; i < this->animation_frame_count_; i++) {
+    total += this->frame_durations_[i];
+  }
+  return total;
+}
+
+bool Animation::has_frame_timing() const { return this->frame_durations_ != nullptr; }
+
+const uint8_t *Animation::get_animation_data_start() const { return this->animation_data_start_; }
 
 }  // namespace animation
 }  // namespace esphome

--- a/esphome/components/animation/animation.h
+++ b/esphome/components/animation/animation.h
@@ -9,7 +9,8 @@ namespace animation {
 class Animation : public image::Image {
  public:
   Animation(const uint8_t *data_start, int width, int height, uint32_t animation_frame_count, image::ImageType type,
-            image::Transparency transparent);
+            image::Transparency transparent, const uint32_t *frame_durations = nullptr,
+            uint32_t default_duration_ms = 100);
 
   uint32_t get_animation_frame_count() const;
   int get_current_frame() const;
@@ -24,6 +25,21 @@ class Animation : public image::Image {
 
   void set_loop(uint32_t start_frame, uint32_t end_frame, int count);
 
+  /** Get duration for specific frame (milliseconds). */
+  uint32_t get_frame_duration(int frame) const;
+
+  /** Get average duration across all frames (milliseconds). */
+  uint32_t get_average_duration() const;
+
+  /** Get total animation duration (milliseconds). */
+  uint32_t get_total_duration() const;
+
+  /** Check if frame timing data is available. */
+  bool has_frame_timing() const;
+
+  /** Get base animation data pointer (for LVGL descriptor generation). */
+  const uint8_t *get_animation_data_start() const;
+
  protected:
   void update_data_start_();
 
@@ -34,6 +50,8 @@ class Animation : public image::Image {
   uint32_t loop_end_frame_;
   int loop_count_;
   int loop_current_iteration_;
+  const uint32_t *frame_durations_{nullptr};
+  uint32_t default_frame_duration_{100};
 };
 
 template<typename... Ts> class AnimationNextFrameAction : public Action<Ts...> {

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -663,6 +663,35 @@ def _config_schema(value):
 CONFIG_SCHEMA = _config_schema
 
 
+# Disposal method constants
+DISPOSAL_NONE = 0  # Leave frame as-is
+DISPOSAL_BACKGROUND = 1  # Clear to background
+DISPOSAL_PREVIOUS = 2  # Restore previous
+
+
+def _get_disposal_method(pil_img):
+    """Get normalized disposal method (GIF and APNG handle this differently)."""
+    # GIF: has disposal_method attribute (0/1=none, 2=background, 3=previous)
+    if hasattr(pil_img, "disposal_method"):
+        disposal = pil_img.disposal_method
+        if disposal in (0, 1):
+            return DISPOSAL_NONE
+        if disposal == 2:
+            return DISPOSAL_BACKGROUND
+        if disposal == 3:
+            return DISPOSAL_PREVIOUS
+    # APNG: uses info['disposal'] dict key (0=none, 1=background, 2=previous)
+    elif "disposal" in pil_img.info:
+        disposal = pil_img.info["disposal"]
+        if disposal == 0:
+            return DISPOSAL_NONE
+        if disposal == 1:
+            return DISPOSAL_BACKGROUND
+        if disposal == 2:
+            return DISPOSAL_PREVIOUS
+    return DISPOSAL_NONE  # default
+
+
 async def write_image(config, all_frames=False):
     path = Path(config[CONF_FILE])
     if not path.is_file():
@@ -720,26 +749,81 @@ async def write_image(config, all_frames=False):
     if byte_order := config.get(CONF_BYTE_ORDER):
         # Check for valid type has already been done in validate_settings
         encoder.set_big_endian(byte_order == "BIG_ENDIAN")
+
+    # Initialize compositing canvas for animated images (RGBA for proper disposal)
+    canvas = None
+    previous_canvas = None
+    frame_durations = []
+    MIN_DELAY_MS = 10  # Clamp very small delays
+
     for frame_index in range(frame_count):
         image.seek(frame_index)
-        pixels = encoder.convert(image.resize((width, height)), path).getdata()
+        image.load()  # Required for WebP to populate .info
+
+        # Extract timing (milliseconds) for animated images
+        if all_frames and frame_count > 1:
+            duration = image.info.get("duration", 100)  # Default 100ms = 10 FPS
+            duration = max(MIN_DELAY_MS, int(duration))
+            frame_durations.append(duration)
+
+            # Get disposal method (normalized across GIF/APNG)
+            disposal = _get_disposal_method(image)
+
+            # Initialize canvas on first frame
+            if canvas is None:
+                canvas = Image.new("RGBA", (width, height), (0, 0, 0, 255))
+
+            # Save previous canvas if needed for DISPOSAL_PREVIOUS
+            if disposal == DISPOSAL_PREVIOUS:
+                previous_canvas = canvas.copy()
+
+            # Resize frame to target dimensions BEFORE compositing
+            frame_rgba = image.convert("RGBA").resize(
+                (width, height), Image.Resampling.LANCZOS
+            )
+            canvas.paste(frame_rgba, (0, 0), frame_rgba)
+
+            # Feed composite through existing encoder (handles format/transparency)
+            pixels = encoder.convert(canvas, path).getdata()
+        else:
+            # Static image - use as-is
+            pixels = encoder.convert(image.resize((width, height)), path).getdata()
+
         for row in range(height):
             for col in range(width):
                 encoder.encode(pixels[row * width + col])
             encoder.end_row()
+
+        # Apply disposal for next iteration
+        if all_frames and frame_count > 1:
+            if disposal == DISPOSAL_BACKGROUND:
+                canvas = Image.new("RGBA", (width, height), (0, 0, 0, 255))
+            elif disposal == DISPOSAL_PREVIOUS and previous_canvas:
+                canvas = previous_canvas.copy()
+            # DISPOSAL_NONE: leave canvas as-is
 
     rhs = [HexInt(x) for x in encoder.data]
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     image_type = get_image_type_enum(type)
     trans_value = get_transparency_enum(encoder.transparency)
 
-    return prog_arr, width, height, image_type, trans_value, frame_count
+    return (
+        prog_arr,
+        width,
+        height,
+        image_type,
+        trans_value,
+        frame_count,
+        frame_durations,
+    )
 
 
 async def to_code(config):
     # By now the config should be a simple list.
     for entry in config:
-        prog_arr, width, height, image_type, trans_value, _ = await write_image(entry)
+        prog_arr, width, height, image_type, trans_value, _, _ = await write_image(
+            entry
+        )
         cg.new_Pvariable(
             entry[CONF_ID], prog_arr, width, height, image_type, trans_value
         )

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -7,6 +7,9 @@
 #ifdef USE_LVGL_IMAGE
 #include "esphome/components/image/image.h"
 #endif  // USE_LVGL_IMAGE
+#ifdef USE_LVGL_ANIMIMG
+#include "esphome/components/animation/animation.h"
+#endif  // USE_LVGL_ANIMIMG
 #ifdef USE_LVGL_ROTARY_ENCODER
 #include "esphome/components/rotary_encoder/rotary_encoder.h"
 #endif  // USE_LVGL_ROTARY_ENCODER
@@ -90,6 +93,49 @@ inline void lv_animimg_set_src(lv_obj_t *img, std::vector<image::Image *> images
     dsc->push_back(image->get_lv_img_dsc());
   }
   lv_animimg_set_src(img, (const void **) dsc->data(), dsc->size());
+}
+
+// Overload for single Animation object - extracts frames automatically
+inline void lv_animimg_set_src(lv_obj_t *img, animation::Animation *anim) {
+  uint32_t frame_count = anim->get_animation_frame_count();
+
+  // Allocate descriptors (one per frame)
+  auto *dsc_array = new std::vector<lv_img_dsc_t>(frame_count);  // NOLINT
+
+  // Get animation parameters
+  uint32_t frame_size = anim->get_width_stride() * anim->get_height();
+  const uint8_t *base_data = anim->get_animation_data_start();
+
+  // Get the first frame's descriptor as template for format info
+  const lv_img_dsc_t *template_dsc = anim->get_lv_img_dsc();
+
+  // Create descriptor for each frame by copying template and updating data pointer
+  for (uint32_t i = 0; i < frame_count; i++) {
+    // Copy entire template descriptor (preserves header structure)
+    (*dsc_array)[i] = *template_dsc;
+    // Update data pointer for this specific frame
+    (*dsc_array)[i].data = base_data + (i * frame_size);
+    (*dsc_array)[i].data_size = frame_size;
+  }
+
+  // Build pointer array for LVGL
+  auto *dsc_ptrs = new std::vector<lv_img_dsc_t *>();  // NOLINT
+  for (auto &dsc : *dsc_array) {
+    dsc_ptrs->push_back(&dsc);
+  }
+
+  // Create struct to hold both vectors (prevents orphaning of descriptor memory)
+  struct AnimImgData {
+    std::vector<lv_img_dsc_t> *descriptors;  // Owns the actual descriptor structs
+    std::vector<lv_img_dsc_t *> *pointers;   // Pointers into descriptors
+  };
+  auto *data = new AnimImgData{dsc_array, dsc_ptrs};  // NOLINT
+
+  // Store both vectors so descriptor memory remains referenced
+  lv_obj_set_user_data(img, data);
+
+  // Call LVGL API with the pointer array
+  lv_animimg_set_src(img, (const void **) data->pointers->data(), frame_count);
 }
 
 #endif  // USE_LVGL_ANIMIMG

--- a/esphome/components/lvgl/widgets/animimg.py
+++ b/esphome/components/lvgl/widgets/animimg.py
@@ -1,7 +1,9 @@
 from esphome import automation
+import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_DURATION, CONF_ID
 
+from ...animation import Animation_
 from ..automation import action_to_code
 from ..defines import CONF_AUTO_START, CONF_MAIN, CONF_REPEAT_COUNT, CONF_SRC
 from ..helpers import lvgl_components_required
@@ -27,17 +29,24 @@ ANIMIMG_BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_AUTO_START, default=True): cv.boolean,
     }
 )
+
 ANIMIMG_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
-        cv.Required(CONF_DURATION): lv_milliseconds,
-        cv.Required(CONF_SRC): lv_image_list,
+        cv.Optional(CONF_DURATION): lv_milliseconds,  # Optional - auto from Animation
+        cv.Required(CONF_SRC): cv.Any(
+            cv.use_id(Animation_),  # Single Animation reference
+            lv_image_list,  # List of images (existing behavior)
+        ),
     }
 )
 
 ANIMIMG_MODIFY_SCHEMA = ANIMIMG_BASE_SCHEMA.extend(
     {
         cv.Optional(CONF_DURATION): lv_milliseconds,
-        cv.Optional(CONF_SRC): lv_image_list,
+        cv.Optional(CONF_SRC): cv.Any(
+            cv.use_id(Animation_),
+            lv_image_list,
+        ),
     }
 )
 
@@ -55,15 +64,39 @@ class AnimimgType(WidgetType):
         )
 
     async def to_code(self, w: Widget, config):
+        from esphome import core
+        from esphome.core import EsphomeError
+
         lvgl_components_required.add(CONF_IMAGE)
         lvgl_components_required.add(CONF_ANIMIMG)
+
         if srcs := config.get(CONF_SRC):
-            srcs = await lv_image_list.process(srcs)
-            lv.animimg_set_src(w.obj, srcs)
+            # Check if source is an Animation ID or a list of images
+            if isinstance(srcs, core.ID):
+                # Single Animation reference
+                anim_var = await cg.get_variable(srcs)
+                lv.animimg_set_src(w.obj, anim_var)
+
+                # Set duration - use Animation's total duration if not specified
+                if duration := config.get(CONF_DURATION):
+                    lv.animimg_set_duration(w.obj, duration)
+                else:
+                    lv.animimg_set_duration(w.obj, anim_var.get_total_duration())
+            else:
+                # List of Images (existing behavior)
+                srcs = await lv_image_list.process(srcs)
+                lv.animimg_set_src(w.obj, srcs)
+
+                # Duration is required for image lists
+                duration = config.get(CONF_DURATION)
+                if duration is None:
+                    raise EsphomeError(
+                        "'duration' is required when 'src' is a list of images"
+                    )
+                lv.animimg_set_duration(w.obj, duration)
+
         if repeat_count := config.get(CONF_REPEAT_COUNT):
             lv.animimg_set_repeat_count(w.obj, repeat_count)
-        if duration := config.get(CONF_DURATION):
-            lv.animimg_set_duration(w.obj, duration)
         if config[CONF_AUTO_START]:
             lv.animimg_start(w.obj)
 


### PR DESCRIPTION
# What does this implement/fix?

LVGL animimg currently needs you to list out frames and figure out the correct duration by number of frames / delay per frame, which is annoying.
GIF/APNG frame disposal was also not handled correctly, so I fixed that.

I'm going to say this is a bug fix more than a new feature, since it seems like this should just work and show more than the first frame like it does now.

[Works, but needs a bit more testing]

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
animation:
  - id: test_anim
    file: jake.gif
    type: RGB565
    transparency: alpha_channel
    resize: 120x64

lvgl:
  pages:
    - id: page_animation_test
      bg_color: 0x0080FF
      widgets:
        - animimg:
            id: my_animimg
            align: CENTER
            src: test_anim
            repeat_count: forever
            auto_start: true
            width: 120
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
