### PR TITLE
[network] Store use_address in RODATA to save RAM

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -224,7 +224,7 @@ void APIServer::dump_config() {
                 "  Address: %s:%u\n"
                 "  Listen backlog: %u\n"
                 "  Max connections: %u",
-                network::get_use_address().c_str(), this->port_, this->listen_backlog_, this->max_connections_);
+                network::get_use_address(), this->port_, this->listen_backlog_, this->max_connections_);
 #ifdef USE_API_NOISE
   ESP_LOGCONFIG(TAG, "  Noise encryption: %s", YESNO(this->noise_ctx_->has_psk()));
   if (!this->noise_ctx_->has_psk()) {

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -94,7 +94,7 @@ void ESPHomeOTAComponent::dump_config() {
                 "Over-The-Air updates:\n"
                 "  Address: %s:%u\n"
                 "  Version: %d",
-                network::get_use_address().c_str(), this->port_, USE_OTA_VERSION);
+                network::get_use_address(), this->port_, USE_OTA_VERSION);
 #ifdef USE_OTA_PASSWORD
   if (!this->password_.empty()) {
     ESP_LOGCONFIG(TAG, "  Password configured");

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -691,9 +691,9 @@ void EthernetComponent::set_manual_ip(const ManualIP &manual_ip) { this->manual_
 
 // set_use_address() is guaranteed to be called during component setup by Python code generation,
 // so use_address_ will always be valid when get_use_address() is called - no fallback needed.
-const std::string &EthernetComponent::get_use_address() const { return this->use_address_; }
+const char *EthernetComponent::get_use_address() const { return this->use_address_; }
 
-void EthernetComponent::set_use_address(const std::string &use_address) { this->use_address_ = use_address; }
+void EthernetComponent::set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
 void EthernetComponent::get_eth_mac_address_raw(uint8_t *mac) {
   esp_err_t err;

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -114,12 +114,6 @@ class EthernetComponent : public Component {
   /// @brief Set arbitratry PHY registers from config.
   void write_phy_register_(esp_eth_mac_t *mac, PHYRegister register_data);
 
- private:
-  // Stores a pointer to a string literal (static storage duration).
-  // ONLY set from Python-generated code with string literals - never dynamic strings.
-  const char *use_address_{""};
-
- protected:
 #ifdef USE_ETHERNET_SPI
   uint8_t clk_pin_;
   uint8_t miso_pin_;
@@ -163,6 +157,11 @@ class EthernetComponent : public Component {
   esp_eth_handle_t eth_handle_;
   esp_eth_phy_t *phy_{nullptr};
   optional<std::array<uint8_t, 6>> fixed_mac_;
+
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
+  const char *use_address_{""};
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -114,7 +114,12 @@ class EthernetComponent : public Component {
   /// @brief Set arbitratry PHY registers from config.
   void write_phy_register_(esp_eth_mac_t *mac, PHYRegister register_data);
 
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
   const char *use_address_{""};
+
+ protected:
 #ifdef USE_ETHERNET_SPI
   uint8_t clk_pin_;
   uint8_t miso_pin_;

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -88,8 +88,8 @@ class EthernetComponent : public Component {
 
   network::IPAddresses get_ip_addresses();
   network::IPAddress get_dns_address(uint8_t num);
-  const std::string &get_use_address() const;
-  void set_use_address(const std::string &use_address);
+  const char *get_use_address() const;
+  void set_use_address(const char *use_address);
   void get_eth_mac_address_raw(uint8_t *mac);
   std::string get_eth_mac_address_pretty();
   eth_duplex_t get_duplex_mode();
@@ -114,7 +114,7 @@ class EthernetComponent : public Component {
   /// @brief Set arbitratry PHY registers from config.
   void write_phy_register_(esp_eth_mac_t *mac, PHYRegister register_data);
 
-  std::string use_address_;
+  const char *use_address_{""};
 #ifdef USE_ETHERNET_SPI
   uint8_t clk_pin_;
   uint8_t miso_pin_;

--- a/esphome/components/network/util.cpp
+++ b/esphome/components/network/util.cpp
@@ -85,7 +85,7 @@ network::IPAddresses get_ip_addresses() {
   return {};
 }
 
-const std::string &get_use_address() {
+const char *get_use_address() {
   // Global component pointers are guaranteed to be set by component constructors when USE_* is defined
 #ifdef USE_ETHERNET
   return ethernet::global_eth_component->get_use_address();
@@ -105,8 +105,7 @@ const std::string &get_use_address() {
 
 #if !defined(USE_ETHERNET) && !defined(USE_MODEM) && !defined(USE_WIFI) && !defined(USE_OPENTHREAD)
   // Fallback when no network component is defined (e.g., host platform)
-  static const std::string empty;
-  return empty;
+  return "";
 #endif
 }
 

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -12,7 +12,7 @@ bool is_connected();
 /// Return whether the network is disabled (only wifi for now)
 bool is_disabled();
 /// Get the active network hostname
-const std::string &get_use_address();
+const char *get_use_address();
 IPAddresses get_ip_addresses();
 
 }  // namespace network

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -254,9 +254,9 @@ void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
 
 // set_use_address() is guaranteed to be called during component setup by Python code generation,
 // so use_address_ will always be valid when get_use_address() is called - no fallback needed.
-const std::string &OpenThreadComponent::get_use_address() const { return this->use_address_; }
+const char *OpenThreadComponent::get_use_address() const { return this->use_address_; }
 
-void OpenThreadComponent::set_use_address(const std::string &use_address) { this->use_address_ = use_address; }
+void OpenThreadComponent::set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
 }  // namespace openthread
 }  // namespace esphome

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -33,15 +33,15 @@ class OpenThreadComponent : public Component {
   void on_factory_reset(std::function<void()> callback);
   void defer_factory_reset_external_callback();
 
-  const std::string &get_use_address() const;
-  void set_use_address(const std::string &use_address);
+  const char *get_use_address() const;
+  void set_use_address(const char *use_address);
 
  protected:
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
   bool teardown_started_{false};
   bool teardown_complete_{false};
   std::function<void()> factory_reset_external_callback_;
-  std::string use_address_;
+  const char *use_address_{""};
 };
 
 extern OpenThreadComponent *global_openthread_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -41,6 +41,10 @@ class OpenThreadComponent : public Component {
   bool teardown_started_{false};
   bool teardown_complete_{false};
   std::function<void()> factory_reset_external_callback_;
+
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
   const char *use_address_{""};
 };
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -324,7 +324,7 @@ void WebServer::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Web Server:\n"
                 "  Address: %s:%u",
-                network::get_use_address().c_str(), this->base_->get_port());
+                network::get_use_address(), this->base_->get_port());
 }
 float WebServer::get_setup_priority() const { return setup_priority::WIFI - 1.0f; }
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -273,8 +273,8 @@ network::IPAddress WiFiComponent::get_dns_address(int num) {
 }
 // set_use_address() is guaranteed to be called during component setup by Python code generation,
 // so use_address_ will always be valid when get_use_address() is called - no fallback needed.
-const std::string &WiFiComponent::get_use_address() const { return this->use_address_; }
-void WiFiComponent::set_use_address(const std::string &use_address) { this->use_address_ = use_address; }
+const char *WiFiComponent::get_use_address() const { return this->use_address_; }
+void WiFiComponent::set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
 #ifdef USE_WIFI_AP
 void WiFiComponent::setup_ap_config_() {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -393,7 +393,12 @@ class WiFiComponent : public Component {
   void wifi_scan_done_callback_();
 #endif
 
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
   const char *use_address_{""};
+
+ protected:
   FixedVector<WiFiAP> sta_;
   std::vector<WiFiSTAPriority> sta_priorities_;
   wifi_scan_vector_t<WiFiScanResult> scan_result_;

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -393,12 +393,6 @@ class WiFiComponent : public Component {
   void wifi_scan_done_callback_();
 #endif
 
- private:
-  // Stores a pointer to a string literal (static storage duration).
-  // ONLY set from Python-generated code with string literals - never dynamic strings.
-  const char *use_address_{""};
-
- protected:
   FixedVector<WiFiAP> sta_;
   std::vector<WiFiSTAPriority> sta_priorities_;
   wifi_scan_vector_t<WiFiScanResult> scan_result_;
@@ -450,6 +444,11 @@ class WiFiComponent : public Component {
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};
   Trigger<> *disconnect_trigger_{new Trigger<>()};
+
+ private:
+  // Stores a pointer to a string literal (static storage duration).
+  // ONLY set from Python-generated code with string literals - never dynamic strings.
+  const char *use_address_{""};
 };
 
 extern WiFiComponent *global_wifi_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -283,8 +283,8 @@ class WiFiComponent : public Component {
 
   network::IPAddress get_dns_address(int num);
   network::IPAddresses get_ip_addresses();
-  const std::string &get_use_address() const;
-  void set_use_address(const std::string &use_address);
+  const char *get_use_address() const;
+  void set_use_address(const char *use_address);
 
   const wifi_scan_vector_t<WiFiScanResult> &get_scan_result() const { return scan_result_; }
 
@@ -393,7 +393,7 @@ class WiFiComponent : public Component {
   void wifi_scan_done_callback_();
 #endif
 
-  std::string use_address_;
+  const char *use_address_{""};
   FixedVector<WiFiAP> sta_;
   std::vector<WiFiSTAPriority> sta_priorities_;
   wifi_scan_vector_t<WiFiScanResult> scan_result_;


### PR DESCRIPTION
# What does this implement/fix?

Change network components to store `use_address_` as `const char*` instead of `std::string`, storing the data in RODATA (flash/ROM) instead of heap.

The `use_address_` field is:
- Set once during setup from a string literal
- Never modified at runtime
- Only used for logging the device address in `dump_config()`

**Memory savings:**
- **RAM**: 32-72 bytes per network component (eliminates std::string object + heap allocation)
- **Flash**: ~100-300 bytes (std::string overhead)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

**Note:** Technically breaking (API signatures changed), but practical impact is near-zero. Only 3 call sites in ESPHome core (all updated). External components rarely call `get_use_address()`, and if they do, it's in format strings which work unchanged.

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Breaking Changes

**Changed signatures:**
```cpp
// Before
const std::string &get_use_address() const;
void set_use_address(const std::string &use_address);

// After
const char *get_use_address() const;
void set_use_address(const char *use_address);
```

**Affected:** WiFi, Ethernet, OpenThread components + `network::get_use_address()`

**Impact:** Virtually none. Only used for logging device address. Common usage in format strings works unchanged.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing changes. Works transparently.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
