### PR TITLE
[sntp] Merge multiple instances to fix crash and undefined behavior

### DIFF
--- a/tests/component_tests/sntp/__init__.py
+++ b/tests/component_tests/sntp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for SNTP component."""

--- a/tests/component_tests/sntp/config/sntp_test.yaml
+++ b/tests/component_tests/sntp/config/sntp_test.yaml
@@ -1,0 +1,22 @@
+esphome:
+  name: sntp-test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "testssid"
+  password: "testpassword"
+
+# Test multiple SNTP instances that should be merged
+time:
+  - platform: sntp
+    servers:
+      - 192.168.1.1
+      - pool.ntp.org
+  - platform: sntp
+    servers:
+      - pool.ntp.org
+      - 192.168.1.2

--- a/tests/component_tests/sntp/test_init.py
+++ b/tests/component_tests/sntp/test_init.py
@@ -1,0 +1,238 @@
+"""Tests for SNTP time configuration validation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.sntp.time import CONF_SNTP, _sntp_final_validate
+from esphome.const import CONF_ID, CONF_PLATFORM, CONF_SERVERS, CONF_TIME
+from esphome.core import ID
+import esphome.final_validate as fv
+
+
+@pytest.mark.parametrize(
+    ("time_configs", "expected_count", "expected_servers", "warning_messages"),
+    [
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                }
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org"],
+            [],
+            id="single_instance_no_merge",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="two_instances_merged",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["pool.ntp.org", "192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="deduplication_preserves_order",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.2", "pool2.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_3", is_manual=False),
+                    CONF_SERVERS: ["pool3.ntp.org"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            [
+                "SNTP supports maximum 3 servers. Dropped excess server(s): ['pool2.ntp.org', 'pool3.ntp.org']",
+                "Found and merged 3 SNTP time configurations into one instance",
+            ],
+            id="three_instances_drops_excess_servers",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: [
+                        "192.168.1.1",
+                        "pool.ntp.org",
+                        "pool.ntp.org",
+                        "192.168.1.1",
+                    ],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["pool.ntp.org", "192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="deduplication_multiple_duplicates",
+        ),
+    ],
+)
+def test_sntp_instance_merging(
+    time_configs: list[dict[str, Any]],
+    expected_count: int,
+    expected_servers: list[str],
+    warning_messages: list[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test SNTP instance merging behavior."""
+    # Create a mock full config with time configs
+    full_conf = {CONF_TIME: time_configs.copy()}
+
+    # Set the context var
+    token = fv.full_config.set(full_conf)
+    try:
+        with caplog.at_level(logging.WARNING):
+            _sntp_final_validate({})
+
+        # Get the updated config
+        updated_conf = fv.full_config.get()
+
+        # Check if merging occurred
+        if len(time_configs) > 1:
+            # Verify only one SNTP instance remains
+            sntp_instances = [
+                tc
+                for tc in updated_conf[CONF_TIME]
+                if tc.get(CONF_PLATFORM) == CONF_SNTP
+            ]
+            assert len(sntp_instances) == expected_count
+
+            # Verify server list
+            assert sntp_instances[0][CONF_SERVERS] == expected_servers
+
+            # Verify warnings
+            for expected_msg in warning_messages:
+                assert any(
+                    expected_msg in record.message for record in caplog.records
+                ), f"Expected warning message '{expected_msg}' not found in log"
+        else:
+            # Single instance should not trigger merging or warnings
+            assert len(caplog.records) == 0
+            # Config should be unchanged
+            assert updated_conf[CONF_TIME] == time_configs
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_sntp_inconsistent_manual_ids() -> None:
+    """Test that inconsistent manual IDs raise an error."""
+    # Create configs with manual IDs that are inconsistent
+    time_configs = [
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_1", is_manual=True),
+            CONF_SERVERS: ["192.168.1.1"],
+        },
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_2", is_manual=True),
+            CONF_SERVERS: ["192.168.1.2"],
+        },
+    ]
+
+    full_conf = {CONF_TIME: time_configs}
+
+    token = fv.full_config.set(full_conf)
+    try:
+        with pytest.raises(
+            cv.Invalid,
+            match="Found multiple SNTP configurations but id is inconsistent",
+        ):
+            _sntp_final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_sntp_with_other_time_platforms(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that SNTP merging doesn't affect other time platforms."""
+    time_configs = [
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_1", is_manual=False),
+            CONF_SERVERS: ["192.168.1.1"],
+        },
+        {
+            CONF_PLATFORM: "homeassistant",
+            CONF_ID: ID("homeassistant_time", is_manual=False),
+        },
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_2", is_manual=False),
+            CONF_SERVERS: ["192.168.1.2"],
+        },
+    ]
+
+    full_conf = {CONF_TIME: time_configs.copy()}
+
+    token = fv.full_config.set(full_conf)
+    try:
+        with caplog.at_level(logging.WARNING):
+            _sntp_final_validate({})
+
+        updated_conf = fv.full_config.get()
+
+        # Should have 2 time platforms: 1 merged SNTP + 1 homeassistant
+        assert len(updated_conf[CONF_TIME]) == 2
+
+        # Find the platforms
+        platforms = {tc[CONF_PLATFORM] for tc in updated_conf[CONF_TIME]}
+        assert platforms == {CONF_SNTP, "homeassistant"}
+
+        # Verify SNTP was merged
+        sntp_instances = [
+            tc for tc in updated_conf[CONF_TIME] if tc[CONF_PLATFORM] == CONF_SNTP
+        ]
+        assert len(sntp_instances) == 1
+        assert sntp_instances[0][CONF_SERVERS] == ["192.168.1.1", "192.168.1.2"]
+    finally:
+        fv.full_config.reset(token)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a crash in the SNTP component introduced by PR #11525 where `dump_config()` causes a LoadProhibited exception on ESP32 devices when multiple SNTP time instances are configured.

**Problem:**
PR #11525 replaced `std::vector<std::string>` with `std::array<const char*, SNTP_SERVER_COUNT>` to reduce heap usage. When multiple SNTP time instances are configured with different numbers of servers, `cg.add_define()` is called multiple times, causing the generated `defines.h` to contain multiple definitions of `SNTP_SERVER_COUNT`. The last definition wins, causing all instances to compile with the same array size even though constructor calls have different numbers of initializer elements. This results in uninitialized array elements (nullptr) which crash when `dump_config()` attempts to log them.

**Background:**
Multiple SNTP instances have always been undefined behavior. The underlying ESP platform APIs (`configTime()` on ESP8266, `esp_sntp_*` on ESP32) only support a single NTP client configuration - calling them multiple times means whichever instance initialized last would overwrite the previous configuration. The crash introduced in PR #11525 made this latent issue immediately visible rather than silently causing undefined behavior.

**Solution:**
Implement SNTP instance merging similar to how OTA handles multiple platform configurations. When multiple SNTP time instances are configured:
- All instances are automatically merged into a single SNTP component
- Server lists are combined and deduplicated (preserving order)
- If more than 3 servers result from merging, excess servers are dropped with a warning (SNTP protocol limitation)
- Only one `SNTP_SERVER_COUNT` define is generated, preventing the macro redefinition issue
- Users are warned when merging occurs

This approach:
- **Prevents the crash**: Only one SNTP instance means no macro redefinition conflicts
- **Fixes undefined behavior**: Ensures only one NTP client configuration is active (matches ESP API expectations)
- **Matches OTA behavior**: Follows established pattern for platform component merging
- **No breaking changes**: Existing single-instance configs continue to work unchanged
- **Helpful warnings**: Users are informed when merging occurs and when servers are dropped

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11899

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes - internal fix only)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration previously crashed - now merges into single instance
time:
  - platform: sntp
    servers:
      - 192.168.1.1
      - pool.ntp.org
  - platform: sntp
    servers:
      - pool.ntp.org      # Deduplicated
      - 192.168.1.2

# Results in single SNTP instance with servers: [192.168.1.1, pool.ntp.org, 192.168.1.2]
# Warning logged: "Found and merged 2 SNTP time configurations into one instance"
```

## Technical Details

**Files Modified:**
1. `esphome/components/sntp/time.py`:
   - Added `CONF_SNTP` constant (local to component)
   - Added `_sntp_final_validate()` function with proper typing
   - Merges multiple SNTP instances into one using `merge_config()`
   - Deduplicates servers using `dict.fromkeys()` (preserves insertion order)
   - Warns when dropping servers beyond 3-server limit
   - Validates that manually-specified IDs are consistent
   - Uses constants (`CONF_TIME`, `CONF_PLATFORM`) instead of string literals
   - Set as `FINAL_VALIDATE_SCHEMA` to run during final validation phase

2. `tests/component_tests/sntp/`:
   - Created comprehensive unit tests covering:
     - Single instance (no merge)
     - Multiple instances merging
     - Server deduplication with order preservation
     - Excess server dropping with warnings
     - Inconsistent manual ID validation error
     - Merging with other time platforms (e.g., homeassistant)
   - All 7 tests pass

**Why instance merging?**
- ESP platform APIs only support a single NTP client configuration (multiple instances = undefined behavior)
- Calling ESP APIs multiple times means the last call wins, silently overwriting previous configurations
- Merging makes the intended behavior explicit and deterministic
- Matches the pattern used by OTA platform component
- Prevents the macro redefinition issue entirely
- Simple and maintainable solution

**Memory Impact:**
- Same memory usage as PR #11525 (array-based storage)
- Still ~72 bytes savings compared to original `std::vector<std::string>` implementation
- No additional overhead from merging (happens at config generation time)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
