### PR TITLE
[core] Deduplicate entity icon and device class logging

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "binary_sensor";
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_device_class(tag, prefix, obj);
+    log_entity_icon_and_device_class(tag, prefix, obj, obj);
   }
 }
 

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -10,8 +10,7 @@ static const char *const TAG = "binary_sensor";
 // Function implementation of LOG_BINARY_SENSOR macro to reduce code size
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj) {
   if (obj != nullptr) {
-    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_icon_and_device_class(tag, prefix, obj, obj);
+    log_entity_name_icon_and_device_class(tag, prefix, type, obj, obj);
   }
 }
 

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -9,14 +9,9 @@ static const char *const TAG = "binary_sensor";
 
 // Function implementation of LOG_BINARY_SENSOR macro to reduce code size
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj) {
-  if (obj == nullptr) {
-    return;
-  }
-
-  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
+  if (obj != nullptr) {
+    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    obj->log_device_class(tag, prefix);
   }
 }
 

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "binary_sensor";
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    obj->log_device_class(tag, prefix);
+    log_entity_device_class(tag, prefix, obj);
   }
 }
 

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -9,8 +9,7 @@ static const char *const TAG = "button";
 // Function implementation of LOG_BUTTON macro to reduce code size
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj) {
   if (obj != nullptr) {
-    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_icon(tag, prefix, obj);
+    log_entity_name_and_icon(tag, prefix, type, obj);
   }
 }
 

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -8,14 +8,9 @@ static const char *const TAG = "button";
 
 // Function implementation of LOG_BUTTON macro to reduce code size
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj) {
-  if (obj == nullptr) {
-    return;
-  }
-
-  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
+  if (obj != nullptr) {
+    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    obj->log_icon(tag, prefix);
   }
 }
 

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "button";
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    obj->log_icon(tag, prefix);
+    log_entity_icon(tag, prefix, obj);
   }
 }
 

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -15,12 +15,11 @@ const extern float COVER_CLOSED;
 
 #define LOG_COVER(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
+    log_entity_name_icon_and_device_class(TAG, prefix, LOG_STR_LITERAL(type), (obj), (obj)); \
     auto traits_ = (obj)->get_traits(); \
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,7 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_device_class(TAG, prefix, (obj)); \
+    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,7 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    (obj)->log_device_class(TAG, prefix); \
+    log_entity_device_class(TAG, prefix, (obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,9 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    (obj)->log_device_class(TAG, prefix); \
   }
 
 class Cover;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -16,7 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -16,9 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -15,8 +15,7 @@ namespace datetime {
 
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -16,7 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -15,8 +15,7 @@ namespace datetime {
 
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -16,9 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -16,7 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -15,8 +15,7 @@ namespace datetime {
 
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -16,9 +16,7 @@ namespace datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
   }
 
 class TimeCall;

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -11,8 +11,7 @@ namespace event {
 
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
+    log_entity_name_icon_and_device_class(TAG, prefix, LOG_STR_LITERAL(type), (obj), (obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -12,8 +12,7 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
-    log_entity_device_class(TAG, prefix, (obj)); \
+    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -12,12 +12,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
+    (obj)->log_device_class(TAG, prefix); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -12,8 +12,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
-    (obj)->log_device_class(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_device_class(TAG, prefix, (obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -15,7 +15,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -15,9 +15,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -14,8 +14,7 @@ class Lock;
 
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -10,13 +10,11 @@ static const char *const TAG = "number";
 void log_number(const char *tag, const char *prefix, const char *type, Number *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_icon(tag, prefix, obj);
-
     if (!obj->traits.get_unit_of_measurement_ref().empty()) {
       ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
     }
 
-    log_entity_device_class(tag, prefix, &obj->traits);
+    log_entity_icon_and_device_class(tag, prefix, obj, &obj->traits);
   }
 }
 

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -10,13 +10,13 @@ static const char *const TAG = "number";
 void log_number(const char *tag, const char *prefix, const char *type, Number *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    obj->log_icon(tag, prefix);
+    log_entity_icon(tag, prefix, obj);
 
     if (!obj->traits.get_unit_of_measurement_ref().empty()) {
       ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
     }
 
-    obj->traits.log_device_class(tag, prefix);
+    log_entity_device_class(tag, prefix, &obj->traits);
   }
 }
 

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -9,12 +9,16 @@ static const char *const TAG = "number";
 // Function implementation of LOG_NUMBER macro to reduce code size
 void log_number(const char *tag, const char *prefix, const char *type, Number *obj) {
   if (obj != nullptr) {
-    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    log_entity_name_and_icon(tag, prefix, type, obj);
+
     if (!obj->traits.get_unit_of_measurement_ref().empty()) {
       ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
     }
 
-    log_entity_icon_and_device_class(tag, prefix, obj, &obj->traits);
+    auto device_class_ref = obj->traits.get_device_class_ref();
+    if (!device_class_ref.empty()) {
+      ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
+    }
   }
 }
 

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -8,22 +8,15 @@ static const char *const TAG = "number";
 
 // Function implementation of LOG_NUMBER macro to reduce code size
 void log_number(const char *tag, const char *prefix, const char *type, Number *obj) {
-  if (obj == nullptr) {
-    return;
-  }
+  if (obj != nullptr) {
+    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    obj->log_icon(tag, prefix);
 
-  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    if (!obj->traits.get_unit_of_measurement_ref().empty()) {
+      ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
+    }
 
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
-
-  if (!obj->traits.get_unit_of_measurement_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
-  }
-
-  if (!obj->traits.get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->traits.get_device_class_ref().c_str());
+    obj->traits.log_device_class(tag, prefix);
   }
 }
 

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,9 +12,7 @@ namespace select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,7 +12,7 @@ namespace select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -11,8 +11,7 @@ namespace select {
 
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -9,16 +9,14 @@ static const char *const TAG = "sensor";
 // Function implementation of LOG_SENSOR macro to reduce code size
 void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *obj) {
   if (obj != nullptr) {
+    log_entity_name_icon_and_device_class(tag, prefix, type, obj, obj);
+
     ESP_LOGCONFIG(tag,
-                  "%s%s '%s'\n"
                   "%s  State Class: '%s'\n"
                   "%s  Unit of Measurement: '%s'\n"
                   "%s  Accuracy Decimals: %d",
-                  prefix, type, obj->get_name().c_str(), prefix,
-                  LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
+                  prefix, LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                   obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
-
-    log_entity_icon_and_device_class(tag, prefix, obj, obj);
 
     if (obj->get_force_update()) {
       ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -18,8 +18,7 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                   LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                   obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-    log_entity_device_class(tag, prefix, obj);
-    log_entity_icon(tag, prefix, obj);
+    log_entity_icon_and_device_class(tag, prefix, obj, obj);
 
     if (obj->get_force_update()) {
       ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -8,29 +8,22 @@ static const char *const TAG = "sensor";
 
 // Function implementation of LOG_SENSOR macro to reduce code size
 void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *obj) {
-  if (obj == nullptr) {
-    return;
-  }
+  if (obj != nullptr) {
+    ESP_LOGCONFIG(tag,
+                  "%s%s '%s'\n"
+                  "%s  State Class: '%s'\n"
+                  "%s  Unit of Measurement: '%s'\n"
+                  "%s  Accuracy Decimals: %d",
+                  prefix, type, obj->get_name().c_str(), prefix,
+                  LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
+                  obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-  ESP_LOGCONFIG(tag,
-                "%s%s '%s'\n"
-                "%s  State Class: '%s'\n"
-                "%s  Unit of Measurement: '%s'\n"
-                "%s  Accuracy Decimals: %d",
-                prefix, type, obj->get_name().c_str(), prefix,
-                LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
-                obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
+    obj->log_device_class(tag, prefix);
+    obj->log_icon(tag, prefix);
 
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-  }
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
-
-  if (obj->get_force_update()) {
-    ESP_LOGV(tag, "%s  Force Update: YES", prefix);
+    if (obj->get_force_update()) {
+      ESP_LOGV(tag, "%s  Force Update: YES", prefix);
+    }
   }
 }
 

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -18,8 +18,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                   LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                   obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-    obj->log_device_class(tag, prefix);
-    obj->log_icon(tag, prefix);
+    log_entity_device_class(tag, prefix, obj);
+    log_entity_icon(tag, prefix, obj);
 
     if (obj->get_force_update()) {
       ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -83,15 +83,11 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
       restore = obj->restore_mode & RESTORE_MODE_PERSISTENT_MASK ? LOG_STR("restore defaults to") : LOG_STR("always");
     }
 
-    // Build the base message with mandatory fields
-    ESP_LOGCONFIG(tag,
-                  "%s%s '%s'\n"
-                  "%s  Restore Mode: %s%s %s",
-                  prefix, type, obj->get_name().c_str(), prefix, LOG_STR_ARG(inverted), LOG_STR_ARG(restore),
+    log_entity_name_icon_and_device_class(tag, prefix, type, obj, obj);
+
+    ESP_LOGCONFIG(tag, "%s  Restore Mode: %s%s %s", prefix, LOG_STR_ARG(inverted), LOG_STR_ARG(restore),
                   LOG_STR_ARG(onoff));
 
-    // Add optional fields separately
-    log_entity_icon_and_device_class(tag, prefix, obj, obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -91,18 +91,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    if (!obj->get_icon_ref().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-    }
+    obj->log_icon(tag, prefix);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    if (!obj->get_device_class_ref().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-    }
+    obj->log_device_class(tag, prefix);
   }
 }
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -91,14 +91,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    obj->log_icon(tag, prefix);
+    log_entity_icon(tag, prefix, obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    obj->log_device_class(tag, prefix);
+    log_entity_device_class(tag, prefix, obj);
   }
 }
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -91,14 +91,13 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    log_entity_icon(tag, prefix, obj);
+    log_entity_icon_and_device_class(tag, prefix, obj, obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    log_entity_device_class(tag, prefix, obj);
   }
 }
 

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,9 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    (obj)->log_icon(TAG, prefix); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -11,8 +11,7 @@ namespace text {
 
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, (obj)); \
+    log_entity_name_and_icon(TAG, prefix, LOG_STR_LITERAL(type), (obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,7 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    (obj)->log_icon(TAG, prefix); \
+    log_entity_icon(TAG, prefix, (obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -9,8 +9,8 @@ static const char *const TAG = "text_sensor";
 void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    obj->log_device_class(tag, prefix);
-    obj->log_icon(tag, prefix);
+    log_entity_device_class(tag, prefix, obj);
+    log_entity_icon(tag, prefix, obj);
   }
 }
 

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -7,18 +7,10 @@ namespace text_sensor {
 static const char *const TAG = "text_sensor";
 
 void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
-  if (obj == nullptr) {
-    return;
-  }
-
-  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-  }
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
+  if (obj != nullptr) {
+    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+    obj->log_device_class(tag, prefix);
+    obj->log_icon(tag, prefix);
   }
 }
 

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -9,8 +9,7 @@ static const char *const TAG = "text_sensor";
 void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
   if (obj != nullptr) {
     ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_device_class(tag, prefix, obj);
-    log_entity_icon(tag, prefix, obj);
+    log_entity_icon_and_device_class(tag, prefix, obj, obj);
   }
 }
 

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -8,8 +8,7 @@ static const char *const TAG = "text_sensor";
 
 void log_text_sensor(const char *tag, const char *prefix, const char *type, TextSensor *obj) {
   if (obj != nullptr) {
-    ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-    log_entity_icon_and_device_class(tag, prefix, obj, obj);
+    log_entity_name_icon_and_device_class(tag, prefix, type, obj, obj);
   }
 }
 

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -19,7 +19,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    (obj)->log_device_class(TAG, prefix); \
+    log_entity_device_class(TAG, prefix, (obj)); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -19,9 +19,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    (obj)->log_device_class(TAG, prefix); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -19,7 +19,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_device_class(TAG, prefix, (obj)); \
+    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -14,12 +14,11 @@ const extern float VALVE_CLOSED;
 
 #define LOG_VALVE(prefix, type, obj) \
   if ((obj) != nullptr) { \
-    ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
+    log_entity_name_icon_and_device_class(TAG, prefix, LOG_STR_LITERAL(type), (obj), (obj)); \
     auto traits_ = (obj)->get_traits(); \
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_icon_and_device_class(TAG, prefix, (obj), (obj)); \
   }
 
 class Valve;

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -110,37 +110,28 @@ void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj)
 #endif
 }
 
-void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
-                                      const EntityBase_DeviceClass *device_class_obj) {
-#ifdef USE_ENTITY_ICON
-  auto icon_ref = icon_obj->get_icon_ref();
-  if (!icon_ref.empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_ref.c_str());
-  }
-#endif
-  auto device_class_ref = device_class_obj->get_device_class_ref();
+void log_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass *obj) {
+  auto device_class_ref = obj->get_device_class_ref();
   if (!device_class_ref.empty()) {
     ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
   }
 }
 
+void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
+                                      const EntityBase_DeviceClass *device_class_obj) {
+  log_entity_icon(tag, prefix, icon_obj);
+  log_device_class(tag, prefix, device_class_obj);
+}
+
 void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj) {
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-#ifdef USE_ENTITY_ICON
-  auto icon_ref = obj->get_icon_ref();
-  if (!icon_ref.empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_ref.c_str());
-  }
-#endif
+  log_entity_icon(tag, prefix, obj);
 }
 
 void log_entity_name_icon_and_device_class(const char *tag, const char *prefix, const char *type, const EntityBase *obj,
                                            const EntityBase_DeviceClass *device_class_obj) {
   log_entity_name_and_icon(tag, prefix, type, obj);
-  auto device_class_ref = device_class_obj->get_device_class_ref();
-  if (!device_class_ref.empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
-  }
+  log_device_class(tag, prefix, device_class_obj);
 }
 
 }  // namespace esphome

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -45,14 +45,6 @@ void EntityBase::set_icon(const char *icon) {
 #endif
 }
 
-void EntityBase::log_icon(const char *tag, const char *prefix) const {
-#ifdef USE_ENTITY_ICON
-  if (!this->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, this->get_icon_ref().c_str());
-  }
-#endif
-}
-
 // Check if the object_id is dynamic (changes with MAC suffix)
 bool EntityBase::is_object_id_dynamic_() const {
   return !this->flags_.has_own_name && App.is_name_add_mac_suffix_enabled();
@@ -99,12 +91,6 @@ std::string EntityBase_DeviceClass::get_device_class() {
 
 void EntityBase_DeviceClass::set_device_class(const char *device_class) { this->device_class_ = device_class; }
 
-void EntityBase_DeviceClass::log_device_class(const char *tag, const char *prefix) const {
-  if (!this->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, this->get_device_class_ref().c_str());
-  }
-}
-
 std::string EntityBase_UnitOfMeasurement::get_unit_of_measurement() {
   if (this->unit_of_measurement_ == nullptr)
     return "";
@@ -112,6 +98,21 @@ std::string EntityBase_UnitOfMeasurement::get_unit_of_measurement() {
 }
 void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_measurement) {
   this->unit_of_measurement_ = unit_of_measurement;
+}
+
+// Helper functions for logging entity attributes
+void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj) {
+#ifdef USE_ENTITY_ICON
+  if (!obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
+  }
+#endif
+}
+
+void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass *obj) {
+  if (!obj->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
+  }
 }
 
 }  // namespace esphome

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -119,4 +119,15 @@ void log_entity_icon_and_device_class(const char *tag, const char *prefix, const
   }
 }
 
+void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj) {
+  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+  log_entity_icon(tag, prefix, obj);
+}
+
+void log_entity_name_icon_and_device_class(const char *tag, const char *prefix, const char *type, const EntityBase *obj,
+                                           const EntityBase_DeviceClass *device_class_obj) {
+  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
+  log_entity_icon_and_device_class(tag, prefix, obj, device_class_obj);
+}
+
 }  // namespace esphome

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -45,6 +45,14 @@ void EntityBase::set_icon(const char *icon) {
 #endif
 }
 
+void EntityBase::log_icon(const char *tag, const char *prefix) const {
+#ifdef USE_ENTITY_ICON
+  if (!this->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, this->get_icon_ref().c_str());
+  }
+#endif
+}
+
 // Check if the object_id is dynamic (changes with MAC suffix)
 bool EntityBase::is_object_id_dynamic_() const {
   return !this->flags_.has_own_name && App.is_name_add_mac_suffix_enabled();
@@ -90,6 +98,12 @@ std::string EntityBase_DeviceClass::get_device_class() {
 }
 
 void EntityBase_DeviceClass::set_device_class(const char *device_class) { this->device_class_ = device_class; }
+
+void EntityBase_DeviceClass::log_device_class(const char *tag, const char *prefix) const {
+  if (!this->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, this->get_device_class_ref().c_str());
+  }
+}
 
 std::string EntityBase_UnitOfMeasurement::get_unit_of_measurement() {
   if (this->unit_of_measurement_ == nullptr)

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -103,21 +103,19 @@ void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_m
 // Helper functions for logging entity attributes
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj) {
 #ifdef USE_ENTITY_ICON
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
+  auto icon_ref = obj->get_icon_ref();
+  if (!icon_ref.empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_ref.c_str());
   }
 #endif
 }
 
 void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
                                       const EntityBase_DeviceClass *device_class_obj) {
-#ifdef USE_ENTITY_ICON
-  if (!icon_obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_obj->get_icon_ref().c_str());
-  }
-#endif
-  if (!device_class_obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_obj->get_device_class_ref().c_str());
+  log_entity_icon(tag, prefix, icon_obj);
+  auto device_class_ref = device_class_obj->get_device_class_ref();
+  if (!device_class_ref.empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
   }
 }
 

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -112,7 +112,12 @@ void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj)
 
 void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
                                       const EntityBase_DeviceClass *device_class_obj) {
-  log_entity_icon(tag, prefix, icon_obj);
+#ifdef USE_ENTITY_ICON
+  auto icon_ref = icon_obj->get_icon_ref();
+  if (!icon_ref.empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_ref.c_str());
+  }
+#endif
   auto device_class_ref = device_class_obj->get_device_class_ref();
   if (!device_class_ref.empty()) {
     ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
@@ -121,13 +126,21 @@ void log_entity_icon_and_device_class(const char *tag, const char *prefix, const
 
 void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj) {
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_icon(tag, prefix, obj);
+#ifdef USE_ENTITY_ICON
+  auto icon_ref = obj->get_icon_ref();
+  if (!icon_ref.empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_ref.c_str());
+  }
+#endif
 }
 
 void log_entity_name_icon_and_device_class(const char *tag, const char *prefix, const char *type, const EntityBase *obj,
                                            const EntityBase_DeviceClass *device_class_obj) {
-  ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_icon_and_device_class(tag, prefix, obj, device_class_obj);
+  log_entity_name_and_icon(tag, prefix, type, obj);
+  auto device_class_ref = device_class_obj->get_device_class_ref();
+  if (!device_class_ref.empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_ref.c_str());
+  }
 }
 
 }  // namespace esphome

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -109,9 +109,15 @@ void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj)
 #endif
 }
 
-void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass *obj) {
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
+void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
+                                      const EntityBase_DeviceClass *device_class_obj) {
+#ifdef USE_ENTITY_ICON
+  if (!icon_obj->get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, icon_obj->get_icon_ref().c_str());
+  }
+#endif
+  if (!device_class_obj->get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, device_class_obj->get_device_class_ref().c_str());
   }
 }
 

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -117,12 +117,6 @@ void log_device_class(const char *tag, const char *prefix, const EntityBase_Devi
   }
 }
 
-void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
-                                      const EntityBase_DeviceClass *device_class_obj) {
-  log_entity_icon(tag, prefix, icon_obj);
-  log_device_class(tag, prefix, device_class_obj);
-}
-
 void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj) {
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
   log_entity_icon(tag, prefix, obj);

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -74,9 +74,6 @@ class EntityBase {
 #endif
   }
 
-  /// Log entity icon if present (guarded by USE_ENTITY_ICON)
-  void log_icon(const char *tag, const char *prefix) const;
-
 #ifdef USE_DEVICES
   // Get/set this entity's device id
   uint32_t get_device_id() const {
@@ -174,9 +171,6 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
     return this->device_class_ == nullptr ? EMPTY_STRING : StringRef(this->device_class_);
   }
 
-  /// Log entity device class if present
-  void log_device_class(const char *tag, const char *prefix) const;
-
  protected:
   const char *device_class_{nullptr};  ///< Device class override
 };
@@ -253,5 +247,13 @@ template<typename T> class StatefulEntityBase : public EntityBase {
   CallbackManager<void(optional<T> previous, optional<T> current)> *full_state_callbacks_{};
   CallbackManager<void(T)> *state_callbacks_{};
 };
+
+// Helper functions for logging entity attributes
+
+/// Log entity icon if present (guarded by USE_ENTITY_ICON)
+void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj);
+
+/// Log entity device class if present
+void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass *obj);
 
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -253,7 +253,8 @@ template<typename T> class StatefulEntityBase : public EntityBase {
 /// Log entity icon if present (guarded by USE_ENTITY_ICON)
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj);
 
-/// Log entity device class if present
-void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass *obj);
+/// Log both entity icon and device class if present (combines both checks for efficiency)
+void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
+                                      const EntityBase_DeviceClass *device_class_obj);
 
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -253,10 +253,6 @@ template<typename T> class StatefulEntityBase : public EntityBase {
 /// Log entity icon if present (guarded by USE_ENTITY_ICON)
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj);
 
-/// Log both entity icon and device class if present (combines both checks for efficiency)
-void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
-                                      const EntityBase_DeviceClass *device_class_obj);
-
 /// Log entity name and icon (combines both for efficiency)
 void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj);
 

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -257,4 +257,11 @@ void log_entity_icon(const char *tag, const char *prefix, const EntityBase *obj)
 void log_entity_icon_and_device_class(const char *tag, const char *prefix, const EntityBase *icon_obj,
                                       const EntityBase_DeviceClass *device_class_obj);
 
+/// Log entity name and icon (combines both for efficiency)
+void log_entity_name_and_icon(const char *tag, const char *prefix, const char *type, const EntityBase *obj);
+
+/// Log entity name, icon, and device class (combines all three for maximum efficiency)
+void log_entity_name_icon_and_device_class(const char *tag, const char *prefix, const char *type, const EntityBase *obj,
+                                           const EntityBase_DeviceClass *device_class_obj);
+
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -74,6 +74,9 @@ class EntityBase {
 #endif
   }
 
+  /// Log entity icon if present (guarded by USE_ENTITY_ICON)
+  void log_icon(const char *tag, const char *prefix) const;
+
 #ifdef USE_DEVICES
   // Get/set this entity's device id
   uint32_t get_device_id() const {
@@ -171,6 +174,9 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
     return this->device_class_ == nullptr ? EMPTY_STRING : StringRef(this->device_class_);
   }
 
+  /// Log entity device class if present
+  void log_device_class(const char *tag, const char *prefix) const;
+
  protected:
   const char *device_class_{nullptr};  ///< Device class override
 };
@@ -247,4 +253,5 @@ template<typename T> class StatefulEntityBase : public EntityBase {
   CallbackManager<void(optional<T> previous, optional<T> current)> *full_state_callbacks_{};
   CallbackManager<void(T)> *state_callbacks_{};
 };
+
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

This PR eliminates duplicated icon and device class logging code across 14 entity components by creating a hierarchy of centralized logging helper functions in `entity_base.h/cpp`.

**Changes:**
- Added `log_entity_icon(tag, prefix, obj)` - Logs entity icon if present (guarded by `USE_ENTITY_ICON`)
- Added `log_device_class(tag, prefix, obj)` - Logs entity device class if present
- Added `log_entity_icon_and_device_class(tag, prefix, icon_obj, device_class_obj)` - Combines icon and device class logging
- Added `log_entity_name_and_icon(tag, prefix, type, obj)` - Logs entity name and icon in one call
- Added `log_entity_name_icon_and_device_class(tag, prefix, type, obj, device_class_obj)` - Logs name, icon, and device class in one call
- Updated all entity logging functions to use combined helpers instead of multiple separate calls

**Benefits:**
- **Flash savings**: -136 bytes on ESP8266, -736 bytes on ESP32-S3 production builds
- **Reduced function call overhead**: Components make 1 combined call instead of 3 separate calls
- **Code maintainability**: Single source of truth for entity logging patterns
- **Consistency**: All entities log these attributes the same way
- **Better conditional compilation**: Icon logging automatically compiled out when `USE_ENTITY_ICON` is disabled

**Components updated (14 total):**
- **Using `log_entity_name_icon_and_device_class()`**: sensor, text_sensor, binary_sensor, event, switch, valve, cover
- **Using `log_entity_name_and_icon()`**: button, select, text, lock, datetime (date, time, datetime entities)
- **Using `log_entity_name_and_icon()` + manual device class**: number

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Code quality improvement

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is purely an internal refactoring
```

## Flash Size Impact

Tested across multiple device configurations:

| Platform | Baseline Flash | After Optimization | Flash Savings | RAM Change |
|----------|----------------|-------------------|---------------|------------|
| **ESP8266 (Arduino)** | 357,675 bytes | 357,539 bytes | **-136 bytes** | 0 bytes |
| **ESP32-S3 (ESP-IDF, production)** | 898,735 bytes | 897,999 bytes | **-736 bytes** | 0 bytes |

**Total savings: 872 bytes across both platforms**

**Analysis**:
- The optimization creates a hierarchy of combined logging functions that reduce function call overhead
- ESP32-S3 sees much better savings because it has more components enabled, resulting in more duplicate code elimination
- All helper functions inline efficiently, allowing the compiler to optimize the entire call chain
- No RAM impact - this is purely a flash optimization

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).