### PR TITLE
Add an event component to the UART

### DIFF
--- a/esphome/components/uart/event/__init__.py
+++ b/esphome/components/uart/event/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import event, uart
+import esphome.config_validation as cv
 from esphome.const import CONF_EVENT_TYPES
 
 DEPENDENCIES = ["uart"]
@@ -12,20 +12,22 @@ UARTEvent = uart_ns.class_("UARTEvent", event.Event, uart.UARTDevice, cg.Compone
 def validate_event_types(value):
     if not isinstance(value, list):
         raise cv.Invalid("Event type must be a list of key-value mappings.")
-    
+
     processed = []
     for item in value:
         if not isinstance(item, dict):
             raise cv.Invalid(f"Event type item must be a mapping (dictionary): {item}")
         if len(item) != 1:
-            raise cv.Invalid(f"Event type item must be a single key-value mapping: {item}")
-        
+            raise cv.Invalid(
+                f"Event type item must be a single key-value mapping: {item}"
+            )
+
         # Get the single key-value pair
         event_name, match_data = next(iter(item.items()))
-        
+
         if not isinstance(event_name, str):
             raise cv.Invalid(f"Event name (key) must be a string: {event_name}")
-        
+
         try:
             # Try to validate as list of hex bytes
             match_data_bin = cv.ensure_list(cv.hex_uint8_t)(match_data)
@@ -46,10 +48,10 @@ def validate_event_types(value):
         raise cv.Invalid(
             f"Event match data for '{event_name}' must be a string or a list of hex bytes. Invalid data: {match_data}"
         )
-            
+
     if not processed:
         raise cv.Invalid("event_types must contain at least one event mapping.")
-        
+
     return processed
 
 

--- a/esphome/components/uart/event/__init__.py
+++ b/esphome/components/uart/event/__init__.py
@@ -2,7 +2,6 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import event, uart
 from esphome.const import CONF_EVENT_TYPES
-from esphome.core import HexInt
 
 DEPENDENCIES = ["uart"]
 

--- a/esphome/components/uart/event/__init__.py
+++ b/esphome/components/uart/event/__init__.py
@@ -1,0 +1,74 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import event, uart
+from esphome.const import CONF_EVENT_TYPES
+from esphome.core import HexInt
+
+DEPENDENCIES = ["uart"]
+
+uart_ns = cg.esphome_ns.namespace("esphome").namespace("uart")
+UARTEvent = uart_ns.class_("UARTEvent", event.Event, uart.UARTDevice, cg.Component)
+
+
+def validate_event_types(value):
+    if not isinstance(value, list):
+        raise cv.Invalid("Event type must be a list of key-value mappings.")
+    
+    processed = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise cv.Invalid(f"Event type item must be a mapping (dictionary): {item}")
+        if len(item) != 1:
+            raise cv.Invalid(f"Event type item must be a single key-value mapping: {item}")
+        
+        # Get the single key-value pair
+        event_name, match_data = next(iter(item.items()))
+        
+        if not isinstance(event_name, str):
+            raise cv.Invalid(f"Event name (key) must be a string: {event_name}")
+        
+        try:
+            # Try to validate as list of hex bytes
+            match_data_bin = cv.ensure_list(cv.hex_uint8_t)(match_data)
+            processed.append((event_name, match_data_bin))
+            continue
+        except cv.Invalid:
+            pass  # Not binary, try string
+
+        try:
+            # Try to validate as string
+            match_data_str = cv.string_strict(match_data)
+            processed.append((event_name, match_data_str))
+            continue
+        except cv.Invalid:
+            pass  # Not string either
+
+        # If neither validation passed
+        raise cv.Invalid(
+            f"Event match data for '{event_name}' must be a string or a list of hex bytes. Invalid data: {match_data}"
+        )
+            
+    if not processed:
+        raise cv.Invalid("event_types must contain at least one event mapping.")
+        
+    return processed
+
+
+CONFIG_SCHEMA = (
+    event.event_schema(UARTEvent)
+    .extend(
+        {
+            cv.Required(CONF_EVENT_TYPES): validate_event_types,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    event_names = [item[0] for item in config[CONF_EVENT_TYPES]]
+    var = await event.new_event(config, event_types=event_names)
+    await uart.register_uart_device(var, config)
+    for event_name, match_data in config[CONF_EVENT_TYPES]:
+        cg.add(var.add_event_matcher(event_name, match_data))

--- a/esphome/components/uart/event/uart_event.cpp
+++ b/esphome/components/uart/event/uart_event.cpp
@@ -17,7 +17,7 @@ void UARTEvent::dump_config() {
 }
 
 void UARTEvent::loop() {
-  read_data();
+  read_data_();
 }
 
 
@@ -37,7 +37,7 @@ void UARTEvent::add_event_matcher(const std::string &event_name, const std::vect
 }
 
 
-void UARTEvent::read_data() {
+void UARTEvent::read_data_() {
   while (available()) {
     uint8_t data;
     read_byte(&data);

--- a/esphome/components/uart/event/uart_event.cpp
+++ b/esphome/components/uart/event/uart_event.cpp
@@ -1,0 +1,72 @@
+#include "uart_event.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include <algorithm>
+
+namespace esphome {
+namespace uart {
+
+static const char *const TAG = "uart.event";
+
+void UARTEvent::setup() {
+  buffer_.clear();
+}
+
+void UARTEvent::dump_config() {
+  LOG_EVENT("", "UART Event", this);
+}
+
+void UARTEvent::loop() {
+  read_data();
+}
+
+
+void UARTEvent::add_event_matcher(const std::string &event_name, const std::string &match_string) {
+  std::vector<uint8_t> data(match_string.begin(), match_string.end());
+  this->matchers_.push_back({event_name, data});
+  if (data.size() > this->max_matcher_len_) {
+    this->max_matcher_len_ = data.size();
+  }
+}
+
+void UARTEvent::add_event_matcher(const std::string &event_name, const std::vector<uint8_t> &match_binary) {
+  this->matchers_.push_back({event_name, match_binary});
+  if (match_binary.size() > this->max_matcher_len_) {
+    this->max_matcher_len_ = match_binary.size();
+  }
+}
+
+
+void UARTEvent::read_data() {
+  while (available()) {
+    uint8_t data;
+    read_byte(&data);
+    this->buffer_.push_back(data);
+
+    bool match_found = false;
+    for (const auto &matcher : this->matchers_) {
+      const auto& match_data = matcher.binary_data;
+      
+      if (this->buffer_.size() < match_data.size()) {
+        continue;
+      }
+
+      if (std::equal(match_data.begin(), match_data.end(),
+                     this->buffer_.end() - match_data.size())) {
+        
+        this->trigger(matcher.event_name);
+        this->buffer_.clear();
+        match_found = true;
+        break;
+      }
+    }
+
+    if (!match_found && this->max_matcher_len_ > 0 && this->buffer_.size() > this->max_matcher_len_) {
+      this->buffer_.erase(this->buffer_.begin());
+    }
+  }
+}
+
+
+} // namespace uart
+} // namespace esphome

--- a/esphome/components/uart/event/uart_event.cpp
+++ b/esphome/components/uart/event/uart_event.cpp
@@ -8,18 +8,11 @@ namespace uart {
 
 static const char *const TAG = "uart.event";
 
-void UARTEvent::setup() {
-  buffer_.clear();
-}
+void UARTEvent::setup() { buffer_.clear(); }
 
-void UARTEvent::dump_config() {
-  LOG_EVENT("", "UART Event", this);
-}
+void UARTEvent::dump_config() { LOG_EVENT("", "UART Event", this); }
 
-void UARTEvent::loop() {
-  read_data_();
-}
-
+void UARTEvent::loop() { read_data_(); }
 
 void UARTEvent::add_event_matcher(const std::string &event_name, const std::string &match_string) {
   std::vector<uint8_t> data(match_string.begin(), match_string.end());
@@ -36,7 +29,6 @@ void UARTEvent::add_event_matcher(const std::string &event_name, const std::vect
   }
 }
 
-
 void UARTEvent::read_data_() {
   while (available()) {
     uint8_t data;
@@ -45,15 +37,13 @@ void UARTEvent::read_data_() {
 
     bool match_found = false;
     for (const auto &matcher : this->matchers_) {
-      const auto& match_data = matcher.binary_data;
-      
+      const auto &match_data = matcher.binary_data;
+
       if (this->buffer_.size() < match_data.size()) {
         continue;
       }
 
-      if (std::equal(match_data.begin(), match_data.end(),
-                     this->buffer_.end() - match_data.size())) {
-        
+      if (std::equal(match_data.begin(), match_data.end(), this->buffer_.end() - match_data.size())) {
         this->trigger(matcher.event_name);
         this->buffer_.clear();
         match_found = true;
@@ -67,6 +57,5 @@ void UARTEvent::read_data_() {
   }
 }
 
-
-} // namespace uart
-} // namespace esphome
+}  // namespace uart
+}  // namespace esphome

--- a/esphome/components/uart/event/uart_event.h
+++ b/esphome/components/uart/event/uart_event.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/event/event.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/log.h"
+#include <vector>
+#include <string>
+#include <map>
+
+namespace esphome {
+namespace uart {
+
+class UARTEvent :public event::Event
+                         ,public UARTDevice
+                         ,public Component{
+ protected:
+  struct EventMatcher {
+    std::string event_name;
+    std::vector<uint8_t> binary_data;
+  };
+
+  void read_data();
+  std::vector<EventMatcher> matchers_;
+  std::vector<uint8_t> buffer_;
+  size_t max_matcher_len_ = 0;
+  
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void add_event_matcher(const std::string &event_name, const std::string &match_string);
+  void add_event_matcher(const std::string &event_name, const std::vector<uint8_t> &match_binary);
+};
+
+} // namespace uart
+} // namespace esphome

--- a/esphome/components/uart/event/uart_event.h
+++ b/esphome/components/uart/event/uart_event.h
@@ -11,9 +11,7 @@
 namespace esphome {
 namespace uart {
 
-class UARTEvent :public event::Event
-                         ,public UARTDevice
-                         ,public Component{
+class UARTEvent : public event::Event, public UARTDevice, public Component {
  protected:
   struct EventMatcher {
     std::string event_name;
@@ -24,7 +22,7 @@ class UARTEvent :public event::Event
   std::vector<EventMatcher> matchers_;
   std::vector<uint8_t> buffer_;
   size_t max_matcher_len_ = 0;
-  
+
  public:
   void setup() override;
   void loop() override;
@@ -34,5 +32,5 @@ class UARTEvent :public event::Event
   void add_event_matcher(const std::string &event_name, const std::vector<uint8_t> &match_binary);
 };
 
-} // namespace uart
-} // namespace esphome
+}  // namespace uart
+}  // namespace esphome

--- a/esphome/components/uart/event/uart_event.h
+++ b/esphome/components/uart/event/uart_event.h
@@ -20,7 +20,7 @@ class UARTEvent :public event::Event
     std::vector<uint8_t> binary_data;
   };
 
-  void read_data();
+  void read_data_();
   std::vector<EventMatcher> matchers_;
   std::vector<uint8_t> buffer_;
   size_t max_matcher_len_ = 0;

--- a/tests/components/uart/test.esp32-idf.yaml
+++ b/tests/components/uart/test.esp32-idf.yaml
@@ -57,3 +57,11 @@ button:
     name: "UART Button String"
     uart_id: uart_uart
     data: "BUTTON_PRESS"
+
+event:
+  - platform: uart
+    uart_id: uart_uart
+    name: "UART Event"
+    event_types:
+      - "EVENT-A": "*A#"
+      - "EVENT-B": [0x2A, 0x42, 0x23]

--- a/tests/components/uart/test.esp8266-ard.yaml
+++ b/tests/components/uart/test.esp8266-ard.yaml
@@ -31,3 +31,11 @@ button:
     name: "UART Button"
     uart_id: uart_uart
     data: [0xFF, 0xEE]
+
+event:
+  - platform: uart
+    uart_id: uart_uart
+    name: "UART Event"
+    event_types:
+      - "EVENT-A": "*A#"
+      - "EVENT-B": [0x2A, 0x42, 0x23]


### PR DESCRIPTION
# What does this implement/fix?

Add uart event component. This component allows users to monitor the UART bus and trigger ESPHome events upon receiving an exact matching string or hexadecimal byte sequence.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
uart:
  - id: uart_uart
    tx_pin: D4
    rx_pin: D5
    baud_rate: 9600
event:
  - platform: uart
    uart_id: uart_uart
    name: "UART Event"
    event_types:
      - "EVENT-A": "*A#"
      - "EVENT-B": [0x2A, 0x42, 0x23]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
