### PR TITLE
[lvgl] Fix event for binary sensor

### DIFF
--- a/esphome/components/lvgl/binary_sensor/__init__.py
+++ b/esphome/components/lvgl/binary_sensor/__init__.py
@@ -31,7 +31,7 @@ async def to_code(config):
             lvgl_static.add_event_cb(
                 widget.obj,
                 await pressed_ctx.get_lambda(),
-                LV_EVENT.PRESSING,
+                LV_EVENT.PRESSED,
                 LV_EVENT.RELEASED,
             )
         )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

LVGL binary sensor was listening for `PRESSING` events, which are only produced by touchpads.
Instead listen for `PRESSED` events which are also produced by encoders.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #10514 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
