### PR TITLE
[mqtt] Fix crash with empty broker during upload/logs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+omit =
+    esphome/components/*
+    esphome/analyze_memory/*
+    tests/integration/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-omit =
-    esphome/components/*
-    esphome/analyze_memory/*
-    tests/integration/*

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -159,7 +159,7 @@ def get_esphome_device_ip(
     username: str | None = None,
     password: str | None = None,
     client_id: str | None = None,
-    timeout=25,
+    timeout: int | float = 25,
 ) -> list[str]:
     if CONF_MQTT not in config:
         raise EsphomeError(

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -6,6 +6,7 @@ import logging
 import ssl
 import tempfile
 import time
+from typing import Any
 
 import paho.mqtt.client as mqtt
 
@@ -154,8 +155,12 @@ def show_discover(config, username=None, password=None, client_id=None):
 
 
 def get_esphome_device_ip(
-    config, username=None, password=None, client_id=None, timeout=25
-):
+    config: dict[str, Any],
+    username: str | None = None,
+    password: str | None = None,
+    client_id: str | None = None,
+    timeout=25,
+) -> list[str]:
     if CONF_MQTT not in config:
         raise EsphomeError(
             "Cannot discover IP via MQTT as the config does not include the mqtt: "
@@ -165,6 +170,10 @@ def get_esphome_device_ip(
         raise EsphomeError(
             "Cannot discover IP via MQTT as the config does not include the device name: "
             "component"
+        )
+    if not config[CONF_MQTT].get(CONF_BROKER):
+        raise EsphomeError(
+            "Cannot discover IP via MQTT as the broker is not configured"
         )
 
     dev_name = config[CONF_ESPHOME][CONF_NAME]

--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -6,7 +6,6 @@ import logging
 import ssl
 import tempfile
 import time
-from typing import Any
 
 import paho.mqtt.client as mqtt
 
@@ -31,6 +30,7 @@ from esphome.const import (
 from esphome.core import CORE, EsphomeError
 from esphome.helpers import get_int_env, get_str_env
 from esphome.log import AnsiFore, color
+from esphome.types import ConfigType
 from esphome.util import safe_print
 
 _LOGGER = logging.getLogger(__name__)
@@ -155,7 +155,7 @@ def show_discover(config, username=None, password=None, client_id=None):
 
 
 def get_esphome_device_ip(
-    config: dict[str, Any],
+    config: ConfigType,
     username: str | None = None,
     password: str | None = None,
     client_id: str | None = None,

--- a/tests/unit_tests/test_mqtt.py
+++ b/tests/unit_tests/test_mqtt.py
@@ -1,0 +1,91 @@
+"""Unit tests for esphome.mqtt module."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome.const import CONF_BROKER, CONF_ESPHOME, CONF_MQTT, CONF_NAME
+from esphome.core import EsphomeError
+from esphome.mqtt import get_esphome_device_ip
+
+
+def test_get_esphome_device_ip_empty_broker() -> None:
+    """Test that get_esphome_device_ip raises EsphomeError when broker is empty."""
+    config = {
+        CONF_MQTT: {
+            CONF_BROKER: "",
+        },
+        CONF_ESPHOME: {
+            CONF_NAME: "test-device",
+        },
+    }
+
+    with pytest.raises(
+        EsphomeError,
+        match="Cannot discover IP via MQTT as the broker is not configured",
+    ):
+        get_esphome_device_ip(config)
+
+
+def test_get_esphome_device_ip_none_broker() -> None:
+    """Test that get_esphome_device_ip raises EsphomeError when broker is None."""
+    config = {
+        CONF_MQTT: {
+            CONF_BROKER: None,
+        },
+        CONF_ESPHOME: {
+            CONF_NAME: "test-device",
+        },
+    }
+
+    with pytest.raises(
+        EsphomeError,
+        match="Cannot discover IP via MQTT as the broker is not configured",
+    ):
+        get_esphome_device_ip(config)
+
+
+def test_get_esphome_device_ip_missing_mqtt() -> None:
+    """Test that get_esphome_device_ip raises EsphomeError when mqtt config is missing."""
+    config = {
+        CONF_ESPHOME: {
+            CONF_NAME: "test-device",
+        },
+    }
+
+    with pytest.raises(
+        EsphomeError,
+        match="Cannot discover IP via MQTT as the config does not include the mqtt:",
+    ):
+        get_esphome_device_ip(config)
+
+
+def test_get_esphome_device_ip_missing_esphome() -> None:
+    """Test that get_esphome_device_ip raises EsphomeError when esphome config is missing."""
+    config = {
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+    }
+
+    with pytest.raises(
+        EsphomeError,
+        match="Cannot discover IP via MQTT as the config does not include the device name:",
+    ):
+        get_esphome_device_ip(config)
+
+
+def test_get_esphome_device_ip_missing_name() -> None:
+    """Test that get_esphome_device_ip raises EsphomeError when device name is missing."""
+    config = {
+        CONF_MQTT: {
+            CONF_BROKER: "mqtt.local",
+        },
+        CONF_ESPHOME: {},
+    }
+
+    with pytest.raises(
+        EsphomeError,
+        match="Cannot discover IP via MQTT as the config does not include the device name:",
+    ):
+        get_esphome_device_ip(config)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression where ESPHome crashes with `ValueError: Invalid host` when attempting to upload/show logs for devices with empty MQTT broker configuration. This commonly occurs when users configure MQTT credentials dynamically at runtime (e.g., via web interface) with `enable_on_boot: false`.

**The Problem:**
When MQTT broker is configured as an empty string and the user attempts upload or logs with MQTT discovery (`MQTTIP` device or `MQTT` logs), ESPHome would crash during the device discovery phase:
```
ValueError: Invalid host.
  File "esphome/mqtt.py", line 129, in prepare
    client.connect(host, port)
```

The `paho-mqtt` library rejects empty hostnames, but ESPHome was passing them through without validation. The resulting `ValueError` was not caught, causing the entire operation to fail.

**The Solution:**
- Added early validation in `get_esphome_device_ip()` to check if broker is empty/None
- Raises `EsphomeError` with clear message instead of allowing `ValueError` from paho-mqtt
- Existing exception handler in `_resolve_network_devices()` catches the error, logs a warning, and continues with fallback upload methods (direct IP, mDNS, etc.)

This allows upload to succeed even with placeholder MQTT configuration (assuming it can be resolved by other means).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11653

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a bugfix with no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

This fix enables the following configuration pattern to work correctly:

```yaml
esphome:
  name: my-device

esp32:
  board: esp32dev
  framework:
    type: esp-idf

wifi:
  ssid: "MyNetwork"
  password: "MyPassword"

mqtt:
  broker: ""  # Empty broker - configured dynamically at runtime
  username: ""
  password: ""
  enable_on_boot: false

# Upload now works with: esphome upload my-device.yaml
# Even though MQTT broker is empty, it falls back to other methods
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
