### PR TITLE
[uart] Setup uart pins only if flags are set

### DIFF
--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -56,11 +56,18 @@ uint32_t ESP8266UartComponent::get_config() {
 }
 
 void ESP8266UartComponent::setup() {
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+  setupPinIfNeeded(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setupPinIfNeeded(this->tx_pin_);
   }
 
   // Use Arduino HardwareSerial UARTs if all used pins match the ones

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -56,19 +56,19 @@ uint32_t ESP8266UartComponent::get_config() {
 }
 
 void ESP8266UartComponent::setup() {
-  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }
-    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
-        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
 
-  setupPinIfNeeded(this->rx_pin_);
+  setup_pin_if_needed(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
-    setupPinIfNeeded(this->tx_pin_);
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   // Use Arduino HardwareSerial UARTs if all used pins match the ones

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -60,11 +60,12 @@ void ESP8266UartComponent::setup() {
     if (!pin) {
       return;
     }
-
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
+        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
+
   setupPinIfNeeded(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
     setupPinIfNeeded(this->tx_pin_);

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -61,7 +61,7 @@ void ESP8266UartComponent::setup() {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & mask) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -61,7 +61,7 @@ void ESP8266UartComponent::setup() {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask) {
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -128,7 +128,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & mask) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -123,19 +123,19 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }
-    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
-        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
 
-  setupPinIfNeeded(this->rx_pin_);
+  setup_pin_if_needed(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
-    setupPinIfNeeded(this->tx_pin_);
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -123,11 +123,18 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+  setupPinIfNeeded(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setupPinIfNeeded(this->tx_pin_);
   }
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -127,11 +127,12 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     if (!pin) {
       return;
     }
-
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
+        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
+
   setupPinIfNeeded(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
     setupPinIfNeeded(this->tx_pin_);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -128,7 +128,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask) {
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -53,7 +53,7 @@ void LibreTinyUARTComponent::setup() {
 
   auto shouldFallbackToSoftwareSerial = [&]() -> bool {
     auto hasFlags = [](InternalGPIOPin *pin, const gpio::Flags mask) -> bool {
-      return pin && pin->get_flags() & mask != gpio::Flags::FLAG_NONE;
+      return pin && (pin->get_flags() & mask) != gpio::Flags::FLAG_NONE;
     };
     if (hasFlags(this->tx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN) ||
         hasFlags(this->rx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -52,11 +52,18 @@ uint16_t RP2040UartComponent::get_config() {
 }
 
 void RP2040UartComponent::setup() {
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+  setupPinIfNeeded(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setupPinIfNeeded(this->tx_pin_);
   }
 
   uint16_t config = get_config();

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -56,11 +56,12 @@ void RP2040UartComponent::setup() {
     if (!pin) {
       return;
     }
-
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
+        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
+
   setupPinIfNeeded(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
     setupPinIfNeeded(this->tx_pin_);

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -57,7 +57,7 @@ void RP2040UartComponent::setup() {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask) {
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -52,7 +52,7 @@ uint16_t RP2040UartComponent::get_config() {
 }
 
 void RP2040UartComponent::setup() {
-  auto setup_component_if_needed = [](InternalGPIOPin *pin) {
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -57,7 +57,7 @@ void RP2040UartComponent::setup() {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
+    if (pin->get_flags() & mask) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -62,9 +62,9 @@ void RP2040UartComponent::setup() {
     }
   };
 
-  setup_component_if_needed(this->rx_pin_);
+  setup_pin_if_needed(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
-    setup_component_if_needed(this->tx_pin_);
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   uint16_t config = get_config();

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -52,19 +52,19 @@ uint16_t RP2040UartComponent::get_config() {
 }
 
 void RP2040UartComponent::setup() {
-  auto setupPinIfNeeded = [](InternalGPIOPin *pin) {
+  auto setup_component_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }
-    if (pin->get_flags() & gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP |
-        gpio::Flags::FLAG_PULLDOWN != gpio::Flags::FLAG_NONE) {
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if (pin->get_flags() & mask != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };
 
-  setupPinIfNeeded(this->rx_pin_);
+  setup_component_if_needed(this->rx_pin_);
   if (this->rx_pin_ != this->tx_pin_) {
-    setupPinIfNeeded(this->tx_pin_);
+    setup_component_if_needed(this->tx_pin_);
   }
 
   uint16_t config = get_config();


### PR DESCRIPTION
# What does this implement/fix?

Don't call pin setup code if there are no pull or open drain flags set

Fixes a regression introduced in PR #9248 where unconditionally calling `pin->setup()` on UART RX/TX pins broke UART communication for some external components.

**Root cause:** PR #9248 added `pin->setup()` calls to enable pullup/pulldown support, but calling `setup()` on pins without any special flags changes their configuration from the hardware default state. Some UART hardware (particularly external components using custom protocols) relies on the default pin state.

**Solution:** Only call `pin->setup()` when the pin has special flags set (`FLAG_PULLUP`, `FLAG_PULLDOWN`, or `FLAG_OPEN_DRAIN`). This preserves the pullup/pulldown functionality from #9248 while maintaining backward compatibility for pins without special configuration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11823

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
