### PR TITLE
[template] alarm_control_panel data restructuring

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -17,13 +17,8 @@ TemplateAlarmControlPanel::TemplateAlarmControlPanel(){};
 
 #ifdef USE_BINARY_SENSOR
 void TemplateAlarmControlPanel::add_sensor(binary_sensor::BinarySensor *sensor, uint16_t flags, AlarmSensorType type) {
-  // Save the flags and type. Assign a store index for the per sensor data type.
-  SensorDataStore sd;
-  sd.last_chime_state = false;
-  this->sensor_map_[sensor].flags = flags;
-  this->sensor_map_[sensor].type = type;
-  this->sensor_data_.push_back(sd);
-  this->sensor_map_[sensor].store_index = this->next_store_index_++;
+  this->sensors_[sensor].flags = flags;
+  this->sensors_[sensor].type = type;
 };
 
 static const LogString *sensor_type_to_string(AlarmSensorType type) {
@@ -58,7 +53,7 @@ void TemplateAlarmControlPanel::dump_config() {
                 (this->arming_home_time_ / 1000), (this->arming_night_time_ / 1000), (this->pending_time_ / 1000),
                 (this->trigger_time_ / 1000), this->get_supported_features());
 #ifdef USE_BINARY_SENSOR
-  for (auto const &[sensor, info] : this->sensor_map_) {
+  for (auto const &[sensor, info] : this->sensors_) {
     ESP_LOGCONFIG(TAG,
                   "  Binary Sensor:\n"
                   "    Name: %s\n"
@@ -99,7 +94,7 @@ void TemplateAlarmControlPanel::loop() {
       delay = this->arming_night_time_;
     }
     if ((millis() - this->last_update_) > delay) {
-      this->bypass_before_arming();
+      this->auto_bypass_sensors_();
       this->publish_state(this->desired_state_);
     }
     return;
@@ -121,24 +116,23 @@ void TemplateAlarmControlPanel::loop() {
 
 #ifdef USE_BINARY_SENSOR
   // Test all of the sensors regardless of the alarm panel state
-  for (auto const &[sensor, info] : this->sensor_map_) {
+  for (auto &[sensor, info] : this->sensors_) {
     // Check for chime zones
     if (info.flags & BINARY_SENSOR_MODE_CHIME) {
       // Look for the transition from closed to open
-      if ((!this->sensor_data_[info.store_index].last_chime_state) && (sensor->state)) {
+      if ((!info.chime_active) && (sensor->state)) {
         // Must be disarmed to chime
         if (this->current_state_ == ACP_STATE_DISARMED) {
           this->chime_callback_.call();
         }
       }
       // Record the sensor state change
-      this->sensor_data_[info.store_index].last_chime_state = sensor->state;
+      info.chime_active = sensor->state;
     }
     // Check for faulted sensors
     if (sensor->state) {
       // Skip if auto bypassed
-      if (std::count(this->bypassed_sensor_indicies_.begin(), this->bypassed_sensor_indicies_.end(),
-                     info.store_index) == 1) {
+      if (info.auto_bypassed) {
         continue;
       }
       // Skip if bypass armed home
@@ -235,19 +229,27 @@ void TemplateAlarmControlPanel::arm_(optional<std::string> code, alarm_control_p
   if (delay > 0) {
     this->publish_state(ACP_STATE_ARMING);
   } else {
-    this->bypass_before_arming();
+    this->auto_bypass_sensors_();
     this->publish_state(state);
   }
 }
 
-void TemplateAlarmControlPanel::bypass_before_arming() {
+void TemplateAlarmControlPanel::auto_bypass_sensors_() {
 #ifdef USE_BINARY_SENSOR
-  for (auto const &[sensor, info] : this->sensor_map_) {
+  for (auto &[sensor, info] : this->sensors_) {
     // Check for faulted bypass_auto sensors and remove them from monitoring
     if ((info.flags & BINARY_SENSOR_MODE_BYPASS_AUTO) && (sensor->state)) {
       ESP_LOGW(TAG, "'%s' is faulted and will be automatically bypassed", sensor->get_name().c_str());
-      this->bypassed_sensor_indicies_.push_back(info.store_index);
+      info.auto_bypassed = true;
     }
+  }
+#endif
+}
+
+void TemplateAlarmControlPanel::clear_auto_bypassed_sensors_() {
+#ifdef USE_BINARY_SENSOR
+  for (auto &[_sensor, info] : this->sensors_) {
+    info.auto_bypassed = false;
   }
 #endif
 }
@@ -267,9 +269,7 @@ void TemplateAlarmControlPanel::control(const AlarmControlPanelCall &call) {
       }
       this->desired_state_ = ACP_STATE_DISARMED;
       this->publish_state(ACP_STATE_DISARMED);
-#ifdef USE_BINARY_SENSOR
-      this->bypassed_sensor_indicies_.clear();
-#endif
+      this->clear_auto_bypassed_sensors_();
     } else if (call.get_state() == ACP_STATE_TRIGGERED) {
       this->publish_state(ACP_STATE_TRIGGERED);
     } else if (call.get_state() == ACP_STATE_PENDING) {

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -39,14 +39,11 @@ enum TemplateAlarmControlPanelRestoreMode {
   ALARM_CONTROL_PANEL_RESTORE_DEFAULT_DISARMED,
 };
 
-struct SensorDataStore {
-  bool last_chime_state;
-};
-
 struct SensorInfo {
   uint16_t flags;
   AlarmSensorType type;
-  uint8_t store_index;
+  bool chime_active;
+  bool auto_bypassed;
 };
 
 class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel, public Component {
@@ -60,7 +57,6 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   bool get_requires_code_to_arm() const override { return this->requires_code_to_arm_; }
   bool get_all_sensors_ready() { return this->sensors_ready_; };
   void set_restore_mode(TemplateAlarmControlPanelRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
-  void bypass_before_arming();
 
 #ifdef USE_BINARY_SENSOR
   /** Add a binary_sensor to the alarm_panel.
@@ -123,9 +119,7 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   void control(const alarm_control_panel::AlarmControlPanelCall &call) override;
 #ifdef USE_BINARY_SENSOR
   // This maps a binary sensor to its alarm specific info
-  std::map<binary_sensor::BinarySensor *, SensorInfo> sensor_map_;
-  // a list of automatically bypassed sensors
-  std::vector<uint8_t> bypassed_sensor_indicies_;
+  std::map<binary_sensor::BinarySensor *, SensorInfo> sensors_;
 #endif
   TemplateAlarmControlPanelRestoreMode restore_mode_{};
 
@@ -142,17 +136,17 @@ class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel,
   // a list of codes
   std::vector<std::string> codes_;
   // Per sensor data store
-  std::vector<SensorDataStore> sensor_data_;
   // requires a code to arm
   bool requires_code_to_arm_ = false;
   bool supports_arm_home_ = false;
   bool supports_arm_night_ = false;
   bool sensors_ready_ = false;
-  uint8_t next_store_index_ = 0;
   // check if the code is valid
   bool is_code_valid_(optional<std::string> code);
 
   void arm_(optional<std::string> code, alarm_control_panel::AlarmControlPanelState state, uint32_t delay);
+  void auto_bypass_sensors_();
+  void clear_auto_bypassed_sensors_();
 };
 
 }  // namespace template_


### PR DESCRIPTION
# What does this implement/fix?

SensorDataStore doesn't add anything, apart from complexity, so collapse its contents into SensorInfo, renaming sensor_map_ to sensors_ and last_chimed_state to chime_active in the process.
Similarly, bypassed_sensor_indicies_ is rather convoluted - replace it with a flag, auto_bypassed, in SensorInfo.

This commit forms the third part of a split up of https://github.com/esphome/esphome/pull/9003.
This part contains data restructuring improvements and has no functional changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
