### PR TITLE
[core] Fix wait_until hanging when used in on_boot automations

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -412,7 +412,12 @@ template<typename... Ts> class WaitUntilAction : public Action<Ts...>, public Co
 
   void setup() override {
     // Start with loop disabled - only enable when there's work to do
-    this->disable_loop();
+    // IMPORTANT: Only disable if num_running_ is 0, otherwise play_complex() was already
+    // called before our setup() (e.g., from on_boot trigger at same priority level)
+    // and we must not undo its enable_loop() call
+    if (this->num_running_ == 0) {
+      this->disable_loop();
+    }
   }
 
   void play_complex(const Ts &...x) override {

--- a/tests/integration/fixtures/wait_until_on_boot.yaml
+++ b/tests/integration/fixtures/wait_until_on_boot.yaml
@@ -8,9 +8,12 @@ esphome:
   on_boot:
     then:
       - logger.log: "on_boot: Starting wait_until test"
+      - globals.set:
+          id: on_boot_started
+          value: 'true'
       - wait_until:
           condition:
-            lambda: return millis() > 1000;
+            lambda: return id(test_flag);
           timeout: 5s
       - logger.log: "on_boot: wait_until completed successfully"
 
@@ -19,13 +22,26 @@ host:
 logger:
   level: DEBUG
 
+globals:
+  - id: on_boot_started
+    type: bool
+    initial_value: 'false'
+  - id: test_flag
+    type: bool
+    initial_value: 'false'
+
 api:
   actions:
-    - action: test_wait_until_on_boot
+    - action: set_test_flag
       then:
-        - logger.log: "Action: Testing wait_until from action"
-        - wait_until:
-            condition:
-              lambda: return millis() > 1000;
-            timeout: 5s
-        - logger.log: "Action: wait_until completed"
+        - globals.set:
+            id: test_flag
+            value: 'true'
+    - action: check_on_boot_started
+      then:
+        - lambda: |-
+            if (id(on_boot_started)) {
+              ESP_LOGI("test", "on_boot has started");
+            } else {
+              ESP_LOGI("test", "on_boot has NOT started");
+            }

--- a/tests/integration/fixtures/wait_until_on_boot.yaml
+++ b/tests/integration/fixtures/wait_until_on_boot.yaml
@@ -1,0 +1,31 @@
+# Test for wait_until in on_boot automation
+# Reproduces bug where wait_until in on_boot would hang forever
+# because WaitUntilAction::setup() would disable_loop() after
+# play_complex() had already enabled it.
+
+esphome:
+  name: wait-until-on-boot
+  on_boot:
+    then:
+      - logger.log: "on_boot: Starting wait_until test"
+      - wait_until:
+          condition:
+            lambda: return millis() > 1000;
+          timeout: 5s
+      - logger.log: "on_boot: wait_until completed successfully"
+
+host:
+
+logger:
+  level: DEBUG
+
+api:
+  actions:
+    - action: test_wait_until_on_boot
+      then:
+        - logger.log: "Action: Testing wait_until from action"
+        - wait_until:
+            condition:
+              lambda: return millis() > 1000;
+            timeout: 5s
+        - logger.log: "Action: wait_until completed"

--- a/tests/integration/test_wait_until_on_boot.py
+++ b/tests/integration/test_wait_until_on_boot.py
@@ -4,6 +4,10 @@ This test validates that wait_until works correctly when triggered from on_boot,
 which runs at the same setup priority as WaitUntilAction itself. This was broken
 before the fix because WaitUntilAction::setup() would unconditionally disable_loop(),
 even if play_complex() had already been called and enabled the loop.
+
+The bug: on_boot fires during StartupTrigger::setup(), which calls WaitUntilAction::play_complex()
+before WaitUntilAction::setup() has run. Then when WaitUntilAction::setup() runs, it calls
+disable_loop(), undoing the enable_loop() from play_complex(), causing wait_until to hang forever.
 """
 
 from __future__ import annotations
@@ -22,48 +26,66 @@ async def test_wait_until_on_boot(
     run_compiled: RunCompiledFunction,
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
-    """Test that wait_until works in on_boot automation."""
+    """Test that wait_until works in on_boot automation with a condition that becomes true later."""
     loop = asyncio.get_running_loop()
 
-    # Track if on_boot completed successfully
+    on_boot_started = False
     on_boot_completed = False
-    action_completed = False
 
+    on_boot_started_pattern = re.compile(r"on_boot: Starting wait_until test")
     on_boot_complete_pattern = re.compile(r"on_boot: wait_until completed successfully")
-    action_complete_pattern = re.compile(r"Action: wait_until completed")
 
-    on_boot_future = loop.create_future()
-    action_future = loop.create_future()
+    on_boot_started_future = loop.create_future()
+    on_boot_complete_future = loop.create_future()
 
     def check_output(line: str) -> None:
-        """Check log output for completion messages."""
-        nonlocal on_boot_completed, action_completed
+        """Check log output for test progress."""
+        nonlocal on_boot_started, on_boot_completed
+
+        if on_boot_started_pattern.search(line):
+            on_boot_started = True
+            if not on_boot_started_future.done():
+                on_boot_started_future.set_result(True)
 
         if on_boot_complete_pattern.search(line):
             on_boot_completed = True
-            if not on_boot_future.done():
-                on_boot_future.set_result(True)
-
-        if action_complete_pattern.search(line):
-            action_completed = True
-            if not action_future.done():
-                action_future.set_result(True)
+            if not on_boot_complete_future.done():
+                on_boot_complete_future.set_result(True)
 
     async with (
         run_compiled(yaml_config, line_callback=check_output),
         api_client_connected() as client,
     ):
-        # Wait for on_boot to complete (should happen within a few seconds)
-        await asyncio.wait_for(on_boot_future, timeout=10.0)
-        assert on_boot_completed, "on_boot wait_until did not complete"
+        # Wait for on_boot to start
+        await asyncio.wait_for(on_boot_started_future, timeout=10.0)
+        assert on_boot_started, "on_boot did not start"
 
-        # Test that wait_until also works from regular actions
+        # At this point, on_boot is blocked in wait_until waiting for test_flag to become true
+        # If the bug exists, wait_until's loop is disabled and it will never complete
+        # even after we set the flag
+
+        # Give a moment for setup to complete
+        await asyncio.sleep(0.5)
+
+        # Now set the flag that wait_until is waiting for
         _, services = await client.list_entities_services()
-        test_service = next(
-            (s for s in services if s.name == "test_wait_until_on_boot"), None
+        set_flag_service = next(
+            (s for s in services if s.name == "set_test_flag"), None
         )
-        assert test_service is not None, "test_wait_until_on_boot service not found"
+        assert set_flag_service is not None, "set_test_flag service not found"
 
-        client.execute_service(test_service, {})
-        await asyncio.wait_for(action_future, timeout=10.0)
-        assert action_completed, "Action wait_until did not complete"
+        client.execute_service(set_flag_service, {})
+
+        # If the fix works, wait_until's loop() will check the condition and proceed
+        # If the bug exists, wait_until is stuck with disabled loop and will timeout
+        try:
+            await asyncio.wait_for(on_boot_complete_future, timeout=2.0)
+            assert on_boot_completed, (
+                "on_boot wait_until did not complete after flag was set"
+            )
+        except TimeoutError:
+            pytest.fail(
+                "wait_until in on_boot did not complete within 2s after condition became true. "
+                "This indicates the bug where WaitUntilAction::setup() disables the loop "
+                "after play_complex() has already enabled it."
+            )

--- a/tests/integration/test_wait_until_on_boot.py
+++ b/tests/integration/test_wait_until_on_boot.py
@@ -1,0 +1,69 @@
+"""Integration test for wait_until in on_boot automation.
+
+This test validates that wait_until works correctly when triggered from on_boot,
+which runs at the same setup priority as WaitUntilAction itself. This was broken
+before the fix because WaitUntilAction::setup() would unconditionally disable_loop(),
+even if play_complex() had already been called and enabled the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_wait_until_on_boot(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that wait_until works in on_boot automation."""
+    loop = asyncio.get_running_loop()
+
+    # Track if on_boot completed successfully
+    on_boot_completed = False
+    action_completed = False
+
+    on_boot_complete_pattern = re.compile(r"on_boot: wait_until completed successfully")
+    action_complete_pattern = re.compile(r"Action: wait_until completed")
+
+    on_boot_future = loop.create_future()
+    action_future = loop.create_future()
+
+    def check_output(line: str) -> None:
+        """Check log output for completion messages."""
+        nonlocal on_boot_completed, action_completed
+
+        if on_boot_complete_pattern.search(line):
+            on_boot_completed = True
+            if not on_boot_future.done():
+                on_boot_future.set_result(True)
+
+        if action_complete_pattern.search(line):
+            action_completed = True
+            if not action_future.done():
+                action_future.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Wait for on_boot to complete (should happen within a few seconds)
+        await asyncio.wait_for(on_boot_future, timeout=10.0)
+        assert on_boot_completed, "on_boot wait_until did not complete"
+
+        # Test that wait_until also works from regular actions
+        _, services = await client.list_entities_services()
+        test_service = next(
+            (s for s in services if s.name == "test_wait_until_on_boot"), None
+        )
+        assert test_service is not None, "test_wait_until_on_boot service not found"
+
+        client.execute_service(test_service, {})
+        await asyncio.wait_for(action_future, timeout=10.0)
+        assert action_completed, "Action wait_until did not complete"


### PR DESCRIPTION
# What does this implement/fix?

Fixes a critical bug where `wait_until` actions in `on_boot` automations would hang forever, never completing even when the condition becomes true.

## Root Cause

When `on_boot` fires during `StartupTrigger::setup()` (priority 600), it triggers automations that create and execute `WaitUntilAction` instances. The execution flow was:

1. `StartupTrigger::setup()` runs (priority 600)
2. Fires the trigger → calls automation → `WaitUntilAction::play_complex()`
3. `play_complex()` sees condition is false, adds to queue, calls `enable_loop()`
4. `StartupTrigger::setup()` completes
5. **THEN** `WaitUntilAction::setup()` runs (also priority 600, but registered after StartupTrigger)
6. `WaitUntilAction::setup()` unconditionally calls `disable_loop()` ❌
7. This **undoes** the `enable_loop()` from step 3
8. `wait_until` is now stuck with its loop disabled, never checking the condition again

## The Fix

Modified `WaitUntilAction::setup()` to check `num_running_` before disabling the loop:

```cpp
void setup() override {
  // Only disable if num_running_ is 0, otherwise play_complex() was already
  // called before our setup() (e.g., from on_boot trigger at same priority level)
  // and we must not undo its enable_loop() call
  if (this->num_running_ == 0) {
    this->disable_loop();
  }
}
```

If `num_running_ > 0`, it means `play_complex()` was already called before `setup()` completed, so we must not interfere with the loop state.

## Impact

This bug affected **any** `wait_until` action triggered during component setup at the same priority level, most commonly:
- `wait_until: wifi.connected:` in `on_boot` automations
- Any `wait_until` in startup triggers
- Potentially other early-boot automations

The bug was introduced by PR #9823 which removed `can_proceed()` from WiFi, changing the timing of when `on_boot` runs relative to WiFi connection.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to PR #9823 (WiFi removed `can_proceed()`)
- Fixes user-reported issue: `wait_until: wifi.connected:` in `on_boot` stopped working between 2025.10.5 and dev

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] Host (integration test)
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Tested on ESP32-C6 device (Apollo PUMP-1) and verified with new integration test.

## Example entry for `config.yaml`:

```yaml
# This previously hung forever on dev, now works correctly:
esphome:
  on_boot:
    then:
      - logger.log: "Waiting for WiFi..."
      - wait_until:
          condition:
            wifi.connected:
          timeout: 60s
      - logger.log: "WiFi connected!"

wifi:
  ssid: "MyNetwork"
  password: "password"
```

## Verification

Before fix:
```
[10:57:41.294][D][main:489]: [TEST] on_boot started
[10:57:41.295][D][main:492]: [TEST] Waiting for WiFi to connect...
[10:58:11.114][I][wifi:1039]: Connected
# Hung forever - never proceeded past wait_until
```

After fix:
```
[11:04:40.844][D][main:489]: [TEST] on_boot started
[11:04:40.845][D][main:492]: [TEST] Waiting for WiFi to connect...
[11:05:00.511][I][wifi:1039]: Connected
[11:05:00.518][D][main:500]: [TEST] After wait_until - checking if we got here
[11:05:00.518][D][main:505]: [TEST] SUCCESS: WiFi is connected!
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). *(Not applicable - bug fix only)*
