### PR TITLE
[ci] Restore parallel execution for clang-tidy split mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         include:
           - id: clang-tidy


### PR DESCRIPTION
# What does this implement/fix?

Restores parallel execution of clang-tidy jobs in split mode. When PR #11402 refactored clang-tidy to support conditional splitting, it accidentally changed `max-parallel` from `2` to `1` for the split mode job, causing sequential execution instead of running 2 jobs in parallel.

**Before:** clang-tidy-split jobs ran one at a time (4 jobs × 10 min = 40 min total)
**After:** clang-tidy-split jobs run 2 at a time (4 jobs ÷ 2 × 10 min = ~20 min total)

This restores the original behavior where clang-tidy always ran with `max-parallel: 2`, significantly reducing CI time for large PRs that trigger split mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes regression introduced in #11402

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - CI infrastructure change only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - CI workflow change only

## Example entry for `config.yaml`:

```yaml
# N/A - CI infrastructure change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
