### PR TITLE
[tests] Fix ID collision between bl0940 and nau7802 component tests

### DIFF
--- a/tests/components/bl0940/common.yaml
+++ b/tests/components/bl0940/common.yaml
@@ -1,11 +1,11 @@
 button:
   - platform: bl0940
-    bl0940_id: test_id
+    bl0940_id: bl0940_test_id
     name: Cal Reset
 
 sensor:
   - platform: bl0940
-    id: test_id
+    id: bl0940_test_id
     voltage:
       name: BL0940 Voltage
     current:
@@ -22,7 +22,7 @@ sensor:
 number:
   - platform: bl0940
     id: bl0940_number_id
-    bl0940_id: test_id
+    bl0940_id: bl0940_test_id
     current_calibration:
       name: Cal Current
       min_value: -5

--- a/tests/components/nau7802/common.yaml
+++ b/tests/components/nau7802/common.yaml
@@ -1,13 +1,13 @@
 sensor:
   - platform: nau7802
     i2c_id: i2c_bus
-    id: test_id
+    id: nau7802_test_id
     name: weight
     gain: 32
     ldo_voltage: "3.0v"
     samples_per_second: 10
     on_value:
       then:
-        - nau7802.calibrate_external_offset: test_id
-        - nau7802.calibrate_internal_offset: test_id
-        - nau7802.calibrate_gain: test_id
+        - nau7802.calibrate_external_offset: nau7802_test_id
+        - nau7802.calibrate_internal_offset: nau7802_test_id
+        - nau7802.calibrate_gain: nau7802_test_id


### PR DESCRIPTION
# What does this implement/fix?

Fixes ID collision between `bl0940` and `nau7802` component tests that was discovered during component grouping testing in PR #11737.

## The Problem

When testing all components together using `./script/test_component_grouping.py --all`, the configuration validation failed with:

```
ID 'test_id' of type nau7802::NAU7802Sensor doesn't inherit from bl0940::BL0940.
Please double check your ID is pointing to the correct value.
```

Both components used the generic ID `test_id` in their test configurations:
- `tests/components/bl0940/common.yaml` - defined `id: test_id` for BL0940 sensor
- `tests/components/nau7802/common.yaml` - defined `id: test_id` for NAU7802 sensor

When components are tested individually, this works fine. However, when grouped together (as done in PR #11737's CI optimization), these IDs collide and cause validation errors.

## The Solution

Renamed generic `test_id` to component-specific IDs to avoid collisions:

**bl0940 component** (3 changes):
- `id: test_id` → `id: bl0940_test_id`
- `bl0940_id: test_id` → `bl0940_id: bl0940_test_id` (button platform)
- `bl0940_id: test_id` → `bl0940_id: bl0940_test_id` (number platform)

**nau7802 component** (4 changes):
- `id: test_id` → `id: nau7802_test_id`
- Updated all action references: `nau7802.calibrate_external_offset`, `nau7802.calibrate_internal_offset`, `nau7802.calibrate_gain`

## Verification

Tested with component grouping script:
```bash
./script/test_component_grouping.py -e config --all
```

Result: ✅ **PASS** All components: 576 components

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- Discovered in https://github.com/esphome/esphome/pull/11737 (component grouping testing)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test infrastructure fix, no user-facing changes)

## Test Environment

- [x] ESP32 IDF (where collision was discovered)

## Example entry for `config.yaml`:

N/A - This is a test file fix with no user-facing changes. The component APIs remain unchanged.

## Checklist:
  - [x] The code change is tested and works locally.
    - Verified with `./script/test_component_grouping.py -e config --all` (576 components pass)
    - No remaining `test_id` collisions found in component tests
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing component tests continue to work with renamed IDs
    - Component grouping test now passes without ID collisions

If user exposed functionality or configuration variables are added/changed:
  - N/A - No user-facing changes
