### PR TITLE
[MIIO] Add new component: Xiaomi IoT Module UART Protocol

### DIFF
--- a/esphome/components/miio/__init__.py
+++ b/esphome/components/miio/__init__.py
@@ -1,0 +1,35 @@
+import esphome.codegen as cg
+from esphome.components import time, uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_TIME_ID
+
+CODEOWNERS = ["@kitsuned"]
+
+DEPENDENCIES = ["uart"]
+
+miio_ns = cg.esphome_ns.namespace("miio")
+Miio = miio_ns.class_("Miio", cg.Component, uart.UARTDevice)
+
+CONF_MIIO_ID = "miio_id"
+CONF_CLUSTER = "cluster"
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Miio),
+            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    if CONF_TIME_ID in config:
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
+        cg.add(var.set_time_id(time_))

--- a/esphome/components/miio/miio.cpp
+++ b/esphome/components/miio/miio.cpp
@@ -1,0 +1,301 @@
+#include "miio.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/core/util.h"
+#include "esphome/components/network/util.h"
+#include "esphome/components/api/api_server.h"
+
+namespace esphome {
+namespace miio {
+
+static const char *const TAG = "miio";
+
+std::string stringify_prop(prop_t property) {
+  return str_sprintf("%u %u", std::get<0>(property), std::get<1>(property));
+}
+
+void Miio::setup() {
+  while (this->available()) {
+    this->read();
+  }
+
+  this->mcu_handlers_["mcu_version"] = [this](const std::vector<std::string> &tokens) {
+    ESP_LOGI(TAG, "Connected to MIIO MCU, version is %s", tokens.front().c_str());
+
+    this->mcu_reply_ok_();
+  };
+
+  this->mcu_handlers_["model"] = [this](const std::vector<std::string> &tokens) {
+    ESP_LOGI(TAG, "Product is %s", tokens.front().c_str());
+
+    this->mcu_reply_ok_();
+  };
+
+  this->mcu_handlers_["net"] = [this](const std::vector<std::string> &tokens) {
+    this->mcu_reply_(this->get_network_state_());
+  };
+
+  this->mcu_handlers_["time"] = [this](const std::vector<std::string> &tokens) {
+    if (this->time_id_.has_value()) {
+      auto time = this->time_id_.value()->now();
+      auto serialized = time.strftime("%Y-%m-%d %H:%M:%S");
+
+      this->mcu_reply_(serialized.c_str());
+    }
+  };
+
+  this->mcu_handlers_["country_code"] = [this](const std::vector<std::string> &tokens) { this->mcu_reply_("EU"); };
+
+  this->mcu_handlers_["ble_config"] = [this](const std::vector<std::string> &tokens) { this->mcu_reply_ok_(); };
+
+  this->mcu_handlers_["get_down"] = [this](const std::vector<std::string> &tokens) { this->process_down_request_(); };
+
+  this->mcu_handlers_["event_occured"] = [this](const std::vector<std::string> &tokens) { this->mcu_reply_ok_(); };
+
+  this->mcu_handlers_["result"] = [this](const std::vector<std::string> &tokens) {
+    this->mcu_reply_ok_();
+    this->process_result_(tokens);
+  };
+
+  this->mcu_handlers_["properties_changed"] = [this](const std::vector<std::string> &tokens) {
+    this->mcu_reply_ok_();
+    this->process_properties_change_(tokens);
+  };
+}
+
+void Miio::loop() {
+  while (this->available()) {
+    uint8_t c;
+    this->read_byte(&c);
+    this->handle_char_(c);
+  }
+
+  this->process_command_queue_();
+}
+
+void Miio::dump_config() {
+  ESP_LOGCONFIG(TAG, "MIIO:");
+  this->check_uart_settings(115200);
+}
+
+void Miio::register_listener(prop_t property, MiioPropertyType type,
+                             const std::function<void(const MiioPropertyValue &)> &fn) {
+  this->mcu_query_.insert(property);
+  this->listeners_[property] = std::make_tuple(type, fn);
+}
+
+void Miio::set_property(prop_t property, std::string value) { this->mcu_pending_changes_[property] = std::move(value); }
+
+void Miio::process_command_queue_() {
+  if (!this->mcu_message_queue_.empty()) {
+    const auto &tokens = std::as_const(this->mcu_message_queue_.front());
+
+    this->process_command_raw_(tokens);
+
+    this->mcu_message_queue_.pop_front();
+  }
+}
+
+void Miio::process_command_raw_(const std::vector<std::string> &tokens) {
+  const auto &command = tokens.front();
+  auto it = this->mcu_handlers_.find(command);
+
+  if (it != this->mcu_handlers_.end()) {
+    std::vector<std::string> v(tokens.begin() + 1, tokens.end());
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+    std::string accumulator = "RX";
+
+    for (const auto &token : tokens) {
+      accumulator += " ";
+      accumulator += token;
+    }
+
+    ESP_LOGVV(TAG, "%s", accumulator.c_str());
+#endif
+
+    it->second(v);
+  } else {
+    ESP_LOGW(TAG, "Received unknown command from MCU: %s", command.c_str());
+  }
+}
+
+void Miio::process_properties_change_(const std::vector<std::string> &tokens) {
+  if (tokens.size() % 3 != 0) {
+    ESP_LOGE(TAG, "Malformed properties_changed arguments: mod by 3 != 0");
+    return;
+  }
+
+  for (size_t i = 0; i < tokens.size(); i += 3) {
+    auto maybe_prop = this->parse_property_specifier_(tokens[i], tokens[i + 1]);
+
+    if (maybe_prop.has_value()) {
+      this->apply_property_(maybe_prop.value(), tokens[i + 2]);
+    }
+  }
+}
+
+void Miio::process_result_(const std::vector<std::string> &tokens) {
+  if (!this->awaiting_for_get_properties_result_) {
+    return;
+  }
+
+  if (tokens.size() % 4 != 0) {
+    ESP_LOGE(TAG, "Malformed result arguments: mod by 4 != 0");
+    return;
+  }
+
+  this->awaiting_for_get_properties_result_ = false;
+
+  for (size_t i = 0; i < tokens.size(); i += 4) {
+    auto maybe_prop = this->parse_property_specifier_(tokens[i], tokens[i + 1]);
+
+    if (!maybe_prop.has_value()) {
+      continue;
+    }
+
+    auto prop = maybe_prop.value();
+    auto maybe_result = parse_number<uint8_t>(tokens[i + 2]);
+
+    if (!maybe_result.has_value() || maybe_result.value() != 0) {
+      ESP_LOGW(TAG, "Non-zero result code of property %s: %s", stringify_prop(prop).c_str(), tokens[i + 2].c_str());
+      continue;
+    }
+
+    this->apply_property_(prop, tokens[i + 3]);
+  }
+}
+
+void Miio::process_down_request_() {
+  if (!this->mcu_pending_changes_.empty()) {
+    std::string query = "down set_properties";
+
+    for (const auto &change : this->mcu_pending_changes_) {
+      query += " " + stringify_prop(change.first);
+      query += " " + change.second;
+    }
+
+    this->mcu_reply_(query);
+    this->mcu_pending_changes_.clear();
+
+    return;
+  }
+
+  if (!this->mcu_query_.empty()) {
+    std::string query = "down get_properties";
+
+    for (const auto &prop : this->mcu_query_) {
+      query += " " + stringify_prop(prop);
+    }
+
+    this->mcu_reply_(query);
+    this->mcu_query_.clear();
+    this->awaiting_for_get_properties_result_ = true;
+
+    return;
+  }
+
+  this->mcu_reply_("down none");
+}
+
+void Miio::apply_property_(prop_t prop, const std::string &value) {
+  auto it = this->listeners_.find(prop);
+
+  if (it == this->listeners_.end()) {
+    ESP_LOGV(TAG, "Handler was not found for %s", stringify_prop(prop).c_str());
+    return;
+  }
+
+  auto excepted_type = std::get<0>(it->second);
+  auto callback = std::get<1>(it->second);
+
+  auto maybe_value = this->parse_property_value_(excepted_type, value);
+
+  if (maybe_value.has_value()) {
+    callback(maybe_value.value());
+  } else {
+    ESP_LOGW(TAG, "Failed to parse property %s value: %s", stringify_prop(prop).c_str(), value.c_str());
+  }
+}
+
+optional<prop_t> Miio::parse_property_specifier_(const std::string &cluster, const std::string &key) {
+  auto maybe_cluster = parse_number<uint8_t>(cluster);
+  auto maybe_key = parse_number<uint8_t>(key);
+
+  if (maybe_cluster.has_value() && maybe_key.has_value()) {
+    return std::make_tuple(maybe_cluster.value(), maybe_key.value());
+  }
+
+  return {};
+}
+
+optional<MiioPropertyValue> Miio::parse_property_value_(MiioPropertyType type, const std::string &value) {
+  MiioPropertyValue p = {.type = type, .value = value, .value_bool = false};
+
+  switch (type) {
+    case MiioPropertyType::BOOLEAN: {
+      p.value_bool = value == "true";
+      return p;
+    };
+
+    case MiioPropertyType::NUMBER: {
+      auto option = parse_number<float>(value);
+
+      if (option.has_value()) {
+        p.value_numeric = option.value();
+        return p;
+      }
+
+      break;
+    };
+
+    case MiioPropertyType::ENUM: {
+      auto option = parse_number<uint8_t>(value);
+
+      if (option.has_value()) {
+        p.value_enum = option.value();
+        return p;
+      }
+
+      break;
+    };
+  }
+
+  return {};
+}
+
+const char *Miio::get_network_state_() {
+  if (!network::is_connected()) {
+    return "offline";
+  }
+
+  return remote_is_connected() ? "cloud" : "local";
+}
+
+void Miio::mcu_reply_(const std::string &message) { this->mcu_reply_(message.c_str()); }
+
+void Miio::mcu_reply_(const char *message) {
+  ESP_LOGVV(TAG, "TX %s", message);
+
+  this->write_str(message);
+  this->write('\r');
+}
+
+void Miio::mcu_reply_ok_() { this->mcu_reply_("ok"); }
+
+void Miio::handle_char_(uint8_t c) {
+  if (this->rx_message_.empty()) {
+    this->rx_message_.emplace_back();
+  }
+
+  if (c == ' ') {
+    this->rx_message_.emplace_back();
+  } else if (c == '\r') {
+    this->mcu_message_queue_.push_back(std::move(this->rx_message_));
+  } else {
+    this->rx_message_.back() += c;
+  }
+}
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/miio.h
+++ b/esphome/components/miio/miio.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <cinttypes>
+#include <vector>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
+#include <tuple>
+
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/uart/uart.h"
+
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#include "esphome/core/time.h"
+#endif
+
+namespace esphome {
+namespace miio {
+
+using prop_t = std::tuple<uint8_t, uint8_t>;
+
+enum class MiioPropertyType : uint8_t {
+  BOOLEAN = 0x01,
+  NUMBER = 0x02,
+  ENUM = 0x03,
+};
+
+struct MiioPropertyValue {
+  MiioPropertyType type;
+  std::string value;
+  union {
+    bool value_bool;
+    float value_numeric;
+    uint8_t value_enum;
+  };
+};
+
+struct MiioPropertyHash {
+  std::size_t operator()(const std::tuple<uint8_t, uint8_t> &t) const {
+    auto a = std::get<0>(t);
+    auto b = std::get<1>(t);
+    return (a << 8) + b;
+  }
+};
+
+class Miio : public Component, public uart::UARTDevice {
+ public:
+  float get_setup_priority() const override { return setup_priority::LATE; }
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  void register_listener(prop_t property, MiioPropertyType type,
+                         const std::function<void(const MiioPropertyValue &)> &fn);
+  void set_property(prop_t property, std::string value);
+#ifdef USE_TIME
+  void set_time_id(time::RealTimeClock *time_id) { this->time_id_ = time_id; }
+#endif
+
+ protected:
+  void handle_char_(uint8_t c);
+  void process_command_queue_();
+  void process_command_raw_(const std::vector<std::string> &tokens);
+  void process_properties_change_(const std::vector<std::string> &tokens);
+  void process_result_(const std::vector<std::string> &tokens);
+  void process_down_request_();
+  void apply_property_(prop_t prop, const std::string &value);
+  optional<prop_t> parse_property_specifier_(const std::string &cluster, const std::string &key);
+  optional<MiioPropertyValue> parse_property_value_(MiioPropertyType type, const std::string &value);
+  const char *get_network_state_();
+  void mcu_reply_(const std::string &message);
+  void mcu_reply_(const char *message);
+  void mcu_reply_ok_();
+
+  bool awaiting_for_get_properties_result_{false};
+#ifdef USE_TIME
+  optional<time::RealTimeClock *> time_id_{};
+#endif
+  std::unordered_map<prop_t, std::tuple<MiioPropertyType, std::function<void(const MiioPropertyValue &)>>,
+                     MiioPropertyHash>
+      listeners_;
+  std::vector<std::string> rx_message_;
+  std::deque<std::vector<std::string>> mcu_message_queue_;
+  std::unordered_map<prop_t, std::string, MiioPropertyHash> mcu_pending_changes_;
+  std::unordered_set<prop_t, MiioPropertyHash> mcu_query_;
+  std::unordered_map<std::string, std::function<void(const std::vector<std::string> &)>> mcu_handlers_;
+};
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/select/__init__.py
+++ b/esphome/components/miio/select/__init__.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_KEY, CONF_OPTIMISTIC, CONF_OPTIONS
+
+from .. import CONF_CLUSTER, CONF_MIIO_ID, Miio, miio_ns
+
+DEPENDENCIES = ["miio"]
+
+MiioSelect = miio_ns.class_("MiioSelect", select.Select, cg.Component)
+
+
+def ensure_option_map(value):
+    cv.check_not_templatable(value)
+    option = cv.All(cv.int_range(0, 2**8 - 1))
+    mapping = cv.All(cv.string_strict)
+    options_map_schema = cv.Schema({option: mapping})
+    value = options_map_schema(value)
+
+    all_values = list(value.keys())
+    unique_values = set(value.keys())
+    if len(all_values) != len(unique_values):
+        raise cv.Invalid("Mapping values must be unique.")
+
+    return value
+
+
+CONFIG_SCHEMA = (
+    select.select_schema(MiioSelect)
+    .extend(
+        {
+            cv.GenerateID(CONF_MIIO_ID): cv.use_id(Miio),
+            cv.Required(CONF_CLUSTER): cv.uint8_t,
+            cv.Required(CONF_KEY): cv.uint8_t,
+            cv.Required(CONF_OPTIONS): ensure_option_map,
+            cv.Optional(CONF_OPTIMISTIC, default=False): cv.boolean,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    options = config[CONF_OPTIONS]
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await select.register_select(var, config, options=list(options.values()))
+
+    parent = await cg.get_variable(config[CONF_MIIO_ID])
+
+    cg.add(var.set_miio_parent(parent))
+    cg.add(var.set_select_id(config[CONF_CLUSTER], config[CONF_KEY]))
+    cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
+    cg.add(var.set_select_mappings(list(options.keys())))

--- a/esphome/components/miio/select/miio_select.cpp
+++ b/esphome/components/miio/select/miio_select.cpp
@@ -1,0 +1,62 @@
+#include "esphome/core/log.h"
+#include "miio_select.h"
+
+namespace esphome {
+namespace miio {
+
+static const char *const TAG = "miio.select";
+
+void MiioSelect::setup() {
+  this->parent_->register_listener(this->select_id_, MiioPropertyType::ENUM, [this](const MiioPropertyValue &value) {
+    auto enum_value = value.value_enum;
+
+    const auto &mappings = this->mappings_;
+
+    auto it = std::find(mappings.cbegin(), mappings.cend(), enum_value);
+
+    if (it == mappings.end()) {
+      ESP_LOGW(TAG, "Invalid value %u", enum_value);
+      return;
+    }
+
+    auto mapping_idx = static_cast<size_t>(std::distance(mappings.cbegin(), it));
+
+    auto maybe_mapped_value = this->at(mapping_idx);
+
+    if (maybe_mapped_value.has_value()) {
+      this->publish_state(maybe_mapped_value.value());
+    }
+  });
+}
+
+void MiioSelect::control(const std::string &value) {
+  if (this->optimistic_) {
+    this->publish_state(value);
+  }
+
+  auto idx = this->index_of(value);
+
+  if (!idx.has_value()) {
+    ESP_LOGW(TAG, "Invalid value %s", value.c_str());
+    return;
+  }
+
+  auto mapping = this->mappings_.at(idx.value());
+
+  this->parent_->set_property(this->select_id_, to_string(mapping));
+}
+
+void MiioSelect::dump_config() {
+  LOG_SELECT("", "MIIO Select", this);
+  ESP_LOGCONFIG(TAG, "  Select has cluster ID: %u", std::get<0>(this->select_id_));
+  ESP_LOGCONFIG(TAG, "  Select has key ID: %u", std::get<1>(this->select_id_));
+  ESP_LOGCONFIG(TAG, "  Options are:");
+
+  const auto &options = this->traits.get_options();
+  for (size_t i = 0; i < this->mappings_.size(); i++) {
+    ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i));
+  }
+}
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/select/miio_select.h
+++ b/esphome/components/miio/select/miio_select.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/miio/miio.h"
+#include "esphome/components/select/select.h"
+
+#include <vector>
+
+namespace esphome {
+namespace miio {
+
+class MiioSelect : public select::Select, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  void set_miio_parent(Miio *parent) { this->parent_ = parent; }
+  void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
+  void set_select_id(uint8_t cluster, uint8_t key) { this->select_id_ = std::make_tuple(cluster, key); }
+  void set_select_mappings(std::vector<uint8_t> mappings) { this->mappings_ = std::move(mappings); }
+
+ protected:
+  void control(const std::string &value) override;
+
+  Miio *parent_;
+  bool optimistic_ = false;
+  prop_t select_id_;
+  std::vector<uint8_t> mappings_;
+};
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/sensor/__init__.py
+++ b/esphome/components/miio/sensor/__init__.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_KEY
+
+from .. import CONF_CLUSTER, CONF_MIIO_ID, Miio, miio_ns
+
+DEPENDENCIES = ["miio"]
+
+MiioSensor = miio_ns.class_("MiioSensor", sensor.Sensor, cg.Component)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(MiioSensor)
+    .extend(
+        {
+            cv.GenerateID(CONF_MIIO_ID): cv.use_id(Miio),
+            cv.Required(CONF_CLUSTER): cv.uint8_t,
+            cv.Required(CONF_KEY): cv.uint8_t,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await sensor.register_sensor(var, config)
+
+    parent = await cg.get_variable(config[CONF_MIIO_ID])
+
+    cg.add(var.set_miio_parent(parent))
+    cg.add(var.set_sensor_id(config[CONF_CLUSTER], config[CONF_KEY]))

--- a/esphome/components/miio/sensor/miio_sensor.cpp
+++ b/esphome/components/miio/sensor/miio_sensor.cpp
@@ -1,0 +1,24 @@
+#include <cinttypes>
+
+#include "esphome/core/log.h"
+#include "miio_sensor.h"
+
+namespace esphome {
+namespace miio {
+
+static const char *const TAG = "miio.sensor";
+
+void MiioSensor::setup() {
+  this->parent_->register_listener(this->sensor_id_, MiioPropertyType::NUMBER, [this](const MiioPropertyValue &value) {
+    this->publish_state(value.value_numeric);
+  });
+}
+
+void MiioSensor::dump_config() {
+  LOG_SENSOR("", "MIIO Sensor", this);
+  ESP_LOGCONFIG(TAG, "  Sensor has cluster ID: %u", std::get<0>(this->sensor_id_));
+  ESP_LOGCONFIG(TAG, "  Sensor has key ID: %u", std::get<1>(this->sensor_id_));
+}
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/sensor/miio_sensor.h
+++ b/esphome/components/miio/sensor/miio_sensor.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/miio/miio.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome {
+namespace miio {
+
+class MiioSensor : public sensor::Sensor, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_sensor_id(uint8_t cluster, uint8_t key) { this->sensor_id_ = std::make_tuple(cluster, key); }
+  void set_miio_parent(Miio *parent) { this->parent_ = parent; }
+
+ protected:
+  Miio *parent_;
+  prop_t sensor_id_;
+};
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/switch/__init__.py
+++ b/esphome/components/miio/switch/__init__.py
@@ -1,0 +1,34 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_KEY
+
+from .. import CONF_CLUSTER, CONF_MIIO_ID, Miio, miio_ns
+
+DEPENDENCIES = ["miio"]
+
+MiioSwitch = miio_ns.class_("MiioSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = (
+    switch.switch_schema(MiioSwitch)
+    .extend(
+        {
+            cv.GenerateID(CONF_MIIO_ID): cv.use_id(Miio),
+            cv.Required(CONF_CLUSTER): cv.uint8_t,
+            cv.Required(CONF_KEY): cv.uint8_t,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+
+    await cg.register_component(var, config)
+    await switch.register_switch(var, config)
+
+    parent = await cg.get_variable(config[CONF_MIIO_ID])
+
+    cg.add(var.set_miio_parent(parent))
+    cg.add(var.set_switch_id(config[CONF_CLUSTER], config[CONF_KEY]))

--- a/esphome/components/miio/switch/miio_switch.cpp
+++ b/esphome/components/miio/switch/miio_switch.cpp
@@ -1,0 +1,26 @@
+#include "esphome/core/log.h"
+#include "miio_switch.h"
+
+namespace esphome {
+namespace miio {
+
+static const char *const TAG = "miio.switch";
+
+void MiioSwitch::setup() {
+  this->parent_->register_listener(this->switch_id_, MiioPropertyType::BOOLEAN,
+                                   [this](const MiioPropertyValue &value) { this->publish_state(value.value_bool); });
+}
+
+void MiioSwitch::write_state(bool state) {
+  this->parent_->set_property(this->switch_id_, state ? "true" : "false");
+  this->publish_state(state);
+}
+
+void MiioSwitch::dump_config() {
+  LOG_SWITCH("", "MIIO Switch", this);
+  ESP_LOGCONFIG(TAG, "  Switch has cluster ID: %u", std::get<0>(this->switch_id_));
+  ESP_LOGCONFIG(TAG, "  Switch has key ID: %u", std::get<1>(this->switch_id_));
+}
+
+}  // namespace miio
+}  // namespace esphome

--- a/esphome/components/miio/switch/miio_switch.h
+++ b/esphome/components/miio/switch/miio_switch.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/miio/miio.h"
+#include "esphome/components/switch/switch.h"
+
+namespace esphome {
+namespace miio {
+
+class MiioSwitch : public switch_::Switch, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void set_switch_id(uint8_t cluster, uint8_t key) { this->switch_id_ = std::make_tuple(cluster, key); }
+  void set_miio_parent(Miio *parent) { this->parent_ = parent; }
+
+ protected:
+  void write_state(bool state) override;
+
+  Miio *parent_;
+  prop_t switch_id_;
+};
+
+}  // namespace miio
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Xiaomi commonly uses ESP32 in their consumer electronics (e.g air purifiers or humidifiers).

These devices *may* follow MCU + IoT architecture:

 - MCU controls the device's hardware
 - IoT module handles cloud connectivity over Wi-Fi / BLE

This component implements communication [protocol](https://iot.mi.com/v2/new/doc/embedded-dev/module-dev/function-dev/serial-communication) between IoT module and MCU.
It allows ESPHome to take the place of Xiaomi IoT Cloud.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
