### PR TITLE
ESP32 Pin loopTask to CORE 1

### DIFF
--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -96,7 +96,11 @@ void loop_task(void *pv_params) {
 
 extern "C" void app_main() {
   esp32::setup_preferences();
+#if CONFIG_FREERTOS_UNICORE
   xTaskCreate(loop_task, "loopTask", 8192, nullptr, 1, &loop_task_handle);
+#else
+  xTaskCreatePinnedToCore(loop_task, "loopTask", 8192, nullptr, 1, &loop_task_handle, 1);
+#endif
 }
 #endif  // USE_ESP_IDF
 


### PR DESCRIPTION
# What does this implement/fix?

Pin ESPhome app core to CORE 1 using xTaskCreatePinnedToCore (with CONFIG_FREERTOS_UNICORE guard)
Summary

This PR changes the ESPhome ESP32 component's app task creation to use xTaskCreatePinnedToCore(..., 1) instead of xTaskCreate(...). In addition, it adds a #if CONFIG_FREERTOS_UNICORE / #else guard so builds for single-core targets keep working (and so the change is safe for different Espressif SoCs such as single-core variants). The goal is to ensure the application (app) core is fixed to CORE 1 on dual-core devices to improve timing determinism and avoid unwanted task migration between cores.

Noticed while trying to get better timing on the ac-dimmer component, since interrupts are installed on the same core which installs the GPIO interrupts, if loop task is in CORE 0 they will trigger after the wifi interrupts are done
According to @kahrendt since this task is using float point arithmetic it will fix pin the task to this core.

I believe overall it is way better to pin to CORE 1 if available instead of leaving it random chose a core.

Tested compiles on ESP32 using the pinned version and ESP32-C6 using the current implementation (single core ESPs does not support this API)

CC @Dilbert66 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
