### PR TITLE
[logger] Reduce UART overhead on ESP32/ESP8266 and fix buffer truncation

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -365,8 +365,10 @@ async def to_code(config):
     if CORE.is_esp32:
         if config[CONF_HARDWARE_UART] == USB_CDC:
             add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_USB_CDC", True)
+            cg.add_define("USE_LOGGER_UART_SELECTION_USB_CDC")
         elif config[CONF_HARDWARE_UART] == USB_SERIAL_JTAG:
             add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG", True)
+            cg.add_define("USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG")
     try:
         uart_selection(USB_SERIAL_JTAG)
         cg.add_define("USE_LOGGER_USB_SERIAL_JTAG")

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -137,16 +137,14 @@ void Logger::log_vprintf_(uint8_t level, const char *tag, int line, const __Flas
   this->format_log_to_buffer_with_terminator_(level, tag, line, this->tx_buffer_, args, this->tx_buffer_,
                                               &this->tx_buffer_at_, this->tx_buffer_size_);
 
-  size_t msg_length =
+  uint16_t msg_length =
       this->tx_buffer_at_ - msg_start;  // Don't subtract 1 - tx_buffer_at_ is already at the null terminator position
 
   // Callbacks get message first (before console write)
   this->log_callback_.call(level, tag, this->tx_buffer_ + msg_start, msg_length);
 
   // Write to console starting at the msg_start
-  if (this->baud_rate_ > 0) {
-    this->write_msg_(this->tx_buffer_ + msg_start, msg_length);
-  }
+  this->write_tx_buffer_to_console_(msg_start, &msg_length);
 
   global_recursion_guard_ = false;
 }

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -65,7 +65,7 @@ void HOT Logger::log_vprintf_(uint8_t level, const char *tag, int line, const ch
     uint16_t buffer_at = 0;                         // Initialize buffer position
     this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, console_buffer, &buffer_at,
                                                 MAX_CONSOLE_LOG_MSG_SIZE);
-    this->write_msg_(console_buffer);
+    this->write_msg_(console_buffer, buffer_at);
   }
 
   // Reset the recursion guard for this task
@@ -135,12 +135,13 @@ void Logger::log_vprintf_(uint8_t level, const char *tag, int line, const __Flas
   this->format_log_to_buffer_with_terminator_(level, tag, line, this->tx_buffer_, args, this->tx_buffer_,
                                               &this->tx_buffer_at_, this->tx_buffer_size_);
 
-  // Write to console and send callback starting at the msg_start
-  if (this->baud_rate_ > 0) {
-    this->write_msg_(this->tx_buffer_ + msg_start);
-  }
   size_t msg_length =
       this->tx_buffer_at_ - msg_start;  // Don't subtract 1 - tx_buffer_at_ is already at the null terminator position
+
+  // Write to console and send callback starting at the msg_start
+  if (this->baud_rate_ > 0) {
+    this->write_msg_(this->tx_buffer_ + msg_start, msg_length);
+  }
   this->log_callback_.call(level, tag, this->tx_buffer_ + msg_start, msg_length);
 
   global_recursion_guard_ = false;
@@ -211,7 +212,7 @@ void Logger::process_messages_() {
       // this is preferred over corrupted/interleaved console output
       if (this->baud_rate_ > 0) {
         this->add_newline_to_buffer_if_needed_();
-        this->write_msg_(this->tx_buffer_);
+        this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
       }
     }
   } else {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -133,7 +133,7 @@ void Logger::log_vprintf_(uint8_t level, const char *tag, int line, const __Flas
 
   // Save the offset before calling format_log_to_buffer_with_terminator_
   // since it will increment tx_buffer_at_ to the end of the formatted string
-  uint32_t msg_start = this->tx_buffer_at_;
+  uint16_t msg_start = this->tx_buffer_at_;
   this->format_log_to_buffer_with_terminator_(level, tag, line, this->tx_buffer_, args, this->tx_buffer_,
                                               &this->tx_buffer_at_, this->tx_buffer_size_);
 

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -65,6 +65,8 @@ void HOT Logger::log_vprintf_(uint8_t level, const char *tag, int line, const ch
     uint16_t buffer_at = 0;                         // Initialize buffer position
     this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, console_buffer, &buffer_at,
                                                 MAX_CONSOLE_LOG_MSG_SIZE);
+    // Add newline if platform needs it (ESP32 doesn't add via write_msg_)
+    this->add_newline_to_buffer_if_needed_(console_buffer, &buffer_at, MAX_CONSOLE_LOG_MSG_SIZE);
     this->write_msg_(console_buffer, buffer_at);
   }
 
@@ -212,10 +214,7 @@ void Logger::process_messages_() {
       // This ensures all log messages appear on the console in a clean, serialized manner
       // Note: Messages may appear slightly out of order due to async processing, but
       // this is preferred over corrupted/interleaved console output
-      if (this->baud_rate_ > 0) {
-        this->add_newline_to_buffer_if_needed_();
-        this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
-      }
+      this->write_tx_buffer_to_console_();
     }
   } else {
     // No messages to process, disable loop if appropriate

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -138,11 +138,13 @@ void Logger::log_vprintf_(uint8_t level, const char *tag, int line, const __Flas
   size_t msg_length =
       this->tx_buffer_at_ - msg_start;  // Don't subtract 1 - tx_buffer_at_ is already at the null terminator position
 
-  // Write to console and send callback starting at the msg_start
+  // Callbacks get message first (before console write)
+  this->log_callback_.call(level, tag, this->tx_buffer_ + msg_start, msg_length);
+
+  // Write to console starting at the msg_start
   if (this->baud_rate_ > 0) {
     this->write_msg_(this->tx_buffer_ + msg_start, msg_length);
   }
-  this->log_callback_.call(level, tag, this->tx_buffer_ + msg_start, msg_length);
 
   global_recursion_guard_ = false;
 }

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -210,6 +210,7 @@ void Logger::process_messages_() {
       // Note: Messages may appear slightly out of order due to async processing, but
       // this is preferred over corrupted/interleaved console output
       if (this->baud_rate_ > 0) {
+        this->add_newline_to_buffer_if_needed_();
         this->write_msg_(this->tx_buffer_);
       }
     }

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -184,7 +184,7 @@ class Logger : public Component {
 
  protected:
   void process_messages_();
-  void write_msg_(const char *msg);
+  void write_msg_(const char *msg, size_t len);
 
   // Format a log message with printf-style arguments and write it to a buffer with header, footer, and null terminator
   // It's the caller's responsibility to initialize buffer_at (typically to 0)

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -232,7 +232,7 @@ class Logger : public Component {
 
   // Helper to write tx_buffer_ to console if logging is enabled
   // INTERNAL USE ONLY - offset > 0 requires length parameter to be non-null
-  inline void HOT write_tx_buffer_to_console_(uint32_t offset = 0, uint16_t *length = nullptr) {
+  inline void HOT write_tx_buffer_to_console_(uint16_t offset = 0, uint16_t *length = nullptr) {
     if (this->baud_rate_ > 0) {
       uint16_t *len_ptr = length ? length : &this->tx_buffer_at_;
       this->add_newline_to_buffer_if_needed_(this->tx_buffer_ + offset, len_ptr, this->tx_buffer_size_ - offset);

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -215,11 +215,14 @@ class Logger : public Component {
   inline void HOT add_newline_to_buffer_if_needed_() {
     if constexpr (!WRITE_MSG_ADDS_NEWLINE) {
       // Add newline - don't need to maintain null termination
-      // write_msg_ uses tx_buffer_at_ as length, not strlen()
+      // write_msg_ now always receives explicit length, so we can safely overwrite the null terminator
+      // This is safe because:
+      // 1. Callbacks already received the message (before we add newline)
+      // 2. write_msg_ receives the length explicitly (doesn't need null terminator)
       if (this->tx_buffer_at_ < this->tx_buffer_size_) {
         this->tx_buffer_[this->tx_buffer_at_++] = '\n';
       } else if (this->tx_buffer_size_ > 0) {
-        // Buffer was full - replace last char with newline
+        // Buffer was full - replace last char with newline to ensure it's visible
         this->tx_buffer_[this->tx_buffer_size_ - 1] = '\n';
         this->tx_buffer_at_ = this->tx_buffer_size_;
       }
@@ -240,7 +243,7 @@ class Logger : public Component {
     // Console gets message WITH newline (if platform needs it)
     if (this->baud_rate_ > 0) {
       this->add_newline_to_buffer_if_needed_();
-      this->write_msg_(this->tx_buffer_);
+      this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
     }
   }
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -72,11 +72,11 @@ static constexpr uint16_t MAX_HEADER_SIZE = 128;
 static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
 
 // Platform-specific: does write_msg_ add its own newline?
-// false: Caller must add newline to buffer before calling write_msg_ (ESP32)
+// false: Caller must add newline to buffer before calling write_msg_ (ESP32, ESP8266)
 //        Allows single write call with newline included for efficiency
 // true:  write_msg_ adds newline itself via puts()/println() (other platforms)
 //        Newline should NOT be added to buffer
-#if defined(USE_ESP32)
+#if defined(USE_ESP32) || defined(USE_ESP8266)
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;
 #else
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = true;

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -231,8 +231,7 @@ class Logger : public Component {
   }
 
   // Helper to write tx_buffer_ to console if logging is enabled
-  // offset: starting position in tx_buffer_ (default 0)
-  // length: pointer to length of message at offset (updated with newline if added)
+  // INTERNAL USE ONLY - offset > 0 requires length parameter to be non-null
   inline void HOT write_tx_buffer_to_console_(uint32_t offset = 0, uint16_t *length = nullptr) {
     if (this->baud_rate_ > 0) {
       uint16_t *len_ptr = length ? length : &this->tx_buffer_at_;

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -72,9 +72,10 @@ static constexpr uint16_t MAX_HEADER_SIZE = 128;
 static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
 
 // Platform-specific: does write_msg_ add its own newline?
-// ESP32: add newline to buffer (write it in one call)
-// Zephyr: let printk/uart_poll_out add newline (unchanged behavior)
-// Other platforms: println()/puts() adds newline, so skip
+// false: Caller must add newline to buffer before calling write_msg_ (ESP32)
+//        Allows single write call with newline included for efficiency
+// true:  write_msg_ adds newline itself via puts()/println() (other platforms)
+//        Newline should NOT be added to buffer
 #if defined(USE_ESP32)
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;
 #else

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -71,6 +71,16 @@ static constexpr uint16_t MAX_HEADER_SIZE = 128;
 // "0x" + 2 hex digits per byte + '\0'
 static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
 
+// Platform-specific: does write_msg_ add its own newline?
+// ESP32: add newline to buffer (write it in one call)
+// Zephyr: let printk/uart_poll_out add newline (unchanged behavior)
+// Other platforms: println()/puts() adds newline, so skip
+#if defined(USE_ESP32)
+static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;
+#else
+static constexpr bool WRITE_MSG_ADDS_NEWLINE = true;
+#endif
+
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
 /** Enum for logging UART selection
  *
@@ -200,6 +210,21 @@ class Logger : public Component {
     }
   }
 
+  // Helper to add newline to buffer for platforms that need it
+  inline void HOT add_newline_to_buffer_if_needed_() {
+    if constexpr (!WRITE_MSG_ADDS_NEWLINE) {
+      // Add newline - don't need to maintain null termination
+      // write_msg_ uses tx_buffer_at_ as length, not strlen()
+      if (this->tx_buffer_at_ < this->tx_buffer_size_) {
+        this->tx_buffer_[this->tx_buffer_at_++] = '\n';
+      } else if (this->tx_buffer_size_ > 0) {
+        // Buffer was full - replace last char with newline
+        this->tx_buffer_[this->tx_buffer_size_ - 1] = '\n';
+        this->tx_buffer_at_ = this->tx_buffer_size_;
+      }
+    }
+  }
+
   // Helper to format and send a log message to both console and callbacks
   inline void HOT log_message_to_buffer_and_send_(uint8_t level, const char *tag, int line, const char *format,
                                                   va_list args) {
@@ -208,10 +233,14 @@ class Logger : public Component {
     this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, this->tx_buffer_, &this->tx_buffer_at_,
                                                 this->tx_buffer_size_);
 
-    if (this->baud_rate_ > 0) {
-      this->write_msg_(this->tx_buffer_);  // If logging is enabled, write to console
-    }
+    // Callbacks get message WITHOUT newline (for API/MQTT/syslog)
     this->log_callback_.call(level, tag, this->tx_buffer_, this->tx_buffer_at_);
+
+    // Console gets message WITH newline (if platform needs it)
+    if (this->baud_rate_ > 0) {
+      this->add_newline_to_buffer_if_needed_();
+      this->write_msg_(this->tx_buffer_);
+    }
   }
 
   // Write the body of the log message to the buffer

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -458,7 +458,9 @@ class Logger : public Component {
     }
 
     // Update buffer_at with the formatted length (handle truncation)
-    uint16_t formatted_len = (ret >= remaining) ? remaining : ret;
+    // When vsnprintf truncates (ret >= remaining), it writes (remaining - 1) chars + null terminator
+    // When it doesn't truncate (ret < remaining), it writes ret chars + null terminator
+    uint16_t formatted_len = (ret >= remaining) ? (remaining - 1) : ret;
     *buffer_at += formatted_len;
 
     // Remove all trailing newlines right after formatting

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -212,20 +212,29 @@ class Logger : public Component {
   }
 
   // Helper to add newline to buffer for platforms that need it
-  inline void HOT add_newline_to_buffer_if_needed_() {
+  // Modifies buffer_at to include the newline
+  inline void HOT add_newline_to_buffer_if_needed_(char *buffer, uint16_t *buffer_at, uint16_t buffer_size) {
     if constexpr (!WRITE_MSG_ADDS_NEWLINE) {
       // Add newline - don't need to maintain null termination
       // write_msg_ now always receives explicit length, so we can safely overwrite the null terminator
       // This is safe because:
       // 1. Callbacks already received the message (before we add newline)
       // 2. write_msg_ receives the length explicitly (doesn't need null terminator)
-      if (this->tx_buffer_at_ < this->tx_buffer_size_) {
-        this->tx_buffer_[this->tx_buffer_at_++] = '\n';
-      } else if (this->tx_buffer_size_ > 0) {
+      if (*buffer_at < buffer_size) {
+        buffer[(*buffer_at)++] = '\n';
+      } else if (buffer_size > 0) {
         // Buffer was full - replace last char with newline to ensure it's visible
-        this->tx_buffer_[this->tx_buffer_size_ - 1] = '\n';
-        this->tx_buffer_at_ = this->tx_buffer_size_;
+        buffer[buffer_size - 1] = '\n';
+        *buffer_at = buffer_size;
       }
+    }
+  }
+
+  // Helper to write tx_buffer_ to console if logging is enabled
+  inline void HOT write_tx_buffer_to_console_() {
+    if (this->baud_rate_ > 0) {
+      this->add_newline_to_buffer_if_needed_(this->tx_buffer_, &this->tx_buffer_at_, this->tx_buffer_size_);
+      this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
     }
   }
 
@@ -241,10 +250,7 @@ class Logger : public Component {
     this->log_callback_.call(level, tag, this->tx_buffer_, this->tx_buffer_at_);
 
     // Console gets message WITH newline (if platform needs it)
-    if (this->baud_rate_ > 0) {
-      this->add_newline_to_buffer_if_needed_();
-      this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
-    }
+    this->write_tx_buffer_to_console_();
   }
 
   // Write the body of the log message to the buffer

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -231,10 +231,13 @@ class Logger : public Component {
   }
 
   // Helper to write tx_buffer_ to console if logging is enabled
-  inline void HOT write_tx_buffer_to_console_() {
+  // offset: starting position in tx_buffer_ (default 0)
+  // length: pointer to length of message at offset (updated with newline if added)
+  inline void HOT write_tx_buffer_to_console_(uint32_t offset = 0, uint16_t *length = nullptr) {
     if (this->baud_rate_ > 0) {
-      this->add_newline_to_buffer_if_needed_(this->tx_buffer_, &this->tx_buffer_at_, this->tx_buffer_size_);
-      this->write_msg_(this->tx_buffer_, this->tx_buffer_at_);
+      uint16_t *len_ptr = length ? length : &this->tx_buffer_at_;
+      this->add_newline_to_buffer_if_needed_(this->tx_buffer_ + offset, len_ptr, this->tx_buffer_size_ - offset);
+      this->write_msg_(this->tx_buffer_ + offset, *len_ptr);
     }
   }
 

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -127,7 +127,8 @@ void HOT Logger::write_msg_(const char *msg) {
 
 #if defined(USE_LOGGER_UART_SELECTION_USB_CDC) || defined(USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG)
   // USB CDC/JTAG - single write including newline (already in buffer)
-  esp_usb_console_write_buf(msg, len);
+  // Use fwrite to stdout which goes through VFS to USB console
+  fwrite(msg, 1, len, stdout);
 #else
   // Regular UART - single write including newline (already in buffer)
   uart_write_bytes(this->uart_num_, msg, len);

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -122,24 +122,16 @@ void Logger::pre_setup() {
 }
 
 void HOT Logger::write_msg_(const char *msg) {
-  if (
-#if defined(USE_LOGGER_USB_CDC) && !defined(USE_LOGGER_USB_SERIAL_JTAG)
-      this->uart_ == UART_SELECTION_USB_CDC
-#elif defined(USE_LOGGER_USB_SERIAL_JTAG) && !defined(USE_LOGGER_USB_CDC)
-      this->uart_ == UART_SELECTION_USB_SERIAL_JTAG
-#elif defined(USE_LOGGER_USB_CDC) && defined(USE_LOGGER_USB_SERIAL_JTAG)
-      this->uart_ == UART_SELECTION_USB_CDC || this->uart_ == UART_SELECTION_USB_SERIAL_JTAG
+  // Use tx_buffer_at_ if msg points to tx_buffer_, otherwise fall back to strlen
+  size_t len = (msg == this->tx_buffer_) ? this->tx_buffer_at_ : strlen(msg);
+
+#if defined(USE_LOGGER_UART_SELECTION_USB_CDC) || defined(USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG)
+  // USB CDC/JTAG - single write including newline (already in buffer)
+  esp_usb_console_write_buf(msg, len);
 #else
-      /* DISABLES CODE */ (false)  // NOLINT
+  // Regular UART - single write including newline (already in buffer)
+  uart_write_bytes(this->uart_num_, msg, len);
 #endif
-  ) {
-    puts(msg);
-  } else {
-    // Use tx_buffer_at_ if msg points to tx_buffer_, otherwise fall back to strlen
-    size_t len = (msg == this->tx_buffer_) ? this->tx_buffer_at_ : strlen(msg);
-    uart_write_bytes(this->uart_num_, msg, len);
-    uart_write_bytes(this->uart_num_, "\n", 1);
-  }
 }
 
 const LogString *Logger::get_uart_selection_() {

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -121,13 +121,18 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg) {
-  // Use tx_buffer_at_ if msg points to tx_buffer_, otherwise fall back to strlen
-  size_t len = (msg == this->tx_buffer_) ? this->tx_buffer_at_ : strlen(msg);
+void HOT Logger::write_msg_(const char *msg, size_t len) {
+  // Length is now always passed explicitly - no strlen() fallback needed
 
 #if defined(USE_LOGGER_UART_SELECTION_USB_CDC) || defined(USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG)
   // USB CDC/JTAG - single write including newline (already in buffer)
   // Use fwrite to stdout which goes through VFS to USB console
+  //
+  // Note: These defines indicate the user's YAML configuration choice (hardware_uart: USB_CDC/USB_SERIAL_JTAG).
+  // They are ONLY defined when the user explicitly selects USB as the logger output in their config.
+  // This is compile-time selection, not runtime detection - if USB is configured, it's always used.
+  // There is no fallback to regular UART if "USB isn't connected" - that's the user's responsibility
+  // to configure correctly for their hardware. This approach eliminates runtime overhead.
   fwrite(msg, 1, len, stdout);
 #else
   // Regular UART - single write including newline (already in buffer)

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -33,7 +33,10 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg, size_t) { this->hw_serial_->println(msg); }
+void HOT Logger::write_msg_(const char *msg, size_t len) {
+  // Single write with newline already in buffer (added by caller)
+  this->hw_serial_->write(msg, len);
+}
 
 const LogString *Logger::get_uart_selection_() {
   switch (this->uart_) {

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -33,7 +33,7 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
+void HOT Logger::write_msg_(const char *msg, size_t) { this->hw_serial_->println(msg); }
 
 const LogString *Logger::get_uart_selection_() {
   switch (this->uart_) {

--- a/esphome/components/logger/logger_host.cpp
+++ b/esphome/components/logger/logger_host.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome::logger {
 
-void HOT Logger::write_msg_(const char *msg) {
+void HOT Logger::write_msg_(const char *msg, size_t) {
   time_t rawtime;
   struct tm *timeinfo;
   char buffer[80];

--- a/esphome/components/logger/logger_libretiny.cpp
+++ b/esphome/components/logger/logger_libretiny.cpp
@@ -49,7 +49,7 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
+void HOT Logger::write_msg_(const char *msg, size_t) { this->hw_serial_->println(msg); }
 
 const LogString *Logger::get_uart_selection_() {
   switch (this->uart_) {

--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -27,7 +27,7 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg) { this->hw_serial_->println(msg); }
+void HOT Logger::write_msg_(const char *msg, size_t) { this->hw_serial_->println(msg); }
 
 const LogString *Logger::get_uart_selection_() {
   switch (this->uart_) {

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -62,7 +62,7 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg) {
+void HOT Logger::write_msg_(const char *msg, size_t) {
 #ifdef CONFIG_PRINTK
   printk("%s\n", msg);
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Optimizes logger performance on ESP32 and ESP8266, and fixes an existing vsnprintf truncation bug.

## Problems Fixed

### 1. ESP32: Wasteful Double UART Write Calls

The ESP32 logger was making **two separate UART write calls** for every log message:
1. `uart_write_bytes(msg, len)` - write the message
2. `uart_write_bytes("\n", 1)` - write the newline

Each call to `uart_write_bytes()` acquires a mutex and blocks with `portMAX_DELAY`, meaning **every log message incurred double the mutex overhead**.

### 2. ESP8266: Unnecessary strlen() Overhead

The ESP8266 logger was using `println(msg)` which internally calls `strlen()` to find the string length, even though we already know the length from formatting.

### 3. vsnprintf Truncation Bug (All Platforms)

When log messages exceed buffer size, `vsnprintf` returns the "would-be" length but only writes `(size - 1)` characters. The code was incorrectly adding `size` to `buffer_at`, causing an off-by-one error where callbacks received incorrect message lengths. This bug has existed since PR #8736 (May 2025).

## Solutions

### ESP32 Optimization

Add newline to buffer and write everything in a single call:

**Before:**
```cpp
uart_write_bytes(this->uart_num_, msg, len);      // Mutex + block
uart_write_bytes(this->uart_num_, "\n", 1);       // Mutex + block AGAIN
```

**After:**
```cpp
// Newline already added to buffer
uart_write_bytes(this->uart_num_, msg, len);      // Single call
```

### ESP8266 Optimization

Replace `println()` with `write()` using explicit length:

**Before:**
```cpp
this->hw_serial_->println(msg);  // Calls strlen() internally
```

**After:**
```cpp
// Newline already added to buffer, use known length
this->hw_serial_->write(msg, len);  // No strlen() overhead
```

### vsnprintf Bug Fix

**Before (wrong):**
```cpp
uint16_t formatted_len = (ret >= remaining) ? remaining : ret;
*buffer_at += formatted_len;
```

**After (correct):**
```cpp
// vsnprintf with size=10 writes 9 chars + null, not 10
uint16_t formatted_len = (ret >= remaining) ? (remaining - 1) : ret;
*buffer_at += formatted_len;
```

## Key Changes

1. **Compile-time platform detection** - Extended `WRITE_MSG_ADDS_NEWLINE` constant to include ESP8266
2. **New ESP32 UART selection defines** - Added `USE_LOGGER_UART_SELECTION_USB_CDC` and `USE_LOGGER_UART_SELECTION_USB_SERIAL_JTAG` to detect actual user selection
3. **Helper functions** - `add_newline_to_buffer_if_needed_()` uses `if constexpr` for zero-cost abstraction, `write_tx_buffer_to_console_()` encapsulates console write logic
4. **Simplified ESP32 write path** - Removed complex nested preprocessor + runtime checks, pure compile-time decision
5. **ESP32 USB optimization** - Changed from `puts()` to `fwrite()` for USB CDC/JTAG (avoids strlen overhead, uses exact length)
6. **ESP8266 optimization** - Changed from `println()` to `write()` (eliminates strlen() overhead)
7. **Explicit length passing** - All `write_msg_()` implementations now receive explicit length parameter
8. **Fixed vsnprintf truncation bug** - Corrected off-by-one error in buffer position tracking when messages are truncated

## Behavioral Notes

**Callback order:** Callbacks are now called *before* console write (previously after). This is necessary because:
- Callbacks need messages WITHOUT newlines (for API/MQTT/syslog network protocols)
- Console needs messages WITH newlines (for readability)
- We add the newline to buffer after callbacks, then write to console

This should not affect functionality as both operations still occur in the same function call within microseconds of each other.

## Platform-Specific Behavior

- **ESP32 (regular UART)**: ✅ Optimized - single `uart_write_bytes()` call with newline in buffer
- **ESP32 (USB CDC/JTAG)**: ✅ Optimized - single `fwrite()` call with newline in buffer
- **ESP8266**: ✅ Optimized - single `write()` call with newline in buffer (eliminates `println()` strlen overhead)
- **RP2040**: ⚫ Unchanged - uses `println()` which adds newline (could be optimized similarly in future)
- **LibreTiny**: ⚫ Unchanged - uses `println()` which adds newline (could be optimized similarly in future)
- **Zephyr**: ⚫ Unchanged - uses `printk("%s\n")` which adds newline (could be optimized similarly in future)
- **Host**: ⚫ Unchanged - uses `puts()` which adds newline (could be optimized similarly in future)

**Note:** All `write_msg_()` implementations now receive explicit length, making it straightforward to optimize remaining platforms in the future by changing `WRITE_MSG_ADDS_NEWLINE` and using length-based write functions.

## Expected Impact

- **ESP32: 50% reduction in UART mutex acquisitions** per log message
- **ESP32: 50% reduction in UART blocking events** per log message
- **ESP8266: Eliminates strlen() overhead** - uses explicit length instead of `println()`
- **No flash/RAM overhead** - all decisions made at compile time via `if constexpr`
- **No functional changes** - output remains identical

For a device logging 100 messages/second, this eliminates 100 unnecessary mutex acquisitions (ESP32) or 100 strlen() calls (ESP8266) per second.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Performance optimization (non-breaking)

**Related issue or feature (if applicable):**

N/A - proactive optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal optimization, no user-facing changes

## Test Environment

- [x] ESP32 (classic with regular UART)
- [x] ESP32-S3 (with USB Serial JTAG)
- [x] ESP32-C3
- [x] ESP32 IDF
- [x] USB CDC
- [x] ESP8266
- [ ] RP2040 (unchanged, no testing needed)
- [ ] BK72xx (unchanged, no testing needed)
- [ ] RTL87xx (unchanged, no testing needed)

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Optimization is automatic for all ESP32 devices

esphome:
  name: test-logger-optimization

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: DEBUG
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Technical Details

### Implementation Strategy

The optimization uses compile-time metaprogramming to eliminate all runtime overhead:

```cpp
// Compile-time constant based on platform
#if defined(USE_ESP32)
static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;  // Add to buffer
#else
static constexpr bool WRITE_MSG_ADDS_NEWLINE = true;   // Platform adds it
#endif

// Zero-cost abstraction - compiles to nothing on non-ESP32
inline void HOT add_newline_to_buffer_if_needed_() {
  if constexpr (!WRITE_MSG_ADDS_NEWLINE) {
    if (this->tx_buffer_at_ < this->tx_buffer_size_) {
      this->tx_buffer_[this->tx_buffer_at_++] = '\n';
    } else if (this->tx_buffer_size_ > 0) {
      this->tx_buffer_[this->tx_buffer_size_ - 1] = '\n';
      this->tx_buffer_at_ = this->tx_buffer_size_;
    }
  }
}
```

### Why `fwrite()` instead of `puts()`?

The original code used `puts(msg)` for USB CDC/JTAG, which has overhead:
1. `puts()` calls `strlen()` internally (wasted work, we already know the length)
2. `puts()` always appends its own newline (forces us to skip adding to buffer)

Using `fwrite(msg, 1, len, stdout)`:
- Uses known length (no strlen overhead)
- Writes exact bytes we specify (newline already in buffer)
- Public stable API (standard C library)
- VFS layer routes to correct USB console backend
- Still thread-safe (has internal locking)
- **Auto-flushes on `\n`** - ESP-IDF configures stdout as line-buffered ([source](https://github.com/espressif/esp-idf/blob/d1e854920a64f657839dffc10e5358ec766ab993/components/newlib/src/reent_syscalls.c#L79)), so no explicit `fflush()` needed

### Buffer Null Termination

After callbacks complete, we don't need to maintain null termination because `write_msg_()` uses `tx_buffer_at_` as the length parameter (not `strlen()`). This allows us to simply append `\n` and increment the position without worrying about the null terminator.

### Bug Fix: vsnprintf Truncation

This PR also fixes an existing bug introduced in PR #8736 (May 2025):

**The Bug:**
```cpp
// OLD CODE (wrong)
uint16_t formatted_len = (ret >= remaining) ? remaining : ret;
*buffer_at += formatted_len;
```

When `vsnprintf(buf, 10, "very long string")` truncates:
- Returns: `ret = 25` (would-be length)
- Actually writes: `9 chars + null` (in a 10-byte buffer)
- Old code set: `formatted_len = 10`
- Result: `buffer_at` was off by one, callbacks received incorrect length

**The Fix:**
```cpp
// NEW CODE (correct)
uint16_t formatted_len = (ret >= remaining) ? (remaining - 1) : ret;
*buffer_at += formatted_len;
```

Now `buffer_at` correctly matches `strlen(buffer)` even when truncation occurs.

This bug only manifested when log messages exceeded buffer size (rare), causing callbacks to potentially receive a length value 1 byte too large. See `test_logger_buffer_truncation.cpp` for verification tests.

### Verification

Successfully tested on:
- **ESP32 classic** with regular UART - Compiles and optimizes correctly
- **ESP32-S3** with USB Serial JTAG - Compiles and optimizes correctly
- **ESP32-C3** - Compiles and optimizes correctly
- **USB CDC** - Compiles and optimizes correctly
- **ESP8266** - Compiles correctly, newline handling works
- **Logger callbacks** - Verified to work correctly (API/MQTT/syslog receive messages without newlines as expected)
- **Buffer truncation** - Verified with test program that vsnprintf fix is correct

Output format and behavior remain identical across all platforms - only the internal implementation is optimized.
