### PR TITLE
[ble_client] Optimize ble_write memory usage - store static data in flash

### DIFF
--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -96,10 +96,7 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   BLEClientWriteAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);
     ble_client_ = ble_client;
-    this->construct_simple_value_();
   }
-
-  ~BLEClientWriteAction() { this->destroy_simple_value_(); }
 
   void set_service_uuid16(uint16_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint16(uuid); }
   void set_service_uuid32(uint32_t uuid) { this->service_uuid_ = espbt::ESPBTUUID::from_uint32(uuid); }
@@ -110,16 +107,14 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
   void set_value_template(std::vector<uint8_t> (*func)(Ts...)) {
-    this->destroy_simple_value_();
     this->value_.template_func = func;
     this->has_simple_value_ = false;
   }
 
-  void set_value_simple(const std::vector<uint8_t> &value) {
-    if (!this->has_simple_value_) {
-      this->construct_simple_value_();
-    }
-    this->value_.simple = value;
+  // Store pointer to static data in flash (no RAM copy)
+  void set_value_simple(const uint8_t *data, size_t len) {
+    this->value_.simple_data.ptr = data;
+    this->value_.simple_data.len = len;
     this->has_simple_value_ = true;
   }
 
@@ -128,7 +123,12 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   void play_complex(const Ts &...x) override {
     this->num_running_++;
     this->var_ = std::make_tuple(x...);
-    auto value = this->has_simple_value_ ? this->value_.simple : this->value_.template_func(x...);
+    std::vector<uint8_t> value;
+    if (this->has_simple_value_) {
+      value.assign(this->value_.simple_data.ptr, this->value_.simple_data.ptr + this->value_.simple_data.len);
+    } else {
+      value = this->value_.template_func(x...);
+    }
     // on write failure, continue the automation chain rather than stopping so that e.g. disconnect can work.
     if (!write(value))
       this->play_next_(x...);
@@ -201,21 +201,14 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   }
 
  private:
-  void construct_simple_value_() { new (&this->value_.simple) std::vector<uint8_t>(); }
-
-  void destroy_simple_value_() {
-    if (this->has_simple_value_) {
-      this->value_.simple.~vector();
-    }
-  }
-
   BLEClient *ble_client_;
-  bool has_simple_value_ = true;
+  bool has_simple_value_{true};
   union Value {
-    std::vector<uint8_t> simple;
     std::vector<uint8_t> (*template_func)(Ts...);
-    Value() {}   // trivial constructor
-    ~Value() {}  // trivial destructor - we manage lifetime via discriminator
+    struct {
+      const uint8_t *ptr;
+      size_t len;
+    } simple_data;
   } value_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -107,15 +107,14 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
   void set_char_uuid128(uint8_t *uuid) { this->char_uuid_ = espbt::ESPBTUUID::from_raw(uuid); }
 
   void set_value_template(std::vector<uint8_t> (*func)(Ts...)) {
-    this->value_.template_func = func;
-    this->has_simple_value_ = false;
+    this->value_.func = func;
+    this->len_ = -1;  // Sentinel value indicates template mode
   }
 
   // Store pointer to static data in flash (no RAM copy)
   void set_value_simple(const uint8_t *data, size_t len) {
-    this->value_.simple_data.ptr = data;
-    this->value_.simple_data.len = len;
-    this->has_simple_value_ = true;
+    this->value_.data = data;
+    this->len_ = len;  // Length >= 0 indicates static mode
   }
 
   void play(const Ts &...x) override {}
@@ -124,10 +123,12 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
     this->num_running_++;
     this->var_ = std::make_tuple(x...);
     std::vector<uint8_t> value;
-    if (this->has_simple_value_) {
-      value.assign(this->value_.simple_data.ptr, this->value_.simple_data.ptr + this->value_.simple_data.len);
+    if (this->len_ >= 0) {
+      // Static mode: copy from flash to vector
+      value.assign(this->value_.data, this->value_.data + this->len_);
     } else {
-      value = this->value_.template_func(x...);
+      // Template mode: call function
+      value = this->value_.func(x...);
     }
     // on write failure, continue the automation chain rather than stopping so that e.g. disconnect can work.
     if (!write(value))
@@ -202,13 +203,10 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
 
  private:
   BLEClient *ble_client_;
-  bool has_simple_value_{true};
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
   union Value {
-    std::vector<uint8_t> (*template_func)(Ts...);
-    struct {
-      const uint8_t *ptr;
-      size_t len;
-    } simple_data;
+    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
+    const uint8_t *data;                  // Pointer to static data in flash
   } value_;
   espbt::ESPBTUUID service_uuid_;
   espbt::ESPBTUUID char_uuid_;

--- a/tests/components/ble_client/common.yaml
+++ b/tests/components/ble_client/common.yaml
@@ -52,3 +52,25 @@ sensor:
     name: "BLE Sensor without Lambda"
     service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
     characteristic_uuid: "abcd1237-abcd-1234-abcd-abcd12345678"
+
+number:
+  - platform: template
+    name: "Test Number"
+    id: test_number
+    optimistic: true
+    min_value: 0
+    max_value: 255
+    step: 1
+
+button:
+  # Test ble_write with lambda that references a component (function pointer)
+  - platform: template
+    name: "BLE Write Lambda Test"
+    on_press:
+      - ble_client.ble_write:
+          id: test_blec
+          service_uuid: "abcd1234-abcd-1234-abcd-abcd12345678"
+          characteristic_uuid: "abcd1235-abcd-1234-abcd-abcd12345678"
+          value: !lambda |-
+            uint8_t val = (uint8_t)id(test_number).state;
+            return std::vector<uint8_t>{0xAA, val, 0xBB};


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `ble_client.ble_write` action to store static data in flash memory instead of RAM, eliminating manual union lifetime management and saving heap memory.

## Problem

The `ble_client.ble_write` action had memory inefficiencies:

1. **Static data copied to RAM**: Compile-time-known byte arrays were copied from flash into heap-allocated `std::vector`, wasting RAM for data that never changes.

2. **Manual lifetime management overhead**: The union containing `std::vector` required explicit construction/destruction with placement new and manual destructor calls, adding code complexity and flash size.

3. **Inefficient mode tracking**: Used separate `bool has_simple_value_` flag (4 bytes with padding) in addition to the union.

## Solution

### Store pointer to flash data instead of vector

**Before:**
```cpp
union Value {
  std::vector<uint8_t> simple;  // Heap allocation + manual lifetime management
  std::vector<uint8_t> (*template_func)(Ts...);
  Value() {}   // trivial constructor
  ~Value() {}  // trivial destructor - we manage lifetime via discriminator
} value_;

void construct_simple_value_() {
  new (&this->value_.simple) std::vector<uint8_t>();
}

void destroy_simple_value_() {
  if (this->has_simple_value_) {
    this->value_.simple.~vector();
  }
}

void set_value_simple(const std::vector<uint8_t> &value) {
  if (!this->has_simple_value_) {
    this->construct_simple_value_();
  }
  this->value_.simple = value;  // Copies to heap
  this->has_simple_value_ = true;
}
```

**After (with sentinel pattern):**
```cpp
void set_value_template(std::vector<uint8_t> (*func)(Ts...)) {
  this->value_.func = func;
  this->len_ = -1;  // Sentinel value indicates template mode
}

// Store pointer to static data in flash (no RAM copy)
void set_value_simple(const uint8_t *data, size_t len) {
  this->value_.data = data;
  this->len_ = len;  // Length >= 0 indicates static mode
}

private:
  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
  union Value {
    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas) - 4 bytes
    const uint8_t *data;                  // Pointer to static data in flash - 4 bytes
  } value_;  // Union size = 4 bytes
  // Total: 8 bytes (4 len + 4 union)
```

All members are trivial POD types - no manual lifetime management needed! The sentinel pattern (`if (this->len_ >= 0)`) is cleaner than a separate boolean flag and saves an additional 4 bytes on 32-bit platforms.

### Python codegen generates flash arrays

**Before:**
```python
if cg.is_template(value):
    templ = await cg.templatable(value, args, cg.std_vector.template(cg.uint8))
    cg.add(var.set_value_template(templ))
else:
    cg.add(var.set_value_simple(value))  # Passes list → copied into vector
```

**After:**
```python
if cg.is_template(value):
    templ = await cg.templatable(value, args, cg.std_vector.template(cg.uint8))
    cg.add(var.set_value_template(templ))
else:
    # Generate static array in flash to avoid RAM copy
    if isinstance(value, bytes):
        value = list(value)
    arr_id = ID(f"{action_id}_data", is_declaration=True, type=cg.uint8)
    arr = cg.static_const_array(arr_id, cg.ArrayInitializer(*value))
    cg.add(var.set_value_simple(arr, len(value)))
```

This generates:
```cpp
static const uint8_t ble_write_action_id_4_data[] = {0x01, 0x02, 0x03};  // In flash (.rodata)
action->set_value_simple(ble_write_action_id_4_data, 3);
```

### Eliminated manual lifetime management

Since both union members are now **POD types** (trivial - no constructors/destructors):
- Removed `construct_simple_value_()`
- Removed `destroy_simple_value_()`
- Removed explicit `~BLEClientWriteAction()` destructor
- Union just works automatically

**Code removed:**
```cpp
BLEClientWriteAction(BLEClient *ble_client) {
  ble_client->register_ble_node(this);
  ble_client_ = ble_client;
  this->construct_simple_value_();  // No longer needed
}

~BLEClientWriteAction() {
  this->destroy_simple_value_();  // No longer needed
}

void set_value_template(std::vector<uint8_t> (*func)(Ts...)) {
  this->destroy_simple_value_();  // No longer needed
  this->value_.template_func = func;
  this->has_simple_value_ = false;
}
```

## Memory Savings

Per `ble_client.ble_write` action on 32-bit platforms (ESP32):

**Before:**
- `bool has_simple_value_` = 4 bytes (with padding)
- `union Value` with `std::vector<uint8_t>` = 12 bytes
- Total: 16 bytes + manual lifetime management code

**After:**
- `ssize_t len_` = 4 bytes
- `union Value` with two pointers = 4 bytes
- Total: 8 bytes, all trivial types

**Savings:**
- **Per action**: 8 bytes saved (16 → 8 bytes, 50% reduction)
- **Heap** (static data): 12+ bytes saved per action (data length dependent - no `std::vector` allocation)
- **Flash**: ~50-100 bytes saved (eliminated manual lifetime management code)
- **Union + sentinel optimization**: Additional 4 bytes saved per action

**Note:** BLE client already used function pointers instead of `std::function`, so no additional savings from that optimization (unlike UART which saved 12 bytes per template action).

## Verification

Static arrays confirmed in flash (`.rodata` section) when generated code is compiled.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Proactive optimization following UART pattern

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes (internal optimization)

## Test Environment

- [x] ESP32 IDF
- [x] Component test build verified

## Example entry for `config.yaml`:

No configuration changes - optimization is transparent to users. All existing `ble_client.ble_write` usage continues to work:

```yaml
ble_client:
  - mac_address: "00:11:22:33:44:55"
    id: my_ble_client
    on_connect:
      - ble_client.ble_write:
          id: my_ble_client
          service_uuid: "UUID"
          characteristic_uuid: "UUID"
          # Static byte array (now stored in flash)
          value: [0x01, 0x02, 0x03]
      - ble_client.ble_write:
          id: my_ble_client
          service_uuid: "UUID"
          characteristic_uuid: "UUID"
          # Lambda (already used function pointer)
          value: !lambda
            return {0x01, 0x02, 0x03};
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes
