### PR TITLE
[api] Release excess buffer capacity after initial sync

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -193,6 +193,11 @@ void APIConnection::loop() {
       if (!this->deferred_batch_.empty()) {
         this->process_batch_();
       }
+      // Release excess capacity from initial entity flood
+      // deferred_batch_ grew up to MAX_INITIAL_PER_BATCH (24) items, now shrink to free up to ~384 bytes
+      this->deferred_batch_.items.shrink_to_fit();
+      // shared_write_buffer_ grew up to ~1.5KB during initial state, now shrink to free up to ~1.4KB
+      this->parent_->get_shared_buffer_ref().shrink_to_fit();
       // Now that everything is sent, enable immediate sending for future state changes
       this->flags_.should_try_send_immediately = true;
     }


### PR DESCRIPTION
# What does this implement/fix?

This PR releases excess memory capacity from API buffers after initial entity list and state synchronization completes.

## Problem

During initial connection, the API connection allocates memory for batching entity info and state messages:
- `deferred_batch_.items` vector grows up to 24 items (~384 bytes)
- Shared `shared_write_buffer_` grows up to ~1.5KB for large batched messages

After initial sync completes, these buffers are cleared but their **capacity is never released**. This wastes ~2KB of RAM per connection for the entire connection lifetime.

## Solution

Call `shrink_to_fit()` on both buffers immediately after initial state synchronization completes in `api_connection.cpp:196-200`.

## Impact

**Memory savings:** ~2KB per API connection
- `deferred_batch_.items`: up to ~384 bytes
- `shared_write_buffer_`: up to ~1.4KB

**Heap churn consideration:** Minimal
- Typical connection lasts weeks/months between restarts
- Reconnection happens 1-2 times per month (HA restart, network issues)
- One-time 2KB reallocation cost is negligible compared to keeping 2KB allocated 24/7

Most users have 1 connection that stays alive for weeks, so this RAM is wasted 99.9% of the time.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
api:
  encryption:
    key: !secret api_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Not applicable - optimization has no observable behavior change, existing API tests cover functionality

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - Not applicable - internal optimization only