### PR TITLE
[ld2410] Add timeout filter to prevent stuck targets

### DIFF
--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -31,35 +31,83 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_STILL_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_MOVING_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_MOTION_SENSOR,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_FLASH,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_LIGHT): sensor.sensor_schema(
             device_class=DEVICE_CLASS_ILLUMINANCE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_LIGHTBULB,
         ),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
@@ -73,7 +121,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_MOVE_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_MOTION_SENSOR,
                     unit_of_measurement=UNIT_PERCENT,
@@ -81,7 +135,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_FLASH,
                     unit_of_measurement=UNIT_PERCENT,


### PR DESCRIPTION
# What does this implement/fix?

This PR adds the missing timeout filter to all ld2410 sensors to match the ld2450 implementation and prevent "stuck targets" issue.

The ld2410 component was missing the timeout filter that was added to ld2450 in PR #10196. This could result in sensor values remaining stuck on stale readings when targets are no longer detected. This fix brings ld2410 into parity with ld2450 by adding the timeout filter (with `value: "last"` and 1000ms timeout) to all sensors alongside the existing `throttle_with_priority` filter.

**Changed sensors:**
- All primary sensors: `light`, `moving_distance`, `still_distance`, `moving_energy`, `still_energy`, `detection_distance`
- All 9 gate sensors (g0 through g8) for both `move_energy` and `still_energy`

The timeout filter ensures that when no new data is received for 1000ms, sensors retain their last value rather than potentially getting stuck on stale readings, preventing the "stuck targets" issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/11912 (ld2412 issue, but ld2410 has the same problem)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This change uses existing filter functionality, no documentation update needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - filters are applied automatically
# Existing configurations will work without modification

sensor:
  - platform: ld2410
    moving_distance:
      name: "Moving Distance"
      # Now automatically includes both timeout and throttle_with_priority filters
    still_distance:
      name: "Still Distance"
      # Now automatically includes both timeout and throttle_with_priority filters
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
