### PR TITLE
Add README for RX8130 RTC component

### DIFF
--- a/esphome/components/rx8130/README.md
+++ b/esphome/components/rx8130/README.md
@@ -1,0 +1,7 @@
+# RX8130
+
+The **RX8130** is a high-accuracy real-time clock (RTC) with a built-in temperature-compensated oscillator that keeps precise time even during power loss.
+
+It serves as a stable time source for systems requiring reliable timestamps or scheduled wake-ups.
+
+For configuration details, see the [Time Component](https://esphome.io/components/time/index.html).


### PR DESCRIPTION
# What does this implement/fix?

This PR adds a short README for the RX8130 real-time clock (RTC) component.
The description highlights its temperature-compensated oscillator and suitability as a stable time source.
Suggested by @martijnbuts based on feedback from @jesserockz.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
