### PR TITLE
[font] Store data in flash only

### DIFF
--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -50,7 +50,6 @@ font_ns = cg.esphome_ns.namespace("font")
 
 Font = font_ns.class_("Font")
 Glyph = font_ns.class_("Glyph")
-GlyphData = font_ns.struct("GlyphData")
 
 CONF_BPP = "bpp"
 CONF_EXTRAS = "extras"
@@ -463,7 +462,7 @@ FONT_SCHEMA = cv.Schema(
             )
         ),
         cv.GenerateID(CONF_RAW_DATA_ID): cv.declare_id(cg.uint8),
-        cv.GenerateID(CONF_RAW_GLYPH_ID): cv.declare_id(GlyphData),
+        cv.GenerateID(CONF_RAW_GLYPH_ID): cv.declare_id(Glyph),
     },
 )
 
@@ -583,22 +582,15 @@ async def to_code(config):
 
     # Create the glyph table that points to data in the above array.
     glyph_initializer = [
-        cg.StructInitializer(
-            GlyphData,
-            (
-                "a_char",
-                cg.RawExpression(f"(const uint8_t *){cpp_string_escape(x.glyph)}"),
-            ),
-            (
-                "data",
-                cg.RawExpression(f"{str(prog_arr)} + {str(y - len(x.bitmap_data))}"),
-            ),
-            ("advance", x.advance),
-            ("offset_x", x.offset_x),
-            ("offset_y", x.offset_y),
-            ("width", x.width),
-            ("height", x.height),
-        )
+        [
+            cg.RawExpression(f"{cpp_string_escape(x.glyph)}"),
+            cg.RawExpression(f"{str(prog_arr)} + {str(y - len(x.bitmap_data))}"),
+            x.advance,
+            x.offset_x,
+            x.offset_y,
+            x.width,
+            x.height,
+        ]
         for (x, y) in zip(
             glyph_args, list(accumulate([len(x.bitmap_data) for x in glyph_args]))
         )

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -36,7 +36,6 @@ from esphome.const import (
     CONF_WEIGHT,
 )
 from esphome.core import CORE, HexInt
-from esphome.helpers import cpp_string_escape
 from esphome.types import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
@@ -583,8 +582,8 @@ async def to_code(config):
     # Create the glyph table that points to data in the above array.
     glyph_initializer = [
         [
-            cg.RawExpression(f"{cpp_string_escape(x.glyph)}"),
-            cg.RawExpression(f"{str(prog_arr)} + {str(y - len(x.bitmap_data))}"),
+            x.glyph,
+            prog_arr + (y - len(x.bitmap_data)),
             x.advance,
             x.offset_x,
             x.offset_y,

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -9,20 +9,20 @@ namespace font {
 
 static const char *const TAG = "font";
 
-const uint8_t *Glyph::get_char() const { return this->glyph_data_->a_char; }
+const uint8_t *Glyph::get_char() const { return (const uint8_t *) this->a_char; }
 // Compare the char at the string position with this char.
 // Return true if this char is less than or equal the other.
 bool Glyph::compare_to(const uint8_t *str) const {
   // 1 -> this->char_
   // 2 -> str
   for (uint32_t i = 0;; i++) {
-    if (this->glyph_data_->a_char[i] == '\0')
+    if (this->a_char[i] == '\0')
       return true;
     if (str[i] == '\0')
       return false;
-    if (this->glyph_data_->a_char[i] > str[i])
+    if (this->a_char[i] > str[i])
       return false;
-    if (this->glyph_data_->a_char[i] < str[i])
+    if (this->a_char[i] < str[i])
       return true;
   }
   // this should not happen
@@ -30,34 +30,31 @@ bool Glyph::compare_to(const uint8_t *str) const {
 }
 int Glyph::match_length(const uint8_t *str) const {
   for (uint32_t i = 0;; i++) {
-    if (this->glyph_data_->a_char[i] == '\0')
+    if (this->a_char[i] == '\0')
       return i;
-    if (str[i] != this->glyph_data_->a_char[i])
+    if (str[i] != this->a_char[i])
       return 0;
   }
   // this should not happen
   return 0;
 }
 void Glyph::scan_area(int *x1, int *y1, int *width, int *height) const {
-  *x1 = this->glyph_data_->offset_x;
-  *y1 = this->glyph_data_->offset_y;
-  *width = this->glyph_data_->width;
-  *height = this->glyph_data_->height;
+  *x1 = this->offset_x;
+  *y1 = this->offset_y;
+  *width = this->width;
+  *height = this->height;
 }
 
-Font::Font(const GlyphData *data, int data_nr, int baseline, int height, int descender, int xheight, int capheight,
+Font::Font(const Glyph *data, int data_nr, int baseline, int height, int descender, int xheight, int capheight,
            uint8_t bpp)
-    : baseline_(baseline),
+    : glyphs_(ConstVector(data, data_nr)),
+      baseline_(baseline),
       height_(height),
       descender_(descender),
       linegap_(height - baseline - descender),
       xheight_(xheight),
       capheight_(capheight),
-      bpp_(bpp) {
-  glyphs_.reserve(data_nr);
-  for (int i = 0; i < data_nr; ++i)
-    glyphs_.emplace_back(&data[i]);
-}
+      bpp_(bpp) {}
 int Font::match_next_glyph(const uint8_t *str, int *match_length) {
   int lo = 0;
   int hi = this->glyphs_.size() - 1;
@@ -88,18 +85,18 @@ void Font::measure(const char *str, int *width, int *x_offset, int *baseline, in
     if (glyph_n < 0) {
       // Unknown char, skip
       if (!this->get_glyphs().empty())
-        x += this->get_glyphs()[0].glyph_data_->advance;
+        x += this->get_glyphs()[0].advance;
       i++;
       continue;
     }
 
     const Glyph &glyph = this->glyphs_[glyph_n];
     if (!has_char) {
-      min_x = glyph.glyph_data_->offset_x;
+      min_x = glyph.offset_x;
     } else {
-      min_x = std::min(min_x, x + glyph.glyph_data_->offset_x);
+      min_x = std::min(min_x, x + glyph.offset_x);
     }
-    x += glyph.glyph_data_->advance;
+    x += glyph.advance;
 
     i += match_length;
     has_char = true;
@@ -118,7 +115,7 @@ void Font::print(int x_start, int y_start, display::Display *display, Color colo
       // Unknown char, skip
       ESP_LOGW(TAG, "Encountered character without representation in font: '%c'", text[i]);
       if (!this->get_glyphs().empty()) {
-        uint8_t glyph_width = this->get_glyphs()[0].glyph_data_->advance;
+        uint8_t glyph_width = this->get_glyphs()[0].advance;
         display->filled_rectangle(x_at, y_start, glyph_width, this->height_, color);
         x_at += glyph_width;
       }
@@ -130,7 +127,7 @@ void Font::print(int x_start, int y_start, display::Display *display, Color colo
     const Glyph &glyph = this->get_glyphs()[glyph_n];
     glyph.scan_area(&scan_x1, &scan_y1, &scan_width, &scan_height);
 
-    const uint8_t *data = glyph.glyph_data_->data;
+    const uint8_t *data = glyph.data;
     const int max_x = x_at + scan_x1 + scan_width;
     const int max_y = y_start + scan_y1 + scan_height;
 
@@ -168,7 +165,7 @@ void Font::print(int x_start, int y_start, display::Display *display, Color colo
         }
       }
     }
-    x_at += glyph.glyph_data_->advance;
+    x_at += glyph.advance;
 
     i += match_length;
   }

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -54,7 +54,7 @@ Font::Font(const Glyph *data, int data_nr, int baseline, int height, int descend
       xheight_(xheight),
       capheight_(capheight),
       bpp_(bpp) {}
-int Font::match_next_glyph(const uint8_t *str, int *match_length) {
+int Font::match_next_glyph(const uint8_t *str, int *match_length) const {
   int lo = 0;
   int hi = this->glyphs_.size() - 1;
   while (lo != hi) {

--- a/esphome/components/font/font.cpp
+++ b/esphome/components/font/font.cpp
@@ -9,7 +9,6 @@ namespace font {
 
 static const char *const TAG = "font";
 
-const uint8_t *Glyph::get_char() const { return (const uint8_t *) this->a_char; }
 // Compare the char at the string position with this char.
 // Return true if this char is less than or equal the other.
 bool Glyph::compare_to(const uint8_t *str) const {

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -12,8 +12,6 @@ namespace font {
 
 class Font;
 
-struct GlyphData {};
-
 class Glyph {
  public:
   constexpr Glyph(const char *a_char, const uint8_t *data, int advance, int offset_x, int offset_y, int width,

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -63,7 +63,7 @@ class Font
   Font(const Glyph *data, int data_nr, int baseline, int height, int descender, int xheight, int capheight,
        uint8_t bpp = 1);
 
-  int match_next_glyph(const uint8_t *str, int *match_length);
+  int match_next_glyph(const uint8_t *str, int *match_length) const;
 
 #ifdef USE_DISPLAY
   void print(int x_start, int y_start, display::Display *display, Color color, const char *text,

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -26,7 +26,7 @@ class Glyph {
         width(width),
         height(height) {}
 
-  const uint8_t *get_char() const;
+  const uint8_t *get_char() const { return reinterpret_cast<const uint8_t *>(this->a_char); }
 
   bool compare_to(const uint8_t *str) const;
 

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -12,19 +12,19 @@ namespace font {
 
 class Font;
 
-struct GlyphData {
-  const uint8_t *a_char;
-  const uint8_t *data;
-  int advance;
-  int offset_x;
-  int offset_y;
-  int width;
-  int height;
-};
+struct GlyphData {};
 
 class Glyph {
  public:
-  Glyph(const GlyphData *data) : glyph_data_(data) {}
+  constexpr Glyph(const char *a_char, const uint8_t *data, int advance, int offset_x, int offset_y, int width,
+                  int height)
+      : a_char(a_char),
+        data(data),
+        advance(advance),
+        offset_x(offset_x),
+        offset_y(offset_y),
+        width(width),
+        height(height) {}
 
   const uint8_t *get_char() const;
 
@@ -34,12 +34,16 @@ class Glyph {
 
   void scan_area(int *x1, int *y1, int *width, int *height) const;
 
-  const GlyphData *get_glyph_data() const { return this->glyph_data_; }
+  const char *a_char;
+  const uint8_t *data;
+  int advance;
+  int offset_x;
+  int offset_y;
+  int width;
+  int height;
 
  protected:
   friend Font;
-
-  const GlyphData *glyph_data_;
 };
 
 class Font
@@ -50,8 +54,7 @@ class Font
  public:
   /** Construct the font with the given glyphs.
    *
-   * @param data A vector of glyphs, must be sorted lexicographically.
-   * @param data_nr The number of glyphs in data.
+   * @param data A list of glyphs, must be sorted lexicographically.
    * @param baseline The y-offset from the top of the text to the baseline.
    * @param height The y-offset from the top of the text to the bottom.
    * @param descender The y-offset from the baseline to the lowest stroke in the font (e.g. from letters like g or p).
@@ -59,7 +62,7 @@ class Font
    * @param capheight The height of capital letters, usually measured at the "X" glyph.
    * @param bpp The bits per pixel used for this font. Used to read data out of the glyph bitmaps.
    */
-  Font(const GlyphData *data, int data_nr, int baseline, int height, int descender, int xheight, int capheight,
+  Font(const Glyph *data, int data_nr, int baseline, int height, int descender, int xheight, int capheight,
        uint8_t bpp = 1);
 
   int match_next_glyph(const uint8_t *str, int *match_length);
@@ -78,10 +81,10 @@ class Font
   inline int get_capheight() { return this->capheight_; }
   inline int get_bpp() { return this->bpp_; }
 
-  const std::vector<Glyph, RAMAllocator<Glyph>> &get_glyphs() const { return glyphs_; }
+  const ConstVector<Glyph> &get_glyphs() const { return glyphs_; }
 
  protected:
-  std::vector<Glyph, RAMAllocator<Glyph>> glyphs_;
+  ConstVector<Glyph> glyphs_;
   int baseline_;
   int height_;
   int descender_;

--- a/esphome/components/font/font.h
+++ b/esphome/components/font/font.h
@@ -53,6 +53,7 @@ class Font
   /** Construct the font with the given glyphs.
    *
    * @param data A list of glyphs, must be sorted lexicographically.
+   * @param data_nr The number of glyphs
    * @param baseline The y-offset from the top of the text to the baseline.
    * @param height The y-offset from the top of the text to the bottom.
    * @param descender The y-offset from the baseline to the lowest stroke in the font (e.g. from letters like g or p).

--- a/esphome/components/lvgl/font.cpp
+++ b/esphome/components/lvgl/font.cpp
@@ -43,7 +43,7 @@ FontEngine::FontEngine(font::Font *esp_font) : font_(esp_font) {
 
 const lv_font_t *FontEngine::get_lv_font() { return &this->lv_font_; }
 
-const font::GlyphData *FontEngine::get_glyph_data(uint32_t unicode_letter) {
+const font::Glyph *FontEngine::get_glyph_data(uint32_t unicode_letter) {
   if (unicode_letter == last_letter_)
     return this->last_data_;
   uint8_t unicode[5];
@@ -67,7 +67,7 @@ const font::GlyphData *FontEngine::get_glyph_data(uint32_t unicode_letter) {
   int glyph_n = this->font_->match_next_glyph(unicode, &match_length);
   if (glyph_n < 0)
     return nullptr;
-  this->last_data_ = this->font_->get_glyphs()[glyph_n].get_glyph_data();
+  this->last_data_ = &this->font_->get_glyphs()[glyph_n];
   this->last_letter_ = unicode_letter;
   return this->last_data_;
 }

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -140,7 +140,7 @@ class FontEngine {
   FontEngine(font::Font *esp_font);
   const lv_font_t *get_lv_font();
 
-  const font::GlyphData *get_glyph_data(uint32_t unicode_letter);
+  const font::Glyph *get_glyph_data(uint32_t unicode_letter);
   uint16_t baseline{};
   uint16_t height{};
   uint8_t bpp{};
@@ -148,7 +148,7 @@ class FontEngine {
  protected:
   font::Font *font_{};
   uint32_t last_letter_{};
-  const font::GlyphData *last_data_{};
+  const font::Glyph *last_data_{};
   lv_font_t lv_font_{};
 };
 #endif  // USE_LVGL_FONT

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -111,15 +111,17 @@ template<> constexpr int64_t byteswap(int64_t n) { return __builtin_bswap64(n); 
 /// @name Container utilities
 ///@{
 
-/// Lightweight wrapper over a const initializer list
+/// Lightweight read-only view over a const array stored in RODATA (will typically be in flash memory)
+/// Avoids copying data from flash to RAM by keeping a pointer to the flash data.
+/// Similar to std::span but with minimal overhead for embedded systems.
 
 template<typename T> class ConstVector {
  public:
-  ConstVector(const T *data, size_t size) : data_(data), size_(size) {}
+  constexpr ConstVector(const T *data, size_t size) : data_(data), size_(size) {}
 
-  operator const T *() const { return data_; }
-  size_t size() const { return size_; }
-  bool empty() const { return size_ == 0; }
+  const constexpr T &operator[](size_t i) const { return data_[i]; }
+  constexpr size_t size() const { return size_; }
+  constexpr bool empty() const { return size_ == 0; }
 
  protected:
   const T *data_;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -111,6 +111,21 @@ template<> constexpr int64_t byteswap(int64_t n) { return __builtin_bswap64(n); 
 /// @name Container utilities
 ///@{
 
+/// Lightweight wrapper over a const initializer list
+
+template<typename T> class ConstVector {
+ public:
+  ConstVector(const T *data, size_t size) : data_(data), size_(size) {}
+
+  operator const T *() const { return data_; }
+  size_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
+
+ protected:
+  const T *data_;
+  size_t size_;
+};
+
 /// Minimal static vector - saves memory by avoiding std::vector overhead
 template<typename T, size_t N> class StaticVector {
  public:

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -430,7 +430,7 @@ class StaticConstAssignmentExpression(AssignmentExpression):
         super().__init__(type_, "", name, rhs)
 
     def __str__(self):
-        return f"static constexpr {self.type} {self.name}[] = {self.rhs}"
+        return f"static const {self.type} {self.name}[] = {self.rhs}"
 
 
 def progmem_array(id_, rhs) -> "MockObj":

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -430,7 +430,7 @@ class StaticConstAssignmentExpression(AssignmentExpression):
         super().__init__(type_, "", name, rhs)
 
     def __str__(self):
-        return f"static const {self.type} {self.name}[] = {self.rhs}"
+        return f"static constexpr {self.type} {self.name}[] = {self.rhs}"
 
 
 def progmem_array(id_, rhs) -> "MockObj":


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Introduce a new helper class `ConstVector` which consists of a pointer to an array of items and a count, with overloads for indexing and size. Can be used to replace `std::vector` in places.
* Use this in the `font` component to eliminate copying of glyph data structures into RAM.
* 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
