### PR TITLE
[template] Mark all component classes as final

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -49,7 +49,7 @@ struct SensorInfo {
   uint8_t store_index;
 };
 
-class TemplateAlarmControlPanel : public alarm_control_panel::AlarmControlPanel, public Component {
+class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControlPanel, public Component {
  public:
   TemplateAlarmControlPanel();
   void dump_config() override;

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateBinarySensor : public Component, public binary_sensor::BinarySensor {
+class TemplateBinarySensor final : public Component, public binary_sensor::BinarySensor {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/button/template_button.h
+++ b/esphome/components/template/button/template_button.h
@@ -5,7 +5,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateButton : public button::Button {
+class TemplateButton final : public button::Button {
  public:
   // Implements the abstract `press_action` but the `on_press` trigger already handles the press.
   void press_action() override{};

--- a/esphome/components/template/cover/template_cover.h
+++ b/esphome/components/template/cover/template_cover.h
@@ -14,7 +14,7 @@ enum TemplateCoverRestoreMode {
   COVER_RESTORE_AND_CALL,
 };
 
-class TemplateCover : public cover::Cover, public Component {
+class TemplateCover final : public cover::Cover, public Component {
  public:
   TemplateCover();
 

--- a/esphome/components/template/datetime/template_date.h
+++ b/esphome/components/template/datetime/template_date.h
@@ -14,7 +14,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateDate : public datetime::DateEntity, public PollingComponent {
+class TemplateDate final : public datetime::DateEntity, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/datetime/template_datetime.h
+++ b/esphome/components/template/datetime/template_datetime.h
@@ -14,7 +14,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateDateTime : public datetime::DateTimeEntity, public PollingComponent {
+class TemplateDateTime final : public datetime::DateTimeEntity, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/datetime/template_time.h
+++ b/esphome/components/template/datetime/template_time.h
@@ -14,7 +14,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateTime : public datetime::TimeEntity, public PollingComponent {
+class TemplateTime final : public datetime::TimeEntity, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/event/template_event.h
+++ b/esphome/components/template/event/template_event.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateEvent : public Component, public event::Event {};
+class TemplateEvent final : public Component, public event::Event {};
 
 }  // namespace template_
 }  // namespace esphome

--- a/esphome/components/template/fan/template_fan.h
+++ b/esphome/components/template/fan/template_fan.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateFan : public Component, public fan::Fan {
+class TemplateFan final : public Component, public fan::Fan {
  public:
   TemplateFan() {}
   void setup() override;

--- a/esphome/components/template/lock/template_lock.h
+++ b/esphome/components/template/lock/template_lock.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateLock : public lock::Lock, public Component {
+class TemplateLock final : public lock::Lock, public Component {
  public:
   TemplateLock();
 

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateNumber : public number::Number, public PollingComponent {
+class TemplateNumber final : public number::Number, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/output/template_output.h
+++ b/esphome/components/template/output/template_output.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateBinaryOutput : public output::BinaryOutput {
+class TemplateBinaryOutput final : public output::BinaryOutput {
  public:
   Trigger<bool> *get_trigger() const { return trigger_; }
 
@@ -17,7 +17,7 @@ class TemplateBinaryOutput : public output::BinaryOutput {
   Trigger<bool> *trigger_ = new Trigger<bool>();
 };
 
-class TemplateFloatOutput : public output::FloatOutput {
+class TemplateFloatOutput final : public output::FloatOutput {
  public:
   Trigger<float> *get_trigger() const { return trigger_; }
 

--- a/esphome/components/template/select/template_select.h
+++ b/esphome/components/template/select/template_select.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateSelect : public select::Select, public PollingComponent {
+class TemplateSelect final : public select::Select, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/sensor/template_sensor.h
+++ b/esphome/components/template/sensor/template_sensor.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateSensor : public sensor::Sensor, public PollingComponent {
+class TemplateSensor final : public sensor::Sensor, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/switch/template_switch.h
+++ b/esphome/components/template/switch/template_switch.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateSwitch : public switch_::Switch, public Component {
+class TemplateSwitch final : public switch_::Switch, public Component {
  public:
   TemplateSwitch();
 

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -60,7 +60,7 @@ template<uint8_t SZ> class TextSaver : public TemplateTextSaverBase {
   }
 };
 
-class TemplateText : public text::Text, public PollingComponent {
+class TemplateText final : public text::Text, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/text_sensor/template_text_sensor.h
+++ b/esphome/components/template/text_sensor/template_text_sensor.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace template_ {
 
-class TemplateTextSensor : public text_sensor::TextSensor, public PollingComponent {
+class TemplateTextSensor final : public text_sensor::TextSensor, public PollingComponent {
  public:
   template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
 

--- a/esphome/components/template/valve/template_valve.h
+++ b/esphome/components/template/valve/template_valve.h
@@ -14,7 +14,7 @@ enum TemplateValveRestoreMode {
   VALVE_RESTORE_AND_CALL,
 };
 
-class TemplateValve : public valve::Valve, public Component {
+class TemplateValve final : public valve::Valve, public Component {
  public:
   TemplateValve();
 


### PR DESCRIPTION
# What does this implement/fix?

This PR marks all 19 template component classes as `final` to enable compiler optimizations and reduce flash size on resource-constrained microcontrollers.

## Background

Template components are leaf classes that are never inherited from. Marking them as `final` provides several benefits:

1. **Compiler optimizations**: Enables devirtualization when the exact type is known, eliminating vtable lookups
2. **Flash size reduction**: Reduces code generation for virtual dispatch mechanisms
3. **Documentation**: Makes it explicit that these classes aren't designed for inheritance
4. **Embedded best practices**: Aligns with ESPHome's goal of minimizing resource usage on microcontrollers

## Classes Modified

All template component classes have been marked `final`:
- TemplateSensor
- TemplateBinarySensor
- TemplateSwitch
- TemplateCover
- TemplateFan
- TemplateLock
- TemplateNumber
- TemplateSelect
- TemplateText
- TemplateTextSensor
- TemplateButton
- TemplateEvent
- TemplateValve
- TemplateAlarmControlPanel
- TemplateDateTime
- TemplateDate
- TemplateTime
- TemplateBinaryOutput
- TemplateFloatOutput

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a C++ implementation optimization
# All existing template component configurations work identically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
