### PR TITLE
[component] Add is_idle method and condition

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -1,3 +1,5 @@
+import voluptuous
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
@@ -15,7 +17,7 @@ from esphome.const import (
     CONF_TYPE_ID,
     CONF_UPDATE_INTERVAL,
 )
-from esphome.core import ID
+from esphome.core import ID, Lambda
 from esphome.cpp_generator import (
     LambdaExpression,
     MockObj,
@@ -61,7 +63,9 @@ def register_action(name: str, action_type: MockObjClass, schema: cv.Schema):
     return ACTION_REGISTRY.register(name, action_type, schema)
 
 
-def register_condition(name: str, condition_type: MockObjClass, schema: cv.Schema):
+def register_condition(
+    name: str, condition_type: MockObjClass, schema: voluptuous.Schema
+):
     return CONDITION_REGISTRY.register(name, condition_type, schema)
 
 
@@ -308,6 +312,30 @@ async def for_condition_to_code(
     templ = await cg.templatable(config[CONF_TIME], args, cg.uint32)
     cg.add(var.set_time(templ))
     return var
+
+
+@register_condition(
+    "component.is_idle",
+    LambdaCondition,
+    maybe_simple_id(
+        {
+            cv.Required(CONF_ID): cv.use_id(cg.Component),
+        }
+    ),
+)
+async def component_is_idle_condition_to_code(
+    config: ConfigType,
+    condition_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    comp = await cg.get_variable(config[CONF_ID])
+    lambda_ = await cg.process_lambda(
+        Lambda(f"return {comp}->is_idle();"), args, return_type=bool
+    )
+    return new_lambda_pvariable(
+        condition_id, lambda_, StatelessLambdaCondition, template_arg
+    )
 
 
 @register_action(

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -1,5 +1,3 @@
-import voluptuous
-
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
@@ -63,9 +61,7 @@ def register_action(name: str, action_type: MockObjClass, schema: cv.Schema):
     return ACTION_REGISTRY.register(name, action_type, schema)
 
 
-def register_condition(
-    name: str, condition_type: MockObjClass, schema: voluptuous.Schema
-):
+def register_condition(name: str, condition_type: MockObjClass, schema: cv.Schema):
     return CONDITION_REGISTRY.register(name, condition_type, schema)
 
 

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -137,7 +137,7 @@ async def lvgl_is_idle(config, condition_id, template_arg, args):
     lvgl = config[CONF_LVGL_ID]
     timeout = await lv_milliseconds.process(config[CONF_TIMEOUT])
     async with LambdaContext(LVGL_COMP_ARG, return_type=cg.bool_) as context:
-        lv_add(ReturnStatement(lvgl_comp.is_idle(timeout)))
+        lv_add(ReturnStatement(lvgl_comp.lvgl_is_idle(timeout)))
     var = cg.new_Pvariable(
         condition_id,
         TemplateArguments(LvglComponent, *template_arg),

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -137,7 +137,11 @@ async def lvgl_is_idle(config, condition_id, template_arg, args):
     lvgl = config[CONF_LVGL_ID]
     timeout = await lv_milliseconds.process(config[CONF_TIMEOUT])
     async with LambdaContext(LVGL_COMP_ARG, return_type=cg.bool_) as context:
-        lv_add(ReturnStatement(lvgl_comp.lvgl_is_idle(timeout)))
+        lv_add(
+            ReturnStatement(
+                lv_expr.disp_get_inactive_time(lvgl_comp.get_disp()) > timeout
+            )
+        )
     var = cg.new_Pvariable(
         condition_id,
         TemplateArguments(LvglComponent, *template_arg),

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -175,7 +175,6 @@ class LvglComponent : public PollingComponent {
   static void monitor_cb(lv_disp_drv_t *disp_drv, uint32_t time, uint32_t px);
   static void render_start_cb(lv_disp_drv_t *disp_drv);
   void dump_config() override;
-  bool lvgl_is_idle(uint32_t idle_ms) { return lv_disp_get_inactive_time(this->disp_) > idle_ms; }
   lv_disp_t *get_disp() { return this->disp_; }
   lv_obj_t *get_scr_act() { return lv_disp_get_scr_act(this->disp_); }
   // Pause or resume the display.

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -175,7 +175,7 @@ class LvglComponent : public PollingComponent {
   static void monitor_cb(lv_disp_drv_t *disp_drv, uint32_t time, uint32_t px);
   static void render_start_cb(lv_disp_drv_t *disp_drv);
   void dump_config() override;
-  bool is_idle(uint32_t idle_ms) { return lv_disp_get_inactive_time(this->disp_) > idle_ms; }
+  bool lvgl_is_idle(uint32_t idle_ms) { return lv_disp_get_inactive_time(this->disp_) > idle_ms; }
   lv_disp_t *get_disp() { return this->disp_; }
   lv_obj_t *get_scr_act() { return lv_disp_get_scr_act(this->disp_); }
   // Pause or resume the display.

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -284,6 +284,7 @@ bool Component::is_ready() const {
          (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE ||
          (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_SETUP;
 }
+bool Component::is_idle() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE; }
 bool Component::can_proceed() { return true; }
 bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
 bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -144,10 +144,11 @@ class Component {
   /** Check if this component is idle.
    * Being idle means being in LOOP_DONE state.
    * This means the component has completed setup, is not failed, but its loop is currently disabled.
+   * The method is virtual so may be overridden by components that are not idle when in LOOP_DONE state.
    *
    * @return True if the component is idle
    */
-  bool is_idle() const;
+  virtual bool is_idle() const;
 
   /** Mark this component as failed. Any future timeouts/intervals/setup/loop will no longer be called.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -198,6 +198,7 @@ class Component {
   bool is_failed() const;
 
   bool is_ready() const;
+  bool is_idle() const;
 
   virtual bool can_proceed();
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -144,11 +144,10 @@ class Component {
   /** Check if this component is idle.
    * Being idle means being in LOOP_DONE state.
    * This means the component has completed setup, is not failed, but its loop is currently disabled.
-   * The method is virtual so may be overridden by components that are not idle when in LOOP_DONE state.
    *
    * @return True if the component is idle
    */
-  virtual bool is_idle() const;
+  bool is_idle() const;
 
   /** Mark this component as failed. Any future timeouts/intervals/setup/loop will no longer be called.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -141,6 +141,14 @@ class Component {
    */
   bool is_in_loop_state() const;
 
+  /** Check if this component is idle.
+   * Being idle means being in LOOP_DONE state.
+   * This means the component has completed setup, is not failed, but its loop is currently disabled.
+   *
+   * @return True if the component is idle
+   */
+  bool is_idle() const;
+
   /** Mark this component as failed. Any future timeouts/intervals/setup/loop will no longer be called.
    *
    * This might be useful if a component wants to indicate that a connection to its peripheral failed.
@@ -198,7 +206,6 @@ class Component {
   bool is_failed() const;
 
   bool is_ready() const;
-  bool is_idle() const;
 
   virtual bool can_proceed();
 

--- a/tests/components/esphome/common.yaml
+++ b/tests/components/esphome/common.yaml
@@ -10,7 +10,11 @@ esphome:
   on_shutdown:
     logger.log: on_shutdown
   on_loop:
-    logger.log: on_loop
+    if:
+      condition:
+        component.is_idle: binary_sensor_id
+      then:
+        logger.log: on_loop - sensor idle
   compile_process_limit: 1
   min_version: "2025.1"
   name_add_mac_suffix: true
@@ -34,5 +38,6 @@ esphome:
 
 binary_sensor:
   - platform: template
+    id: binary_sensor_id
     name: Other device sensor
     device_id: other_device


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add a method to `Component` that reports if the component is idle, where being idle is
defined as in state LOOP_END. This indicates that the component has completed setup, but its loop is disabled.

The specific use case motivating this is to determine when a display component is able to accept buffer updates, e.g. an e-paper display driver that has finished sending its buffer to the display panel.

Also add a condition `component.is_idle` for use in automations.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5546

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

lvgl:
  on_draw_end:
    - logger.log: Draw end
    - lvgl.pause:
    - component.update: epaper_display
    - wait_until:
        component.is_idle: epaper_display
    - lvgl.resume:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
