### PR TITLE
[web_server] Eliminate nested lambdas in DeferredUpdateEventSourceList

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -229,7 +229,7 @@ void DeferredUpdateEventSourceList::add_new_client(WebServer *ws, AsyncWebServer
 
 void DeferredUpdateEventSourceList::on_client_connect_(DeferredUpdateEventSource *source) {
   WebServer *ws = source->web_server_;
-  ws->defer([this, ws, source]() {
+  ws->defer([ws, source]() {
     // Configure reconnect timeout and send config
     // this should always go through since the AsyncEventSourceClient event queue is empty on connect
     std::string message = ws->get_config_json();

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -220,50 +220,51 @@ void DeferredUpdateEventSourceList::add_new_client(WebServer *ws, AsyncWebServer
   DeferredUpdateEventSource *es = new DeferredUpdateEventSource(ws, "/events");
   this->push_back(es);
 
-  es->onConnect([this, ws, es](AsyncEventSourceClient *client) {
-    ws->defer([this, ws, es]() { this->on_client_connect_(ws, es); });
-  });
+  es->onConnect([this, es](AsyncEventSourceClient *client) { this->on_client_connect_(es); });
 
-  es->onDisconnect([this, ws, es](AsyncEventSourceClient *client) {
-    ws->defer([this, es]() { this->on_client_disconnect_((DeferredUpdateEventSource *) es); });
-  });
+  es->onDisconnect([this, es](AsyncEventSourceClient *client) { this->on_client_disconnect_(es); });
 
   es->handleRequest(request);
 }
 
-void DeferredUpdateEventSourceList::on_client_connect_(WebServer *ws, DeferredUpdateEventSource *source) {
-  // Configure reconnect timeout and send config
-  // this should always go through since the AsyncEventSourceClient event queue is empty on connect
-  std::string message = ws->get_config_json();
-  source->try_send_nodefer(message.c_str(), "ping", millis(), 30000);
+void DeferredUpdateEventSourceList::on_client_connect_(DeferredUpdateEventSource *source) {
+  WebServer *ws = source->web_server_;
+  ws->defer([this, ws, source]() {
+    // Configure reconnect timeout and send config
+    // this should always go through since the AsyncEventSourceClient event queue is empty on connect
+    std::string message = ws->get_config_json();
+    source->try_send_nodefer(message.c_str(), "ping", millis(), 30000);
 
 #ifdef USE_WEBSERVER_SORTING
-  for (auto &group : ws->sorting_groups_) {
-    json::JsonBuilder builder;
-    JsonObject root = builder.root();
-    root["name"] = group.second.name;
-    root["sorting_weight"] = group.second.weight;
-    message = builder.serialize();
+    for (auto &group : ws->sorting_groups_) {
+      json::JsonBuilder builder;
+      JsonObject root = builder.root();
+      root["name"] = group.second.name;
+      root["sorting_weight"] = group.second.weight;
+      message = builder.serialize();
 
-    // up to 31 groups should be able to be queued initially without defer
-    source->try_send_nodefer(message.c_str(), "sorting_group");
-  }
+      // up to 31 groups should be able to be queued initially without defer
+      source->try_send_nodefer(message.c_str(), "sorting_group");
+    }
 #endif
 
-  source->entities_iterator_.begin(ws->include_internal_);
+    source->entities_iterator_.begin(ws->include_internal_);
 
-  // just dump them all up-front and take advantage of the deferred queue
-  //     on second thought that takes too long, but leaving the commented code here for debug purposes
-  // while(!source->entities_iterator_.completed()) {
-  //  source->entities_iterator_.advance();
-  //}
+    // just dump them all up-front and take advantage of the deferred queue
+    //     on second thought that takes too long, but leaving the commented code here for debug purposes
+    // while(!source->entities_iterator_.completed()) {
+    //  source->entities_iterator_.advance();
+    //}
+  });
 }
 
 void DeferredUpdateEventSourceList::on_client_disconnect_(DeferredUpdateEventSource *source) {
-  // This method was called via WebServer->defer() and is no longer executing in the
-  // context of the network callback. The object is now dead and can be safely deleted.
-  this->remove(source);
-  delete source;  // NOLINT
+  source->web_server_->defer([this, source]() {
+    // This method was called via WebServer->defer() and is no longer executing in the
+    // context of the network callback. The object is now dead and can be safely deleted.
+    this->remove(source);
+    delete source;  // NOLINT
+  });
 }
 #endif
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -141,7 +141,7 @@ class DeferredUpdateEventSource : public AsyncEventSource {
 
 class DeferredUpdateEventSourceList : public std::list<DeferredUpdateEventSource *> {
  protected:
-  void on_client_connect_(WebServer *ws, DeferredUpdateEventSource *source);
+  void on_client_connect_(DeferredUpdateEventSource *source);
   void on_client_disconnect_(DeferredUpdateEventSource *source);
 
  public:


### PR DESCRIPTION
# What does this implement/fix?

Reduces flash size overhead in the web server's event source client management by eliminating nested lambda instantiations and removing unused lambda captures in `DeferredUpdateEventSourceList::add_new_client()`.

## Changes

The optimization moves `defer()` calls from nested lambdas into the callback methods themselves, and removes unnecessary lambda captures:

**Before:**
- 4 lambda instantiations (2 outer + 2 nested)
- Outer lambdas captured `this`, `ws`, `es` (with `this` unused in one case)
- Nested lambdas added extra template instantiation overhead

**After:**
- 2 simpler lambdas (no nesting)
- Removed unused `this` capture from `on_client_connect_` lambda
- Uses `source->web_server_` instead of capturing `ws`
- Each lambda now captures only what it actually uses

**Flash Impact (from CI analysis):**
- **-208 bytes total** (-0.05%)
- **-192 bytes in web_server component** (-2.71%)
- Zero RAM impact
- Identical runtime behavior

**Key optimization:** Removing the unused `this` capture was the primary driver, saving ~120-180 bytes by reducing `std::function` template instantiation overhead in `_M_manager` and `_M_invoke` handlers.

## Technical Details

This code path only applies to `!defined(USE_ESP32) && defined(USE_ARDUINO)` (ESP8266, RP2040, LibreTiny with Arduino framework). The optimization is thread-safe because:
1. `Component::defer()` is thread-safe on all platforms (uses scheduler lock)
2. WebServer pointer lifetime = program lifetime
3. Deferred lambda captures remain valid until explicit deletion

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing flash size optimization efforts for resource-constrained platforms

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-visible changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
# Existing web_server configurations continue to work unchanged

web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
