### PR TITLE
[core] Fix #11676 as per Copilot suggestions.

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -110,7 +110,7 @@ template<typename... Ts> class ForCondition : public Condition<Ts...>, public Co
   bool check(Ts... x) override {
     if (!this->check_internal())
       return false;
-    return millis() - this->last_inactive_ >= this->time_.value(x...);
+    return App.get_loop_component_start_time() - this->last_inactive_ >= this->time_.value(x...);
   }
 
  protected:
@@ -367,7 +367,7 @@ template<typename... Ts> class WaitUntilAction : public Action<Ts...>, public Co
     }
 
     // Store for later processing
-    auto now = millis();
+    auto now = App.get_loop_component_start_time();
     auto timeout = this->timeout_value_.optional_value(x...);
     this->var_queue_.emplace_front(now, timeout, std::make_tuple(x...));
 


### PR DESCRIPTION
# What does this implement/fix?

After updating dev, my alarm_control_panel test suite - https://gist.github.com/warthog618/982eb18533c0fc15f81dc89d591ca765, which runs automations on the board to exercise the ACP, has started behaving rather badly - as though waits/timeouts aren't working anymore.
A git bisect pointed to #11676. Reverting that commit restored expected behaviour, confirming that as the root cause.
The Copilot review of that PR suggested additional changes for consistent time comparisons.
This PR contains those suggested changes which also restore the expected behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
