### PR TITLE
[pzemac] 0 volts instead of unavailable

### DIFF
--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,8 +4,10 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t last_update_time_; // No errors were found during local compilation; everything works correctly on IDF and Arduino.
-float last_energy_sensor[10] = {}; // No errors were found during local compilation; everything works correctly on IDF and Arduino.
+uint32_t
+    last_update_time_;  // No errors were found during local compilation; everything works correctly on IDF and Arduino.
+float last_energy_sensor[10] =
+    {};  // No errors were found during local compilation; everything works correctly on IDF and Arduino.
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,13 +4,13 @@
 namespace esphome {
 namespace pzemac {
 
-class pzemac_temp {
- public:
-  uint32_t last_update_time_;
-  float last_energy_sensor[10] = {};
+class PzemacTemp {
+public:
+    uint32_t last_update_time_;
+    float last_energy_sensor[10] = {};
 };
 
-pzemac_temp tmp;
+PzemacTemp tmp;
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -1,12 +1,11 @@
 #include "pzemac.h"
 #include "esphome/core/log.h"
 
-unsigned long last_update_time_;
-
-static float last_energy_sensor[10] = {};
-
 namespace esphome {
 namespace pzemac {
+
+uint32_t last_update_time_;
+static float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace pzemac {
 
-static uint32_t last_update_time_[1] = {};
+static uint32_t last_update_time_;
 static float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
@@ -18,7 +18,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  last_update_time_[0] = millis();
+  last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -53,8 +53,9 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
-           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy,
+           last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1],
+           frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);
@@ -101,7 +102,7 @@ void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - last_update_time_[0]) > this->get_update_interval() * 2) {
+      (millis() - last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,13 +4,8 @@
 namespace esphome {
 namespace pzemac {
 
-class PzemacTemp {
- public:
-  uint32_t last_update_time_;
-  float last_energy_sensor[10] = {};
-};
-
-PzemacTemp static tmp;
+static uint32_t last_update_time_[1] = {};
+static float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 
@@ -23,7 +18,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  tmp.last_update_time_ = millis();
+  last_update_time_[0] = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -59,7 +54,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
            int(this->address_), voltage, current, active_power, active_energy,
-           tmp.last_energy_sensor[this->address_ - 1], active_energy - tmp.last_energy_sensor[this->address_ - 1],
+           last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1],
            frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
@@ -83,15 +78,15 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     }
   }
   if (this->energy_sensor_ != nullptr) {
-    if (tmp.last_energy_sensor[this->address_ - 1] == 0) {
+    if (last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
-      tmp.last_energy_sensor[this->address_ - 1] = active_energy;
+      last_energy_sensor[this->address_ - 1] = active_energy;
     } else {
-      if (abs(active_energy - tmp.last_energy_sensor[this->address_ - 1]) < 1000) {
+      if (abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
-        tmp.last_energy_sensor[this->address_ - 1] = active_energy;
+        last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
-        this->energy_sensor_->publish_state(tmp.last_energy_sensor[this->address_ - 1]);
+        this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
       }
     }
   }
@@ -107,7 +102,7 @@ void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - tmp.last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - last_update_time_[0]) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -119,7 +114,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      this->energy_sensor_->publish_state(tmp.last_energy_sensor[this->address_ - 1]);
+      this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,9 +5,9 @@ namespace esphome {
 namespace pzemac {
 
 class PzemacTemp {
-protected:
-    uint32_t m_last_update_time_;
-    float m_last_energy_sensor[10] = {};
+ protected:
+  uint32_t m_last_update_time_;
+  float m_last_energy_sensor[10] = {};
 };
 
 PzemacTemp Tmp;
@@ -58,8 +58,9 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, Tmp.m_last_energy_sensor[this->address_ - 1],
-           active_energy - Tmp.m_last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy,
+           Tmp.m_last_energy_sensor[this->address_ - 1], active_energy - Tmp.m_last_energy_sensor[this->address_ - 1],
+           frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,21 +4,21 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t last_update_time_;
+uint32_t last_update_time_[10] = {};
 float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 
-static const uint8_t PZECMD_READ_IN_REGISTERS = 0x04;
-static const uint8_t PZECMD_RESET_ENERGY = 0x42;
-static const uint8_t PZEREGISTER_COUNT = 10;  // 10x 16-bit registers
+static const uint8_t PZEM_CMD_READ_IN_REGISTERS = 0x04;
+static const uint8_t PZEM_CMD_RESET_ENERGY = 0x42;
+static const uint8_t PZEM_REGISTER_COUNT = 10;  // 10x 16-bit registers
 
 void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   if (data.size() < 20) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  last_update_time_ = millis();
+  last_update_time_[this->address_ - 1] = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -26,26 +26,28 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   // Id Cc Sz Volt- Current---- Power------ Energy----- Frequ PFact Alarm Crc--
   //           0     2           6          10          14    16
 
-  auto pzeget_16bit = [&](size_t i) -> uint16_t { return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0); };
-  auto pzeget_32bit = [&](size_t i) -> uint32_t {
-    return (uint32_t(pzeget_16bit(i + 2)) << 16) | (uint32_t(pzeget_16bit(i + 0)) << 0);
+  auto pzem_get_16bit = [&](size_t i) -> uint16_t {
+    return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
+  };
+  auto pzem_get_32bit = [&](size_t i) -> uint32_t {
+    return (uint32_t(pzem_get_16bit(i + 2)) << 16) | (uint32_t(pzem_get_16bit(i + 0)) << 0);
   };
 
-  uint16_t raw_voltage = pzeget_16bit(0);
+  uint16_t raw_voltage = pzem_get_16bit(0);
   float voltage = raw_voltage / 10.0f;  // max 6553.5 V
 
-  uint32_t raw_current = pzeget_32bit(2);
+  uint32_t raw_current = pzem_get_32bit(2);
   float current = raw_current / 1000.0f;  // max 4294967.295 A
 
-  uint32_t raw_active_power = pzeget_32bit(6);
+  uint32_t raw_active_power = pzem_get_32bit(6);
   float active_power = raw_active_power / 10.0f;  // max 429496729.5 W
 
-  float active_energy = static_cast<float>(pzeget_32bit(10));
+  float active_energy = static_cast<float>(pzem_get_32bit(10));
 
-  uint16_t raw_frequency = pzeget_16bit(14);
+  uint16_t raw_frequency = pzem_get_16bit(14);
   float frequency = raw_frequency / 10.0f;
 
-  uint16_t raw_power_factor = pzeget_16bit(16);
+  uint16_t raw_power_factor = pzem_get_16bit(16);
   float power_factor = raw_power_factor / 100.0f;
 
   ESP_LOGD(TAG,
@@ -96,10 +98,10 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
 }
 
 void PZEMAC::update() {
-  this->send(PZECMD_READ_IN_REGISTERS, 0, PZEREGISTER_COUNT);
+  this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - last_update_time_[this->address_ - 1]) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -136,7 +138,7 @@ void PZEMAC::dump_config() {
 void PZEMAC::reset_energy_() {
   std::vector<uint8_t> cmd;
   cmd.push_back(this->address_);
-  cmd.push_back(PZECMD_RESET_ENERGY);
+  cmd.push_back(PZEM_CMD_RESET_ENERGY);
   this->send_raw(cmd);
 }
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -26,9 +26,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   // Id Cc Sz Volt- Current---- Power------ Energy----- Frequ PFact Alarm Crc--
   //           0     2           6          10          14    16
 
-  auto pzeget_16bit = [&](size_t i) -> uint16_t {
-    return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
-  };
+  auto pzeget_16bit = [&](size_t i) -> uint16_t { return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0); };
   auto pzeget_32bit = [&](size_t i) -> uint32_t {
     return (uint32_t(pzeget_16bit(i + 2)) << 16) | (uint32_t(pzeget_16bit(i + 0)) << 0);
   };
@@ -53,9 +51,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy,
-           last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1],
-           frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
+           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,9 +5,9 @@ namespace esphome {
 namespace pzemac {
 
 class PzemacTemp {
-public:
-    uint32_t last_update_time_;
-    float last_energy_sensor[10] = {};
+ public:
+  uint32_t last_update_time_;
+  float last_energy_sensor[10] = {};
 };
 
 PzemacTemp tmp;

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,10 +4,13 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t
-    last_update_time_;  // No errors were found during local compilation; everything works correctly on IDF and Arduino.
-float last_energy_sensor[10] =
-    {};  // No errors were found during local compilation; everything works correctly on IDF and Arduino.
+class PzemacTemp {
+protected:
+    uint32_t last_update_time_;
+    float last_energy_sensor[10] = {};
+};
+
+PzemacTemp Tmp;
 
 static const char *const TAG = "pzemac";
 
@@ -20,7 +23,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  last_update_time_ = millis();
+  Tmp.last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -55,8 +58,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
-           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy, Tmp.last_energy_sensor[this->address_ - 1],
+           active_energy - Tmp.last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);
@@ -79,15 +82,15 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     }
   }
   if (this->energy_sensor_ != nullptr) {
-    if (last_energy_sensor[this->address_ - 1] == 0) {
+    if (Tmp.last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
-      last_energy_sensor[this->address_ - 1] = active_energy;
+      Tmp.last_energy_sensor[this->address_ - 1] = active_energy;
     } else {
-      if (abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
+      if (abs(active_energy - Tmp.last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
-        last_energy_sensor[this->address_ - 1] = active_energy;
+        Tmp.last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
-        this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+        this->energy_sensor_->publish_state(Tmp.last_energy_sensor[this->address_ - 1]);
       }
     }
   }
@@ -103,7 +106,7 @@ void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - Tmp.last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -115,7 +118,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+      this->energy_sensor_->publish_state(Tmp.last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,9 +5,9 @@ namespace esphome {
 namespace pzemac {
 
 class PzemacTemp {
-protected:
-    uint32_t last_update_time_;
-    float last_energy_sensor[10] = {};
+ protected:
+  uint32_t last_update_time_;
+  float last_energy_sensor[10] = {};
 };
 
 PzemacTemp Tmp;
@@ -58,8 +58,9 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, Tmp.last_energy_sensor[this->address_ - 1],
-           active_energy - Tmp.last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy,
+           Tmp.last_energy_sensor[this->address_ - 1], active_energy - Tmp.last_energy_sensor[this->address_ - 1],
+           frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -56,10 +56,11 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
            int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
            active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
-    if (voltage < 450)
+    if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);
-    else
+    } else {
       this->voltage_sensor_->publish_state(220.0f);
+    }
   }
   if (this->current_sensor_ != nullptr) {
     if (current < 150) {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,8 +4,8 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t last_update_time_;
-float last_energy_sensor[10] = {};
+uint32_t last_update_time_; // No errors were found during local compilation; everything works correctly on IDF and Arduino.
+float last_energy_sensor[10] = {}; // No errors were found during local compilation; everything works correctly on IDF and Arduino.
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -3,7 +3,7 @@
 
 uint32_t last_update_time_;
 
-static uint32_t last_energy_sensor [10] = {};
+static uint32_t last_energy_sensor[10] = {};
 
 namespace esphome {
 namespace pzemac {
@@ -51,41 +51,43 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   uint16_t raw_power_factor = pzem_get_16bit(16);
   float power_factor = raw_power_factor / 100.0f;
 
-  ESP_LOGD(TAG, "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f Hz, PF=%.2f", int(this->address_), voltage, current, active_power,
-           active_energy, last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
+  ESP_LOGD(TAG,
+           "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
+           "Hz, PF=%.2f",
+           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
+           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
-    if (voltage < 450) 
+    if (voltage < 450)
       this->voltage_sensor_->publish_state(voltage);
-    else 
-      this->voltage_sensor_->publish_state(220.0f); }
+    else
+      this->voltage_sensor_->publish_state(220.0f);
+  }
   if (this->current_sensor_ != nullptr) {
-    if (current < 150) 
+    if (current < 150)
       this->current_sensor_->publish_state(current);
     else
-      this->current_sensor_->publish_state(1.0f); }
+      this->current_sensor_->publish_state(1.0f);
+  }
   if (this->power_sensor_ != nullptr) {
-    if (active_power < 16000) 
+    if (active_power < 16000)
       this->power_sensor_->publish_state(active_power);
     else
-      this->power_sensor_->publish_state(101.0f); }
-//  if (this->energy_sensor_ != nullptr)
-//    this->energy_sensor_->publish_state(active_energy);
+      this->power_sensor_->publish_state(101.0f);
+  }
+  //  if (this->energy_sensor_ != nullptr)
+  //    this->energy_sensor_->publish_state(active_energy);
   if (this->energy_sensor_ != nullptr) {
     if (last_energy_sensor[this->address_ - 1] == 0) {
+      this->energy_sensor_->publish_state(active_energy);
+      last_energy_sensor[this->address_ - 1] = active_energy;
+    } else {
+      if (abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
         last_energy_sensor[this->address_ - 1] = active_energy;
-    }
-    else
-    {
-        if ( abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
-            this->energy_sensor_->publish_state(active_energy);
-            last_energy_sensor[this->address_ - 1] = active_energy;
-        }
-        else
-        {
-            this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
-//            active_energy = last_energy_sensor[this->address_ - 1];
-        }
+      } else {
+        this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+        //            active_energy = last_energy_sensor[this->address_ - 1];
+      }
     }
   }
   if (this->frequency_sensor_ != nullptr)
@@ -97,7 +99,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
 void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
-  if (this->get_update_interval() != SCHEDULER_DONT_RUN && (millis() - last_update_time_) > this->get_update_interval() * 2) {
+  if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
+      (millis() - last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr)
       this->voltage_sensor_->publish_state(0.0f);
@@ -105,8 +108,8 @@ void PZEMAC::update() {
       this->current_sensor_->publish_state(0.0f);
     if (this->power_sensor_ != nullptr)
       this->power_sensor_->publish_state(0.0f);
-    if (this->energy_sensor_ != nullptr)           //
-//      this->energy_sensor_->publish_state(0.0f);   //
+    if (this->energy_sensor_ != nullptr)  //
+                                          //      this->energy_sensor_->publish_state(0.0f);   //
       this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
     if (this->frequency_sensor_ != nullptr)
       this->frequency_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -10,7 +10,7 @@ class PzemacTemp {
   float last_energy_sensor[10] = {};
 };
 
-PzemacTemp tmp;
+PzemacTemp static tmp;
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,9 +5,9 @@ namespace esphome {
 namespace pzemac {
 
 class pzemac_temp {
-public:
-    uint32_t last_update_time_;
-    float last_energy_sensor[10] = {};
+ public:
+  uint32_t last_update_time_;
+  float last_energy_sensor[10] = {};
 };
 
 pzemac_temp tmp;
@@ -58,8 +58,9 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, tmp.last_energy_sensor[this->address_ - 1],
-           active_energy - tmp.last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy,
+           tmp.last_energy_sensor[this->address_ - 1], active_energy - tmp.last_energy_sensor[this->address_ - 1],
+           frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -1,9 +1,9 @@
 #include "pzemac.h"
 #include "esphome/core/log.h"
 
-unsigned long last_update_time_;
+uint32_t last_update_time_;
 
-static uint16_t last_energy_sensor [10] = {};
+static uint32_t last_energy_sensor [10] = {};
 
 namespace esphome {
 namespace pzemac {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t last_update_time_;
+const uint32_t last_update_time_;
 static float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -3,7 +3,7 @@
 
 unsigned long last_update_time_;
 
-static float last_energy_sensor [10] = {};
+static uint16_t last_energy_sensor [10] = {};
 
 namespace esphome {
 namespace pzemac {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -64,16 +64,14 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   if (this->current_sensor_ != nullptr) {
     if (current < 150) {
       this->current_sensor_->publish_state(current);
-    }
-    else {
+    } else {
       this->current_sensor_->publish_state(1.0f);
     }
   }
   if (this->power_sensor_ != nullptr) {
     if (active_power < 16000) {
       this->power_sensor_->publish_state(active_power);
-    }
-    else {
+    } else {
       this->power_sensor_->publish_state(101.0f);
     }
   }
@@ -117,7 +115,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-//      this->energy_sensor_->publish_state(0.0f);   //
+      //      this->energy_sensor_->publish_state(0.0f);   //
       this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,8 +4,8 @@
 namespace esphome {
 namespace pzemac {
 
-const uint32_t last_update_time_;
-static float last_energy_sensor[10] = {};
+uint32_t last_update_time_;
+static float last_energy_sensor [10] = {};
 
 static const char *const TAG = "pzemac";
 
@@ -76,8 +76,6 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
       this->power_sensor_->publish_state(101.0f);
     }
   }
-  //  if (this->energy_sensor_ != nullptr)
-  //    this->energy_sensor_->publish_state(active_energy);
   if (this->energy_sensor_ != nullptr) {
     if (last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
@@ -88,7 +86,6 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
         last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
         this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
-        //            active_energy = last_energy_sensor[this->address_ - 1];
       }
     }
   }
@@ -116,7 +113,6 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      //      this->energy_sensor_->publish_state(0.0f);   //
       this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace pzemac {
 
 uint32_t last_update_time_;
-static float last_energy_sensor [10] = {};
+static float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,8 +4,13 @@
 namespace esphome {
 namespace pzemac {
 
-uint32_t last_update_time_;
-static float last_energy_sensor[10] = {};
+class pzemac_temp {
+public:
+    uint32_t last_update_time_;
+    float last_energy_sensor[10] = {};
+};
+
+pzemac_temp tmp;
 
 static const char *const TAG = "pzemac";
 
@@ -18,7 +23,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  last_update_time_ = millis();
+  tmp.last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -53,8 +58,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
-           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy, tmp.last_energy_sensor[this->address_ - 1],
+           active_energy - tmp.last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);
@@ -77,15 +82,15 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     }
   }
   if (this->energy_sensor_ != nullptr) {
-    if (last_energy_sensor[this->address_ - 1] == 0) {
+    if (tmp.last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
-      last_energy_sensor[this->address_ - 1] = active_energy;
+      tmp.last_energy_sensor[this->address_ - 1] = active_energy;
     } else {
-      if (abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
+      if (abs(active_energy - tmp.last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
-        last_energy_sensor[this->address_ - 1] = active_energy;
+        tmp.last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
-        this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+        this->energy_sensor_->publish_state(tmp.last_energy_sensor[this->address_ - 1]);
       }
     }
   }
@@ -101,7 +106,7 @@ void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - tmp.last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -113,7 +118,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+      this->energy_sensor_->publish_state(tmp.last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,8 +4,8 @@
 namespace esphome {
 namespace pzemac {
 
-static uint32_t last_update_time_;
-static float last_energy_sensor[10] = {};
+uint32_t last_update_time_;
+float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -1,6 +1,10 @@
 #include "pzemac.h"
 #include "esphome/core/log.h"
 
+unsigned long last_update_time_;
+
+static float last_energy_sensor [10] = {};
+
 namespace esphome {
 namespace pzemac {
 
@@ -15,6 +19,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
+  last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -46,28 +51,73 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   uint16_t raw_power_factor = pzem_get_16bit(16);
   float power_factor = raw_power_factor / 100.0f;
 
-  ESP_LOGD(TAG, "PZEM AC: V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, F=%.1f Hz, PF=%.2f", voltage, current, active_power,
-           active_energy, frequency, power_factor);
-  if (this->voltage_sensor_ != nullptr)
-    this->voltage_sensor_->publish_state(voltage);
-  if (this->current_sensor_ != nullptr)
-    this->current_sensor_->publish_state(current);
-  if (this->power_sensor_ != nullptr)
-    this->power_sensor_->publish_state(active_power);
-  if (this->energy_sensor_ != nullptr)
-    this->energy_sensor_->publish_state(active_energy);
+  ESP_LOGD(TAG, "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f Hz, PF=%.2f", int(this->address_), voltage, current, active_power,
+           active_energy, last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
+  if (this->voltage_sensor_ != nullptr) {
+    if (voltage < 450) 
+      this->voltage_sensor_->publish_state(voltage);
+    else 
+      this->voltage_sensor_->publish_state(220.0f); }
+  if (this->current_sensor_ != nullptr) {
+    if (current < 150) 
+      this->current_sensor_->publish_state(current);
+    else
+      this->current_sensor_->publish_state(1.0f); }
+  if (this->power_sensor_ != nullptr) {
+    if (active_power < 16000) 
+      this->power_sensor_->publish_state(active_power);
+    else
+      this->power_sensor_->publish_state(101.0f); }
+//  if (this->energy_sensor_ != nullptr)
+//    this->energy_sensor_->publish_state(active_energy);
+  if (this->energy_sensor_ != nullptr) {
+    if (last_energy_sensor[this->address_ - 1] == 0) {
+        this->energy_sensor_->publish_state(active_energy);
+        last_energy_sensor[this->address_ - 1] = active_energy;
+    }
+    else
+    {
+        if ( abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
+            this->energy_sensor_->publish_state(active_energy);
+            last_energy_sensor[this->address_ - 1] = active_energy;
+        }
+        else
+        {
+            this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+//            active_energy = last_energy_sensor[this->address_ - 1];
+        }
+    }
+  }
   if (this->frequency_sensor_ != nullptr)
     this->frequency_sensor_->publish_state(frequency);
   if (this->power_factor_sensor_ != nullptr)
     this->power_factor_sensor_->publish_state(power_factor);
 }
 
-void PZEMAC::update() { this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT); }
+void PZEMAC::update() {
+  this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
+
+  if (this->get_update_interval() != SCHEDULER_DONT_RUN && (millis() - last_update_time_) > this->get_update_interval() * 2) {
+    ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
+    if (this->voltage_sensor_ != nullptr)
+      this->voltage_sensor_->publish_state(0.0f);
+    if (this->current_sensor_ != nullptr)
+      this->current_sensor_->publish_state(0.0f);
+    if (this->power_sensor_ != nullptr)
+      this->power_sensor_->publish_state(0.0f);
+    if (this->energy_sensor_ != nullptr)           //
+//      this->energy_sensor_->publish_state(0.0f);   //
+      this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
+    if (this->frequency_sensor_ != nullptr)
+      this->frequency_sensor_->publish_state(0.0f);
+    if (this->power_factor_sensor_ != nullptr)
+      this->power_factor_sensor_->publish_state(0.0f);
+  }
+}
+
 void PZEMAC::dump_config() {
-  ESP_LOGCONFIG(TAG,
-                "PZEMAC:\n"
-                "  Address: 0x%02X",
-                this->address_);
+  ESP_LOGCONFIG(TAG, "PZEMAC:");
+  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -5,9 +5,9 @@ namespace esphome {
 namespace pzemac {
 
 class PzemacTemp {
- protected:
-  uint32_t last_update_time_;
-  float last_energy_sensor[10] = {};
+protected:
+    uint32_t m_last_update_time_;
+    float m_last_energy_sensor[10] = {};
 };
 
 PzemacTemp Tmp;
@@ -23,7 +23,7 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  Tmp.last_update_time_ = millis();
+  Tmp.m_last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -58,9 +58,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy,
-           Tmp.last_energy_sensor[this->address_ - 1], active_energy - Tmp.last_energy_sensor[this->address_ - 1],
-           frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy, Tmp.m_last_energy_sensor[this->address_ - 1],
+           active_energy - Tmp.m_last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);
@@ -83,15 +82,15 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     }
   }
   if (this->energy_sensor_ != nullptr) {
-    if (Tmp.last_energy_sensor[this->address_ - 1] == 0) {
+    if (Tmp.m_last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
-      Tmp.last_energy_sensor[this->address_ - 1] = active_energy;
+      Tmp.m_last_energy_sensor[this->address_ - 1] = active_energy;
     } else {
-      if (abs(active_energy - Tmp.last_energy_sensor[this->address_ - 1]) < 1000) {
+      if (abs(active_energy - Tmp.m_last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
-        Tmp.last_energy_sensor[this->address_ - 1] = active_energy;
+        Tmp.m_last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
-        this->energy_sensor_->publish_state(Tmp.last_energy_sensor[this->address_ - 1]);
+        this->energy_sensor_->publish_state(Tmp.m_last_energy_sensor[this->address_ - 1]);
       }
     }
   }
@@ -107,7 +106,7 @@ void PZEMAC::update() {
   this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - Tmp.last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - Tmp.m_last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -119,7 +118,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      this->energy_sensor_->publish_state(Tmp.last_energy_sensor[this->address_ - 1]);
+      this->energy_sensor_->publish_state(Tmp.m_last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -53,9 +53,8 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
-           int(this->address_), voltage, current, active_power, active_energy,
-           last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1],
-           frequency, power_factor);
+           int(this->address_), voltage, current, active_power, active_energy, last_energy_sensor[this->address_ - 1],
+           active_energy - last_energy_sensor[this->address_ - 1], frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
       this->voltage_sensor_->publish_state(voltage);

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -1,9 +1,9 @@
 #include "pzemac.h"
 #include "esphome/core/log.h"
 
-uint32_t last_update_time_;
+unsigned long last_update_time_;
 
-static uint32_t last_energy_sensor[10] = {};
+static float last_energy_sensor [10] = {};
 
 namespace esphome {
 namespace pzemac {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -3,7 +3,7 @@
 
 unsigned long last_update_time_;
 
-static float last_energy_sensor [10] = {};
+static float last_energy_sensor[10] = {};
 
 namespace esphome {
 namespace pzemac {

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -4,26 +4,21 @@
 namespace esphome {
 namespace pzemac {
 
-class PzemacTemp {
- protected:
-  uint32_t m_last_update_time_;
-  float m_last_energy_sensor[10] = {};
-};
-
-PzemacTemp Tmp;
+uint32_t last_update_time_;
+float last_energy_sensor[10] = {};
 
 static const char *const TAG = "pzemac";
 
-static const uint8_t PZEM_CMD_READ_IN_REGISTERS = 0x04;
-static const uint8_t PZEM_CMD_RESET_ENERGY = 0x42;
-static const uint8_t PZEM_REGISTER_COUNT = 10;  // 10x 16-bit registers
+static const uint8_t PZECMD_READ_IN_REGISTERS = 0x04;
+static const uint8_t PZECMD_RESET_ENERGY = 0x42;
+static const uint8_t PZEREGISTER_COUNT = 10;  // 10x 16-bit registers
 
 void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   if (data.size() < 20) {
     ESP_LOGW(TAG, "Invalid size for PZEM AC!");
     return;
   }
-  Tmp.m_last_update_time_ = millis();
+  last_update_time_ = millis();
 
   // See https://github.com/esphome/feature-requests/issues/49#issuecomment-538636809
   //  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24
@@ -31,35 +26,35 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
   // Id Cc Sz Volt- Current---- Power------ Energy----- Frequ PFact Alarm Crc--
   //           0     2           6          10          14    16
 
-  auto pzem_get_16bit = [&](size_t i) -> uint16_t {
+  auto pzeget_16bit = [&](size_t i) -> uint16_t {
     return (uint16_t(data[i + 0]) << 8) | (uint16_t(data[i + 1]) << 0);
   };
-  auto pzem_get_32bit = [&](size_t i) -> uint32_t {
-    return (uint32_t(pzem_get_16bit(i + 2)) << 16) | (uint32_t(pzem_get_16bit(i + 0)) << 0);
+  auto pzeget_32bit = [&](size_t i) -> uint32_t {
+    return (uint32_t(pzeget_16bit(i + 2)) << 16) | (uint32_t(pzeget_16bit(i + 0)) << 0);
   };
 
-  uint16_t raw_voltage = pzem_get_16bit(0);
+  uint16_t raw_voltage = pzeget_16bit(0);
   float voltage = raw_voltage / 10.0f;  // max 6553.5 V
 
-  uint32_t raw_current = pzem_get_32bit(2);
+  uint32_t raw_current = pzeget_32bit(2);
   float current = raw_current / 1000.0f;  // max 4294967.295 A
 
-  uint32_t raw_active_power = pzem_get_32bit(6);
+  uint32_t raw_active_power = pzeget_32bit(6);
   float active_power = raw_active_power / 10.0f;  // max 429496729.5 W
 
-  float active_energy = static_cast<float>(pzem_get_32bit(10));
+  float active_energy = static_cast<float>(pzeget_32bit(10));
 
-  uint16_t raw_frequency = pzem_get_16bit(14);
+  uint16_t raw_frequency = pzeget_16bit(14);
   float frequency = raw_frequency / 10.0f;
 
-  uint16_t raw_power_factor = pzem_get_16bit(16);
+  uint16_t raw_power_factor = pzeget_16bit(16);
   float power_factor = raw_power_factor / 100.0f;
 
   ESP_LOGD(TAG,
            "PZEM AC: Addr 0x%02X, V=%.1f V, I=%.3f A, P=%.1f W, E=%.1f Wh, E(pre)=%.1f Wh, E-E(pre)=%.1f Wh, F=%.1f "
            "Hz, PF=%.2f",
            int(this->address_), voltage, current, active_power, active_energy,
-           Tmp.m_last_energy_sensor[this->address_ - 1], active_energy - Tmp.m_last_energy_sensor[this->address_ - 1],
+           last_energy_sensor[this->address_ - 1], active_energy - last_energy_sensor[this->address_ - 1],
            frequency, power_factor);
   if (this->voltage_sensor_ != nullptr) {
     if (voltage < 450) {
@@ -83,15 +78,15 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
     }
   }
   if (this->energy_sensor_ != nullptr) {
-    if (Tmp.m_last_energy_sensor[this->address_ - 1] == 0) {
+    if (last_energy_sensor[this->address_ - 1] == 0) {
       this->energy_sensor_->publish_state(active_energy);
-      Tmp.m_last_energy_sensor[this->address_ - 1] = active_energy;
+      last_energy_sensor[this->address_ - 1] = active_energy;
     } else {
-      if (abs(active_energy - Tmp.m_last_energy_sensor[this->address_ - 1]) < 1000) {
+      if (abs(active_energy - last_energy_sensor[this->address_ - 1]) < 1000) {
         this->energy_sensor_->publish_state(active_energy);
-        Tmp.m_last_energy_sensor[this->address_ - 1] = active_energy;
+        last_energy_sensor[this->address_ - 1] = active_energy;
       } else {
-        this->energy_sensor_->publish_state(Tmp.m_last_energy_sensor[this->address_ - 1]);
+        this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
       }
     }
   }
@@ -104,10 +99,10 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
 }
 
 void PZEMAC::update() {
-  this->send(PZEM_CMD_READ_IN_REGISTERS, 0, PZEM_REGISTER_COUNT);
+  this->send(PZECMD_READ_IN_REGISTERS, 0, PZEREGISTER_COUNT);
 
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
-      (millis() - Tmp.m_last_update_time_) > this->get_update_interval() * 2) {
+      (millis() - last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
     if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
@@ -119,7 +114,7 @@ void PZEMAC::update() {
       this->power_sensor_->publish_state(0.0f);
     }
     if (this->energy_sensor_ != nullptr) {
-      this->energy_sensor_->publish_state(Tmp.m_last_energy_sensor[this->address_ - 1]);
+      this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
     }
     if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);
@@ -144,7 +139,7 @@ void PZEMAC::dump_config() {
 void PZEMAC::reset_energy_() {
   std::vector<uint8_t> cmd;
   cmd.push_back(this->address_);
-  cmd.push_back(PZEM_CMD_RESET_ENERGY);
+  cmd.push_back(PZECMD_RESET_ENERGY);
   this->send_raw(cmd);
 }
 

--- a/esphome/components/pzemac/pzemac.cpp
+++ b/esphome/components/pzemac/pzemac.cpp
@@ -62,16 +62,20 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
       this->voltage_sensor_->publish_state(220.0f);
   }
   if (this->current_sensor_ != nullptr) {
-    if (current < 150)
+    if (current < 150) {
       this->current_sensor_->publish_state(current);
-    else
+    }
+    else {
       this->current_sensor_->publish_state(1.0f);
+    }
   }
   if (this->power_sensor_ != nullptr) {
-    if (active_power < 16000)
+    if (active_power < 16000) {
       this->power_sensor_->publish_state(active_power);
-    else
+    }
+    else {
       this->power_sensor_->publish_state(101.0f);
+    }
   }
   //  if (this->energy_sensor_ != nullptr)
   //    this->energy_sensor_->publish_state(active_energy);
@@ -89,10 +93,12 @@ void PZEMAC::on_modbus_data(const std::vector<uint8_t> &data) {
       }
     }
   }
-  if (this->frequency_sensor_ != nullptr)
+  if (this->frequency_sensor_ != nullptr) {
     this->frequency_sensor_->publish_state(frequency);
-  if (this->power_factor_sensor_ != nullptr)
+  }
+  if (this->power_factor_sensor_ != nullptr) {
     this->power_factor_sensor_->publish_state(power_factor);
+  }
 }
 
 void PZEMAC::update() {
@@ -101,19 +107,25 @@ void PZEMAC::update() {
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
       (millis() - last_update_time_) > this->get_update_interval() * 2) {
     ESP_LOGE(TAG, "PZEM AC Addr 0x%02X: Timeout!!!", int(this->address_));
-    if (this->voltage_sensor_ != nullptr)
+    if (this->voltage_sensor_ != nullptr) {
       this->voltage_sensor_->publish_state(0.0f);
-    if (this->current_sensor_ != nullptr)
+    }
+    if (this->current_sensor_ != nullptr) {
       this->current_sensor_->publish_state(0.0f);
-    if (this->power_sensor_ != nullptr)
+    }
+    if (this->power_sensor_ != nullptr) {
       this->power_sensor_->publish_state(0.0f);
-    if (this->energy_sensor_ != nullptr)  //
-                                          //      this->energy_sensor_->publish_state(0.0f);   //
+    }
+    if (this->energy_sensor_ != nullptr) {
+//      this->energy_sensor_->publish_state(0.0f);   //
       this->energy_sensor_->publish_state(last_energy_sensor[this->address_ - 1]);
-    if (this->frequency_sensor_ != nullptr)
+    }
+    if (this->frequency_sensor_ != nullptr) {
       this->frequency_sensor_->publish_state(0.0f);
-    if (this->power_factor_sensor_ != nullptr)
+    }
+    if (this->power_factor_sensor_ != nullptr) {
       this->power_factor_sensor_->publish_state(0.0f);
+    }
   }
 }
 


### PR DESCRIPTION
Get a 0 volts from the PZEM instead of "unavailable," provided there's voltage on the ESP. For example, the ESP on a UPS. As a bonus, interference in the form of megawatts and kilovolts is slightly reduced when voltage is applied to the PZEM.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  name: pzem5

esp32:
  board: esp32-s3-devkitc-1
  flash_size: 16MB
  framework:
#    type: arduino
#    version: recommended
    type: esp-idf
    version: recommended

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
logger:

api:
  password: ""

ota:
  - platform: esphome
    password: ""

uart:
  id: pzem_in3
  rx_pin: GPIO4
  tx_pin: GPIO5
  baud_rate: 9600
  stop_bits: 1

binary_sensor:
  - platform: status
    name: "PZEM-004T V3 in3 status"

sensor:
  - platform: uptime
    name: "PZEM-004T V3 in3 Uptime"
    state_class: total

  - platform: wifi_signal
    name: "WiFi Signal dB"
    id: wifi_signal_db
    update_interval: 60s
    entity_category: "diagnostic"

  - platform: pzemac
    address: 0x1
    current:
      name: "PZEM-004T V3 in3 Current"
    voltage:
      name: "PZEM-004T V3 in3 Voltage"
    energy:
      name: "PZEM-004T V3 in3 Energy"
    power:
      name: "PZEM-004T V3 in3 Power"
      id: pzem_in3_power
    frequency:
      name: "PZEM-004T V3 in3 Frequency"
    power_factor:
      name: "PZEM-004T V3 in3 Power Factor"
      device_class: "power_factor"
      unit_of_measurement: "%"
    update_interval: 3s

  - platform: total_daily_energy
    name: "pzem_in3 Total Daily Energy"
    power_id: pzem_in3_power
    filters:
      - multiply: 0.001
    accuracy_decimals: 2
    unit_of_measurement: kWh
    icon: mdi:counter 

switch:
  - platform: uart
    uart_id: pzem_in3
    name: "pzem_in3 reset"
    data: [0x01, 0x42, 0x80, 0x11]

time:
  - platform: homeassistant
    id: hass_time

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
