### PR TITLE
[speaker] Optimize speaker.play action memory usage - store static data in flash

### DIFF
--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -3,7 +3,7 @@ import esphome.codegen as cg
 from esphome.components import audio, audio_dac
 import esphome.config_validation as cv
 from esphome.const import CONF_DATA, CONF_ID, CONF_VOLUME
-from esphome.core import CORE
+from esphome.core import CORE, ID
 from esphome.coroutine import CoroPriority, coroutine_with_priority
 
 AUTO_LOAD = ["audio"]
@@ -90,7 +90,10 @@ async def speaker_play_action(config, action_id, template_arg, args):
         templ = await cg.templatable(data, args, cg.std_vector.template(cg.uint8))
         cg.add(var.set_data_template(templ))
     else:
-        cg.add(var.set_data_static(data))
+        # Generate static array in flash to avoid RAM copy
+        arr_id = ID(f"{action_id}_data", is_declaration=True, type=cg.uint8)
+        arr = cg.static_const_array(arr_id, cg.ArrayInitializer(*data))
+        cg.add(var.set_data_static(arr, len(data)))
     return var
 
 

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -12,32 +12,30 @@ template<typename... Ts> class PlayAction : public Action<Ts...>, public Parente
  public:
   void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
     this->data_.func = func;
-    this->static_ = false;
+    this->len_ = -1;  // Sentinel value indicates template mode
   }
 
   void set_data_static(const uint8_t *data, size_t len) {
-    this->data_.static_data.ptr = data;
-    this->data_.static_data.len = len;
-    this->static_ = true;
+    this->data_.data = data;
+    this->len_ = len;  // Length >= 0 indicates static mode
   }
 
   void play(const Ts &...x) override {
-    if (this->static_) {
-      this->parent_->play(this->data_.static_data.ptr, this->data_.static_data.len);
+    if (this->len_ >= 0) {
+      // Static mode: pass pointer directly to play(const uint8_t *, size_t)
+      this->parent_->play(this->data_.data, static_cast<size_t>(this->len_));
     } else {
+      // Template mode: call function and pass vector to play(const std::vector<uint8_t> &)
       auto val = this->data_.func(x...);
       this->parent_->play(val);
     }
   }
 
  protected:
-  bool static_{true};
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
   union Data {
-    std::vector<uint8_t> (*func)(Ts...);
-    struct {
-      const uint8_t *ptr;
-      size_t len;
-    } static_data;
+    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
+    const uint8_t *data;                  // Pointer to static data in flash
   } data_;
 };
 

--- a/esphome/components/speaker/automation.h
+++ b/esphome/components/speaker/automation.h
@@ -10,28 +10,35 @@ namespace speaker {
 
 template<typename... Ts> class PlayAction : public Action<Ts...>, public Parented<Speaker> {
  public:
-  void set_data_template(std::function<std::vector<uint8_t>(Ts...)> func) {
-    this->data_func_ = func;
+  void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
+    this->data_.func = func;
     this->static_ = false;
   }
-  void set_data_static(const std::vector<uint8_t> &data) {
-    this->data_static_ = data;
+
+  void set_data_static(const uint8_t *data, size_t len) {
+    this->data_.static_data.ptr = data;
+    this->data_.static_data.len = len;
     this->static_ = true;
   }
 
   void play(const Ts &...x) override {
     if (this->static_) {
-      this->parent_->play(this->data_static_);
+      this->parent_->play(this->data_.static_data.ptr, this->data_.static_data.len);
     } else {
-      auto val = this->data_func_(x...);
+      auto val = this->data_.func(x...);
       this->parent_->play(val);
     }
   }
 
  protected:
-  bool static_{false};
-  std::function<std::vector<uint8_t>(Ts...)> data_func_{};
-  std::vector<uint8_t> data_static_{};
+  bool static_{true};
+  union Data {
+    std::vector<uint8_t> (*func)(Ts...);
+    struct {
+      const uint8_t *ptr;
+      size_t len;
+    } static_data;
+  } data_;
 };
 
 template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<Speaker> {

--- a/tests/components/speaker/common.yaml
+++ b/tests/components/speaker/common.yaml
@@ -1,3 +1,12 @@
+number:
+  - platform: template
+    name: "Speaker Number"
+    id: my_number
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+
 esphome:
   on_boot:
     then:
@@ -13,6 +22,15 @@ esphome:
           then:
             - speaker.finish:
       - speaker.stop:
+
+button:
+  - platform: template
+    name: "Speaker Button"
+    on_press:
+      then:
+        - speaker.play: [0x10, 0x20, 0x30, 0x40]
+        - speaker.play: !lambda |-
+            return {0x01, 0x02, (uint8_t)id(my_number).state};
 
 i2s_audio:
   i2s_lrclk_pin: ${i2s_bclk_pin}


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `speaker.play` action to store static data in flash memory instead of RAM and use function pointers instead of `std::function` for lambdas, saving memory per speaker configuration.

## Problem

The `speaker.play` action had two memory inefficiencies:

1. **Static data copied to RAM**: When using static audio data (byte arrays), the data was copied from flash into a `std::vector<uint8_t>` allocated on the heap, wasting RAM for data that never changes.

2. **Overkill `std::function` for stateless lambdas**: Template-based plays always use stateless lambdas (they only reference global component pointers), but were stored as `std::function` (16 bytes on 32-bit) instead of function pointers (4 bytes on 32-bit).

## Solution

### 1. Flash-based static data storage

**Before:**
```cpp
void set_data_static(const std::vector<uint8_t> &data) {
    this->data_static_ = data;  // Copies to heap
    this->static_ = true;
}

protected:
  std::vector<uint8_t> data_static_{};  // Heap allocation
```

**After:**
```cpp
// Store pointer to static data in flash (no RAM copy)
void set_data_static(const uint8_t *data, size_t len) {
    this->data_.data = data;
    this->len_ = len;  // Length >= 0 indicates static mode
}
```

Python codegen generates:
```cpp
static const uint8_t playaction_id_4_data[] = {0x10, 0x20, 0x30};  // In flash (.rodata)
action->set_data_static(playaction_id_4_data, 3);
```

### 2. Function pointer for stateless lambdas

**Before:**
```cpp
std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
```

**After:**
```cpp
std::vector<uint8_t> (*func)(Ts...);  // 4 bytes on 32-bit - stateless lambdas auto-convert
```

### 3. Memory layout optimization with union and sentinel

Since template and static modes are mutually exclusive, use a union to minimize memory footprint. A sentinel value (`len_ = -1`) indicates template mode, making the code cleaner and more idiomatic:

**Before:**
```cpp
protected:
  bool static_{false};                                      // 1 byte (+ 3 padding = 4 bytes on 32-bit)
  std::function<std::vector<uint8_t>(Ts...)> data_func_{};  // 16 bytes on 32-bit
  std::vector<uint8_t> data_static_{};                      // 12 bytes on 32-bit
  // Total: 32 bytes (4 + 16 + 12)
```

**After:**
```cpp
void set_data_template(std::vector<uint8_t> (*func)(Ts...)) {
  this->data_.func = func;
  this->len_ = -1;  // Sentinel value indicates template mode
}

protected:
  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
  union Data {
    std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
    const uint8_t *data;                  // Pointer to static data in flash
  } data_;
  // Total: 8 bytes (4 len + 4 union)
```

The sentinel pattern (`if (this->len_ >= 0)`) is cleaner than a separate boolean flag and saves an additional 4 bytes on 32-bit platforms.

### 4. No temporary vector needed

**Before:**
```cpp
if (this->static_) {
    this->parent_->play(this->data_static_);
} else {
    auto val = this->data_func_(x...);
    this->parent_->play(val);
}
```

**After:**
```cpp
if (this->len_ >= 0) {
    // Static mode: pass pointer directly to play(const uint8_t *, size_t)
    this->parent_->play(this->data_.data, static_cast<size_t>(this->len_));
} else {
    // Template mode: call function and pass vector to play(const std::vector<uint8_t> &)
    auto val = this->data_.func(x...);
    this->parent_->play(val);
}
```

**Note:** Like UART and UDP, speaker already has both `play()` overloads (pointer/length and vector), so static data can be sent directly without creating a temporary vector.

## Memory Savings

Per `speaker.play` action on 32-bit platforms (ESP32):
- **Per template action**: 12 bytes saved from `std::function` → function pointer
- **Per static action**: Heap allocation eliminated (audio data size dependent - can be very large)
- **Union + sentinel optimization**: Additional 8 bytes saved per action
- **Total per action**: 24 bytes saved (32 bytes → 8 bytes, 75% reduction)
- **Flash**: Reduced STL template instantiations for `std::function`

**Bonus:** No temporary vector allocation for static data since speaker has the pointer/length overload.

**Note:** Audio data can be much larger than CAN frames (8 bytes) or typical network packets, so heap savings per action may be very significant for speaker applications.

## Verification

This optimization uses the **exact same pattern** as PR #11784 (uart) which has been tested and verified on real hardware:

**UART PR #11784 verification:**
- CI builds passing with expected memory impact
- Verified on real hardware (Athom Presence Sensor)
- ~2.8KB memory savings confirmed (2KB heap + 812 bytes flash)
- All three modes tested: static strings, static arrays, lambdas with component references

**This PR (speaker) similarities to uart:**
- Component has both `play()` overloads (pointer/length and vector)
- No temporary vector needed for static data
- Same header changes: `std::function` → function pointer, heap vector → flash pointer
- Same codegen changes: generate `static const uint8_t[]` arrays
- Same union pattern for memory efficiency

**CI will verify:**
- Compilation succeeds for all platforms
- Memory impact analysis shows expected results
- Component tests pass

Static arrays confirmed in flash (`.rodata` section) when generated code is compiled.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Proactive optimization following UART/BLE client/canbus/sx126x/sx127x/udp pattern

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes (internal optimization)

## Test Environment

- [ ] ESP32 IDF
- [ ] ESP32 Arduino
- [x] Component test build verified

## Example entry for `config.yaml`:

No configuration changes - optimization is transparent to users. All existing `speaker.play` usage continues to work:

```yaml
speaker:
  - platform: i2s_audio
    id: my_speaker
    dac_type: external
    i2s_dout_pin: GPIO25

button:
  - platform: template
    name: "Play Audio"
    on_press:
      # Static byte array (stored in flash)
      - speaker.play: [0x10, 0x20, 0x30, 0x40]
      # Lambda (uses function pointer)
      - speaker.play: !lambda
          return {0x01, 0x02, 0x03};
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes
