### PR TITLE
[bl0940] Fix calibration number preference hash for multi-device configs

### DIFF
--- a/esphome/components/bl0940/number/calibration_number.cpp
+++ b/esphome/components/bl0940/number/calibration_number.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "bl0940.number";
 void CalibrationNumber::setup() {
   float value = 0.0f;
   if (this->restore_value_) {
-    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
     if (!this->pref_.load(&value)) {
       value = 0.0f;
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes the BL0940 calibration number to use the correct preference hash method that accounts for multi-device configurations.

## Problem

The `CalibrationNumber::setup()` method was using `get_object_id_hash()` directly to create preferences, which bypasses the proper device ID handling provided by `get_preference_hash()`.

In multi-device configurations (when `USE_DEVICES` is defined), this would cause preference collisions when the same calibration number entity exists on multiple devices, as all devices would share the same preference storage key.

## Solution

Changed `esphome/components/bl0940/number/calibration_number.cpp:12` from:
```cpp
this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
```

to:
```cpp
this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
```

This is consistent with all other Number components in the codebase (e.g., `opentherm_number`, `template_number`, `tuya_number`).

## Impact

- **Single-device configs**: No change in behavior (backward compatible)
- **Multi-device configs**: Calibration values are now correctly isolated per device

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal bug fix, no user-facing documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 4800

sensor:
  - platform: bl0940
    voltage:
      name: 'Voltage'
    current:
      name: 'Current'

number:
  - platform: bl0940
    calibration_number:
      name: 'Power Calibration'
      restore_value: true  # Will now correctly persist per device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
