### PR TITLE
[ci] Fix component batching for beta/release branches (3-4 → 40 per batch)

### DIFF
--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -19,6 +19,8 @@ sys.path.insert(0, script_dir)
 # Import helpers module for patching
 import helpers  # noqa: E402
 
+import script.helpers  # noqa: E402
+
 spec = importlib.util.spec_from_file_location(
     "determine_jobs", os.path.join(script_dir, "determine-jobs.py")
 )
@@ -125,6 +127,16 @@ def test_main_all_tests_should_run(
                 ["wifi", "api"] if not deps else ["wifi", "api", "sensor"]
             ),
         ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs,
+            "create_intelligent_batches",
+            return_value=([["wifi", "api", "sensor"]], {}),
+        ),
     ):
         determine_jobs.main()
 
@@ -196,6 +208,16 @@ def test_main_no_tests_should_run(
         patch.object(
             determine_jobs, "get_components_with_dependencies", return_value=[]
         ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs,
+            "create_intelligent_batches",
+            return_value=([], {}),
+        ),
     ):
         determine_jobs.main()
 
@@ -258,6 +280,16 @@ def test_main_with_branch_argument(
         ),
         patch.object(
             determine_jobs, "get_components_with_dependencies", return_value=["mqtt"]
+        ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs,
+            "create_intelligent_batches",
+            return_value=([["mqtt"]], {}),
         ),
     ):
         determine_jobs.main()
@@ -564,6 +596,11 @@ def test_main_filters_components_without_tests(
             ),
         ),
         patch.object(determine_jobs, "changed_files", return_value=[]),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
     ):
         # Clear the cache since we're mocking root_path
         determine_jobs.main()
@@ -663,6 +700,11 @@ def test_main_detects_components_with_variant_tests(
             ),
         ),
         patch.object(determine_jobs, "changed_files", return_value=[]),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
     ):
         # Clear the cache since we're mocking root_path
         determine_jobs.main()
@@ -1112,6 +1154,16 @@ def test_main_core_files_changed_still_detects_components(
                 else ["select", "api", "bluetooth_proxy", "logger"]
             ),
         ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs,
+            "create_intelligent_batches",
+            return_value=([["select", "api", "bluetooth_proxy", "logger"]], {}),
+        ),
     ):
         determine_jobs.main()
 
@@ -1353,3 +1405,99 @@ def test_detect_memory_impact_config_runs_at_component_limit(tmp_path: Path) -> 
     # Memory impact should run at exactly 40 components (at limit but not over)
     assert result["should_run"] == "true"
     assert len(result["components"]) == 40
+
+
+def test_component_batching_beta_branch_40_per_batch(
+    tmp_path: Path,
+    mock_should_run_integration_tests: Mock,
+    mock_should_run_clang_tidy: Mock,
+    mock_should_run_clang_format: Mock,
+    mock_should_run_python_linters: Mock,
+    mock_changed_files: Mock,
+    mock_determine_cpp_unit_tests: Mock,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test that beta/release branches create batches with 40 actual components each.
+
+    For beta/release branches, all components should be groupable (not isolated),
+    and each batch should contain 40 actual components with weight 1 each.
+    This matches the original behavior before consolidation.
+    """
+    # Create 120 test components with test files
+    component_names = [f"comp_{i:03d}" for i in range(120)]
+    tests_dir = tmp_path / "tests" / "components"
+
+    for comp in component_names:
+        comp_dir = tests_dir / comp
+        comp_dir.mkdir(parents=True)
+        (comp_dir / "test.esp32-idf.yaml").write_text(f"# Test for {comp}")
+
+    # Setup mocks
+    mock_should_run_integration_tests.return_value = False
+    mock_should_run_clang_tidy.return_value = False
+    mock_should_run_clang_format.return_value = False
+    mock_should_run_python_linters.return_value = False
+    mock_determine_cpp_unit_tests.return_value = (False, [])
+
+    # Mock changed_files to return all component files
+    changed_files = [
+        f"esphome/components/{comp}/{comp}.cpp" for comp in component_names
+    ]
+    mock_changed_files.return_value = changed_files
+
+    # Run main function with beta branch
+    # Don't mock create_intelligent_batches - that's what we're testing!
+    with (
+        patch("sys.argv", ["determine-jobs.py", "--branch", "beta"]),
+        patch.object(determine_jobs, "root_path", str(tmp_path)),
+        patch.object(helpers, "root_path", str(tmp_path)),
+        patch.object(script.helpers, "root_path", str(tmp_path)),
+        patch.object(determine_jobs, "get_target_branch", return_value="beta"),
+        patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=False),
+        patch.object(
+            determine_jobs,
+            "get_changed_components",
+            return_value=component_names,
+        ),
+        patch.object(
+            determine_jobs,
+            "filter_component_and_test_files",
+            side_effect=lambda f: f.startswith("esphome/components/"),
+        ),
+        patch.object(
+            determine_jobs,
+            "get_components_with_dependencies",
+            side_effect=lambda files, deps: component_names,
+        ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+    ):
+        determine_jobs.main()
+
+    # Check output
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+
+    # Verify batches are present and properly sized
+    assert "component_test_batches" in output
+    batches = output["component_test_batches"]
+
+    # Should have 3 batches (120 components / 40 per batch = 3)
+    assert len(batches) == 3, f"Expected 3 batches, got {len(batches)}"
+
+    # Each batch should have approximately 40 components (all weight=1, groupable)
+    for i, batch_str in enumerate(batches):
+        batch_components = batch_str.split()
+        assert len(batch_components) == 40, (
+            f"Batch {i} should have 40 components, got {len(batch_components)}"
+        )
+
+    # Verify all 120 components are in batches
+    all_components = []
+    for batch_str in batches:
+        all_components.extend(batch_str.split())
+    assert len(all_components) == 120
+    assert set(all_components) == set(component_names)


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes component test batching for beta/release branches, restoring the behavior where all components are grouped efficiently (40 per batch) instead of being isolated (3-4 per batch).

## Problem

After consolidating component splitting into `determine-jobs.py` (commit 08aae39ea), beta/release branch CI started producing inefficient batches:
- First batch: 40 components ✓
- Subsequent batches: Only 3-4 components ✗

**Root Cause:** All components were being marked as "isolated" (weight=10) instead of "groupable" (weight=1), because `directly_changed` was being populated with all components instead of being empty.

**Before consolidation (`.github/workflows/ci.yml`):**
```yaml
directly_changed='[]'  # Empty - all components groupable
```

**After consolidation (`determine-jobs.py`):**
```python
batch_directly_changed = directly_changed_with_tests  # ALL components isolated
```

## Solution

Added branch detection logic in `script/determine-jobs.py`:
- Beta/release branches: Use empty `directly_changed` set → all components groupable (weight=1) → 40 per batch
- Normal PRs: Use `directly_changed_with_tests` → only changed components isolated (weight=10)

## Additional Improvements

1. **Test Coverage:** Added `test_component_batching_beta_branch_40_per_batch` to verify beta branch batching
. **Test Performance:** Improved test suite performance from ~10s to ~1s by mocking expensive operations in non-critical tests

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (regression introduced during consolidation)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (CI-only changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - This is a CI infrastructure change only

## Example entry for `config.yaml`:

```yaml
# N/A - No user-facing configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

N/A - No user-facing changes
