### PR TITLE
[lvgl] Apply scale to spinbox value

### DIFF
--- a/esphome/components/lvgl/widgets/spinbox.py
+++ b/esphome/components/lvgl/widgets/spinbox.py
@@ -1,6 +1,7 @@
 from esphome import automation
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_RANGE_FROM, CONF_RANGE_TO, CONF_STEP, CONF_VALUE
+from esphome.cpp_generator import MockObj
 
 from ..automation import action_to_code
 from ..defines import (
@@ -114,7 +115,9 @@ class SpinboxType(WidgetType):
                 w.obj, digits, digits - config[CONF_DECIMAL_PLACES]
             )
         if (value := config.get(CONF_VALUE)) is not None:
-            lv.spinbox_set_value(w.obj, await lv_float.process(value))
+            lv.spinbox_set_value(
+                w.obj, MockObj(await lv_float.process(value)) * w.get_scale()
+            )
 
     def get_scale(self, config):
         return 10 ** config[CONF_DECIMAL_PLACES]

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -703,7 +703,9 @@ lvgl:
             on_value:
               - lvgl.spinbox.update:
                   id: spinbox_id
-                  value: !lambda return x;
+                  value: !lambda |-
+                      static float yyy = 83.0;
+                      return yyy + .8;
         - button:
             styles: spin_button
             id: spin_up


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Setting a value for a spinbox did not scale it based on the number of decimal digits.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-docs/issues/5495

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
lvgl:
  widgets:
  - button:
      align: top_mid
      text: Set value
      on_click:
        lvgl.spinbox.update:
          id: spinbox_id
          value: 83.5
  - spinbox:
      id: spinbox_id
      align: CENTER
      text_align: CENTER
      range_from: 1
      range_to: 100
      digits: 3
      decimal_places: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
