### PR TITLE
[light] Fix dangling reference in compute_color_mode causing memory corruption

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -476,8 +476,9 @@ uint16_t APIConnection::try_send_light_info(EntityBase *entity, APIConnection *c
   auto *light = static_cast<light::LightState *>(entity);
   ListEntitiesLightResponse msg;
   auto traits = light->get_traits();
+  auto supported_modes = traits.get_supported_color_modes();
   // Pass pointer to ColorModeMask so the iterator can encode actual ColorMode enum values
-  msg.supported_color_modes = &traits.get_supported_color_modes();
+  msg.supported_color_modes = &supported_modes;
   if (traits.supports_color_capability(light::ColorCapability::COLOR_TEMPERATURE) ||
       traits.supports_color_capability(light::ColorCapability::COLD_WARM_WHITE)) {
     msg.min_mireds = traits.get_min_mireds();

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -406,7 +406,11 @@ void LightCall::transform_parameters_() {
   }
 }
 ColorMode LightCall::compute_color_mode_() {
-  const auto &supported_modes = this->parent_->get_traits().get_supported_color_modes();
+  // Store traits locally to avoid dangling reference: get_traits() returns by value, so
+  // calling get_traits().get_supported_color_modes() would create a temporary LightTraits
+  // object, return a reference to its member, then destroy the temporary, leaving a dangling reference.
+  auto traits = this->parent_->get_traits();
+  const auto &supported_modes = traits.get_supported_color_modes();
   int supported_count = supported_modes.size();
 
   // Some lights don't support any color modes (e.g. monochromatic light), leave it at unknown.

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -406,11 +406,7 @@ void LightCall::transform_parameters_() {
   }
 }
 ColorMode LightCall::compute_color_mode_() {
-  // Store traits locally to avoid dangling reference: get_traits() returns by value, so
-  // calling get_traits().get_supported_color_modes() would create a temporary LightTraits
-  // object, return a reference to its member, then destroy the temporary, leaving a dangling reference.
-  auto traits = this->parent_->get_traits();
-  const auto &supported_modes = traits.get_supported_color_modes();
+  auto supported_modes = this->parent_->get_traits().get_supported_color_modes();
   int supported_count = supported_modes.size();
 
   // Some lights don't support any color modes (e.g. monochromatic light), leave it at unknown.

--- a/esphome/components/light/light_traits.h
+++ b/esphome/components/light/light_traits.h
@@ -18,7 +18,8 @@ class LightTraits {
  public:
   LightTraits() = default;
 
-  const ColorModeMask &get_supported_color_modes() const { return this->supported_color_modes_; }
+  // Return by value to avoid dangling reference when get_traits() returns a temporary
+  ColorModeMask get_supported_color_modes() const { return this->supported_color_modes_; }
   void set_supported_color_modes(ColorModeMask supported_color_modes) {
     this->supported_color_modes_ = supported_color_modes;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a critical dangling reference bug in light color mode handling introduced in #11348 that caused memory corruption and incorrect color mode detection.

## Problem

The bitmask optimization in #11348 changed `get_supported_color_modes()` to return `const ColorModeMask &` instead of copying a `std::set<ColorMode>`. This created dangling reference bugs wherever `get_traits()` (which returns by value) was chained with `get_supported_color_modes()`:

```cpp
const auto &supported_modes = this->parent_->get_traits().get_supported_color_modes();
```

Since `get_traits()` returns a temporary `LightTraits` object, the returned reference points into that temporary which is immediately destroyed, leaving `supported_modes` as a dangling reference to freed memory.

## Symptoms

- RGB-only lights incorrectly reported 6-9 supported color modes instead of 1
- Random garbage color modes enumerated (White, Color Temperature on RGB-only lights)
- Excessive INFO logging: `'RGB Light': color mode not specified; using RGB` on every light call
- Wrong `supported_count` causing early-return optimization to fail
- Validation warnings about unsupported modes
- Potential crashes depending on memory contents

## Root Cause Analysis

**Old code (pre-#11348) - SAFE:**
```cpp
auto supported_modes = this->parent_->get_traits().get_supported_color_modes();
// std::set returned by value - makes a copy, safe
```

**Broken code (post-#11348) - DANGLING:**
```cpp
const auto &supported_modes = this->parent_->get_traits().get_supported_color_modes();
// const ColorModeMask& returned - but points into destroyed temporary!
```

**Debug evidence:**
```
[D][light.traits]: set_supported_color_modes: mask=0x0040, size=1
[D][rmt_led_strip]: get_traits() returning: mask=0x0040, size=1
[I][light]: 'RGB Light': supported_count=8, mask=0x8ed5  ← garbage!
```

The mask is correct (`0x0040` = RGB only) when set and returned, but becomes garbage (`0x8ed5`) when read through the dangling reference.

## Solution

Return `ColorModeMask` by value instead of const reference. Since `ColorModeMask` is just a `uint16_t` wrapper (2 bytes), copying it is trivial:

```cpp
// Return by value to avoid dangling reference when get_traits() returns a temporary
ColorModeMask get_supported_color_modes() const { return this->supported_color_modes_; }
```

This also required updating one call site in the API code that was taking the address of the return value:

```cpp
auto supported_modes = traits.get_supported_color_modes();
msg.supported_color_modes = &supported_modes;  // Now taking address of local variable
```

## Benefits of this approach

1. **Fixes root cause** - Impossible to create dangling references from this getter
2. **Minimal overhead** - Copying 2 bytes is negligible (much cheaper than the old `std::set` copy)
3. **Fixes all call sites** - Don't need to audit every place `get_traits()` is used
4. **Future-proof** - Prevents similar bugs in new code

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #11348
- Fixes excessive logging and memory corruption affecting all lights

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal bugfix)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Affects all light platforms, example:
light:
  - platform: esp32_rmt_led_strip
    id: rgb_light
    name: RGB Light
    pin: 3
    chipset: WS2812
    num_leds: 1
    rgb_order: GRB
    effects:
      - pulse:
          name: Pulse
          update_interval: 250ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
