### PR TITLE
[nextion] Send `auto_wake_on_touch` as part of startup commands on loop

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -323,6 +323,8 @@ void Nextion::loop() {
       this->set_touch_sleep_timeout(this->touch_sleep_timeout_);
     }
 
+    this->set_auto_wake_on_touch(this->connection_state_.auto_wake_on_touch_);
+
     this->connection_state_.ignore_is_setup_ = false;
   }
 


### PR DESCRIPTION
Resolves #11516

# What does this implement/fix?

This is a fix for the missing `auto_wake_on_touch` command on Nextion startup sequence.
With the current implementation, this command is added to the queue at boot time and could get there even before the Nextion is connected. The command will be sent to Nextion, but any reset (which also happens on the boot), the device will go back to it's defaults, and this command will be ignored.
With this fix, the command is send together with the wake-up timeout during the setup sequence on the loop, so it will happen every time the device gets into a setup sequence.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11516 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
