### PR TITLE
[binary_sensor] Modernize to C++17 nested namespaces and remove redundant qualifications

### DIFF
--- a/esphome/components/binary_sensor/automation.cpp
+++ b/esphome/components/binary_sensor/automation.cpp
@@ -1,12 +1,11 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 static const char *const TAG = "binary_sensor.automation";
 
-void binary_sensor::MultiClickTrigger::on_state_(bool state) {
+void MultiClickTrigger::on_state_(bool state) {
   // Handle duplicate events
   if (state == this->last_state_) {
     return;
@@ -67,7 +66,7 @@ void binary_sensor::MultiClickTrigger::on_state_(bool state) {
 
   *this->at_index_ = *this->at_index_ + 1;
 }
-void binary_sensor::MultiClickTrigger::schedule_cooldown_() {
+void MultiClickTrigger::schedule_cooldown_() {
   ESP_LOGV(TAG, "Multi Click: Invalid length of press, starting cooldown of %" PRIu32 " ms", this->invalid_cooldown_);
   this->is_in_cooldown_ = true;
   this->set_timeout("cooldown", this->invalid_cooldown_, [this]() {
@@ -79,7 +78,7 @@ void binary_sensor::MultiClickTrigger::schedule_cooldown_() {
   this->cancel_timeout("is_valid");
   this->cancel_timeout("is_not_valid");
 }
-void binary_sensor::MultiClickTrigger::schedule_is_valid_(uint32_t min_length) {
+void MultiClickTrigger::schedule_is_valid_(uint32_t min_length) {
   if (min_length == 0) {
     this->is_valid_ = true;
     return;
@@ -90,19 +89,19 @@ void binary_sensor::MultiClickTrigger::schedule_is_valid_(uint32_t min_length) {
     this->is_valid_ = true;
   });
 }
-void binary_sensor::MultiClickTrigger::schedule_is_not_valid_(uint32_t max_length) {
+void MultiClickTrigger::schedule_is_not_valid_(uint32_t max_length) {
   this->set_timeout("is_not_valid", max_length, [this]() {
     ESP_LOGV(TAG, "Multi Click: You waited too long to %s.", this->parent_->state ? "RELEASE" : "PRESS");
     this->is_valid_ = false;
     this->schedule_cooldown_();
   });
 }
-void binary_sensor::MultiClickTrigger::cancel() {
+void MultiClickTrigger::cancel() {
   ESP_LOGV(TAG, "Multi Click: Sequence explicitly cancelled.");
   this->is_valid_ = false;
   this->schedule_cooldown_();
 }
-void binary_sensor::MultiClickTrigger::trigger_() {
+void MultiClickTrigger::trigger_() {
   ESP_LOGV(TAG, "Multi Click: Hooray, multi click is valid. Triggering!");
   this->at_index_.reset();
   this->cancel_timeout("trigger");
@@ -118,5 +117,4 @@ bool match_interval(uint32_t min_length, uint32_t max_length, uint32_t length) {
     return length >= min_length && length <= max_length;
   }
 }
-}  // namespace binary_sensor
-}  // namespace esphome
+}  // namespace esphome::binary_sensor

--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -9,8 +9,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 struct MultiClickTriggerEvent {
   bool state;
@@ -172,5 +171,4 @@ template<typename... Ts> class BinarySensorInvalidateAction : public Action<Ts..
   BinarySensor *sensor_;
 };
 
-}  // namespace binary_sensor
-}  // namespace esphome
+}  // namespace esphome::binary_sensor

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -3,9 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 static const char *const TAG = "binary_sensor";
 
@@ -63,6 +61,4 @@ void BinarySensor::add_filters(std::initializer_list<Filter *> filters) {
 }
 bool BinarySensor::is_status_binary_sensor() const { return false; }
 
-}  // namespace binary_sensor
-
-}  // namespace esphome
+}  // namespace esphome::binary_sensor

--- a/esphome/components/binary_sensor/binary_sensor.h
+++ b/esphome/components/binary_sensor/binary_sensor.h
@@ -6,9 +6,7 @@
 
 #include <initializer_list>
 
-namespace esphome {
-
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 class BinarySensor;
 void log_binary_sensor(const char *tag, const char *prefix, const char *type, BinarySensor *obj);
@@ -70,5 +68,4 @@ class BinarySensorInitiallyOff : public BinarySensor {
   bool has_state() const override { return true; }
 };
 
-}  // namespace binary_sensor
-}  // namespace esphome
+}  // namespace esphome::binary_sensor

--- a/esphome/components/binary_sensor/filter.cpp
+++ b/esphome/components/binary_sensor/filter.cpp
@@ -2,9 +2,7 @@
 
 #include "binary_sensor.h"
 
-namespace esphome {
-
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 static const char *const TAG = "sensor.filter";
 
@@ -132,6 +130,4 @@ optional<bool> SettleFilter::new_value(bool value) {
 
 float SettleFilter::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-}  // namespace binary_sensor
-
-}  // namespace esphome
+}  // namespace esphome::binary_sensor

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -4,9 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-
-namespace binary_sensor {
+namespace esphome::binary_sensor {
 
 class BinarySensor;
 
@@ -139,6 +137,4 @@ class SettleFilter : public Filter, public Component {
   bool steady_{true};
 };
 
-}  // namespace binary_sensor
-
-}  // namespace esphome
+}  // namespace esphome::binary_sensor


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the `binary_sensor` component to use C++17 nested namespace syntax and removes redundant namespace qualifications that have existed since 2018.

**Changes:**
1. **C++17 nested namespaces**: Convert from `namespace esphome { namespace binary_sensor {` to `namespace esphome::binary_sensor {`
2. **Remove redundant qualifications**: Fix method implementations in `automation.cpp` that unnecessarily used `binary_sensor::MultiClickTrigger::` instead of just `MultiClickTrigger::` (these were already inside the `binary_sensor` namespace)

**Example of redundant qualification fixed:**
```cpp
// Before (inside namespace esphome { namespace binary_sensor {)
void binary_sensor::MultiClickTrigger::on_state_(bool state) { ... }

// After (inside namespace esphome::binary_sensor {)
void MultiClickTrigger::on_state_(bool state) { ... }
```

The redundant `binary_sensor::` prefix has been present since the initial C++ merge in 2018 (commit 6682c43df) but was never necessary.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Code modernization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
