### PR TITLE
[ai_instructions] Add public API and breaking changes guidelines

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -450,7 +450,8 @@ This document provides essential context for AI models interacting with this pro
 
 *   **Public Python API:**
     *   All documented configuration options at [esphome.io](https://esphome.io) are public API.
-    *   Python code is internal unless explicitly documented for external component use.
+    *   Python code in `esphome/core/` actively used by existing core components is considered stable API.
+    *   Other Python code is internal unless explicitly documented for external component use.
 
 *   **Breaking Changes Policy:**
     *   Aim for **6-month deprecation window** when possible

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -440,3 +440,44 @@ This document provides essential context for AI models interacting with this pro
     *   **Python:** When adding a new Python dependency, add it to the appropriate `requirements*.txt` file and `pyproject.toml`.
     *   **C++ / PlatformIO:** When adding a new C++ dependency, add it to `platformio.ini` and use `cg.add_library`.
     *   **Build Flags:** Use `cg.add_build_flag(...)` to add compiler flags.
+
+## 8. Public API and Breaking Changes
+
+*   **Public C++ API:**
+    *   **Components**: Only documented features at [esphome.io](https://esphome.io) are public API. Undocumented `public` members are internal.
+    *   **Core/Base Classes** (`esphome/core/`, `Component`, `Sensor`, etc.): All `public` members are public API.
+    *   **Components with Global Accessors** (`global_api_server`, etc.): All `public` members are public API (except config setters).
+
+*   **Public Python API:**
+    *   All documented configuration options at [esphome.io](https://esphome.io) are public API.
+    *   Python code is internal unless explicitly documented for external component use.
+
+*   **Breaking Changes Policy:**
+    *   Aim for **6-month deprecation window** when possible
+    *   Clean breaks allowed for: signature changes, deep refactorings, resource constraints
+    *   Must document migration path in PR description (generates release notes)
+    *   Blog post required for core/base class changes or significant architectural changes
+    *   Full details: https://developers.esphome.io/contributing/code/#public-api-and-breaking-changes
+
+*   **Breaking Change Checklist:**
+    - [ ] Clear justification (RAM/flash savings, architectural improvement)
+    - [ ] Explored non-breaking alternatives
+    - [ ] Added deprecation warnings if possible (use `ESPDEPRECATED` macro for C++)
+    - [ ] Documented migration path in PR description with before/after examples
+    - [ ] Updated all internal usage and esphome-docs
+    - [ ] Tested backward compatibility during deprecation period
+
+*   **Deprecation Pattern (C++):**
+    ```cpp
+    // Remove before 2026.6.0
+    ESPDEPRECATED("Use new_method() instead. Removed in 2026.6.0", "2025.12.0")
+    void old_method() { this->new_method(); }
+    ```
+
+*   **Deprecation Pattern (Python):**
+    ```python
+    # Remove before 2026.6.0
+    if CONF_OLD_KEY in config:
+        _LOGGER.warning(f"'{CONF_OLD_KEY}' deprecated, use '{CONF_NEW_KEY}'. Removed in 2026.6.0")
+        config[CONF_NEW_KEY] = config.pop(CONF_OLD_KEY)  # Auto-migrate
+    ```


### PR DESCRIPTION
# What does this implement/fix?

Adds comprehensive public API and breaking changes guidelines to CLAUDE.md (AI collaboration guide) based on the recently merged documentation from https://github.com/esphome/developers.esphome.io/pull/65.

This update provides AI assistants with clear context about:
- What constitutes ESPHome's public C++ and Python APIs
- When changes are considered "breaking"
- Required deprecation processes and timelines (6-month window)
- When clean breaks are acceptable vs. requiring deprecation periods
- Practical code examples for deprecation patterns

**Benefits:**
- AI assistants can better evaluate whether proposed changes require deprecation warnings
- Reduces accidental breaking changes to public APIs
- Ensures AI-suggested refactorings follow project standards
- Provides quick reference to breaking change checklist and examples

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other (Documentation update to AI collaboration guide)

**Related issue or feature (if applicable):**

- Related: https://github.com/esphome/developers.esphome.io/pull/65

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This updates internal AI instructions (CLAUDE.md), not user-facing docs

## Test Environment

- N/A - Documentation-only change

## Example entry for `config.yaml`:

N/A - No configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).