### PR TITLE
[micro_wake_word] Add wake_loop_threadsafe() for low-latency wake word detection

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 from esphome import automation, external_files, git
 from esphome.automation import register_action, register_condition
 import esphome.codegen as cg
-from esphome.components import esp32, microphone
+from esphome.components import esp32, microphone, socket
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FILE,
@@ -32,6 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@kahrendt", "@jesserockz"]
 DEPENDENCIES = ["microphone"]
+AUTO_LOAD = ["socket"]
 DOMAIN = "micro_wake_word"
 
 
@@ -442,6 +443,10 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    # Enable wake_loop_threadsafe() for low-latency wake word detection
+    # The inference task queues detection events that need immediate processing
+    socket.require_wake_loop_threadsafe()
 
     mic_source = await microphone.microphone_source_to_code(config[CONF_MICROPHONE])
     cg.add(var.set_microphone_source(mic_source))

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -2,6 +2,7 @@
 
 #ifdef USE_ESP_IDF
 
+#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -426,6 +427,12 @@ void MicroWakeWord::process_probabilities_() {
         if (vad_state.detected) {
 #endif
           xQueueSend(this->detection_queue_, &wake_word_state, portMAX_DELAY);
+
+          // Wake main loop immediately to process wake word detection
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+          App.wake_loop_threadsafe();
+#endif
+
           model->reset_probabilities();
 #ifdef USE_MICRO_WAKE_WORD_VAD
         } else {


### PR DESCRIPTION
# What does this implement/fix?

Adds low-latency wake word detection processing by integrating with the `wake_loop_threadsafe()` mechanism introduced in #11681 and #11683.

## Changes

- When wake words are detected by the inference task, the main loop is immediately woken instead of waiting for the next `select()` timeout
- Reduces wake word detection processing latency from **0-16ms** to **~12μs**
- Follows the same pattern as USB host (#11683), MQTT (#11695), and ESP-NOW (#11696) implementations

## Implementation Details

The `micro_wake_word` component runs a dedicated FreeRTOS inference task that performs ML-based wake word detection. When a wake word is detected (and passes VAD validation if enabled), the inference task queues a detection event via `xQueueSend()` that is later processed by the main loop's `loop()` method.

Previously, these queued detection events would wait up to 16ms for the next `select()` timeout before being processed. Now they wake the main loop immediately, enabling near-instant automation responses.

**Important:** Only real wake word detections trigger the wake. VAD-blocked detections (which only generate a debug log message) do not wake the main loop, as they have no user-visible impact.

**Testing:** This change has been tested on a Home Assistant Voice PE device (ESP32-S3) with real wake word detection. The logs confirm immediate processing of wake word events with all automation triggers occurring within the same millisecond timestamp, demonstrating the sub-millisecond wake latency.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (Performance improvement - reduces wake word detection latency)

**Related issue or feature (if applicable):**

- Part of the wake_loop_threadsafe() infrastructure introduced in #11681
- Follows pattern from #11683 (USB host), #11695 (MQTT), and #11696 (ESP-NOW)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-visible changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266 (Not applicable - micro_wake_word is ESP32 IDF only)
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - automatically enabled
micro_wake_word:
  models:
    - model: okay_nabu
  on_wake_word_detected:
    - logger.log: "Wake word detected!"
```

## Checklist:
  - [x] The code change is tested and works locally. *(Tested on Home Assistant Voice PE device with real wake word detection)*
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). *(Existing micro_wake_word tests cover functionality; latency improvement is not testable in CI)*

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *(N/A - Internal optimization, no user-facing changes)*
