### PR TITLE
[ld2420] Eliminate substr() allocation in firmware version parsing

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -174,7 +174,7 @@ static uint8_t calc_checksum(void *data, size_t size) {
 static int get_firmware_int(const char *version_string) {
   std::string version_str = version_string;
   if (version_str[0] == 'v') {
-    version_str = version_str.substr(1);
+    version_str.erase(0, 1);
   }
   version_str.erase(remove(version_str.begin(), version_str.end(), '.'), version_str.end());
   int version_integer = stoi(version_str);


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the `ld2420` component's firmware version parsing to eliminate an unnecessary `substr()` allocation when stripping the leading 'v' from version strings.

**Changes:**
- Replaced `version_str.substr(1)` with `version_str.erase(0, 1)` in `get_firmware_int()` helper function

**Benefits:**
- Eliminates heap allocation from `substr()` call
- Modifies string in-place instead of creating a copy
- Reduces flash size by removing STL `substr()` template instantiation
- Called 3 times in the codebase, so saves 3 allocations per firmware version check

**Technical details:**
The `get_firmware_int()` function converts firmware version strings like "v1.5.4" to integers (154) by:
1. Stripping the leading 'v' if present
2. Removing all dots
3. Converting to integer

The original code used `substr(1)` which allocates a new string. Using `erase(0, 1)` achieves the same result by modifying the string in-place without allocation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts for embedded systems

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization

uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

ld2420:
  # Firmware version parsing now uses less memory
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
