### PR TITLE
2025.11.0b3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.11.0b2
+PROJECT_NUMBER         = 2025.11.0b3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -381,8 +381,9 @@ PLATFORM_VERSION_LOOKUP = {
 }
 
 
-def _check_versions(value):
-    value = value.copy()
+def _check_versions(config):
+    config = config.copy()
+    value = config[CONF_FRAMEWORK]
 
     if value[CONF_VERSION] in PLATFORM_VERSION_LOOKUP:
         if CONF_SOURCE in value or CONF_PLATFORM_VERSION in value:
@@ -447,7 +448,7 @@ def _check_versions(value):
             "If there are connectivity or build issues please remove the manual version."
         )
 
-    return value
+    return config
 
 
 def _parse_platform_version(value):
@@ -598,89 +599,72 @@ def _validate_idf_component(config: ConfigType) -> ConfigType:
 
 FRAMEWORK_ESP_IDF = "esp-idf"
 FRAMEWORK_ARDUINO = "arduino"
-FRAMEWORK_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.Optional(CONF_TYPE, default=FRAMEWORK_ARDUINO): cv.one_of(
-                FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO
-            ),
-            cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
-            cv.Optional(CONF_RELEASE): cv.string_strict,
-            cv.Optional(CONF_SOURCE): cv.string_strict,
-            cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
-            cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
-                cv.string_strict: cv.string_strict
-            },
-            cv.Optional(CONF_LOG_LEVEL, default="ERROR"): cv.one_of(
-                *LOG_LEVELS_IDF, upper=True
-            ),
-            cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
-                {
-                    cv.Optional(CONF_ASSERTION_LEVEL): cv.one_of(
-                        *ASSERTION_LEVELS, upper=True
-                    ),
-                    cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
-                        *COMPILER_OPTIMIZATIONS, upper=True
-                    ),
-                    cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
-                    cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
-                    cv.Optional(
-                        CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False
-                    ): cv.boolean,
-                    cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
-                    # DHCP server is needed for WiFi AP mode. When WiFi component is used,
-                    # it will handle disabling DHCP server when AP is not configured.
-                    # Default to false (disabled) when WiFi is not used.
-                    cv.OnlyWithout(
-                        CONF_ENABLE_LWIP_DHCP_SERVER, "wifi", default=False
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_MDNS_QUERIES, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_BRIDGE_INTERFACE, default=False
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_LIBC_LOCKS_IN_IRAM, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True
-                    ): cv.boolean,
-                    cv.Optional(
-                        CONF_DISABLE_VFS_SUPPORT_SELECT, default=True
-                    ): cv.boolean,
-                    cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
-                    cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
-                    cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
-                        min=8192, max=32768
-                    ),
-                }
-            ),
-            cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
-                cv.All(
-                    cv.Schema(
-                        {
-                            cv.Required(CONF_NAME): cv.string_strict,
-                            cv.Optional(CONF_SOURCE): cv.git_ref,
-                            cv.Optional(CONF_REF): cv.string,
-                            cv.Optional(CONF_PATH): cv.string,
-                            cv.Optional(CONF_REFRESH): cv.All(
-                                cv.string, cv.source_refresh
-                            ),
-                        }
-                    ),
-                    _validate_idf_component,
-                )
-            ),
-        }
-    ),
-    _check_versions,
+FRAMEWORK_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_TYPE): cv.one_of(FRAMEWORK_ESP_IDF, FRAMEWORK_ARDUINO),
+        cv.Optional(CONF_VERSION, default="recommended"): cv.string_strict,
+        cv.Optional(CONF_RELEASE): cv.string_strict,
+        cv.Optional(CONF_SOURCE): cv.string_strict,
+        cv.Optional(CONF_PLATFORM_VERSION): _parse_platform_version,
+        cv.Optional(CONF_SDKCONFIG_OPTIONS, default={}): {
+            cv.string_strict: cv.string_strict
+        },
+        cv.Optional(CONF_LOG_LEVEL, default="ERROR"): cv.one_of(
+            *LOG_LEVELS_IDF, upper=True
+        ),
+        cv.Optional(CONF_ADVANCED, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_ASSERTION_LEVEL): cv.one_of(
+                    *ASSERTION_LEVELS, upper=True
+                ),
+                cv.Optional(CONF_COMPILER_OPTIMIZATION, default="SIZE"): cv.one_of(
+                    *COMPILER_OPTIMIZATIONS, upper=True
+                ),
+                cv.Optional(CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES): cv.boolean,
+                cv.Optional(CONF_ENABLE_LWIP_ASSERT, default=True): cv.boolean,
+                cv.Optional(CONF_IGNORE_EFUSE_CUSTOM_MAC, default=False): cv.boolean,
+                cv.Optional(CONF_IGNORE_EFUSE_MAC_CRC): cv.boolean,
+                # DHCP server is needed for WiFi AP mode. When WiFi component is used,
+                # it will handle disabling DHCP server when AP is not configured.
+                # Default to false (disabled) when WiFi is not used.
+                cv.OnlyWithout(
+                    CONF_ENABLE_LWIP_DHCP_SERVER, "wifi", default=False
+                ): cv.boolean,
+                cv.Optional(CONF_ENABLE_LWIP_MDNS_QUERIES, default=True): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_BRIDGE_INTERFACE, default=False
+                ): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_TCPIP_CORE_LOCKING, default=True
+                ): cv.boolean,
+                cv.Optional(
+                    CONF_ENABLE_LWIP_CHECK_THREAD_SAFETY, default=True
+                ): cv.boolean,
+                cv.Optional(CONF_DISABLE_LIBC_LOCKS_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_SELECT, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
+                cv.Optional(CONF_EXECUTE_FROM_PSRAM): cv.boolean,
+                cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
+                    min=8192, max=32768
+                ),
+            }
+        ),
+        cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
+            cv.All(
+                cv.Schema(
+                    {
+                        cv.Required(CONF_NAME): cv.string_strict,
+                        cv.Optional(CONF_SOURCE): cv.git_ref,
+                        cv.Optional(CONF_REF): cv.string,
+                        cv.Optional(CONF_PATH): cv.string,
+                        cv.Optional(CONF_REFRESH): cv.All(cv.string, cv.source_refresh),
+                    }
+                ),
+                _validate_idf_component,
+            )
+        ),
+    }
 )
 
 
@@ -743,11 +727,11 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
 
 
 def _set_default_framework(config):
+    config = config.copy()
     if CONF_FRAMEWORK not in config:
-        config = config.copy()
-
-        variant = config[CONF_VARIANT]
         config[CONF_FRAMEWORK] = FRAMEWORK_SCHEMA({})
+    if CONF_TYPE not in config[CONF_FRAMEWORK]:
+        variant = config[CONF_VARIANT]
         if variant in ARDUINO_ALLOWED_VARIANTS:
             config[CONF_FRAMEWORK][CONF_TYPE] = FRAMEWORK_ARDUINO
             _show_framework_migration_message(
@@ -787,6 +771,7 @@ CONFIG_SCHEMA = cv.All(
     ),
     _detect_variant,
     _set_default_framework,
+    _check_versions,
     set_core_data,
     cv.has_at_least_one_key(CONF_BOARD, CONF_VARIANT),
 )

--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -31,35 +31,83 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_STILL_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_MOVING_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_MOTION_SENSOR,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_FLASH,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_LIGHT): sensor.sensor_schema(
             device_class=DEVICE_CLASS_ILLUMINANCE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_LIGHTBULB,
         ),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
@@ -73,7 +121,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_MOVE_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_MOTION_SENSOR,
                     unit_of_measurement=UNIT_PERCENT,
@@ -81,7 +135,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_FLASH,
                     unit_of_measurement=UNIT_PERCENT,

--- a/esphome/components/ld2412/sensor.py
+++ b/esphome/components/ld2412/sensor.py
@@ -31,36 +31,84 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_LIGHT): sensor.sensor_schema(
             device_class=DEVICE_CLASS_ILLUMINANCE,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_LIGHTBULB,
             unit_of_measurement=UNIT_EMPTY,  # No standard unit for this light sensor
         ),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_MOVING_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_MOTION_SENSOR,
             unit_of_measurement=UNIT_PERCENT,
         ),
         cv.Optional(CONF_STILL_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_SIGNAL,
             unit_of_measurement=UNIT_CENTIMETER,
         ),
         cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
-            filters=[{"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}],
+            filters=[
+                {
+                    "timeout": {
+                        "timeout": cv.TimePeriod(milliseconds=1000),
+                        "value": "last",
+                    }
+                },
+                {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
+            ],
             icon=ICON_FLASH,
             unit_of_measurement=UNIT_PERCENT,
         ),
@@ -74,7 +122,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_MOVE_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_MOTION_SENSOR,
                     unit_of_measurement=UNIT_PERCENT,
@@ -82,7 +136,13 @@ CONFIG_SCHEMA = CONFIG_SCHEMA.extend(
                 cv.Optional(CONF_STILL_ENERGY): sensor.sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                     filters=[
-                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)}
+                        {
+                            "timeout": {
+                                "timeout": cv.TimePeriod(milliseconds=1000),
+                                "value": "last",
+                            }
+                        },
+                        {"throttle_with_priority": cv.TimePeriod(milliseconds=1000)},
                     ],
                     icon=ICON_FLASH,
                     unit_of_measurement=UNIT_PERCENT,

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -52,8 +52,10 @@ static void log_invalid_parameter(const char *name, const LogString *message) {
   }
 
 static const LogString *color_mode_to_human(ColorMode color_mode) {
-  if (color_mode == ColorMode::UNKNOWN)
-    return LOG_STR("Unknown");
+  if (color_mode == ColorMode::ON_OFF)
+    return LOG_STR("On/Off");
+  if (color_mode == ColorMode::BRIGHTNESS)
+    return LOG_STR("Brightness");
   if (color_mode == ColorMode::WHITE)
     return LOG_STR("White");
   if (color_mode == ColorMode::COLOR_TEMPERATURE)
@@ -68,7 +70,7 @@ static const LogString *color_mode_to_human(ColorMode color_mode) {
     return LOG_STR("RGB + cold/warm white");
   if (color_mode == ColorMode::RGB_COLOR_TEMPERATURE)
     return LOG_STR("RGB + color temperature");
-  return LOG_STR("");
+  return LOG_STR("Unknown");
 }
 
 // Helper to log percentage values

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 import math
 import re
 
@@ -34,6 +35,8 @@ from esphome.const import (
 from esphome.core import CORE, ID
 import esphome.final_validate as fv
 from esphome.yaml_util import make_data_base
+
+_LOGGER = getLogger(__name__)
 
 CODEOWNERS = ["@esphome/core"]
 uart_ns = cg.esphome_ns.namespace("uart")
@@ -126,6 +129,21 @@ def validate_host_config(config):
             raise cv.Invalid(
                 f"Host platform doesn't support baud rate {config[CONF_BAUD_RATE]}",
                 path=[CONF_BAUD_RATE],
+            )
+    return config
+
+
+def validate_rx_buffer_size(config):
+    if CORE.is_esp32:
+        # ESP32 UART hardware FIFO is 128 bytes (LP UART is 16 bytes, but we use 128 as safe minimum)
+        # rx_buffer_size must be greater than the hardware FIFO length
+        min_buffer_size = 128
+        if config[CONF_RX_BUFFER_SIZE] <= min_buffer_size:
+            _LOGGER.warning(
+                "UART rx_buffer_size (%d bytes) is too small and must be greater than the hardware "
+                "FIFO size (%d bytes). The buffer size will be automatically adjusted at runtime.",
+                config[CONF_RX_BUFFER_SIZE],
+                min_buffer_size,
             )
     return config
 
@@ -247,6 +265,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     cv.has_at_least_one_key(CONF_TX_PIN, CONF_RX_PIN, CONF_PORT),
     validate_host_config,
+    validate_rx_buffer_size,
 )
 
 

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -56,11 +56,19 @@ uint32_t ESP8266UartComponent::get_config() {
 }
 
 void ESP8266UartComponent::setup() {
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+
+  setup_pin_if_needed(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   // Use Arduino HardwareSerial UARTs if all used pins match the ones

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -133,11 +133,19 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+
+  setup_pin_if_needed(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -53,7 +53,7 @@ void LibreTinyUARTComponent::setup() {
 
   auto shouldFallbackToSoftwareSerial = [&]() -> bool {
     auto hasFlags = [](InternalGPIOPin *pin, const gpio::Flags mask) -> bool {
-      return pin && pin->get_flags() & mask != gpio::Flags::FLAG_NONE;
+      return pin && (pin->get_flags() & mask) != gpio::Flags::FLAG_NONE;
     };
     if (hasFlags(this->tx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN) ||
         hasFlags(this->rx_pin_, gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN)) {

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -52,11 +52,19 @@ uint16_t RP2040UartComponent::get_config() {
 }
 
 void RP2040UartComponent::setup() {
-  if (this->rx_pin_) {
-    this->rx_pin_->setup();
-  }
-  if (this->tx_pin_ && this->rx_pin_ != this->tx_pin_) {
-    this->tx_pin_->setup();
+  auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
+    if (!pin) {
+      return;
+    }
+    const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
+      pin->setup();
+    }
+  };
+
+  setup_pin_if_needed(this->rx_pin_);
+  if (this->rx_pin_ != this->tx_pin_) {
+    setup_pin_if_needed(this->tx_pin_);
   }
 
   uint16_t config = get_config();

--- a/esphome/components/web_server/ota/__init__.py
+++ b/esphome/components/web_server/ota/__init__.py
@@ -1,16 +1,70 @@
+import logging
+
 import esphome.codegen as cg
 from esphome.components.esp32 import add_idf_component
 from esphome.components.ota import BASE_OTA_SCHEMA, OTAComponent, ota_to_code
+from esphome.config_helpers import merge_config
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_OTA, CONF_PLATFORM, CONF_WEB_SERVER
 from esphome.core import CORE, coroutine_with_priority
 from esphome.coroutine import CoroPriority
+import esphome.final_validate as fv
+from esphome.types import ConfigType
+
+_LOGGER = logging.getLogger(__name__)
 
 CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["network", "web_server_base"]
 
 web_server_ns = cg.esphome_ns.namespace("web_server")
 WebServerOTAComponent = web_server_ns.class_("WebServerOTAComponent", OTAComponent)
+
+
+def _web_server_ota_final_validate(config: ConfigType) -> None:
+    """Merge multiple web_server OTA instances into one.
+
+    Multiple web_server OTA instances register duplicate HTTP handlers for /update,
+    causing undefined behavior. Merge them into a single instance.
+    """
+    full_conf = fv.full_config.get()
+    ota_confs = full_conf.get(CONF_OTA, [])
+
+    web_server_ota_configs: list[ConfigType] = []
+    other_ota_configs: list[ConfigType] = []
+
+    for ota_conf in ota_confs:
+        if ota_conf.get(CONF_PLATFORM) == CONF_WEB_SERVER:
+            web_server_ota_configs.append(ota_conf)
+        else:
+            other_ota_configs.append(ota_conf)
+
+    if len(web_server_ota_configs) <= 1:
+        return
+
+    # Merge all web_server OTA configs into the first one
+    merged = web_server_ota_configs[0]
+    for ota_conf in web_server_ota_configs[1:]:
+        # Validate that IDs are consistent if manually specified
+        if (
+            merged[CONF_ID].is_manual
+            and ota_conf[CONF_ID].is_manual
+            and merged[CONF_ID] != ota_conf[CONF_ID]
+        ):
+            raise cv.Invalid(
+                f"Found multiple web_server OTA configurations but {CONF_ID} is inconsistent"
+            )
+        merged = merge_config(merged, ota_conf)
+
+    _LOGGER.warning(
+        "Found and merged %d web_server OTA configurations into one instance",
+        len(web_server_ota_configs),
+    )
+
+    # Replace OTA configs with merged web_server + other OTA platforms
+    other_ota_configs.append(merged)
+    full_conf[CONF_OTA] = other_ota_configs
+    fv.full_config.set(full_conf)
+
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -21,6 +75,8 @@ CONFIG_SCHEMA = (
     .extend(BASE_OTA_SCHEMA)
     .extend(cv.COMPONENT_SCHEMA)
 )
+
+FINAL_VALIDATE_SCHEMA = _web_server_ota_final_validate
 
 
 @coroutine_with_priority(CoroPriority.WEB_SERVER_OTA)

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -12,7 +12,6 @@ from esphome.components.network import (
 from esphome.components.psram import is_guaranteed as psram_is_guaranteed
 from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
-from esphome.config_validation import only_with_esp_idf
 from esphome.const import (
     CONF_AP,
     CONF_BSSID,
@@ -352,7 +351,7 @@ CONFIG_SCHEMA = cv.All(
                 single=True
             ),
             cv.Optional(CONF_USE_PSRAM): cv.All(
-                only_with_esp_idf, cv.requires_component("psram"), cv.boolean
+                cv.only_on_esp32, cv.requires_component("psram"), cv.boolean
             ),
         }
     ),

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.11.0b2"
+__version__ = "2025.11.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -609,13 +609,12 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
   if (now < last && (last - now) > HALF_MAX_UINT32) {
     this->millis_major_++;
     major++;
+    this->last_millis_ = now;
 #ifdef ESPHOME_DEBUG_SCHEDULER
     ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
-  }
-
-  // Only update if time moved forward
-  if (now > last) {
+  } else if (now > last) {
+    // Only update if time moved forward
     this->last_millis_ = now;
   }
 

--- a/tests/component_tests/sntp/__init__.py
+++ b/tests/component_tests/sntp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for SNTP component."""

--- a/tests/component_tests/sntp/config/sntp_test.yaml
+++ b/tests/component_tests/sntp/config/sntp_test.yaml
@@ -1,0 +1,22 @@
+esphome:
+  name: sntp-test
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: "testssid"
+  password: "testpassword"
+
+# Test multiple SNTP instances that should be merged
+time:
+  - platform: sntp
+    servers:
+      - 192.168.1.1
+      - pool.ntp.org
+  - platform: sntp
+    servers:
+      - pool.ntp.org
+      - 192.168.1.2

--- a/tests/component_tests/sntp/test_init.py
+++ b/tests/component_tests/sntp/test_init.py
@@ -1,0 +1,238 @@
+"""Tests for SNTP time configuration validation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.sntp.time import CONF_SNTP, _sntp_final_validate
+from esphome.const import CONF_ID, CONF_PLATFORM, CONF_SERVERS, CONF_TIME
+from esphome.core import ID
+import esphome.final_validate as fv
+
+
+@pytest.mark.parametrize(
+    ("time_configs", "expected_count", "expected_servers", "warning_messages"),
+    [
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                }
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org"],
+            [],
+            id="single_instance_no_merge",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="two_instances_merged",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["pool.ntp.org", "192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="deduplication_preserves_order",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.1", "pool.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["192.168.1.2", "pool2.ntp.org"],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_3", is_manual=False),
+                    CONF_SERVERS: ["pool3.ntp.org"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            [
+                "SNTP supports maximum 3 servers. Dropped excess server(s): ['pool2.ntp.org', 'pool3.ntp.org']",
+                "Found and merged 3 SNTP time configurations into one instance",
+            ],
+            id="three_instances_drops_excess_servers",
+        ),
+        pytest.param(
+            [
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_1", is_manual=False),
+                    CONF_SERVERS: [
+                        "192.168.1.1",
+                        "pool.ntp.org",
+                        "pool.ntp.org",
+                        "192.168.1.1",
+                    ],
+                },
+                {
+                    CONF_PLATFORM: CONF_SNTP,
+                    CONF_ID: ID("sntp_time_2", is_manual=False),
+                    CONF_SERVERS: ["pool.ntp.org", "192.168.1.2"],
+                },
+            ],
+            1,
+            ["192.168.1.1", "pool.ntp.org", "192.168.1.2"],
+            ["Found and merged 2 SNTP time configurations into one instance"],
+            id="deduplication_multiple_duplicates",
+        ),
+    ],
+)
+def test_sntp_instance_merging(
+    time_configs: list[dict[str, Any]],
+    expected_count: int,
+    expected_servers: list[str],
+    warning_messages: list[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test SNTP instance merging behavior."""
+    # Create a mock full config with time configs
+    full_conf = {CONF_TIME: time_configs.copy()}
+
+    # Set the context var
+    token = fv.full_config.set(full_conf)
+    try:
+        with caplog.at_level(logging.WARNING):
+            _sntp_final_validate({})
+
+        # Get the updated config
+        updated_conf = fv.full_config.get()
+
+        # Check if merging occurred
+        if len(time_configs) > 1:
+            # Verify only one SNTP instance remains
+            sntp_instances = [
+                tc
+                for tc in updated_conf[CONF_TIME]
+                if tc.get(CONF_PLATFORM) == CONF_SNTP
+            ]
+            assert len(sntp_instances) == expected_count
+
+            # Verify server list
+            assert sntp_instances[0][CONF_SERVERS] == expected_servers
+
+            # Verify warnings
+            for expected_msg in warning_messages:
+                assert any(
+                    expected_msg in record.message for record in caplog.records
+                ), f"Expected warning message '{expected_msg}' not found in log"
+        else:
+            # Single instance should not trigger merging or warnings
+            assert len(caplog.records) == 0
+            # Config should be unchanged
+            assert updated_conf[CONF_TIME] == time_configs
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_sntp_inconsistent_manual_ids() -> None:
+    """Test that inconsistent manual IDs raise an error."""
+    # Create configs with manual IDs that are inconsistent
+    time_configs = [
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_1", is_manual=True),
+            CONF_SERVERS: ["192.168.1.1"],
+        },
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_2", is_manual=True),
+            CONF_SERVERS: ["192.168.1.2"],
+        },
+    ]
+
+    full_conf = {CONF_TIME: time_configs}
+
+    token = fv.full_config.set(full_conf)
+    try:
+        with pytest.raises(
+            cv.Invalid,
+            match="Found multiple SNTP configurations but id is inconsistent",
+        ):
+            _sntp_final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_sntp_with_other_time_platforms(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that SNTP merging doesn't affect other time platforms."""
+    time_configs = [
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_1", is_manual=False),
+            CONF_SERVERS: ["192.168.1.1"],
+        },
+        {
+            CONF_PLATFORM: "homeassistant",
+            CONF_ID: ID("homeassistant_time", is_manual=False),
+        },
+        {
+            CONF_PLATFORM: CONF_SNTP,
+            CONF_ID: ID("sntp_time_2", is_manual=False),
+            CONF_SERVERS: ["192.168.1.2"],
+        },
+    ]
+
+    full_conf = {CONF_TIME: time_configs.copy()}
+
+    token = fv.full_config.set(full_conf)
+    try:
+        with caplog.at_level(logging.WARNING):
+            _sntp_final_validate({})
+
+        updated_conf = fv.full_config.get()
+
+        # Should have 2 time platforms: 1 merged SNTP + 1 homeassistant
+        assert len(updated_conf[CONF_TIME]) == 2
+
+        # Find the platforms
+        platforms = {tc[CONF_PLATFORM] for tc in updated_conf[CONF_TIME]}
+        assert platforms == {CONF_SNTP, "homeassistant"}
+
+        # Verify SNTP was merged
+        sntp_instances = [
+            tc for tc in updated_conf[CONF_TIME] if tc[CONF_PLATFORM] == CONF_SNTP
+        ]
+        assert len(sntp_instances) == 1
+        assert sntp_instances[0][CONF_SERVERS] == ["192.168.1.1", "192.168.1.2"]
+    finally:
+        fv.full_config.reset(token)

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -1,0 +1,27 @@
+esp32:
+  variant: esp32p4
+  flash_size: 32MB
+  cpu_frequency: 400MHz
+  framework:
+    type: esp-idf
+    advanced:
+      enable_idf_experimental_features: yes
+
+ota:
+  platform: esphome
+
+wifi:
+  ssid: MySSID
+  password: password1
+
+esp32_hosted:
+  variant: ESP32C6
+  slot: 1
+  active_high: true
+  reset_pin: GPIO15
+  cmd_pin: GPIO13
+  clk_pin: GPIO12
+  d0_pin: GPIO11
+  d1_pin: GPIO10
+  d2_pin: GPIO9
+  d3_pin: GPIO8


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32] Make esp-idf default framework for P4 [esphome#11884](https://github.com/esphome/esphome/pull/11884)
- [esp32] Add sdkconfig flag to make OTA work for 32MB flash [esphome#11883](https://github.com/esphome/esphome/pull/11883)
- [light] Fix missing `ColorMode::BRIGHTNESS` case in logging [esphome#11836](https://github.com/esphome/esphome/pull/11836)
- [wifi] Allow `use_psram` with Arduino [esphome#11902](https://github.com/esphome/esphome/pull/11902)
- [uart] Improve error handling and validate buffer size [esphome#11895](https://github.com/esphome/esphome/pull/11895)
- [ld2412] Fix stuck targets by adding timeout filter [esphome#11919](https://github.com/esphome/esphome/pull/11919)
- [ld2410] Add timeout filter to prevent stuck targets [esphome#11920](https://github.com/esphome/esphome/pull/11920)
- [scheduler] Fix timing breakage after 49 days of uptime on ESP8266/RP2040 [esphome#11924](https://github.com/esphome/esphome/pull/11924)
- [analyze-memory] Show all core symbols > 100 B instead of top 15 [esphome#11909](https://github.com/esphome/esphome/pull/11909)
- [sntp] Merge multiple instances to fix crash and undefined behavior [esphome#11904](https://github.com/esphome/esphome/pull/11904)
- [web_server.ota] Merge multiple instances to prevent undefined behavior [esphome#11905](https://github.com/esphome/esphome/pull/11905)
- [web_server_idf] Fix lwIP assertion crash by shutting down sockets on connection close [esphome#11937](https://github.com/esphome/esphome/pull/11937)
- [uart] Setup uart pins only if flags are set [esphome#11914](https://github.com/esphome/esphome/pull/11914)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
