### PR TITLE
[esp32_ble] Store custom GAP device name in flash

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -257,8 +257,8 @@ bool ESP32BLE::ble_setup_() {
 #endif
 
   std::string name;
-  if (this->name_.has_value()) {
-    name = this->name_.value();
+  if (this->name_ != nullptr) {
+    name = this->name_;
     if (App.is_name_add_mac_suffix_enabled()) {
       // MAC address suffix length (last 6 characters of 12-char MAC address string)
       constexpr size_t mac_address_suffix_len = 6;

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -112,7 +112,7 @@ class ESP32BLE : public Component {
   void loop() override;
   void dump_config() override;
   float get_setup_priority() const override;
-  void set_name(const std::string &name) { this->name_ = name; }
+  void set_name(const char *name) { this->name_ = name; }
 
 #ifdef USE_ESP32_BLE_ADVERTISING
   void advertising_start();
@@ -191,8 +191,8 @@ class ESP32BLE : public Component {
   esphome::LockFreeQueue<BLEEvent, MAX_BLE_QUEUE_SIZE> ble_events_;
   esphome::EventPool<BLEEvent, MAX_BLE_QUEUE_SIZE> ble_event_pool_;
 
-  // optional<string> (typically 16+ bytes on 32-bit, aligned to 4 bytes)
-  optional<std::string> name_;
+  // Pointer to compile-time string literal or nullptr (4 bytes on 32-bit)
+  const char *name_{nullptr};
 
   // 4-byte aligned members
 #ifdef USE_ESP32_BLE_ADVERTISING


### PR DESCRIPTION
# What does this implement/fix?

Store ESP32 BLE GAP device name as pointer to flash string literal instead of `optional<std::string>`. Follows the same optimization pattern as PR #11734 (mDNS hostname) and PR #11744 (API service names).

**Key points:**
- Saves ~4-8 bytes per ESP32 BLE device even when name is not set
- `optional<std::string>` overhead (~8 bytes) → `const char*` pointer (4 bytes)
- ESP-IDF makes its own copy via `osi_malloc()`, so `const char*` is safe
- Affects all ESP32 BLE devices (bluetooth_proxy, ble_tracker, etc.)
- No Python changes needed - codegen already works correctly

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (memory optimization)

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce memory usage on ESP32/ESP8266
- Related to PR #11734 (mDNS hostname in flash) and PR #11744 (API service names in flash)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal optimization, no user-visible changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
esp32_ble:
  name: "MyDevice"  # Optional - stored as const char* to flash literal
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - internal optimization, no API changes
