### PR TITLE
feat(cover/single_button_garage_door): add implementation of single b…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -420,6 +420,7 @@ esphome/components/sht4x/* @sjtrny
 esphome/components/shutdown/* @esphome/core @jsuanet
 esphome/components/sigma_delta_output/* @Cat-Ion
 esphome/components/sim800l/* @glmnet
+esphome/components/single_button_garage_door/* @gbrd
 esphome/components/sm10bit_base/* @Cossid
 esphome/components/sm2135/* @BoukeHaarsma23 @dd32 @matika77
 esphome/components/sm2235/* @Cossid

--- a/esphome/components/single_button_garage_door/__init__.py
+++ b/esphome/components/single_button_garage_door/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@gbrd"]

--- a/esphome/components/single_button_garage_door/cover.py
+++ b/esphome/components/single_button_garage_door/cover.py
@@ -12,7 +12,7 @@ from esphome.const import (
 
 CONF_SINGLE_BUTTON_ACTION = "single_button_action"
 
-singlebutton_ns = cg.esphome_ns.namespace("singlebutton")
+singlebutton_ns = cg.esphome_ns.namespace("single_button_garage_door")
 SingleButtonCover = singlebutton_ns.class_(
     "SingleButtonCover", cover.Cover, cg.Component
 )

--- a/esphome/components/single_button_garage_door/cover.py
+++ b/esphome/components/single_button_garage_door/cover.py
@@ -1,0 +1,55 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import binary_sensor, cover
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CLOSE_DURATION,
+    CONF_CLOSE_ENDSTOP,
+    CONF_MAX_DURATION,
+    CONF_OPEN_DURATION,
+    CONF_OPEN_ENDSTOP,
+)
+
+CONF_SINGLE_BUTTON_ACTION = "single_button_action"
+
+singlebutton_ns = cg.esphome_ns.namespace("singlebutton")
+SingleButtonCover = singlebutton_ns.class_(
+    "SingleButtonCover", cover.Cover, cg.Component
+)
+
+CONFIG_SCHEMA = (
+    cover.cover_schema(SingleButtonCover)
+    .extend(
+        {
+            cv.Required(CONF_OPEN_ENDSTOP): cv.use_id(binary_sensor.BinarySensor),
+            cv.Required(CONF_SINGLE_BUTTON_ACTION): automation.validate_automation(
+                single=True
+            ),
+            cv.Required(CONF_OPEN_DURATION): cv.positive_time_period_milliseconds,
+            cv.Required(CONF_CLOSE_ENDSTOP): cv.use_id(binary_sensor.BinarySensor),
+            cv.Required(CONF_CLOSE_DURATION): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_MAX_DURATION): cv.positive_time_period_milliseconds,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    var = await cover.new_cover(config)
+    await cg.register_component(var, config)
+
+    await automation.build_automation(
+        var.get_single_button_trigger(), [], config[CONF_SINGLE_BUTTON_ACTION]
+    )
+
+    bin = await cg.get_variable(config[CONF_OPEN_ENDSTOP])
+    cg.add(var.set_open_endstop(bin))
+    cg.add(var.set_open_duration(config[CONF_OPEN_DURATION]))
+
+    bin = await cg.get_variable(config[CONF_CLOSE_ENDSTOP])
+    cg.add(var.set_close_endstop(bin))
+    cg.add(var.set_close_duration(config[CONF_CLOSE_DURATION]))
+
+    if CONF_MAX_DURATION in config:
+        cg.add(var.set_max_duration(config[CONF_MAX_DURATION]))

--- a/esphome/components/single_button_garage_door/sb_cover.cpp
+++ b/esphome/components/single_button_garage_door/sb_cover.cpp
@@ -1,0 +1,290 @@
+#include "sb_cover.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace singlebutton {
+
+static const char *const TAG = "singlebutton.cover";
+
+using namespace esphome::cover;
+
+CoverTraits SingleButtonCover::get_traits() {
+  auto traits = CoverTraits();
+  traits.set_supports_stop(true);
+  traits.set_supports_position(true);
+  traits.set_supports_toggle(true);
+  traits.set_is_assumed_state(false);
+  return traits;
+}
+void SingleButtonCover::control(const CoverCall &call) {
+  ESP_LOGD(TAG, "control start");
+  if (call.get_stop()) {
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->publish_state();
+  }
+  if (call.get_toggle().has_value()) {
+    if (this->current_operation != COVER_OPERATION_IDLE) {
+      this->start_direction_(COVER_OPERATION_IDLE);
+      this->publish_state();
+    } else {
+      if (this->position == COVER_CLOSED || this->last_operation_ == COVER_OPERATION_CLOSING) {
+        this->target_position_ = COVER_OPEN;
+        this->start_direction_(COVER_OPERATION_OPENING);
+      } else {
+        this->target_position_ = COVER_CLOSED;
+        this->start_direction_(COVER_OPERATION_CLOSING);
+      }
+    }
+  }
+  if (call.get_position().has_value()) {
+    auto pos = *call.get_position();
+    if (pos == this->position) {
+      // already at target
+    } else {
+      auto op = pos < this->position ? COVER_OPERATION_CLOSING : COVER_OPERATION_OPENING;
+      this->target_position_ = pos;
+      this->start_direction_(op);
+    }
+  }
+}
+void SingleButtonCover::setup() {
+  ESP_LOGD(TAG, "setup start");
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->apply(this);
+    ESP_LOGD(TAG, "setup => restored pos");
+  }
+
+  if (this->is_open_()) {
+    ESP_LOGD(TAG, "setup => open");
+    this->position = COVER_OPEN;
+  } else if (this->is_closed_()) {
+    this->position = COVER_CLOSED;
+    ESP_LOGD(TAG, "setup => closed");
+  } else if (!restore.has_value()) {
+    this->position = 0.5f;
+    ESP_LOGD(TAG, "setup => 0.5");
+  }
+  this->was_closed_ = this->is_closed_();
+  this->was_open_ = this->is_open_();
+
+  ESP_LOGD(TAG, "setup end.");
+}
+void SingleButtonCover::loop() {
+  const uint32_t now = App.get_loop_component_start_time();
+
+  // sometime the garage door can be opened or closed using original remote control or manually the motor button
+  // in those cases, a "resync" is needed because the start_direction was not called
+  // the only way to detect this is through endstops
+
+  if (now - this->last_resync_time_ > 1000) {
+    this->last_resync_time_ = now;
+
+    if (this->is_open_() && !(this->position == COVER_OPEN)) {
+      ESP_LOGD(TAG, "open endstop => resync pos ");
+      this->position = COVER_OPEN;
+      this->publish_state();
+    } else if (this->is_closed_() && !(this->position == COVER_CLOSED)) {
+      ESP_LOGD(TAG, "closed endstop => resync pos ");
+      this->position = COVER_CLOSED;
+      this->publish_state();
+    }
+  }
+
+  if (this->is_open_() && !this->was_open_) {
+    ESP_LOGD(TAG, "open endstop just reached, may need to resync");
+    // this->start_direction_(COVER_OPERATION_IDLE);
+    this->position = COVER_OPEN;
+    this->publish_state();
+  } else if (this->is_closed_() && !this->was_closed_) {
+    ESP_LOGD(TAG, "closed endstop just reached, may need to resync");
+    // this->start_direction_(COVER_OPERATION_IDLE);
+    this->position = COVER_CLOSED;
+    this->publish_state();
+  } else if (!this->is_closed_() && this->was_closed_ && !(this->current_operation == COVER_OPERATION_OPENING)) {
+    ESP_LOGD(TAG, "closed endstop just left, may need to resync");
+    // this->start_direction_(COVER_OPERATION_IDLE);
+    this->current_operation = COVER_OPERATION_OPENING;
+    this->position = COVER_CLOSED;
+    this->start_dir_time_ = now;
+    this->last_recompute_time_ = now;
+    this->publish_state();
+  } else if (!this->is_open_() && this->was_open_ && !(this->current_operation == COVER_OPERATION_CLOSING)) {
+    ESP_LOGD(TAG, "open endstop just left, may need to resync");
+    // this->start_direction_(COVER_OPERATION_IDLE);
+    this->current_operation = COVER_OPERATION_CLOSING;
+    this->position = COVER_CLOSED;
+    this->start_dir_time_ = now;
+    this->last_recompute_time_ = now;
+    this->publish_state();
+  }
+
+  this->was_closed_ = this->is_closed_();
+  this->was_open_ = this->is_open_();
+
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  if (this->current_operation == COVER_OPERATION_OPENING && this->is_open_()) {
+    float dur = (now - this->start_dir_time_) / 1e3f;
+    ESP_LOGD(TAG, "'%s' - Open endstop reached. Took %.1fs.", this->name_.c_str(), dur);
+
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->position = COVER_OPEN;
+    this->publish_state();
+  } else if (this->current_operation == COVER_OPERATION_CLOSING && this->is_closed_()) {
+    float dur = (now - this->start_dir_time_) / 1e3f;
+    ESP_LOGD(TAG, "'%s' - Close endstop reached. Took %.1fs.", this->name_.c_str(), dur);
+
+    this->start_direction_(COVER_OPERATION_IDLE);
+    this->position = COVER_CLOSED;
+    this->publish_state();
+  } else if (now - this->start_dir_time_ > this->max_duration_) {
+    ESP_LOGD(TAG, "'%s' - Max duration reached. cover must be idle now.", this->name_.c_str());
+    // this->start_direction_(COVER_OPERATION_IDLE);
+    this->current_operation = COVER_OPERATION_IDLE;
+    this->publish_state();
+  }
+
+  // Recompute position every loop cycle
+  this->recompute_position_();
+
+  // this code is commented for now because if we use orinal remote control,
+  // it immediatly stops the door (because target position is unknown)
+  // todo find a solution to "wait for" endstop left before checking this
+  // if (this->current_operation != COVER_OPERATION_IDLE && this->is_at_target_()) {
+  //   ESP_LOGD(TAG,"stop because pos already at target");
+  //   this->start_direction_(COVER_OPERATION_IDLE);
+  //   this->publish_state();
+  // }
+
+  // Send current position every second
+  if (this->current_operation != COVER_OPERATION_IDLE && now - this->last_publish_time_ > 1000) {
+    ESP_LOGD(TAG, "closed=%s , position=%f (closed is 0)", this->is_closed_() ? "true" : "false", this->position);
+    this->publish_state(false);
+    this->last_publish_time_ = now;
+  }
+}
+void SingleButtonCover::dump_config() {
+  LOG_COVER("", "Endstop Cover", this);
+  LOG_BINARY_SENSOR("  ", "Open Endstop", this->open_endstop_);
+  ESP_LOGCONFIG(TAG, "  Open Duration: %.1fs", this->open_duration_ / 1e3f);
+  LOG_BINARY_SENSOR("  ", "Close Endstop", this->close_endstop_);
+  ESP_LOGCONFIG(TAG, "  Close Duration: %.1fs", this->close_duration_ / 1e3f);
+}
+float SingleButtonCover::get_setup_priority() const { return setup_priority::DATA; }
+void SingleButtonCover::stop_prev_trigger_() {
+  if (this->prev_command_trigger_ != nullptr) {
+    this->prev_command_trigger_->stop_action();
+    this->prev_command_trigger_ = nullptr;
+  }
+}
+bool SingleButtonCover::is_at_target_() const {
+  switch (this->current_operation) {
+    case COVER_OPERATION_OPENING:
+      if (this->target_position_ == COVER_OPEN)
+        return this->is_open_();
+      return this->position >= this->target_position_;
+    case COVER_OPERATION_CLOSING:
+      if (this->target_position_ == COVER_CLOSED)
+        return this->is_closed_();
+      return this->position <= this->target_position_;
+    case COVER_OPERATION_IDLE:
+    default:
+      return true;
+  }
+}
+void SingleButtonCover::start_direction_(CoverOperation dir) {
+  if (dir == this->current_operation)
+    return;
+
+  this->recompute_position_();
+  Trigger<> *trig;
+  trig = this->single_button_trigger_;
+  int clic_count_needed = 0;
+
+  switch (dir) {
+    case COVER_OPERATION_IDLE:
+      clic_count_needed = 1;
+      break;
+    case COVER_OPERATION_OPENING:
+
+      switch (this->current_operation) {
+        case COVER_OPERATION_IDLE:
+          clic_count_needed = 1;
+          break;
+        case COVER_OPERATION_OPENING:
+          // shoud not occur
+          break;
+        case COVER_OPERATION_CLOSING:
+          clic_count_needed = 3;
+          break;
+      }
+      this->last_operation_ = dir;
+
+      break;
+    case COVER_OPERATION_CLOSING:
+
+      switch (this->current_operation) {
+        case COVER_OPERATION_IDLE:
+          clic_count_needed = 1;
+          break;
+        case COVER_OPERATION_OPENING:
+          clic_count_needed = 3;
+          break;
+        case COVER_OPERATION_CLOSING:
+          // shoud not occur
+          break;
+      }
+
+      this->last_operation_ = dir;
+
+      break;
+    default:
+      return;
+  }
+
+  this->current_operation = dir;
+
+  // this->stop_prev_trigger_();
+  int i = 0;
+  for (i = 0; i < clic_count_needed; i++) {
+    trig->trigger();
+    delay(500);
+  }
+  this->prev_command_trigger_ = trig;
+
+  const uint32_t now = millis();
+  this->start_dir_time_ = now;
+  this->last_recompute_time_ = now;
+}
+void SingleButtonCover::recompute_position_() {
+  if (this->current_operation == COVER_OPERATION_IDLE)
+    return;
+
+  float dir;
+  float action_dur;
+  switch (this->current_operation) {
+    case COVER_OPERATION_OPENING:
+      dir = 1.0f;
+      action_dur = this->open_duration_;
+      break;
+    case COVER_OPERATION_CLOSING:
+      dir = -1.0f;
+      action_dur = this->close_duration_;
+      break;
+    default:
+      return;
+  }
+
+  const uint32_t now = millis();
+  this->position += dir * (now - this->last_recompute_time_) / action_dur;
+  this->position = clamp(this->position, 0.0f, 1.0f);
+
+  this->last_recompute_time_ = now;
+}
+
+}  // namespace singlebutton
+}  // namespace esphome

--- a/esphome/components/single_button_garage_door/sb_cover.cpp
+++ b/esphome/components/single_button_garage_door/sb_cover.cpp
@@ -4,7 +4,7 @@
 #include "esphome/core/application.h"
 
 namespace esphome {
-namespace singlebutton {
+namespace single_button_garage_door {
 
 static const char *const TAG = "singlebutton.cover";
 
@@ -286,5 +286,5 @@ void SingleButtonCover::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}  // namespace singlebutton
+}  // namespace single_button_garage_door
 }  // namespace esphome

--- a/esphome/components/single_button_garage_door/sb_cover.cpp
+++ b/esphome/components/single_button_garage_door/sb_cover.cpp
@@ -250,9 +250,13 @@ void SingleButtonCover::start_direction_(CoverOperation dir) {
 
   // this->stop_prev_trigger_();
   int i = 0;
+  int interval_ms = 500;
+
   for (i = 0; i < clic_count_needed; i++) {
-    trig->trigger();
-    delay(500);
+    // trig->trigger();
+    // delay(500);
+
+    this->set_timeout(i * interval_ms, [this]() { this->single_button_trigger_->trigger(); });
   }
   this->prev_command_trigger_ = trig;
 

--- a/esphome/components/single_button_garage_door/sb_cover.h
+++ b/esphome/components/single_button_garage_door/sb_cover.h
@@ -6,7 +6,7 @@
 #include "esphome/components/cover/cover.h"
 
 namespace esphome {
-namespace singlebutton {
+namespace single_button_garage_door {
 
 class SingleButtonCover : public cover::Cover, public Component {
  public:
@@ -55,5 +55,5 @@ class SingleButtonCover : public cover::Cover, public Component {
   cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
 };
 
-}  // namespace singlebutton
+}  // namespace single_button_garage_door
 }  // namespace esphome

--- a/esphome/components/single_button_garage_door/sb_cover.h
+++ b/esphome/components/single_button_garage_door/sb_cover.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/cover/cover.h"
+
+namespace esphome {
+namespace singlebutton {
+
+class SingleButtonCover : public cover::Cover, public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  Trigger<> *get_single_button_trigger() const { return this->single_button_trigger_; }
+
+  void set_open_endstop(binary_sensor::BinarySensor *open_endstop) { this->open_endstop_ = open_endstop; }
+  void set_close_endstop(binary_sensor::BinarySensor *close_endstop) { this->close_endstop_ = close_endstop; }
+  void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
+  void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
+  void set_max_duration(uint32_t max_duration) { this->max_duration_ = max_duration; }
+
+  cover::CoverTraits get_traits() override;
+
+ protected:
+  void control(const cover::CoverCall &call) override;
+  void stop_prev_trigger_();
+  bool is_open_() const { return this->open_endstop_->state; }
+  bool is_closed_() const { return this->close_endstop_->state; }
+  bool is_at_target_() const;
+
+  bool was_open_ = false;
+  bool was_closed_ = false;
+
+  void start_direction_(cover::CoverOperation dir);
+
+  void recompute_position_();
+
+  binary_sensor::BinarySensor *open_endstop_;
+  binary_sensor::BinarySensor *close_endstop_;
+  Trigger<> *single_button_trigger_{new Trigger<>()};
+  uint32_t open_duration_;
+  uint32_t close_duration_;
+  uint32_t max_duration_{UINT32_MAX};
+
+  Trigger<> *prev_command_trigger_{nullptr};
+  uint32_t last_recompute_time_{0};
+  uint32_t start_dir_time_{0};
+  uint32_t last_publish_time_{0};
+  uint32_t last_resync_time_{0};
+  float target_position_{0};
+  cover::CoverOperation last_operation_{cover::COVER_OPERATION_OPENING};
+};
+
+}  // namespace singlebutton
+}  // namespace esphome


### PR DESCRIPTION
…utton garage door (based on endstop)

# What does this implement/fix?

I have a garage-door motor with a remote control (only one button on it) and a (single) contact on the motor intended to be used to connect a push button. The button (remote control or connected to motor) work like this.
- door open => clic => start closing the door
- door closed => clic => start opening the door
- door opening => clic => door stopped (partially open) => clic => door closing ...etc..

I added 2 endstop sensors to be able to know when door is fully open or fully closed.

This kind of motor is complex to implement using endstop cover, template, etc.. 

This (first) implementation is forked from endstop (should I add options to endstop else ?) and try to manage the fact that (original) remote control can be used and in that case, the component did trigger the movment itself.

At first I would like to have feedback about 
- the best way to support this kind of garage door motor (new component like this, extend an existing component, somthing else ? ) 
- what is missing here (at least doc I guess)
- the code itself, for exemple: 
  - should I keep single_button_action *trigger* in conf of should I use a *switch* directly ?
  - should I add a conf key for delay between "clicks" on button ?

![IMG_20251102_174122](https://github.com/user-attachments/assets/662b1867-4f20-460f-a6fb-320b3fe696ef)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5561

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

binary_sensor:
  - platform: gpio
    pin:
      number: D7
      mode: INPUT_PULLUP
      inverted: true
    name: "Open Endstop Sensor"
    id: open_endstop
    #internal: true
    filters:
      - delayed_on_off: 100ms
    
  - platform: gpio
    pin:
      number: D6
      mode: INPUT_PULLUP
      inverted: true
    name: "Close Endstop Sensor"
    id: close_endstop
    #internal: true
    filters:
      - delayed_on_off: 100ms
switch:
  - platform: gpio
    pin: D1
    name: "Door Switch"
    id: door_switch
    #internal: true
    restore_mode: ALWAYS_OFF
    # on_turn_on:
    #   - delay: 200ms
    #   - switch.turn_off: door_switch

cover:
  - platform: single_button_garage_door
    name: garage-door
    id: garage_door
    device_class: garage
    open_duration: 19s
    open_endstop: open_endstop
    close_duration: 19s
    close_endstop: close_endstop
    max_duration: 30s
    single_button_action: 
      - switch.turn_on: door_switch
      - delay: 200ms
      - switch.turn_off: door_switch
      - delay: 200ms





```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
