### PR TITLE
[wifi] Fix slow reconnection after connection loss for all network types

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1050,7 +1050,7 @@ void WiFiComponent::check_connecting_finished() {
     this->retry_phase_ = WiFiRetryPhase::INITIAL_CONNECT;
     this->num_retried_ = 0;
     // Ensure next connection attempt does not inherit error state
-    // so when WiFi disconnects later we start fresh we don't see
+    // so when WiFi disconnects later we start fresh and don't see
     // the first connection as a failure.
     this->error_from_callback_ = false;
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -465,6 +465,8 @@ void WiFiComponent::loop() {
         if (!this->is_connected()) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
+          // Clear error flag before reconnecting so first attempt is not seen as immediate failure
+          this->error_from_callback_ = false;
           this->retry_connect();
         } else {
           this->status_clear_warning();
@@ -1047,6 +1049,10 @@ void WiFiComponent::check_connecting_finished() {
     // Reset to initial phase on successful connection (don't log transition, just reset state)
     this->retry_phase_ = WiFiRetryPhase::INITIAL_CONNECT;
     this->num_retried_ = 0;
+    // Ensure next connection attempt does not inherit error state
+    // so when WiFi disconnects later we start fresh we don't see
+    // the first connection as a failure.
+    this->error_from_callback_ = false;
 
     this->print_connect_params_();
 
@@ -1133,6 +1139,11 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
         return WiFiRetryPhase::FAST_CONNECT_CYCLING_APS;  // Move to next AP
       }
 #endif
+      // Check if we should try explicit hidden networks before scanning
+      // This handles reconnection after connection loss where first network is hidden
+      if (!this->sta_.empty() && this->sta_[0].get_hidden()) {
+        return WiFiRetryPhase::EXPLICIT_HIDDEN;
+      }
       // No more APs to try, fall back to scan
       return WiFiRetryPhase::SCAN_CONNECTING;
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes two issues with WiFi reconnection after connection loss that significantly slow down reconnection time:

## Issue 1: Explicit hidden networks skipped during reconnection

When WiFi connection was lost and the device tried to reconnect, the system would skip directly from `INITIAL_CONNECT` to `SCAN_CONNECTING` phase without attempting explicitly hidden networks first, even when the first configured network was marked as `hidden: true`. This caused the hidden networks to be incorrectly marked as "already tried" in the `RETRY_HIDDEN` phase. The device would eventually reconnect after going through the full scan/retry/restart cycle, but this added unnecessary delay (10+ seconds) compared to trying the hidden networks immediately (5-10 seconds).

**Root cause:** `determine_next_phase_()` was missing logic to check for explicit hidden networks when transitioning from `INITIAL_CONNECT` phase. This logic existed in `start_initial_connection_()` for initial boot but not for reconnection scenarios.

**Fix:** Added check in `determine_next_phase_()` to return `EXPLICIT_HIDDEN` phase if the first configured network is marked as `hidden: true`, ensuring consistent behavior between initial connection and reconnection.

**Impact:** Reduces reconnection time by ~10 seconds when using explicitly hidden networks.

## Issue 2: First reconnection attempt immediately marked as failed (affects networks not marked as explicit hidden)

When reconnecting after connection loss to networks not marked with `hidden: true` in the configuration, the first connection attempt was immediately flagged as failed within 3ms, requiring an unnecessary retry. This added 5-10 seconds to reconnection time depending on the phase. The device would eventually connect on the second attempt, but the spurious failure wasted time.

**Root cause:** Disconnect events set `error_from_callback_ = true`, and this flag wasn't cleared before attempting reconnection. Since `is_connected()` checks `!error_from_callback_`, the first connection attempt appeared to fail immediately even though it was actually in progress.

**Fix:** Clear `error_from_callback_` in two places:
1. Before calling `retry_connect()` when connection loss is detected
2. After successful connection to ensure clean state for future disconnects

**Impact:** Eliminates unnecessary retry on first reconnection attempt for networks not marked as explicit hidden, saving 5-10 seconds.

## Before (connection loss)
```
[12:26:31.760][W][wifi:466]: Connection lost; reconnecting
[12:26:31.761][D][wifi:1247]: Retry phase: INITIAL_CONNECT → SCAN_CONNECTING  ❌ Skips EXPLICIT_HIDDEN
[12:26:31.761][D][wifi:862]: Starting scan
...
[12:26:40.580][D][wifi:273]: Skipping 'MyHiddenSSID1' (explicit hidden, already tried)  ❌ Incorrectly skipped
[12:26:40.581][D][wifi:273]: Skipping 'MyHiddenSSID2' (explicit hidden, already tried)
[12:26:40.582][D][wifi:273]: Skipping 'MyHiddenSSID3' (explicit hidden, already tried)
```

```
[12:40:47.686][I][wifi:679]: Connecting to 'MyHiddenSSID3' (A2:05:D6:37:65:E0) (priority 0, attempt 1/2 in phase SCAN_CONNECTING)...
[12:40:47.689][W][wifi:1112]: Connecting to network failed (callback)  ❌ Immediate failure (3ms)
[12:40:47.691][D][wifi:1418]: Failed 'MyHiddenSSID3' (A2:05:D6:37:65:E0), priority 0 → 0
[12:40:47.691][D][wifi:1489]: Retry attempt 2/2 in phase SCAN_CONNECTING  ❌ Unnecessary retry
```

## After (connection loss)
```
[12:34:48.524][W][wifi:466]: Connection lost; reconnecting
[12:34:48.525][D][wifi:1252]: Retry phase: INITIAL_CONNECT → EXPLICIT_HIDDEN  ✓ Correct phase
[12:34:48.527][I][wifi:679]: Connecting to 'MyHiddenSSID1' (any) (priority 0, attempt 1/1 in phase EXPLICIT_HIDDEN)...
[12:34:54.364][D][wifi:1453]: Next explicit hidden network at index 1
[12:34:54.365][I][wifi:679]: Connecting to 'MyHiddenSSID2' (any) (priority 0, attempt 1/1 in phase EXPLICIT_HIDDEN)...
[12:34:59.184][D][wifi:1453]: Next explicit hidden network at index 2
[12:34:59.186][I][wifi:679]: Connecting to 'MyHiddenSSID3' (any) (priority 0, attempt 1/1 in phase EXPLICIT_HIDDEN)...
[12:35:04.059][I][wifi:1052]: Connected  ✓ Success
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  networks:
    - ssid: "MyHiddenSSID1"
      password: "password123"
      hidden: true
    - ssid: "MyHiddenSSID2"
      password: "password456"
      hidden: true
    - ssid: "MyHiddenSSID3"
      password: "password789"
      hidden: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
