### PR TITLE
[wifi] Skip redundant setter calls for default values

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -479,11 +479,14 @@ async def to_code(config):
         cg.add(var.set_min_auth_mode(config[CONF_MIN_AUTH_MODE]))
     if config[CONF_FAST_CONNECT]:
         cg.add_define("USE_WIFI_FAST_CONNECT")
-    cg.add(var.set_passive_scan(config[CONF_PASSIVE_SCAN]))
+    # passive_scan defaults to false in C++ - only set if true
+    if config[CONF_PASSIVE_SCAN]:
+        cg.add(var.set_passive_scan(True))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
-
-    cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
+    # enable_on_boot defaults to true in C++ - only set if false
+    if not config[CONF_ENABLE_ON_BOOT]:
+        cg.add(var.set_enable_on_boot(False))
 
     if CORE.is_esp8266:
         cg.add_library("ESP8266WiFi", None)

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -526,7 +526,7 @@ class WiFiComponent : public Component {
   bool btm_{false};
   bool rrm_{false};
 #endif
-  bool enable_on_boot_;
+  bool enable_on_boot_{true};
   bool got_ipv4_address_{false};
   bool keep_scan_results_{false};
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes WiFi component code generation by skipping redundant setter calls when values match C++ defaults.

**Changes:**
1. Added default initializer `{true}` to `enable_on_boot_` field in `wifi_component.h`
2. Modified Python codegen to only call setters when values differ from C++ defaults:
   - `set_passive_scan()` - only called when `true` (C++ default is `false`)
   - `set_enable_on_boot()` - only called when `false` (C++ default is now `true`)

**Benefits:**
- Reduces generated code size by eliminating unnecessary setter calls in common configurations
- Improves code generation efficiency
- No functional changes - behavior remains identical

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Code optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - optimization is transparent
wifi:
  ssid: "MySSID"
  password: "MyPassword"
  # These now generate less code when using defaults:
  # passive_scan: false  # (default) - set_passive_scan() not called
  # enable_on_boot: true # (default) - set_enable_on_boot() not called
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
