### PR TITLE
[socket] Deduplicate IP formatting in LWIP raw TCP implementation

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -172,16 +172,7 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return "";
     }
-    char buffer[50] = {};
-    if (IP_IS_V4_VAL(pcb_->remote_ip)) {
-      inet_ntoa_r(pcb_->remote_ip, buffer, sizeof(buffer));
-    }
-#if LWIP_IPV6
-    else if (IP_IS_V6_VAL(pcb_->remote_ip)) {
-      inet6_ntoa_r(pcb_->remote_ip, buffer, sizeof(buffer));
-    }
-#endif
-    return std::string(buffer);
+    return this->format_ip_address_(pcb_->remote_ip);
   }
   int getsockname(struct sockaddr *name, socklen_t *addrlen) override {
     if (pcb_ == nullptr) {
@@ -199,16 +190,7 @@ class LWIPRawImpl : public Socket {
       errno = ECONNRESET;
       return "";
     }
-    char buffer[50] = {};
-    if (IP_IS_V4_VAL(pcb_->local_ip)) {
-      inet_ntoa_r(pcb_->local_ip, buffer, sizeof(buffer));
-    }
-#if LWIP_IPV6
-    else if (IP_IS_V6_VAL(pcb_->local_ip)) {
-      inet6_ntoa_r(pcb_->local_ip, buffer, sizeof(buffer));
-    }
-#endif
-    return std::string(buffer);
+    return this->format_ip_address_(pcb_->local_ip);
   }
   int getsockopt(int level, int optname, void *optval, socklen_t *optlen) override {
     if (pcb_ == nullptr) {
@@ -499,6 +481,19 @@ class LWIPRawImpl : public Socket {
   }
 
  protected:
+  std::string format_ip_address_(const ip_addr_t &ip) {
+    char buffer[50] = {};
+    if (IP_IS_V4_VAL(ip)) {
+      inet_ntoa_r(ip, buffer, sizeof(buffer));
+    }
+#if LWIP_IPV6
+    else if (IP_IS_V6_VAL(ip)) {
+      inet6_ntoa_r(ip, buffer, sizeof(buffer));
+    }
+#endif
+    return std::string(buffer);
+  }
+
   int ip2sockaddr_(ip_addr_t *ip, uint16_t port, struct sockaddr *name, socklen_t *addrlen) {
     if (family_ == AF_INET) {
       if (*addrlen < sizeof(struct sockaddr_in)) {


### PR DESCRIPTION
# What does this implement/fix?

Deduplicates IP address formatting code in the LWIP raw TCP socket implementation.

Both `getpeername()` and `getsockname()` had identical logic for formatting IP addresses to strings (IPv4 with `inet_ntoa_r` and IPv6 with `inet6_ntoa_r`). This refactors the duplicate code into a single `format_ip_address_()` helper method.

**Benefits:**
- Single source of truth for IP formatting logic
- Easier maintenance - only one place to update if formatting needs change
- Prevents accidental divergence between the two methods
- Clearer code intent with descriptive helper method

**Note:** This is a code quality improvement with no functional changes or binary size impact (compiler already optimizes to the same 2,773 B with `-Os`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code cleanup only)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal implementation only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
