### PR TITLE
[remote_base] Optimize raw transmit action memory usage - use function pointers

### DIFF
--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -42,17 +42,21 @@ class RawTrigger : public Trigger<RawTimings>, public Component, public RemoteRe
 
 template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts...> {
  public:
-  void set_code_template(std::function<RawTimings(Ts...)> func) { this->code_func_ = func; }
+  void set_code_template(RawTimings (*func)(Ts...)) {
+    this->code_.func = func;
+    this->static_ = false;
+  }
   void set_code_static(const int32_t *code, size_t len) {
-    this->code_static_ = code;
-    this->code_static_len_ = len;
+    this->code_.static_code.data = code;
+    this->code_.static_code.len = len;
+    this->static_ = true;
   }
   TEMPLATABLE_VALUE(uint32_t, carrier_frequency);
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
-    if (this->code_static_ != nullptr) {
-      for (size_t i = 0; i < this->code_static_len_; i++) {
-        auto val = this->code_static_[i];
+    if (this->static_) {
+      for (size_t i = 0; i < this->code_.static_code.len; i++) {
+        auto val = this->code_.static_code.data[i];
         if (val < 0) {
           dst->space(static_cast<uint32_t>(-val));
         } else {
@@ -60,15 +64,20 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
         }
       }
     } else {
-      dst->set_data(this->code_func_(x...));
+      dst->set_data(this->code_.func(x...));
     }
     dst->set_carrier_frequency(this->carrier_frequency_.value(x...));
   }
 
  protected:
-  std::function<RawTimings(Ts...)> code_func_{nullptr};
-  const int32_t *code_static_{nullptr};
-  int32_t code_static_len_{0};
+  bool static_{true};
+  union Code {
+    RawTimings (*func)(Ts...);
+    struct {
+      const int32_t *data;
+      size_t len;
+    } static_code;
+  } code_;
 };
 
 class RawDumper : public RemoteReceiverDumperBase {

--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -44,19 +44,18 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
  public:
   void set_code_template(RawTimings (*func)(Ts...)) {
     this->code_.func = func;
-    this->static_ = false;
+    this->len_ = -1;
   }
   void set_code_static(const int32_t *code, size_t len) {
-    this->code_.static_code.data = code;
-    this->code_.static_code.len = len;
-    this->static_ = true;
+    this->code_.data = code;
+    this->len_ = len;
   }
   TEMPLATABLE_VALUE(uint32_t, carrier_frequency);
 
   void encode(RemoteTransmitData *dst, Ts... x) override {
-    if (this->static_) {
-      for (size_t i = 0; i < this->code_.static_code.len; i++) {
-        auto val = this->code_.static_code.data[i];
+    if (this->len_ >= 0) {
+      for (size_t i = 0; i < static_cast<size_t>(this->len_); i++) {
+        auto val = this->code_.data[i];
         if (val < 0) {
           dst->space(static_cast<uint32_t>(-val));
         } else {
@@ -70,13 +69,10 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
   }
 
  protected:
-  bool static_{true};
+  ssize_t len_{-1};
   union Code {
     RawTimings (*func)(Ts...);
-    struct {
-      const int32_t *data;
-      size_t len;
-    } static_code;
+    const int32_t *data;
   } code_;
 };
 

--- a/esphome/components/remote_base/raw_protocol.h
+++ b/esphome/components/remote_base/raw_protocol.h
@@ -44,11 +44,11 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
  public:
   void set_code_template(RawTimings (*func)(Ts...)) {
     this->code_.func = func;
-    this->len_ = -1;
+    this->len_ = -1;  // Sentinel value indicates template mode
   }
   void set_code_static(const int32_t *code, size_t len) {
     this->code_.data = code;
-    this->len_ = len;
+    this->len_ = len;  // Length >= 0 indicates static mode
   }
   TEMPLATABLE_VALUE(uint32_t, carrier_frequency);
 
@@ -69,7 +69,7 @@ template<typename... Ts> class RawAction : public RemoteTransmitterActionBase<Ts
   }
 
  protected:
-  ssize_t len_{-1};
+  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
   union Code {
     RawTimings (*func)(Ts...);
     const int32_t *data;

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -1,3 +1,11 @@
+number:
+  - platform: template
+    id: test_number
+    optimistic: true
+    min_value: 0
+    max_value: 255
+    step: 1
+
 button:
   - platform: template
     name: Beo4 audio mute
@@ -128,10 +136,16 @@ button:
         address: 0x00
         command: 0x0B
   - platform: template
-    name: RC5 Raw
+    name: RC5 Raw static
     on_press:
       remote_transmitter.transmit_raw:
         code: [1000, -1000]
+  - platform: template
+    name: RC5 Raw lambda
+    on_press:
+      remote_transmitter.transmit_raw:
+        code: !lambda |-
+          return {(int32_t)id(test_number).state * 100, -1000};
   - platform: template
     name: AEHA
     id: eaha_hitachi_climate_power_on


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `remote_transmitter.transmit_raw` action to use function pointers instead of `std::function` for lambdas, saving memory per raw remote configuration.

## Problem

The `remote_transmitter.transmit_raw` action used `std::function<RawTimings(Ts...)>` (16 bytes on 32-bit) for template-based transmits, even though ESPHome generates stateless lambdas that only reference global component pointers.

## Solution

Replace `std::function<RawTimings(Ts...)>` with function pointer `RawTimings (*)(Ts...)` (4 bytes on 32-bit). Stateless lambdas generated by ESPHome implicitly convert to function pointers.

### Memory layout optimization with union and sentinel

Since template and static modes are mutually exclusive, use a union to minimize memory footprint. A sentinel value (`len_ = -1`) indicates template mode, making the code cleaner and more idiomatic:

**Before:**
```cpp
protected:
  std::function<RawTimings(Ts...)> code_func_{nullptr};  // 16 bytes on 32-bit
  const int32_t *code_static_{nullptr};                  // 4 bytes on 32-bit
  int32_t code_static_len_{0};                           // 4 bytes on 32-bit
  // Total: 24 bytes
```

**After:**
```cpp
void set_code_template(RawTimings (*func)(Ts...)) {
  this->code_.func = func;
  this->len_ = -1;  // Sentinel value indicates template mode
}
void set_code_static(const int32_t *code, size_t len) {
  this->code_.data = code;
  this->len_ = len;  // Length >= 0 indicates static mode
}

protected:
  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
  union Code {
    RawTimings (*func)(Ts...);  // 4 bytes on 32-bit
    const int32_t *data;        // 4 bytes on 32-bit
  } code_;  // Union size = 4 bytes
  // Total: 8 bytes (4 len + 4 union)
```

The sentinel pattern (`if (this->len_ >= 0)`) is cleaner than a separate boolean flag and saves an additional 4 bytes on 32-bit platforms. Comments clearly indicate the sentinel value and mode selection.

## Memory Savings

Per `remote_transmitter.transmit_raw` action on 32-bit platforms (ESP32/ESP8266):
- **Per template action**: 12 bytes saved from `std::function` → function pointer
- **Union + sentinel optimization**: Additional 4 bytes saved
- **Total per action**: 16 bytes saved (24 bytes → 8 bytes, 67% reduction)
- **Flash**: Reduced STL template instantiations for `std::function`

**Note:** Static data was already stored in flash using `cg.progmem_array`, so no additional heap savings for static mode (only the structural memory improvement from the union + sentinel pattern).

## Verification

This optimization uses the **exact same pattern** as PR #11784 (uart), #11786 (ble_client), #11788 (canbus), #11790 (sx126x), #11794 (udp), #11796 (speaker), and #11798 (abbwelcome) which have been tested and verified:

**Pattern verification:**
- Same optimization: `std::function` → function pointer for stateless lambdas
- ESPHome generates stateless lambdas that only reference global component pointers
- Function pointers work identically to `std::function` for stateless lambdas
- Union-based storage for mutually exclusive modes
- Component tests pass with both static and lambda code

**CI will verify:**
- Compilation succeeds for all platforms
- Memory impact analysis shows expected results
- Component tests pass

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A - Proactive optimization following uart/ble_client/canbus/sx126x/sx127x/udp/speaker/abbwelcome pattern

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes (internal optimization)

## Test Environment

- [ ] ESP32 IDF
- [ ] ESP32 Arduino
- [ ] ESP8266 Arduino
- [ ] RP2040 Arduino
- [x] Component test build verified

## Example entry for `config.yaml`:

No configuration changes - optimization is transparent to users. All existing `remote_transmitter.transmit_raw` usage continues to work:

```yaml
remote_transmitter:
  pin: GPIO4
  carrier_duty_percent: 50%

button:
  - platform: template
    name: "Raw Static"
    on_press:
      # Static code array
      remote_transmitter.transmit_raw:
        code: [1000, -1000, 500, -500]

  - platform: template
    name: "Raw Lambda"
    on_press:
      # Lambda (uses function pointer)
      remote_transmitter.transmit_raw:
        code: !lambda |-
          return {1000, -1000, 500, -500};
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - Internal optimization only, no user-facing changes
