### PR TITLE
[scheduler] Fix timing breakage after 49 days of uptime on ESP8266/RP2040

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -609,13 +609,12 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   if (now < last && (last - now) > HALF_MAX_UINT32) {
     this->millis_major_++;
     major++;
+    this->last_millis_ = now;
 #ifdef ESPHOME_DEBUG_SCHEDULER
     ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
-  }
-
-  // Only update if time moved forward
-  if (now > last) {
+  } else if (now > last) {
+    // Only update if time moved forward
     this->last_millis_ = now;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a critical bug in the scheduler's `millis_64_()` function for single-threaded platforms (ESP8266, RP2040) that caused all timing-based functionality to break after ~49 days of continuous runtime.

**Background:**
This bug was introduced in PR #9716 (commit `fde80bc53`, July 19, 2025) when refactoring `millis_64_()` to use platform-specific implementations. During the split, the `ESPHOME_THREAD_SINGLE` implementation inadvertently omitted the `this->last_millis_ = now;` update in the rollover detection path, despite it being present in both the `ESPHOME_THREAD_MULTI_NO_ATOMICS` and `ESPHOME_THREAD_MULTI_ATOMICS` implementations. I should have caught this during review.

**The Problem:**
When `millis()` rolls over from `4,294,967,295` back to `0` after ~49.7 days, the `ESPHOME_THREAD_SINGLE` implementation of `millis_64_()` failed to update `last_millis_` after detecting the rollover. This caused:

1. `last_millis_` to remain stuck at its pre-rollover value (~4.29 billion)
2. Every subsequent call to `millis_64_()` to increment `millis_major_` again (because the rollover condition kept being true)
3. `millis_major_` to increase wildly: 1, 2, 3, 4... on every call
4. Scheduler timeouts to fire immediately or fail completely
5. Components like `on_multi_click`, `set_timeout`, `set_interval` to become unusable

**The Fix:**
Added the missing `this->last_millis_ = now;` update in the rollover detection path, matching how the multi-threaded implementations (`ESPHOME_THREAD_MULTI_NO_ATOMICS` and `ESPHOME_THREAD_MULTI_ATOMICS`) already handle rollover correctly.

**Before:**
```cpp
if (now < last && (last - now) > HALF_MAX_UINT32) {
  this->millis_major_++;
  major++;
  // BUG: last_millis_ never updated after rollover!
}
if (now > last) {
  this->last_millis_ = now;  // This condition is always false after rollover
}
```

**After:**
```cpp
if (now < last && (last - now) > HALF_MAX_UINT32) {
  this->millis_major_++;
  major++;
  this->last_millis_ = now;  // FIX: Update last_millis_ after rollover
} else if (now > last) {
  this->last_millis_ = now;
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11908

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - This is a bugfix with no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note:** Only platforms using `ESPHOME_THREAD_SINGLE` are affected (ESP8266, RP2040). ESP32 uses `ESPHOME_THREAD_MULTI_ATOMICS` and LibreTiny uses `ESPHOME_THREAD_MULTI_NO_ATOMICS` - both already had the correct implementation with `last_millis_` being updated in the rollover path.

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is a core scheduler bugfix
# that affects all timing-based functionality:

binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_multi_click:  # This was broken after 49 days, now fixed
      - timing:
          - ON for 50ms to 500ms
        then:
          - logger.log: "Single click"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
