### PR TITLE
[ci] Fix non-component files incorrectly detected as components

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -101,7 +101,11 @@ def get_component_from_path(file_path: str) -> str | None:
     ):
         parts = file_path.split("/")
         if len(parts) >= 3 and parts[2]:
-            return parts[2]
+            # Verify that parts[2] is actually a component directory, not a file
+            # like .gitignore or README.md in the components directory itself
+            component_name = parts[2]
+            if "." not in component_name:
+                return component_name
     return None
 
 

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1093,6 +1093,11 @@ def test_parse_list_components_output(output: str, expected: list[str]) -> None:
         ("tests/components/", None),  # No component name
         ("esphome/components", None),  # No trailing slash
         ("tests/components", None),  # No trailing slash
+        # Files in component directories that are not components
+        ("tests/components/.gitignore", None),  # Hidden file
+        ("tests/components/README.md", None),  # Documentation file
+        ("esphome/components/__init__.py", None),  # Python init file
+        ("tests/components/main.cpp", None),  # File with extension
     ],
 )
 def test_get_component_from_path(


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug in CI where non-component files like `.gitignore`, `README.md`, and `__init__.py` in the `esphome/components/` or `tests/components/` directories were incorrectly being detected as component names.

This caused the "Changed components" list in CI to include entries like:
```
Changed components: ['.gitignore', 'README.md', 'absolute_humidity', ...]
```

The fix adds validation to `get_component_from_path()` to filter out any path segment containing a dot (file extension), which correctly excludes files while allowing all valid component directory names (which never contain dots).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Found during internal CI debugging

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal CI fix, no user-facing changes

## Test Environment

- N/A - CI/script changes only, no platform-specific code

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI/script fix with no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
