### PR TITLE
[api] Convert logger callback to stateless function pointer to reduce flash

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -27,6 +27,28 @@ static const char *const TAG = "api";
 // APIServer
 APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+#ifdef USE_LOGGER
+// Stateless log handler for API server (uses global_api_server)
+static void api_server_log_handler(uint8_t level, const char *tag, const char *message, size_t message_len) {
+  if (global_api_server->shutting_down_)
+    return;
+  for (auto &c : global_api_server->clients_) {
+    if (!c->flags_.remove && c->get_log_subscription_level() >= level)
+      c->try_send_log_message(level, tag, message, message_len);
+  }
+}
+#endif
+
+#ifdef USE_CAMERA
+// Stateless camera image handler for API server (uses global_api_server)
+static void api_server_camera_image_handler(const std::shared_ptr<camera::CameraImage> &image) {
+  for (auto &c : global_api_server->clients_) {
+    if (!c->flags_.remove)
+      c->set_camera_state(image);
+  }
+}
+#endif
+
 APIServer::APIServer() {
   global_api_server = this;
   // Pre-allocate shared write buffer
@@ -100,30 +122,13 @@ void APIServer::setup() {
 
 #ifdef USE_LOGGER
   if (logger::global_logger != nullptr) {
-    logger::global_logger->add_on_log_callback(
-        [this](int level, const char *tag, const char *message, size_t message_len) {
-          if (this->shutting_down_) {
-            // Don't try to send logs during shutdown
-            // as it could result in a recursion and
-            // we would be filling a buffer we are trying to clear
-            return;
-          }
-          for (auto &c : this->clients_) {
-            if (!c->flags_.remove && c->get_log_subscription_level() >= level)
-              c->try_send_log_message(level, tag, message, message_len);
-          }
-        });
+    logger::global_logger->add_on_log_callback(api_server_log_handler);
   }
 #endif
 
 #ifdef USE_CAMERA
   if (camera::Camera::instance() != nullptr && !camera::Camera::instance()->is_internal()) {
-    camera::Camera::instance()->add_image_callback([this](const std::shared_ptr<camera::CameraImage> &image) {
-      for (auto &c : this->clients_) {
-        if (!c->flags_.remove)
-          c->set_camera_state(image);
-      }
-    });
+    camera::Camera::instance()->add_image_callback(api_server_camera_image_handler);
   }
 #endif
 }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -28,23 +28,13 @@ static const char *const TAG = "api";
 APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 #ifdef USE_LOGGER
-// Stateless log handler for API server (uses global_api_server)
-static void api_server_log_handler(uint8_t level, const char *tag, const char *message, size_t message_len) {
+// Static log handler for API server (uses global_api_server)
+void APIServer::log_callback_(uint8_t level, const char *tag, const char *message, size_t message_len) {
   if (global_api_server->shutting_down_)
     return;
   for (auto &c : global_api_server->clients_) {
     if (!c->flags_.remove && c->get_log_subscription_level() >= level)
       c->try_send_log_message(level, tag, message, message_len);
-  }
-}
-#endif
-
-#ifdef USE_CAMERA
-// Stateless camera image handler for API server (uses global_api_server)
-static void api_server_camera_image_handler(const std::shared_ptr<camera::CameraImage> &image) {
-  for (auto &c : global_api_server->clients_) {
-    if (!c->flags_.remove)
-      c->set_camera_state(image);
   }
 }
 #endif
@@ -122,13 +112,18 @@ void APIServer::setup() {
 
 #ifdef USE_LOGGER
   if (logger::global_logger != nullptr) {
-    logger::global_logger->add_on_log_callback(api_server_log_handler);
+    logger::global_logger->add_on_log_callback(APIServer::log_callback_);
   }
 #endif
 
 #ifdef USE_CAMERA
   if (camera::Camera::instance() != nullptr && !camera::Camera::instance()->is_internal()) {
-    camera::Camera::instance()->add_image_callback(api_server_camera_image_handler);
+    camera::Camera::instance()->add_image_callback([this](const std::shared_ptr<camera::CameraImage> &image) {
+      for (auto &c : this->clients_) {
+        if (!c->flags_.remove)
+          c->set_camera_state(image);
+      }
+    });
   }
 #endif
 }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -51,6 +51,11 @@ class APIServer : public Component, public Controller {
   // Get reference to shared buffer for API connections
   std::vector<uint8_t> &get_shared_buffer_ref() { return shared_write_buffer_; }
 
+#ifdef USE_LOGGER
+  // Static log handler (uses global_api_server)
+  static void log_callback_(uint8_t level, const char *tag, const char *message, size_t message_len);
+#endif
+
 #ifdef USE_API_NOISE
   bool save_noise_psk(psk_t psk, bool make_active = true);
   bool clear_noise_psk(bool make_active = true);


### PR DESCRIPTION
# What does this implement/fix?

This PR converts the logger callback in the API component from a stateful lambda (capturing `[this]`) to a stateless function pointer, reducing flash usage.

## Changes:

**Logger callback** (`api_server.cpp:102-116`): Converted from `[this]` lambda to `APIServer::log_callback_()` static member function

The callback now uses the existing `global_api_server` pointer instead of capturing `this`, making it a stateless lambda that automatically decays to a function pointer.

## Flash savings:

Each stateful lambda in a callback generates ~200-400 bytes of `std::function` template instantiation code (including `_M_invoke`, type erasure wrapper, constructors, etc.). Converting to a stateless function pointer eliminates this overhead entirely.

**Estimated savings**: ~200-400 bytes flash per build

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (flash size optimization)

**Related issue or feature (if applicable):**

- Related to ongoing efforts to reduce flash usage on ESP8266 and other memory-constrained platforms

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-visible changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No configuration changes - this is an internal optimization.

```yaml
# Existing API configuration works unchanged
api:
  password: "test"

logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
