### PR TITLE
[template] alarm_control_panel more ESP_LOGCONFIG reductions

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -42,23 +42,21 @@ static const LogString *sensor_type_to_string(AlarmSensorType type) {
 #endif
 
 void TemplateAlarmControlPanel::dump_config() {
-  ESP_LOGCONFIG(TAG, "TemplateAlarmControlPanel:");
   ESP_LOGCONFIG(TAG,
+                "TemplateAlarmControlPanel:\n"
                 "  Current State: %s\n"
-                "  Number of Codes: %u",
-                LOG_STR_ARG(alarm_control_panel_state_to_string(this->current_state_)), this->codes_.size());
-  if (!this->codes_.empty())
-    ESP_LOGCONFIG(TAG, "  Requires Code To Arm: %s", YESNO(this->requires_code_to_arm_));
-  ESP_LOGCONFIG(TAG, "  Arming Away Time: %" PRIu32 "s", (this->arming_away_time_ / 1000));
-  if (this->arming_home_time_ != 0)
-    ESP_LOGCONFIG(TAG, "  Arming Home Time: %" PRIu32 "s", (this->arming_home_time_ / 1000));
-  if (this->arming_night_time_ != 0)
-    ESP_LOGCONFIG(TAG, "  Arming Night Time: %" PRIu32 "s", (this->arming_night_time_ / 1000));
-  ESP_LOGCONFIG(TAG,
+                "  Number of Codes: %u\n"
+                "  Requires Code To Arm: %s\n"
+                "  Arming Away Time: %" PRIu32 "s\n"
+                "  Arming Home Time: %" PRIu32 "s\n"
+                "  Arming Night Time: %" PRIu32 "s\n"
                 "  Pending Time: %" PRIu32 "s\n"
                 "  Trigger Time: %" PRIu32 "s\n"
                 "  Supported Features: %" PRIu32,
-                (this->pending_time_ / 1000), (this->trigger_time_ / 1000), this->get_supported_features());
+                LOG_STR_ARG(alarm_control_panel_state_to_string(this->current_state_)), this->codes_.size(),
+                YESNO(!this->codes_.empty() && this->requires_code_to_arm_), (this->arming_away_time_ / 1000),
+                (this->arming_home_time_ / 1000), (this->arming_night_time_ / 1000), (this->pending_time_ / 1000),
+                (this->trigger_time_ / 1000), this->get_supported_features());
 #ifdef USE_BINARY_SENSOR
   for (auto const &[sensor, info] : this->sensor_map_) {
     ESP_LOGCONFIG(TAG,


### PR DESCRIPTION
# What does this implement/fix?

More reductions of ESP_LOGCONFIG calls in dump_config(), this time for the alarm object itself.
Minor change to behaviour - now always reports arming_home_time_ and arming_night_time_ even if they are their default value (0).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
