### PR TITLE
[ci] Skip memory impact analysis for release and beta branches

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -63,6 +63,7 @@ from helpers import (
     get_components_from_integration_fixtures,
     get_components_with_dependencies,
     get_cpp_changed_components,
+    get_target_branch,
     git_ls_files,
     parse_test_filename,
     root_path,
@@ -471,6 +472,20 @@ def detect_memory_impact_config(
         - platform: platform name for the merged build
         - use_merged_config: "true" (always use merged config)
     """
+    # Skip memory impact analysis for release* or beta* branches
+    # These branches typically contain many merged changes from dev, and building
+    # all components at once would produce nonsensical memory impact results.
+    # Memory impact analysis is most useful for focused PRs targeting dev.
+    target_branch = get_target_branch()
+    if target_branch and (
+        target_branch.startswith("release") or target_branch.startswith("beta")
+    ):
+        print(
+            f"Memory impact: Skipping analysis for target branch {target_branch} "
+            f"(would try to build all components at once, giving nonsensical results)",
+            file=sys.stderr,
+        )
+        return {"should_run": "false"}
 
     # Get actually changed files (not dependencies)
     files = changed_files(branch)

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -31,6 +31,13 @@ print_file_list = helpers.print_file_list
 get_all_dependencies = helpers.get_all_dependencies
 
 
+@pytest.fixture(autouse=True)
+def clear_helpers_cache() -> None:
+    """Clear cached functions before each test."""
+    helpers._get_github_event_data.cache_clear()
+    helpers._get_changed_files_github_actions.cache_clear()
+
+
 @pytest.mark.parametrize(
     ("github_ref", "expected_pr_number"),
     [


### PR DESCRIPTION
# What does this implement/fix?

This PR modifies the CI system to skip memory impact analysis when the target branch is `release*` or `beta*`.

**Why this is needed:**

When PRs target release or beta branches, they typically contain many merged changes from dev (often an entire dev branch merge). Running memory impact analysis on these PRs would attempt to build all changed components at once in a merged configuration, producing nonsensical and meaningless results. Memory impact analysis is only useful for focused PRs targeting the dev branch where the number of changed components is small and the results are meaningful.

**Implementation details:**

- Added `get_target_branch()` helper function to detect the PR's target branch from GitHub environment variables
- Added `_get_github_event_data()` cached helper to efficiently read the GitHub event file once
- Modified `detect_memory_impact_config()` to check the target branch and return `should_run: false` for release*/beta* branches
- Refactored existing code to use the cached event data reader, reducing duplicate file reads

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other (CI improvement)

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI change, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a CI-only change that doesn't affect runtime behavior

## Example entry for `config.yaml`:

```yaml
# N/A - This is a CI infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
