### PR TITLE
[helpers] Add `get_mac_address_into_buffer()`

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -643,10 +643,10 @@ std::string get_mac_address_pretty() {
   return format_mac_address_pretty(mac);
 }
 
-void get_mac_address_into_buffer(char *buf) {
+void get_mac_address_into_buffer(std::span<char, 13> buf) {
   uint8_t mac[6];
   get_mac_address_raw(mac);
-  format_mac_addr_lower_no_sep(mac, buf);
+  format_mac_addr_lower_no_sep(mac, buf.data());
 }
 
 #ifndef USE_ESP32

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -643,6 +643,12 @@ std::string get_mac_address_pretty() {
   return format_mac_address_pretty(mac);
 }
 
+void get_mac_address_into_buffer(char *buf) {
+  uint8_t mac[6];
+  get_mac_address_raw(mac);
+  format_mac_addr_lower_no_sep(mac, buf);
+}
+
 #ifndef USE_ESP32
 bool has_custom_mac_address() { return false; }
 #endif

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1027,6 +1027,10 @@ std::string get_mac_address();
 /// Get the device MAC address as a string, in colon-separated uppercase hex notation.
 std::string get_mac_address_pretty();
 
+/// Get the device MAC address into the given buffer, in lowercase hex notation.
+/// Assumes buffer length is 13 (12 digits for hexadecimal representation followed by null terminator).
+void get_mac_address_into_buffer(char *buf);
+
 #ifdef USE_ESP32
 /// Set the MAC address to use from the provided byte array (6 bytes).
 void set_mac_address(uint8_t *mac);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <span>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -1029,7 +1030,7 @@ std::string get_mac_address_pretty();
 
 /// Get the device MAC address into the given buffer, in lowercase hex notation.
 /// Assumes buffer length is 13 (12 digits for hexadecimal representation followed by null terminator).
-void get_mac_address_into_buffer(char *buf);
+void get_mac_address_into_buffer(std::span<char, 13> buf);
 
 #ifdef USE_ESP32
 /// Set the MAC address to use from the provided byte array (6 bytes).


### PR DESCRIPTION
# What does this implement/fix?

Small PR to add a new helper function: `void get_mac_address_into_buffer(char *buf)`

Useful for #11678

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
