### PR TITLE
[esp32_ble] Remove leftover lwip/sockets.h include

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -27,10 +27,6 @@ extern "C" {
 #include <esp32-hal-bt.h>
 #endif
 
-#ifdef USE_SOCKET_SELECT_SUPPORT
-#include <lwip/sockets.h>
-#endif
-
 namespace esphome::esp32_ble {
 
 static const char *const TAG = "esp32_ble";

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -25,10 +25,6 @@
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
 
-#ifdef USE_SOCKET_SELECT_SUPPORT
-#include <lwip/sockets.h>
-#endif
-
 namespace esphome::esp32_ble {
 
 // Maximum size of the BLE event queue


### PR DESCRIPTION
# What does this implement/fix?

Removes leftover `#include <lwip/sockets.h>` from esp32_ble component header and implementation files.

The esp32_ble component only calls `App.wake_loop_threadsafe()`, which is declared in `application.h`. The socket handling is internal to the Application class, so esp32_ble doesn't need to directly include the lwip sockets header. The conditional compilation checks around the `wake_loop_threadsafe()` calls are still needed and remain in place.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - existing esp32_ble configs work unchanged

esp32_ble:
  # ... existing configuration ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
