### PR TITLE
[esp32] Update the recommended platform to 55.03.31-2

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -334,12 +334,14 @@ def _is_framework_url(source: str) -> str:
 #  - https://github.com/espressif/arduino-esp32/releases
 ARDUINO_FRAMEWORK_VERSION_LOOKUP = {
     "recommended": cv.Version(3, 3, 2),
-    "latest": cv.Version(3, 3, 2),
-    "dev": cv.Version(3, 3, 2),
+    "latest": cv.Version(3, 3, 4),
+    "dev": cv.Version(3, 3, 4),
 }
 ARDUINO_PLATFORM_VERSION_LOOKUP = {
-    cv.Version(3, 3, 2): cv.Version(55, 3, 31, "1"),
-    cv.Version(3, 3, 1): cv.Version(55, 3, 31, "1"),
+    cv.Version(3, 3, 4): cv.Version(55, 3, 31, "2"),
+    cv.Version(3, 3, 3): cv.Version(55, 3, 31, "2"),
+    cv.Version(3, 3, 2): cv.Version(55, 3, 31, "2"),
+    cv.Version(3, 3, 1): cv.Version(55, 3, 31, "2"),
     cv.Version(3, 3, 0): cv.Version(55, 3, 30, "2"),
     cv.Version(3, 2, 1): cv.Version(54, 3, 21, "2"),
     cv.Version(3, 2, 0): cv.Version(54, 3, 20),
@@ -357,8 +359,8 @@ ESP_IDF_FRAMEWORK_VERSION_LOOKUP = {
     "dev": cv.Version(5, 5, 1),
 }
 ESP_IDF_PLATFORM_VERSION_LOOKUP = {
-    cv.Version(5, 5, 1): cv.Version(55, 3, 31, "1"),
-    cv.Version(5, 5, 0): cv.Version(55, 3, 31, "1"),
+    cv.Version(5, 5, 1): cv.Version(55, 3, 31, "2"),
+    cv.Version(5, 5, 0): cv.Version(55, 3, 31, "2"),
     cv.Version(5, 4, 3): cv.Version(55, 3, 32),
     cv.Version(5, 4, 2): cv.Version(54, 3, 21, "2"),
     cv.Version(5, 4, 1): cv.Version(54, 3, 21, "2"),
@@ -373,9 +375,9 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
 # The platform-espressif32 version
 #  - https://github.com/pioarduino/platform-espressif32/releases
 PLATFORM_VERSION_LOOKUP = {
-    "recommended": cv.Version(55, 3, 31, "1"),
-    "latest": cv.Version(55, 3, 31, "1"),
-    "dev": cv.Version(55, 3, 31, "1"),
+    "recommended": cv.Version(55, 3, 31, "2"),
+    "latest": cv.Version(55, 3, 31, "2"),
+    "dev": cv.Version(55, 3, 31, "2"),
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

Update the recommended platform to 55.03.31-2 and add Arduino 3.3.3 and 3.3.4

See the attached issue and https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.31-2

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11864

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
