### PR TITLE
[nrf52] make reset pin optional

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -141,6 +141,22 @@ CONF_UICR_ERASE = "uicr_erase"
 VOLTAGE_LEVELS = [1.8, 2.1, 2.4, 2.7, 3.0, 3.3]
 
 
+_DFU_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(DeviceFirmwareUpdate),
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+    }
+)
+
+
+def _dfu_schema(value):
+    if isinstance(value, bool):
+        if not value:
+            raise cv.Invalid("Use 'dfu: true' or specify a configuration dict")
+        return _DFU_SCHEMA({})
+    return _DFU_SCHEMA(value)
+
+
 CONFIG_SCHEMA = cv.All(
     _detect_bootloader,
     set_core_data,
@@ -150,12 +166,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.string_strict, cv.ByteLength(max=BOARD_MAX_LENGTH)
             ),
             cv.Optional(KEY_BOOTLOADER): cv.one_of(*BOOTLOADERS, lower=True),
-            cv.Optional(CONF_DFU): cv.Schema(
-                {
-                    cv.GenerateID(): cv.declare_id(DeviceFirmwareUpdate),
-                    cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
-                }
-            ),
+            cv.Optional(CONF_DFU): _dfu_schema,
             cv.Optional(CONF_DCDC, default=True): cv.boolean,
             cv.Optional(CONF_REG0): cv.Schema(
                 {
@@ -321,8 +332,9 @@ async def to_code(config: ConfigType) -> None:
 async def _dfu_to_code(dfu_config):
     cg.add_define("USE_NRF52_DFU")
     var = cg.new_Pvariable(dfu_config[CONF_ID])
-    pin = await cg.gpio_pin_expression(dfu_config[CONF_RESET_PIN])
-    cg.add(var.set_reset_pin(pin))
+    if CONF_RESET_PIN in dfu_config:
+        pin = await cg.gpio_pin_expression(dfu_config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(pin))
     zephyr_add_prj_conf("CDC_ACM_DTE_RATE_CALLBACK_SUPPORT", True)
     await cg.register_component(var, dfu_config)
 

--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -149,7 +149,7 @@ _DFU_SCHEMA = cv.Schema(
 )
 
 
-def _dfu_schema(value):
+def _dfu_schema(value: bool | ConfigType) -> ConfigType:
     if isinstance(value, bool):
         if not value:
             raise cv.Invalid("Use 'dfu: true' or specify a configuration dict")

--- a/esphome/components/nrf52/dfu.cpp
+++ b/esphome/components/nrf52/dfu.cpp
@@ -2,6 +2,8 @@
 
 #ifdef USE_NRF52_DFU
 
+#include <hal/nrf_power.h>
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/components/zephyr/cdc_acm.h"
 
@@ -11,15 +13,23 @@ namespace nrf52 {
 static const char *const TAG = "dfu";
 
 static const uint32_t DFU_DBL_RESET_MAGIC = 0x5A1AD5;  // SALADS
+static const uint8_t DFU_MAGIC_UF2_RESET = 0x57;
 
 void DeviceFirmwareUpdate::setup() {
-  this->reset_pin_->setup();
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->setup();
+  }
 #if defined(CONFIG_CDC_ACM_DTE_RATE_CALLBACK_SUPPORT)
   zephyr::global_cdc_acm->add_on_rate_callback([this](const device *, uint32_t rate) {
     if (rate == 1200) {
       volatile uint32_t *dbl_reset_mem = (volatile uint32_t *) 0x20007F7C;
       (*dbl_reset_mem) = DFU_DBL_RESET_MAGIC;
-      this->reset_pin_->digital_write(true);
+      if (this->reset_pin_ != nullptr) {
+        this->reset_pin_->digital_write(true);
+      } else {
+        NRF_POWER->GPREGRET = DFU_MAGIC_UF2_RESET;
+        App.reboot();
+      }
     }
   });
 #endif
@@ -27,7 +37,9 @@ void DeviceFirmwareUpdate::setup() {
 
 void DeviceFirmwareUpdate::dump_config() {
   ESP_LOGCONFIG(TAG, "DFU:");
-  LOG_PIN("  RESET Pin: ", this->reset_pin_);
+  if (this->reset_pin_ != nullptr) {
+    LOG_PIN("  RESET Pin: ", this->reset_pin_);
+  }
 }
 
 }  // namespace nrf52

--- a/esphome/components/nrf52/dfu.cpp
+++ b/esphome/components/nrf52/dfu.cpp
@@ -2,18 +2,18 @@
 
 #ifdef USE_NRF52_DFU
 
-#include <hal/nrf_power.h>
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/components/zephyr/cdc_acm.h"
 
-namespace esphome {
-namespace nrf52 {
+#include <hal/nrf_power.h>
+
+namespace esphome::nrf52 {
 
 static const char *const TAG = "dfu";
 
 static const uint32_t DFU_DBL_RESET_MAGIC = 0x5A1AD5;  // SALADS
-static const uint8_t DFU_MAGIC_UF2_RESET = 0x57;
+static const uint8_t DFU_MAGIC_UF2_RESET = 0x57;       // Adafruit nRF52 bootloader UF2 magic
 
 void DeviceFirmwareUpdate::setup() {
   if (this->reset_pin_ != nullptr) {
@@ -39,10 +39,11 @@ void DeviceFirmwareUpdate::dump_config() {
   ESP_LOGCONFIG(TAG, "DFU:");
   if (this->reset_pin_ != nullptr) {
     LOG_PIN("  RESET Pin: ", this->reset_pin_);
+  } else {
+    ESP_LOGCONFIG(TAG, "  Method: GPREGRET");
   }
 }
 
-}  // namespace nrf52
-}  // namespace esphome
+}  // namespace esphome::nrf52
 
 #endif

--- a/esphome/components/nrf52/dfu.h
+++ b/esphome/components/nrf52/dfu.h
@@ -14,7 +14,7 @@ class DeviceFirmwareUpdate : public Component {
   void dump_config() override;
 
  protected:
-  GPIOPin *reset_pin_;
+  GPIOPin *reset_pin_{nullptr};
 };
 
 }  // namespace nrf52

--- a/esphome/components/nrf52/dfu.h
+++ b/esphome/components/nrf52/dfu.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
 
-namespace esphome {
-namespace nrf52 {
+namespace esphome::nrf52 {
 class DeviceFirmwareUpdate : public Component {
  public:
   void setup() override;
@@ -17,7 +16,6 @@ class DeviceFirmwareUpdate : public Component {
   GPIOPin *reset_pin_{nullptr};
 };
 
-}  // namespace nrf52
-}  // namespace esphome
+}  // namespace esphome::nrf52
 
 #endif

--- a/tests/components/nrf52/test-dfu-pin.nrf52-xiao-ble.yaml
+++ b/tests/components/nrf52/test-dfu-pin.nrf52-xiao-ble.yaml
@@ -1,0 +1,9 @@
+nrf52:
+  dfu:
+    reset_pin:
+      number: 14
+      inverted: true
+      mode:
+        output: true
+  reg0:
+    voltage: 1.8V

--- a/tests/components/nrf52/test.nrf52-xiao-ble.yaml
+++ b/tests/components/nrf52/test.nrf52-xiao-ble.yaml
@@ -1,9 +1,4 @@
 nrf52:
-  dfu:
-    reset_pin:
-      number: 14
-      inverted: true
-      mode:
-        output: true
+  dfu: true
   reg0:
     voltage: 1.8V


### PR DESCRIPTION
# What does this implement/fix?

It is possible to enter DFU without using nRESET pin. It less reliable way. Sometime it should be repeated a few times. Probably it would be possible to fix it on python side.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/6531

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
