### PR TITLE
[spi] Low data rate fixes

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -61,7 +61,7 @@ SPI_DATA_RATE_OPTIONS = {
     75e3: SPIDataRate.DATA_RATE_75KHZ,
     1e3: SPIDataRate.DATA_RATE_1KHZ,
 }
-SPI_DATA_RATE_SCHEMA = cv.All(cv.frequency, cv.enum(SPI_DATA_RATE_OPTIONS))
+SPI_DATA_RATE_SCHEMA = cv.Any(cv.frequency, cv.enum(SPI_DATA_RATE_OPTIONS))
 
 SPI_MODE_OPTIONS = {
     "MODE0": SPIMode.MODE0,
@@ -410,7 +410,7 @@ async def register_spi_device(var, config):
         pin = await cg.gpio_pin_expression(cs_pin)
         cg.add(var.set_cs_pin(pin))
     if data_rate := config.get(CONF_DATA_RATE):
-        cg.add(var.set_data_rate(data_rate))
+        cg.add(var.set_data_rate(int(data_rate)))
     if spi_mode := config.get(CONF_SPI_MODE):
         cg.add(var.set_mode(spi_mode))
     if release_device := config.get(CONF_RELEASE_DEVICE):

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -304,6 +304,10 @@ class SPIDelegateBitBash : public SPIDelegate {
   SPIClockPhase clock_phase_;
 
   void HOT cycle_clock_() {
+    if (this->data_rate_ <= 1000) {
+      delay(1000 / this->data_rate_);
+      return;
+    }
     while (this->last_transition_ - arch_get_cpu_cycle_count() < this->wait_cycle_)
       continue;
     this->last_transition_ += this->wait_cycle_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Allow any frequency to be used with SPI, not just the enumerated ones
* When doing software SPI at low data rates (e.g. through an expander) use `delay()`` instead of counting CPU cycles


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11748

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
