### PR TITLE
[json] Fix component test compilation errors

### DIFF
--- a/tests/components/json/common.yaml
+++ b/tests/components/json/common.yaml
@@ -14,12 +14,14 @@ interval:
 
           // Test parse_json
           bool parse_ok = esphome::json::parse_json(json_str, [](JsonObject root) {
-            if (root.containsKey("sensor") && root.containsKey("value")) {
+            if (root["sensor"].is<const char*>() && root["value"].is<float>()) {
               const char* sensor = root["sensor"];
               float value = root["value"];
               ESP_LOGD("test", "Parsed: sensor=%s, value=%.1f", sensor, value);
+              return true;
             } else {
               ESP_LOGD("test", "Parsed JSON missing required keys");
+              return false;
             }
           });
           ESP_LOGD("test", "Parse result (JSON syntax only): %s", parse_ok ? "success" : "failed");


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation errors in the JSON component test that were accidentally introduced when the wrong branch iteration was merged in PR #11409. The errors went undetected because CI skipped compilation tests for test-only changes at the time.

The test had two issues:
1. **Missing return value**: The lambda passed to `parse_json()` didn't return a `bool`, but the signature requires `std::function<bool(JsonObject)>`
2. **Deprecated ArduinoJson API**: Used `containsKey()` which is deprecated in favor of `obj[key].is<T>()`

These compilation errors were exposed after PR #11580 fixed the CI to actually run component tests when test files change.

**Changes:**
- Added `return true;` when JSON keys are found and processed successfully
- Added `return false;` when required keys are missing
- Replaced deprecated `root.containsKey("sensor")` with modern `root["sensor"].is<const char*>()`
- Replaced deprecated `root.containsKey("value")` with modern `root["value"].is<float>()`
- Eliminates deprecation warnings from ArduinoJson

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes compilation failure exposed by #11580
- Original test added in #11409

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test-only change, no user-facing impact)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Tested with: `script/test_build_components -c json -t esp32-idf`

## Example entry for `config.yaml`:

N/A - This only fixes the test code, not the json component itself. No user configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
