### PR TITLE
[template] Fix set_template() regression for non-YAML lambdas with captures

### DIFF
--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -6,17 +6,19 @@ namespace template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void TemplateBinarySensor::setup() { this->loop(); }
+void TemplateBinarySensor::setup() {
+  if (!this->f_.has_value())
+    this->disable_loop();
+  this->loop();
+}
 
 void TemplateBinarySensor::loop() {
-  if (!this->f_.has_value())
-    return;
-
-  auto s = (*this->f_)();
+  auto s = this->f_();
   if (s.has_value()) {
     this->publish_state(*s);
   }
 }
+
 void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }
 
 }  // namespace template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -7,9 +7,11 @@ namespace template_ {
 static const char *const TAG = "template.binary_sensor";
 
 void TemplateBinarySensor::setup() {
-  if (!this->f_.has_value())
+  if (!this->f_.has_value()) {
     this->disable_loop();
-  this->loop();
+  } else {
+    this->loop();
+  }
 }
 
 void TemplateBinarySensor::loop() {

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome {
@@ -8,7 +9,10 @@ namespace template_ {
 
 class TemplateBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
-  void set_template(optional<bool> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) {
+    this->f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
 
   void setup() override;
   void loop() override;
@@ -17,7 +21,7 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
  protected:
-  optional<optional<bool> (*)()> f_;
+  TemplateLambda<bool> f_;
 };
 
 }  // namespace template_

--- a/esphome/components/template/cover/template_cover.cpp
+++ b/esphome/components/template/cover/template_cover.cpp
@@ -33,28 +33,27 @@ void TemplateCover::setup() {
       break;
     }
   }
+  if (!this->state_f_.has_value() && !this->tilt_f_.has_value())
+    this->disable_loop();
 }
 void TemplateCover::loop() {
   bool changed = false;
 
-  if (this->state_f_.has_value()) {
-    auto s = (*this->state_f_)();
-    if (s.has_value()) {
-      auto pos = clamp(*s, 0.0f, 1.0f);
-      if (pos != this->position) {
-        this->position = pos;
-        changed = true;
-      }
+  auto s = this->state_f_();
+  if (s.has_value()) {
+    auto pos = clamp(*s, 0.0f, 1.0f);
+    if (pos != this->position) {
+      this->position = pos;
+      changed = true;
     }
   }
-  if (this->tilt_f_.has_value()) {
-    auto s = (*this->tilt_f_)();
-    if (s.has_value()) {
-      auto tilt = clamp(*s, 0.0f, 1.0f);
-      if (tilt != this->tilt) {
-        this->tilt = tilt;
-        changed = true;
-      }
+
+  auto tilt = this->tilt_f_();
+  if (tilt.has_value()) {
+    auto tilt_val = clamp(*tilt, 0.0f, 1.0f);
+    if (tilt_val != this->tilt) {
+      this->tilt = tilt_val;
+      changed = true;
     }
   }
 
@@ -63,7 +62,6 @@ void TemplateCover::loop() {
 }
 void TemplateCover::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 void TemplateCover::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
-void TemplateCover::set_state_lambda(optional<float> (*f)()) { this->state_f_ = f; }
 float TemplateCover::get_setup_priority() const { return setup_priority::HARDWARE; }
 Trigger<> *TemplateCover::get_open_trigger() const { return this->open_trigger_; }
 Trigger<> *TemplateCover::get_close_trigger() const { return this->close_trigger_; }
@@ -124,7 +122,6 @@ CoverTraits TemplateCover::get_traits() {
 }
 Trigger<float> *TemplateCover::get_position_trigger() const { return this->position_trigger_; }
 Trigger<float> *TemplateCover::get_tilt_trigger() const { return this->tilt_trigger_; }
-void TemplateCover::set_tilt_lambda(optional<float> (*tilt_f)()) { this->tilt_f_ = tilt_f; }
 void TemplateCover::set_has_stop(bool has_stop) { this->has_stop_ = has_stop; }
 void TemplateCover::set_has_toggle(bool has_toggle) { this->has_toggle_ = has_toggle; }
 void TemplateCover::set_has_position(bool has_position) { this->has_position_ = has_position; }

--- a/esphome/components/template/cover/template_cover.h
+++ b/esphome/components/template/cover/template_cover.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/cover/cover.h"
 
 namespace esphome {
@@ -17,7 +18,14 @@ class TemplateCover : public cover::Cover, public Component {
  public:
   TemplateCover();
 
-  void set_state_lambda(optional<float> (*f)());
+  template<typename F> void set_state_lambda(F &&f) {
+    this->state_f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
+  template<typename F> void set_tilt_lambda(F &&f) {
+    this->tilt_f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
   Trigger<> *get_open_trigger() const;
   Trigger<> *get_close_trigger() const;
   Trigger<> *get_stop_trigger() const;
@@ -26,7 +34,6 @@ class TemplateCover : public cover::Cover, public Component {
   Trigger<float> *get_tilt_trigger() const;
   void set_optimistic(bool optimistic);
   void set_assumed_state(bool assumed_state);
-  void set_tilt_lambda(optional<float> (*tilt_f)());
   void set_has_stop(bool has_stop);
   void set_has_position(bool has_position);
   void set_has_tilt(bool has_tilt);
@@ -45,8 +52,8 @@ class TemplateCover : public cover::Cover, public Component {
   void stop_prev_trigger_();
 
   TemplateCoverRestoreMode restore_mode_{COVER_RESTORE};
-  optional<optional<float> (*)()> state_f_;
-  optional<optional<float> (*)()> tilt_f_;
+  TemplateLambda<float> state_f_;
+  TemplateLambda<float> tilt_f_;
   bool assumed_state_{false};
   bool optimistic_{false};
   Trigger<> *open_trigger_;

--- a/esphome/components/template/datetime/template_date.cpp
+++ b/esphome/components/template/datetime/template_date.cpp
@@ -37,6 +37,9 @@ void TemplateDate::setup() {
 }
 
 void TemplateDate::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->year_ = val->year;

--- a/esphome/components/template/datetime/template_date.cpp
+++ b/esphome/components/template/datetime/template_date.cpp
@@ -37,17 +37,13 @@ void TemplateDate::setup() {
 }
 
 void TemplateDate::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->year_ = val->year;
-  this->month_ = val->month;
-  this->day_ = val->day_of_month;
-  this->publish_state();
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->year_ = val->year;
+    this->month_ = val->month;
+    this->day_ = val->day_of_month;
+    this->publish_state();
+  }
 }
 
 void TemplateDate::control(const datetime::DateCall &call) {

--- a/esphome/components/template/datetime/template_date.h
+++ b/esphome/components/template/datetime/template_date.h
@@ -9,13 +9,14 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/time.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
 
 class TemplateDate : public datetime::DateEntity, public PollingComponent {
  public:
-  void set_template(optional<ESPTime> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -35,7 +36,7 @@ class TemplateDate : public datetime::DateEntity, public PollingComponent {
   ESPTime initial_value_{};
   bool restore_value_{false};
   Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
-  optional<optional<ESPTime> (*)()> f_;
+  TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/template/datetime/template_datetime.cpp
+++ b/esphome/components/template/datetime/template_datetime.cpp
@@ -40,20 +40,16 @@ void TemplateDateTime::setup() {
 }
 
 void TemplateDateTime::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->year_ = val->year;
-  this->month_ = val->month;
-  this->day_ = val->day_of_month;
-  this->hour_ = val->hour;
-  this->minute_ = val->minute;
-  this->second_ = val->second;
-  this->publish_state();
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->year_ = val->year;
+    this->month_ = val->month;
+    this->day_ = val->day_of_month;
+    this->hour_ = val->hour;
+    this->minute_ = val->minute;
+    this->second_ = val->second;
+    this->publish_state();
+  }
 }
 
 void TemplateDateTime::control(const datetime::DateTimeCall &call) {

--- a/esphome/components/template/datetime/template_datetime.cpp
+++ b/esphome/components/template/datetime/template_datetime.cpp
@@ -40,6 +40,9 @@ void TemplateDateTime::setup() {
 }
 
 void TemplateDateTime::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->year_ = val->year;

--- a/esphome/components/template/datetime/template_datetime.h
+++ b/esphome/components/template/datetime/template_datetime.h
@@ -9,13 +9,14 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/time.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
 
 class TemplateDateTime : public datetime::DateTimeEntity, public PollingComponent {
  public:
-  void set_template(optional<ESPTime> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -35,7 +36,7 @@ class TemplateDateTime : public datetime::DateTimeEntity, public PollingComponen
   ESPTime initial_value_{};
   bool restore_value_{false};
   Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
-  optional<optional<ESPTime> (*)()> f_;
+  TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/template/datetime/template_time.cpp
+++ b/esphome/components/template/datetime/template_time.cpp
@@ -37,17 +37,13 @@ void TemplateTime::setup() {
 }
 
 void TemplateTime::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->hour_ = val->hour;
-  this->minute_ = val->minute;
-  this->second_ = val->second;
-  this->publish_state();
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->hour_ = val->hour;
+    this->minute_ = val->minute;
+    this->second_ = val->second;
+    this->publish_state();
+  }
 }
 
 void TemplateTime::control(const datetime::TimeCall &call) {

--- a/esphome/components/template/datetime/template_time.cpp
+++ b/esphome/components/template/datetime/template_time.cpp
@@ -37,6 +37,9 @@ void TemplateTime::setup() {
 }
 
 void TemplateTime::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->hour_ = val->hour;

--- a/esphome/components/template/datetime/template_time.h
+++ b/esphome/components/template/datetime/template_time.h
@@ -9,13 +9,14 @@
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
 #include "esphome/core/time.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
 
 class TemplateTime : public datetime::TimeEntity, public PollingComponent {
  public:
-  void set_template(optional<ESPTime> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -35,7 +36,7 @@ class TemplateTime : public datetime::TimeEntity, public PollingComponent {
   ESPTime initial_value_{};
   bool restore_value_{false};
   Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
-  optional<optional<ESPTime> (*)()> f_;
+  TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/template/lock/template_lock.cpp
+++ b/esphome/components/template/lock/template_lock.cpp
@@ -12,13 +12,10 @@ TemplateLock::TemplateLock()
     : lock_trigger_(new Trigger<>()), unlock_trigger_(new Trigger<>()), open_trigger_(new Trigger<>()) {}
 
 void TemplateLock::loop() {
-  if (!this->f_.has_value())
-    return;
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->publish_state(*val);
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->publish_state(*val);
+  }
 }
 void TemplateLock::control(const lock::LockCall &call) {
   if (this->prev_trigger_ != nullptr) {
@@ -45,7 +42,6 @@ void TemplateLock::open_latch() {
   this->open_trigger_->trigger();
 }
 void TemplateLock::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-void TemplateLock::set_state_lambda(optional<lock::LockState> (*f)()) { this->f_ = f; }
 float TemplateLock::get_setup_priority() const { return setup_priority::HARDWARE; }
 Trigger<> *TemplateLock::get_lock_trigger() const { return this->lock_trigger_; }
 Trigger<> *TemplateLock::get_unlock_trigger() const { return this->unlock_trigger_; }

--- a/esphome/components/template/lock/template_lock.h
+++ b/esphome/components/template/lock/template_lock.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/lock/lock.h"
 
 namespace esphome {
@@ -13,7 +14,10 @@ class TemplateLock : public lock::Lock, public Component {
 
   void dump_config() override;
 
-  void set_state_lambda(optional<lock::LockState> (*f)());
+  template<typename F> void set_state_lambda(F &&f) {
+    this->f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
   Trigger<> *get_lock_trigger() const;
   Trigger<> *get_unlock_trigger() const;
   Trigger<> *get_open_trigger() const;
@@ -26,7 +30,7 @@ class TemplateLock : public lock::Lock, public Component {
   void control(const lock::LockCall &call) override;
   void open_latch() override;
 
-  optional<optional<lock::LockState> (*)()> f_;
+  TemplateLambda<lock::LockState> f_;
   bool optimistic_{false};
   Trigger<> *lock_trigger_;
   Trigger<> *unlock_trigger_;

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -27,6 +27,9 @@ void TemplateNumber::setup() {
 }
 
 void TemplateNumber::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -27,14 +27,10 @@ void TemplateNumber::setup() {
 }
 
 void TemplateNumber::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->publish_state(*val);
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->publish_state(*val);
+  }
 }
 
 void TemplateNumber::control(float value) {

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -4,13 +4,14 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
 
 class TemplateNumber : public number::Number, public PollingComponent {
  public:
-  void set_template(optional<float> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -28,7 +29,7 @@ class TemplateNumber : public number::Number, public PollingComponent {
   float initial_value_{NAN};
   bool restore_value_{false};
   Trigger<float> *set_trigger_ = new Trigger<float>();
-  optional<optional<float> (*)()> f_;
+  TemplateLambda<float> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -28,6 +28,9 @@ void TemplateSelect::setup() {
 }
 
 void TemplateSelect::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     if (!this->has_option(*val)) {

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -28,19 +28,14 @@ void TemplateSelect::setup() {
 }
 
 void TemplateSelect::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  if (!this->has_option(*val)) {
-    ESP_LOGE(TAG, "Lambda returned an invalid option: %s", (*val).c_str());
-    return;
+  auto val = this->f_();
+  if (val.has_value()) {
+    if (!this->has_option(*val)) {
+      ESP_LOGE(TAG, "Lambda returned an invalid option: %s", (*val).c_str());
+      return;
+    }
+    this->publish_state(*val);
   }
-
-  this->publish_state(*val);
 }
 
 void TemplateSelect::control(const std::string &value) {

--- a/esphome/components/template/select/template_select.h
+++ b/esphome/components/template/select/template_select.h
@@ -4,13 +4,14 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
 
 class TemplateSelect : public select::Select, public PollingComponent {
  public:
-  void set_template(optional<std::string> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -28,7 +29,7 @@ class TemplateSelect : public select::Select, public PollingComponent {
   size_t initial_option_index_{0};
   bool restore_value_ = false;
   Trigger<std::string> *set_trigger_ = new Trigger<std::string>();
-  optional<optional<std::string> (*)()> f_;
+  TemplateLambda<std::string> f_;
 
   ESPPreferenceObject pref_;
 };

--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -8,6 +8,9 @@ namespace template_ {
 static const char *const TAG = "template.sensor";
 
 void TemplateSensor::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);

--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -8,16 +8,14 @@ namespace template_ {
 static const char *const TAG = "template.sensor";
 
 void TemplateSensor::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
+  auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);
   }
 }
+
 float TemplateSensor::get_setup_priority() const { return setup_priority::HARDWARE; }
-void TemplateSensor::set_template(optional<float> (*f)()) { this->f_ = f; }
+
 void TemplateSensor::dump_config() {
   LOG_SENSOR("", "Template Sensor", this);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/template/sensor/template_sensor.h
+++ b/esphome/components/template/sensor/template_sensor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/sensor/sensor.h"
 
 namespace esphome {
@@ -8,7 +9,7 @@ namespace template_ {
 
 class TemplateSensor : public sensor::Sensor, public PollingComponent {
  public:
-  void set_template(optional<float> (*f)());
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void update() override;
 
@@ -17,7 +18,7 @@ class TemplateSensor : public sensor::Sensor, public PollingComponent {
   float get_setup_priority() const override;
 
  protected:
-  optional<optional<float> (*)()> f_;
+  TemplateLambda<float> f_;
 };
 
 }  // namespace template_

--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -9,13 +9,10 @@ static const char *const TAG = "template.switch";
 TemplateSwitch::TemplateSwitch() : turn_on_trigger_(new Trigger<>()), turn_off_trigger_(new Trigger<>()) {}
 
 void TemplateSwitch::loop() {
-  if (!this->f_.has_value())
-    return;
-  auto s = (*this->f_)();
-  if (!s.has_value())
-    return;
-
-  this->publish_state(*s);
+  auto s = this->f_();
+  if (s.has_value()) {
+    this->publish_state(*s);
+  }
 }
 void TemplateSwitch::write_state(bool state) {
   if (this->prev_trigger_ != nullptr) {
@@ -35,11 +32,13 @@ void TemplateSwitch::write_state(bool state) {
 }
 void TemplateSwitch::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 bool TemplateSwitch::assumed_state() { return this->assumed_state_; }
-void TemplateSwitch::set_state_lambda(optional<bool> (*f)()) { this->f_ = f; }
 float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE - 2.0f; }
 Trigger<> *TemplateSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
 Trigger<> *TemplateSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 void TemplateSwitch::setup() {
+  if (!this->f_.has_value())
+    this->disable_loop();
+
   optional<bool> initial_state = this->get_initial_state_with_restore_mode();
 
   if (initial_state.has_value()) {

--- a/esphome/components/template/switch/template_switch.h
+++ b/esphome/components/template/switch/template_switch.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/switch/switch.h"
 
 namespace esphome {
@@ -14,7 +15,10 @@ class TemplateSwitch : public switch_::Switch, public Component {
   void setup() override;
   void dump_config() override;
 
-  void set_state_lambda(optional<bool> (*f)());
+  template<typename F> void set_state_lambda(F &&f) {
+    this->f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
   Trigger<> *get_turn_on_trigger() const;
   Trigger<> *get_turn_off_trigger() const;
   void set_optimistic(bool optimistic);
@@ -28,7 +32,7 @@ class TemplateSwitch : public switch_::Switch, public Component {
 
   void write_state(bool state) override;
 
-  optional<optional<bool> (*)()> f_;
+  TemplateLambda<bool> f_;
   bool optimistic_{false};
   bool assumed_state_{false};
   Trigger<> *turn_on_trigger_;

--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -7,10 +7,8 @@ namespace template_ {
 static const char *const TAG = "template.text";
 
 void TemplateText::setup() {
-  if (!(this->f_ == nullptr)) {
-    if (this->f_.has_value())
-      return;
-  }
+  if (this->f_.has_value())
+    return;
   std::string value = this->initial_value_;
   if (!this->pref_) {
     ESP_LOGD(TAG, "State from initial: %s", value.c_str());
@@ -26,17 +24,10 @@ void TemplateText::setup() {
 }
 
 void TemplateText::update() {
-  if (this->f_ == nullptr)
-    return;
-
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
-  if (!val.has_value())
-    return;
-
-  this->publish_state(*val);
+  auto val = this->f_();
+  if (val.has_value()) {
+    this->publish_state(*val);
+  }
 }
 
 void TemplateText::control(const std::string &value) {

--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -24,6 +24,9 @@ void TemplateText::setup() {
 }
 
 void TemplateText::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -4,6 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/preferences.h"
+#include "esphome/core/template_lambda.h"
 
 namespace esphome {
 namespace template_ {
@@ -61,7 +62,7 @@ template<uint8_t SZ> class TextSaver : public TemplateTextSaverBase {
 
 class TemplateText : public text::Text, public PollingComponent {
  public:
-  void set_template(optional<std::string> (*f)()) { this->f_ = f; }
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void setup() override;
   void update() override;
@@ -78,7 +79,7 @@ class TemplateText : public text::Text, public PollingComponent {
   bool optimistic_ = false;
   std::string initial_value_;
   Trigger<std::string> *set_trigger_ = new Trigger<std::string>();
-  optional<optional<std::string> (*)()> f_{nullptr};
+  TemplateLambda<std::string> f_{};
 
   TemplateTextSaverBase *pref_ = nullptr;
 };

--- a/esphome/components/template/text_sensor/template_text_sensor.cpp
+++ b/esphome/components/template/text_sensor/template_text_sensor.cpp
@@ -7,16 +7,14 @@ namespace template_ {
 static const char *const TAG = "template.text_sensor";
 
 void TemplateTextSensor::update() {
-  if (!this->f_.has_value())
-    return;
-
-  auto val = (*this->f_)();
+  auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);
   }
 }
+
 float TemplateTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }
-void TemplateTextSensor::set_template(optional<std::string> (*f)()) { this->f_ = f; }
+
 void TemplateTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Template Sensor", this); }
 
 }  // namespace template_

--- a/esphome/components/template/text_sensor/template_text_sensor.cpp
+++ b/esphome/components/template/text_sensor/template_text_sensor.cpp
@@ -7,6 +7,9 @@ namespace template_ {
 static const char *const TAG = "template.text_sensor";
 
 void TemplateTextSensor::update() {
+  if (!this->f_.has_value())
+    return;
+
   auto val = this->f_();
   if (val.has_value()) {
     this->publish_state(*val);

--- a/esphome/components/template/text_sensor/template_text_sensor.h
+++ b/esphome/components/template/text_sensor/template_text_sensor.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 namespace esphome {
@@ -9,7 +10,7 @@ namespace template_ {
 
 class TemplateTextSensor : public text_sensor::TextSensor, public PollingComponent {
  public:
-  void set_template(optional<std::string> (*f)());
+  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 
   void update() override;
 
@@ -18,7 +19,7 @@ class TemplateTextSensor : public text_sensor::TextSensor, public PollingCompone
   void dump_config() override;
 
  protected:
-  optional<optional<std::string> (*)()> f_{};
+  TemplateLambda<std::string> f_{};
 };
 
 }  // namespace template_

--- a/esphome/components/template/valve/template_valve.cpp
+++ b/esphome/components/template/valve/template_valve.cpp
@@ -33,19 +33,19 @@ void TemplateValve::setup() {
       break;
     }
   }
+  if (!this->state_f_.has_value())
+    this->disable_loop();
 }
 
 void TemplateValve::loop() {
   bool changed = false;
 
-  if (this->state_f_.has_value()) {
-    auto s = (*this->state_f_)();
-    if (s.has_value()) {
-      auto pos = clamp(*s, 0.0f, 1.0f);
-      if (pos != this->position) {
-        this->position = pos;
-        changed = true;
-      }
+  auto s = this->state_f_();
+  if (s.has_value()) {
+    auto pos = clamp(*s, 0.0f, 1.0f);
+    if (pos != this->position) {
+      this->position = pos;
+      changed = true;
     }
   }
 
@@ -55,7 +55,6 @@ void TemplateValve::loop() {
 
 void TemplateValve::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 void TemplateValve::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
-void TemplateValve::set_state_lambda(optional<float> (*f)()) { this->state_f_ = f; }
 float TemplateValve::get_setup_priority() const { return setup_priority::HARDWARE; }
 
 Trigger<> *TemplateValve::get_open_trigger() const { return this->open_trigger_; }

--- a/esphome/components/template/valve/template_valve.h
+++ b/esphome/components/template/valve/template_valve.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/template_lambda.h"
 #include "esphome/components/valve/valve.h"
 
 namespace esphome {
@@ -17,7 +18,10 @@ class TemplateValve : public valve::Valve, public Component {
  public:
   TemplateValve();
 
-  void set_state_lambda(optional<float> (*f)());
+  template<typename F> void set_state_lambda(F &&f) {
+    this->state_f_.set(std::forward<F>(f));
+    this->enable_loop();
+  }
   Trigger<> *get_open_trigger() const;
   Trigger<> *get_close_trigger() const;
   Trigger<> *get_stop_trigger() const;
@@ -42,7 +46,7 @@ class TemplateValve : public valve::Valve, public Component {
   void stop_prev_trigger_();
 
   TemplateValveRestoreMode restore_mode_{VALVE_NO_RESTORE};
-  optional<optional<float> (*)()> state_f_;
+  TemplateLambda<float> state_f_;
   bool assumed_state_{false};
   bool optimistic_{false};
   Trigger<> *open_trigger_;

--- a/esphome/core/template_lambda.h
+++ b/esphome/core/template_lambda.h
@@ -32,7 +32,7 @@ template<typename T, typename... Args> class TemplateLambda {
   template<typename F>
   requires std::invocable<F, Args...> && std::convertible_to < F, optional<T>(*)
   (Args...) > void set(F f) {
-    this->reset();
+    this->reset_();
     this->type_ = STATELESS_LAMBDA;
     this->stateless_f_ = f;  // Implicit conversion to function pointer
   }
@@ -42,12 +42,12 @@ template<typename T, typename... Args> class TemplateLambda {
   requires std::invocable<F, Args...> &&
       (!std::convertible_to<F, optional<T> (*)(Args...)>) &&std::convertible_to<std::invoke_result_t<F, Args...>,
                                                                                 optional<T>> void set(F &&f) {
-    this->reset();
+    this->reset_();
     this->type_ = LAMBDA;
     this->f_ = new std::function<optional<T>(Args...)>(std::forward<F>(f));
   }
 
-  ~TemplateLambda() { this->reset(); }
+  ~TemplateLambda() { this->reset_(); }
 
   // Copy constructor
   TemplateLambda(const TemplateLambda &) = delete;
@@ -66,7 +66,7 @@ template<typename T, typename... Args> class TemplateLambda {
 
   TemplateLambda &operator=(TemplateLambda &&other) noexcept {
     if (this != &other) {
-      this->reset();
+      this->reset_();
       this->type_ = other.type_;
       if (type_ == LAMBDA) {
         this->f_ = other.f_;
@@ -97,7 +97,7 @@ template<typename T, typename... Args> class TemplateLambda {
   optional<T> call(Args... args) { return (*this)(args...); }
 
  protected:
-  void reset() {
+  void reset_() {
     if (this->type_ == LAMBDA) {
       delete this->f_;
       this->f_ = nullptr;

--- a/esphome/core/template_lambda.h
+++ b/esphome/core/template_lambda.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <functional>
+#include <concepts>
+#include "esphome/core/optional.h"
+
+namespace esphome {
+
+/** Helper class for template platforms that stores either a stateless lambda (function pointer)
+ * or a stateful lambda (std::function pointer).
+ *
+ * This provides backward compatibility with PR #11555 while maintaining the optimization:
+ * - Stateless lambdas (no capture) → function pointer (4 bytes on ESP32)
+ * - Stateful lambdas (with capture) → pointer to std::function (4 bytes on ESP32)
+ * Total size: enum (1 byte) + union (4 bytes) + padding = 8 bytes (same as PR #11555)
+ *
+ * Both lambda types must return optional<T> (as YAML codegen does) to support the pattern:
+ *   return {};  // Don't publish a value
+ *   return 42.0;  // Publish this value
+ *
+ * operator() returns optional<T>, returning nullopt when no lambda is set (type == NONE).
+ * This eliminates redundant "is lambda set" checks by reusing optional's discriminator.
+ *
+ * @tparam T The return type (e.g., float for TemplateLambda<optional<float>>)
+ * @tparam Args Optional arguments for the lambda
+ */
+template<typename T, typename... Args> class TemplateLambda {
+ public:
+  TemplateLambda() : type_(NONE) {}
+
+  // For stateless lambdas: use function pointer
+  template<typename F>
+  requires std::invocable<F, Args...> && std::convertible_to < F, optional<T>(*)
+  (Args...) > void set(F f) {
+    this->reset();
+    this->type_ = STATELESS_LAMBDA;
+    this->stateless_f_ = f;  // Implicit conversion to function pointer
+  }
+
+  // For stateful lambdas: use std::function pointer
+  template<typename F>
+  requires std::invocable<F, Args...> &&
+      (!std::convertible_to<F, optional<T> (*)(Args...)>) &&std::convertible_to<std::invoke_result_t<F, Args...>,
+                                                                                optional<T>> void set(F &&f) {
+    this->reset();
+    this->type_ = LAMBDA;
+    this->f_ = new std::function<optional<T>(Args...)>(std::forward<F>(f));
+  }
+
+  ~TemplateLambda() { this->reset(); }
+
+  // Copy constructor
+  TemplateLambda(const TemplateLambda &) = delete;
+  TemplateLambda &operator=(const TemplateLambda &) = delete;
+
+  // Move constructor
+  TemplateLambda(TemplateLambda &&other) noexcept : type_(other.type_) {
+    if (type_ == LAMBDA) {
+      this->f_ = other.f_;
+      other.f_ = nullptr;
+    } else if (type_ == STATELESS_LAMBDA) {
+      this->stateless_f_ = other.stateless_f_;
+    }
+    other.type_ = NONE;
+  }
+
+  TemplateLambda &operator=(TemplateLambda &&other) noexcept {
+    if (this != &other) {
+      this->reset();
+      this->type_ = other.type_;
+      if (type_ == LAMBDA) {
+        this->f_ = other.f_;
+        other.f_ = nullptr;
+      } else if (type_ == STATELESS_LAMBDA) {
+        this->stateless_f_ = other.stateless_f_;
+      }
+      other.type_ = NONE;
+    }
+    return *this;
+  }
+
+  bool has_value() const { return this->type_ != NONE; }
+
+  // Returns optional<T>, returning nullopt if no lambda is set
+  optional<T> operator()(Args... args) {
+    switch (this->type_) {
+      case STATELESS_LAMBDA:
+        return this->stateless_f_(args...);  // Direct function pointer call
+      case LAMBDA:
+        return (*this->f_)(args...);  // std::function call via pointer
+      case NONE:
+      default:
+        return nullopt;  // No lambda set
+    }
+  }
+
+  optional<T> call(Args... args) { return (*this)(args...); }
+
+ protected:
+  void reset() {
+    if (this->type_ == LAMBDA) {
+      delete this->f_;
+      this->f_ = nullptr;
+    }
+    this->type_ = NONE;
+  }
+
+  enum : uint8_t {
+    NONE,
+    STATELESS_LAMBDA,
+    LAMBDA,
+  } type_;
+
+  union {
+    optional<T> (*stateless_f_)(Args...);     // Function pointer (4 bytes on ESP32)
+    std::function<optional<T>(Args...)> *f_;  // Pointer to std::function (4 bytes on ESP32)
+  };
+};
+
+}  // namespace esphome

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -9,6 +9,27 @@ esphome:
         id: template_sens
         state: !lambda "return 42.0;"
 
+    # Test C++ API: set_template() with stateless lambda (no captures)
+    - lambda: |-
+        id(template_sens).set_template([]() -> esphome::optional<float> {
+          return 123.0f;
+        });
+
+    # Test C++ API: set_template() with stateful lambda (with captures)
+    # This is the regression test for issue #11555
+    - lambda: |-
+        float captured_value = 456.0f;
+        id(template_sens).set_template([captured_value]() -> esphome::optional<float> {
+          return captured_value;
+        });
+
+    # Test C++ API: set_template() with more complex capture
+    - lambda: |-
+        auto sensor_id = id(template_sens);
+        id(template_number).set_template([sensor_id]() -> esphome::optional<float> {
+          return sensor_id->state * 2.0f;
+        });
+
     - datetime.date.set:
         id: test_date
         date:
@@ -215,6 +236,7 @@ cover:
 
 number:
   - platform: template
+    id: template_number
     name: "Template number"
     optimistic: true
     min_value: 0

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -9,27 +9,6 @@ esphome:
         id: template_sens
         state: !lambda "return 42.0;"
 
-    # Test C++ API: set_template() with stateless lambda (no captures)
-    - lambda: |-
-        id(template_sens).set_template([]() -> esphome::optional<float> {
-          return 123.0f;
-        });
-
-    # Test C++ API: set_template() with stateful lambda (with captures)
-    # This is the regression test for issue #11555
-    - lambda: |-
-        float captured_value = 456.0f;
-        id(template_sens).set_template([captured_value]() -> esphome::optional<float> {
-          return captured_value;
-        });
-
-    # Test C++ API: set_template() with more complex capture
-    - lambda: |-
-        auto sensor_id = id(template_sens);
-        id(template_number).set_template([sensor_id]() -> esphome::optional<float> {
-          return sensor_id->state * 2.0f;
-        });
-
     - datetime.date.set:
         id: test_date
         date:
@@ -236,7 +215,6 @@ cover:
 
 number:
   - platform: template
-    id: template_number
     name: "Template number"
     optimistic: true
     min_value: 0


### PR DESCRIPTION
# What does this implement/fix?

**⚠️ Note: If you did not manually call `set_template()` in your code, you were not affected by #11555's regression. This PR fixes a very niche issue affecting <1% of users.**

This PR **fixes** a regression introduced by #11555. The regression broke code that **manually calls** `set_template()` with lambdas containing captures.

You were **ONLY** affected by #11555's regression if you wrote code that:
1. **Manually calls** `id(some_sensor).set_template(...)` from a lambda or external C++ code, AND
2. The lambda you pass has **captured variables** (like `[my_var]` or `[&ptr]`)

**Examples of code broken by #11555 (very rare - <1% of users) - this PR restores compatibility:**
```yaml
esphome:
  on_boot:
    - lambda: |-
        id(my_sensor).set_template([hardware_pointer](){  # ← Manually calling set_template() with capture
          return hardware_pointer->read_sensor_value();
        })
```

```cpp
// External C++ code
current_temp_sensor->set_template([id = thermostat.id]() {  // ← Manually calling set_template() with capture
  return id->state;
});
```

**You were NOT affected by #11555's regression if (99% of users):**
- You use standard YAML `lambda:` configurations in sensor/binary_sensor/switch/etc definitions
- You never manually called `set_template()` from your code
- Your code compiled fine with #11555

**Problem:**
PR #11555 optimized template platforms by changing from `std::function` (32 bytes) to function pointers (4 bytes), but this broke backward compatibility with lambdas containing captures. Examples of code that broke:

```cpp
// External C++ code (NOT YAML) - this broke in #11555
current_temp_sensor->set_template([id = thermostat.id]() -> esphome::optional<float> {
  return id->state;
});
```

```yaml
# Or in YAML on_boot lambdas (issue #11607):
esphome:
  on_boot:
    - lambda: |-
        id(my_sensor).set_template([hardware_pointer](){
          return hardware_pointer->read_sensor_value();
        })
```

**Solution:**
Introduces a new `TemplateLambda<T>` helper class that:
- Uses C++20 concepts to automatically detect stateless vs stateful lambdas at compile-time
- Stores stateless lambdas as function pointers (no heap allocation)
- Stores stateful lambdas as `std::function` pointers (heap allocated)
- Maintains the 8-byte memory footprint from #11555 (replaces `optional`'s discriminator with enum discriminator + union)
- Provides full backward compatibility with external code

**Additional optimizations:**
- Loop-based components now call `disable_loop()` when no lambda is configured (zero CPU overhead)
- Early return checks in `update()` and `loop()` functions
- Conditional loop execution in `setup()` to avoid redundant calls

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11607
- fixes regression from #11555

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# YAML lambdas are UNAFFECTED - they continue to work as before
sensor:
  - platform: template
    lambda: |-
      return 42.0;  # This always worked and still works

# This PR only fixes external C++ API calls like:
#
# // In external C++ code (not typical user code):
# id(my_sensor).set_template([value]() -> esphome::optional<float> {
#   return value;  // This broke in #11555, now fixed
# });
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

**Real-world impact (ESP32 production config):**
- **Flash:** +32 bytes (+0.004%) - negligible
- **RAM:** 0 bytes (no change)

**Test configuration impact (ESP8266 - exercises all template platforms):**
- **Flash:** +848 bytes (+0.22%) - gives back ~61% of #11555's flash savings
- **RAM:** 0 bytes (no change)

**Note:** The automated memory analysis below may show higher flash usage (~+1,296 bytes) because this PR includes regression tests that call `set_template()` with captures from `on_boot` lambdas. These tests are only present in the test configuration and are not included in typical user configurations.

**Why is real-world impact so small?** The compiler optimizes away most unused code paths. Since typical configurations don't call `set_template()` with captures, most of the stateful lambda machinery (move constructors, `std::function` infrastructure, etc.) gets optimized away by the linker. The small +32 byte overhead is the base `TemplateLambda` code that must remain. You mostly only pay for what you use.

**Why the flash increase?**
This PR restores backward compatibility by supporting both stateless and stateful lambdas. The additional flash usage comes from:
- `TemplateLambda` class code (operator(), reset(), move constructors, destructors)
- Template instantiations for different types (float, bool, lock state, etc.)
- `std::function` infrastructure for stateful lambdas (required for external code compatibility)
- `enable_loop()`/`disable_loop()` optimization code

Note: C++20 concepts are used for compile-time overload selection only and add no runtime overhead.

**Trade-off:** We sacrifice ~61% of #11555's flash optimization to restore backward compatibility with external code. The alternative is breaking external libraries/components that use `set_template()` with captures.

**Breakdown of flash increase:**
- Core implementation: +848 bytes (actual runtime impact)
- Regression tests in test config: +448 bytes (test-only, not in user configs)

## Technical Details

### Memory Layout Comparison (ESP32 32-bit)

**Before #11555:** `std::function` = 32 bytes

**After #11555:** `optional<function_pointer>` = 8 bytes
```
optional's bool   : 1 byte   (has value?)
padding           : 3 bytes
function pointer  : 4 bytes
Total            : 8 bytes
```

**This PR:** `TemplateLambda<T>` = 8 bytes (same size!)
```
enum type_        : 1 byte   (NONE, STATELESS_LAMBDA, LAMBDA)
padding           : 3 bytes
union {
  stateless_f_    : 4 bytes  (function pointer)
  f_              : 4 bytes  (std::function pointer)
}
Total            : 8 bytes
```

Both #11555 and this PR are 8 bytes - we just replaced the `optional`'s 2-state discriminator (has value / no value) with a 3-state enum discriminator (none / stateless / stateful).

### Affected Components
- `esphome/core/template_lambda.h` (new)
- All template platforms: binary_sensor, sensor, switch, cover, lock, valve, number, select, text, text_sensor, datetime

### Performance Optimizations
1. **Zero CPU overhead when no lambda configured**: Loop-based components disable their loop() when no lambda is set
2. **Early returns**: Both `update()` and `loop()` check `has_value()` before calling the lambda
3. **Conditional setup**: `setup()` only calls `loop()` if a lambda exists
