### PR TITLE
[core] Avoid redundant millis() calls in base_automation loop methods

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -103,7 +103,7 @@ template<typename... Ts> class ForCondition : public Condition<Ts...>, public Co
   bool check_internal() {
     bool cond = this->condition_->check();
     if (!cond)
-      this->last_inactive_ = millis();
+      this->last_inactive_ = App.get_loop_component_start_time();
     return cond;
   }
 
@@ -380,7 +380,7 @@ template<typename... Ts> class WaitUntilAction : public Action<Ts...>, public Co
     if (this->num_running_ == 0)
       return;
 
-    auto now = millis();
+    auto now = App.get_loop_component_start_time();
 
     this->var_queue_.remove_if([&](auto &queued) {
       auto start = std::get<uint32_t>(queued);


### PR DESCRIPTION
# What does this implement/fix?

Use `App.get_loop_component_start_time()` instead of `millis()` in `base_automation.h` loop methods to avoid unnecessary time syscalls.

This changes two locations in `esphome/core/base_automation.h`:
- `WaitUntilAction::loop()` - followup to #7972
- `ForCondition::check_internal()` (called from `loop()`) - while fixing the above, it became obvious this could be optimized too

The time is already captured once at the start of each loop iteration and stored in `App`, so we can reuse that value instead of making redundant `millis()` syscalls. This improves performance by reducing unnecessary system calls during the main loop.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Followup to #7972

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
