### PR TITLE
[core] Optimize DelayAction for no-argument case using if constexpr

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -178,7 +178,6 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
   TEMPLATABLE_VALUE(uint32_t, delay)
 
   void play_complex(const Ts &...x) override {
-    auto f = std::bind(&DelayAction<Ts...>::play_next_, this, x...);
     this->num_running_++;
 
     // If num_running_ > 1, we have multiple instances running in parallel
@@ -187,9 +186,27 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
     // WARNING: This can accumulate delays if scripts are triggered faster than they complete!
     // Users should set max_runs on parallel scripts to limit concurrent executions.
     // Issue #10264: This is a workaround for parallel script delays interfering with each other.
-    App.scheduler.set_timer_common_(this, Scheduler::SchedulerItem::TIMEOUT,
-                                    /* is_static_string= */ true, "delay", this->delay_.value(x...), std::move(f),
-                                    /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
+
+    // Optimization: For no-argument delays (most common case), use direct lambda
+    // instead of std::bind to avoid bind overhead (~16 bytes heap + faster execution)
+    if constexpr (sizeof...(Ts) == 0) {
+      App.scheduler.set_timer_common_(
+          this, Scheduler::SchedulerItem::TIMEOUT,
+          /* is_static_string= */ true, "delay", this->delay_.value(),
+          [this]() {
+            if (this->num_running_ > 0) {
+              this->play_next_();
+            }
+          },
+          /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
+    } else {
+      // For delays with arguments, use std::bind to preserve argument values
+      // Arguments must be copied because original references may be invalid after delay
+      auto f = std::bind(&DelayAction<Ts...>::play_next_, this, x...);
+      App.scheduler.set_timer_common_(this, Scheduler::SchedulerItem::TIMEOUT,
+                                      /* is_static_string= */ true, "delay", this->delay_.value(x...), std::move(f),
+                                      /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
+    }
   }
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -192,12 +192,7 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
     if constexpr (sizeof...(Ts) == 0) {
       App.scheduler.set_timer_common_(
           this, Scheduler::SchedulerItem::TIMEOUT,
-          /* is_static_string= */ true, "delay", this->delay_.value(),
-          [this]() {
-            if (this->num_running_ > 0) {
-              this->play_next_();
-            }
-          },
+          /* is_static_string= */ true, "delay", this->delay_.value(), [this]() { this->play_next_(); },
           /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
     } else {
       // For delays with arguments, use std::bind to preserve argument values


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `DelayAction` for the most common use case (no arguments) by using direct lambda capture instead of `std::bind`, eliminating unnecessary overhead.

## Background

Most delay actions in ESPHome configs have no arguments:
```yaml
on_press:
  - switch.turn_on: relay
  - delay: 1s          # ← No arguments
  - switch.turn_off: relay
```

Previously, `DelayAction` used `std::bind` for all cases, even when there were no arguments to bind. This created unnecessary heap allocation and slower execution.

## Implementation

Uses C++20 `if constexpr (sizeof...(Ts) == 0)` to select optimal implementation at compile time:
- **No-argument path**: Direct lambda capture (optimized)
- **With-arguments path**: `std::bind` to preserve argument values (unchanged for correctness)

## Performance & Memory Impact

**Benchmark results (100k iterations):**
- Before: 891 µs (8.9 ns/iter)
- After: 336 µs (3.4 ns/iter)
- **Speedup: 2.7x faster**

**Real-world config (gatetrigger.yaml):**
- Flash: **-212 bytes** (489947 → 489735)
- RAM: No change (16156 bytes - optimization is compile-time)
- Heap: **~16 bytes saved per no-arg delay**

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (Performance optimization)

**Related issue or feature (if applicable):**

- Part of ongoing action framework optimization effort (see PR #11704, #11551-11556)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - optimization is automatic and transparent

# Example that benefits (no-argument delay):
binary_sensor:
  - platform: gpio
    on_press:
      - switch.turn_on: relay1
      - delay: 20s          # ← Optimized path
      - switch.turn_off: relay1

# Example that uses existing path (with-argument delay):
script:
  - id: test_script
    parameters:
      value: int
    then:
      - logger.log: !lambda 'return "Value: " + to_string(value);'
      - delay: 100ms        # ← std::bind path (preserves 'value')
      - logger.log: !lambda 'return "Done: " + to_string(value);'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - Existing tests already cover this in tests/integration

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
