### PR TITLE
[ld2412] Fix stuck targets by adding timeout filter

### DIFF
--- a/esphome/components/ld2412/sensor.py
+++ b/esphome/components/ld2412/sensor.py
@@ -31,36 +31,84 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_LIGHT): sensor.sensor_schema(
             device_class=DEVICE_CLASS_ILLUMINANCE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_LIGHTBULB,
             unit_of_measurement=UNIT_EMPTY,  # No standard unit for this light sensor
         ),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_MOVING_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_MOTION_SENSOR,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_STILL_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_FLASH,
             unit_of_measurement=UNIT_PERCENT,
         ),
@@ -74,7 +122,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_MOVE_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_MOTION_SENSOR,
                     unit_of_measurement=UNIT_PERCENT,
@@ -82,7 +136,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_FLASH,
                     unit_of_measurement=UNIT_PERCENT,


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the missing timeout filter to all ld2412 sensors to match the ld2450 implementation and prevent "stuck targets" issue.

The ld2412 component was missing the timeout filter that was added to ld2450 in PR #10196. This could result in sensor values remaining stuck on stale readings when targets are no longer detected. This fix brings ld2412 into parity with ld2450 by adding the timeout filter (with `value: "last"` and 1000ms timeout) to all sensors alongside the existing `throttle_with_priority` filter.

**Changed sensors:**
- All primary sensors: `detection_distance`, `light`, `moving_distance`, `moving_energy`, `still_distance`, `still_energy`
- All 14 gate sensors (gate_0 through gate_13) for both `move_energy` and `still_energy`

The timeout filter ensures that when no new data is received for 1000ms, sensors retain their last value rather than potentially getting stuck on stale readings, preventing the "stuck targets" issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11912

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This change uses existing filter functionality, no documentation update needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - filters are applied automatically
# Existing configurations will work without modification

sensor:
  - platform: ld2412
    moving_distance:
      name: "Moving Distance"
      # Now automatically includes both timeout and throttle_with_priority filters
    still_distance:
      name: "Still Distance"
      # Now automatically includes both timeout and throttle_with_priority filters
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
