### PR TITLE
[sx126x] Change BUSY, RST, DIO1 pins to general GPIO (from internal)

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -189,7 +189,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(SX126x),
             cv.Optional(CONF_BANDWIDTH, default="125_0kHz"): cv.enum(BW),
             cv.Optional(CONF_BITRATE, default=4800): cv.int_range(min=600, max=300000),
-            cv.Required(CONF_BUSY_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Required(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
             cv.Optional(CONF_CODING_RATE, default="CR_4_5"): cv.enum(CODING_RATE),
             cv.Optional(CONF_CRC_ENABLE, default=False): cv.boolean,
             cv.Optional(CONF_CRC_INVERTED, default=True): cv.boolean,
@@ -201,7 +201,7 @@ CONFIG_SCHEMA = (
                 cv.hex_int, cv.Range(min=0, max=0xFFFF)
             ),
             cv.Optional(CONF_DEVIATION, default=5000): cv.int_range(min=0, max=100000),
-            cv.Required(CONF_DIO1_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Required(CONF_DIO1_PIN): pins.gpio_input_pin_schema,
             cv.Required(CONF_FREQUENCY): cv.int_range(min=137000000, max=1020000000),
             cv.Required(CONF_HW_VERSION): cv.one_of(
                 "sx1261", "sx1262", "sx1268", "llcc68", lower=True
@@ -213,7 +213,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_PAYLOAD_LENGTH, default=0): cv.int_range(min=0, max=256),
             cv.Optional(CONF_PREAMBLE_DETECT, default=2): cv.int_range(min=0, max=4),
             cv.Optional(CONF_PREAMBLE_SIZE, default=8): cv.int_range(min=1, max=65535),
-            cv.Required(CONF_RST_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Required(CONF_RST_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_RX_START, default=True): cv.boolean,
             cv.Required(CONF_RF_SWITCH): cv.boolean,
             cv.Optional(CONF_SHAPING, default="NONE"): cv.enum(SHAPING),

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -64,7 +64,7 @@ class SX126x : public Component,
   void dump_config() override;
   void set_bandwidth(SX126xBw bandwidth) { this->bandwidth_ = bandwidth; }
   void set_bitrate(uint32_t bitrate) { this->bitrate_ = bitrate; }
-  void set_busy_pin(InternalGPIOPin *busy_pin) { this->busy_pin_ = busy_pin; }
+  void set_busy_pin(GPIOPin *busy_pin) { this->busy_pin_ = busy_pin; }
   void set_coding_rate(uint8_t coding_rate) { this->coding_rate_ = coding_rate; }
   void set_crc_enable(bool crc_enable) { this->crc_enable_ = crc_enable; }
   void set_crc_inverted(bool crc_inverted) { this->crc_inverted_ = crc_inverted; }
@@ -72,7 +72,7 @@ class SX126x : public Component,
   void set_crc_polynomial(uint16_t crc_polynomial) { this->crc_polynomial_ = crc_polynomial; }
   void set_crc_initial(uint16_t crc_initial) { this->crc_initial_ = crc_initial; }
   void set_deviation(uint32_t deviation) { this->deviation_ = deviation; }
-  void set_dio1_pin(InternalGPIOPin *dio1_pin) { this->dio1_pin_ = dio1_pin; }
+  void set_dio1_pin(GPIOPin *dio1_pin) { this->dio1_pin_ = dio1_pin; }
   void set_frequency(uint32_t frequency) { this->frequency_ = frequency; }
   void set_hw_version(const std::string &hw_version) { this->hw_version_ = hw_version; }
   void set_mode_rx();
@@ -85,7 +85,7 @@ class SX126x : public Component,
   void set_payload_length(uint8_t payload_length) { this->payload_length_ = payload_length; }
   void set_preamble_detect(uint16_t preamble_detect) { this->preamble_detect_ = preamble_detect; }
   void set_preamble_size(uint16_t preamble_size) { this->preamble_size_ = preamble_size; }
-  void set_rst_pin(InternalGPIOPin *rst_pin) { this->rst_pin_ = rst_pin; }
+  void set_rst_pin(GPIOPin *rst_pin) { this->rst_pin_ = rst_pin; }
   void set_rx_start(bool rx_start) { this->rx_start_ = rx_start; }
   void set_rf_switch(bool rf_switch) { this->rf_switch_ = rf_switch; }
   void set_shaping(uint8_t shaping) { this->shaping_ = shaping; }
@@ -115,9 +115,9 @@ class SX126x : public Component,
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;
   std::vector<uint8_t> sync_value_;
-  InternalGPIOPin *busy_pin_{nullptr};
-  InternalGPIOPin *dio1_pin_{nullptr};
-  InternalGPIOPin *rst_pin_{nullptr};
+  GPIOPin *busy_pin_{nullptr};
+  GPIOPin *dio1_pin_{nullptr};
+  GPIOPin *rst_pin_{nullptr};
   std::string hw_version_;
   char version_[16];
   SX126xBw bandwidth_{SX126X_BW_125000};


### PR DESCRIPTION
The SeeedStudio SenseCAP Indicator connects to the SX1262 Radio partly via a PCA9554 I2C port expander, for the BUSY(input), RST(output) and DIO1(input).

# What does this implement/fix?

GPIO pins for BUSY, RST and DIO1 were specified as Interal GPIO pins (directly connented from ESP32S3 to SX1262 radio).

The SeeedStudio SenseCap Indicator  D1L display, uses a GPIO port expander to connect these GPIOs. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
pca9554:
  - id: pca9554a_device
    address: 0x20
    pin_count: 16

sx126x:
 ...
  rst_pin:
    pca9554: pca9554a_device
    number: 1
    mode:
      output: true
  busy_pin:
    pca9554: pca9554a_device
    number: 2
    mode:
      input: true
  dio1_pin:
    pca9554: pca9554a_device
    number: 3
    mode:
      output: true

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
