### PR TITLE
[select][lvgl] Fix FixedVector size() returning 0 when using operator[] after init()

### DIFF
--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -59,8 +59,8 @@ class LVGLSelect : public select::Select, public Component {
     const auto &opts = this->widget_->get_options();
     FixedVector<const char *> opt_ptrs;
     opt_ptrs.init(opts.size());
-    for (size_t i = 0; i < opts.size(); i++) {
-      opt_ptrs[i] = opts[i].c_str();
+    for (const auto &opt : opts) {
+      opt_ptrs.push_back(opt.c_str());
     }
     this->traits.set_options(opt_ptrs);
   }

--- a/esphome/components/select/select_traits.cpp
+++ b/esphome/components/select/select_traits.cpp
@@ -7,8 +7,8 @@ void SelectTraits::set_options(const std::initializer_list<const char *> &option
 
 void SelectTraits::set_options(const FixedVector<const char *> &options) {
   this->options_.init(options.size());
-  for (size_t i = 0; i < options.size(); i++) {
-    this->options_[i] = options[i];
+  for (const auto &opt : options) {
+    this->options_.push_back(opt);
   }
 }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -248,6 +248,8 @@ template<typename T> class FixedVector {
   }
 
   // Allocate capacity - can be called multiple times to reinit
+  // IMPORTANT: After calling init(), you MUST use push_back() to add elements.
+  // Direct assignment via operator[] does NOT update the size counter.
   void init(size_t n) {
     cleanup_();
     reset_();


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where `FixedVector::size()` returns 0 after calling `init()` and using `operator[]` for assignment. The issue is that `init()` allocates capacity but doesn't set the size counter - only `push_back()` updates the size.

**Bug scenario:**
```cpp
FixedVector<const char *> opt_ptrs;
opt_ptrs.init(opts.size());
for (size_t i = 0; i < opts.size(); i++) {
  opt_ptrs[i] = opts[i].c_str();  // BUG: size() stays 0!
}
ESP_LOGD("select", "Setting options, length = %d", opt_ptrs.size());  // Prints 0
```

**Fixed code:**
```cpp
FixedVector<const char *> opt_ptrs;
opt_ptrs.init(opts.size());
for (const auto &opt : opts) {
  opt_ptrs.push_back(opt.c_str());  // Correct: size() is updated
}
```

**Changes:**
1. Fixed `lvgl_select.h` - Changed indexed assignment to `push_back()` (with `.c_str()` transformation)
2. Fixed `select_traits.cpp` - Changed indexed assignment to `push_back()` (direct copy)
3. Added warning comment on `FixedVector::init()` to prevent future occurrences

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression introduced in #11514

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation fix, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is an internal bug fix
# Affects LVGL select components and select traits internally
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
