### PR TITLE
[core] Update clamp functions to allow mixed but comparable types

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1174,12 +1174,17 @@ template<class T> using ExternalRAMAllocator = RAMAllocator<T>;
  * Functions to constrain the range of arithmetic values.
  */
 
-template<std::totally_ordered T> T clamp_at_least(T value, T min) {
+template<typename T, typename U>
+concept comparable_with = requires(T a, U b) {
+  { a == b } -> std::convertible_to<bool>;
+};
+
+template<std::totally_ordered T, comparable_with<T> U> bool clamp_at_least(T value, U min) {
   if (value < min)
     return min;
   return value;
 }
-template<std::totally_ordered T> T clamp_at_most(T value, T max) {
+template<std::totally_ordered T, comparable_with<T> U> bool clamp_at_most(T value, U max) {
   if (value > max)
     return max;
   return value;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1177,6 +1177,7 @@ template<class T> using ExternalRAMAllocator = RAMAllocator<T>;
 template<typename T, typename U>
 concept comparable_with = requires(T a, U b) {
   { a > b } -> std::convertible_to<bool>;
+  { a < b } -> std::convertible_to<bool>;
 };
 
 template<std::totally_ordered T, comparable_with<T> U> T clamp_at_least(T value, U min) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1176,7 +1176,7 @@ template<class T> using ExternalRAMAllocator = RAMAllocator<T>;
 
 template<typename T, typename U>
 concept comparable_with = requires(T a, U b) {
-  { a == b } -> std::convertible_to<bool>;
+  { a > b } -> std::convertible_to<bool>;
 };
 
 template<std::totally_ordered T, comparable_with<T> U> bool clamp_at_least(T value, U min) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1179,12 +1179,12 @@ concept comparable_with = requires(T a, U b) {
   { a > b } -> std::convertible_to<bool>;
 };
 
-template<std::totally_ordered T, comparable_with<T> U> bool clamp_at_least(T value, U min) {
+template<std::totally_ordered T, comparable_with<T> U> T clamp_at_least(T value, U min) {
   if (value < min)
     return min;
   return value;
 }
-template<std::totally_ordered T, comparable_with<T> U> bool clamp_at_most(T value, U max) {
+template<std::totally_ordered T, comparable_with<T> U> T clamp_at_most(T value, U max) {
   if (value > max)
     return max;
   return value;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The original versions of `clamp_at_least` and `clamp_at_most` did not work with mixed types, e.g.

```
uint16_t x = 0;
x = clamp_at_least(x, 1);
```

fails because 1 is int, not uint16_t.

This PR allows any type for the second argument as long as it is comparable with the first argument.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
