### PR TITLE
[ruff] Remove deprecated UP038 rule from ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ ignore = [
   "PLW1641", # Object does not implement `__hash__` method
   "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
   "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
-  "UP038", # https://github.com/astral-sh/ruff/issues/7871 https://github.com/astral-sh/ruff/pull/16681
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
# What does this implement/fix?

This PR removes the `UP038` rule from the ruff ignore list in `pyproject.toml` because the rule was deprecated and removed from ruff in v0.10 (March 2025).

## Background

The `UP038` rule (non-pep604-isinstance) was designed to convert `isinstance()` checks from tuple syntax to PEP 604 pipe syntax. However:

1. **Rule was deprecated:** Ruff deprecated UP038 in v0.10 (PR #16681) because using PEP 604 syntax in `isinstance()` calls "isn't a recommended pattern" and causes measurable performance degradation.

2. **ESPHome already compliant:** PR #11645 fixes the only instance of pipe syntax in ESPHome's codebase, aligning with the tuple syntax standard.

3. **Warning on every run:** Ruff now emits a warning when this rule is in the ignore list:
   ```
   warning: The following rules have been removed and ignoring them has no effect:
       - UP038
   ```

4. **No longer needed:** Since the anti-pattern has been corrected and the rule no longer exists in ruff, keeping it in the ignore list serves no purpose and generates noise.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Related to #11645 (fixes the isinstance usage)
- Related to ruff issue https://github.com/astral-sh/ruff/issues/7871
- Related to ruff PR https://github.com/astral-sh/ruff/pull/16681

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal tooling configuration cleanup)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This is a linter configuration cleanup with no user-facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
