### PR TITLE
[uart] Improve error handling and validate buffer size

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 import math
 import re
 
@@ -34,6 +35,8 @@ from esphome.const import (
 from esphome.core import CORE, ID
 import esphome.final_validate as fv
 from esphome.yaml_util import make_data_base
+
+_LOGGER = getLogger(__name__)
 
 CODEOWNERS = ["@esphome/core"]
 uart_ns = cg.esphome_ns.namespace("uart")
@@ -126,6 +129,21 @@ def validate_host_config(config):
             raise cv.Invalid(
                 f"Host platform doesn't support baud rate {config[CONF_BAUD_RATE]}",
                 path=[CONF_BAUD_RATE],
+            )
+    return config
+
+
+def validate_rx_buffer_size(config):
+    if CORE.is_esp32:
+        # ESP32 UART hardware FIFO is 128 bytes (LP UART is 16 bytes, but we use 128 as safe minimum)
+        # rx_buffer_size must be greater than the hardware FIFO length
+        min_buffer_size = 128
+        if config[CONF_RX_BUFFER_SIZE] <= min_buffer_size:
+            _LOGGER.warning(
+                "UART rx_buffer_size (%d bytes) is too small and must be greater than the hardware "
+                "FIFO size (%d bytes). The buffer size will be automatically adjusted at runtime.",
+                config[CONF_RX_BUFFER_SIZE],
+                min_buffer_size,
             )
     return config
 
@@ -247,6 +265,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN, CONF_PORT),
     validate_host_config,
+    validate_rx_buffer_size,
 )
 
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -91,6 +91,16 @@ void IDFUARTComponent::setup() {
   this->uart_num_ = static_cast<uart_port_t>(next_uart_num++);
   this->lock_ = xSemaphoreCreateMutex();
 
+#if (SOC_UART_LP_NUM >= 1)
+  size_t fifo_len = ((this->uart_num_ < SOC_UART_HP_NUM) ? SOC_UART_FIFO_LEN : SOC_LP_UART_FIFO_LEN);
+#else
+  size_t fifo_len = SOC_UART_FIFO_LEN;
+#endif
+  if (this->rx_buffer_size_ <= fifo_len) {
+    ESP_LOGW(TAG, "rx_buffer_size is too small, must be greater than %zu", fifo_len);
+    this->rx_buffer_size_ = fifo_len * 2;
+  }
+
   xSemaphoreTake(this->lock_, portMAX_DELAY);
 
   this->load_settings(false);
@@ -237,8 +247,12 @@ void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
 
 void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreTake(this->lock_, portMAX_DELAY);
-  uart_write_bytes(this->uart_num_, data, len);
+  int32_t write_len = uart_write_bytes(this->uart_num_, data, len);
   xSemaphoreGive(this->lock_);
+  if (write_len != (int32_t) len) {
+    ESP_LOGW(TAG, "uart_write_bytes failed: %d != %zu", write_len, len);
+    mark_failed();
+  }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_TX, data[i]);
@@ -267,6 +281,7 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
 
 bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   size_t length_to_read = len;
+  int32_t read_len = 0;
   if (!this->check_read_timeout_(len))
     return false;
   xSemaphoreTake(this->lock_, portMAX_DELAY);
@@ -277,25 +292,31 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
     this->has_peek_ = false;
   }
   if (length_to_read > 0)
-    uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
+    read_len = uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
   xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
   }
 #endif
-  return true;
+  return read_len == (int32_t) length_to_read;
 }
 
 int IDFUARTComponent::available() {
-  size_t available;
+  size_t available = 0;
+  esp_err_t err;
 
   xSemaphoreTake(this->lock_, portMAX_DELAY);
-  uart_get_buffered_data_len(this->uart_num_, &available);
-  if (this->has_peek_)
-    available++;
+  err = uart_get_buffered_data_len(this->uart_num_, &available);
   xSemaphoreGive(this->lock_);
 
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_get_buffered_data_len failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+  }
+  if (this->has_peek_) {
+    available++;
+  }
   return available;
 }
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -251,7 +251,7 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   xSemaphoreGive(this->lock_);
   if (write_len != (int32_t) len) {
     ESP_LOGW(TAG, "uart_write_bytes failed: %d != %zu", write_len, len);
-    mark_failed();
+    this->mark_failed();
   }
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {


### PR DESCRIPTION
# What does this implement/fix?

  Improved error handling in ESP32 UART component implementation.

  Changes Made

  1. Added RX Buffer Size Validation
    - Added check to ensure rx_buffer_size_ meets minimum hardware FIFO length
    - Automatically adjusts buffer size with warning if configured too small
    - Prevents potential ESP-IDF driver errors during initialization
  2. Added Error Checking to write_array()
    - Added error checking for uart_write_bytes() return value
    - Previously ignored the return value and couldn't detect write failures
    - Now logs error and marks component as failed when write operation fails
  3. Fixed Variable Initialization in available()
    - Changed size_t available; to size_t available = 0;
    - Prevents undefined behavior if uart_get_buffered_data_len() fails
  4. Added Error Checking to available()
    - Added error checking for uart_get_buffered_data_len() return value
    - Previously ignored the return value and couldn't detect buffer query failures
    - Now logs error and marks component as failed when operation fails
  5. Fixed read_array() Return Value
    - Added read_len variable to track actual bytes read from uart_read_bytes()
    - Now returns false if read operation doesn't return expected number of bytes
    - Previously always returned true even on partial/failed reads
  6. Integrated validation into CONFIG_SCHEMA:
    - Added validate_rx_buffer_size() function
    - Added validate_rx_buffer_size to the validation chain

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11559

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
