### PR TITLE
[core] Remove redundant fd bounds check in yield_with_select_()

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -576,10 +576,9 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     // Update fd_set if socket list has changed
     if (this->socket_fds_changed_) {
       FD_ZERO(&this->base_read_fds_);
+      // fd bounds are already validated in register_socket_fd()
       for (int fd : this->socket_fds_) {
-        if (fd >= 0 && fd < FD_SETSIZE) {
-          FD_SET(fd, &this->base_read_fds_);
-        }
+        FD_SET(fd, &this->base_read_fds_);
       }
       this->socket_fds_changed_ = false;
     }

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -576,16 +576,11 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     // Update fd_set if socket list has changed
     if (this->socket_fds_changed_) {
       FD_ZERO(&this->base_read_fds_);
+      // fd bounds are already validated in register_socket_fd() or guaranteed by platform design:
+      // - ESP32: LwIP guarantees fd < FD_SETSIZE by design (LWIP_SOCKET_OFFSET = FD_SETSIZE - CONFIG_LWIP_MAX_SOCKETS)
+      // - Other platforms: register_socket_fd() validates fd < FD_SETSIZE
       for (int fd : this->socket_fds_) {
-#ifdef USE_ESP32
-        // On ESP32, register_socket_fd() relies on LwIP design guarantees and doesn't validate FD_SETSIZE
-        if (fd >= 0 && fd < FD_SETSIZE) {
-          FD_SET(fd, &this->base_read_fds_);
-        }
-#else
-        // Non-ESP32: fd bounds already validated in register_socket_fd()
         FD_SET(fd, &this->base_read_fds_);
-#endif
       }
       this->socket_fds_changed_ = false;
     }

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -576,9 +576,16 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     // Update fd_set if socket list has changed
     if (this->socket_fds_changed_) {
       FD_ZERO(&this->base_read_fds_);
-      // fd bounds are already validated in register_socket_fd()
       for (int fd : this->socket_fds_) {
+#ifdef USE_ESP32
+        // On ESP32, register_socket_fd() relies on LwIP design guarantees and doesn't validate FD_SETSIZE
+        if (fd >= 0 && fd < FD_SETSIZE) {
+          FD_SET(fd, &this->base_read_fds_);
+        }
+#else
+        // Non-ESP32: fd bounds already validated in register_socket_fd()
         FD_SET(fd, &this->base_read_fds_);
+#endif
       }
       this->socket_fds_changed_ = false;
     }


### PR DESCRIPTION
# What does this implement/fix?

Removes redundant bounds checking for file descriptors in `Application::yield_with_select_()`. The bounds validation is either already performed or guaranteed by platform design.

**Why this is safe:**

- **ESP32 platforms**: LwIP design **guarantees** that socket fds are always < FD_SETSIZE by construction (`LWIP_SOCKET_OFFSET = FD_SETSIZE - CONFIG_LWIP_MAX_SOCKETS` per lwipopts.h). This is why `register_socket_fd()` doesn't check FD_SETSIZE on ESP32 - the check is architecturally impossible to fail.

- **Non-ESP32 platforms** (ESP8266, RP2040, LibreTiny, etc.): `register_socket_fd()` validates both `fd < 0` and `fd >= FD_SETSIZE` (lines 508-519), so the check in the select loop is redundant.

Since only valid file descriptors can enter `socket_fds_`, the bounds check in `yield_with_select_()` is redundant on all platforms.

This cleanup:
- Eliminates duplicate validation logic
- Slightly reduces code size
- Improves code clarity with a detailed comment explaining the safety rationale

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal code cleanup, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
