### PR TITLE
[nrf52,gpio] switch input gpio to polling mode

### DIFF
--- a/esphome/components/gpio/binary_sensor/__init__.py
+++ b/esphome/components/gpio/binary_sensor/__init__.py
@@ -39,6 +39,7 @@ CONFIG_SCHEMA = (
             # due to hardware limitations or lack of reliable interrupt support. This ensures
             # stable operation on these platforms. Future maintainers should verify platform
             # capabilities before changing this default behavior.
+            # nrf52 has no gpio interrupts implemented yet
             cv.SplitDefault(
                 CONF_USE_INTERRUPT,
                 bk72xx=False,
@@ -46,7 +47,7 @@ CONFIG_SCHEMA = (
                 esp8266=True,
                 host=True,
                 ln882x=False,
-                nrf52=True,
+                nrf52=False,
                 rp2040=True,
                 rtl87xx=False,
             ): cv.boolean,

--- a/esphome/components/zephyr/gpio.cpp
+++ b/esphome/components/zephyr/gpio.cpp
@@ -8,8 +8,8 @@ namespace zephyr {
 
 static const char *const TAG = "zephyr";
 
-static int flags_to_mode(gpio::Flags flags, bool inverted, bool value) {
-  int ret = 0;
+static gpio_flags_t flags_to_mode(gpio::Flags flags, bool inverted, bool value) {
+  gpio_flags_t ret = 0;
   if (flags & gpio::FLAG_INPUT) {
     ret |= GPIO_INPUT;
   }
@@ -79,7 +79,10 @@ void ZephyrGPIOPin::pin_mode(gpio::Flags flags) {
   if (nullptr == this->gpio_) {
     return;
   }
-  gpio_pin_configure(this->gpio_, this->pin_ % 32, flags_to_mode(flags, this->inverted_, this->value_));
+  auto ret = gpio_pin_configure(this->gpio_, this->pin_ % 32, flags_to_mode(flags, this->inverted_, this->value_));
+  if (ret != 0) {
+    ESP_LOGE(TAG, "gpio %u cannot be configured %d.", this->pin_, ret);
+  }
 }
 
 std::string ZephyrGPIOPin::dump_summary() const {


### PR DESCRIPTION
# What does this implement/fix?

switch to polling mode. gpio irq were never implemented. https://github.com/esphome/esphome/blob/55af8186294b900d52cd31eabd20407f30563286/esphome/components/zephyr/gpio.cpp#L108

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
