### PR TITLE
[sx126x] Optimize send_packet action memory usage - store static data in flash

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -3,7 +3,7 @@ import esphome.codegen as cg
 from esphome.components import spi
 import esphome.config_validation as cv
 from esphome.const import CONF_BUSY_PIN, CONF_DATA, CONF_FREQUENCY, CONF_ID
-from esphome.core import TimePeriod
+from esphome.core import ID, TimePeriod
 
 MULTI_CONF = True
 CODEOWNERS = ["@swoboda1337"]
@@ -329,5 +329,8 @@ async def send_packet_action_to_code(config, action_id, template_arg, args):
         templ = await cg.templatable(data, args, cg.std_vector.template(cg.uint8))
         cg.add(var.set_data_template(templ))
     else:
-        cg.add(var.set_data_static(data))
+        # Generate static array in flash to avoid RAM copy
+        arr_id = ID(f"{action_id}_data", is_declaration=True, type=cg.uint8)
+        arr = cg.static_const_array(arr_id, cg.ArrayInitializer(*data))
+        cg.add(var.set_data_static(arr, len(data)))
     return var

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -14,28 +14,36 @@ template<typename... Ts> class RunImageCalAction : public Action<Ts...>, public 
 
 template<typename... Ts> class SendPacketAction : public Action<Ts...>, public Parented<SX126x> {
  public:
-  void set_data_template(std::function<std::vector<uint8_t>(Ts...)> func) {
-    this->data_func_ = func;
+  void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
+    this->data_.func = func;
     this->static_ = false;
   }
 
-  void set_data_static(const std::vector<uint8_t> &data) {
-    this->data_static_ = data;
+  void set_data_static(const uint8_t *data, size_t len) {
+    this->data_.static_data.ptr = data;
+    this->data_.static_data.len = len;
     this->static_ = true;
   }
 
   void play(const Ts &...x) override {
+    std::vector<uint8_t> data;
     if (this->static_) {
-      this->parent_->transmit_packet(this->data_static_);
+      data.assign(this->data_.static_data.ptr, this->data_.static_data.ptr + this->data_.static_data.len);
     } else {
-      this->parent_->transmit_packet(this->data_func_(x...));
+      data = this->data_.func(x...);
     }
+    this->parent_->transmit_packet(data);
   }
 
  protected:
-  bool static_{false};
-  std::function<std::vector<uint8_t>(Ts...)> data_func_{};
-  std::vector<uint8_t> data_static_{};
+  bool static_{true};
+  union Data {
+    std::vector<uint8_t> (*func)(Ts...);
+    struct {
+      const uint8_t *ptr;
+      size_t len;
+    } static_data;
+  } data_;
 };
 
 template<typename... Ts> class SetModeTxAction : public Action<Ts...>, public Parented<SX126x> {

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -16,33 +16,31 @@ template<typename... Ts> class SendPacketAction : public Action<Ts...>, public P
  public:
   void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
     this->data_.func = func;
-    this->static_ = false;
+    this->len_ = -1;  // Sentinel value indicates template mode
   }
 
   void set_data_static(const uint8_t *data, size_t len) {
-    this->data_.static_data.ptr = data;
-    this->data_.static_data.len = len;
-    this->static_ = true;
+    this->data_.data = data;
+    this->len_ = len;  // Length >= 0 indicates static mode
   }
 
   void play(const Ts &...x) override {
     std::vector<uint8_t> data;
-    if (this->static_) {
-      data.assign(this->data_.static_data.ptr, this->data_.static_data.ptr + this->data_.static_data.len);
+    if (this->len_ >= 0) {
+      // Static mode: copy from flash to vector
+      data.assign(this->data_.data, this->data_.data + this->len_);
     } else {
+      // Template mode: call function
       data = this->data_.func(x...);
     }
     this->parent_->transmit_packet(data);
   }
 
  protected:
-  bool static_{true};
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
   union Data {
-    std::vector<uint8_t> (*func)(Ts...);
-    struct {
-      const uint8_t *ptr;
-      size_t len;
-    } static_data;
+    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
+    const uint8_t *data;                  // Pointer to static data in flash
   } data_;
 };
 

--- a/tests/components/sx126x/common.yaml
+++ b/tests/components/sx126x/common.yaml
@@ -26,6 +26,15 @@ sx126x:
       - lambda: |-
           ESP_LOGD("lambda", "packet %.2f %.2f %s", rssi, snr, format_hex(x).c_str());
 
+number:
+  - platform: template
+    name: "SX126x Number"
+    id: my_number
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+
 button:
   - platform: template
     name: "SX126x Button"
@@ -37,3 +46,5 @@ button:
         - sx126x.set_mode_rx
         - sx126x.send_packet:
             data: [0xC5, 0x51, 0x78, 0x82, 0xB7, 0xF9, 0x9C, 0x5C]
+        - sx126x.send_packet: !lambda |-
+            return {0x01, 0x02, (uint8_t)id(my_number).state};


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `sx126x.send_packet` action to store static data in flash memory instead of RAM and use function pointers instead of `std::function` for lambdas, saving memory per LoRa configuration.

## Problem

The `sx126x.send_packet` action had two memory inefficiencies:

1. **Static data copied to RAM**: When using static data (strings or byte arrays), the data was copied from flash into a `std::vector<uint8_t>` allocated on the heap, wasting RAM for data that never changes.

2. **Overkill `std::function` for stateless lambdas**: Template-based sends always use stateless lambdas (they only reference global component pointers), but were stored as `std::function` (16 bytes on 32-bit) instead of function pointers (4 bytes on 32-bit).

## Solution

### 1. Flash-based static data storage

**Before:**
```cpp
void set_data_static(const std::vector<uint8_t> &data) {
    this->data_static_ = data;  // Copies to heap
    this->static_ = true;
}

protected:
  std::vector<uint8_t> data_static_{};  // Heap allocation
```

**After:**
```cpp
// Store pointer to static data in flash (no RAM copy)
void set_data_static(const uint8_t *data, size_t len) {
    this->data_.data = data;
    this->len_ = len;  // Length >= 0 indicates static mode
}
```

Python codegen generates:
```cpp
static const uint8_t sendpacketaction_id_4_data[] = {0xC5, 0x51, 0x78};  // In flash (.rodata)
action->set_data_static(sendpacketaction_id_4_data, 3);
```

### 2. Function pointer for stateless lambdas

**Before:**
```cpp
std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
```

**After:**
```cpp
std::vector<uint8_t> (*func)(Ts...);  // 4 bytes on 32-bit - stateless lambdas auto-convert
```

### 3. Memory layout optimization with union and sentinel

Since template and static modes are mutually exclusive, use a union to minimize memory footprint. A sentinel value (`len_ = -1`) indicates template mode, making the code cleaner and more idiomatic:

**Before:**
```cpp
protected:
  bool static_{false};                                      // 1 byte (+ 3 padding = 4 bytes on 32-bit)
  std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
  std::vector<uint8_t> data_static_{};                      // 12 bytes on 32-bit
  // Total: 32 bytes (4 + 16 + 12)
```

**After:**
```cpp
void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
  this->data_.func = func;
  this->len_ = -1;  // Sentinel value indicates template mode
}

protected:
  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
  union Data {
    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
    const uint8_t *data;                  // Pointer to static data in flash
  } data_;
  // Total: 8 bytes (4 len + 4 union)
```

The sentinel pattern (`if (this->len_ >= 0)`) is cleaner than a separate boolean flag and saves an additional 4 bytes on 32-bit platforms.

### 4. Eliminated code duplication

**Before:**
```cpp
if (this->static_) {
    this->parent_->transmit_packet(this->data_static_);
} else {
    this->parent_->transmit_packet(this->data_func_(x...));
}
```

**After:**
```cpp
std::vector<uint8_t> data;
if (this->len_ >= 0) {
    // Static mode: copy from flash to vector
    data.assign(this->data_.data, this->data_.data + this->len_);
} else {
    // Template mode: call function
    data = this->data_.func(x...);
}
this->parent_->transmit_packet(data);
```

## Memory Savings

Per `sx126x.send_packet` action on 32-bit platforms (ESP32):
- **Per template action**: 12 bytes saved from `std::function` → function pointer
- **Per static action**: Heap allocation eliminated (packet size dependent - LoRa can have larger packets than CAN)
- **Union + sentinel optimization**: Additional 8 bytes saved per action
- **Total per action**: 24 bytes saved (32 bytes → 8 bytes, 75% reduction)
- **Flash**: Reduced STL template instantiations for `std::function`

**Note:** LoRa packets can be larger than CAN frames (which are limited to 8 bytes), so heap savings per action may be more significant for LoRa applications. The structural savings (75% reduction) are the same as UART and CAN.

**Future optimization:** The `play()` method currently creates a temporary `std::vector<uint8_t>` to pass to `transmit_packet()`. Adding an overload `transmit_packet(const uint8_t *data, size_t len)` would eliminate this temporary allocation for static data.

## Verification

This optimization uses the **exact same pattern** as PR #11784 (uart) which has been tested and verified on real hardware:

**UART PR #11784 verification:**
- CI builds passing with expected memory impact
- Verified on real hardware (Athom Presence Sensor)
- ~2.8KB memory savings confirmed (2KB heap + 812 bytes flash)
- All three modes tested: static strings, static arrays, lambdas with component references

**This PR (sx126x) differences from uart:**
- Component-specific usage only (LoRa packet transmission)
- LoRa packets can be larger than CAN frames (more heap savings potential)
- Same header changes: `std::function` → function pointer, heap vector → flash pointer
- Same codegen changes: generate `static const uint8_t[]` arrays
- Same union pattern for memory efficiency

**CI will verify:**
- Compilation succeeds for all platforms
- Memory impact analysis shows expected results
- Component tests pass

Static arrays confirmed in flash (`.rodata` section) when generated code is compiled.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Proactive optimization following UART/BLE client/canbus pattern

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes (internal optimization)

## Test Environment

- [ ] ESP32 IDF
- [ ] ESP8266 Arduino
- [ ] RP2040 Arduino
- [x] Component test build verified

## Example entry for `config.yaml`:

No configuration changes - optimization is transparent to users. All existing `sx126x.send_packet` usage continues to work:

```yaml
sx126x:
  id: my_lora
  dio1_pin: GPIO4
  cs_pin: GPIO5
  busy_pin: GPIO6
  rst_pin: GPIO7
  frequency: 433920000
  modulation: LORA
  hw_version: sx1262
  rf_switch: true

button:
  - platform: template
    name: "Send LoRa Packet"
    on_press:
      # Static byte array (stored in flash)
      - sx126x.send_packet:
          data: [0xC5, 0x51, 0x78, 0x82, 0xB7, 0xF9, 0x9C, 0x5C]
      # Lambda (uses function pointer)
      - sx126x.send_packet: !lambda
          return {0x01, 0x02, 0x03};
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes
