### PR TITLE
[esp32] Add sdkconfig flag to make OTA work for 32MB flash

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -497,6 +497,8 @@ def final_validate(config):
     from esphome.components.psram import DOMAIN as PSRAM_DOMAIN
 
     errs = []
+    conf_fw = config[CONF_FRAMEWORK]
+    advanced = conf_fw[CONF_ADVANCED]
     full_config = fv.full_config.get()
     if pio_options := full_config[CONF_ESPHOME].get(CONF_PLATFORMIO_OPTIONS):
         pio_flash_size_key = "board_upload.flash_size"
@@ -513,22 +515,14 @@ def final_validate(config):
                     f"Please specify {CONF_FLASH_SIZE} within esp32 configuration only"
                 )
             )
-    if (
-        config[CONF_VARIANT] != VARIANT_ESP32
-        and CONF_ADVANCED in (conf_fw := config[CONF_FRAMEWORK])
-        and CONF_IGNORE_EFUSE_MAC_CRC in conf_fw[CONF_ADVANCED]
-    ):
+    if config[CONF_VARIANT] != VARIANT_ESP32 and advanced[CONF_IGNORE_EFUSE_MAC_CRC]:
         errs.append(
             cv.Invalid(
                 f"'{CONF_IGNORE_EFUSE_MAC_CRC}' is not supported on {config[CONF_VARIANT]}",
                 path=[CONF_FRAMEWORK, CONF_ADVANCED, CONF_IGNORE_EFUSE_MAC_CRC],
             )
         )
-    if (
-        config.get(CONF_FRAMEWORK, {})
-        .get(CONF_ADVANCED, {})
-        .get(CONF_EXECUTE_FROM_PSRAM)
-    ):
+    if advanced[CONF_EXECUTE_FROM_PSRAM]:
         if config[CONF_VARIANT] != VARIANT_ESP32S3:
             errs.append(
                 cv.Invalid(
@@ -544,6 +538,17 @@ def final_validate(config):
                 )
             )
 
+    if (
+        config[CONF_FLASH_SIZE] == "32MB"
+        and "ota" in full_config
+        and not advanced[CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES]
+    ):
+        errs.append(
+            cv.Invalid(
+                f"OTA with 32MB flash requires {CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES} to be set in the {CONF_ADVANCED} section of the esp32 configuration",
+                path=[CONF_FLASH_SIZE],
+            )
+        )
     if errs:
         raise cv.MultipleInvalid(errs)
 
@@ -622,12 +627,14 @@ FRAMEWORK_SCHEMA = cv.All(
                     cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
                         *COMPILER_OPTIMIZATIONS, upper=True
                     ),
-                    cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
+                    cv.Optional(
+                        CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES, default=False
+                    ): cv.boolean,
                     cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
                     cv.Optional(
                         CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False
                     ): cv.boolean,
-                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
+                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC, default=False): cv.boolean,
                     # DHCP server is needed for WiFi AP mode. When WiFi component is used,
                     # it will handle disabling DHCP server when AP is not configured.
                     # Default to false (disabled) when WiFi is not used.
@@ -656,7 +663,7 @@ FRAMEWORK_SCHEMA = cv.All(
                         CONF_DISABLE_VFS_SUPPORT_SELECT, default=True
                     ): cv.boolean,
                     cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
-                    cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
+                    cv.Optional(CONF_EXECUTE_FROM_PSRAM, default=False): cv.boolean,
                     cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
                         min=8192, max=32768
                     ),
@@ -805,9 +812,7 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
     from esphome.components.socket import KEY_SOCKET_CONSUMERS
 
     # Check if user manually specified CONFIG_LWIP_MAX_SOCKETS
-    user_max_sockets = conf.get(CONF_SDKCONFIG_OPTIONS, {}).get(
-        "CONFIG_LWIP_MAX_SOCKETS"
-    )
+    user_max_sockets = conf[CONF_SDKCONFIG_OPTIONS].get("CONFIG_LWIP_MAX_SOCKETS")
 
     socket_consumers: dict[str, int] = CORE.data.get(KEY_SOCKET_CONSUMERS, {})
     total_sockets = sum(socket_consumers.values())
@@ -977,23 +982,18 @@ async def to_code(config):
     # WiFi component handles its own optimization when AP mode is not used
     # When using Arduino with Ethernet, DHCP server functions must be available
     # for the Network library to compile, even if not actively used
-    if (
-        CONF_ENABLE_LWIP_DHCP_SERVER in advanced
-        and not advanced[CONF_ENABLE_LWIP_DHCP_SERVER]
-        and not (
-            conf[CONF_TYPE] == FRAMEWORK_ARDUINO
-            and "ethernet" in CORE.loaded_integrations
-        )
+    if advanced.get(CONF_ENABLE_LWIP_DHCP_SERVER) is False and not (
+        conf[CONF_TYPE] == FRAMEWORK_ARDUINO and "ethernet" in CORE.loaded_integrations
     ):
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
-    if not advanced.get(CONF_ENABLE_LWIP_MDNS_QUERIES, True):
+    if not advanced[CONF_ENABLE_LWIP_MDNS_QUERIES]:
         add_idf_sdkconfig_option("CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES", False)
-    if not advanced.get(CONF_ENABLE_LWIP_BRIDGE_INTERFACE, False):
+    if not advanced[CONF_ENABLE_LWIP_BRIDGE_INTERFACE]:
         add_idf_sdkconfig_option("CONFIG_LWIP_BRIDGEIF_MAX_PORTS", 0)
 
     _configure_lwip_max_sockets(conf)
 
-    if advanced.get(CONF_EXECUTE_FROM_PSRAM, False):
+    if advanced[CONF_EXECUTE_FROM_PSRAM]:
         add_idf_sdkconfig_option("CONFIG_SPIRAM_FETCH_INSTRUCTIONS", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_RODATA", True)
 
@@ -1004,23 +1004,22 @@ async def to_code(config):
     # - select() on 4 sockets: ~190μs (Arduino/core locking) vs ~235μs (ESP-IDF default)
     # - Up to 200% slower under load when all operations queue through tcpip_thread
     # Enabling this makes ESP-IDF socket performance match Arduino framework.
-    if advanced.get(CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, True):
+    if advanced[CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING]:
         add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_CORE_LOCKING", True)
-    if advanced.get(CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, True):
+    if advanced[CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY]:
         add_idf_sdkconfig_option("CONFIG_LWIP_CHECK_THREAD_SAFETY", True)
 
     # Disable placing libc locks in IRAM to save RAM
     # This is safe for ESPHome since no IRAM ISRs (interrupts that run while cache is disabled)
     # use libc lock APIs. Saves approximately 1.3KB (1,356 bytes) of IRAM.
-    if advanced.get(CONF_DISABLE_LIBC_LOCKS_IN_IRAM, True):
+    if advanced[CONF_DISABLE_LIBC_LOCKS_IN_IRAM]:
         add_idf_sdkconfig_option("CONFIG_LIBC_LOCKS_PLACE_IN_IRAM", False)
 
     # Disable VFS support for termios (terminal I/O functions)
     # ESPHome doesn't use termios functions on ESP32 (only used in host UART driver).
     # Saves approximately 1.8KB of flash when disabled (default).
     add_idf_sdkconfig_option(
-        "CONFIG_VFS_SUPPORT_TERMIOS",
-        not advanced.get(CONF_DISABLE_VFS_SUPPORT_TERMIOS, True),
+        "CONFIG_VFS_SUPPORT_TERMIOS", not advanced[CONF_DISABLE_VFS_SUPPORT_TERMIOS]
     )
 
     # Disable VFS support for select() with file descriptors
@@ -1034,8 +1033,7 @@ async def to_code(config):
     else:
         # No component needs it - allow user to control (default: disabled)
         add_idf_sdkconfig_option(
-            "CONFIG_VFS_SUPPORT_SELECT",
-            not advanced.get(CONF_DISABLE_VFS_SUPPORT_SELECT, True),
+            "CONFIG_VFS_SUPPORT_SELECT", not advanced[CONF_DISABLE_VFS_SUPPORT_SELECT]
         )
 
     # Disable VFS support for directory functions (opendir, readdir, mkdir, etc.)
@@ -1048,8 +1046,7 @@ async def to_code(config):
     else:
         # No component needs it - allow user to control (default: disabled)
         add_idf_sdkconfig_option(
-            "CONFIG_VFS_SUPPORT_DIR",
-            not advanced.get(CONF_DISABLE_VFS_SUPPORT_DIR, True),
+            "CONFIG_VFS_SUPPORT_DIR", not advanced[CONF_DISABLE_VFS_SUPPORT_DIR]
         )
 
     cg.add_platformio_option("board_build.partitions", "partitions.csv")
@@ -1063,7 +1060,7 @@ async def to_code(config):
             add_idf_sdkconfig_option(flag, assertion_level == key)
 
     add_idf_sdkconfig_option("CONFIG_COMPILER_OPTIMIZATION_DEFAULT", False)
-    compiler_optimization = advanced.get(CONF_COMPILER_OPTIMIZATION)
+    compiler_optimization = advanced[CONF_COMPILER_OPTIMIZATION]
     for key, flag in COMPILER_OPTIMIZATIONS.items():
         add_idf_sdkconfig_option(flag, compiler_optimization == key)
 
@@ -1072,18 +1069,20 @@ async def to_code(config):
         conf[CONF_ADVANCED][CONF_ENABLE_LWIP_ASSERT],
     )
 
-    if advanced.get(CONF_IGNORE_EFUSE_MAC_CRC):
+    if advanced[CONF_IGNORE_EFUSE_MAC_CRC]:
         add_idf_sdkconfig_option("CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR", True)
         add_idf_sdkconfig_option("CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE", False)
-    if advanced.get(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES):
+    if advanced[CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES]:
         _LOGGER.warning(
             "Using experimental features in ESP-IDF may result in unexpected failures."
         )
         add_idf_sdkconfig_option("CONFIG_IDF_EXPERIMENTAL_FEATURES", True)
+        if config[CONF_FLASH_SIZE] == "32MB":
+            add_idf_sdkconfig_option(
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH", True
+            )
 
-    cg.add_define(
-        "ESPHOME_LOOP_TASK_STACK_SIZE", advanced.get(CONF_LOOP_TASK_STACK_SIZE)
-    )
+    cg.add_define("ESPHOME_LOOP_TASK_STACK_SIZE", advanced[CONF_LOOP_TASK_STACK_SIZE])
 
     cg.add_define(
         "USE_ESP_IDF_VERSION_CODE",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -498,6 +498,8 @@ def final_validate(config):
     from esphome.components.psram import DOMAIN as PSRAM_DOMAIN
 
     errs = []
+    conf_fw = config[CONF_FRAMEWORK]
+    advanced = conf_fw[CONF_ADVANCED]
     full_config = fv.full_config.get()
     if pio_options := full_config[CONF_ESPHOME].get(CONF_PLATFORMIO_OPTIONS):
         pio_flash_size_key = "board_upload.flash_size"
@@ -514,22 +516,14 @@ def final_validate(config):
                     f"Please specify {CONF_FLASH_SIZE} within esp32 configuration only"
                 )
             )
-    if (
-        config[CONF_VARIANT] != VARIANT_ESP32
-        and CONF_ADVANCED in (conf_fw := config[CONF_FRAMEWORK])
-        and CONF_IGNORE_EFUSE_MAC_CRC in conf_fw[CONF_ADVANCED]
-    ):
+    if config[CONF_VARIANT] != VARIANT_ESP32 and advanced[CONF_IGNORE_EFUSE_MAC_CRC]:
         errs.append(
             cv.Invalid(
                 f"'{CONF_IGNORE_EFUSE_MAC_CRC}' is not supported on {config[CONF_VARIANT]}",
                 path=[CONF_FRAMEWORK, CONF_ADVANCED, CONF_IGNORE_EFUSE_MAC_CRC],
             )
         )
-    if (
-        config.get(CONF_FRAMEWORK, {})
-        .get(CONF_ADVANCED, {})
-        .get(CONF_EXECUTE_FROM_PSRAM)
-    ):
+    if advanced[CONF_EXECUTE_FROM_PSRAM]:
         if config[CONF_VARIANT] != VARIANT_ESP32S3:
             errs.append(
                 cv.Invalid(
@@ -545,6 +539,17 @@ def final_validate(config):
                 )
             )
 
+    if (
+        config[CONF_FLASH_SIZE] == "32MB"
+        and "ota" in full_config
+        and not advanced[CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES]
+    ):
+        errs.append(
+            cv.Invalid(
+                f"OTA with 32MB flash requires {CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES} to be set in the {CONF_ADVANCED} section of the esp32 configuration",
+                path=[CONF_FLASH_SIZE],
+            )
+        )
     if errs:
         raise cv.MultipleInvalid(errs)
 
@@ -620,10 +625,12 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
                     *COMPILER_OPTIMIZATIONS, upper=True
                 ),
-                cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES, default=False
+                ): cv.boolean,
                 cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
                 cv.Optional(CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False): cv.boolean,
-                cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
+                cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC, default=False): cv.boolean,
                 # DHCP server is needed for WiFi AP mode. When WiFi component is used,
                 # it will handle disabling DHCP server when AP is not configured.
                 # Default to false (disabled) when WiFi is not used.
@@ -644,7 +651,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_SELECT, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
-                cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
+                cv.Optional(CONF_EXECUTE_FROM_PSRAM, default=False): cv.boolean,
                 cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
                     min=8192, max=32768
                 ),
@@ -790,9 +797,7 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
     from esphome.components.socket import KEY_SOCKET_CONSUMERS
 
     # Check if user manually specified CONFIG_LWIP_MAX_SOCKETS
-    user_max_sockets = conf.get(CONF_SDKCONFIG_OPTIONS, {}).get(
-        "CONFIG_LWIP_MAX_SOCKETS"
-    )
+    user_max_sockets = conf[CONF_SDKCONFIG_OPTIONS].get("CONFIG_LWIP_MAX_SOCKETS")
 
     socket_consumers: dict[str, int] = CORE.data.get(KEY_SOCKET_CONSUMERS, {})
     total_sockets = sum(socket_consumers.values())
@@ -962,23 +967,18 @@ async def to_code(config):
     # WiFi component handles its own optimization when AP mode is not used
     # When using Arduino with Ethernet, DHCP server functions must be available
     # for the Network library to compile, even if not actively used
-    if (
-        CONF_ENABLE_LWIP_DHCP_SERVER in advanced
-        and not advanced[CONF_ENABLE_LWIP_DHCP_SERVER]
-        and not (
-            conf[CONF_TYPE] == FRAMEWORK_ARDUINO
-            and "ethernet" in CORE.loaded_integrations
-        )
+    if advanced.get(CONF_ENABLE_LWIP_DHCP_SERVER) is False and not (
+        conf[CONF_TYPE] == FRAMEWORK_ARDUINO and "ethernet" in CORE.loaded_integrations
     ):
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
-    if not advanced.get(CONF_ENABLE_LWIP_MDNS_QUERIES, True):
+    if not advanced[CONF_ENABLE_LWIP_MDNS_QUERIES]:
         add_idf_sdkconfig_option("CONFIG_LWIP_DNS_SUPPORT_MDNS_QUERIES", False)
-    if not advanced.get(CONF_ENABLE_LWIP_BRIDGE_INTERFACE, False):
+    if not advanced[CONF_ENABLE_LWIP_BRIDGE_INTERFACE]:
         add_idf_sdkconfig_option("CONFIG_LWIP_BRIDGEIF_MAX_PORTS", 0)
 
     _configure_lwip_max_sockets(conf)
 
-    if advanced.get(CONF_EXECUTE_FROM_PSRAM, False):
+    if advanced[CONF_EXECUTE_FROM_PSRAM]:
         add_idf_sdkconfig_option("CONFIG_SPIRAM_FETCH_INSTRUCTIONS", True)
         add_idf_sdkconfig_option("CONFIG_SPIRAM_RODATA", True)
 
@@ -989,23 +989,22 @@ async def to_code(config):
     # - select() on 4 sockets: ~190μs (Arduino/core locking) vs ~235μs (ESP-IDF default)
     # - Up to 200% slower under load when all operations queue through tcpip_thread
     # Enabling this makes ESP-IDF socket performance match Arduino framework.
-    if advanced.get(CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, True):
+    if advanced[CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING]:
         add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_CORE_LOCKING", True)
-    if advanced.get(CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, True):
+    if advanced[CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY]:
         add_idf_sdkconfig_option("CONFIG_LWIP_CHECK_THREAD_SAFETY", True)
 
     # Disable placing libc locks in IRAM to save RAM
     # This is safe for ESPHome since no IRAM ISRs (interrupts that run while cache is disabled)
     # use libc lock APIs. Saves approximately 1.3KB (1,356 bytes) of IRAM.
-    if advanced.get(CONF_DISABLE_LIBC_LOCKS_IN_IRAM, True):
+    if advanced[CONF_DISABLE_LIBC_LOCKS_IN_IRAM]:
         add_idf_sdkconfig_option("CONFIG_LIBC_LOCKS_PLACE_IN_IRAM", False)
 
     # Disable VFS support for termios (terminal I/O functions)
     # ESPHome doesn't use termios functions on ESP32 (only used in host UART driver).
     # Saves approximately 1.8KB of flash when disabled (default).
     add_idf_sdkconfig_option(
-        "CONFIG_VFS_SUPPORT_TERMIOS",
-        not advanced.get(CONF_DISABLE_VFS_SUPPORT_TERMIOS, True),
+        "CONFIG_VFS_SUPPORT_TERMIOS", not advanced[CONF_DISABLE_VFS_SUPPORT_TERMIOS]
     )
 
     # Disable VFS support for select() with file descriptors
@@ -1019,8 +1018,7 @@ async def to_code(config):
     else:
         # No component needs it - allow user to control (default: disabled)
         add_idf_sdkconfig_option(
-            "CONFIG_VFS_SUPPORT_SELECT",
-            not advanced.get(CONF_DISABLE_VFS_SUPPORT_SELECT, True),
+            "CONFIG_VFS_SUPPORT_SELECT", not advanced[CONF_DISABLE_VFS_SUPPORT_SELECT]
         )
 
     # Disable VFS support for directory functions (opendir, readdir, mkdir, etc.)
@@ -1033,8 +1031,7 @@ async def to_code(config):
     else:
         # No component needs it - allow user to control (default: disabled)
         add_idf_sdkconfig_option(
-            "CONFIG_VFS_SUPPORT_DIR",
-            not advanced.get(CONF_DISABLE_VFS_SUPPORT_DIR, True),
+            "CONFIG_VFS_SUPPORT_DIR", not advanced[CONF_DISABLE_VFS_SUPPORT_DIR]
         )
 
     cg.add_platformio_option("board_build.partitions", "partitions.csv")
@@ -1048,7 +1045,7 @@ async def to_code(config):
             add_idf_sdkconfig_option(flag, assertion_level == key)
 
     add_idf_sdkconfig_option("CONFIG_COMPILER_OPTIMIZATION_DEFAULT", False)
-    compiler_optimization = advanced.get(CONF_COMPILER_OPTIMIZATION)
+    compiler_optimization = advanced[CONF_COMPILER_OPTIMIZATION]
     for key, flag in COMPILER_OPTIMIZATIONS.items():
         add_idf_sdkconfig_option(flag, compiler_optimization == key)
 
@@ -1057,18 +1054,20 @@ async def to_code(config):
         conf[CONF_ADVANCED][CONF_ENABLE_LWIP_ASSERT],
     )
 
-    if advanced.get(CONF_IGNORE_EFUSE_MAC_CRC):
+    if advanced[CONF_IGNORE_EFUSE_MAC_CRC]:
         add_idf_sdkconfig_option("CONFIG_ESP_MAC_IGNORE_MAC_CRC_ERROR", True)
         add_idf_sdkconfig_option("CONFIG_ESP_PHY_CALIBRATION_AND_DATA_STORAGE", False)
-    if advanced.get(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES):
+    if advanced[CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES]:
         _LOGGER.warning(
             "Using experimental features in ESP-IDF may result in unexpected failures."
         )
         add_idf_sdkconfig_option("CONFIG_IDF_EXPERIMENTAL_FEATURES", True)
+        if config[CONF_FLASH_SIZE] == "32MB":
+            add_idf_sdkconfig_option(
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH", True
+            )
 
-    cg.add_define(
-        "ESPHOME_LOOP_TASK_STACK_SIZE", advanced.get(CONF_LOOP_TASK_STACK_SIZE)
-    )
+    cg.add_define("ESPHOME_LOOP_TASK_STACK_SIZE", advanced[CONF_LOOP_TASK_STACK_SIZE])
 
     cg.add_define(
         "USE_ESP_IDF_VERSION_CODE",

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -546,7 +546,7 @@ def final_validate(config):
     ):
         errs.append(
             cv.Invalid(
-                f"OTA with 32MB flash requires {CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES} to be set in the {CONF_ADVANCED} section of the esp32 configuration",
+                f"OTA with 32MB flash requires '{CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES}' to be set in the '{CONF_ADVANCED}' section of the esp32 configuration",
                 path=[CONF_FLASH_SIZE],
             )
         )

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -599,86 +599,72 @@ def _validate_idf_component(config: ConfigType) -> ConfigType:
 
 FRAMEWORK_ESP_IDF = "esp-idf"
 FRAMEWORK_ARDUINO = "arduino"
-FRAMEWORK_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.Optional(CONF_TYPE): cv.one_of(FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO),
-            cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_RELEASE): cv.string_strict,
-            cv.Optional(CONF_SOURCE): cv.string_strict,
-            cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
-            cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
-                cv.string_strict: cv.string_strict
-            },
-            cv.Optional(CONF_LOG_LEVEL, default="ERROR"): cv.one_of(
-                *LOG_LEVELS_IDF, upper=True
-            ),
-            cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
-                {
-                    cv.Optional(CONF_ASSERTION_LEVEL): cv.one_of(
-                        *ASSERTION_LEVELS, upper=True
-                    ),
-                    cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
-                        *COMPILER_OPTIMIZATIONS, upper=True
-                    ),
-                    cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
-                    cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
-                    cv.Optional(
-                        CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False
-                    ): cv.boolean,
-                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
-                    # DHCP server is needed for WiFi AP mode. When WiFi component is used,
-                    # it will handle disabling DHCP server when AP is not configured.
-                    # Default to false (disabled) when WiFi is not used.
-                    cv.OnlyWithout(
-                        CONF_ENABLE_LWIP_DHCP_SERVER, "wifi", default=False
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_MDNS_QUERIES, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_BRIDGE_INTERFACE, default=False
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_LIBC_LOCKS_IN_IRAM, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_VFS_SUPPORT_SELECT, default=True
-                    ): cv.boolean,
-                    cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
-                    cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
-                    cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
-                        min=8192, max=32768
-                    ),
-                }
-            ),
-            cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
-                cv.All(
-                    cv.Schema(
-                        {
-                            cv.Required(CONF_NAME): cv.string_strict,
-                            cv.Optional(CONF_SOURCE): cv.git_ref,
-                            cv.Optional(CONF_REF): cv.string,
-                            cv.Optional(CONF_PATH): cv.string,
-                            cv.Optional(CONF_REFRESH): cv.All(
-                                cv.string, cv.source_refresh
-                            ),
-                        }
-                    ),
-                    _validate_idf_component,
-                )
-            ),
-        }
-    ),
+FRAMEWORK_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_TYPE): cv.one_of(FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO),
+        cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
+        cv.Optional(CONF_RELEASE): cv.string_strict,
+        cv.Optional(CONF_SOURCE): cv.string_strict,
+        cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
+        cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
+            cv.string_strict: cv.string_strict
+        },
+        cv.Optional(CONF_LOG_LEVEL, default="ERROR"): cv.one_of(
+            *LOG_LEVELS_IDF, upper=True
+        ),
+        cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_ASSERTION_LEVEL): cv.one_of(
+                    *ASSERTION_LEVELS, upper=True
+                ),
+                cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
+                    *COMPILER_OPTIMIZATIONS, upper=True
+                ),
+                cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
+                cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
+                cv.Optional(CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False): cv.boolean,
+                cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
+                # DHCP server is needed for WiFi AP mode. When WiFi component is used,
+                # it will handle disabling DHCP server when AP is not configured.
+                # Default to false (disabled) when WiFi is not used.
+                cv.OnlyWithout(
+                    CONF_ENABLE_LWIP_DHCP_SERVER, "wifi", default=False
+                ): cv.boolean,
+                cv.Optional(CONF_ENABLE_LWIP_MDNS_QUERIES, default=True): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_BRIDGE_INTERFACE, default=False
+                ): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, default=True
+                ): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, default=True
+                ): cv.boolean,
+                cv.Optional(CONF_DISABLE_LIBC_LOCKS_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_SELECT, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
+                cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
+                cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
+                    min=8192, max=32768
+                ),
+            }
+        ),
+        cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
+            cv.All(
+                cv.Schema(
+                    {
+                        cv.Required(CONF_NAME): cv.string_strict,
+                        cv.Optional(CONF_SOURCE): cv.git_ref,
+                        cv.Optional(CONF_REF): cv.string,
+                        cv.Optional(CONF_PATH): cv.string,
+                        cv.Optional(CONF_REFRESH): cv.All(cv.string, cv.source_refresh),
+                    }
+                ),
+                _validate_idf_component,
+            )
+        ),
+    }
 )
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -139,6 +139,7 @@ FULL_CPU_FREQUENCIES = set(itertools.chain.from_iterable(CPU_FREQUENCIES.values(
 
 def set_core_data(config):
     cpu_frequency = config.get(CONF_CPU_FREQUENCY, None)
+    print(config)
     variant = config[CONF_VARIANT]
     # if not specified in config, set to 160MHz if supported, the fastest otherwise
     if cpu_frequency is None:
@@ -381,8 +382,9 @@ PLATFORM_VERSION_LOOKUP = {
 }
 
 
-def _check_versions(value):
-    value = value.copy()
+def _check_versions(config):
+    config = config.copy()
+    value = config[CONF_FRAMEWORK]
 
     if value[CONF_VERSION] in PLATFORM_VERSION_LOOKUP:
         if CONF_SOURCE in value or CONF_PLATFORM_VERSION in value:
@@ -447,7 +449,7 @@ def _check_versions(value):
             "If there are connectivity or build issues please remove the manual version."
         )
 
-    return value
+    return config
 
 
 def _parse_platform_version(value):
@@ -601,9 +603,7 @@ FRAMEWORK_ARDUINO = "arduino"
 FRAMEWORK_SCHEMA = cv.All(
     cv.Schema(
         {
-            cv.Optional(CONF_TYPE, default=FRAMEWORK_ARDUINO): cv.one_of(
-                FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO
-            ),
+            cv.Optional(CONF_TYPE): cv.one_of(FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO),
             cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
             cv.Optional(CONF_RELEASE): cv.string_strict,
             cv.Optional(CONF_SOURCE): cv.string_strict,
@@ -680,7 +680,6 @@ FRAMEWORK_SCHEMA = cv.All(
             ),
         }
     ),
-    _check_versions,
 )
 
 
@@ -743,11 +742,11 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
 
 
 def _set_default_framework(config):
+    config = config.copy()
     if CONF_FRAMEWORK not in config:
-        config = config.copy()
-
-        variant = config[CONF_VARIANT]
         config[CONF_FRAMEWORK] = FRAMEWORK_SCHEMA({})
+    if CONF_TYPE not in config[CONF_FRAMEWORK]:
+        variant = config[CONF_VARIANT]
         if variant in ARDUINO_ALLOWED_VARIANTS:
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
             _show_framework_migration_message(
@@ -787,6 +786,7 @@ CONFIG_SCHEMA = cv.All(
     ),
     _detect_variant,
     _set_default_framework,
+    _check_versions,
     set_core_data,
     cv.has_at_least_one_key(CONF_BOARD, CONF_VARIANT),
 )

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -139,7 +139,6 @@ FULL_CPU_FREQUENCIES = set(itertools.chain.from_iterable(CPU_FREQUENCIES.values(
 
 def set_core_data(config):
     cpu_frequency = config.get(CONF_CPU_FREQUENCY, None)
-    print(config)
     variant = config[CONF_VARIANT]
     # if not specified in config, set to 160MHz if supported, the fastest otherwise
     if cpu_frequency is None:

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -1,0 +1,27 @@
+esp32:
+  variant: esp32p4
+  flash_size: 32MB
+  cpu_frequency: 400MHz
+  framework:
+    type: esp-idf
+    advanced:
+      enable_idf_experimental_features: yes
+
+ota:
+  platform: esphome
+
+wifi:
+  ssid: MySSID
+  password: password1
+
+esp32_hosted:
+  variant: ESP32C6
+  slot: 1
+  active_high: true
+  reset_pin: GPIO15
+  cmd_pin: GPIO13
+  clk_pin: GPIO12
+  d0_pin: GPIO11
+  d1_pin: GPIO10
+  d2_pin: GPIO9
+  d3_pin: GPIO8


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add sdkconfig options to make OTA work with 32MB quad flash.

Also clean up some config access operations.

Note: this is rebased to #11884 so that PR should be merged before this one.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #11775 
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
