### PR TITLE
[nrf52,debug] fix status of nRESET pin, add extra registry from UICR

### DIFF
--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -288,7 +288,7 @@ void DebugComponent::get_device_info_(std::string &device_info) {
       TAG, "GPIO as NFC pins: %s, GPIO as nRESET pin: %s",
       YESNO((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)),
       YESNO(nRESET_enabled));
-  if (NRF_FICR) {
+  if (nRESET_enabled) {
     uint8_t port = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PORT_Msk) >> UICR_PSELRESET_PORT_Pos;
     uint8_t pin = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PIN_Msk) >> UICR_PSELRESET_PIN_Pos;
     ESP_LOGD(TAG, "nRESET port P%u.%02u", port, pin);

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -8,8 +8,7 @@
 
 #define BOOTLOADER_VERSION_REGISTER NRF_TIMER2->CC[0]
 
-namespace esphome {
-namespace debug {
+namespace esphome::debug {
 
 static const char *const TAG = "debug";
 constexpr std::uintptr_t MBR_PARAM_PAGE_ADDR = 0xFFC;
@@ -343,6 +342,5 @@ void DebugComponent::get_device_info_(std::string &device_info) {
 
 void DebugComponent::update_platform_() {}
 
-}  // namespace debug
-}  // namespace esphome
+}  // namespace esphome::debug
 #endif

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -326,6 +326,21 @@ void DebugComponent::get_device_info_(std::string &device_info) {
 #endif
   }
 #endif
+  auto uicr = [](volatile uint32_t *data, uint8_t size) {
+    std::string res;
+    char buf[sizeof(uint32_t) * 2 + 1];
+    for (size_t i = 0; i < size; i++) {
+      if (i > 0) {
+        res += ' ';
+      }
+      sprintf(buf, "%08X", data[i]);
+      res += buf;
+    }
+    return res;
+  };
+  ESP_LOGD(TAG, "NRFFW %s", uicr(NRF_UICR->NRFFW, 13).c_str());
+  ESP_LOGD(TAG, "NRFHW %s", uicr(NRF_UICR->NRFHW, 12).c_str());
+  // ESP_LOGD(TAG, "CUSTOMER %s", uicr(NRF_UICR->CUSTOMER, 32).c_str());
 }
 
 void DebugComponent::update_platform_() {}

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -333,8 +333,7 @@ void DebugComponent::get_device_info_(std::string &device_info) {
       if (i > 0) {
         res += ' ';
       }
-      sprintf(buf, "%08X", data[i]);
-      res += buf;
+      res += format_hex_pretty<uint32_t>(data[i], '\0', false);
     }
     return res;
   };

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -339,7 +339,6 @@ void DebugComponent::get_device_info_(std::string &device_info) {
   };
   ESP_LOGD(TAG, "NRFFW %s", uicr(NRF_UICR->NRFFW, 13).c_str());
   ESP_LOGD(TAG, "NRFHW %s", uicr(NRF_UICR->NRFHW, 12).c_str());
-  // ESP_LOGD(TAG, "CUSTOMER %s", uicr(NRF_UICR->CUSTOMER, 32).c_str());
 }
 
 void DebugComponent::update_platform_() {}

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -281,14 +281,18 @@ void DebugComponent::get_device_info_(std::string &device_info) {
            NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE));
   ESP_LOGD(TAG, "RAM: %ukB, Flash: %ukB, production test: %sdone", NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH,
            (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
+  bool nRESET_enabled = NRF_UICR->PSELRESET[0] == NRF_UICR->PSELRESET[1] &&
+                        (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) == UICR_PSELRESET_CONNECT_Connected
+                                                                                     << UICR_PSELRESET_CONNECT_Pos;
   ESP_LOGD(
       TAG, "GPIO as NFC pins: %s, GPIO as nRESET pin: %s",
       YESNO((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)),
-      YESNO(((NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) !=
-             (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos)) ||
-            ((NRF_UICR->PSELRESET[1] & UICR_PSELRESET_CONNECT_Msk) !=
-             (UICR_PSELRESET_CONNECT_Connected << UICR_PSELRESET_CONNECT_Pos))));
-
+      YESNO(nRESET_enabled));
+  if (NRF_FICR) {
+    uint8_t port = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PORT_Msk) >> UICR_PSELRESET_PORT_Pos;
+    uint8_t pin = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PIN_Msk) >> UICR_PSELRESET_PIN_Pos;
+    ESP_LOGD(TAG, "nRESET port P%u.%02u", port, pin);
+  }
 #ifdef USE_BOOTLOADER_MCUBOOT
   ESP_LOGD(TAG, "bootloader: mcuboot");
 #else

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -281,14 +281,14 @@ void DebugComponent::get_device_info_(std::string &device_info) {
            NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE));
   ESP_LOGD(TAG, "RAM: %ukB, Flash: %ukB, production test: %sdone", NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH,
            (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
-  bool nRESET_enabled = NRF_UICR->PSELRESET[0] == NRF_UICR->PSELRESET[1] &&
-                        (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) == UICR_PSELRESET_CONNECT_Connected
-                                                                                     << UICR_PSELRESET_CONNECT_Pos;
+  bool n_reset_enabled = NRF_UICR->PSELRESET[0] == NRF_UICR->PSELRESET[1] &&
+                         (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) == UICR_PSELRESET_CONNECT_Connected
+                                                                                      << UICR_PSELRESET_CONNECT_Pos;
   ESP_LOGD(
       TAG, "GPIO as NFC pins: %s, GPIO as nRESET pin: %s",
       YESNO((NRF_UICR->NFCPINS & UICR_NFCPINS_PROTECT_Msk) == (UICR_NFCPINS_PROTECT_NFC << UICR_NFCPINS_PROTECT_Pos)),
-      YESNO(nRESET_enabled));
-  if (nRESET_enabled) {
+      YESNO(n_reset_enabled));
+  if (n_reset_enabled) {
     uint8_t port = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PORT_Msk) >> UICR_PSELRESET_PORT_Pos;
     uint8_t pin = (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_PIN_Msk) >> UICR_PSELRESET_PIN_Pos;
     ESP_LOGD(TAG, "nRESET port P%u.%02u", port, pin);


### PR DESCRIPTION
# What does this implement/fix?

1. fix status of nReset pin in debug component (before it was just random value)
2. add pin number of nReset in debug component
3. Print UICR Nordic Firmware registry values in debug
4. Print UICR Nordic Hardware registry values in debug

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
