### PR TITLE
[wifi] Change priority type from float to int8_t

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -174,7 +174,7 @@ WIFI_NETWORK_STA = WIFI_NETWORK_BASE.extend(
     {
         cv.Optional(CONF_BSSID): cv.mac_address,
         cv.Optional(CONF_HIDDEN): cv.boolean,
-        cv.Optional(CONF_PRIORITY, default=0.0): cv.float_,
+        cv.Optional(CONF_PRIORITY, default=0): cv.int_range(min=-128, max=127),
         cv.Optional(CONF_EAP): EAP_AUTH_SCHEMA,
     }
 )

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1062,8 +1062,8 @@ void WiFiComponent::check_connecting_finished() {
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
     this->num_retried_ = 0;
 
-    // Reset all priorities if they're all the same (can't differentiate)
-    this->reset_priorities_if_all_same_();
+    // Clear priority tracking if all priorities are identical
+    this->clear_priorities_if_all_same_();
 
 #ifdef USE_WIFI_FAST_CONNECT
     this->save_fast_connect_settings_();
@@ -1293,9 +1293,9 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
   return false;  // Did not start scan, can proceed with connection
 }
 
-/// Reset all BSSID priorities if they're all identical (can't differentiate)
+/// Clear BSSID priority tracking if all priorities are identical (can't differentiate, saves memory)
 /// Called when starting a fresh connection attempt or after successful connection
-void WiFiComponent::reset_priorities_if_all_same_() {
+void WiFiComponent::clear_priorities_if_all_same_() {
   if (this->sta_priorities_.empty()) {
     return;
   }
@@ -1360,8 +1360,8 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
            format_mac_address_pretty(failed_bssid.value().data()).c_str(), old_priority, new_priority);
 
   // After adjusting priority, check if all priorities are now identical
-  // If so, reset them all to 0 to start fresh
-  this->reset_priorities_if_all_same_();
+  // If so, clear the vector to save memory
+  this->clear_priorities_if_all_same_();
 }
 
 /// Handle target advancement or retry counter increment when staying in the same phase

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -675,7 +675,7 @@ void WiFiComponent::start_connecting(const WiFiAP &ap, bool two) {
   }
 
   ESP_LOGI(TAG,
-           "Connecting to " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") " (priority %.1f, attempt %u/%u in phase %s)...",
+           "Connecting to " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") " (priority %d, attempt %u/%u in phase %s)...",
            ap.get_ssid().c_str(), ap.get_bssid().has_value() ? bssid_formatted.c_str() : LOG_STR_LITERAL("any"),
            priority, this->num_retried_ + 1, get_max_retries_for_phase(this->retry_phase_),
            LOG_STR_ARG(retry_phase_to_log_string(this->retry_phase_)));
@@ -812,7 +812,7 @@ void WiFiComponent::print_connect_params_() {
                 wifi_gateway_ip_().str().c_str(), wifi_dns_ip_(0).str().c_str(), wifi_dns_ip_(1).str().c_str());
 #ifdef ESPHOME_LOG_HAS_VERBOSE
   if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_bssid().has_value()) {
-    ESP_LOGV(TAG, "  Priority: %.1f", this->get_sta_priority(*config->get_bssid()));
+    ESP_LOGV(TAG, "  Priority: %d", this->get_sta_priority(*config->get_bssid()));
   }
 #endif
 #ifdef USE_WIFI_11KV_SUPPORT
@@ -933,8 +933,7 @@ __attribute__((noinline)) static void log_scan_result(const WiFiScanResult &res)
     ESP_LOGI(TAG, "- '%s' %s" LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(),
              res.get_is_hidden() ? LOG_STR_LITERAL("(HIDDEN) ") : LOG_STR_LITERAL(""), bssid_s,
              LOG_STR_ARG(get_signal_bars(res.get_rssi())));
-    ESP_LOGD(TAG, "  Channel: %2u, RSSI: %3d dB, Priority: %4.1f", res.get_channel(), res.get_rssi(),
-             res.get_priority());
+    ESP_LOGD(TAG, "  Channel: %2u, RSSI: %3d dB, Priority: %4d", res.get_channel(), res.get_rssi(), res.get_priority());
   } else {
     ESP_LOGD(TAG, "- " LOG_SECRET("'%s'") " " LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(), bssid_s,
              LOG_STR_ARG(get_signal_bars(res.get_rssi())));
@@ -1062,6 +1061,9 @@ void WiFiComponent::check_connecting_finished() {
 
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
     this->num_retried_ = 0;
+
+    // Reset all priorities if they're all the same (can't differentiate)
+    this->reset_priorities_if_all_same_();
 
 #ifdef USE_WIFI_FAST_CONNECT
     this->save_fast_connect_settings_();
@@ -1291,6 +1293,27 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
   return false;  // Did not start scan, can proceed with connection
 }
 
+/// Reset all BSSID priorities to 0 if they're all identical (can't differentiate)
+/// Called when starting a fresh connection attempt or after successful connection
+void WiFiComponent::reset_priorities_if_all_same_() {
+  if (this->sta_priorities_.empty()) {
+    return;
+  }
+
+  int8_t first_priority = this->sta_priorities_[0].priority;
+  for (const auto &pri : this->sta_priorities_) {
+    if (pri.priority != first_priority) {
+      return;  // Not all same, nothing to do
+    }
+  }
+
+  // All priorities are identical, reset to 0
+  ESP_LOGD(TAG, "Resetting all BSSID priorities (all identical)");
+  for (auto &pri : this->sta_priorities_) {
+    pri.priority = 0;
+  }
+}
+
 /// Log failed connection attempt and decrease BSSID priority to avoid repeated failures
 /// This function identifies which BSSID was attempted (from scan results or config),
 /// decreases its priority by 1.0 to discourage future attempts, and logs the change.
@@ -1321,8 +1344,9 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
   }
 
   // Decrease priority to avoid repeatedly trying the same failed BSSID
-  float old_priority = this->get_sta_priority(failed_bssid.value());
-  float new_priority = old_priority - 1.0f;
+  int8_t old_priority = this->get_sta_priority(failed_bssid.value());
+  int8_t new_priority =
+      (old_priority > std::numeric_limits<int8_t>::min()) ? (old_priority - 1) : std::numeric_limits<int8_t>::min();
   this->set_sta_priority(failed_bssid.value(), new_priority);
 
   // Get SSID for logging
@@ -1333,8 +1357,12 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
     ssid = config->get_ssid();
   }
 
-  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %.1f → %.1f", ssid.c_str(),
+  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d", ssid.c_str(),
            format_mac_address_pretty(failed_bssid.value().data()).c_str(), old_priority, new_priority);
+
+  // After adjusting priority, check if all priorities are now identical
+  // If so, reset them all to 0 to start fresh
+  this->reset_priorities_if_all_same_();
 }
 
 /// Handle target advancement or retry counter increment when staying in the same phase

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1062,8 +1062,8 @@ void WiFiComponent::check_connecting_finished() {
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
     this->num_retried_ = 0;
 
-    // Clear priority tracking if all priorities are identical
-    this->clear_priorities_if_all_same_();
+    // Clear priority tracking if all priorities are at minimum
+    this->clear_priorities_if_all_min_();
 
 #ifdef USE_WIFI_FAST_CONNECT
     this->save_fast_connect_settings_();
@@ -1293,9 +1293,10 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
   return false;  // Did not start scan, can proceed with connection
 }
 
-/// Clear BSSID priority tracking if all priorities are identical (can't differentiate, saves memory)
-/// Called when starting a fresh connection attempt or after successful connection
-void WiFiComponent::clear_priorities_if_all_same_() {
+/// Clear BSSID priority tracking if all priorities are at minimum (saves memory)
+/// At minimum priority, all BSSIDs are equally bad, so priority tracking is useless
+/// Called after successful connection or after failed connection attempts
+void WiFiComponent::clear_priorities_if_all_min_() {
   if (this->sta_priorities_.empty()) {
     return;
   }
@@ -1366,9 +1367,9 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
   ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d", ssid.c_str(),
            format_mac_address_pretty(failed_bssid.value().data()).c_str(), old_priority, new_priority);
 
-  // After adjusting priority, check if all priorities are now identical
-  // If so, clear the vector to save memory
-  this->clear_priorities_if_all_same_();
+  // After adjusting priority, check if all priorities are now at minimum
+  // If so, clear the vector to save memory and reset for fresh start
+  this->clear_priorities_if_all_min_();
 }
 
 /// Handle target advancement or retry counter increment when staying in the same phase

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1293,7 +1293,7 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
   return false;  // Did not start scan, can proceed with connection
 }
 
-/// Reset all BSSID priorities to 0 if they're all identical (can't differentiate)
+/// Reset all BSSID priorities if they're all identical (can't differentiate)
 /// Called when starting a fresh connection attempt or after successful connection
 void WiFiComponent::reset_priorities_if_all_same_() {
   if (this->sta_priorities_.empty()) {
@@ -1307,11 +1307,10 @@ void WiFiComponent::reset_priorities_if_all_same_() {
     }
   }
 
-  // All priorities are identical, reset to 0
-  ESP_LOGD(TAG, "Resetting all BSSID priorities (all identical)");
-  for (auto &pri : this->sta_priorities_) {
-    pri.priority = 0;
-  }
+  // All priorities are identical - clear the vector to save memory
+  ESP_LOGD(TAG, "Clearing BSSID priorities (all identical)");
+  this->sta_priorities_.clear();
+  this->sta_priorities_.shrink_to_fit();
 }
 
 /// Log failed connection attempt and decrease BSSID priority to avoid repeated failures

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1301,14 +1301,21 @@ void WiFiComponent::clear_priorities_if_all_same_() {
   }
 
   int8_t first_priority = this->sta_priorities_[0].priority;
+
+  // Only clear if all priorities have been decremented to the minimum value
+  // At this point, all BSSIDs have been equally penalized and priority info is useless
+  if (first_priority != std::numeric_limits<int8_t>::min()) {
+    return;
+  }
+
   for (const auto &pri : this->sta_priorities_) {
     if (pri.priority != first_priority) {
       return;  // Not all same, nothing to do
     }
   }
 
-  // All priorities are identical - clear the vector to save memory
-  ESP_LOGD(TAG, "Clearing BSSID priorities (all identical)");
+  // All priorities are at minimum - clear the vector to save memory and reset
+  ESP_LOGD(TAG, "Clearing BSSID priorities (all at minimum)");
   this->sta_priorities_.clear();
   this->sta_priorities_.shrink_to_fit();
 }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -667,7 +667,7 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
 void WiFiComponent::start_connecting(const WiFiAP &ap, bool two) {
   // Log connection attempt at INFO level with priority
   std::string bssid_formatted;
-  float priority = 0.0f;
+  int8_t priority = 0;
 
   if (ap.get_bssid().has_value()) {
     bssid_formatted = format_mac_address_pretty(ap.get_bssid().value().data());
@@ -1575,9 +1575,9 @@ bool WiFiAP::get_hidden() const { return this->hidden_; }
 WiFiScanResult::WiFiScanResult(const bssid_t &bssid, std::string ssid, uint8_t channel, int8_t rssi, bool with_auth,
                                bool is_hidden)
     : bssid_(bssid),
-      ssid_(std::move(ssid)),
       channel_(channel),
       rssi_(rssi),
+      ssid_(std::move(ssid)),
       with_auth_(with_auth),
       is_hidden_(is_hidden) {}
 bool WiFiScanResult::matches(const WiFiAP &config) const {

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -157,7 +157,7 @@ class WiFiAP {
   void set_eap(optional<EAPAuth> eap_auth);
 #endif  // USE_WIFI_WPA2_EAP
   void set_channel(optional<uint8_t> channel);
-  void set_priority(float priority) { priority_ = priority; }
+  void set_priority(int8_t priority) { priority_ = priority; }
   void set_manual_ip(optional<ManualIP> manual_ip);
   void set_hidden(bool hidden);
   const std::string &get_ssid() const;
@@ -167,7 +167,7 @@ class WiFiAP {
   const optional<EAPAuth> &get_eap() const;
 #endif  // USE_WIFI_WPA2_EAP
   const optional<uint8_t> &get_channel() const;
-  float get_priority() const { return priority_; }
+  int8_t get_priority() const { return priority_; }
   const optional<ManualIP> &get_manual_ip() const;
   bool get_hidden() const;
 
@@ -179,8 +179,8 @@ class WiFiAP {
   optional<EAPAuth> eap_;
 #endif  // USE_WIFI_WPA2_EAP
   optional<ManualIP> manual_ip_;
-  float priority_{0};
   optional<uint8_t> channel_;
+  int8_t priority_{0};
   bool hidden_{false};
 };
 
@@ -198,17 +198,17 @@ class WiFiScanResult {
   int8_t get_rssi() const;
   bool get_with_auth() const;
   bool get_is_hidden() const;
-  float get_priority() const { return priority_; }
-  void set_priority(float priority) { priority_ = priority; }
+  int8_t get_priority() const { return priority_; }
+  void set_priority(int8_t priority) { priority_ = priority; }
 
   bool operator==(const WiFiScanResult &rhs) const;
 
  protected:
   bssid_t bssid_;
-  std::string ssid_;
-  float priority_{0.0f};
   uint8_t channel_;
   int8_t rssi_;
+  std::string ssid_;
+  int8_t priority_{0};
   bool matches_{false};
   bool with_auth_;
   bool is_hidden_;
@@ -216,7 +216,7 @@ class WiFiScanResult {
 
 struct WiFiSTAPriority {
   bssid_t bssid;
-  float priority;
+  int8_t priority;
 };
 
 enum WiFiPowerSaveMode : uint8_t {
@@ -317,14 +317,14 @@ class WiFiComponent : public Component {
     }
     return false;
   }
-  float get_sta_priority(const bssid_t bssid) {
+  int8_t get_sta_priority(const bssid_t bssid) {
     for (auto &it : this->sta_priorities_) {
       if (it.bssid == bssid)
         return it.priority;
     }
-    return 0.0f;
+    return 0;
   }
-  void set_sta_priority(const bssid_t bssid, float priority) {
+  void set_sta_priority(const bssid_t bssid, int8_t priority) {
     for (auto &it : this->sta_priorities_) {
       if (it.bssid == bssid) {
         it.priority = priority;
@@ -383,6 +383,8 @@ class WiFiComponent : public Component {
   int8_t find_next_hidden_sta_(int8_t start_index, bool include_explicit_hidden = true);
   /// Log failed connection and decrease BSSID priority to avoid repeated attempts
   void log_and_adjust_priority_for_failed_connect_();
+  /// Reset all BSSID priorities to 0 if they're all identical (can't differentiate)
+  void reset_priorities_if_all_same_();
   /// Advance to next target (AP/SSID) within current phase, or increment retry counter
   /// Called when staying in the same phase after a failed connection attempt
   void advance_to_next_target_or_increment_retry_();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -383,8 +383,8 @@ class WiFiComponent : public Component {
   int8_t find_next_hidden_sta_(int8_t start_index, bool include_explicit_hidden = true);
   /// Log failed connection and decrease BSSID priority to avoid repeated attempts
   void log_and_adjust_priority_for_failed_connect_();
-  /// Reset all BSSID priorities to 0 if they're all identical (can't differentiate)
-  void reset_priorities_if_all_same_();
+  /// Clear BSSID priority tracking if all priorities are identical (saves memory)
+  void clear_priorities_if_all_same_();
   /// Advance to next target (AP/SSID) within current phase, or increment retry counter
   /// Called when staying in the same phase after a failed connection attempt
   void advance_to_next_target_or_increment_retry_();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -383,8 +383,8 @@ class WiFiComponent : public Component {
   int8_t find_next_hidden_sta_(int8_t start_index, bool include_explicit_hidden = true);
   /// Log failed connection and decrease BSSID priority to avoid repeated attempts
   void log_and_adjust_priority_for_failed_connect_();
-  /// Clear BSSID priority tracking if all priorities are identical (saves memory)
-  void clear_priorities_if_all_same_();
+  /// Clear BSSID priority tracking if all priorities are at minimum (saves memory)
+  void clear_priorities_if_all_min_();
   /// Advance to next target (AP/SSID) within current phase, or increment retry counter
   /// Called when staying in the same phase after a failed connection attempt
   void advance_to_next_target_or_increment_retry_();

--- a/tests/components/wifi/common.yaml
+++ b/tests/components/wifi/common.yaml
@@ -15,5 +15,10 @@ wifi:
   networks:
     - ssid: MySSID
       password: password1
+      priority: 10
     - ssid: MySSID2
       password: password2
+      priority: 5
+    - ssid: MySSID3
+      password: password3
+      priority: 0


### PR DESCRIPTION
# What does this implement/fix?

Converts WiFi priority from `float` to `int8_t`, saving memory and adding auto-recovery when all BSSIDs fail equally.

## Changes

- Changed priority type from `float` to `int8_t`, saving RAM:
  - **WiFiSTAPriority**: 12 bytes → 8 bytes per entry (33% reduction)
  - **WiFiScanResult**: 3 bytes saved per scan result (all kept in memory during connection process)
  - **WiFiAP**: 3 bytes saved per configured network with improved struct packing on ESP32
- YAML now accepts integers -128 to 127 instead of floats
- Auto-clear priority tracking when all BSSIDs reach minimum priority (-128)
  - Only clears when all priorities at minimum (all equally bad)
  - Prevents stuck state and saves up to 96 bytes (with 12 BSSIDs)
  - Allows priority system to reset and try again
- Added underflow protection (clamps at `int8_t::min`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5590

## Breaking Change Details

### What breaks
The `priority` configuration option for WiFi networks now only accepts integers instead of floats.

**Before:**
```yaml
wifi:
  networks:
    - ssid: "MyNetwork"
      priority: 5.5  # Float values accepted
```

**After:**
```yaml
wifi:
  networks:
    - ssid: "MyNetwork"
      priority: 5  # Only integers -128 to 127 accepted
```

### Impact Assessment
**Impact: Very Low**

- `priority` is rarely used
- When used, it's almost always integers anyway
- Float values like `5.5` are extremely rare

### Migration
Change floats to integers: `priority: 5.5` → `priority: 5`

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  networks:
    - ssid: "HomeNetwork"
      password: "password123"
      priority: 10  # Higher priority = tried first (integers only, range: -128 to 127)

    - ssid: "BackupNetwork"
      password: "password456"
      priority: 0  # Default priority

    - ssid: "GuestNetwork"
      password: "password789"
      priority: -10  # Lower priority = tried last
```

## Behavioral Changes

### Auto-Clear at Minimum Priority
When all tracked BSSIDs have been penalized to minimum priority (-128), the tracking vector is cleared entirely. This happens when:
- All BSSIDs have failed repeatedly and reached minimum priority
- At this point, all BSSIDs are equally bad (priority info is useless)
- Clearing resets everything to start fresh

Benefits:
- Prevents permanent stuck state when all APs are bad
- Saves up to 96 bytes of RAM (with 12 tracked BSSIDs: 12 × 8 bytes)
- Allows priority system to recover and try again from scratch

## Technical Details

- Priority was always used as an integer (decrements by 1, never fractional)
- Range -128 to 127 is sufficient (ESPHome limits to 127 configured networks anyway)
- Memory optimization matters because WiFi component keeps all scan results in memory during connection and stores STA priorities permanently in RAM

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
