### PR TITLE
[udp] Optimize udp.write action memory usage - store static data in flash

### DIFF
--- a/esphome/components/udp/automation.h
+++ b/esphome/components/udp/automation.h
@@ -11,28 +11,35 @@ namespace udp {
 
 template<typename... Ts> class UDPWriteAction : public Action<Ts...>, public Parented<UDPComponent> {
  public:
-  void set_data_template(std::function<std::vector<uint8_t>(Ts...)> func) {
-    this->data_func_ = func;
+  void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
+    this->data_.func = func;
     this->static_ = false;
   }
-  void set_data_static(const std::vector<uint8_t> &data) {
-    this->data_static_ = data;
+
+  void set_data_static(const uint8_t *data, size_t len) {
+    this->data_.static_data.ptr = data;
+    this->data_.static_data.len = len;
     this->static_ = true;
   }
 
   void play(const Ts &...x) override {
     if (this->static_) {
-      this->parent_->send_packet(this->data_static_);
+      this->parent_->send_packet(this->data_.static_data.ptr, this->data_.static_data.len);
     } else {
-      auto val = this->data_func_(x...);
+      auto val = this->data_.func(x...);
       this->parent_->send_packet(val);
     }
   }
 
  protected:
-  bool static_{false};
-  std::function<std::vector<uint8_t>(Ts...)> data_func_{};
-  std::vector<uint8_t> data_static_{};
+  bool static_{true};
+  union Data {
+    std::vector<uint8_t> (*func)(Ts...);
+    struct {
+      const uint8_t *ptr;
+      size_t len;
+    } static_data;
+  } data_;
 };
 
 }  // namespace udp

--- a/esphome/components/udp/automation.h
+++ b/esphome/components/udp/automation.h
@@ -13,32 +13,30 @@ template<typename... Ts> class UDPWriteAction : public Action<Ts...>, public Par
  public:
   void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
     this->data_.func = func;
-    this->static_ = false;
+    this->len_ = -1;  // Sentinel value indicates template mode
   }
 
   void set_data_static(const uint8_t *data, size_t len) {
-    this->data_.static_data.ptr = data;
-    this->data_.static_data.len = len;
-    this->static_ = true;
+    this->data_.data = data;
+    this->len_ = len;  // Length >= 0 indicates static mode
   }
 
   void play(const Ts &...x) override {
-    if (this->static_) {
-      this->parent_->send_packet(this->data_.static_data.ptr, this->data_.static_data.len);
+    if (this->len_ >= 0) {
+      // Static mode: pass pointer directly to send_packet(const uint8_t *, size_t)
+      this->parent_->send_packet(this->data_.data, static_cast<size_t>(this->len_));
     } else {
+      // Template mode: call function and pass vector to send_packet(const std::vector<uint8_t> &)
       auto val = this->data_.func(x...);
       this->parent_->send_packet(val);
     }
   }
 
  protected:
-  bool static_{true};
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
   union Data {
-    std::vector<uint8_t> (*func)(Ts...);
-    struct {
-      const uint8_t *ptr;
-      size_t len;
-    } static_data;
+    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
+    const uint8_t *data;                  // Pointer to static data in flash
   } data_;
 };
 

--- a/tests/components/udp/common.yaml
+++ b/tests/components/udp/common.yaml
@@ -17,3 +17,22 @@ udp:
         id: my_udp
         data: !lambda |-
           return std::vector<uint8_t>{1,3,4,5,6};
+
+number:
+  - platform: template
+    name: "UDP Number"
+    id: my_number
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+
+button:
+  - platform: template
+    name: "UDP Button"
+    on_press:
+      then:
+        - udp.write:
+            data: [0x01, 0x02, 0x03]
+        - udp.write: !lambda |-
+            return {0x10, 0x20, (uint8_t)id(my_number).state};


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `udp.write` action to store static data in flash memory instead of RAM and use function pointers instead of `std::function` for lambdas, saving memory per UDP configuration.

## Problem

The `udp.write` action had two memory inefficiencies:

1. **Static data copied to RAM**: When using static data (strings or byte arrays), the data was copied from flash into a `std::vector<uint8_t>` allocated on the heap, wasting RAM for data that never changes.

2. **Overkill `std::function` for stateless lambdas**: Template-based sends always use stateless lambdas (they only reference global component pointers), but were stored as `std::function` (16 bytes on 32-bit) instead of function pointers (4 bytes on 32-bit).

## Solution

### 1. Flash-based static data storage

**Before:**
```cpp
void set_data_static(const std::vector<uint8_t> &data) {
    this->data_static_ = data;  // Copies to heap
    this->static_ = true;
}

protected:
  std::vector<uint8_t> data_static_{};  // Heap allocation
```

**After:**
```cpp
// Store pointer to static data in flash (no RAM copy)
void set_data_static(const uint8_t *data, size_t len) {
    this->data_.data = data;
    this->len_ = len;  // Length >= 0 indicates static mode
}
```

Python codegen generates:
```cpp
static const uint8_t udpwriteaction_id_4_data[] = {0x01, 0x02, 0x03};  // In flash (.rodata)
action->set_data_static(udpwriteaction_id_4_data, 3);
```

### 2. Function pointer for stateless lambdas

**Before:**
```cpp
std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
```

**After:**
```cpp
std::vector<uint8_t> (*func)(Ts...);  // 4 bytes on 32-bit - stateless lambdas auto-convert
```

### 3. Memory layout optimization with union and sentinel

Since template and static modes are mutually exclusive, use a union to minimize memory footprint. A sentinel value (`len_ = -1`) indicates template mode, making the code cleaner and more idiomatic:

**Before:**
```cpp
protected:
  bool static_{false};                                      // 1 byte (+ 3 padding = 4 bytes on 32-bit)
  std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
  std::vector<uint8_t> data_static_{};                      // 12 bytes on 32-bit
  // Total: 32 bytes (4 + 16 + 12)
```

**After:**
```cpp
void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
  this->data_.func = func;
  this->len_ = -1;  // Sentinel value indicates template mode
}

protected:
  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
  union Data {
    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
    const uint8_t *data;                  // Pointer to static data in flash
  } data_;
  // Total: 8 bytes (4 len + 4 union)
```

The sentinel pattern (`if (this->len_ >= 0)`) is cleaner than a separate boolean flag and saves an additional 4 bytes on 32-bit platforms.

### 4. No temporary vector needed

**Before:**
```cpp
if (this->static_) {
    this->parent_->send_packet(this->data_static_);
} else {
    auto val = this->data_func_(x...);
    this->parent_->send_packet(val);
}
```

**After:**
```cpp
if (this->len_ >= 0) {
    // Static mode: pass pointer directly to send_packet(const uint8_t *, size_t)
    this->parent_->send_packet(this->data_.data, static_cast<size_t>(this->len_));
} else {
    // Template mode: call function and pass vector to send_packet(const std::vector<uint8_t> &)
    auto val = this->data_.func(x...);
    this->parent_->send_packet(val);
}
```

**Note:** Like UART, UDP has both `send_packet()` overloads (pointer/length and vector), so static data can be sent directly without creating a temporary vector.

## Memory Savings

Per `udp.write` action on 32-bit platforms (ESP32/ESP8266):
- **Per template action**: 12 bytes saved from `std::function` → function pointer
- **Per static action**: Heap allocation eliminated (packet size dependent)
- **Union + sentinel optimization**: Additional 8 bytes saved per action
- **Total per action**: 24 bytes saved (32 bytes → 8 bytes, 75% reduction)
- **Flash**: Reduced STL template instantiations for `std::function`

**Bonus:** Like UART, no temporary vector allocation for static data since UDP has the pointer/length overload - static data is passed directly from flash.

## Verification

This optimization uses the **exact same pattern** as PR #11784 (uart) which has been tested and verified on real hardware:

**UART PR #11784 verification:**
- CI builds passing with expected memory impact
- Verified on real hardware (Athom Presence Sensor)
- ~2.8KB memory savings confirmed (2KB heap + 812 bytes flash)
- All three modes tested: static strings, static arrays, lambdas with component references

**This PR (udp) similarities to uart:**
- Component has both `send_packet()` overloads (pointer/length and vector)
- No temporary vector needed for static data
- Same header changes: `std::function` → function pointer, heap vector → flash pointer
- Same codegen changes: generate `static const uint8_t[]` arrays
- Same union pattern for memory efficiency

**CI will verify:**
- Compilation succeeds for all platforms
- Memory impact analysis shows expected results
- Component tests pass

Static arrays confirmed in flash (`.rodata` section) when generated code is compiled.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Proactive optimization following UART/BLE client/canbus/sx126x/sx127x pattern

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes (internal optimization)

## Test Environment

- [ ] ESP32 IDF
- [ ] ESP8266 Arduino
- [ ] RP2040 Arduino
- [x] Component test build verified

## Example entry for `config.yaml`:

No configuration changes - optimization is transparent to users. All existing `udp.write` usage continues to work:

```yaml
udp:
  id: my_udp
  port: 18511

button:
  - platform: template
    name: "Send UDP Packet"
    on_press:
      # Static byte array (stored in flash)
      - udp.write:
          data: [0x01, 0x02, 0x03]
      # Static string (stored in flash)
      - udp.write:
          data: "hello world"
      # Lambda (uses function pointer)
      - udp.write: !lambda
          return {0x10, 0x20, 0x30};
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes
