### PR TITLE
[core] Replace seq<>/gens<> with std::index_sequence for code clarity

### DIFF
--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -51,13 +51,14 @@ template<typename... Ts> class UserServiceBase : public UserServiceDescriptor {
       return false;
     if (req.args.size() != sizeof...(Ts))
       return false;
-    this->execute_(req.args, typename gens<sizeof...(Ts)>::type());
+    this->execute_(req.args, std::make_index_sequence<sizeof...(Ts)>{});
     return true;
   }
 
  protected:
   virtual void execute(Ts... x) = 0;
-  template<typename ArgsContainer, int... S> void execute_(const ArgsContainer &args, seq<S...> type) {
+  template<typename ArgsContainer, size_t... S>
+  void execute_(const ArgsContainer &args, std::index_sequence<S...> type) {
     this->execute((get_execute_arg_value<Ts>(args[S]))...);
   }
 
@@ -95,13 +96,14 @@ template<typename... Ts> class UserServiceDynamic : public UserServiceDescriptor
       return false;
     if (req.args.size() != sizeof...(Ts))
       return false;
-    this->execute_(req.args, typename gens<sizeof...(Ts)>::type());
+    this->execute_(req.args, std::make_index_sequence<sizeof...(Ts)>{});
     return true;
   }
 
  protected:
   virtual void execute(Ts... x) = 0;
-  template<typename ArgsContainer, int... S> void execute_(const ArgsContainer &args, seq<S...> type) {
+  template<typename ArgsContainer, size_t... S>
+  void execute_(const ArgsContainer &args, std::index_sequence<S...> type) {
     this->execute((get_execute_arg_value<Ts>(args[S]))...);
   }
 

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -46,14 +46,14 @@ template<typename... Ts> class Script : public ScriptLogger, public Trigger<Ts..
 
   // execute this script using a tuple that contains the arguments
   void execute_tuple(const std::tuple<Ts...> &tuple) {
-    this->execute_tuple_(tuple, typename gens<sizeof...(Ts)>::type());
+    this->execute_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
   }
 
   // Internal function to give scripts readable names.
   void set_name(const LogString *name) { name_ = name; }
 
  protected:
-  template<int... S> void execute_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> void execute_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     this->execute(std::get<S>(tuple)...);
   }
 
@@ -157,7 +157,7 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
       const size_t queue_capacity = static_cast<size_t>(this->max_runs_ - 1);
       auto tuple_ptr = std::move(this->var_queue_[this->queue_front_]);
       this->queue_front_ = (this->queue_front_ + 1) % queue_capacity;
-      this->trigger_tuple_(*tuple_ptr, typename gens<sizeof...(Ts)>::type());
+      this->trigger_tuple_(*tuple_ptr, std::make_index_sequence<sizeof...(Ts)>{});
     }
   }
 
@@ -174,7 +174,7 @@ template<typename... Ts> class QueueingScript : public Script<Ts...>, public Com
     }
   }
 
-  template<int... S> void trigger_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> void trigger_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     this->trigger(std::get<S>(tuple)...);
   }
 
@@ -305,7 +305,7 @@ template<class C, typename... Ts> class ScriptWaitAction : public Action<Ts...>,
 
     while (!this->param_queue_.empty()) {
       auto &params = this->param_queue_.front();
-      this->play_next_tuple_(params, typename gens<sizeof...(Ts)>::type());
+      this->play_next_tuple_(params, std::make_index_sequence<sizeof...(Ts)>{});
       this->param_queue_.pop_front();
     }
     // Queue is now empty - disable loop until next play_complex
@@ -321,7 +321,7 @@ template<class C, typename... Ts> class ScriptWaitAction : public Action<Ts...>,
   }
 
  protected:
-  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     this->play_next_(std::get<S>(tuple)...);
   }
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -13,6 +13,7 @@ namespace esphome {
 
 // C++20 std::index_sequence is now used for tuple unpacking
 // Legacy seq<>/gens<> pattern deprecated but kept for backwards compatibility
+// https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer/7858971#7858971
 // Remove before 2026.6.0
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -15,23 +15,22 @@ namespace esphome {
 // Legacy seq<>/gens<> pattern deprecated but kept for backwards compatibility
 // https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer/7858971#7858971
 // Remove before 2026.6.0
+// NOLINTBEGIN(readability-identifier-naming)
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 template<int...> struct ESPDEPRECATED("Use std::index_sequence instead. Removed in 2026.6.0", "2025.12.0") seq {};
-// NOLINTNEXTLINE(readability-identifier-naming)
 template<int N, int... S>
 struct ESPDEPRECATED("Use std::make_index_sequence instead. Removed in 2026.6.0", "2025.12.0") gens
     : gens<N - 1, N - 1, S...> {};
-// NOLINTNEXTLINE(readability-identifier-naming)
 template<int... S> struct gens<0, S...> { using type = seq<S...>; };
 
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
+// NOLINTEND(readability-identifier-naming)
 
 #define TEMPLATABLE_VALUE_(type, name) \
  protected: \

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -19,10 +19,13 @@ namespace esphome {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 template<int...> struct ESPDEPRECATED("Use std::index_sequence instead. Removed in 2026.6.0", "2025.12.0") seq {};
+// NOLINTNEXTLINE(readability-identifier-naming)
 template<int N, int... S>
 struct ESPDEPRECATED("Use std::make_index_sequence instead. Removed in 2026.6.0", "2025.12.0") gens
     : gens<N - 1, N - 1, S...> {};
+// NOLINTNEXTLINE(readability-identifier-naming)
 template<int... S> struct gens<0, S...> { using type = seq<S...>; };
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -11,10 +11,23 @@
 
 namespace esphome {
 
-// https://stackoverflow.com/questions/7858817/unpacking-a-tuple-to-call-a-matching-function-pointer/7858971#7858971
-template<int...> struct seq {};                                       // NOLINT
-template<int N, int... S> struct gens : gens<N - 1, N - 1, S...> {};  // NOLINT
-template<int... S> struct gens<0, S...> { using type = seq<S...>; };  // NOLINT
+// C++20 std::index_sequence is now used for tuple unpacking
+// Legacy seq<>/gens<> pattern deprecated but kept for backwards compatibility
+// Remove before 2026.6.0
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+template<int...> struct ESPDEPRECATED("Use std::index_sequence instead. Removed in 2026.6.0", "2025.12.0") seq {};
+template<int N, int... S>
+struct ESPDEPRECATED("Use std::make_index_sequence instead. Removed in 2026.6.0", "2025.12.0") gens
+    : gens<N - 1, N - 1, S...> {};
+template<int... S> struct gens<0, S...> { using type = seq<S...>; };
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 #define TEMPLATABLE_VALUE_(type, name) \
  protected: \
@@ -152,11 +165,11 @@ template<typename... Ts> class Condition {
 
   /// Call check with a tuple of values as parameter.
   bool check_tuple(const std::tuple<Ts...> &tuple) {
-    return this->check_tuple_(tuple, typename gens<sizeof...(Ts)>::type());
+    return this->check_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
   }
 
  protected:
-  template<int... S> bool check_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> bool check_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     return this->check(std::get<S>(tuple)...);
   }
 };
@@ -231,11 +244,11 @@ template<typename... Ts> class Action {
       }
     }
   }
-  template<int... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     this->play_next_(std::get<S>(tuple)...);
   }
   void play_next_tuple_(const std::tuple<Ts...> &tuple) {
-    this->play_next_tuple_(tuple, typename gens<sizeof...(Ts)>::type());
+    this->play_next_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
   }
 
   virtual void stop() {}
@@ -277,7 +290,9 @@ template<typename... Ts> class ActionList {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->play_complex(x...);
   }
-  void play_tuple(const std::tuple<Ts...> &tuple) { this->play_tuple_(tuple, typename gens<sizeof...(Ts)>::type()); }
+  void play_tuple(const std::tuple<Ts...> &tuple) {
+    this->play_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
+  }
   void stop() {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->stop_complex();
@@ -298,7 +313,7 @@ template<typename... Ts> class ActionList {
   }
 
  protected:
-  template<int... S> void play_tuple_(const std::tuple<Ts...> &tuple, seq<S...> /*unused*/) {
+  template<size_t... S> void play_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
     this->play(std::get<S>(tuple)...);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Replaces the legacy custom `seq<>`/`gens<>` tuple unpacking pattern with C++20's built-in `std::index_sequence`, improving code clarity and maintainability.

## Background

ESPHome has been using a custom implementation for tuple unpacking based on a pre-C++17 Stack Overflow pattern:
```cpp
template<int...> struct seq {};
template<int N, int... S> struct gens : gens<N - 1, N - 1, S...> {};
template<int... S> struct gens<0, S...> { using type = seq<S...>; };
```

Since ESPHome now requires C++20, we can use the standard library's `std::index_sequence` and `std::make_index_sequence` instead, which provides identical functionality with better clarity.

## Implementation

**Pattern migration:**
```cpp
// OLD (deprecated but still works)
typename gens<sizeof...(Ts)>::type()
template<int... S> void func(seq<S...> /*unused*/)

// NEW (recommended)
std::make_index_sequence<sizeof...(Ts)>{}
template<size_t... S> void func(std::index_sequence<S...> /*unused*/)
```

**Files updated:**
- `esphome/core/automation.h` - Core automation framework (4 locations)
- `esphome/components/script/script.h` - Script component (3 locations)
- `esphome/components/api/user_services.h` - API services (2 locations)

**Backwards compatibility:**
Legacy `seq<>`/`gens<>` types remain available with `ESPDEPRECATED` markers:
- Deprecated in: 2025.12.0
- Remove before: 2026.6.0

External components using these types will continue to work with a deprecation warning.

## Performance & Memory Impact

**Zero performance impact:**
- Both patterns generate identical code at compile time
- Verified through compilation testing on ESP8266 and ESP32
- Template metaprogramming expansion is equivalent

**Code size:**
- Net reduction: 4 lines of custom metaprogramming code
- Deprecated types add ~10 lines (removed in 6 months)

## Benefits

1. **Code Clarity** - Uses standard library types that all C++ developers know
2. **Better IDE Support** - Standard library types have better autocomplete and documentation
3. **Modern C++** - Embraces C++20 features (already required by ESPHome)
4. **Less Maintenance** - Removes custom metaprogramming in favor of standard library
5. **Backwards Compatible** - Gradual migration path with 6-month deprecation window

## Why Not Use C++20 Lambda Templates?

C++20 allows lambdas with template parameters, which could theoretically eliminate the helper functions:

```cpp
// NOT recommended for ESPHome (increases code size)
void play_tuple(const std::tuple<Ts...> &tuple) {
  [&]<size_t... S>(std::index_sequence<S...>) {
    this->play(std::get<S>(tuple)...);
  }(std::make_index_sequence<sizeof...(Ts)>{});
}
```

**This PR intentionally uses the traditional helper function pattern because:**
- **Code size** - Lambdas increase flash usage on embedded systems (additional lambda infrastructure)
- **Debuggability** - Helper functions provide clearer stack traces and easier breakpoints
- **Protected helpers** - Part of the class API, potentially useful for derived classes
- **Team familiarity** - Traditional pattern is more widely understood

For embedded systems like ESP8266/ESP32, minimizing flash usage is more important than saving a few lines of code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other (Code modernization)

**Breaking change details:**
- Legacy `seq<>`/`gens<>` types are deprecated and will be removed in 2026.6.0
- External components using these types must migrate to `std::index_sequence` before removal
- 6-month deprecation window provides time for gradual migration

**Related issue or feature (if applicable):**

- Part of ongoing C++20 modernization effort (see PR #11913)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation detail, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - optimization is automatic and transparent

# All existing automations continue to work:
binary_sensor:
  - platform: gpio
    pin: GPIO5
    name: "Test Button"
    on_press:
      - delay: 1s
      - logger.log: "Done"

# Scripts with parameters work identically:
script:
  - id: test_script
    parameters:
      value: int
      name: string
    then:
      - logger.log:
          format: "Script: %d, %s"
          args: ['value', 'name']
      - delay: 100ms

# API services with variables work identically:
api:
  services:
    - service: test_service
      variables:
        value: int
        name: string
      then:
        - logger.log:
            format: "Service: %d, %s"
            args: ['value', 'name']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing integration tests cover all updated code paths (delays, scripts, API services)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - Internal implementation detail, no user-facing changes

## Migration Notes for External Component Developers

If you have external components using `seq<>`/`gens<>`, they will continue to work with a deprecation warning until 2026.6.0.

To migrate:
```cpp
// Before
template<int... S> void my_func(seq<S...>);
auto result = my_func(typename gens<N>::type());

// After
template<size_t... S> void my_func(std::index_sequence<S...>);
auto result = my_func(std::make_index_sequence<N>{});
```

Key changes:
1. `seq<S...>` → `std::index_sequence<S...>`
2. `typename gens<N>::type()` → `std::make_index_sequence<N>{}`
3. `int... S` → `size_t... S` (template parameters)
