### PR TITLE
[event] Store event types in flash memory

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -2147,7 +2147,7 @@ message ListEntitiesEventResponse {
   EntityCategory entity_category = 7;
   string device_class = 8;
 
-  repeated string event_types = 9;
+  repeated string event_types = 9 [(container_pointer_no_template) = "FixedVector<const char *>"];
   uint32 device_id = 10 [(field_ifdef) = "USE_DEVICES"];
 }
 message EventResponse {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -2147,7 +2147,7 @@ message ListEntitiesEventResponse {
   EntityCategory entity_category = 7;
   string device_class = 8;
 
-  repeated string event_types = 9 [(container_pointer_no_template) = "FixedVector<const char *>"];
+  repeated string event_types = 9 [(container_pointer_no_template) = "std::vector<const char *>"];
   uint32 device_id = 10 [(field_ifdef) = "USE_DEVICES"];
 }
 message EventResponse {

--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -2147,7 +2147,7 @@ message ListEntitiesEventResponse {
   EntityCategory entity_category = 7;
   string device_class = 8;
 
-  repeated string event_types = 9 [(container_pointer_no_template) = "std::vector<const char *>"];
+  repeated string event_types = 9 [(container_pointer_no_template) = "FixedVector<const char *>"];
   uint32 device_id = 10 [(field_ifdef) = "USE_DEVICES"];
 }
 message EventResponse {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1310,8 +1310,7 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
   auto *event = static_cast<event::Event *>(entity);
   ListEntitiesEventResponse msg;
   msg.set_device_class(event->get_device_class_ref());
-  for (const char *event_type : event->get_event_types())
-    msg.event_types->push_back(event_type);
+  msg.event_types = &event->get_event_types();
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1311,7 +1311,7 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
   ListEntitiesEventResponse msg;
   msg.set_device_class(event->get_device_class_ref());
   for (const char *event_type : event->get_event_types())
-    msg.event_types.push_back(event_type);
+    msg.event_types->push_back(event_type);
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1310,7 +1310,7 @@ uint16_t APIConnection::try_send_event_info(EntityBase *entity, APIConnection *c
   auto *event = static_cast<event::Event *>(entity);
   ListEntitiesEventResponse msg;
   msg.set_device_class(event->get_device_class_ref());
-  for (const auto &event_type : event->get_event_types())
+  for (const char *event_type : event->get_event_types())
     msg.event_types.push_back(event_type);
   return fill_and_encode_entity_info(event, msg, ListEntitiesEventResponse::MESSAGE_TYPE, conn, remaining_size,
                                      is_single);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2877,8 +2877,8 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_bool(6, this->disabled_by_default);
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_string(8, this->device_class_ref_);
-  for (auto &it : this->event_types) {
-    buffer.encode_string(9, it, true);
+  for (const char *it : *this->event_types) {
+    buffer.encode_string(9, it, strlen(it), true);
   }
 #ifdef USE_DEVICES
   buffer.encode_uint32(10, this->device_id);
@@ -2894,9 +2894,9 @@ void ListEntitiesEventResponse::calculate_size(ProtoSize &size) const {
   size.add_bool(1, this->disabled_by_default);
   size.add_uint32(1, static_cast<uint32_t>(this->entity_category));
   size.add_length(1, this->device_class_ref_.size());
-  if (!this->event_types.empty()) {
-    for (const auto &it : this->event_types) {
-      size.add_length_force(1, it.size());
+  if (!this->event_types->empty()) {
+    for (const char *it : *this->event_types) {
+      size.add_length_force(1, strlen(it));
     }
   }
 #ifdef USE_DEVICES

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2788,7 +2788,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
 #endif
   StringRef device_class_ref_{};
   void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
-  std::vector<std::string> event_types{};
+  const FixedVector<const char *> *event_types{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2788,7 +2788,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
 #endif
   StringRef device_class_ref_{};
   void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
-  const FixedVector<const char *> *event_types{};
+  const std::vector<const char *> *event_types{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -2788,7 +2788,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
 #endif
   StringRef device_class_ref_{};
   void set_device_class(const StringRef &ref) { this->device_class_ref_ = ref; }
-  const std::vector<const char *> *event_types{};
+  const FixedVector<const char *> *event_types{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -2053,7 +2053,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   dump_field(out, "disabled_by_default", this->disabled_by_default);
   dump_field(out, "entity_category", static_cast<enums::EntityCategory>(this->entity_category));
   dump_field(out, "device_class", this->device_class_ref_);
-  for (const auto &it : this->event_types) {
+  for (const auto &it : *this->event_types) {
     dump_field(out, "event_types", it, 4);
   }
 #ifdef USE_DEVICES

--- a/esphome/components/event/event.cpp
+++ b/esphome/components/event/event.cpp
@@ -25,6 +25,22 @@ void Event::trigger(const std::string &event_type) {
   this->event_callback_.call(event_type);
 }
 
+void Event::set_event_types(const FixedVector<const char *> &event_types) {
+  this->types_.init(event_types.size());
+  for (const char *type : event_types) {
+    this->types_.push_back(type);
+  }
+  this->last_event_type_ = nullptr;  // Reset when types change
+}
+
+void Event::set_event_types(const std::vector<const char *> &event_types) {
+  this->types_.init(event_types.size());
+  for (const char *type : event_types) {
+    this->types_.push_back(type);
+  }
+  this->last_event_type_ = nullptr;  // Reset when types change
+}
+
 void Event::add_on_event_callback(std::function<void(const std::string &event_type)> &&callback) {
   this->event_callback_.add(std::move(callback));
 }

--- a/esphome/components/event/event.cpp
+++ b/esphome/components/event/event.cpp
@@ -20,8 +20,8 @@ void Event::trigger(const std::string &event_type) {
     ESP_LOGE(TAG, "'%s': invalid event type for trigger(): %s", this->get_name().c_str(), event_type.c_str());
     return;
   }
-  this->last_event_type = found;
-  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), this->last_event_type);
+  this->last_event_type_ = found;
+  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), this->last_event_type_);
   this->event_callback_.call(event_type);
 }
 

--- a/esphome/components/event/event.cpp
+++ b/esphome/components/event/event.cpp
@@ -8,11 +8,11 @@ namespace event {
 static const char *const TAG = "event";
 
 void Event::trigger(const std::string &event_type) {
-  // Linear search - faster than std::set for small datasets (1-5 items typical)
-  const std::string *found = nullptr;
-  for (const auto &type : this->types_) {
-    if (type == event_type) {
-      found = &type;
+  // Linear search with strcmp - faster than std::set for small datasets (1-5 items typical)
+  const char *found = nullptr;
+  for (const char *type : this->types_) {
+    if (strcmp(type, event_type.c_str()) == 0) {
+      found = type;
       break;
     }
   }
@@ -20,8 +20,8 @@ void Event::trigger(const std::string &event_type) {
     ESP_LOGE(TAG, "'%s': invalid event type for trigger(): %s", this->get_name().c_str(), event_type.c_str());
     return;
   }
-  last_event_type = found;
-  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), last_event_type->c_str());
+  this->last_event_type = found;
+  ESP_LOGD(TAG, "'%s' Triggered event '%s'", this->get_name().c_str(), this->last_event_type);
   this->event_callback_.call(event_type);
 }
 

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
@@ -30,13 +31,23 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
     this->types_ = event_types;
     this->last_event_type_ = nullptr;  // Reset when types change
   }
+  /// Set the event types supported by this event (from vector).
+  void set_event_types(const std::vector<const char *> &event_types) {
+    this->types_ = event_types;
+    this->last_event_type_ = nullptr;  // Reset when types change
+  }
+  /// Set the event types supported by this event (from C array).
+  template<size_t N> void set_event_types(const char *const (&event_types)[N]) {
+    this->types_.assign(event_types, event_types + N);
+    this->last_event_type_ = nullptr;  // Reset when types change
+  }
 
   // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
   void set_event_types(std::initializer_list<std::string> event_types) = delete;
-  void set_event_types(const FixedVector<std::string> &event_types) = delete;
+  void set_event_types(const std::vector<std::string> &event_types) = delete;
 
   /// Return the event types supported by this event.
-  const FixedVector<const char *> &get_event_types() const { return this->types_; }
+  const std::vector<const char *> &get_event_types() const { return this->types_; }
 
   /// Return the last triggered event type (pointer to string in types_), or nullptr if no event triggered yet.
   const char *get_last_event_type() const { return this->last_event_type_; }
@@ -45,7 +56,7 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
 
  protected:
   CallbackManager<void(const std::string &event_type)> event_callback_;
-  FixedVector<const char *> types_;
+  std::vector<const char *> types_;
 
  private:
   /// Last triggered event type - must point to entry in types_ to ensure valid lifetime.

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -23,17 +23,22 @@ namespace event {
 
 class Event : public EntityBase, public EntityBase_DeviceClass {
  public:
-  const char *last_event_type{nullptr};
-
   void trigger(const std::string &event_type);
 
   /// Set the event types supported by this event (from initializer list).
-  void set_event_types(std::initializer_list<const char *> event_types) { this->types_ = event_types; }
+  void set_event_types(std::initializer_list<const char *> event_types) {
+    this->types_ = event_types;
+    this->last_event_type_ = nullptr;  // Reset when types change
+  }
   /// Set the event types supported by this event (from FixedVector).
-  void set_event_types(const FixedVector<const char *> &event_types) { this->types_ = event_types; }
+  void set_event_types(const FixedVector<const char *> &event_types) {
+    this->types_ = event_types;
+    this->last_event_type_ = nullptr;  // Reset when types change
+  }
   /// Set the event types supported by this event (from C array).
   template<size_t N> void set_event_types(const char *const (&event_types)[N]) {
     this->types_.assign(event_types, event_types + N);
+    this->last_event_type_ = nullptr;  // Reset when types change
   }
 
   // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
@@ -43,11 +48,19 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
   /// Return the event types supported by this event.
   const FixedVector<const char *> &get_event_types() const { return this->types_; }
 
+  /// Return the last triggered event type (pointer to string in types_), or nullptr if no event triggered yet.
+  const char *get_last_event_type() const { return this->last_event_type_; }
+
   void add_on_event_callback(std::function<void(const std::string &event_type)> &&callback);
 
  protected:
   CallbackManager<void(const std::string &event_type)> event_callback_;
   FixedVector<const char *> types_;
+
+ private:
+  /// Last triggered event type - must point to entry in types_ to ensure valid lifetime.
+  /// Set by trigger() after validation, reset to nullptr when types_ changes.
+  const char *last_event_type_{nullptr};
 };
 
 }  // namespace event

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -36,11 +36,6 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
     this->types_ = event_types;
     this->last_event_type_ = nullptr;  // Reset when types change
   }
-  /// Set the event types supported by this event (from C array).
-  template<size_t N> void set_event_types(const char *const (&event_types)[N]) {
-    this->types_.assign(event_types, event_types + N);
-    this->last_event_type_ = nullptr;  // Reset when types change
-  }
 
   // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
   void set_event_types(std::initializer_list<std::string> event_types) = delete;

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -31,18 +31,18 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
     this->types_ = event_types;
     this->last_event_type_ = nullptr;  // Reset when types change
   }
+  /// Set the event types supported by this event (from FixedVector).
+  void set_event_types(const FixedVector<const char *> &event_types);
   /// Set the event types supported by this event (from vector).
-  void set_event_types(const std::vector<const char *> &event_types) {
-    this->types_ = event_types;
-    this->last_event_type_ = nullptr;  // Reset when types change
-  }
+  void set_event_types(const std::vector<const char *> &event_types);
 
   // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
   void set_event_types(std::initializer_list<std::string> event_types) = delete;
+  void set_event_types(const FixedVector<std::string> &event_types) = delete;
   void set_event_types(const std::vector<std::string> &event_types) = delete;
 
   /// Return the event types supported by this event.
-  const std::vector<const char *> &get_event_types() const { return this->types_; }
+  const FixedVector<const char *> &get_event_types() const { return this->types_; }
 
   /// Return the last triggered event type (pointer to string in types_), or nullptr if no event triggered yet.
   const char *get_last_event_type() const { return this->last_event_type_; }
@@ -51,7 +51,7 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
 
  protected:
   CallbackManager<void(const std::string &event_type)> event_callback_;
-  std::vector<const char *> types_;
+  FixedVector<const char *> types_;
 
  private:
   /// Last triggered event type - must point to entry in types_ to ensure valid lifetime.

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <string>
 
 #include "esphome/core/component.h"
@@ -22,16 +23,31 @@ namespace event {
 
 class Event : public EntityBase, public EntityBase_DeviceClass {
  public:
-  const std::string *last_event_type;
+  const char *last_event_type{nullptr};
 
   void trigger(const std::string &event_type);
-  void set_event_types(const std::initializer_list<std::string> &event_types) { this->types_ = event_types; }
-  const FixedVector<std::string> &get_event_types() const { return this->types_; }
+
+  /// Set the event types supported by this event (from initializer list).
+  void set_event_types(std::initializer_list<const char *> event_types) { this->types_ = event_types; }
+  /// Set the event types supported by this event (from FixedVector).
+  void set_event_types(const FixedVector<const char *> &event_types) { this->types_ = event_types; }
+  /// Set the event types supported by this event (from C array).
+  template<size_t N> void set_event_types(const char *const (&event_types)[N]) {
+    this->types_.assign(event_types, event_types + N);
+  }
+
+  // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
+  void set_event_types(std::initializer_list<std::string> event_types) = delete;
+  void set_event_types(const FixedVector<std::string> &event_types) = delete;
+
+  /// Return the event types supported by this event.
+  const FixedVector<const char *> &get_event_types() const { return this->types_; }
+
   void add_on_event_callback(std::function<void(const std::string &event_type)> &&callback);
 
  protected:
   CallbackManager<void(const std::string &event_type)> event_callback_;
-  FixedVector<std::string> types_;
+  FixedVector<const char *> types_;
 };
 
 }  // namespace event

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -30,16 +30,6 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
     this->types_ = event_types;
     this->last_event_type_ = nullptr;  // Reset when types change
   }
-  /// Set the event types supported by this event (from FixedVector).
-  void set_event_types(const FixedVector<const char *> &event_types) {
-    this->types_ = event_types;
-    this->last_event_type_ = nullptr;  // Reset when types change
-  }
-  /// Set the event types supported by this event (from C array).
-  template<size_t N> void set_event_types(const char *const (&event_types)[N]) {
-    this->types_.assign(event_types, event_types + N);
-    this->last_event_type_ = nullptr;  // Reset when types change
-  }
 
   // Deleted overloads to catch incorrect std::string usage at compile time with clear error messages
   void set_event_types(std::initializer_list<std::string> event_types) = delete;

--- a/esphome/components/mqtt/mqtt_event.cpp
+++ b/esphome/components/mqtt/mqtt_event.cpp
@@ -38,8 +38,8 @@ void MQTTEventComponent::setup() {
 void MQTTEventComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "MQTT Event '%s': ", this->event_->get_name().c_str());
   ESP_LOGCONFIG(TAG, "Event Types: ");
-  for (const auto &event_type : this->event_->get_event_types()) {
-    ESP_LOGCONFIG(TAG, "- %s", event_type.c_str());
+  for (const char *event_type : this->event_->get_event_types()) {
+    ESP_LOGCONFIG(TAG, "- %s", event_type);
   }
   LOG_MQTT_COMPONENT(true, true);
 }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1649,7 +1649,7 @@ std::string WebServer::event_json(event::Event *obj, const std::string &event_ty
   }
   if (start_config == DETAIL_ALL) {
     JsonArray event_types = root["event_types"].to<JsonArray>();
-    for (auto const &event_type : obj->get_event_types()) {
+    for (const char *event_type : obj->get_event_types()) {
       event_types.add(event_type);
     }
     root["device_class"] = obj->get_device_class_ref();

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1628,7 +1628,8 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
 }
 
 static std::string get_event_type(event::Event *event) {
-  return (event && event->get_last_event_type()) ? event->get_last_event_type() : "";
+  const char *last_type = event ? event->get_last_event_type() : nullptr;
+  return last_type ? last_type : "";
 }
 
 std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1628,7 +1628,7 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
 }
 
 static std::string get_event_type(event::Event *event) {
-  return (event && event->last_event_type) ? *event->last_event_type : "";
+  return (event && event->get_last_event_type()) ? event->get_last_event_type() : "";
 }
 
 std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {


### PR DESCRIPTION
Note: I realized I forgot to do the 2nd pr for event when I was writing https://github.com/esphome/developers.esphome.io/pull/71 so tagged for 2025.11.0b1 so we don't have to do two have downstream change things twice.

# What does this implement/fix?

Replaces `FixedVector<std::string>` with `FixedVector<const char *>` for Event entity event type storage, eliminating std::string heap allocations and storing strings in flash/rodata.

**Context:** [PR #11463](https://github.com/esphome/esphome/pull/11463) replaced `std::set<std::string>` with `FixedVector<std::string>` (~80 bytes std::set overhead eliminated). This PR completes the optimization by replacing `FixedVector<std::string>` with `FixedVector<const char *>`.

**Memory savings:**
- Eliminates std::string heap allocations for each event type string
- **ESP32**: Event type strings stored in flash (ROM), saving heap
- **ESP8266**: Event type strings in rodata section (still RAM, but eliminates std::string overhead)
- Typical savings: 24+ bytes per event type string (std::string overhead + string content)

**Changes:**
- Event entity: `FixedVector<std::string>` → `FixedVector<const char *>`
- Setter accepts initializer_list, FixedVector, or vector of const char * (string literals)
- Added deleted overloads for compile-time safety against std::string usage
- Updated `trigger()` to use `strcmp()` for const char* comparison
- Moved `last_event_type` to private with `get_last_event_type()` getter for pointer lifetime safety
- Updated all consuming components (mqtt, api, web_server)
- Updated api.proto with `container_pointer_no_template` annotation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of memory optimization effort for embedded systems

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Breaking Changes

**What breaks:**
- External components explicitly passing `FixedVector<std::string>`, `std::vector<std::string>`, or `std::initializer_list<std::string>` to `set_event_types()` will fail at compile time (deleted overload)
- External components storing result of `get_event_types()` as `FixedVector<std::string>` or `std::vector<std::string>` will fail at compile time (type mismatch)
- External components iterating with `for (const std::string &event_type : ...)` will fail at compile time (type mismatch)
- External components accessing `last_event_type` field directly will fail at compile time (now private, use `get_last_event_type()` getter)

**Migration guide:**

1. **Setting event types** - Use string literals (most common, no changes needed):
   ```cpp
   // Still works - no changes needed
   event->set_event_types({"single", "double", "long"});
   ```

2. **Getting event types** - Change return type (if storing result):
   ```cpp
   // Before:
   const FixedVector<std::string> &types = event->get_event_types();

   // After:
   const std::vector<const char *> &types = event->get_event_types();
   // Or simply use auto:
   const auto &types = event->get_event_types();

   // Most code just iterates directly (no changes needed):
   for (const char *type : event->get_event_types()) { ... }
   ```

3. **Iterating event types** - Change loop variable type:
   ```cpp
   // Before:
   for (const std::string &event_type : event->get_event_types()) { ... }

   // After:
   for (const char *event_type : event->get_event_types()) { ... }
   ```

4. **Accessing last_event_type** - Use getter instead of field:
   ```cpp
   // Before:
   if (event->last_event_type != nullptr) {
     ESP_LOGD(TAG, "Last: %s", event->last_event_type);
   }

   // After:
   if (event->get_last_event_type() != nullptr) {
     ESP_LOGD(TAG, "Last: %s", event->get_last_event_type());
   }
   ```

5. **Checking if event type exists** - Use strcmp or create helper:
   ```cpp
   // Option 1: Manual strcmp
   bool found = false;
   for (const char *type : event->get_event_types()) {
     if (strcmp(type, "single") == 0) {
       found = true;
       break;
     }
   }

   // Option 2: FixedVector has iterators, can use std::find_if
   #include <algorithm>
   auto &types = event->get_event_types();
   auto it = std::find_if(types.begin(), types.end(),
     [](const char *t) { return strcmp(t, "single") == 0; });
   bool found = (it != types.end());
   ```

**Pointer lifetime safety:**
- `last_event_type` moved to private with getter to ensure it always points to a string in `types_` (or is nullptr)
- Prevents dangling pointer bugs when event types are reconfigured
- Field is reset to nullptr when `set_event_types()` is called, then set to validated pointer in `trigger()`

**Core components updated:**
- No core ESPHome components needed changes (all use initializer_list syntax which still works)
- mqtt/mqtt_event.cpp - Updated loop variable
- api/api_connection.cpp - Updated loop variable
- web_server/web_server.cpp - Updated loop variable to const char *, fixed last_event_type to use getter
- api/api.proto - Added container annotation

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config.yaml changes - user-facing syntax unchanged
# Event types still defined the same way in components

# Example: doorbellimport esphome
event:
  - platform: template
    name: "Doorbell"
    id: doorbell_event
    event_types:
      - "single"
      - "double"
      - "long"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
