### PR TITLE
[web_server] Remove redundant assignment in deq_push_back_with_dedup_

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -111,8 +111,7 @@ void DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_
   // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
   for (auto &event : this->deferred_queue_) {
     if (event == item) {
-      event = item;
-      return;
+      return;  // Already in queue, no need to update since items are equal
     }
   }
   this->deferred_queue_.push_back(item);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -494,8 +494,7 @@ void AsyncEventSourceResponse::deq_push_back_with_dedup_(void *source, message_g
   // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size
   for (auto &event : this->deferred_queue_) {
     if (event == item) {
-      event = item;
-      return;
+      return;  // Already in queue, no need to update since items are equal
     }
   }
   this->deferred_queue_.push_back(item);


### PR DESCRIPTION
# What does this implement/fix?

Removes a redundant assignment operation in the `deq_push_back_with_dedup_` function for both ESP-IDF and Arduino web server implementations, reducing flash usage by 32 bytes on ESP8266.

## Background

The deduplication function checks if an event is already in the deferred queue by comparing both the `source_` and `message_generator_` pointers. When a match is found, the original code would re-assign the event with an identical copy:

```cpp
if (event == item) {
  event = item;  // No-op: they're already equal!
  return;
}
```

Since `operator==` returns `true` only when both pointers are identical, the assignment copies values that are already equal, making it a complete no-op. However, the compiler still generated code for this operation.

## Changes

**Before:**
```cpp
for (auto &event : this->deferred_queue_) {
  if (event == item) {
    event = item;  // Redundant assignment
    return;
  }
}
```

**After:**
```cpp
for (auto &event : this->deferred_queue_) {
  if (event == item) {
    return;  // Already in queue, no need to update since items are equal
  }
}
```

## Flash Savings

Tested on ESP8266 with web server enabled:
- **Before:** 402,277 bytes
- **After:** 402,245 bytes
- **Savings:** 32 bytes

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
