### PR TITLE
[voice_assistant] Eliminate substr() allocations in text truncation

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -657,7 +657,8 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         ESP_LOGW(TAG, "No text in STT_END event");
         return;
       } else if (text.length() > 500) {
-        text = text.substr(0, 497) + "...";
+        text.resize(497);
+        text += "...";
       }
       ESP_LOGD(TAG, "Speech recognised as: \"%s\"", text.c_str());
       this->defer([this, text]() { this->stt_end_trigger_->trigger(text); });
@@ -714,7 +715,8 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
         return;
       }
       if (text.length() > 500) {
-        text = text.substr(0, 497) + "...";
+        text.resize(497);
+        text += "...";
       }
       ESP_LOGD(TAG, "Response: \"%s\"", text.c_str());
       this->defer([this, text]() {


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the `voice_assistant` component's text truncation logic to eliminate unnecessary `substr()` allocations when logging long speech recognition and TTS responses.

**Changes:**
- Replaced `text.substr(0, 497) + "..."` with in-place `resize()` + `append()` operations
- Affects two locations: STT_END event (line 660) and TTS_START event (line 717)

**Benefits:**
- Eliminates 2-3 heap allocations per voice assistant event that exceeds 500 characters
- Reduces flash size by removing STL `substr()` template instantiation
- Maintains identical functionality - still truncates to 500 chars total (497 + "...")

**Technical details:**
When voice assistant responses exceed 500 characters, they are truncated for logging purposes. The original implementation created multiple temporary string objects, while the optimized version modifies the string in-place.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization efforts for embedded systems

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# This is an internal optimization

voice_assistant:
  microphone: my_mic
  speaker: my_speaker
  # Text truncation now uses less memory when responses exceed 500 chars
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
