### PR TITLE
[network, psram, speaker wifi] Use CORE.data to enable high performance networking

### DIFF
--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -11,7 +11,6 @@ KEY_REFRESH = "refresh"
 KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
-KEY_PSRAM_GUARANTEED = "psram_guaranteed"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32S2 = "ESP32S2"

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -11,6 +11,7 @@ KEY_REFRESH = "refresh"
 KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
+KEY_PSRAM_GUARANTEED = "psram_guaranteed"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32S2 = "ESP32S2"

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -2,7 +2,7 @@ import ipaddress
 
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
-from esphome.components.esp32.const import KEY_ESP32, KEY_PSRAM_GUARANTEED
+from esphome.components.psram import KEY_PSRAM_GUARANTEED
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_IPV6, CONF_MIN_IPV6_ADDR_COUNT
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
@@ -126,7 +126,7 @@ async def to_code(config):
         and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
     ):
         # Check if PSRAM is guaranteed (set by psram component during final validation)
-        psram_guaranteed = CORE.data.get(KEY_ESP32, {}).get(KEY_PSRAM_GUARANTEED, False)
+        psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
 
         if psram_guaranteed:
             # PSRAM is guaranteed - use aggressive settings

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -62,13 +62,11 @@ def require_high_performance_networking() -> None:
 
     Settings applied (ESP-IDF only):
     - lwip: Larger TCP buffers, windows, and mailbox sizes
-    - WiFi: Increased RX/TX buffers, AMPDU aggregation, PSRAM allocation
+    - WiFi: Increased RX/TX buffers, AMPDU aggregation, PSRAM allocation (set by wifi component)
 
     Configuration is PSRAM-aware:
     - With PSRAM guaranteed: Aggressive settings (512 RX buffers, 512KB TCP windows)
-    - Without PSRAM: Conservative settings (64 buffers, 65KB TCP windows)
-
-    This function is idempotent - safe to call multiple times from different components.
+    - Without PSRAM: Conservative optimized settings (64 buffers, 65KB TCP windows)
 
     Example:
         from esphome.components import network
@@ -132,6 +130,8 @@ async def to_code(config):
 
         if psram_guaranteed:
             # PSRAM is guaranteed - use aggressive settings
+            # Higher maximum values are allowed because CONFIG_LWIP_WND_SCALE is set to true
+            # CONFIG_LWIP_WND_SCALE can only be enabled if CONFIG_SPIRAM_IGNORE_NOTFOUND isn't set
             # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
 
             # Enable window scaling for much larger TCP windows
@@ -158,7 +158,7 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_OVERSIZE_MSS", True)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_QUEUE_OOSEQ", True)
         else:
-            # PSRAM not guaranteed - use more conservative optimized settings
+            # PSRAM not guaranteed - use more conservative, but still optimized settings
             # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 65534)

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -2,12 +2,17 @@ import ipaddress
 
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
+from esphome.components.esp32.const import KEY_ESP32, KEY_PSRAM_GUARANTEED
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_IPV6, CONF_MIN_IPV6_ADDR_COUNT
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
 
 CODEOWNERS = ["@esphome/core"]
 AUTO_LOAD = ["mdns"]
+
+# High performance networking tracking infrastructure
+# Components can request high performance networking and this configures lwip and WiFi settings
+KEY_HIGH_PERFORMANCE_NETWORKING = "high_performance_networking"
 
 network_ns = cg.esphome_ns.namespace("network")
 IPAddress = network_ns.class_("IPAddress")
@@ -47,6 +52,41 @@ def ip_address_literal(ip: str | int | None) -> cg.MockObj:
     return IPAddress(str(ip))
 
 
+def require_high_performance_networking() -> None:
+    """Request high performance networking for network and WiFi.
+
+    Call this from components that need optimized network performance for streaming
+    or high-throughput data transfer. This enables high performance mode which
+    configures both lwip TCP settings and WiFi driver settings for improved
+    network performance.
+
+    Settings applied (ESP-IDF only):
+    - lwip: Larger TCP buffers, windows, and mailbox sizes
+    - WiFi: Increased RX/TX buffers, AMPDU aggregation, PSRAM allocation
+
+    Configuration is PSRAM-aware:
+    - With PSRAM guaranteed: Aggressive settings (512 RX buffers, 512KB TCP windows)
+    - Without PSRAM: Conservative settings (64 buffers, 65KB TCP windows)
+
+    This function is idempotent - safe to call multiple times from different components.
+
+    Example:
+        from esphome.components import network
+
+        def _request_high_performance_networking(config):
+            network.require_high_performance_networking()
+            return config
+
+        CONFIG_SCHEMA = cv.All(
+            ...,
+            _request_high_performance_networking,
+        )
+    """
+    # Only set up once (idempotent - multiple components can call this)
+    if not CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False):
+        CORE.data[KEY_HIGH_PERFORMANCE_NETWORKING] = True
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.SplitDefault(
@@ -80,6 +120,51 @@ async def to_code(config):
     cg.add_define("USE_NETWORK")
     if CORE.using_arduino and CORE.is_esp32:
         cg.add_library("Networking", None)
+
+    # Apply high performance networking settings if requested by any component
+    if (
+        CORE.is_esp32
+        and CORE.using_esp_idf
+        and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
+    ):
+        # Check if PSRAM is guaranteed (set by psram component during final validation)
+        psram_guaranteed = CORE.data.get(KEY_ESP32, {}).get(KEY_PSRAM_GUARANTEED, False)
+
+        if psram_guaranteed:
+            # PSRAM is guaranteed - use aggressive settings
+            # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
+
+            # Enable window scaling for much larger TCP windows
+            add_idf_sdkconfig_option("CONFIG_LWIP_WND_SCALE", True)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RCV_SCALE", 3)
+
+            # Large TCP buffers and windows (requires PSRAM)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 512000)
+
+            # Large mailboxes for high throughput
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 512)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 512)
+
+            # TCP connection limits
+            add_idf_sdkconfig_option("CONFIG_LWIP_MAX_ACTIVE_TCP", 16)
+            add_idf_sdkconfig_option("CONFIG_LWIP_MAX_LISTENING_TCP", 16)
+
+            # TCP optimizations
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MAXRTX", 12)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SYNMAXRTX", 6)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MSS", 1436)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_MSL", 60000)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_OVERSIZE_MSS", True)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_QUEUE_OOSEQ", True)
+        else:
+            # PSRAM not guaranteed - use more conservative optimized settings
+            # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_WND_DEFAULT", 65534)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
+            add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
+
     if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
         cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
         if enable_ipv6:

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 # High performance networking tracking infrastructure
 # Components can request high performance networking and this configures lwip and WiFi settings
 KEY_HIGH_PERFORMANCE_NETWORKING = "high_performance_networking"
+CONF_ENABLE_HIGH_PERFORMANCE = "enable_high_performance"
 
 network_ns = cg.esphome_ns.namespace("network")
 IPAddress = network_ns.class_("IPAddress")
@@ -112,6 +113,7 @@ CONFIG_SCHEMA = cv.Schema(
             ),
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
+        cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.boolean,
     }
 )
 
@@ -122,12 +124,23 @@ async def to_code(config):
     if CORE.using_arduino and CORE.is_esp32:
         cg.add_library("Networking", None)
 
-    # Apply high performance networking settings if requested by any component
-    if (
-        CORE.is_esp32
-        and CORE.using_esp_idf
-        and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
-    ):
+    # Apply high performance networking settings
+    # Config can explicitly enable/disable, or default to component-driven behavior
+    enable_high_perf = config.get(CONF_ENABLE_HIGH_PERFORMANCE)
+    component_requested = CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
+
+    # Explicit config overrides component request
+    should_enable = (
+        enable_high_perf if enable_high_perf is not None else component_requested
+    )
+
+    # Log when user explicitly disables but a component requested it
+    if enable_high_perf is False and component_requested:
+        _LOGGER.info(
+            "High performance networking disabled by user configuration (overriding component request)"
+        )
+
+    if CORE.is_esp32 and CORE.using_esp_idf and should_enable:
         # Check if PSRAM is guaranteed (set by psram component during final validation)
         psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
 

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
-from esphome.components.psram import KEY_PSRAM_GUARANTEED
+from esphome.components.psram import is_guaranteed as psram_is_guaranteed
 import esphome.config_validation as cv
 from esphome.const import CONF_ENABLE_IPV6, CONF_MIN_IPV6_ADDR_COUNT
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
@@ -89,6 +89,22 @@ def require_high_performance_networking() -> None:
         CORE.data[KEY_HIGH_PERFORMANCE_NETWORKING] = True
 
 
+def has_high_performance_networking() -> bool:
+    """Check if high performance networking mode is enabled.
+
+    Returns True when high performance networking has been requested by a
+    component or explicitly enabled in the network configuration. This indicates
+    that lwip and WiFi will use optimized buffer sizes and settings.
+
+    This function should be called during code generation (to_code phase) by
+    components that need to apply performance-related settings.
+
+    Returns:
+        bool: True if high performance networking is enabled, False otherwise
+    """
+    return CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.SplitDefault(
@@ -142,7 +158,7 @@ async def to_code(config):
 
     if CORE.is_esp32 and CORE.using_esp_idf and should_enable:
         # Check if PSRAM is guaranteed (set by psram component during final validation)
-        psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
+        psram_guaranteed = psram_is_guaranteed()
 
         if psram_guaranteed:
             _LOGGER.info(

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -113,7 +113,7 @@ CONFIG_SCHEMA = cv.Schema(
             ),
         ),
         cv.Optional(CONF_MIN_IPV6_ADDR_COUNT, default=0): cv.positive_int,
-        cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.boolean,
+        cv.Optional(CONF_ENABLE_HIGH_PERFORMANCE): cv.All(cv.boolean, cv.only_on_esp32),
     }
 )
 

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -1,4 +1,5 @@
 import ipaddress
+import logging
 
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_sdkconfig_option
@@ -9,6 +10,8 @@ from esphome.core import CORE, CoroPriority, coroutine_with_priority
 
 CODEOWNERS = ["@esphome/core"]
 AUTO_LOAD = ["mdns"]
+
+_LOGGER = logging.getLogger(__name__)
 
 # High performance networking tracking infrastructure
 # Components can request high performance networking and this configures lwip and WiFi settings
@@ -129,6 +132,9 @@ async def to_code(config):
         psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
 
         if psram_guaranteed:
+            _LOGGER.info(
+                "Applying high-performance lwip settings (PSRAM guaranteed): 512KB TCP windows, 512 mailbox sizes"
+            )
             # PSRAM is guaranteed - use aggressive settings
             # Higher maximum values are allowed because CONFIG_LWIP_WND_SCALE is set to true
             # CONFIG_LWIP_WND_SCALE can only be enabled if CONFIG_SPIRAM_IGNORE_NOTFOUND isn't set
@@ -158,6 +164,9 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_OVERSIZE_MSS", True)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_QUEUE_OOSEQ", True)
         else:
+            _LOGGER.info(
+                "Applying optimized lwip settings: 65KB TCP windows, 64 mailbox sizes"
+            )
             # PSRAM not guaranteed - use more conservative, but still optimized settings
             # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_SND_BUF_DEFAULT", 65534)

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -74,6 +74,23 @@ def supported() -> bool:
     return variant in SPIRAM_MODES
 
 
+def is_guaranteed() -> bool:
+    """Check if PSRAM is guaranteed to be available.
+
+    Returns True when PSRAM is configured with both 'disabled: false' and
+    'ignore_not_found: false', meaning the device will fail to boot if PSRAM
+    is not found. This ensures safe use of high buffer configurations that
+    depend on PSRAM.
+
+    This function should be called during code generation (to_code phase) by
+    components that need to know PSRAM availability for configuration decisions.
+
+    Returns:
+        bool: True if PSRAM is guaranteed, False otherwise
+    """
+    return CORE.data.get(KEY_PSRAM_GUARANTEED, False)
+
+
 def validate_psram_mode(config):
     esp32_config = fv.full_config.get()[PLATFORM_ESP32]
     if config[CONF_SPEED] == "120MHZ":

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -11,6 +11,8 @@ from esphome.components.esp32 import (
     get_esp32_variant,
 )
 from esphome.components.esp32.const import (
+    KEY_ESP32,
+    KEY_PSRAM_GUARANTEED,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -131,7 +133,22 @@ def get_config_schema(config):
 
 CONFIG_SCHEMA = get_config_schema
 
-FINAL_VALIDATE_SCHEMA = validate_psram_mode
+
+def _store_psram_guaranteed(config):
+    """Store PSRAM guaranteed status in CORE.data for other components.
+
+    PSRAM is "guaranteed" when it will fail if not found, ensuring safe use
+    of high buffer configurations in network/wifi components.
+
+    Called during final validation to ensure the flag is available
+    before any to_code() functions run.
+    """
+    psram_guaranteed = not config[CONF_DISABLED] and not config[CONF_IGNORE_NOT_FOUND]
+    CORE.data[KEY_ESP32][KEY_PSRAM_GUARANTEED] = psram_guaranteed
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = cv.All(validate_psram_mode, _store_psram_guaranteed)
 
 
 async def to_code(config):

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -11,8 +11,6 @@ from esphome.components.esp32 import (
     get_esp32_variant,
 )
 from esphome.components.esp32.const import (
-    KEY_ESP32,
-    KEY_PSRAM_GUARANTEED,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -36,6 +34,9 @@ CODEOWNERS = ["@esphome/core"]
 DOMAIN = "psram"
 
 DEPENDENCIES = [PLATFORM_ESP32]
+
+# PSRAM availability tracking for cross-component coordination
+KEY_PSRAM_GUARANTEED = "psram_guaranteed"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ def _store_psram_guaranteed(config):
     before any to_code() functions run.
     """
     psram_guaranteed = not config[CONF_DISABLED] and not config[CONF_IGNORE_NOT_FOUND]
-    CORE.data[KEY_ESP32][KEY_PSRAM_GUARANTEED] = psram_guaranteed
+    CORE.data[KEY_PSRAM_GUARANTEED] = psram_guaranteed
     return config
 
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -3,7 +3,11 @@ from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
-from esphome.components.network import ip_address_literal
+from esphome.components.esp32.const import KEY_ESP32, KEY_PSRAM_GUARANTEED
+from esphome.components.network import (
+    KEY_HIGH_PERFORMANCE_NETWORKING,
+    ip_address_literal,
+)
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.config_validation import only_with_esp_idf
@@ -444,6 +448,53 @@ async def to_code(config):
 
     if config.get(CONF_USE_PSRAM):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
+
+    # Apply high performance WiFi settings if high performance networking is enabled
+    if (
+        CORE.is_esp32
+        and CORE.using_esp_idf
+        and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
+    ):
+        # Check if PSRAM is guaranteed (set by psram component during final validation)
+        psram_guaranteed = CORE.data.get(KEY_ESP32, {}).get(KEY_PSRAM_GUARANTEED, False)
+
+        # Always allocate WiFi buffers in PSRAM if available
+        add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
+
+        if psram_guaranteed:
+            # PSRAM is guaranteed - use aggressive settings
+            # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
+
+            # Large dynamic RX buffers (requires PSRAM)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM", 16)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM", 512)
+
+            # Static TX buffers for better performance
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_TX_BUFFER", True)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BUFFER_TYPE", 0)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_CACHE_TX_BUFFER_NUM", 32)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_TX_BUFFER_NUM", 8)
+
+            # AMPDU settings optimized for PSRAM
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_TX_ENABLED", True)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BA_WIN", 16)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
+        else:
+            # PSRAM not guaranteed - use more conservative optimized settings
+            # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
+
+            # Standard buffer counts
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM", 16)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM", 64)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM", 64)
+
+            # Standard AMPDU settings
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_TX_ENABLED", True)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_TX_BA_WIN", 32)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
+            add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
+
     cg.add_define("USE_WIFI")
 
     # must register before OTA safe mode check

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import automation
 from esphome.automation import Condition
 import esphome.codegen as cg
@@ -54,6 +56,8 @@ import esphome.final_validate as fv
 from . import wpa2_eap
 
 AUTO_LOAD = ["network"]
+
+_LOGGER = logging.getLogger(__name__)
 
 NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2, const.VARIANT_ESP32P4]
 CONF_SAVE = "save"
@@ -462,6 +466,9 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
 
         if psram_guaranteed:
+            _LOGGER.info(
+                "Applying high-performance WiFi settings (PSRAM guaranteed): 512 RX buffers, 32 TX buffers"
+            )
             # PSRAM is guaranteed - use aggressive settings
             # Higher maximum values are allowed because CONFIG_LWIP_WND_SCALE is set to true in networking component
             # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
@@ -482,6 +489,9 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
             add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
         else:
+            _LOGGER.info(
+                "Applying optimized WiFi settings: 64 RX buffers, 64 TX buffers"
+            )
             # PSRAM not guaranteed - use more conservative, but still optimized settings
             # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -463,6 +463,7 @@ async def to_code(config):
 
         if psram_guaranteed:
             # PSRAM is guaranteed - use aggressive settings
+            # Higher maximum values are allowed because CONFIG_LWIP_WND_SCALE is set to true in networking component
             # Based on https://github.com/espressif/esp-adf/issues/297#issuecomment-783811702
 
             # Large dynamic RX buffers (requires PSRAM)
@@ -481,7 +482,7 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_ESP_WIFI_AMPDU_RX_ENABLED", True)
             add_idf_sdkconfig_option("CONFIG_ESP_WIFI_RX_BA_WIN", 32)
         else:
-            # PSRAM not guaranteed - use more conservative optimized settings
+            # PSRAM not guaranteed - use more conservative, but still optimized settings
             # Based on https://github.com/espressif/esp-idf/blob/release/v5.4/examples/wifi/iperf/sdkconfig.defaults.esp32
 
             # Standard buffer counts

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -3,11 +3,11 @@ from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
-from esphome.components.esp32.const import KEY_ESP32, KEY_PSRAM_GUARANTEED
 from esphome.components.network import (
     KEY_HIGH_PERFORMANCE_NETWORKING,
     ip_address_literal,
 )
+from esphome.components.psram import KEY_PSRAM_GUARANTEED
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.config_validation import only_with_esp_idf
@@ -456,7 +456,7 @@ async def to_code(config):
         and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
     ):
         # Check if PSRAM is guaranteed (set by psram component during final validation)
-        psram_guaranteed = CORE.data.get(KEY_ESP32, {}).get(KEY_PSRAM_GUARANTEED, False)
+        psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
 
         # Always allocate WiFi buffers in PSRAM if available
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -6,10 +6,10 @@ import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
 from esphome.components.network import (
-    KEY_HIGH_PERFORMANCE_NETWORKING,
+    has_high_performance_networking,
     ip_address_literal,
 )
-from esphome.components.psram import KEY_PSRAM_GUARANTEED
+from esphome.components.psram import is_guaranteed as psram_is_guaranteed
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.config_validation import only_with_esp_idf
@@ -454,13 +454,9 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
 
     # Apply high performance WiFi settings if high performance networking is enabled
-    if (
-        CORE.is_esp32
-        and CORE.using_esp_idf
-        and CORE.data.get(KEY_HIGH_PERFORMANCE_NETWORKING, False)
-    ):
+    if CORE.is_esp32 and CORE.using_esp_idf and has_high_performance_networking():
         # Check if PSRAM is guaranteed (set by psram component during final validation)
-        psram_guaranteed = CORE.data.get(KEY_PSRAM_GUARANTEED, False)
+        psram_guaranteed = psram_is_guaranteed()
 
         # Always allocate WiFi buffers in PSRAM if available
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)

--- a/tests/components/network/test.esp32-idf.yaml
+++ b/tests/components/network/test.esp32-idf.yaml
@@ -1,1 +1,4 @@
 <<: !include common.yaml
+
+network:
+  enable_high_performance: true


### PR DESCRIPTION
# What does this implement/fix?

Introduces a centralized high-performance networking system where components request optimized settings through a
helper function instead of directly configuring low-level sdkconfig options.

### Changes
- Add network.require_high_performance_networking() helper function that components call during config validation
- Network component applies PSRAM-aware lwip TCP settings (aggressive: 512KB windows, conservative: 65KB)
- WiFi component automatically applies optimized WiFi settings when networking flag is set
- PSRAM component stores "guarantee" status in CORE.data[KEY_ESP32][KEY_PSRAM_GUARANTEED] during final validation
- Speaker media player now uses the helper function instead of directly setting sdkconfig options
- Network component has new configuration option ``enable_high_performance`` to explicitly enable/disable these changes.

### Benefits
- Single API for requesting high-performance networking
- Network/WiFi components control their own configuration details
- PSRAM-aware: Uses aggressive settings when PSRAM is guaranteed, conservative otherwise

### Breaking Change Description
High performance networking mode is always enabled with the speaker media player. Previously, it was only enabled if codec support was enabled.

This didn't seem to cause any issues with the voice assistant firmware on an ATOM Echo, a device without PSRAM. Since PSRAM isn't guaranteed, this still uses optimized, but not extreme, low-level driver settings that still work on devices without PSRAM. If it is causing problems, users can override it with ``enable_high_performance`` under the network component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (most likely!) <https://github.com/esphome/home-assistant-voice-pe/issues/455> (if we guarantee PSRAM is available, we go back to the previous wifi driver settings that didn't have this issue)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5599

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

psram:
  mode: octal
  speed: 80MHz
  ignore_not_found: false

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    volume_min: 0.5
    volume_max: 0.8
    announcement_pipeline:
      speaker: box_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 1  # S3 Box only has one output channel

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
