### PR TITLE
add integration test for script re-entry argument issue

### DIFF
--- a/tests/integration/fixtures/action_concurrent_reentry.yaml
+++ b/tests/integration/fixtures/action_concurrent_reentry.yaml
@@ -1,0 +1,44 @@
+esphome:
+  name: action-concurrent-reentry-test
+host:
+
+api:
+
+globals:
+  - id: global_counter
+    type: int
+
+script:
+  - id: handler
+
+    mode: parallel
+
+    parameters:
+      arg: int
+
+    then:
+      - logger.log:
+          format: "BEFORE WAIT ARG %d"
+          args:
+            - arg
+
+      - wait_until:
+          condition:
+            lambda: return (id(global_counter) % 3) == 0;
+
+      - logger.log:
+          format: "AFTER WAIT ARG %d"
+          args:
+            - arg
+
+time:
+  - platform: host
+    timezone: Etc/UTC
+
+    on_time:
+      - seconds: '*'
+        then:
+          - lambda: id(handler)->execute(id(global_counter)++);
+
+logger:
+  level: DEBUG

--- a/tests/integration/fixtures/action_concurrent_reentry.yaml
+++ b/tests/integration/fixtures/action_concurrent_reentry.yaml
@@ -1,5 +1,19 @@
 esphome:
-  name: action-concurrent-reentry-test
+  name: action-concurrent-reentry
+  on_boot:
+    - priority: -100
+      then:
+        - repeat:
+            count: 5
+            then:
+              - lambda: id(handler_wait_until)->execute(id(global_counter));
+              - lambda: id(handler_repeat)->execute(id(global_counter));
+              - lambda: id(handler_while)->execute(id(global_counter));
+              - lambda: id(handler_script_wait)->execute(id(global_counter));
+              - delay: 50ms
+              - lambda: id(global_counter)++;
+              - delay: 50ms
+
 host:
 
 api:
@@ -9,7 +23,7 @@ globals:
     type: int
 
 script:
-  - id: handler
+  - id: handler_wait_until
 
     mode: parallel
 
@@ -17,28 +31,75 @@ script:
       arg: int
 
     then:
-      - logger.log:
-          format: "BEFORE WAIT ARG %d"
-          args:
-            - arg
-
       - wait_until:
           condition:
-            lambda: return (id(global_counter) % 3) == 0;
+            lambda: return id(global_counter) == 5;
 
       - logger.log:
-          format: "AFTER WAIT ARG %d"
+          format: "AFTER wait_until ARG %d"
           args:
             - arg
 
-time:
-  - platform: host
-    timezone: Etc/UTC
+  - id: handler_script_wait
 
-    on_time:
-      - seconds: '*'
-        then:
-          - lambda: id(handler)->execute(id(global_counter)++);
+    mode: parallel
+
+    parameters:
+      arg: int
+
+    then:
+      - script.wait: handler_wait_until
+
+      - logger.log:
+          format: "AFTER script.wait ARG %d"
+          args:
+            - arg
+
+  - id: handler_repeat
+
+    mode: parallel
+
+    parameters:
+      arg: int
+
+    then:
+      - repeat:
+          count: 3
+          then:
+            - logger.log:
+                format: "IN repeat %d ARG %d"
+                args:
+                  - iteration
+                  - arg
+            - delay: 100ms
+
+      - logger.log:
+          format: "AFTER repeat ARG %d"
+          args:
+            - arg
+
+  - id: handler_while
+
+    mode: parallel
+
+    parameters:
+      arg: int
+
+    then:
+      - while:
+          condition:
+            lambda: return id(global_counter) != 5;
+          then:
+            - logger.log:
+                format: "IN while ARG %d"
+                args:
+                  - arg
+            - delay: 100ms
+
+      - logger.log:
+          format: "AFTER while ARG %d"
+          args:
+            - arg
 
 logger:
   level: DEBUG

--- a/tests/integration/test_action_concurrent_reentry.py
+++ b/tests/integration/test_action_concurrent_reentry.py
@@ -84,4 +84,10 @@ async def test_action_concurrent_reentry(
         assert set(after_script_wait_args) == expected, after_script_wait_args
         assert set(after_repeat_args) == expected, after_repeat_args
         assert set(after_while_args) == expected, after_while_args
-        assert dict(collections.Counter(in_while_args)) == {0: 5, 1: 4, 2: 3, 3: 2, 4: 1}, in_while_args
+        assert dict(collections.Counter(in_while_args)) == {
+            0: 5,
+            1: 4,
+            2: 3,
+            3: 2,
+            4: 1,
+        }, in_while_args

--- a/tests/integration/test_action_concurrent_reentry.py
+++ b/tests/integration/test_action_concurrent_reentry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import re
 
 import pytest
@@ -22,24 +23,41 @@ async def test_action_concurrent_reentry(
     each script keeps its original argument throughout its execution
     """
     test_complete = asyncio.Event()
+    expected = {0, 1, 2, 3, 4}
 
     # Patterns to match in logs
-    before_wait_pattern = re.compile(r"BEFORE WAIT ARG (\d+)")
-    after_wait_pattern = re.compile(r"AFTER WAIT ARG (\d+)")
+    after_wait_until_pattern = re.compile(r"AFTER wait_until ARG (\d+)")
+    after_script_wait_pattern = re.compile(r"AFTER script\.wait ARG (\d+)")
+    after_repeat_pattern = re.compile(r"AFTER repeat ARG (\d+)")
+    in_repeat_pattern = re.compile(r"IN repeat (\d+) ARG (\d+)")
+    after_while_pattern = re.compile(r"AFTER while ARG (\d+)")
+    in_while_pattern = re.compile(r"IN while ARG (\d+)")
 
-    before_wait_args = []
-    after_wait_args = []
+    after_wait_until_args = []
+    after_script_wait_args = []
+    after_while_args = []
+    in_while_args = []
+    after_repeat_args = []
+    in_repeat_args = collections.defaultdict(list)
 
     def check_output(line: str) -> None:
         """Check log output for expected messages."""
         if test_complete.is_set():
             return
 
-        if mo := before_wait_pattern.search(line):
-            before_wait_args.append(int(mo.group(1)))
-        elif mo := after_wait_pattern.search(line):
-            after_wait_args.append(int(mo.group(1)))
-            if len(after_wait_args) == 3:
+        if mo := after_wait_until_pattern.search(line):
+            after_wait_until_args.append(int(mo.group(1)))
+        elif mo := after_script_wait_pattern.search(line):
+            after_script_wait_args.append(int(mo.group(1)))
+        elif mo := in_while_pattern.search(line):
+            in_while_args.append(int(mo.group(1)))
+        elif mo := after_while_pattern.search(line):
+            after_while_args.append(int(mo.group(1)))
+        elif mo := in_repeat_pattern.search(line):
+            in_repeat_args[int(mo.group(1))].append(int(mo.group(2)))
+        elif mo := after_repeat_pattern.search(line):
+            after_repeat_args.append(int(mo.group(1)))
+            if len(after_repeat_args) == len(expected):
                 test_complete.set()
 
     # Run with log monitoring
@@ -50,7 +68,7 @@ async def test_action_concurrent_reentry(
         # Verify device info
         device_info = await client.device_info()
         assert device_info is not None
-        assert device_info.name == "action-concurrent-reentry-test"
+        assert device_info.name == "action-concurrent-reentry"
 
         # Wait for tests to complete with timeout
         try:
@@ -58,6 +76,12 @@ async def test_action_concurrent_reentry(
         except TimeoutError:
             pytest.fail("test timed out")
 
-        assert before_wait_args == list(range(len(before_wait_args)))
         # order may change, but all args must be present
-        assert set(before_wait_args) == set(after_wait_args)
+        for args in in_repeat_args.values():
+            assert set(args) == expected
+        assert set(in_repeat_args.keys()) == {0, 1, 2}
+        assert set(after_wait_until_args) == expected, after_wait_until_args
+        assert set(after_script_wait_args) == expected, after_script_wait_args
+        assert set(after_repeat_args) == expected, after_repeat_args
+        assert set(after_while_args) == expected, after_while_args
+        assert dict(collections.Counter(in_while_args)) == {0: 5, 1: 4, 2: 3, 3: 2, 4: 1}, in_while_args

--- a/tests/integration/test_action_concurrent_reentry.py
+++ b/tests/integration/test_action_concurrent_reentry.py
@@ -1,0 +1,63 @@
+"""Integration test for API conditional memory optimization with triggers and services."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.xfail(reason="https://github.com/esphome/issues/issues/6534")
+@pytest.mark.asyncio
+async def test_action_concurrent_reentry(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """
+    This test runs a script in parallel with varying arguments and verifies if
+    each script keeps its original argument throughout its execution
+    """
+    test_complete = asyncio.Event()
+
+    # Patterns to match in logs
+    before_wait_pattern = re.compile(r"BEFORE WAIT ARG (\d+)")
+    after_wait_pattern = re.compile(r"AFTER WAIT ARG (\d+)")
+
+    before_wait_args = []
+    after_wait_args = []
+
+    def check_output(line: str) -> None:
+        """Check log output for expected messages."""
+        if test_complete.is_set():
+            return
+
+        if mo := before_wait_pattern.search(line):
+            before_wait_args.append(int(mo.group(1)))
+        elif mo := after_wait_pattern.search(line):
+            after_wait_args.append(int(mo.group(1)))
+            if len(after_wait_args) == 3:
+                test_complete.set()
+
+    # Run with log monitoring
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Verify device info
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "action-concurrent-reentry-test"
+
+        # Wait for tests to complete with timeout
+        try:
+            await asyncio.wait_for(test_complete.wait(), timeout=8.0)
+        except TimeoutError:
+            pytest.fail("test timed out")
+
+        assert before_wait_args == list(range(len(before_wait_args)))
+        # order may change, but all args must be present
+        assert set(before_wait_args) == set(after_wait_args)


### PR DESCRIPTION
see issue esphome/issues#6534

# What does this implement/fix?

test for https://github.com/esphome/issues/issues/6534 as per https://github.com/esphome/esphome/pull/7972#pullrequestreview-3394060237

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- relates to esphome/issues#6534

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

see esphome/issues#6534

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
