### PR TITLE
[wifi] Allow `use_psram` with Arduino

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -12,7 +12,6 @@ from esphome.components.network import (
 from esphome.components.psram import is_guaranteed as psram_is_guaranteed
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
-from esphome.config_validation import only_with_esp_idf
 from esphome.const import (
     CONF_AP,
     CONF_BSSID,

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -352,7 +352,7 @@ CONFIG_SCHEMA = cv.All(
                 single=True
             ),
             cv.Optional(CONF_USE_PSRAM): cv.All(
-                only_with_esp_idf, cv.requires_component("psram"), cv.boolean
+                cv.only_on_esp32, cv.requires_component("psram"), cv.boolean
             ),
         }
     ),


### PR DESCRIPTION
# What does this implement/fix?

With Arduino running as an ESP-IDF component, the use of PSRAM for Wi-Fi component should be transparent.

I don't really see any significant change on memory usage (with only simple tests with `debug` component), but at least this will allow code sharing between frameworks:

#### With `use_psram: true`:
```log
[08:49:30.122][C][debug:018]: Debug component:
[08:49:30.122][D][debug:033]: ESPHome version 2025.12.0-dev
[08:49:30.124][D][debug:037]: Free Heap Size: 179496 bytes

[08:51:26.207][C][debug:018]: Debug component:
[08:51:26.207][D][debug:033]: ESPHome version 2025.12.0-dev
[08:51:26.207][D][debug:037]: Free Heap Size: 179748 bytes

[08:52:50.592][C][debug:018]: Debug component:
[08:52:50.592][D][debug:033]: ESPHome version 2025.12.0-dev
[08:52:50.592][D][debug:037]: Free Heap Size: 179512 bytes
```

#### With `use_psram: false`:
```log
[08:54:26.650][C][debug:018]: Debug component:
[08:54:26.651][D][debug:033]: ESPHome version 2025.12.0-dev
[08:54:26.651][D][debug:037]: Free Heap Size: 179712 bytes

[08:55:59.015][C][debug:018]: Debug component:
[08:55:59.017][D][debug:033]: ESPHome version 2025.12.0-dev
[08:55:59.022][D][debug:037]: Free Heap Size: 179700 bytes

[08:57:23.425][C][debug:018]: Debug component:
[08:57:23.425][D][debug:033]: ESPHome version 2025.12.0-dev
[08:57:23.426][D][debug:037]: Free Heap Size: 179560 bytes
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

I don't think the doc needs update, as it already mention it is "For ESP32 only", so basically this PR is aligning the code to the docs:

> **use_psram** (*Optional*, boolean): For ESP32 only, requests that the WiFi libraries try to allocate memory from PSRAM. Defaults to false. Requires PSRAM to be configured.

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
