### PR TITLE
[mqtt] Fix climate custom fan mode and preset compilation errors

### DIFF
--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -357,8 +357,8 @@ bool MQTTClimateComponent::publish_state_() {
           payload = "unknown";
       }
     }
-    if (this->device_->custom_preset.has_value())
-      payload = this->device_->custom_preset.value();
+    if (this->device_->has_custom_preset())
+      payload = this->device_->get_custom_preset();
     if (!this->publish(this->get_preset_state_topic(), payload))
       success = false;
   }
@@ -429,8 +429,8 @@ bool MQTTClimateComponent::publish_state_() {
           payload = "unknown";
       }
     }
-    if (this->device_->custom_fan_mode.has_value())
-      payload = this->device_->custom_fan_mode.value();
+    if (this->device_->has_custom_fan_mode())
+      payload = this->device_->get_custom_fan_mode();
     if (!this->publish(this->get_fan_mode_state_topic(), payload))
       success = false;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation errors in `mqtt_climate.cpp` that were introduced by PR #11621 but not caught during the initial merge.

PR #11621 changed `custom_preset` and `custom_fan_mode` in the `Climate` class from public `optional<std::string>` members to private `const char*` pointers with public accessor methods (`has_custom_preset()`, `get_custom_preset()`, `has_custom_fan_mode()`, `get_custom_fan_mode()`).

The MQTT climate component was not updated to use these new accessor methods, causing compilation failures:
```
error: no member named 'custom_preset' in 'esphome::climate::Climate'
error: no member named 'custom_fan_mode' in 'esphome::climate::Climate'
```

This PR updates the MQTT climate component to use the correct accessor methods.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #11621 (follow-up fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml demonstrating MQTT climate with custom modes

mqtt:
  broker: test.mosquitto.org

climate:
  - platform: thermostat
    id: my_climate
    name: "My Thermostat"
    sensor: temp_sensor
    default_preset: Home
    preset:
      - name: Home
        default_target_temperature_low: 18°C
        default_target_temperature_high: 24°C
    # MQTT will now correctly publish custom presets and fan modes

sensor:
  - platform: homeassistant
    id: temp_sensor
    entity_id: sensor.temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
