### PR TITLE
[gt911] Fix gt911 touchscreen with reset pin not initializing when loglevel is set to NONE

### DIFF
--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -34,8 +34,8 @@ void GT911Touchscreen::setup() {
       this->interrupt_pin_->digital_write(false);
     }
     delay(2);
-    this->reset_pin_->digital_write(true);  // wait 50ms after reset
-    this->set_timeout(50, [this] { this->setup_internal_(); });
+    this->reset_pin_->digital_write(true);  // wait at least T3+T4 ms as per the datasheet
+    this->set_timeout(5 + 50 + 1, [this] { this->setup_internal_(); });
     return;
   }
   this->setup_internal_();


### PR DESCRIPTION
# What does this implement/fix?

This PR increases the gt911 touchscreen reset pin initialization delay to a higher value to comply with the datasheet specs.

I could not get gt911 touchscreen to work when setting log level to `NONE`. In `DEBUG`, the touch screen works normally. Because the original timeout was set so tight, the extra work to print out debug messages was creating an artificial extra delay that allowed it to work. When setting logging to `NONE`, that extra work is not present and the timeout is insufficient.

As per the datasheet:

<img width="2062" height="864" alt="image" src="https://github.com/user-attachments/assets/4a6eeb8c-4fd4-433f-82c8-161ed20bd2e3" />

It is required to wait for at least `T3` (5ms) and then for at least `T4` (50ms) more after the RESET pin is set to high. The PR increases this timeout to T3+T4 + 1ms margin.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml

logger:
  level: NONE

touchscreen:
  - platform: gt911
    id: device_touchscreen
    reset_pin: 38
    interrupt_pin:
      number: 3
      ignore_strapping_warning: true
    i2c_id: touch_i2c
    display: device_display

i2c:
  - id: touch_i2c
    sda: 8
    scl: 4

display:
 # [...]
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
