### PR TITLE
[core] Fix substitution id redefinition false positive

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -319,6 +319,9 @@ def iter_ids(config, path=None):
             yield from iter_ids(item, path + [i])
     elif isinstance(config, dict):
         for key, value in config.items():
+            if len(path) == 0 and key == CONF_SUBSTITUTIONS:
+                # Ignore IDs in substitution definitions.
+                continue
             if isinstance(key, core.ID):
                 yield key, path
             yield from iter_ids(value, path + [key])

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -261,6 +261,17 @@ def test_device_duplicate_id(
     assert "ID duplicate_device redefined!" in captured.out
 
 
+def test_substitution_with_id(
+    yaml_file: Callable[[str], str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that a ids coming from substitutions do not cause false positive ID redefinition."""
+    load_config_from_fixture(
+        yaml_file, "id_collision_with_substitution.yaml", FIXTURES_DIR
+    )
+    captured = capsys.readouterr()
+    assert "ID some_switch_id redefined!" not in captured.out
+
+
 def test_add_platform_defines_priority() -> None:
     """Test that _add_platform_defines runs after globals.
 

--- a/tests/unit_tests/fixtures/core/config/id_collision_with_substitution.yaml
+++ b/tests/unit_tests/fixtures/core/config/id_collision_with_substitution.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: conditional_example
+  name: test
 
 host:
 

--- a/tests/unit_tests/fixtures/core/config/id_collision_with_substitution.yaml
+++ b/tests/unit_tests/fixtures/core/config/id_collision_with_substitution.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: conditional_example
+
+host:
+
+substitutions:
+  support_switches:
+    - platform: gpio
+      id: some_switch_id
+      pin: 12
+
+switch: $support_switches


### PR DESCRIPTION
# What does this implement/fix?

If a component with ID is defined in a substitution variable, the ID duplicate validator incorrectly detects it as a duplicate. This is because after substitution, the ID appears in both locations in the configuration.

The PR makes sure that what look like IDs that are in `substitutions` are ignored when checking for duplicates. It does not make sense to scan what is under `substitutions` to look for ID declarations, since literally anything can be in there but certainly no components are being really declared there, so on top we also save a bit of time by ignoring it.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] all (config)

## Example entry for `config.yaml`:

```yaml
substitutions:
  my_switches:
    - platform: gpio
      id: some_switch_id
      pin: 12

switch: $my_switches
```

expands to:

```yaml
substitutions:
  my_switches:
    - platform: gpio
      id: some_switch_id
      pin: 12

switch:
  - platform: gpio
    id: some_switch_id
    pin: 12
```
which looks like `some_switch_id` is being declared in two places.


## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
