### PR TITLE
[number] Modernize to C++17 nested namespaces

### DIFF
--- a/esphome/components/number/automation.cpp
+++ b/esphome/components/number/automation.cpp
@@ -1,8 +1,7 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 static const char *const TAG = "number.automation";
 
@@ -52,5 +51,4 @@ void ValueRangeTrigger::on_state_(float state) {
   this->rtc_.save(&in_range);
 }
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/automation.h
+++ b/esphome/components/number/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 class NumberStateTrigger : public Trigger<float> {
  public:
@@ -91,5 +90,4 @@ template<typename... Ts> class NumberInRangeCondition : public Condition<Ts...> 
   float max_{NAN};
 };
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 static const char *const TAG = "number";
 
@@ -43,5 +42,4 @@ void Number::add_on_state_callback(std::function<void(float)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -6,8 +6,7 @@
 #include "number_call.h"
 #include "number_traits.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 class Number;
 void log_number(const char *tag, const char *prefix, const char *type, Number *obj);
@@ -53,5 +52,4 @@ class Number : public EntityBase {
   CallbackManager<void(float)> state_callback_;
 };
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number_call.cpp
+++ b/esphome/components/number/number_call.cpp
@@ -2,8 +2,7 @@
 #include "number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 static const char *const TAG = "number";
 
@@ -125,5 +124,4 @@ void NumberCall::perform() {
   this->parent_->control(target_value);
 }
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number_call.h
+++ b/esphome/components/number/number_call.h
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "number_traits.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 class Number;
 
@@ -44,5 +43,4 @@ class NumberCall {
   bool cycle_;
 };
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number_traits.cpp
+++ b/esphome/components/number/number_traits.cpp
@@ -1,10 +1,8 @@
 #include "esphome/core/log.h"
 #include "number_traits.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 static const char *const TAG = "number";
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number

--- a/esphome/components/number/number_traits.h
+++ b/esphome/components/number/number_traits.h
@@ -3,8 +3,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 
 enum NumberMode : uint8_t {
   NUMBER_MODE_AUTO = 0,
@@ -35,5 +34,4 @@ class NumberTraits : public EntityBase_DeviceClass, public EntityBase_UnitOfMeas
   NumberMode mode_{NUMBER_MODE_AUTO};
 };
 
-}  // namespace number
-}  // namespace esphome
+}  // namespace esphome::number


### PR DESCRIPTION
# What does this implement/fix?

Modernizes the `number` component to use C++17 nested namespace syntax. This is a code quality improvement that aligns the codebase with modern C++ standards.

**Changes:**
- Converted traditional nested namespaces to C++17 syntax (`namespace esphome::number` instead of `namespace esphome { namespace number {`)
- Updated all 8 files in the number component (4 headers, 4 implementation files)
- No functional changes, purely syntactic modernization

**Before:**
```cpp
namespace esphome {
namespace number {
  // code here
} // namespace number
} // namespace esphome
```

**After:**
```cpp
namespace esphome::number {
  // code here
} // namespace esphome::number
```

This follows the same pattern established in PR #11929 (binary_sensor) and PR #11935 (cover).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing C++17 modernization effort (related to #11929, #11935)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No changes to configuration - purely internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
