### PR TITLE
[core] Use ESPDEPRECATED macro for deprecation warnings

### DIFF
--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -35,7 +35,7 @@ class Select : public EntityBase {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   /// @deprecated Use current_option() instead. This member will be removed in ESPHome 2026.5.0.
-  __attribute__((deprecated("Use current_option() instead of .state. Will be removed in 2026.5.0")))
+  ESPDEPRECATED("Use current_option() instead of .state. Will be removed in 2026.5.0", "2025.11.0")
   std::string state{};
 
   Select() = default;

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -61,9 +61,10 @@ class EntityBase {
   }
 
   // Get/set this entity's icon
-  [[deprecated("Use get_icon_ref() instead for better performance (avoids string copy). Will stop working in ESPHome "
-               "2026.5.0")]] std::string
-  get_icon() const;
+  ESPDEPRECATED(
+      "Use get_icon_ref() instead for better performance (avoids string copy). Will be removed in ESPHome 2026.5.0",
+      "2025.11.0")
+  std::string get_icon() const;
   void set_icon(const char *icon);
   StringRef get_icon_ref() const {
     static constexpr auto EMPTY_STRING = StringRef::from_lit("");
@@ -160,9 +161,10 @@ class EntityBase {
 class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
  public:
   /// Get the device class, using the manual override if set.
-  [[deprecated("Use get_device_class_ref() instead for better performance (avoids string copy). Will stop working in "
-               "ESPHome 2026.5.0")]] std::string
-  get_device_class();
+  ESPDEPRECATED("Use get_device_class_ref() instead for better performance (avoids string copy). Will be removed in "
+                "ESPHome 2026.5.0",
+                "2025.11.0")
+  std::string get_device_class();
   /// Manually set the device class.
   void set_device_class(const char *device_class);
   /// Get the device class as StringRef
@@ -178,9 +180,10 @@ class EntityBase_DeviceClass {  // NOLINT(readability-identifier-naming)
 class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
  public:
   /// Get the unit of measurement, using the manual override if set.
-  [[deprecated("Use get_unit_of_measurement_ref() instead for better performance (avoids string copy). Will stop "
-               "working in ESPHome 2026.5.0")]] std::string
-  get_unit_of_measurement();
+  ESPDEPRECATED("Use get_unit_of_measurement_ref() instead for better performance (avoids string copy). Will be "
+                "removed in ESPHome 2026.5.0",
+                "2025.11.0")
+  std::string get_unit_of_measurement();
   /// Manually set the unit of measurement.
   void set_unit_of_measurement(const char *unit_of_measurement);
   /// Get the unit of measurement as StringRef


### PR DESCRIPTION
# What does this implement/fix?

This PR updates all deprecation attributes in core files to use the `ESPDEPRECATED` macro consistently, following ESPHome's coding conventions.

**Note:** This change is being made in preparation for the contributing guide update in esphome/developers.esphome.io#65, which documents the `ESPDEPRECATED` macro as the standard deprecation pattern. This PR proactively aligns the codebase with the upcoming documentation standards.

## Changes

Replaced C++ standard deprecation attributes (`[[deprecated]]` and `__attribute__((deprecated))`) with the `ESPDEPRECATED` macro in the following locations:

### `esphome/core/entity_base.h`
- `EntityBase::get_icon()` - Use `get_icon_ref()` instead
- `EntityBase_DeviceClass::get_device_class()` - Use `get_device_class_ref()` instead
- `EntityBase_UnitOfMeasurement::get_unit_of_measurement()` - Use `get_unit_of_measurement_ref()` instead

### `esphome/components/select/select.h`
- `Select::state` field - Use `current_option()` instead

All deprecations now follow the standard format:
```cpp
ESPDEPRECATED("Use <new_method>() instead. Will be removed in ESPHome 2026.5.0", "2025.11.0")
```

## Benefits

1. **Consistency**: All deprecations now use the same macro format across the codebase
2. **Maintainability**: Easier to search and manage deprecations with a single pattern
3. **Standards compliance**: Follows the coding conventions documented in `code.md`
4. **No functional changes**: Same warnings are emitted, just using the proper ESPHome macro

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to esphome/developers.esphome.io#65 (contributing guide update documenting ESPDEPRECATED usage)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code quality improvement, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(All platforms - no platform-specific changes)

## Example entry for `config.yaml`:

N/A - This change does not affect user configuration. Deprecation warnings remain unchanged from a user perspective.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
