### PR TITLE
Add support for Sonoff SPM

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -432,6 +432,7 @@ esphome/components/smt100/* @piechade
 esphome/components/sn74hc165/* @jesserockz
 esphome/components/socket/* @esphome/core
 esphome/components/sonoff_d1/* @anatoly-savchenkov
+esphome/components/sonoff_spm/* @fhedberg
 esphome/components/sound_level/* @kahrendt
 esphome/components/speaker/* @jesserockz @kahrendt
 esphome/components/speaker/media_player/* @kahrendt @synesthesiam

--- a/esphome/components/sonoff_spm/__init__.py
+++ b/esphome/components/sonoff_spm/__init__.py
@@ -1,0 +1,158 @@
+"""Support for Sonoff SPM (Smart Power Manager)."""
+
+import esphome.codegen as cg
+from esphome.components import sensor, switch, uart
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CURRENT,
+    CONF_ENERGY,
+    CONF_ID,
+    CONF_POWER,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_AMPERE,
+    UNIT_KILOWATT_HOURS,
+    UNIT_VOLT,
+    UNIT_WATT,
+)
+
+CODEOWNERS = ["@fhedberg"]
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["switch", "sensor"]
+MULTI_CONF = False
+
+CONF_SONOFF_SPM_ID = "sonoff_spm_id"
+CONF_MODULE_COUNT = "module_count"
+CONF_AUTO_CREATE_SWITCHES = "auto_create_switches"
+CONF_AUTO_CREATE_SENSORS = "auto_create_sensors"
+CONF_NAME_PREFIX = "name_prefix"
+CONF_SENSOR_TYPES = "sensor_types"
+
+sonoff_spm_ns = cg.esphome_ns.namespace("sonoff_spm")
+SonoffSPM = sonoff_spm_ns.class_("SonoffSPM", cg.Component, uart.UARTDevice)
+SonoffSPMSwitch = sonoff_spm_ns.class_("SonoffSPMSwitch", switch.Switch, cg.Component)
+SonoffSPMSensor = sonoff_spm_ns.class_("SonoffSPMSensor", cg.Component)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SonoffSPM),
+            cv.Optional(CONF_MODULE_COUNT, default=32): cv.int_range(min=1, max=32),
+            cv.Optional(CONF_AUTO_CREATE_SWITCHES, default=False): cv.boolean,
+            cv.Optional(CONF_AUTO_CREATE_SENSORS, default=False): cv.boolean,
+            cv.Optional(CONF_NAME_PREFIX, default="SPM Relay"): cv.string,
+            cv.Optional(
+                CONF_SENSOR_TYPES,
+                default=[CONF_VOLTAGE, CONF_CURRENT, CONF_POWER, CONF_ENERGY],
+            ): cv.ensure_list(
+                cv.one_of(
+                    CONF_VOLTAGE, CONF_CURRENT, CONF_POWER, CONF_ENERGY, lower=True
+                )
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA)
+)
+
+
+async def to_code(config):
+    """Generate code for Sonoff SPM component."""
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    cg.add(var.set_module_count(config[CONF_MODULE_COUNT]))
+
+    # Auto-create switches for all relays if enabled
+    if config[CONF_AUTO_CREATE_SWITCHES]:
+        max_relays = config[CONF_MODULE_COUNT] * 4
+        name_prefix = config[CONF_NAME_PREFIX]
+
+        for relay_id in range(max_relays):
+            switch_config = {
+                CONF_ID: cv.declare_id(SonoffSPMSwitch)(
+                    f"sonoff_spm_switch_{relay_id}"
+                ),
+                "name": f"{name_prefix} {relay_id}",
+                "relay_id": relay_id,
+            }
+
+            switch_var = cg.new_Pvariable(switch_config[CONF_ID])
+            await cg.register_component(switch_var, {})
+            await switch.register_switch(switch_var, switch_config)
+
+            cg.add(switch_var.set_parent(var))
+            cg.add(switch_var.set_relay_id(relay_id))
+            cg.add(var.register_switch(switch_var, relay_id))
+
+    # Auto-create sensors for all relays if enabled
+    if config[CONF_AUTO_CREATE_SENSORS]:
+        max_relays = config[CONF_MODULE_COUNT] * 4
+        name_prefix = config[CONF_NAME_PREFIX]
+        sensor_types = config[CONF_SENSOR_TYPES]
+
+        for relay_id in range(max_relays):
+            sensor_var = cg.new_Pvariable(
+                cv.declare_id(SonoffSPMSensor)(f"sonoff_spm_sensor_{relay_id}")
+            )
+            await cg.register_component(sensor_var, {})
+
+            cg.add(sensor_var.set_parent(var))
+            cg.add(sensor_var.set_relay_id(relay_id))
+
+            # Create requested sensor types
+            if CONF_VOLTAGE in sensor_types:
+                sens = await sensor.new_sensor(
+                    {
+                        "name": f"{name_prefix} {relay_id} Voltage",
+                        "unit_of_measurement": UNIT_VOLT,
+                        "accuracy_decimals": 1,
+                        "device_class": DEVICE_CLASS_VOLTAGE,
+                        "state_class": STATE_CLASS_MEASUREMENT,
+                    }
+                )
+                cg.add(sensor_var.set_voltage_sensor(sens))
+
+            if CONF_CURRENT in sensor_types:
+                sens = await sensor.new_sensor(
+                    {
+                        "name": f"{name_prefix} {relay_id} Current",
+                        "unit_of_measurement": UNIT_AMPERE,
+                        "accuracy_decimals": 2,
+                        "device_class": DEVICE_CLASS_CURRENT,
+                        "state_class": STATE_CLASS_MEASUREMENT,
+                    }
+                )
+                cg.add(sensor_var.set_current_sensor(sens))
+
+            if CONF_POWER in sensor_types:
+                sens = await sensor.new_sensor(
+                    {
+                        "name": f"{name_prefix} {relay_id} Power",
+                        "unit_of_measurement": UNIT_WATT,
+                        "accuracy_decimals": 1,
+                        "device_class": DEVICE_CLASS_POWER,
+                        "state_class": STATE_CLASS_MEASUREMENT,
+                    }
+                )
+                cg.add(sensor_var.set_power_sensor(sens))
+
+            if CONF_ENERGY in sensor_types:
+                sens = await sensor.new_sensor(
+                    {
+                        "name": f"{name_prefix} {relay_id} Energy",
+                        "unit_of_measurement": UNIT_KILOWATT_HOURS,
+                        "accuracy_decimals": 2,
+                        "device_class": DEVICE_CLASS_ENERGY,
+                        "state_class": STATE_CLASS_TOTAL_INCREASING,
+                    }
+                )
+                cg.add(sensor_var.set_energy_sensor(sens))
+
+            cg.add(var.register_sensor(sensor_var, relay_id))

--- a/esphome/components/sonoff_spm/sensor/__init__.py
+++ b/esphome/components/sonoff_spm/sensor/__init__.py
@@ -1,0 +1,122 @@
+"""Sensor platform for Sonoff SPM energy monitoring."""
+
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_APPARENT_POWER,
+    CONF_CURRENT,
+    CONF_ENERGY,
+    CONF_ID,
+    CONF_POWER,
+    CONF_POWER_FACTOR,
+    CONF_REACTIVE_POWER,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_AMPERE,
+    UNIT_KILOWATT_HOURS,
+    UNIT_VOLT,
+    UNIT_WATT,
+)
+
+from .. import CONF_SONOFF_SPM_ID, SonoffSPM, sonoff_spm_ns
+
+CONF_RELAY_ID = "relay_id"
+
+UNIT_VOLT_AMPERE = "VA"
+UNIT_VOLT_AMPERE_REACTIVE = "var"
+
+SonoffSPMSensor = sonoff_spm_ns.class_("SonoffSPMSensor", cg.Component)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(SonoffSPMSensor),
+        cv.GenerateID(CONF_SONOFF_SPM_ID): cv.use_id(SonoffSPM),
+        cv.Required(CONF_RELAY_ID): cv.int_range(min=0, max=127),
+        cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
+            unit_of_measurement=UNIT_AMPERE,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPERE,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_REACTIVE_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPERE_REACTIVE,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
+            accuracy_decimals=2,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_ENERGY): sensor.sensor_schema(
+            unit_of_measurement=UNIT_KILOWATT_HOURS,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    """Generate code for Sonoff SPM sensor."""
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    parent = await cg.get_variable(config[CONF_SONOFF_SPM_ID])
+    cg.add(var.set_parent(parent))
+    cg.add(var.set_relay_id(config[CONF_RELAY_ID]))
+
+    if CONF_VOLTAGE in config:
+        sens = await sensor.new_sensor(config[CONF_VOLTAGE])
+        cg.add(var.set_voltage_sensor(sens))
+
+    if CONF_CURRENT in config:
+        sens = await sensor.new_sensor(config[CONF_CURRENT])
+        cg.add(var.set_current_sensor(sens))
+
+    if CONF_POWER in config:
+        sens = await sensor.new_sensor(config[CONF_POWER])
+        cg.add(var.set_power_sensor(sens))
+
+    if CONF_APPARENT_POWER in config:
+        sens = await sensor.new_sensor(config[CONF_APPARENT_POWER])
+        cg.add(var.set_apparent_power_sensor(sens))
+
+    if CONF_REACTIVE_POWER in config:
+        sens = await sensor.new_sensor(config[CONF_REACTIVE_POWER])
+        cg.add(var.set_reactive_power_sensor(sens))
+
+    if CONF_POWER_FACTOR in config:
+        sens = await sensor.new_sensor(config[CONF_POWER_FACTOR])
+        cg.add(var.set_power_factor_sensor(sens))
+
+    if CONF_ENERGY in config:
+        sens = await sensor.new_sensor(config[CONF_ENERGY])
+        cg.add(var.set_energy_sensor(sens))
+
+    cg.add(parent.register_sensor(var, config[CONF_RELAY_ID]))

--- a/esphome/components/sonoff_spm/sensor/sonoff_spm_sensor.cpp
+++ b/esphome/components/sonoff_spm/sensor/sonoff_spm_sensor.cpp
@@ -1,0 +1,77 @@
+#include "sonoff_spm_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace sonoff_spm {
+
+static const char *const TAG = "sonoff_spm.sensor";
+
+void SonoffSPMSensor::setup() { ESP_LOGCONFIG(TAG, "Setting up Sonoff SPM Sensor..."); }
+
+void SonoffSPMSensor::loop() {
+  // Update sensors every second
+  uint32_t now = millis();
+  if (now - this->last_update_ > 1000) {
+    this->update_sensors_();
+    this->last_update_ = now;
+  }
+}
+
+void SonoffSPMSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Sonoff SPM Sensor:");
+  ESP_LOGCONFIG(TAG, "  Relay ID: %d", this->relay_id_);
+  LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
+  LOG_SENSOR("  ", "Current", this->current_sensor_);
+  LOG_SENSOR("  ", "Power", this->power_sensor_);
+  LOG_SENSOR("  ", "Apparent Power", this->apparent_power_sensor_);
+  LOG_SENSOR("  ", "Reactive Power", this->reactive_power_sensor_);
+  LOG_SENSOR("  ", "Power Factor", this->power_factor_sensor_);
+  LOG_SENSOR("  ", "Energy", this->energy_sensor_);
+}
+
+void SonoffSPMSensor::update_sensors_() {
+  if (this->parent_ == nullptr) {
+    return;
+  }
+
+  const ChannelData *data = this->parent_->get_channel_data(this->relay_id_);
+  if (data == nullptr) {
+    return;
+  }
+
+  // Only update if relay is on
+  if (!data->relay_state) {
+    return;
+  }
+
+  if (this->voltage_sensor_ != nullptr && data->voltage > 0) {
+    this->voltage_sensor_->publish_state(data->voltage);
+  }
+
+  if (this->current_sensor_ != nullptr && data->current > 0) {
+    this->current_sensor_->publish_state(data->current);
+  }
+
+  if (this->power_sensor_ != nullptr && data->active_power > 0) {
+    this->power_sensor_->publish_state(data->active_power);
+  }
+
+  if (this->apparent_power_sensor_ != nullptr && data->apparent_power > 0) {
+    this->apparent_power_sensor_->publish_state(data->apparent_power);
+  }
+
+  if (this->reactive_power_sensor_ != nullptr && data->reactive_power > 0) {
+    this->reactive_power_sensor_->publish_state(data->reactive_power);
+  }
+
+  if (this->power_factor_sensor_ != nullptr && data->power_factor > 0) {
+    this->power_factor_sensor_->publish_state(data->power_factor);
+  }
+
+  if (this->energy_sensor_ != nullptr && data->energy_total > 0) {
+    this->energy_sensor_->publish_state(data->energy_total);
+  }
+}
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/esphome/components/sonoff_spm/sensor/sonoff_spm_sensor.h
+++ b/esphome/components/sonoff_spm/sensor/sonoff_spm_sensor.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "../sonoff_spm.h"
+
+namespace esphome {
+namespace sonoff_spm {
+
+class SonoffSPMSensor : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_parent(SonoffSPM *parent) { this->parent_ = parent; }
+  void set_relay_id(uint8_t relay_id) { this->relay_id_ = relay_id; }
+
+  void set_voltage_sensor(sensor::Sensor *voltage_sensor) { this->voltage_sensor_ = voltage_sensor; }
+  void set_current_sensor(sensor::Sensor *current_sensor) { this->current_sensor_ = current_sensor; }
+  void set_power_sensor(sensor::Sensor *power_sensor) { this->power_sensor_ = power_sensor; }
+  void set_apparent_power_sensor(sensor::Sensor *apparent_power_sensor) {
+    this->apparent_power_sensor_ = apparent_power_sensor;
+  }
+  void set_reactive_power_sensor(sensor::Sensor *reactive_power_sensor) {
+    this->reactive_power_sensor_ = reactive_power_sensor;
+  }
+  void set_power_factor_sensor(sensor::Sensor *power_factor_sensor) {
+    this->power_factor_sensor_ = power_factor_sensor;
+  }
+  void set_energy_sensor(sensor::Sensor *energy_sensor) { this->energy_sensor_ = energy_sensor; }
+
+  uint8_t get_relay_id() const { return this->relay_id_; }
+
+ protected:
+  void update_sensors_();
+
+  SonoffSPM *parent_{nullptr};
+  uint8_t relay_id_{0};
+
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *power_sensor_{nullptr};
+  sensor::Sensor *apparent_power_sensor_{nullptr};
+  sensor::Sensor *reactive_power_sensor_{nullptr};
+  sensor::Sensor *power_factor_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+
+  uint32_t last_update_{0};
+};
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/esphome/components/sonoff_spm/sonoff_spm.cpp
+++ b/esphome/components/sonoff_spm/sonoff_spm.cpp
@@ -1,0 +1,548 @@
+#include "sonoff_spm.h"
+#include "switch/sonoff_spm_switch.h"
+#include "sensor/sonoff_spm_sensor.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace sonoff_spm {
+
+static const char *const TAG = "sonoff_spm";
+
+void SonoffSPM::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Sonoff SPM...");
+  this->state_ = SPM_STATE_RESET;
+}
+
+void SonoffSPM::loop() {
+  // Process incoming serial data
+  this->process_serial_();
+
+  // Update state machine
+  this->update_state_machine_();
+
+  // Request energy updates periodically (every 5 seconds)
+  uint32_t now = millis();
+  if (this->state_ == SPM_STATE_RUNNING && now - this->last_energy_request_ > 5000) {
+    this->request_energy_updates_();
+    this->last_energy_request_ = now;
+  }
+}
+
+void SonoffSPM::dump_config() {
+  ESP_LOGCONFIG(TAG, "Sonoff SPM:");
+  ESP_LOGCONFIG(TAG, "  Max Modules: %d (up to %d relays)", this->module_count_, this->module_count_ * 4);
+  ESP_LOGCONFIG(TAG, "  Scanned Modules: %d (%d relays)", this->scanned_modules_, this->scanned_modules_ * 4);
+  ESP_LOGCONFIG(TAG, "  Main Version: %d.%d.%d", (this->main_version_ >> 16) & 0xFF, (this->main_version_ >> 8) & 0xFF,
+                this->main_version_ & 0xFF);
+  ESP_LOGCONFIG(TAG, "  Registered Switches: %d", this->switches_.size());
+  ESP_LOGCONFIG(TAG, "  Registered Sensors: %d", this->sensors_.size());
+}
+
+void SonoffSPM::register_switch(SonoffSPMSwitch *switch_obj, uint8_t relay_id) {
+  if (relay_id >= SPM_MAX_RELAYS) {
+    ESP_LOGE(TAG, "Invalid relay ID: %d", relay_id);
+    return;
+  }
+  this->switches_.push_back(switch_obj);
+}
+
+void SonoffSPM::register_sensor(SonoffSPMSensor *sensor, uint8_t relay_id) {
+  if (relay_id >= SPM_MAX_RELAYS) {
+    ESP_LOGE(TAG, "Invalid relay ID: %d", relay_id);
+    return;
+  }
+  this->sensors_.push_back(sensor);
+}
+
+void SonoffSPM::set_relay_state(uint8_t relay_id, bool state) {
+  if (relay_id >= SPM_MAX_RELAYS) {
+    ESP_LOGE(TAG, "Invalid relay ID: %d", relay_id);
+    return;
+  }
+  this->send_set_relay_(relay_id, state);
+}
+
+const ChannelData *SonoffSPM::get_channel_data(uint8_t relay_id) const {
+  if (relay_id >= SPM_MAX_RELAYS) {
+    return nullptr;
+  }
+  return &this->channels_[relay_id];
+}
+
+bool SonoffSPM::get_relay_state(uint8_t relay_id) const {
+  if (relay_id >= SPM_MAX_RELAYS) {
+    return false;
+  }
+  return this->channels_[relay_id].relay_state;
+}
+
+uint16_t SonoffSPM::calculate_crc_(const uint8_t *data, size_t len) {
+  // CRC-16/ARC (polynomial 0x8005 reflected as 0xA001)
+  uint16_t crc = 0;
+  for (size_t i = 2; i < len; i++) {
+    crc ^= data[i];
+    for (uint8_t j = 0; j < 8; j++) {
+      crc = (crc & 1) ? (crc >> 1) ^ 0xA001 : crc >> 1;
+    }
+  }
+  return crc;
+}
+
+void SonoffSPM::init_send_() {
+  memset(this->buffer_.data(), 0, 19);
+  this->buffer_[0] = 0xAA;
+  this->buffer_[1] = 0x55;
+  this->buffer_[2] = 0x01;
+}
+
+void SonoffSPM::send_buffer_(size_t size) {
+  uint16_t crc = this->calculate_crc_(this->buffer_.data(), size - 2);
+  this->buffer_[size - 2] = (crc >> 8) & 0xFF;
+  this->buffer_[size - 1] = crc & 0xFF;
+
+  ESP_LOGVV(TAG, "TX: %s", format_hex_pretty(this->buffer_.data(), size).c_str());
+  this->write_array(this->buffer_.data(), size);
+  this->flush();
+}
+
+void SonoffSPM::send_command_(uint8_t command) {
+  this->init_send_();
+  this->buffer_[16] = command;
+  if (command != SPM_FUNC_FIND) {
+    this->command_sequence_++;
+  } else {
+    this->command_sequence_ = 0;
+  }
+  this->buffer_[19] = this->command_sequence_;
+  this->send_buffer_(22);
+}
+
+void SonoffSPM::send_find_() {
+  this->init_send_();
+  this->buffer_[15] = 0x80;  // Ack
+  this->buffer_[18] = 1;
+  this->buffer_[19] = 0;
+  this->send_buffer_(23);
+}
+
+void SonoffSPM::send_init_scan_() {
+  memset(this->buffer_.data(), 0xFF, 15);
+  this->buffer_[0] = 0xAA;
+  this->buffer_[1] = 0x55;
+  this->buffer_[2] = 0x01;
+  this->buffer_[15] = 0;
+  this->buffer_[16] = SPM_FUNC_INIT_SCAN;
+  this->buffer_[17] = 0;
+  this->buffer_[18] = 0;
+  this->command_sequence_++;
+  this->buffer_[19] = this->command_sequence_;
+  this->send_buffer_(22);
+  ESP_LOGD(TAG, "Starting module scan...");
+}
+
+void SonoffSPM::send_get_main_version_() { this->send_command_(SPM_FUNC_GET_MAIN_VERSION); }
+
+void SonoffSPM::send_set_relay_(uint8_t relay_id, bool state) {
+  uint8_t module = relay_id / SPM_CHANNELS_PER_MODULE;
+  uint8_t channel = relay_id % SPM_CHANNELS_PER_MODULE;
+
+  if (module >= this->scanned_modules_) {
+    ESP_LOGE(TAG, "Module %d not found", module);
+    return;
+  }
+
+  uint8_t channel_mask = 1 << channel;
+  if (state) {
+    channel_mask |= (channel_mask << 4);
+  }
+
+  this->init_send_();
+  memcpy(&this->buffer_[3], this->modules_[module].module_id.data(), SPM_MODULE_NAME_SIZE);
+  this->buffer_[16] = SPM_FUNC_SET_RELAY;
+  this->buffer_[18] = 0x01;
+  this->buffer_[19] = channel_mask;
+  this->command_sequence_++;
+  this->buffer_[20] = this->command_sequence_;
+  this->send_buffer_(23);
+}
+
+void SonoffSPM::send_get_module_state_(uint8_t module) {
+  if (module >= this->scanned_modules_) {
+    return;
+  }
+
+  this->init_send_();
+  memcpy(&this->buffer_[3], this->modules_[module].module_id.data(), SPM_MODULE_NAME_SIZE);
+  this->buffer_[16] = SPM_FUNC_GET_MODULE_STATE;
+  this->buffer_[18] = 0x01;
+  this->buffer_[19] = 0x0F;  // State of all four relays
+  this->command_sequence_++;
+  this->buffer_[20] = this->command_sequence_;
+  this->send_buffer_(23);
+}
+
+void SonoffSPM::send_ack_(uint8_t sequence) {
+  this->buffer_[15] = 0x80;
+  this->buffer_[17] = 0x00;
+  this->buffer_[18] = 0x01;
+  this->buffer_[19] = 0x00;
+  this->buffer_[20] = sequence;
+  this->send_buffer_(23);
+}
+
+float SonoffSPM::get_value_(const uint8_t *buffer) {
+  // Return float from three bytes in buffer
+  return (buffer[0] << 8) + buffer[1] + static_cast<float>(buffer[2]) / 100.0f;
+}
+
+void SonoffSPM::set_value_(uint8_t *buffer, float value) {
+  // Store float in three bytes
+  uint32_t integer = static_cast<uint32_t>(value);
+  buffer[0] = (integer >> 8) & 0xFF;
+  buffer[1] = integer & 0xFF;
+  buffer[2] = static_cast<uint8_t>((value * 100.0f) - (integer * 100.0f));
+}
+
+void SonoffSPM::process_serial_() {
+  while (this->available()) {
+    uint8_t byte;
+    this->read_byte(&byte);
+
+    // Check for start of message
+    if ((byte == 0x01) && (this->serial_in_byte_counter_ >= 2) &&
+        (this->buffer_[this->serial_in_byte_counter_ - 1] == 0x55) &&
+        (this->buffer_[this->serial_in_byte_counter_ - 2] == 0xAA)) {
+      // Start of new message
+      this->expected_bytes_ = 0;
+      this->buffer_[0] = 0xAA;
+      this->buffer_[1] = 0x55;
+      this->serial_in_byte_counter_ = 2;
+    }
+
+    if (this->serial_in_byte_counter_ < SPM_SERIAL_BUFFER_SIZE - 1) {
+      this->buffer_[this->serial_in_byte_counter_++] = byte;
+
+      // Calculate expected message size after receiving header
+      if ((this->serial_in_byte_counter_ == 19) && (this->buffer_[0] == 0xAA) && (this->buffer_[1] == 0x55) &&
+          (this->buffer_[2] == 0x01)) {
+        this->expected_bytes_ = 22 + (this->buffer_[17] << 8) + this->buffer_[18];
+      }
+
+      // Check if complete message received
+      if (this->serial_in_byte_counter_ == this->expected_bytes_) {
+        ESP_LOGVV(TAG, "RX: %s", format_hex_pretty(this->buffer_.data(), this->serial_in_byte_counter_).c_str());
+
+        // Verify CRC
+        uint16_t crc_received =
+            (this->buffer_[this->serial_in_byte_counter_ - 2] << 8) | this->buffer_[this->serial_in_byte_counter_ - 1];
+        uint16_t crc_calculated = this->calculate_crc_(this->buffer_.data(), this->serial_in_byte_counter_ - 2);
+
+        if (crc_received == crc_calculated) {
+          this->handle_received_data_();
+        } else {
+          ESP_LOGW(TAG, "CRC error: expected 0x%04X, got 0x%04X", crc_calculated, crc_received);
+        }
+
+        this->serial_in_byte_counter_ = 0;
+        this->expected_bytes_ = 0;
+      }
+    } else {
+      ESP_LOGW(TAG, "Serial buffer overflow");
+      this->serial_in_byte_counter_ = 0;
+      this->expected_bytes_ = 0;
+    }
+  }
+}
+
+void SonoffSPM::handle_received_data_() {
+  bool ack = (this->buffer_[15] == 0x80);
+  uint8_t command = this->buffer_[16];
+  uint16_t size = (this->buffer_[17] << 8) + this->buffer_[18];
+  uint8_t status = this->buffer_[19];
+
+  ESP_LOGV(TAG, "Received command 0x%02X, ack=%d, size=%d, status=%d", command, ack, size, status);
+
+  if (ack) {
+    // Handle acknowledged commands
+    switch (command) {
+      case SPM_FUNC_GET_MAIN_VERSION:
+        if (size >= 4) {
+          this->main_version_ = (this->buffer_[20] << 16) | (this->buffer_[21] << 8) | this->buffer_[22];
+          ESP_LOGI(TAG, "Main firmware version: %d.%d.%d", this->buffer_[20], this->buffer_[21], this->buffer_[22]);
+          this->state_ = SPM_STATE_START_SCAN;
+        }
+        break;
+
+      case SPM_FUNC_INIT_SCAN:
+        ESP_LOGD(TAG, "Scan initiated");
+        this->state_ = SPM_STATE_SCANNING;
+        break;
+
+      case SPM_FUNC_GET_MODULE_STATE:
+        this->handle_module_state_();
+        break;
+
+      default:
+        break;
+    }
+  } else {
+    // Handle unsolicited messages from ARM
+    uint8_t cmd_sequence = this->buffer_[19 + size];
+
+    switch (command) {
+      case SPM_FUNC_ENERGY_RESULT:
+        this->handle_energy_result_();
+        this->send_ack_(cmd_sequence);
+        break;
+
+      case SPM_FUNC_KEY_PRESS:
+        this->handle_key_press_();
+        this->send_ack_(cmd_sequence);
+        break;
+
+      case SPM_FUNC_SCAN_START:
+        ESP_LOGD(TAG, "Scan started");
+        this->send_ack_(cmd_sequence);
+        break;
+
+      case SPM_FUNC_SCAN_RESULT:
+        this->handle_scan_result_();
+        this->send_ack_(cmd_sequence);
+        break;
+
+      case SPM_FUNC_SCAN_DONE:
+        this->handle_scan_done_();
+        this->send_ack_(cmd_sequence);
+        break;
+
+      default:
+        ESP_LOGV(TAG, "Unknown command: 0x%02X", command);
+        break;
+    }
+  }
+}
+
+void SonoffSPM::handle_energy_result_() {
+  // Extract module ID from bytes 19-20
+  uint16_t module_id_short = (this->buffer_[19] << 8) | this->buffer_[20];
+
+  // Find module by ID
+  uint8_t module = 0xFF;
+  for (uint8_t i = 0; i < this->scanned_modules_; i++) {
+    uint16_t stored_id = (this->modules_[i].module_id[0] << 8) | this->modules_[i].module_id[1];
+    if (stored_id == module_id_short) {
+      module = i;
+      break;
+    }
+  }
+
+  if (module == 0xFF) {
+    ESP_LOGV(TAG, "Energy result from unknown module");
+    return;
+  }
+
+  uint8_t channel_mask = this->buffer_[31];
+  size_t offset = 32;
+  size_t max_offset = this->buffer_[18] + 18;
+
+  for (uint8_t channel = 0; channel < 4; channel++) {
+    if (!(channel_mask & (1 << channel))) {
+      continue;
+    }
+
+    uint8_t relay_id = (module * 4) + channel;
+    if (offset + 14 > max_offset) {
+      break;
+    }
+
+    // Only update if relay is on
+    if (this->channels_[relay_id].relay_state) {
+      this->channels_[relay_id].current =
+          this->buffer_[offset] + static_cast<float>(this->buffer_[offset + 1]) / 100.0f;
+      this->channels_[relay_id].voltage = this->get_value_(&this->buffer_[offset + 2]);
+      this->channels_[relay_id].active_power = this->get_value_(&this->buffer_[offset + 5]);
+      this->channels_[relay_id].reactive_power = this->get_value_(&this->buffer_[offset + 8]);
+      this->channels_[relay_id].apparent_power = this->get_value_(&this->buffer_[offset + 11]);
+
+      if (this->channels_[relay_id].apparent_power > 0) {
+        this->channels_[relay_id].power_factor =
+            this->channels_[relay_id].active_power / this->channels_[relay_id].apparent_power;
+        if (this->channels_[relay_id].power_factor > 1.0f) {
+          this->channels_[relay_id].power_factor = 1.0f;
+        }
+      }
+
+      ESP_LOGV(TAG, "Relay %d: %.1fV, %.2fA, %.1fW", relay_id, this->channels_[relay_id].voltage,
+               this->channels_[relay_id].current, this->channels_[relay_id].active_power);
+    }
+
+    offset += 14;
+  }
+}
+
+void SonoffSPM::handle_key_press_() {
+  // Extract module ID from bytes 19-20
+  uint16_t module_id_short = (this->buffer_[19] << 8) | this->buffer_[20];
+
+  // Find module by ID
+  uint8_t module = 0xFF;
+  for (uint8_t i = 0; i < this->scanned_modules_; i++) {
+    uint16_t stored_id = (this->modules_[i].module_id[0] << 8) | this->modules_[i].module_id[1];
+    if (stored_id == module_id_short) {
+      module = i;
+      break;
+    }
+  }
+
+  if (module == 0xFF) {
+    return;
+  }
+
+  uint8_t relay_mask = this->buffer_[31] & 0x0F;
+  uint8_t relay_state = this->buffer_[31] >> 4;
+
+  for (uint8_t channel = 0; channel < 4; channel++) {
+    if (relay_mask & (1 << channel)) {
+      uint8_t relay_id = (module * 4) + channel;
+      bool state = (relay_state & (1 << channel)) != 0;
+      this->channels_[relay_id].relay_state = state;
+      ESP_LOGD(TAG, "Relay %d state changed to %s", relay_id, state ? "ON" : "OFF");
+
+      // Notify switches
+      for (auto *switch_obj : this->switches_) {
+        // Switch will check if it matches this relay_id
+        switch_obj->publish_state(state);
+      }
+    }
+  }
+}
+
+void SonoffSPM::handle_scan_result_() {
+  if (this->scanned_modules_ >= SPM_MAX_MODULES) {
+    ESP_LOGW(TAG, "Too many modules scanned");
+    return;
+  }
+
+  // Copy module ID (bytes 19-30)
+  memcpy(this->modules_[this->scanned_modules_].module_id.data(), &this->buffer_[19], SPM_MODULE_NAME_SIZE);
+
+  // Extract firmware version
+  this->modules_[this->scanned_modules_].firmware_version =
+      (this->buffer_[37] << 16) | (this->buffer_[38] << 8) | this->buffer_[39];
+  this->modules_[this->scanned_modules_].online = true;
+
+  ESP_LOGI(TAG, "Module %d: FW v%d.%d.%d", this->scanned_modules_, this->buffer_[37], this->buffer_[38],
+           this->buffer_[39]);
+
+  this->scanned_modules_++;
+}
+
+void SonoffSPM::handle_scan_done_() {
+  ESP_LOGI(TAG, "Scan complete: %d modules found", this->scanned_modules_);
+
+  if (this->scanned_modules_ > 0) {
+    this->current_module_ = 0;
+    this->state_ = SPM_STATE_GET_STATES;
+  } else {
+    ESP_LOGW(TAG, "No modules found");
+    this->state_ = SPM_STATE_IDLE;
+  }
+}
+
+void SonoffSPM::handle_module_state_() {
+  if (this->buffer_[18] < 6) {
+    return;
+  }
+
+  // Extract module ID from bytes 3-4
+  uint16_t module_id_short = (this->buffer_[3] << 8) | this->buffer_[4];
+
+  // Find module by ID
+  uint8_t module = 0xFF;
+  for (uint8_t i = 0; i < this->scanned_modules_; i++) {
+    uint16_t stored_id = (this->modules_[i].module_id[0] << 8) | this->modules_[i].module_id[1];
+    if (stored_id == module_id_short) {
+      module = i;
+      break;
+    }
+  }
+
+  if (module == 0xFF) {
+    return;
+  }
+
+  uint8_t relay_state = this->buffer_[20] >> 4;
+
+  for (uint8_t channel = 0; channel < 4; channel++) {
+    uint8_t relay_id = (module * 4) + channel;
+    bool state = (relay_state & (1 << channel)) != 0;
+    this->channels_[relay_id].relay_state = state;
+    ESP_LOGD(TAG, "Module %d, relay %d initial state: %s", module, channel, state ? "ON" : "OFF");
+  }
+
+  // Move to next module
+  this->current_module_++;
+  if (this->current_module_ >= this->scanned_modules_) {
+    ESP_LOGI(TAG, "All module states retrieved, entering running mode");
+    this->state_ = SPM_STATE_RUNNING;
+  }
+}
+
+void SonoffSPM::update_state_machine_() {
+  uint32_t now = millis();
+
+  switch (this->state_) {
+    case SPM_STATE_IDLE:
+      // Do nothing
+      break;
+
+    case SPM_STATE_RESET:
+      // Wait a bit after setup
+      if (now > 1000) {
+        this->send_get_main_version_();
+        this->state_ = SPM_STATE_WAIT_VERSION;
+      }
+      break;
+
+    case SPM_STATE_WAIT_VERSION:
+      // Waiting for version response
+      break;
+
+    case SPM_STATE_START_SCAN:
+      this->scanned_modules_ = 0;
+      this->send_init_scan_();
+      this->last_scan_time_ = now;
+      this->state_ = SPM_STATE_SCANNING;
+      break;
+
+    case SPM_STATE_SCANNING:
+      // Waiting for scan to complete (handled by SCAN_DONE message)
+      // Timeout after 30 seconds
+      if (now - this->last_scan_time_ > 30000) {
+        ESP_LOGW(TAG, "Scan timeout");
+        this->state_ = SPM_STATE_IDLE;
+      }
+      break;
+
+    case SPM_STATE_GET_STATES:
+      if (this->current_module_ < this->scanned_modules_) {
+        this->send_get_module_state_(this->current_module_);
+      }
+      break;
+
+    case SPM_STATE_RUNNING:
+      // Normal operation
+      break;
+  }
+}
+
+void SonoffSPM::start_scan_() { this->state_ = SPM_STATE_START_SCAN; }
+
+void SonoffSPM::request_energy_updates_() {
+  // Energy updates are sent automatically by the ARM processor
+  // No explicit request needed
+}
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/esphome/components/sonoff_spm/sonoff_spm.h
+++ b/esphome/components/sonoff_spm/sonoff_spm.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/uart/uart.h"
+#include <vector>
+#include <array>
+
+namespace esphome {
+namespace sonoff_spm {
+
+// Forward declarations
+class SonoffSPMSwitch;
+class SonoffSPMSensor;
+
+// Protocol constants
+static const uint8_t SPM_MAX_MODULES = 32;  // Max 32 SPM-4Relay modules
+static const uint8_t SPM_CHANNELS_PER_MODULE = 4;
+static const uint8_t SPM_MAX_RELAYS = SPM_MAX_MODULES * SPM_CHANNELS_PER_MODULE;  // 128 relays
+static const size_t SPM_SERIAL_BUFFER_SIZE = 548;
+static const uint8_t SPM_MODULE_NAME_SIZE = 12;
+
+// Commands from ESP to ARM
+static const uint8_t SPM_FUNC_FIND = 0x00;
+static const uint8_t SPM_FUNC_SET_RELAY = 0x08;
+static const uint8_t SPM_FUNC_GET_MODULE_STATE = 0x09;
+static const uint8_t SPM_FUNC_SET_TIME = 0x0C;
+static const uint8_t SPM_FUNC_INIT_SCAN = 0x10;
+static const uint8_t SPM_FUNC_GET_MAIN_VERSION = 0x15;
+static const uint8_t SPM_FUNC_GET_ENERGY_TOTAL = 0x16;
+static const uint8_t SPM_FUNC_GET_ENERGY = 0x18;
+
+// Commands from ARM to ESP
+static const uint8_t SPM_FUNC_ENERGY_RESULT = 0x06;
+static const uint8_t SPM_FUNC_KEY_PRESS = 0x07;
+static const uint8_t SPM_FUNC_SCAN_START = 0x0F;
+static const uint8_t SPM_FUNC_SCAN_RESULT = 0x13;
+static const uint8_t SPM_FUNC_SCAN_DONE = 0x19;
+
+// State machine states
+enum SPMState : uint8_t {
+  SPM_STATE_IDLE = 0,
+  SPM_STATE_RESET,
+  SPM_STATE_WAIT_VERSION,
+  SPM_STATE_START_SCAN,
+  SPM_STATE_SCANNING,
+  SPM_STATE_GET_STATES,
+  SPM_STATE_RUNNING,
+};
+
+// Module information
+struct ModuleInfo {
+  std::array<uint8_t, SPM_MODULE_NAME_SIZE> module_id{};
+  uint32_t firmware_version{0};
+  bool online{false};
+};
+
+// Energy data per channel
+struct ChannelData {
+  float voltage{0.0f};
+  float current{0.0f};
+  float active_power{0.0f};
+  float reactive_power{0.0f};
+  float apparent_power{0.0f};
+  float power_factor{0.0f};
+  float energy_today{0.0f};
+  float energy_total{0.0f};
+  bool relay_state{false};
+};
+
+class SonoffSPM : public Component, public uart::UARTDevice {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::LATE; }
+
+  // Configuration
+  void set_module_count(uint8_t count) { this->module_count_ = count; }
+
+  // Switch registration
+  void register_switch(SonoffSPMSwitch *switch_obj, uint8_t relay_id);
+
+  // Sensor registration
+  void register_sensor(SonoffSPMSensor *sensor, uint8_t relay_id);
+
+  // Switch control
+  void set_relay_state(uint8_t relay_id, bool state);
+
+  // Get channel data
+  const ChannelData *get_channel_data(uint8_t relay_id) const;
+
+  // Get relay state
+  bool get_relay_state(uint8_t relay_id) const;
+
+ protected:
+  // Protocol functions
+  void send_command_(uint8_t command);
+  void send_find_();
+  void send_init_scan_();
+  void send_get_main_version_();
+  void send_set_relay_(uint8_t relay_id, bool state);
+  void send_get_module_state_(uint8_t module);
+  void send_ack_(uint8_t sequence);
+
+  // Message handling
+  void process_serial_();
+  void handle_received_data_();
+  void handle_energy_result_();
+  void handle_key_press_();
+  void handle_scan_result_();
+  void handle_scan_done_();
+  void handle_module_state_();
+
+  // Utility functions
+  uint16_t calculate_crc_(const uint8_t *data, size_t len);
+  void init_send_();
+  void send_buffer_(size_t size);
+  float get_value_(const uint8_t *buffer);
+  void set_value_(uint8_t *buffer, float value);
+
+  // State management
+  void update_state_machine_();
+  void start_scan_();
+  void request_energy_updates_();
+
+  // Data members
+  SPMState state_{SPM_STATE_IDLE};
+  uint8_t module_count_{SPM_MAX_MODULES};
+  uint8_t command_sequence_{0};
+  uint8_t scanned_modules_{0};
+  uint8_t current_module_{0};
+  uint32_t main_version_{0};
+  uint32_t last_scan_time_{0};
+  uint32_t last_energy_request_{0};
+  uint16_t expected_bytes_{0};
+  uint16_t serial_in_byte_counter_{0};
+
+  // Buffers and data structures
+  std::array<uint8_t, SPM_SERIAL_BUFFER_SIZE> buffer_{};
+  std::array<ModuleInfo, SPM_MAX_MODULES> modules_{};
+  std::array<ChannelData, SPM_MAX_RELAYS> channels_{};
+
+  // Switch and sensor registration
+  std::vector<SonoffSPMSwitch *> switches_{};
+  std::vector<SonoffSPMSensor *> sensors_{};
+};
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/esphome/components/sonoff_spm/switch/__init__.py
+++ b/esphome/components/sonoff_spm/switch/__init__.py
@@ -1,0 +1,29 @@
+"""Switch platform for Sonoff SPM relays."""
+
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+
+from .. import CONF_SONOFF_SPM_ID, SonoffSPM, sonoff_spm_ns
+
+CONF_RELAY_ID = "relay_id"
+
+SonoffSPMSwitch = sonoff_spm_ns.class_("SonoffSPMSwitch", switch.Switch, cg.Component)
+
+CONFIG_SCHEMA = switch.switch_schema(SonoffSPMSwitch).extend(
+    {
+        cv.GenerateID(CONF_SONOFF_SPM_ID): cv.use_id(SonoffSPM),
+        cv.Required(CONF_RELAY_ID): cv.int_range(min=0, max=127),
+    }
+)
+
+
+async def to_code(config):
+    """Generate code for Sonoff SPM switch."""
+    var = await switch.new_switch(config)
+    await cg.register_component(var, config)
+
+    parent = await cg.get_variable(config[CONF_SONOFF_SPM_ID])
+    cg.add(var.set_parent(parent))
+    cg.add(var.set_relay_id(config[CONF_RELAY_ID]))
+    cg.add(parent.register_switch(var, config[CONF_RELAY_ID]))

--- a/esphome/components/sonoff_spm/switch/sonoff_spm_switch.cpp
+++ b/esphome/components/sonoff_spm/switch/sonoff_spm_switch.cpp
@@ -1,0 +1,31 @@
+#include "sonoff_spm_switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace sonoff_spm {
+
+static const char *const TAG = "sonoff_spm.switch";
+
+void SonoffSPMSwitch::setup() {
+  // Get initial state from parent
+  if (this->parent_ != nullptr) {
+    bool state = this->parent_->get_relay_state(this->relay_id_);
+    this->publish_state(state);
+  }
+}
+
+void SonoffSPMSwitch::dump_config() {
+  LOG_SWITCH("", "Sonoff SPM Switch", this);
+  ESP_LOGCONFIG(TAG, "  Relay ID: %d", this->relay_id_);
+}
+
+void SonoffSPMSwitch::write_state(bool state) {
+  if (this->parent_ != nullptr) {
+    this->parent_->set_relay_state(this->relay_id_, state);
+    // Publish state immediately (will be confirmed by device response)
+    this->publish_state(state);
+  }
+}
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/esphome/components/sonoff_spm/switch/sonoff_spm_switch.h
+++ b/esphome/components/sonoff_spm/switch/sonoff_spm_switch.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+#include "../sonoff_spm.h"
+
+namespace esphome {
+namespace sonoff_spm {
+
+class SonoffSPMSwitch : public switch_::Switch, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  void set_parent(SonoffSPM *parent) { this->parent_ = parent; }
+  void set_relay_id(uint8_t relay_id) { this->relay_id_ = relay_id; }
+
+  uint8_t get_relay_id() const { return this->relay_id_; }
+
+ protected:
+  void write_state(bool state) override;
+
+  SonoffSPM *parent_{nullptr};
+  uint8_t relay_id_{0};
+};
+
+}  // namespace sonoff_spm
+}  // namespace esphome

--- a/tests/components/sonoff_spm/common.yaml
+++ b/tests/components/sonoff_spm/common.yaml
@@ -1,0 +1,55 @@
+uart:
+  - id: uart_bus
+    tx_pin: 4
+    rx_pin: 16
+    baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 2
+
+switch:
+  - platform: sonoff_spm
+    name: "SPM Relay 1"
+    sonoff_spm_id: spm_main
+    relay_id: 0
+
+  - platform: sonoff_spm
+    name: "SPM Relay 2"
+    sonoff_spm_id: spm_main
+    relay_id: 1
+
+  - platform: sonoff_spm
+    name: "SPM Relay 5"
+    sonoff_spm_id: spm_main
+    relay_id: 4
+
+sensor:
+  - platform: sonoff_spm
+    sonoff_spm_id: spm_main
+    relay_id: 0
+    voltage:
+      name: "SPM Relay 1 Voltage"
+    current:
+      name: "SPM Relay 1 Current"
+    power:
+      name: "SPM Relay 1 Power"
+    apparent_power:
+      name: "SPM Relay 1 Apparent Power"
+    reactive_power:
+      name: "SPM Relay 1 Reactive Power"
+    power_factor:
+      name: "SPM Relay 1 Power Factor"
+    energy:
+      name: "SPM Relay 1 Energy"
+
+  - platform: sonoff_spm
+    sonoff_spm_id: spm_main
+    relay_id: 4
+    voltage:
+      name: "SPM Relay 5 Voltage"
+    current:
+      name: "SPM Relay 5 Current"
+    power:
+      name: "SPM Relay 5 Power"

--- a/tests/components/sonoff_spm/test.esp32-ard.yaml
+++ b/tests/components/sonoff_spm/test.esp32-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/sonoff_spm/test.esp32-idf.yaml
+++ b/tests/components/sonoff_spm/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/sonoff_spm/test_autocreate.esp32-ard.yaml
+++ b/tests/components/sonoff_spm/test_autocreate.esp32-ard.yaml
@@ -1,0 +1,18 @@
+uart:
+  - id: uart_bus
+    tx_pin: 4
+    rx_pin: 16
+    baud_rate: 115200
+
+sonoff_spm:
+  id: spm_main
+  uart_id: uart_bus
+  module_count: 2
+  auto_create_switches: true
+  auto_create_sensors: true
+  name_prefix: "Auto SPM"
+  sensor_types:
+    - voltage
+    - current
+    - power
+    - energy


### PR DESCRIPTION
# What does this implement/fix?

Add support for Sonoff Smart Stackable Power Meter (SPM) 4 channel relay and power meter multi-unit system. The system comprise of a main unit onto which esphome is loaded. Commands are sent over a UART to an integrated ARM CPU which in turn controls up to 32 serially connected 4-channel units over RS485, providing support for up to 128 channels of relays with power metering.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5594

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  id: uart_bus
  tx_pin: GPIO4
  rx_pin: GPIO16
  baud_rate: 115200
sonoff_spm:
  id: spm_main
  uart_id: uart_bus
  module_count: 4                # Number of SPM-4Relay modules you have
  auto_create_switches: true     # Automatically create switches for all relays
  auto_create_sensors: true      # Automatically create sensors for all relays
  name_prefix: "Power"           # Optional: customize entity names
  sensor_types:                  # Optional: choose which sensors to create
    - voltage
    - current
    - power
    - energy
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
