### PR TITLE
[core] Fix ESPTime crash

### DIFF
--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -84,6 +84,9 @@ struct ESPTime {
    */
   static ESPTime from_epoch_local(time_t epoch) {
     struct tm *c_tm = ::localtime(&epoch);
+    if (c_tm == nullptr) {
+      return ESPTime{};  // Return an invalid ESPTime that will fail is_valid()
+    }
     return ESPTime::from_c_tm(c_tm, epoch);
   }
   /** Convert an UTC epoch timestamp to a UTC time ESPTime instance.
@@ -93,6 +96,9 @@ struct ESPTime {
    */
   static ESPTime from_epoch_utc(time_t epoch) {
     struct tm *c_tm = ::gmtime(&epoch);
+    if (c_tm == nullptr) {
+      return ESPTime{};  // Return an invalid ESPTime that will fail is_valid()
+    }
     return ESPTime::from_c_tm(c_tm, epoch);
   }
 

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -85,7 +85,7 @@ struct ESPTime {
   static ESPTime from_epoch_local(time_t epoch) {
     struct tm *c_tm = ::localtime(&epoch);
     if (c_tm == nullptr) {
-      return ESPTime{};  // Return an invalid ESPTime that will fail is_valid()
+      return ESPTime{};  // Return an invalid ESPTime
     }
     return ESPTime::from_c_tm(c_tm, epoch);
   }
@@ -97,7 +97,7 @@ struct ESPTime {
   static ESPTime from_epoch_utc(time_t epoch) {
     struct tm *c_tm = ::gmtime(&epoch);
     if (c_tm == nullptr) {
-      return ESPTime{};  // Return an invalid ESPTime that will fail is_valid()
+      return ESPTime{};  // Return an invalid ESPTime
     }
     return ESPTime::from_c_tm(c_tm, epoch);
   }


### PR DESCRIPTION
# What does this implement/fix?

Need to check the return value from localtime etc. If time conversion fails the return value is a null pointer. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11660

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
