### PR TITLE
[ci] Cache component dependency graph for up to 3.4x faster determine-jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .temp/components_graph.json
-          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
+          key: components-graph-${{ hashFiles('esphome/components/**/*.py') }}
       - name: Determine which tests to run
         id: determine
         env:
@@ -226,7 +226,7 @@ jobs:
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .temp/components_graph.json
-          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
+          key: components-graph-${{ hashFiles('esphome/components/**/*.py') }}
 
   integration-tests:
     name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,11 +192,12 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Restore components graph cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Components graph cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .temp/components_graph.json
           key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
+          save-always: ${{ github.ref == 'refs/heads/dev' }}
       - name: Determine which tests to run
         id: determine
         env:
@@ -221,12 +222,6 @@ jobs:
           echo "cpp-unit-tests-run-all=$(echo "$output" | jq -r '.cpp_unit_tests_run_all')" >> $GITHUB_OUTPUT
           echo "cpp-unit-tests-components=$(echo "$output" | jq -c '.cpp_unit_tests_components')" >> $GITHUB_OUTPUT
           echo "component-test-batches=$(echo "$output" | jq -c '.component_test_batches')" >> $GITHUB_OUTPUT
-      - name: Save components graph cache
-        # temp disabled for testing - if: github.ref == 'refs/heads/dev'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: .temp/components_graph.json
-          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
 
   integration-tests:
     name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,12 +192,11 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
-      - name: Components graph cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Restore components graph cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .temp/components_graph.json
           key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
-          save-always: ${{ github.ref == 'refs/heads/dev' }}
       - name: Determine which tests to run
         id: determine
         env:
@@ -222,6 +221,12 @@ jobs:
           echo "cpp-unit-tests-run-all=$(echo "$output" | jq -r '.cpp_unit_tests_run_all')" >> $GITHUB_OUTPUT
           echo "cpp-unit-tests-components=$(echo "$output" | jq -c '.cpp_unit_tests_components')" >> $GITHUB_OUTPUT
           echo "component-test-batches=$(echo "$output" | jq -c '.component_test_batches')" >> $GITHUB_OUTPUT
+      - name: Save components graph cache
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .temp/components_graph.json
+          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
 
   integration-tests:
     name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,11 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
           cache-key: ${{ needs.common.outputs.cache-key }}
+      - name: Restore components graph cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .temp/components_graph.json
+          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
       - name: Determine which tests to run
         id: determine
         env:
@@ -216,6 +221,12 @@ jobs:
           echo "cpp-unit-tests-run-all=$(echo "$output" | jq -r '.cpp_unit_tests_run_all')" >> $GITHUB_OUTPUT
           echo "cpp-unit-tests-components=$(echo "$output" | jq -c '.cpp_unit_tests_components')" >> $GITHUB_OUTPUT
           echo "component-test-batches=$(echo "$output" | jq -c '.component_test_batches')" >> $GITHUB_OUTPUT
+      - name: Save components graph cache
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .temp/components_graph.json
+          key: components-graph-${{ hashFiles('esphome/components/**/__init__.py') }}
 
   integration-tests:
     name: Run integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
           echo "cpp-unit-tests-components=$(echo "$output" | jq -c '.cpp_unit_tests_components')" >> $GITHUB_OUTPUT
           echo "component-test-batches=$(echo "$output" | jq -c '.component_test_batches')" >> $GITHUB_OUTPUT
       - name: Save components graph cache
-        if: github.ref == 'refs/heads/dev'
+        # temp disabled for testing - if: github.ref == 'refs/heads/dev'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .temp/components_graph.json

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -759,7 +759,7 @@ def resolve_auto_load(
 
 @cache
 def get_components_graph_cache_key() -> str:
-    """Generate cache key based on all component __init__.py file hashes.
+    """Generate cache key based on all component Python file hashes.
 
     Uses git ls-files with sha1 hashes to generate a stable cache key that works
     across different machines and CI runs. This is faster and more reliable than
@@ -769,16 +769,18 @@ def get_components_graph_cache_key() -> str:
         SHA256 hex string uniquely identifying the current component state
     """
 
-    # Use git ls-files -s to get sha1 hashes of all component __init__.py files
+    # Use git ls-files -s to get sha1 hashes of all component Python files
     # Format: <mode> <sha1> <stage> <path>
     # This is fast and works consistently across CI and local dev
-    cmd = ["git", "ls-files", "-s", "esphome/components/**/__init__.py"]
+    # We hash all .py files because AUTO_LOAD, DEPENDENCIES, etc. can be defined
+    # in any Python file, not just __init__.py
+    cmd = ["git", "ls-files", "-s", "esphome/components/**/*.py"]
     result = subprocess.run(
         cmd, capture_output=True, text=True, check=True, cwd=root_path, close_fds=False
     )
 
     # Hash the git output (includes file paths and their sha1 hashes)
-    # This changes only when component __init__.py files actually change
+    # This changes only when component Python files actually change
     hasher = hashlib.sha256()
     hasher.update(result.stdout.encode())
 

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import cache
+import hashlib
 import json
 import os
 import os.path
@@ -767,7 +768,6 @@ def get_components_graph_cache_key() -> str:
     Returns:
         SHA256 hex string uniquely identifying the current component state
     """
-    import hashlib
 
     # Use git ls-files -s to get sha1 hashes of all component __init__.py files
     # Format: <mode> <sha1> <stage> <path>

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -756,7 +756,8 @@ def resolve_auto_load(
     return auto_load()
 
 
-def _get_components_graph_cache_key() -> str:
+@cache
+def get_components_graph_cache_key() -> str:
     """Generate cache key based on all component __init__.py file hashes.
 
     Uses git ls-files with sha1 hashes to generate a stable cache key that works
@@ -807,7 +808,7 @@ def create_components_graph() -> dict[str, list[str]]:
             # Verify cache version matches
             if cached_data.get("_version") == COMPONENTS_GRAPH_CACHE_VERSION:
                 # Verify cache is for current component state
-                cache_key = _get_components_graph_cache_key()
+                cache_key = get_components_graph_cache_key()
                 if cached_data.get("_cache_key") == cache_key:
                     return cached_data.get("graph", {})
                 # Cache key mismatch - stale cache, rebuild
@@ -898,7 +899,7 @@ def create_components_graph() -> dict[str, list[str]]:
     # Save to cache with version and cache key for validation
     cache_data = {
         "_version": COMPONENTS_GRAPH_CACHE_VERSION,
-        "_cache_key": _get_components_graph_cache_key(),
+        "_cache_key": get_components_graph_cache_key(),
         "graph": components_graph,
     }
     cache_file.parent.mkdir(exist_ok=True)

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -52,6 +52,10 @@ BASE_BUS_COMPONENTS = {
     "remote_receiver",
 }
 
+# Cache version for components graph
+# Increment this when the cache format or graph building logic changes
+COMPONENTS_GRAPH_CACHE_VERSION = 1
+
 
 def parse_list_components_output(output: str) -> list[str]:
     """Parse the output from list-components.py script.
@@ -752,20 +756,69 @@ def resolve_auto_load(
     return auto_load()
 
 
+def _get_components_graph_cache_key() -> str:
+    """Generate cache key based on all component __init__.py file hashes.
+
+    Uses git ls-files with sha1 hashes to generate a stable cache key that works
+    across different machines and CI runs. This is faster and more reliable than
+    reading file contents or using modification times.
+
+    Returns:
+        SHA256 hex string uniquely identifying the current component state
+    """
+    import hashlib
+
+    # Use git ls-files -s to get sha1 hashes of all component __init__.py files
+    # Format: <mode> <sha1> <stage> <path>
+    # This is fast and works consistently across CI and local dev
+    cmd = ["git", "ls-files", "-s", "esphome/components/**/__init__.py"]
+    result = subprocess.run(
+        cmd, capture_output=True, text=True, check=True, cwd=root_path
+    )
+
+    # Hash the git output (includes file paths and their sha1 hashes)
+    # This changes only when component __init__.py files actually change
+    hasher = hashlib.sha256()
+    hasher.update(result.stdout.encode())
+
+    return hasher.hexdigest()
+
+
 def create_components_graph() -> dict[str, list[str]]:
-    """Create a graph of component dependencies.
+    """Create a graph of component dependencies (cached).
+
+    This function is expensive (5-6 seconds) because it imports all ESPHome components
+    to extract their DEPENDENCIES and AUTO_LOAD metadata. The result is cached based
+    on component file modification times, so unchanged components don't trigger a rebuild.
 
     Returns:
         Dictionary mapping parent components to their children (dependencies)
     """
-    from pathlib import Path
+    # Check cache first - use fixed filename since GitHub Actions cache doesn't support wildcards
+    cache_file = Path(temp_folder) / "components_graph.json"
+
+    if cache_file.exists():
+        try:
+            cached_data = json.loads(cache_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            # Cache file corrupted or unreadable, rebuild
+            pass
+        else:
+            # Verify cache version matches
+            if cached_data.get("_version") == COMPONENTS_GRAPH_CACHE_VERSION:
+                # Verify cache is for current component state
+                cache_key = _get_components_graph_cache_key()
+                if cached_data.get("_cache_key") == cache_key:
+                    return cached_data.get("graph", {})
+                # Cache key mismatch - stale cache, rebuild
+            # Cache version mismatch - incompatible format, rebuild
 
     from esphome import const
     from esphome.core import CORE
     from esphome.loader import ComponentManifest, get_component, get_platform
 
     # The root directory of the repo
-    root = Path(__file__).parent.parent
+    root = Path(root_path)
     components_dir = root / ESPHOME_COMPONENTS_PATH
     # Fake some directory so that get_component works
     CORE.config_path = root
@@ -841,6 +894,15 @@ def create_components_graph() -> dict[str, list[str]]:
                     add_item_to_components_graph(components_graph, item, name)
             # restore config
             CORE.data[KEY_CORE] = TARGET_CONFIGURATIONS[0]
+
+    # Save to cache with version and cache key for validation
+    cache_data = {
+        "_version": COMPONENTS_GRAPH_CACHE_VERSION,
+        "_cache_key": _get_components_graph_cache_key(),
+        "graph": components_graph,
+    }
+    cache_file.parent.mkdir(exist_ok=True)
+    cache_file.write_text(json.dumps(cache_data))
 
     return components_graph
 

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -773,7 +773,7 @@ def _get_components_graph_cache_key() -> str:
     # This is fast and works consistently across CI and local dev
     cmd = ["git", "ls-files", "-s", "esphome/components/**/__init__.py"]
     result = subprocess.run(
-        cmd, capture_output=True, text=True, check=True, cwd=root_path
+        cmd, capture_output=True, text=True, check=True, cwd=root_path, close_fds=False
     )
 
     # Hash the git output (includes file paths and their sha1 hashes)

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -543,6 +543,7 @@ def test_main_filters_components_without_tests(
     with (
         patch.object(determine_jobs, "root_path", str(tmp_path)),
         patch.object(helpers, "root_path", str(tmp_path)),
+        patch.object(helpers, "create_components_graph", return_value={}),
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(
             determine_jobs,
@@ -640,6 +641,7 @@ def test_main_detects_components_with_variant_tests(
     with (
         patch.object(determine_jobs, "root_path", str(tmp_path)),
         patch.object(helpers, "root_path", str(tmp_path)),
+        patch.object(helpers, "create_components_graph", return_value={}),
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(
             determine_jobs,

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1099,5 +1099,222 @@ def test_get_component_from_path(
     file_path: str, expected_component: str | None
 ) -> None:
     """Test extraction of component names from file paths."""
-    result = helpers.get_component_from_path(file_path)
-    assert result == expected_component
+
+
+# Components graph cache tests
+
+
+@pytest.fixture
+def mock_git_output() -> str:
+    """Fixture for mock git ls-files output."""
+    return (
+        "100644 abc123... 0 esphome/components/wifi/__init__.py\n"
+        "100644 def456... 0 esphome/components/api/__init__.py\n"
+    )
+
+
+@pytest.fixture
+def mock_cache_file(tmp_path: Path) -> Path:
+    """Fixture for a temporary cache file path."""
+    return tmp_path / "components_graph.json"
+
+
+def test_cache_key_generation(mock_git_output: str) -> None:
+    """Test that cache key is generated based on git file hashes."""
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with patch("subprocess.run", return_value=mock_result):
+        key = helpers._get_components_graph_cache_key()
+
+        # Should be a 64-character hex string (SHA256)
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+
+def test_cache_key_consistent_for_same_files(mock_git_output: str) -> None:
+    """Test that same git output produces same cache key."""
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with patch("subprocess.run", return_value=mock_result):
+        key1 = helpers._get_components_graph_cache_key()
+        key2 = helpers._get_components_graph_cache_key()
+
+        assert key1 == key2
+
+
+def test_cache_key_different_for_changed_files() -> None:
+    """Test that different git output produces different cache key."""
+    mock_result1 = Mock()
+    mock_result1.stdout = "100644 abc123... 0 esphome/components/wifi/__init__.py\n"
+
+    mock_result2 = Mock()
+    mock_result2.stdout = "100644 xyz789... 0 esphome/components/wifi/__init__.py\n"
+
+    with patch("subprocess.run", return_value=mock_result1):
+        key1 = helpers._get_components_graph_cache_key()
+
+    with patch("subprocess.run", return_value=mock_result2):
+        key2 = helpers._get_components_graph_cache_key()
+
+    assert key1 != key2
+
+
+def test_cache_key_uses_git_ls_files(mock_git_output: str) -> None:
+    """Test that git ls-files command is called correctly."""
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with patch("subprocess.run", return_value=mock_result) as mock_run:
+        helpers._get_components_graph_cache_key()
+
+        # Verify git ls-files was called with correct arguments
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args
+        assert call_args[0][0] == [
+            "git",
+            "ls-files",
+            "-s",
+            "esphome/components/**/__init__.py",
+        ]
+        assert call_args[1]["capture_output"] is True
+        assert call_args[1]["text"] is True
+        assert call_args[1]["check"] is True
+        assert call_args[1]["close_fds"] is False
+
+
+def test_cache_hit_returns_cached_graph(tmp_path: Path, mock_git_output: str) -> None:
+    """Test that cache hit returns cached data without rebuilding."""
+    mock_graph = {"wifi": ["network"], "api": ["socket"]}
+    cache_key = "a" * 64
+    cache_data = {
+        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
+        "_cache_key": cache_key,
+        "graph": mock_graph,
+    }
+
+    # Write cache file
+    cache_file = tmp_path / "components_graph.json"
+    cache_file.write_text(json.dumps(cache_data))
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("helpers._get_components_graph_cache_key", return_value=cache_key),
+        patch("helpers.temp_folder", str(tmp_path)),
+    ):
+        result = helpers.create_components_graph()
+        assert result == mock_graph
+
+
+def test_cache_version_mismatch_rebuilds(tmp_path: Path) -> None:
+    """Test that cache version mismatch is detected and ignored."""
+    cache_data = {
+        "_version": 999,  # Wrong version
+        "_cache_key": "a" * 64,
+        "graph": {"old": ["data"]},
+    }
+
+    cache_file = tmp_path / "components_graph.json"
+    cache_file.write_text(json.dumps(cache_data))
+
+    # Verify cache file exists but would be ignored due to version mismatch
+    with patch("helpers.temp_folder", str(tmp_path)):
+        assert cache_file.exists()
+        cached = json.loads(cache_file.read_text())
+        assert cached["_version"] != helpers.COMPONENTS_GRAPH_CACHE_VERSION
+
+
+def test_cache_key_mismatch_ignored(tmp_path: Path, mock_git_output: str) -> None:
+    """Test that cache key mismatch causes cache to be ignored."""
+    old_key = "old_key_" + "a" * 56
+    new_key = "new_key_" + "b" * 56
+    cache_data = {
+        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
+        "_cache_key": old_key,
+        "graph": {"old": ["data"]},
+    }
+
+    cache_file = tmp_path / "components_graph.json"
+    cache_file.write_text(json.dumps(cache_data))
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("helpers._get_components_graph_cache_key", return_value=new_key),
+        patch("helpers.temp_folder", str(tmp_path)),
+    ):
+        # Cache key mismatch should cause cache to be ignored
+        cached = json.loads(cache_file.read_text())
+        assert cached["_cache_key"] != new_key
+
+
+def test_corrupted_cache_handled_gracefully(
+    tmp_path: Path, mock_git_output: str
+) -> None:
+    """Test that corrupted cache file is handled gracefully."""
+    cache_file = tmp_path / "components_graph.json"
+    cache_file.write_text("{invalid json")
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("helpers.temp_folder", str(tmp_path)),
+    ):
+        # Should not crash when encountering corrupted cache
+        assert cache_file.exists()
+
+
+def test_cache_structure_has_required_fields() -> None:
+    """Test that cache structure has all required fields."""
+    mock_graph = {"wifi": ["network"]}
+    cache_structure = {
+        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
+        "_cache_key": "test_key_" + "a" * 55,
+        "graph": mock_graph,
+    }
+
+    # Verify required fields exist
+    assert "_version" in cache_structure
+    assert "_cache_key" in cache_structure
+    assert "graph" in cache_structure
+    assert isinstance(cache_structure["_version"], int)
+    assert isinstance(cache_structure["_cache_key"], str)
+    assert isinstance(cache_structure["graph"], dict)
+
+
+def test_cache_version_constant_exists() -> None:
+    """Test that cache version constant exists and is valid."""
+    assert hasattr(helpers, "COMPONENTS_GRAPH_CACHE_VERSION")
+    assert isinstance(helpers.COMPONENTS_GRAPH_CACHE_VERSION, int)
+    assert helpers.COMPONENTS_GRAPH_CACHE_VERSION >= 1
+
+
+def test_cache_file_location_correct() -> None:
+    """Test that cache file path is constructed correctly."""
+    cache_path = Path(helpers.temp_folder) / "components_graph.json"
+    assert str(cache_path).endswith("components_graph.json")
+    assert helpers.temp_folder in str(cache_path)
+
+
+def test_empty_cache_file_handled(tmp_path: Path, mock_git_output: str) -> None:
+    """Test that empty cache file is handled gracefully."""
+    cache_file = tmp_path / "components_graph.json"
+    cache_file.write_text("")
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+
+    with (
+        patch("subprocess.run", return_value=mock_result),
+        patch("helpers.temp_folder", str(tmp_path)),
+    ):
+        # Should not crash with empty cache file
+        assert cache_file.exists()

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1229,3 +1229,115 @@ def test_cache_hit_returns_cached_graph(
     ):
         result = helpers.create_components_graph()
         assert result == mock_graph
+
+
+def test_cache_miss_no_cache_file(
+    tmp_path: Path, mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
+    """Test that cache miss rebuilds graph when no cache file exists."""
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
+
+    # Create minimal components directory structure
+    components_dir = tmp_path / "esphome" / "components"
+    components_dir.mkdir(parents=True)
+
+    with (
+        patch("helpers.root_path", str(tmp_path)),
+        patch("helpers.temp_folder", str(tmp_path / ".temp")),
+        patch("helpers.get_components_graph_cache_key", return_value="test_key"),
+    ):
+        result = helpers.create_components_graph()
+        # Should return empty graph for empty components directory
+        assert result == {}
+
+
+def test_cache_miss_version_mismatch(
+    tmp_path: Path, mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
+    """Test that cache miss rebuilds graph when version doesn't match."""
+    cache_data = {
+        "_version": 999,  # Wrong version
+        "_cache_key": "test_key",
+        "graph": {"old": ["data"]},
+    }
+
+    cache_file = tmp_path / ".temp" / "components_graph.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text(json.dumps(cache_data))
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
+
+    # Create minimal components directory structure
+    components_dir = tmp_path / "esphome" / "components"
+    components_dir.mkdir(parents=True)
+
+    with (
+        patch("helpers.root_path", str(tmp_path)),
+        patch("helpers.temp_folder", str(tmp_path / ".temp")),
+        patch("helpers.get_components_graph_cache_key", return_value="test_key"),
+    ):
+        result = helpers.create_components_graph()
+        # Should rebuild and return empty graph, not use cached data
+        assert result == {}
+
+
+def test_cache_miss_key_mismatch(
+    tmp_path: Path, mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
+    """Test that cache miss rebuilds graph when cache key doesn't match."""
+    cache_data = {
+        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
+        "_cache_key": "old_key",
+        "graph": {"old": ["data"]},
+    }
+
+    cache_file = tmp_path / ".temp" / "components_graph.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text(json.dumps(cache_data))
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
+
+    # Create minimal components directory structure
+    components_dir = tmp_path / "esphome" / "components"
+    components_dir.mkdir(parents=True)
+
+    with (
+        patch("helpers.root_path", str(tmp_path)),
+        patch("helpers.temp_folder", str(tmp_path / ".temp")),
+        patch("helpers.get_components_graph_cache_key", return_value="new_key"),
+    ):
+        result = helpers.create_components_graph()
+        # Should rebuild and return empty graph, not use cached data with old key
+        assert result == {}
+
+
+def test_cache_miss_corrupted_json(
+    tmp_path: Path, mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
+    """Test that cache miss rebuilds graph when cache file has invalid JSON."""
+    cache_file = tmp_path / ".temp" / "components_graph.json"
+    cache_file.parent.mkdir(parents=True)
+    cache_file.write_text("{invalid json")
+
+    mock_result = Mock()
+    mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
+
+    # Create minimal components directory structure
+    components_dir = tmp_path / "esphome" / "components"
+    components_dir.mkdir(parents=True)
+
+    with (
+        patch("helpers.root_path", str(tmp_path)),
+        patch("helpers.temp_folder", str(tmp_path / ".temp")),
+        patch("helpers.get_components_graph_cache_key", return_value="test_key"),
+    ):
+        result = helpers.create_components_graph()
+        # Should handle corruption gracefully and rebuild
+        assert result == {}

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1272,38 +1272,6 @@ def test_corrupted_cache_handled_gracefully(
         assert cache_file.exists()
 
 
-def test_cache_structure_has_required_fields() -> None:
-    """Test that cache structure has all required fields."""
-    mock_graph = {"wifi": ["network"]}
-    cache_structure = {
-        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
-        "_cache_key": "test_key_" + "a" * 55,
-        "graph": mock_graph,
-    }
-
-    # Verify required fields exist
-    assert "_version" in cache_structure
-    assert "_cache_key" in cache_structure
-    assert "graph" in cache_structure
-    assert isinstance(cache_structure["_version"], int)
-    assert isinstance(cache_structure["_cache_key"], str)
-    assert isinstance(cache_structure["graph"], dict)
-
-
-def test_cache_version_constant_exists() -> None:
-    """Test that cache version constant exists and is valid."""
-    assert hasattr(helpers, "COMPONENTS_GRAPH_CACHE_VERSION")
-    assert isinstance(helpers.COMPONENTS_GRAPH_CACHE_VERSION, int)
-    assert helpers.COMPONENTS_GRAPH_CACHE_VERSION >= 1
-
-
-def test_cache_file_location_correct() -> None:
-    """Test that cache file path is constructed correctly."""
-    cache_path = Path(helpers.temp_folder) / "components_graph.json"
-    assert str(cache_path).endswith("components_graph.json")
-    assert helpers.temp_folder in str(cache_path)
-
-
 def test_empty_cache_file_handled(tmp_path: Path, mock_git_output: str) -> None:
     """Test that empty cache file is handled gracefully."""
     cache_file = tmp_path / "components_graph.json"

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1,5 +1,6 @@
 """Unit tests for script/helpers.py module."""
 
+from collections.abc import Generator
 import json
 import os
 from pathlib import Path
@@ -1119,32 +1120,47 @@ def mock_cache_file(tmp_path: Path) -> Path:
     return tmp_path / "components_graph.json"
 
 
-def test_cache_key_generation(mock_git_output: str) -> None:
+@pytest.fixture(autouse=True)
+def clear_cache_key_cache() -> None:
+    """Clear the components graph cache key cache before each test."""
+    helpers.get_components_graph_cache_key.cache_clear()
+
+
+@pytest.fixture
+def mock_subprocess_run() -> Generator[Mock, None, None]:
+    """Fixture to mock subprocess.run for git commands."""
+    with patch("subprocess.run") as mock_run:
+        yield mock_run
+
+
+def test_cache_key_generation(mock_git_output: str, mock_subprocess_run: Mock) -> None:
     """Test that cache key is generated based on git file hashes."""
     mock_result = Mock()
     mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
 
-    with patch("subprocess.run", return_value=mock_result):
-        key = helpers.get_components_graph_cache_key()
+    key = helpers.get_components_graph_cache_key()
 
-        # Should be a 64-character hex string (SHA256)
-        assert len(key) == 64
-        assert all(c in "0123456789abcdef" for c in key)
+    # Should be a 64-character hex string (SHA256)
+    assert len(key) == 64
+    assert all(c in "0123456789abcdef" for c in key)
 
 
-def test_cache_key_consistent_for_same_files(mock_git_output: str) -> None:
+def test_cache_key_consistent_for_same_files(
+    mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
     """Test that same git output produces same cache key."""
     mock_result = Mock()
     mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
 
-    with patch("subprocess.run", return_value=mock_result):
-        key1 = helpers.get_components_graph_cache_key()
-        key2 = helpers.get_components_graph_cache_key()
+    key1 = helpers.get_components_graph_cache_key()
+    key2 = helpers.get_components_graph_cache_key()
 
-        assert key1 == key2
+    assert key1 == key2
 
 
-def test_cache_key_different_for_changed_files() -> None:
+def test_cache_key_different_for_changed_files(mock_subprocess_run: Mock) -> None:
     """Test that different git output produces different cache key."""
     mock_result1 = Mock()
     mock_result1.stdout = "100644 abc123... 0 esphome/components/wifi/__init__.py\n"
@@ -1152,39 +1168,44 @@ def test_cache_key_different_for_changed_files() -> None:
     mock_result2 = Mock()
     mock_result2.stdout = "100644 xyz789... 0 esphome/components/wifi/__init__.py\n"
 
-    with patch("subprocess.run", return_value=mock_result1):
-        key1 = helpers.get_components_graph_cache_key()
+    mock_subprocess_run.return_value = mock_result1
+    key1 = helpers.get_components_graph_cache_key()
 
-    with patch("subprocess.run", return_value=mock_result2):
-        key2 = helpers.get_components_graph_cache_key()
+    helpers.get_components_graph_cache_key.cache_clear()
+    mock_subprocess_run.return_value = mock_result2
+    key2 = helpers.get_components_graph_cache_key()
 
     assert key1 != key2
 
 
-def test_cache_key_uses_git_ls_files(mock_git_output: str) -> None:
+def test_cache_key_uses_git_ls_files(
+    mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
     """Test that git ls-files command is called correctly."""
     mock_result = Mock()
     mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
 
-    with patch("subprocess.run", return_value=mock_result) as mock_run:
-        helpers.get_components_graph_cache_key()
+    helpers.get_components_graph_cache_key()
 
-        # Verify git ls-files was called with correct arguments
-        mock_run.assert_called_once()
-        call_args = mock_run.call_args
-        assert call_args[0][0] == [
-            "git",
-            "ls-files",
-            "-s",
-            "esphome/components/**/__init__.py",
-        ]
-        assert call_args[1]["capture_output"] is True
-        assert call_args[1]["text"] is True
-        assert call_args[1]["check"] is True
-        assert call_args[1]["close_fds"] is False
+    # Verify git ls-files was called with correct arguments
+    mock_subprocess_run.assert_called_once()
+    call_args = mock_subprocess_run.call_args
+    assert call_args[0][0] == [
+        "git",
+        "ls-files",
+        "-s",
+        "esphome/components/**/__init__.py",
+    ]
+    assert call_args[1]["capture_output"] is True
+    assert call_args[1]["text"] is True
+    assert call_args[1]["check"] is True
+    assert call_args[1]["close_fds"] is False
 
 
-def test_cache_hit_returns_cached_graph(tmp_path: Path, mock_git_output: str) -> None:
+def test_cache_hit_returns_cached_graph(
+    tmp_path: Path, mock_git_output: str, mock_subprocess_run: Mock
+) -> None:
     """Test that cache hit returns cached data without rebuilding."""
     mock_graph = {"wifi": ["network"], "api": ["socket"]}
     cache_key = "a" * 64
@@ -1200,89 +1221,11 @@ def test_cache_hit_returns_cached_graph(tmp_path: Path, mock_git_output: str) ->
 
     mock_result = Mock()
     mock_result.stdout = mock_git_output
+    mock_subprocess_run.return_value = mock_result
 
     with (
-        patch("subprocess.run", return_value=mock_result),
         patch("helpers.get_components_graph_cache_key", return_value=cache_key),
         patch("helpers.temp_folder", str(tmp_path)),
     ):
         result = helpers.create_components_graph()
         assert result == mock_graph
-
-
-def test_cache_version_mismatch_rebuilds(tmp_path: Path) -> None:
-    """Test that cache version mismatch is detected and ignored."""
-    cache_data = {
-        "_version": 999,  # Wrong version
-        "_cache_key": "a" * 64,
-        "graph": {"old": ["data"]},
-    }
-
-    cache_file = tmp_path / "components_graph.json"
-    cache_file.write_text(json.dumps(cache_data))
-
-    # Verify cache file exists but would be ignored due to version mismatch
-    with patch("helpers.temp_folder", str(tmp_path)):
-        assert cache_file.exists()
-        cached = json.loads(cache_file.read_text())
-        assert cached["_version"] != helpers.COMPONENTS_GRAPH_CACHE_VERSION
-
-
-def test_cache_key_mismatch_ignored(tmp_path: Path, mock_git_output: str) -> None:
-    """Test that cache key mismatch causes cache to be ignored."""
-    old_key = "old_key_" + "a" * 56
-    new_key = "new_key_" + "b" * 56
-    cache_data = {
-        "_version": helpers.COMPONENTS_GRAPH_CACHE_VERSION,
-        "_cache_key": old_key,
-        "graph": {"old": ["data"]},
-    }
-
-    cache_file = tmp_path / "components_graph.json"
-    cache_file.write_text(json.dumps(cache_data))
-
-    mock_result = Mock()
-    mock_result.stdout = mock_git_output
-
-    with (
-        patch("subprocess.run", return_value=mock_result),
-        patch("helpers.get_components_graph_cache_key", return_value=new_key),
-        patch("helpers.temp_folder", str(tmp_path)),
-    ):
-        # Cache key mismatch should cause cache to be ignored
-        cached = json.loads(cache_file.read_text())
-        assert cached["_cache_key"] != new_key
-
-
-def test_corrupted_cache_handled_gracefully(
-    tmp_path: Path, mock_git_output: str
-) -> None:
-    """Test that corrupted cache file is handled gracefully."""
-    cache_file = tmp_path / "components_graph.json"
-    cache_file.write_text("{invalid json")
-
-    mock_result = Mock()
-    mock_result.stdout = mock_git_output
-
-    with (
-        patch("subprocess.run", return_value=mock_result),
-        patch("helpers.temp_folder", str(tmp_path)),
-    ):
-        # Should not crash when encountering corrupted cache
-        assert cache_file.exists()
-
-
-def test_empty_cache_file_handled(tmp_path: Path, mock_git_output: str) -> None:
-    """Test that empty cache file is handled gracefully."""
-    cache_file = tmp_path / "components_graph.json"
-    cache_file.write_text("")
-
-    mock_result = Mock()
-    mock_result.stdout = mock_git_output
-
-    with (
-        patch("subprocess.run", return_value=mock_result),
-        patch("helpers.temp_folder", str(tmp_path)),
-    ):
-        # Should not crash with empty cache file
-        assert cache_file.exists()

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1109,10 +1109,18 @@ def test_get_component_from_path(
 
 @pytest.fixture
 def mock_git_output() -> str:
-    """Fixture for mock git ls-files output."""
+    """Fixture for mock git ls-files output with realistic component files.
+
+    Includes examples of AUTO_LOAD in sensor.py and binary_sensor.py files,
+    which is why we need to hash all .py files, not just __init__.py.
+    """
     return (
         "100644 abc123... 0 esphome/components/wifi/__init__.py\n"
         "100644 def456... 0 esphome/components/api/__init__.py\n"
+        "100644 ghi789... 0 esphome/components/xiaomi_lywsd03mmc/__init__.py\n"
+        "100644 jkl012... 0 esphome/components/xiaomi_lywsd03mmc/sensor.py\n"
+        "100644 mno345... 0 esphome/components/xiaomi_cgpr1/__init__.py\n"
+        "100644 pqr678... 0 esphome/components/xiaomi_cgpr1/binary_sensor.py\n"
     )
 
 
@@ -1163,12 +1171,22 @@ def test_cache_key_consistent_for_same_files(
 
 
 def test_cache_key_different_for_changed_files(mock_subprocess_run: Mock) -> None:
-    """Test that different git output produces different cache key."""
+    """Test that different git output produces different cache key.
+
+    This test demonstrates that changes to any .py file (not just __init__.py)
+    will invalidate the cache, which is important because AUTO_LOAD can be
+    defined in sensor.py, binary_sensor.py, etc.
+    """
     mock_result1 = Mock()
-    mock_result1.stdout = "100644 abc123... 0 esphome/components/wifi/__init__.py\n"
+    mock_result1.stdout = (
+        "100644 abc123... 0 esphome/components/xiaomi_lywsd03mmc/sensor.py\n"
+    )
 
     mock_result2 = Mock()
-    mock_result2.stdout = "100644 xyz789... 0 esphome/components/wifi/__init__.py\n"
+    # Same file, different hash - simulates a change to AUTO_LOAD
+    mock_result2.stdout = (
+        "100644 xyz789... 0 esphome/components/xiaomi_lywsd03mmc/sensor.py\n"
+    )
 
     mock_subprocess_run.return_value = mock_result1
     key1 = helpers.get_components_graph_cache_key()
@@ -1197,7 +1215,7 @@ def test_cache_key_uses_git_ls_files(
         "git",
         "ls-files",
         "-s",
-        "esphome/components/**/__init__.py",
+        "esphome/components/**/*.py",
     ]
     assert call_args[1]["capture_output"] is True
     assert call_args[1]["text"] is True

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1125,7 +1125,7 @@ def test_cache_key_generation(mock_git_output: str) -> None:
     mock_result.stdout = mock_git_output
 
     with patch("subprocess.run", return_value=mock_result):
-        key = helpers._get_components_graph_cache_key()
+        key = helpers.get_components_graph_cache_key()
 
         # Should be a 64-character hex string (SHA256)
         assert len(key) == 64
@@ -1138,8 +1138,8 @@ def test_cache_key_consistent_for_same_files(mock_git_output: str) -> None:
     mock_result.stdout = mock_git_output
 
     with patch("subprocess.run", return_value=mock_result):
-        key1 = helpers._get_components_graph_cache_key()
-        key2 = helpers._get_components_graph_cache_key()
+        key1 = helpers.get_components_graph_cache_key()
+        key2 = helpers.get_components_graph_cache_key()
 
         assert key1 == key2
 
@@ -1153,10 +1153,10 @@ def test_cache_key_different_for_changed_files() -> None:
     mock_result2.stdout = "100644 xyz789... 0 esphome/components/wifi/__init__.py\n"
 
     with patch("subprocess.run", return_value=mock_result1):
-        key1 = helpers._get_components_graph_cache_key()
+        key1 = helpers.get_components_graph_cache_key()
 
     with patch("subprocess.run", return_value=mock_result2):
-        key2 = helpers._get_components_graph_cache_key()
+        key2 = helpers.get_components_graph_cache_key()
 
     assert key1 != key2
 
@@ -1167,7 +1167,7 @@ def test_cache_key_uses_git_ls_files(mock_git_output: str) -> None:
     mock_result.stdout = mock_git_output
 
     with patch("subprocess.run", return_value=mock_result) as mock_run:
-        helpers._get_components_graph_cache_key()
+        helpers.get_components_graph_cache_key()
 
         # Verify git ls-files was called with correct arguments
         mock_run.assert_called_once()
@@ -1203,7 +1203,7 @@ def test_cache_hit_returns_cached_graph(tmp_path: Path, mock_git_output: str) ->
 
     with (
         patch("subprocess.run", return_value=mock_result),
-        patch("helpers._get_components_graph_cache_key", return_value=cache_key),
+        patch("helpers.get_components_graph_cache_key", return_value=cache_key),
         patch("helpers.temp_folder", str(tmp_path)),
     ):
         result = helpers.create_components_graph()
@@ -1246,7 +1246,7 @@ def test_cache_key_mismatch_ignored(tmp_path: Path, mock_git_output: str) -> Non
 
     with (
         patch("subprocess.run", return_value=mock_result),
-        patch("helpers._get_components_graph_cache_key", return_value=new_key),
+        patch("helpers.get_components_graph_cache_key", return_value=new_key),
         patch("helpers.temp_folder", str(tmp_path)),
     ):
         # Cache key mismatch should cause cache to be ignored

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1100,6 +1100,8 @@ def test_get_component_from_path(
     file_path: str, expected_component: str | None
 ) -> None:
     """Test extraction of component names from file paths."""
+    result = helpers.get_component_from_path(file_path)
+    assert result == expected_component
 
 
 # Components graph cache tests


### PR DESCRIPTION
# What does this implement/fix?

This PR speeds up the `determine-jobs` CI job by caching the components dependency graph, reducing the time spent building the graph from ~18-24 seconds to ~1 second on cache hit.

## Problem

The `determine-jobs` job imports all 800+ ESPHome components to build the dependency graph during every CI run. This operation takes 18-24 seconds in CI because it needs to import every component to extract `DEPENDENCIES` and `AUTO_LOAD` metadata. This expensive operation was repeated on every PR commit, even when component files hadn't changed.

## Solution

Added intelligent caching for the components dependency graph:

1. **Cache Key Generation**: Uses `git ls-files -s` to generate SHA256 hash of all component Python files (`esphome/components/**/*.py`)
   - Includes all `.py` files because `AUTO_LOAD` and `DEPENDENCIES` can be defined in any Python file (e.g., `sensor.py`, `binary_sensor.py`), not just `__init__.py`
   - Example: `esphome/components/xiaomi_lywsd03mmc/sensor.py:AUTO_LOAD = ["xiaomi_ble"]`
   - Uses git hashes for fast, consistent cache keys across machines and CI runs

2. **Graph Caching**: Modified `create_components_graph()` to:
   - Check for cached graph in `.temp/components_graph.json` before rebuilding
   - Validate cache version and cache key before using cached data
   - Save newly built graph to cache with version metadata

3. **GitHub Actions Integration**:
   - Added cache restore step before "Determine which tests to run"
   - Added cache save step (only on `dev` branch)
   - Cache key: `components-graph-${{ hashFiles('esphome/components/**/*.py') }}`

## Performance Impact

**CI (GitHub Actions):**
- Graph building time: ~18-24 seconds → ~1 second on cache hit
- Cache hit rate: High - cache only invalidates when component Python files change
- Savings: **17-23 seconds per CI run** (on cache hit)

## Cache Strategy

- **Cache invalidation**: Automatically invalidates when any `.py` file in `esphome/components/` changes
- **Cache scope**: Only `dev` branch saves cache; all PRs/branches use read-only cache
- **Version control**: Cache includes version number; increment `COMPONENTS_GRAPH_CACHE_VERSION` to invalidate all caches

## Tests Added

Added comprehensive tests in `tests/script/test_helpers.py`:
- Cache key generation and consistency
- Cache key changes when files change
- Git ls-files command validation
- Proper handling of cache hits, misses, version mismatches, and corrupted cache files

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (CI performance optimization)

**Related issue or feature (if applicable):**

- Addresses review feedback from PR #11648

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI optimization, no user-facing changes)

## Test Environment

- [x] All platforms (CI infrastructure change)

## Example entry for `config.yaml`:

N/A - This is an internal CI optimization with no user-facing configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - No user-facing changes