### PR TITLE
[esp32_ble] Reduce GATT event latency from 8ms to 12μs with notification socket

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -486,6 +486,8 @@ async def to_code(config):
     # This enables low-latency (~12μs) BLE event processing instead of waiting for
     # select() timeout (0-16ms). The socket is created in ble_setup_() and used to
     # wake lwip_select() when BLE events arrive from the BLE thread.
+    # Note: Called during config generation, socket is created at runtime. In practice,
+    # always used since esp32_ble only runs on ESP32 which always has USE_SOCKET_SELECT_SUPPORT.
     socket.consume_sockets(1, "esp32_ble")(config)
 
     # Define max connections for use in C++ code (e.g., ble_server.h)

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from esphome import automation
 import esphome.codegen as cg
+from esphome.components import socket
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
 import esphome.config_validation as cv
 from esphome.const import (
@@ -480,6 +481,12 @@ async def to_code(config):
     if (name := config.get(CONF_NAME)) is not None:
         cg.add(var.set_name(name))
     await cg.register_component(var, config)
+
+    # BLE uses 1 UDP socket for event notification to wake up main loop from select()
+    # This enables low-latency (~12μs) BLE event processing instead of waiting for
+    # select() timeout (0-16ms). The socket is created in ble_setup_() and used to
+    # wake lwip_select() when BLE events arrive from the BLE thread.
+    socket.consume_sockets(1, "esp32_ble")(config)
 
     # Define max connections for use in C++ code (e.g., ble_server.h)
     max_connections = config.get(CONF_MAX_CONNECTIONS, DEFAULT_MAX_CONNECTIONS)

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -732,8 +732,10 @@ void ESP32BLE::drain_event_notifications_() {
     char buffer[BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE];
     // Drain all pending notifications with non-blocking reads
     // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
+    // We control both ends of this loopback socket (always write 1 byte per event),
+    // so no error checking needed - any errors indicate catastrophic system failure
     while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
-      // Just draining, no action needed
+      // Just draining, no action needed - actual BLE events are already queued
     }
   }
 }

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -27,6 +27,10 @@ extern "C" {
 #include <esp32-hal-bt.h>
 #endif
 
+#ifdef USE_SOCKET_SELECT_SUPPORT
+#include <lwip/sockets.h>
+#endif
+
 namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble";
@@ -273,10 +277,21 @@ bool ESP32BLE::ble_setup_() {
   // BLE takes some time to be fully set up, 200ms should be more than enough
   delay(200);  // NOLINT
 
+  // Set up notification socket to wake main loop for BLE events
+  // This enables low-latency (~12μs) event processing instead of waiting for select() timeout
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  this->setup_event_notification_();
+#endif
+
   return true;
 }
 
 bool ESP32BLE::ble_dismantle_() {
+  // Clean up notification socket first before dismantling BLE stack
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  this->cleanup_event_notification_();
+#endif
+
   esp_err_t err = esp_bluedroid_disable();
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "esp_bluedroid_disable failed: %d", err);
@@ -373,6 +388,12 @@ void ESP32BLE::loop() {
     case BLE_COMPONENT_STATE_ACTIVE:
       break;
   }
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  // Drain any notification socket events first
+  // This clears the socket so it doesn't stay "ready" in subsequent select() calls
+  this->drain_event_notifications_();
+#endif
 
   BLEEvent *ble_event = this->ble_events_.pop();
   while (ble_event != nullptr) {
@@ -531,6 +552,12 @@ template<typename... Args> void enqueue_ble_event(Args... args) {
   // Push the event to the queue
   global_ble->ble_events_.push(event);
   // Push always succeeds because we're the only producer and the pool ensures we never exceed queue size
+
+  // Wake up main loop to process event immediately
+  // This is thread-safe - notify_main_loop_() uses lwip_sendto which is thread-safe
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  global_ble->notify_main_loop_();
+#endif
 }
 
 // Explicit template instantiations for the friend function
@@ -629,6 +656,94 @@ void ESP32BLE::dump_config() {
     ESP_LOGCONFIG(TAG, "Bluetooth stack is not enabled");
   }
 }
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+void ESP32BLE::setup_event_notification_() {
+  // Guard against multiple calls (reentrant safety for ble.enable automation)
+  if (this->notify_fd_ >= 0) {
+    return;  // Already set up
+  }
+
+  // Create UDP socket for event notifications
+  this->notify_fd_ = lwip_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (this->notify_fd_ < 0) {
+    ESP_LOGW(TAG, "Event socket create failed: %d", errno);
+    return;
+  }
+
+  // Bind to loopback with auto-assigned port
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = lwip_htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;  // Auto-assign port
+
+  if (lwip_bind(this->notify_fd_, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+    ESP_LOGW(TAG, "Event socket bind failed: %d", errno);
+    lwip_close(this->notify_fd_);
+    this->notify_fd_ = -1;
+    return;
+  }
+
+  // Get the assigned port for sendto()
+  socklen_t len = sizeof(this->notify_addr_);
+  if (lwip_getsockname(this->notify_fd_, (struct sockaddr *) &this->notify_addr_, &len) < 0) {
+    ESP_LOGW(TAG, "Event socket address failed: %d", errno);
+    lwip_close(this->notify_fd_);
+    this->notify_fd_ = -1;
+    return;
+  }
+
+  // Set non-blocking mode
+  int flags = lwip_fcntl(this->notify_fd_, F_GETFL, 0);
+  lwip_fcntl(this->notify_fd_, F_SETFL, flags | O_NONBLOCK);
+
+  // Register with application's select() loop
+  if (!App.register_socket_fd(this->notify_fd_)) {
+    ESP_LOGW(TAG, "Event socket register failed");
+    lwip_close(this->notify_fd_);
+    this->notify_fd_ = -1;
+    return;
+  }
+
+  ESP_LOGD(TAG, "Event socket ready");
+}
+
+void ESP32BLE::cleanup_event_notification_() {
+  // Guard against multiple calls (reentrant safety for ble.disable automation)
+  if (this->notify_fd_ < 0) {
+    return;  // Already cleaned up
+  }
+
+  App.unregister_socket_fd(this->notify_fd_);
+  lwip_close(this->notify_fd_);
+  this->notify_fd_ = -1;
+  ESP_LOGD(TAG, "Event socket closed");
+}
+
+void ESP32BLE::notify_main_loop_() {
+  // Called from BLE thread context when events are queued
+  // Wakes up lwip_select() in main loop by writing to loopback socket
+  if (this->notify_fd_ >= 0) {
+    const char dummy = 1;
+    // Non-blocking sendto - if it fails (unlikely), select() will wake on timeout anyway
+    // This is safe to call from BLE thread - sendto() is thread-safe in lwip
+    lwip_sendto(this->notify_fd_, &dummy, 1, 0, (struct sockaddr *) &this->notify_addr_, sizeof(this->notify_addr_));
+  }
+}
+
+void ESP32BLE::drain_event_notifications_() {
+  // Called from main loop to drain any pending notifications
+  // Must check is_socket_ready() to avoid blocking on empty socket
+  if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
+    char buffer[64];
+    // Drain all pending notifications with non-blocking reads
+    // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
+    while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
+      // Just draining, no action needed
+    }
+  }
+}
+#endif  // USE_SOCKET_SELECT_SUPPORT
 
 uint64_t ble_addr_to_uint64(const esp_bd_addr_t address) {
   uint64_t u = 0;

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -679,10 +679,21 @@ void ESP32BLE::setup_event_notification_() {
     return;
   }
 
-  // Get the assigned port for sendto()
-  socklen_t len = sizeof(this->notify_addr_);
-  if (lwip_getsockname(this->notify_fd_, (struct sockaddr *) &this->notify_addr_, &len) < 0) {
+  // Get the assigned address and connect to it
+  // Connecting a UDP socket allows using send() instead of sendto() for better performance
+  struct sockaddr_in notify_addr;
+  socklen_t len = sizeof(notify_addr);
+  if (lwip_getsockname(this->notify_fd_, (struct sockaddr *) &notify_addr, &len) < 0) {
     ESP_LOGW(TAG, "Event socket address failed: %d", errno);
+    lwip_close(this->notify_fd_);
+    this->notify_fd_ = -1;
+    return;
+  }
+
+  // Connect to self (loopback) - allows using send() instead of sendto()
+  // After connect(), no need to store notify_addr - the socket remembers it
+  if (lwip_connect(this->notify_fd_, (struct sockaddr *) &notify_addr, sizeof(notify_addr)) < 0) {
+    ESP_LOGW(TAG, "Event socket connect failed: %d", errno);
     lwip_close(this->notify_fd_);
     this->notify_fd_ = -1;
     return;

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -659,11 +659,6 @@ void ESP32BLE::dump_config() {
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
 void ESP32BLE::setup_event_notification_() {
-  // Guard against multiple calls (reentrant safety for ble.enable automation)
-  if (this->notify_fd_ >= 0) {
-    return;  // Already set up
-  }
-
   // Create UDP socket for event notifications
   this->notify_fd_ = lwip_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (this->notify_fd_ < 0) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -723,6 +723,19 @@ void ESP32BLE::cleanup_event_notification_() {
   }
 }
 
+void ESP32BLE::drain_event_notifications_() {
+  // Called from main loop to drain any pending notifications
+  // Must check is_socket_ready() to avoid blocking on empty socket
+  if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
+    char buffer[BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE];
+    // Drain all pending notifications with non-blocking reads
+    // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
+    while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
+      // Just draining, no action needed
+    }
+  }
+}
+
 #endif  // USE_SOCKET_SELECT_SUPPORT
 
 uint64_t ble_addr_to_uint64(const esp_bd_addr_t address) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -704,39 +704,14 @@ void ESP32BLE::setup_event_notification_() {
 }
 
 void ESP32BLE::cleanup_event_notification_() {
-  if (this->notify_fd_ < 0) {
-    return;
-  }
-
-  App.unregister_socket_fd(this->notify_fd_);
-  lwip_close(this->notify_fd_);
-  this->notify_fd_ = -1;
-  ESP_LOGD(TAG, "Event socket closed");
-}
-
-void ESP32BLE::notify_main_loop_() {
-  // Called from BLE thread context when events are queued
-  // Wakes up lwip_select() in main loop by writing to loopback socket
   if (this->notify_fd_ >= 0) {
-    const char dummy = 1;
-    // Non-blocking sendto - if it fails (unlikely), select() will wake on timeout anyway
-    // This is safe to call from BLE thread - sendto() is thread-safe in lwip
-    lwip_sendto(this->notify_fd_, &dummy, 1, 0, (struct sockaddr *) &this->notify_addr_, sizeof(this->notify_addr_));
+    App.unregister_socket_fd(this->notify_fd_);
+    lwip_close(this->notify_fd_);
+    this->notify_fd_ = -1;
+    ESP_LOGD(TAG, "Event socket closed");
   }
 }
 
-void ESP32BLE::drain_event_notifications_() {
-  // Called from main loop to drain any pending notifications
-  // Must check is_socket_ready() to avoid blocking on empty socket
-  if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
-    char buffer[64];
-    // Drain all pending notifications with non-blocking reads
-    // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
-    while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
-      // Just draining, no action needed
-    }
-  }
-}
 #endif  // USE_SOCKET_SELECT_SUPPORT
 
 uint64_t ble_addr_to_uint64(const esp_bd_addr_t address) {

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -704,9 +704,8 @@ void ESP32BLE::setup_event_notification_() {
 }
 
 void ESP32BLE::cleanup_event_notification_() {
-  // Guard against multiple calls (reentrant safety for ble.disable automation)
   if (this->notify_fd_ < 0) {
-    return;  // Already cleaned up
+    return;
   }
 
   App.unregister_socket_fd(this->notify_fd_);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -552,12 +552,6 @@ template<typename... Args> void enqueue_ble_event(Args... args) {
   // Push the event to the queue
   global_ble->ble_events_.push(event);
   // Push always succeeds because we're the only producer and the pool ensures we never exceed queue size
-
-  // Wake up main loop to process event immediately
-  // This is thread-safe - notify_main_loop_() uses lwip_sendto which is thread-safe
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  global_ble->notify_main_loop_();
-#endif
 }
 
 // Explicit template instantiations for the friend function
@@ -611,6 +605,10 @@ void ESP32BLE::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_pa
 void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
                                    esp_ble_gatts_cb_param_t *param) {
   enqueue_ble_event(event, gatts_if, param);
+  // Wake up main loop to process GATT event immediately
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  global_ble->notify_main_loop_();
+#endif
 }
 #endif
 
@@ -618,6 +616,10 @@ void ESP32BLE::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t gat
 void ESP32BLE::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                    esp_ble_gattc_cb_param_t *param) {
   enqueue_ble_event(event, gattc_if, param);
+  // Wake up main loop to process GATT event immediately
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  global_ble->notify_main_loop_();
+#endif
 }
 #endif
 

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -162,6 +162,13 @@ class ESP32BLE : public Component {
   void advertising_init_();
 #endif
 
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  void setup_event_notification_();    // Create notification socket
+  void cleanup_event_notification_();  // Close and unregister socket
+  void notify_main_loop_();            // Wake up select() from BLE thread
+  void drain_event_notifications_();   // Read pending notifications in main loop
+#endif
+
  private:
   template<typename... Args> friend void enqueue_ble_event(Args... args);
 
@@ -195,6 +202,13 @@ class ESP32BLE : public Component {
 #endif
   esp_ble_io_cap_t io_cap_{ESP_IO_CAP_NONE};  // 4 bytes (enum)
   uint32_t advertising_cycle_time_{};         // 4 bytes
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+  // Event notification socket for waking up main loop from BLE thread
+  // Uses UDP loopback to wake lwip_select() with ~12μs latency vs 0-16ms timeout
+  struct sockaddr_in notify_addr_ {};  // 16 bytes (sockaddr_in structure)
+  int notify_fd_{-1};                  // 4 bytes (file descriptor)
+#endif
 
   // 2-byte aligned members
   uint16_t appearance_{0};  // 2 bytes

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -244,19 +244,6 @@ inline void ESP32BLE::notify_main_loop_() {
     lwip_send(this->notify_fd_, &dummy, 1, 0);
   }
 }
-
-inline void ESP32BLE::drain_event_notifications_() {
-  // Called from main loop to drain any pending notifications
-  // Must check is_socket_ready() to avoid blocking on empty socket
-  if (this->notify_fd_ >= 0 && esphome::App.is_socket_ready(this->notify_fd_)) {
-    char buffer[BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE];
-    // Drain all pending notifications with non-blocking reads
-    // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
-    while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
-      // Just draining, no action needed
-    }
-  }
-}
 #endif  // USE_SOCKET_SELECT_SUPPORT
 
 template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -25,6 +25,10 @@
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
 
+#ifdef USE_SOCKET_SELECT_SUPPORT
+#include <lwip/sockets.h>
+#endif
+
 namespace esphome::esp32_ble {
 
 // Maximum size of the BLE event queue
@@ -163,10 +167,10 @@ class ESP32BLE : public Component {
 #endif
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
-  void setup_event_notification_();    // Create notification socket
-  void cleanup_event_notification_();  // Close and unregister socket
-  void notify_main_loop_();            // Wake up select() from BLE thread
-  void drain_event_notifications_();   // Read pending notifications in main loop
+  void setup_event_notification_();          // Create notification socket
+  void cleanup_event_notification_();        // Close and unregister socket
+  inline void notify_main_loop_();           // Wake up select() from BLE thread (hot path - inlined)
+  inline void drain_event_notifications_();  // Read pending notifications in main loop (hot path - inlined)
 #endif
 
  private:
@@ -220,6 +224,37 @@ class ESP32BLE : public Component {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern ESP32BLE *global_ble;
+
+#ifdef USE_SOCKET_SELECT_SUPPORT
+// Inline implementations for hot-path functions
+// These are called from BLE thread (notify) and main loop (drain) on every event
+
+inline void ESP32BLE::notify_main_loop_() {
+  // Called from BLE thread context when events are queued
+  // Wakes up lwip_select() in main loop by writing to loopback socket
+  if (this->notify_fd_ >= 0) {
+    const char dummy = 1;
+    // Non-blocking sendto - if it fails (unlikely), select() will wake on timeout anyway
+    // This is safe to call from BLE thread - sendto() is thread-safe in lwip
+    lwip_sendto(this->notify_fd_, &dummy, 1, 0, (struct sockaddr *) &this->notify_addr_, sizeof(this->notify_addr_));
+  }
+}
+
+inline void ESP32BLE::drain_event_notifications_() {
+  // Called from main loop to drain any pending notifications
+  // Must check is_socket_ready() to avoid blocking on empty socket
+  // Requires App to be defined - include esphome/core/application.h in .cpp files that use this
+  extern esphome::Application App;
+  if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
+    char buffer[16];
+    // Drain all pending notifications with non-blocking reads
+    // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
+    while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
+      // Just draining, no action needed
+    }
+  }
+}
+#endif  // USE_SOCKET_SELECT_SUPPORT
 
 template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {
  public:

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -167,10 +167,10 @@ class ESP32BLE : public Component {
 #endif
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
-  void setup_event_notification_();          // Create notification socket
-  void cleanup_event_notification_();        // Close and unregister socket
-  inline void notify_main_loop_();           // Wake up select() from BLE thread (hot path - inlined)
-  inline void drain_event_notifications_();  // Read pending notifications in main loop (hot path - inlined)
+  void setup_event_notification_();    // Create notification socket
+  void cleanup_event_notification_();  // Close and unregister socket
+  inline void notify_main_loop_();     // Wake up select() from BLE thread (hot path - inlined)
+  void drain_event_notifications_();   // Read pending notifications in main loop
 #endif
 
  private:
@@ -248,9 +248,7 @@ inline void ESP32BLE::notify_main_loop_() {
 inline void ESP32BLE::drain_event_notifications_() {
   // Called from main loop to drain any pending notifications
   // Must check is_socket_ready() to avoid blocking on empty socket
-  // Requires App to be defined - include esphome/core/application.h in .cpp files that use this
-  extern esphome::Application App;
-  if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
+  if (this->notify_fd_ >= 0 && esphome::App.is_socket_ready(this->notify_fd_)) {
     char buffer[BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE];
     // Drain all pending notifications with non-blocking reads
     // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -239,6 +239,8 @@ inline void ESP32BLE::notify_main_loop_() {
   if (this->notify_fd_ >= 0) {
     const char dummy = 1;
     // Non-blocking send - if it fails (unlikely), select() will wake on timeout anyway
+    // No error checking needed: we control both ends of this loopback socket, and the
+    // BLE event is already queued. Notification is best-effort to reduce latency.
     // This is safe to call from BLE thread - send() is thread-safe in lwip
     // Socket is already connected to loopback address, so send() is faster than sendto()
     lwip_send(this->notify_fd_, &dummy, 1, 0);

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -229,6 +229,10 @@ extern ESP32BLE *global_ble;
 // Inline implementations for hot-path functions
 // These are called from BLE thread (notify) and main loop (drain) on every event
 
+// Small buffer for draining notification bytes (1 byte sent per BLE event)
+// Size allows draining multiple notifications per recvfrom() without wasting stack
+static constexpr size_t BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE = 16;
+
 inline void ESP32BLE::notify_main_loop_() {
   // Called from BLE thread context when events are queued
   // Wakes up lwip_select() in main loop by writing to loopback socket
@@ -246,7 +250,7 @@ inline void ESP32BLE::drain_event_notifications_() {
   // Requires App to be defined - include esphome/core/application.h in .cpp files that use this
   extern esphome::Application App;
   if (this->notify_fd_ >= 0 && App.is_socket_ready(this->notify_fd_)) {
-    char buffer[16];
+    char buffer[BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE];
     // Drain all pending notifications with non-blocking reads
     // Multiple BLE events may have triggered multiple writes, so drain until EWOULDBLOCK
     while (lwip_recvfrom(this->notify_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -209,9 +209,9 @@ class ESP32BLE : public Component {
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
   // Event notification socket for waking up main loop from BLE thread
-  // Uses UDP loopback to wake lwip_select() with ~12μs latency vs 0-16ms timeout
-  struct sockaddr_in notify_addr_ {};  // 16 bytes (sockaddr_in structure)
-  int notify_fd_{-1};                  // 4 bytes (file descriptor)
+  // Uses connected UDP loopback socket to wake lwip_select() with ~12μs latency vs 0-16ms timeout
+  // Socket is connected during setup, allowing use of send() instead of sendto() for efficiency
+  int notify_fd_{-1};  // 4 bytes (file descriptor)
 #endif
 
   // 2-byte aligned members
@@ -235,12 +235,13 @@ static constexpr size_t BLE_EVENT_NOTIFY_DRAIN_BUFFER_SIZE = 16;
 
 inline void ESP32BLE::notify_main_loop_() {
   // Called from BLE thread context when events are queued
-  // Wakes up lwip_select() in main loop by writing to loopback socket
+  // Wakes up lwip_select() in main loop by writing to connected loopback socket
   if (this->notify_fd_ >= 0) {
     const char dummy = 1;
-    // Non-blocking sendto - if it fails (unlikely), select() will wake on timeout anyway
-    // This is safe to call from BLE thread - sendto() is thread-safe in lwip
-    lwip_sendto(this->notify_fd_, &dummy, 1, 0, (struct sockaddr *) &this->notify_addr_, sizeof(this->notify_addr_));
+    // Non-blocking send - if it fails (unlikely), select() will wake on timeout anyway
+    // This is safe to call from BLE thread - send() is thread-safe in lwip
+    // Socket is already connected to loopback address, so send() is faster than sendto()
+    lwip_send(this->notify_fd_, &dummy, 1, 0);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Reduces BLE GATT event processing latency by **600x** (from 0-16ms average ~8ms to ~12μs) by waking the main loop immediately when GATT events arrive, instead of waiting for `lwip_select()` timeout.

## Problem

Currently, BLE GATT events (reads, writes, notifications) experience high latency because:

1. BLE events arrive in the ESP-IDF BLE task context
2. Events are queued to a lock-free queue for processing
3. Main loop is blocked in `lwip_select()` waiting for socket activity
4. Select timeout is determined by scheduler's next task (8-16ms depending on what's scheduled)
5. Events sit in the queue until `select()` times out or socket data arrives
6. Only then does the main loop process the queued BLE events

**Result:** 0-16ms latency (average ~8ms) for GATT event processing, depending on scheduler state.

## Solution

Use a **connected UDP loopback socket** to wake up `lwip_select()` immediately when GATT events arrive:

1. Create a UDP socket bound to loopback during BLE setup
2. Connect the socket to itself (allows using `send()` instead of `sendto()`)
3. Register socket with application's `select()` loop
4. When GATTC/GATTS events arrive, write 1 byte to wake `select()`
5. Main loop drains notification bytes and processes queued events

**Result:** ~12μs latency for GATT event processing (600x improvement).

## Why UDP Loopback Instead of eventfd()?

**The eventfd() Problem:**

Using `eventfd()` would seem like the natural choice for waking up `select()`, but it has a critical performance penalty on ESP32:

1. **VFS Layer Overhead:** `eventfd()` requires `CONFIG_VFS_SUPPORT_SELECT=y` to work with `select()`
2. **Forced VFS select():** When VFS select support is enabled, ALL select calls go through the VFS layer wrapper
3. **Performance Impact:** VFS `select()` has significant overhead compared to direct `lwip_select()`:
   - VFS wrapper must iterate through registered drivers
   - Additional abstraction layers and indirection
   - Compatibility shims for file descriptors vs socket descriptors

**ESPHome's Current Optimization:**

ESPHome currently **disables** `CONFIG_VFS_SUPPORT_SELECT` to avoid this overhead. The application directly calls `lwip_select()` which:
- Goes straight to the lwIP network stack
- No VFS layer indirection or iteration
- Optimized for socket file descriptors only
- Significantly lower latency and CPU overhead

**Using eventfd() would force us to:**
1. Enable `CONFIG_VFS_SUPPORT_SELECT=y`
2. Slow down **all** select() calls in the application (not just BLE events)
3. Impact network performance, API response times, etc.

**UDP Loopback Advantages:**

- Works directly with `lwip_select()` - no VFS layer needed
- Zero overhead for existing select() calls
- Highly optimized - loopback packets never hit the network hardware
- Thread-safe - `lwip_send()` can be called from BLE thread
- Simple API - standard socket operations everyone understands

**Other Alternatives Considered:**

- **socketpair()** - Not available in lwip (would also require VFS support)
- **pipe()** - Requires VFS layer, same problem as eventfd
- **FreeRTOS task notification** - Main loop doesn't run in a dedicated task where we control unblocking the lwip_select

**Result:** UDP loopback is the cleanest solution that maintains ESPHome's current performance optimizations while adding low-latency event notification.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing configuration changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** This optimization only applies to ESP32 with `USE_SOCKET_SELECT_SUPPORT` defined (ESP32 with network stack). The code is conditionally compiled and has no effect on other platforms.

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# The notification socket is automatically created when esp32_ble is enabled
# and the platform supports select() (USE_SOCKET_SELECT_SUPPORT is defined)

esp32_ble:
  # Existing configuration works unchanged

bluetooth_proxy:
  active: true

# Or with BLE client
ble_client:
  - mac_address: "XX:XX:XX:XX:XX:XX"
    id: my_ble_device
```

## Implementation Details

### Socket Lifecycle

1. **Setup** (`ble_setup_()`):
   - Create UDP socket with `lwip_socket()`
   - Bind to loopback with auto-assigned port
   - **Connect to self** - enables using `lwip_send()` instead of `lwip_sendto()` (faster, saves 16 bytes RAM)
   - Set non-blocking mode
   - Register with `App.register_socket_fd()`

2. **Notification** (GATTC/GATTS event handlers):
   - After queueing event, call `notify_main_loop_()` (inlined for hot path)
   - Writes 1 byte to connected socket via `lwip_send()`
   - Thread-safe - `lwip_send()` can be called from BLE thread

3. **Drain** (`loop()`):
   - Check `App.is_socket_ready()` to see if socket has data
   - Read all pending bytes with `lwip_recvfrom()` until `EWOULDBLOCK`
   - Process queued BLE events as normal

4. **Cleanup** (`ble_dismantle_()`):
   - Unregister socket with `App.unregister_socket_fd()`
   - Close socket with `lwip_close()`

### Event Notification Strategy

**Currently notifies on:**
- **GATTC events** (client operations: connect, read, write, notify, etc.)
- **GATTS events** (server operations: connect, write, etc.)

**Does NOT notify on:**
- **GAP scan events** - Would cause excessive wakeups from continuous scanning

**Future optimization (after PR #11627):**
- Add notification for `GAP_SECURITY_EVENTS` (pairing/bonding - rare but interactive)

### Memory Impact

- **Flash:** ~460 bytes (notification socket code)
- **RAM:** 4 bytes (socket file descriptor only - `notify_addr_` eliminated by using connected socket)
- **Sockets:** +1 (automatically counted via `consume_sockets(1, "esp32_ble")`)

### Performance Characteristics

**Latency:**
- Before: 0-16ms (average ~8ms) - waiting for `select()` timeout
- After: ~12μs (write 2μs + select wake 10μs)
- **Improvement: 600x faster**

**Thread Safety:**
- `lwip_send()` is thread-safe and can be called from BLE thread
- Lock-free queue already handles concurrent access
- Socket operations use lwip's internal locking

**Graceful Degradation:**
- If socket creation fails (unlikely), logs warning and continues
- Falls back to timeout-based processing (original behavior)
- No crashes or functionality loss

## Testing Performed

1. **Bluetooth Proxy** - Tested with multiple concurrent BLE connections (3+ devices)
2. **BLE Client** - Verified GATT read/write/notify operations have low latency
3. **BLE Server** - Tested incoming connections and characteristic updates
4. **Stress Testing** - High-frequency BLE notifications processed without delays
5. **Socket Cleanup** - Verified proper cleanup on `ble.disable` / `ble.enable` cycles

**Test logs show:**
- Notification socket successfully created during setup
- GATT events trigger immediate socket notification (1-6 bytes drained per event batch)
- GAP scan events do NOT trigger notifications (no spam)
- Proper cleanup when BLE is disabled

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - N/A - Internal optimization with no new user-facing behavior. Tested manually with real hardware (see "Testing Performed" section).

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  - N/A - No user-facing changes, internal optimization only
