### PR TITLE
[nrf52] fix boot loop

### DIFF
--- a/esphome/components/nrf52/__init__.py
+++ b/esphome/components/nrf52/__init__.py
@@ -107,7 +107,6 @@ CONF_REG0 = "reg0"
 CONF_UICR_ERASE = "uicr_erase"
 
 VOLTAGE_LEVELS = [1.8, 2.1, 2.4, 2.7, 3.0, 3.3]
-DEFAULT_VOLTAGE_LEVEL = "default"
 
 CONFIG_SCHEMA = cv.All(
     _detect_bootloader,
@@ -124,12 +123,9 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_REG0): cv.Schema(
                 {
-                    cv.Required(CONF_VOLTAGE): cv.Any(
-                        cv.All(
-                            cv.voltage,
-                            cv.one_of(*VOLTAGE_LEVELS, float=True),
-                        ),
-                        cv.one_of(*[DEFAULT_VOLTAGE_LEVEL], lower=True),
+                    cv.Required(CONF_VOLTAGE): cv.All(
+                        cv.voltage,
+                        cv.one_of(*VOLTAGE_LEVELS, float=True),
                     ),
                     cv.Optional(CONF_UICR_ERASE, default=False): cv.boolean,
                 }
@@ -202,9 +198,7 @@ async def to_code(config: ConfigType) -> None:
         CORE.add_job(_dfu_to_code, dfu_config)
 
     if reg0_config := config.get(CONF_REG0):
-        value = 7  # DEFAULT_VOLTAGE_LEVEL
-        if reg0_config[CONF_VOLTAGE] in VOLTAGE_LEVELS:
-            value = VOLTAGE_LEVELS.index(reg0_config[CONF_VOLTAGE])
+        value = VOLTAGE_LEVELS.index(reg0_config[CONF_VOLTAGE])
         cg.add_define("USE_NRF52_REG0_VOUT", value)
         if reg0_config[CONF_UICR_ERASE]:
             cg.add_define("USE_NRF52_UICR_ERASE")

--- a/esphome/components/nrf52/uicr.cpp
+++ b/esphome/components/nrf52/uicr.cpp
@@ -69,9 +69,20 @@ static StatusFlags fix_bootloader() {
 }
 #endif
 
+#define BOOTLOADER_VERSION_REGISTER NRF_TIMER2->CC[0]
+
 static StatusFlags set_uicr() {
   StatusFlags status = StatusFlags::OK;
-  status |= set_regout0();
+#ifndef USE_BOOTLOADER_MCUBOOT
+  if (BOOTLOADER_VERSION_REGISTER <= 0x902) {
+#ifdef CONFIG_PRINTK
+    printk("cannot control regout0 for %#x\n", BOOTLOADER_VERSION_REGISTER);
+#endif
+  } else
+#endif
+  {
+    status |= set_regout0();
+  }
 #ifndef USE_BOOTLOADER_MCUBOOT
   status |= fix_bootloader();
 #endif

--- a/tests/components/nrf52/test.nrf52-xiao-ble.yaml
+++ b/tests/components/nrf52/test.nrf52-xiao-ble.yaml
@@ -6,4 +6,4 @@ nrf52:
       mode:
         output: true
   reg0:
-    voltage: default
+    voltage: 1.8V


### PR DESCRIPTION
# What does this implement/fix?

There could be boot loop with Adafruit_nRF52_Bootloader
1. https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/344 this is not released in version 0.9.2. Before that NVIC_SystemReset is called each time when REGOUT0 is different in bootloader
2. https://github.com/adafruit/Adafruit_nRF52_Bootloader/pull/367 the bootloader seems to call NVIC_SystemReset even with fix for point 1

- allow to set REGOUT0 only if Adafruit_nRF52_Bootloader version is bigger than 0.9.2
- do not allow to use `default` which is overwritten by bootloader which might lead to boot loop

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
