### PR TITLE
[wifi][ethernet] Fix spurious warnings and unclear status after PR #9823

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -381,7 +381,10 @@ void EthernetComponent::dump_config() {
       break;
   }
 
-  ESP_LOGCONFIG(TAG, "Ethernet:");
+  ESP_LOGCONFIG(TAG,
+                "Ethernet:\n"
+                "  Connected: %s",
+                YESNO(this->is_connected()));
   this->dump_connect_params_();
 #ifdef USE_ETHERNET_SPI
   ESP_LOGCONFIG(TAG,

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -743,6 +743,14 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
 }
 
 const LogString *get_signal_bars(int8_t rssi) {
+  // Check for disconnected sentinel value first
+  if (rssi == WIFI_RSSI_DISCONNECTED) {
+    // MULTIPLICATION SIGN
+    // Unicode: U+00D7, UTF-8: C3 97
+    return LOG_STR("\033[0;31m"  // red
+                   "\xc3\x97\xc3\x97\xc3\x97\xc3\x97"
+                   "\033[0m");
+  }
   // LOWER ONE QUARTER BLOCK
   // Unicode: U+2582, UTF-8: E2 96 82
   // LOWER HALF BLOCK
@@ -1022,7 +1030,10 @@ void WiFiComponent::check_scanning_finished() {
 }
 
 void WiFiComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "WiFi:");
+  ESP_LOGCONFIG(TAG,
+                "WiFi:\n"
+                "  Connected: %s",
+                YESNO(this->is_connected()));
   this->print_connect_params_();
 }
 

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -52,6 +52,9 @@ extern "C" {
 namespace esphome {
 namespace wifi {
 
+/// Sentinel value for RSSI when WiFi is not connected
+static constexpr int8_t WIFI_RSSI_DISCONNECTED = -127;
+
 struct SavedWifiSettings {
   char ssid[33];
   char password[65];

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -870,7 +870,7 @@ bssid_t WiFiComponent::wifi_bssid() {
   return bssid;
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
-int8_t WiFiComponent::wifi_rssi() { return WiFi.RSSI(); }
+int8_t WiFiComponent::wifi_rssi() { return WiFi.status() == WL_CONNECTED ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
 int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 network::IPAddress WiFiComponent::wifi_subnet_mask_() { return {(const ip_addr_t *) WiFi.subnetMask()}; }
 network::IPAddress WiFiComponent::wifi_gateway_ip_() { return {(const ip_addr_t *) WiFi.gatewayIP()}; }

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -1029,7 +1029,8 @@ bssid_t WiFiComponent::wifi_bssid() {
   wifi_ap_record_t info;
   esp_err_t err = esp_wifi_sta_get_ap_info(&info);
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
+    // Very verbose only: this is expected during dump_config() before connection is established (PR #9823)
+    ESP_LOGVV(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
     return bssid;
   }
   std::copy(info.bssid, info.bssid + 6, bssid.begin());
@@ -1039,7 +1040,8 @@ std::string WiFiComponent::wifi_ssid() {
   wifi_ap_record_t info{};
   esp_err_t err = esp_wifi_sta_get_ap_info(&info);
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
+    // Very verbose only: this is expected during dump_config() before connection is established (PR #9823)
+    ESP_LOGVV(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
     return "";
   }
   auto *ssid_s = reinterpret_cast<const char *>(info.ssid);
@@ -1050,8 +1052,9 @@ int8_t WiFiComponent::wifi_rssi() {
   wifi_ap_record_t info;
   esp_err_t err = esp_wifi_sta_get_ap_info(&info);
   if (err != ESP_OK) {
-    ESP_LOGW(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
-    return 0;
+    // Very verbose only: this is expected during dump_config() before connection is established (PR #9823)
+    ESP_LOGVV(TAG, "esp_wifi_sta_get_ap_info failed: %s", esp_err_to_name(err));
+    return WIFI_RSSI_DISCONNECTED;
   }
   return info.rssi;
 }

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -484,7 +484,7 @@ bssid_t WiFiComponent::wifi_bssid() {
   return bssid;
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
-int8_t WiFiComponent::wifi_rssi() { return WiFi.RSSI(); }
+int8_t WiFiComponent::wifi_rssi() { return WiFi.status() == WL_CONNECTED ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
 int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 network::IPAddress WiFiComponent::wifi_subnet_mask_() { return {WiFi.subnetMask()}; }
 network::IPAddress WiFiComponent::wifi_gateway_ip_() { return {WiFi.gatewayIP()}; }

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -200,7 +200,7 @@ bssid_t WiFiComponent::wifi_bssid() {
   return bssid;
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
-int8_t WiFiComponent::wifi_rssi() { return WiFi.RSSI(); }
+int8_t WiFiComponent::wifi_rssi() { return WiFi.status() == WL_CONNECTED ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
 int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 
 network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {


### PR DESCRIPTION
# What does this implement/fix?

After PR #9823 removed blocking setup behavior from WiFi and Ethernet components, `dump_config()` can now be called before network connection is established. This PR addresses the resulting issues:

1. **ESP-IDF WiFi warnings**: `esp_wifi_sta_get_ap_info` failures during `dump_config()` generated spurious `ESP_LOGW` messages. These are now `ESP_LOGVV` (expected behavior, only visible with very verbose logging).

2. **Misleading WiFi signal display**: When disconnected, `wifi_rssi()` returned `0` which displayed as full green signal bars. Now returns `-127` (sentinel value) and displays as red ××××'s.

3. **Unclear connection status**: Users had to infer connection state from IP addresses. Now both WiFi and Ethernet explicitly show "Connected: YES/NO" as the first line in their config output.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #9823

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - improvements are automatic

wifi:
  ssid: "MyNetwork"
  password: "password"

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0
```

## Before/After Comparison

### Before (Confusing):
```
[W][wifi_esp32:1034]: esp_wifi_sta_get_ap_info failed: ESP_ERR_WIFI_NOT_CONNECT
[W][wifi_esp32:1055]: esp_wifi_sta_get_ap_info failed: ESP_ERR_WIFI_NOT_CONNECT
[W][wifi_esp32:1044]: esp_wifi_sta_get_ap_info failed: ESP_ERR_WIFI_NOT_CONNECT
[C][wifi:1027]: WiFi:
[C][wifi:793]:   Local MAC: 7C:2C:67:5D:9B:DC
[C][wifi:804]:   SSID: ''
[C][wifi:804]:   Signal strength: 0 dB ▂▄▆█  ← Misleading!
[C][ethernet:384]: Ethernet:
[C][ethernet:644]:   IP Address: 0.0.0.0  ← Must parse to know disconnected
```

### After (Clear):
```
[C][wifi:1032]: WiFi:
[C][wifi:1033]:   Connected: NO  ← Immediately obvious
[C][wifi:803]:   Local MAC: 7C:2C:67:5D:9B:DC
[C][wifi:814]:   Signal strength: -127 dB ××××  ← Clear indicator
[C][ethernet:384]: Ethernet:
[C][ethernet:385]:   Connected: NO  ← Immediately obvious
[C][ethernet:646]:   IP Address: 0.0.0.0
```

## Technical Details

### WiFi Changes:

1. **Added sentinel constant** (`wifi_component.h`):
   ```cpp
   static constexpr int8_t WIFI_RSSI_DISCONNECTED = -127;
   ```

2. **Updated signal bars display** (`wifi_component.cpp`):
   - Checks for sentinel value and displays red ××××'s (multiplication signs)
   - Added "Connected: YES/NO" to `dump_config()` output

3. **ESP-IDF platform** (`wifi_component_esp_idf.cpp`):
   - Downgraded `ESP_LOGW` → `ESP_LOGVV` with explanatory comments
   - Returns `WIFI_RSSI_DISCONNECTED` instead of `0`

4. **Arduino platforms** (ESP8266, Pico W, LibreTiny):
   - Check `WiFi.status() == WL_CONNECTED` and return sentinel value if not connected
   - Implemented with ternary operator for consistency

### Ethernet Changes:

- Added "Connected: YES/NO" to `dump_config()` output for consistency with WiFi

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
