### PR TITLE
[cover] Modernize to C++17 nested namespaces

### DIFF
--- a/esphome/components/cover/automation.h
+++ b/esphome/components/cover/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "cover.h"
 
-namespace esphome {
-namespace cover {
+namespace esphome::cover {
 
 template<typename... Ts> class OpenAction : public Action<Ts...> {
  public:
@@ -131,5 +130,4 @@ class CoverClosedTrigger : public Trigger<> {
   }
 };
 
-}  // namespace cover
-}  // namespace esphome
+}  // namespace esphome::cover

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -6,8 +6,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cover {
+namespace esphome::cover {
 
 static const char *const TAG = "cover";
 
@@ -212,5 +211,4 @@ void CoverRestoreState::apply(Cover *cover) {
   cover->publish_state();
 }
 
-}  // namespace cover
-}  // namespace esphome
+}  // namespace esphome::cover

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -7,8 +7,7 @@
 
 #include "cover_traits.h"
 
-namespace esphome {
-namespace cover {
+namespace esphome::cover {
 
 const extern float COVER_OPEN;
 const extern float COVER_CLOSED;
@@ -157,5 +156,4 @@ class Cover : public EntityBase, public EntityBase_DeviceClass {
   ESPPreferenceObject rtc_;
 };
 
-}  // namespace cover
-}  // namespace esphome
+}  // namespace esphome::cover

--- a/esphome/components/cover/cover_traits.h
+++ b/esphome/components/cover/cover_traits.h
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace esphome {
-namespace cover {
+namespace esphome::cover {
 
 class CoverTraits {
  public:
@@ -26,5 +25,4 @@ class CoverTraits {
   bool supports_stop_{false};
 };
 
-}  // namespace cover
-}  // namespace esphome
+}  // namespace esphome::cover


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the `cover` component to use C++17 nested namespace syntax, following the same pattern established in PR #11929 for the `binary_sensor` component.

**Changes:**
- Converts traditional nested namespace declarations (`namespace esphome { namespace cover {`) to C++17 syntax (`namespace esphome::cover {`)
- Updates namespace closing comments to match the new structure (`}  // namespace esphome::cover`)

This is purely a code quality improvement with no functional changes or memory impact. The refactoring makes the codebase more consistent with modern C++ standards and improves readability.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing C++17 modernization effort (see PR #11929)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a code quality improvement only
# Existing cover configurations remain unchanged

cover:
  - platform: template
    name: "Template Cover"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Note: No new tests needed - existing tests verify functionality is unchanged

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - N/A - No user-facing changes
