### PR TITLE
[ci] Fix memory impact analysis to filter incompatible platform components

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -94,6 +94,22 @@ class Platform(StrEnum):
 MEMORY_IMPACT_FALLBACK_COMPONENT = "api"  # Representative component for core changes
 MEMORY_IMPACT_FALLBACK_PLATFORM = Platform.ESP32_IDF  # Most representative platform
 
+# Platform-specific components that can only be built on their respective platforms
+# These components contain platform-specific code and cannot be cross-compiled
+# Regular components (wifi, logger, api, etc.) are cross-platform and not listed here
+PLATFORM_SPECIFIC_COMPONENTS = frozenset(
+    {
+        "esp32",  # ESP32 platform implementation
+        "esp8266",  # ESP8266 platform implementation
+        "rp2040",  # Raspberry Pi Pico / RP2040 platform implementation
+        "bk72xx",  # Beken BK72xx platform implementation (uses LibreTiny)
+        "rtl87xx",  # Realtek RTL87xx platform implementation (uses LibreTiny)
+        "ln882x",  # Winner Micro LN882x platform implementation (uses LibreTiny)
+        "host",  # Host platform (for testing on development machine)
+        "nrf52",  # Nordic nRF52 platform implementation
+    }
+)
+
 # Platform preference order for memory impact analysis
 # This order is used when no platform-specific hints are detected from filenames
 # Priority rationale:
@@ -568,12 +584,14 @@ def detect_memory_impact_config(
         )
         platform = _select_platform_by_count(platform_counts)
 
-    # Filter components to only those that support the selected platform
-    # This ensures we don't try to build ESP32 components on ESP8266, etc.
+    # Filter out platform-specific components that are incompatible with selected platform
+    # Platform components (esp32, esp8266, rp2040, etc.) can only build on their own platform
+    # Other components (wifi, logger, etc.) are cross-platform and can build anywhere
     compatible_components = [
         component
         for component in components_with_tests
-        if platform in component_platforms_map.get(component, set())
+        if component not in PLATFORM_SPECIFIC_COMPONENTS
+        or platform in component_platforms_map.get(component, set())
     ]
 
     # If no components are compatible with the selected platform, don't run

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -568,6 +568,18 @@ def detect_memory_impact_config(
         )
         platform = _select_platform_by_count(platform_counts)
 
+    # Filter components to only those that support the selected platform
+    # This ensures we don't try to build ESP32 components on ESP8266, etc.
+    compatible_components = [
+        component
+        for component in components_with_tests
+        if platform in component_platforms_map.get(component, set())
+    ]
+
+    # If no components are compatible with the selected platform, don't run
+    if not compatible_components:
+        return {"should_run": "false"}
+
     # Debug output
     print("Memory impact analysis:", file=sys.stderr)
     print(f"  Changed components: {sorted(changed_component_set)}", file=sys.stderr)
@@ -579,10 +591,11 @@ def detect_memory_impact_config(
     print(f"  Platform hints from filenames: {platform_hints}", file=sys.stderr)
     print(f"  Common platforms: {sorted(common_platforms)}", file=sys.stderr)
     print(f"  Selected platform: {platform}", file=sys.stderr)
+    print(f"  Compatible components: {compatible_components}", file=sys.stderr)
 
     return {
         "should_run": "true",
-        "components": components_with_tests,
+        "components": compatible_components,
         "platform": platform,
         "use_merged_config": "true",
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug in the CI memory impact analysis where platform-specific components were being included in cross-platform builds, causing failures.

When a PR modifies test files for multiple platform-specific components (e.g., both ESP32 and ESP8266), the memory impact analysis would select one platform (e.g., `esp8266-ard`) but try to build all platform components, including incompatible ones (e.g., ESP32 platform component on ESP8266).

Platform-specific components (esp32, esp8266, rp2040, bk72xx, rtl87xx, ln882x, host, nrf52) can only be built on their respective platforms. Regular components (wifi, logger, api, etc.) are cross-platform and can build anywhere.

This fix adds filtering to exclude incompatible platform-specific components from the build.

**Before:** Platform `esp8266-ard` with components `["esp32", "esp8266"]` - build fails
**After:** Platform `esp8266-ard` with components `["esp8266"]` - build succeeds (esp32 platform component filtered out)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes memory impact analysis failures on cross-platform PRs like #10387

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI fix, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Test environment is CI/CD infrastructure - tested with mock ESP32 and ESP8266 components)

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI/CD infrastructure fix with no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
