### PR TITLE
[thermostat] Replace std::map with FixedVector, reduce flash usage

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -3,12 +3,12 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/sensor/sensor.h"
 
 #include <array>
 #include <cinttypes>
-#include <map>
 
 namespace esphome {
 namespace thermostat {
@@ -72,14 +72,30 @@ struct ThermostatClimateTargetTempConfig {
   optional<climate::ClimateMode> mode_{};
 };
 
+/// Entry for standard preset lookup
+struct ThermostatPresetEntry {
+  climate::ClimatePreset preset;
+  ThermostatClimateTargetTempConfig config;
+};
+
+/// Entry for custom preset lookup
+struct ThermostatCustomPresetEntry {
+  const char *name;
+  ThermostatClimateTargetTempConfig config;
+};
+
 class ThermostatClimate : public climate::Climate, public Component {
+ public:
+  using PresetEntry = ThermostatPresetEntry;
+  using CustomPresetEntry = ThermostatCustomPresetEntry;
+
  public:
   ThermostatClimate();
   void setup() override;
   void dump_config() override;
   void loop() override;
 
-  void set_default_preset(const std::string &custom_preset);
+  void set_default_preset(const char *custom_preset);
   void set_default_preset(climate::ClimatePreset preset);
   void set_on_boot_restore_from(OnBootRestoreFrom on_boot_restore_from);
   void set_set_point_minimum_differential(float differential);
@@ -131,8 +147,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   void set_supports_humidification(bool supports_humidification);
   void set_supports_two_points(bool supports_two_points);
 
-  void set_preset_config(climate::ClimatePreset preset, const ThermostatClimateTargetTempConfig &config);
-  void set_custom_preset_config(const std::string &name, const ThermostatClimateTargetTempConfig &config);
+  void set_preset_config(std::initializer_list<PresetEntry> presets);
+  void set_custom_preset_config(std::initializer_list<CustomPresetEntry> presets);
 
   Trigger<> *get_cool_action_trigger() const;
   Trigger<> *get_supplemental_cool_action_trigger() const;
@@ -516,9 +532,6 @@ class ThermostatClimate : public climate::Climate, public Component {
   Trigger<> *prev_swing_mode_trigger_{nullptr};
   Trigger<> *prev_humidity_control_trigger_{nullptr};
 
-  /// Default custom preset to use on start up
-  std::string default_custom_preset_{};
-
   /// Climate action timers
   std::array<ThermostatClimateTimer, THERMOSTAT_TIMER_COUNT> timer_{
       ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_max_run_time_timer_callback_, this)),
@@ -534,9 +547,11 @@ class ThermostatClimate : public climate::Climate, public Component {
   };
 
   /// The set of standard preset configurations this thermostat supports (Eg. AWAY, ECO, etc)
-  std::map<climate::ClimatePreset, ThermostatClimateTargetTempConfig> preset_config_{};
+  FixedVector<PresetEntry> preset_config_{};
   /// The set of custom preset configurations this thermostat supports (eg. "My Custom Preset")
-  std::map<std::string, ThermostatClimateTargetTempConfig> custom_preset_config_{};
+  FixedVector<CustomPresetEntry> custom_preset_config_{};
+  /// Default custom preset to use on start up (pointer to entry in custom_preset_config_)
+  const char *default_custom_preset_{nullptr};
 };
 
 }  // namespace thermostat

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -89,7 +89,6 @@ class ThermostatClimate : public climate::Climate, public Component {
   using PresetEntry = ThermostatPresetEntry;
   using CustomPresetEntry = ThermostatCustomPresetEntry;
 
- public:
   ThermostatClimate();
   void setup() override;
   void dump_config() override;
@@ -551,6 +550,7 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// The set of custom preset configurations this thermostat supports (eg. "My Custom Preset")
   FixedVector<CustomPresetEntry> custom_preset_config_{};
   /// Default custom preset to use on start up (pointer to entry in custom_preset_config_)
+ private:
   const char *default_custom_preset_{nullptr};
 };
 

--- a/tests/integration/fixtures/climate_custom_fan_modes_and_presets.yaml
+++ b/tests/integration/fixtures/climate_custom_fan_modes_and_presets.yaml
@@ -14,6 +14,7 @@ climate:
     id: test_thermostat
     name: Test Thermostat Custom Modes
     sensor: thermostat_sensor
+    default_preset: "Eco Plus"
     preset:
       - name: Away
         default_target_temperature_low: 16°C

--- a/tests/integration/test_climate_custom_modes.py
+++ b/tests/integration/test_climate_custom_modes.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from aioesphomeapi import ClimateInfo, ClimatePreset
+import asyncio
+
+import aioesphomeapi
+from aioesphomeapi import ClimateInfo, ClimatePreset, EntityState
 import pytest
 
+from .state_utils import InitialStateHelper
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -14,14 +18,49 @@ async def test_climate_custom_fan_modes_and_presets(
     run_compiled: RunCompiledFunction,
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
-    """Test that custom presets are properly exposed via API."""
+    """Test that custom presets are properly exposed and can be changed."""
+    loop = asyncio.get_running_loop()
     async with run_compiled(yaml_config), api_client_connected() as client:
-        # Get entities and services
+        states: dict[int, EntityState] = {}
+        super_saver_future: asyncio.Future[EntityState] = loop.create_future()
+        vacation_future: asyncio.Future[EntityState] = loop.create_future()
+
+        def on_state(state: EntityState) -> None:
+            states[state.key] = state
+            if isinstance(state, aioesphomeapi.ClimateState):
+                # Wait for Super Saver preset
+                if (
+                    state.custom_preset == "Super Saver"
+                    and state.target_temperature_low == 20.0
+                    and state.target_temperature_high == 24.0
+                    and not super_saver_future.done()
+                ):
+                    super_saver_future.set_result(state)
+                # Wait for Vacation Mode preset
+                elif (
+                    state.custom_preset == "Vacation Mode"
+                    and state.target_temperature_low == 15.0
+                    and state.target_temperature_high == 18.0
+                    and not vacation_future.done()
+                ):
+                    vacation_future.set_result(state)
+
+        # Get entities and set up state synchronization
         entities, services = await client.list_entities_services()
+        initial_state_helper = InitialStateHelper(entities)
         climate_infos = [e for e in entities if isinstance(e, ClimateInfo)]
         assert len(climate_infos) == 1, "Expected exactly 1 climate entity"
 
         test_climate = climate_infos[0]
+
+        # Subscribe with the wrapper that filters initial states
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+
+        # Wait for all initial states to be broadcast
+        try:
+            await initial_state_helper.wait_for_initial_states()
+        except TimeoutError:
+            pytest.fail("Timeout waiting for initial states")
 
         # Verify enum presets are exposed (from preset: config map)
         assert ClimatePreset.AWAY in test_climate.supported_presets, (
@@ -40,3 +79,43 @@ async def test_climate_custom_fan_modes_and_presets(
         assert "Vacation Mode" in custom_presets, (
             "Expected 'Vacation Mode' in custom presets"
         )
+
+        # Get initial state and verify default preset
+        initial_state = initial_state_helper.initial_states.get(test_climate.key)
+        assert initial_state is not None, "Climate initial state not found"
+        assert isinstance(initial_state, aioesphomeapi.ClimateState)
+        assert initial_state.custom_preset == "Eco Plus", (
+            f"Expected default preset 'Eco Plus', got '{initial_state.custom_preset}'"
+        )
+        assert initial_state.target_temperature_low == 18.0, (
+            f"Expected low temp 18.0, got {initial_state.target_temperature_low}"
+        )
+        assert initial_state.target_temperature_high == 22.0, (
+            f"Expected high temp 22.0, got {initial_state.target_temperature_high}"
+        )
+
+        # Test changing to "Super Saver" custom preset
+        client.climate_command(test_climate.key, custom_preset="Super Saver")
+
+        try:
+            super_saver_state = await asyncio.wait_for(super_saver_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Super Saver preset change not received within 5 seconds")
+
+        assert isinstance(super_saver_state, aioesphomeapi.ClimateState)
+        assert super_saver_state.custom_preset == "Super Saver"
+        assert super_saver_state.target_temperature_low == 20.0
+        assert super_saver_state.target_temperature_high == 24.0
+
+        # Test changing to "Vacation Mode" custom preset
+        client.climate_command(test_climate.key, custom_preset="Vacation Mode")
+
+        try:
+            vacation_state = await asyncio.wait_for(vacation_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Vacation Mode preset change not received within 5 seconds")
+
+        assert isinstance(vacation_state, aioesphomeapi.ClimateState)
+        assert vacation_state.custom_preset == "Vacation Mode"
+        assert vacation_state.target_temperature_low == 15.0
+        assert vacation_state.target_temperature_high == 18.0


### PR DESCRIPTION
# What does this implement/fix?

Optimizes thermostat component preset storage by replacing `std::map` with `FixedVector` and linear search, reducing flash usage by **1,632 bytes** and increasing free heap by **527 bytes**.

## Motivation

The thermostat component used `std::map<std::string, Config>` for custom presets and `std::map<ClimatePreset, Config>` for standard presets. This is overkill for typical usage (1-5 presets) and generates significant unnecessary code:
- Red-black tree implementation (~300-400 bytes)
- Heap-allocated string storage infrastructure (~200-300 bytes)
- Template instantiation overhead (~100-200 bytes)
- Map node allocations during runtime initialization

## Changes

### Storage Optimization:
- **Replaced** `std::map<ClimatePreset, Config>` → `FixedVector<PresetEntry>`
- **Replaced** `std::map<std::string, Config>` → `FixedVector<CustomPresetEntry>`
- **Changed** custom preset names from `std::string` → `const char*` (stored in flash)
- **Changed** `default_custom_preset_` from `std::string` → `const char*` with pointer lifetime management

### API Changes:
- **Changed** `set_preset_config()` to accept `std::initializer_list<PresetEntry>`
- **Changed** `set_custom_preset_config()` to accept `std::initializer_list<CustomPresetEntry>`
- Presets now initialized in a single call during code generation

### Implementation:
- Linear search instead of tree traversal (simple loop with enum/strcmp)
- Per-instance optimal sizing (each thermostat allocates exactly what it needs)
- Safe pointer management (`default_custom_preset_` stores pointer from vector)
- Temporary vector in `traits()` for custom preset names (184 bytes, acceptable trade-off)

## Memory Impact

### CI Analysis (ESP8266):
| Component | Flash Change | Notes |
|-----------|--------------|-------|
| `[esphome]thermostat` | **-766 bytes (-5.28%)** | Direct component savings |
| `cpp_runtime` | **-548 bytes (-39.94%)** | STL template code eliminated |
| `[esphome]climate` | **-293 bytes (-7.04%)** | Reduced template instantiations |
| `app_framework` | **+34 bytes (+0.71%)** | Minor overhead |
| **Total Flash** | **-1,632 bytes (-0.54%)** | **Net savings** |

### Real Device Testing:
- **Heap Free Before**: 277,645 bytes
- **Heap Free After**: 278,172 bytes
- **Heap Improvement**: **+527 bytes** (eliminated map node allocations)

### Breakdown:
**Removed** (~1,857 bytes):
- `std::_Rb_tree_insert_and_rebalance`: 239 bytes
- `set_custom_preset_config` (old): 300 bytes
- `set_preset_config` (old): 225 bytes
- `_M_get_insert_hint_unique_pos`: 223 bytes
- Red-black tree helpers: ~130 bytes
- Template instantiation overhead: ~740 bytes

**Added** (~184 bytes):
- `_M_realloc_insert` for temporary vector in `traits()`: 184 bytes
- This is acceptable because `traits()` is called once at setup

**Net Savings**: **1,673 bytes of pure STL elimination**

## Performance

Linear search is ideal for typical preset counts (1-5):
- O(n) search vs O(log n) tree traversal
- In practice: 5 comparisons vs tree overhead
- No measurable performance difference for this use case

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems optimization effort

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: thermostat
    id: my_thermostat
    name: "My Thermostat"
    sensor: temp_sensor
    default_preset: "Eco Plus"  # Custom preset as default
    preset:
      - name: Away  # Standard preset (enum)
        default_target_temperature_low: 16°C
        default_target_temperature_high: 20°C
      - name: Eco Plus  # Custom preset (string)
        default_target_temperature_low: 18°C
        default_target_temperature_high: 22°C
      - name: Vacation Mode  # Custom preset (string)
        default_target_temperature_low: 15°C
        default_target_temperature_high: 18°C
    idle_action:
      - logger.log: "Idle"
    cool_action:
      - logger.log: "Cooling"
    heat_action:
      - logger.log: "Heating"
    min_cooling_off_time: 300s
    min_cooling_run_time: 300s
    min_heating_off_time: 300s
    min_heating_run_time: 300s
    min_idle_time: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Extended `tests/integration/test_climate_custom_modes.py` to test:
      - Default preset behavior
      - Changing custom presets at runtime
      - Pointer lifetime safety
      - Linear search functionality

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - No documentation changes needed - optimization is transparent to users
