### PR TITLE
[dashboard_import] Store package import URL in .rodata instead of RAM

### DIFF
--- a/esphome/components/dashboard_import/dashboard_import.cpp
+++ b/esphome/components/dashboard_import/dashboard_import.cpp
@@ -3,10 +3,10 @@
 namespace esphome {
 namespace dashboard_import {
 
-static std::string g_package_import_url;  // NOLINT
+static const char *g_package_import_url = "";  // NOLINT
 
-const std::string &get_package_import_url() { return g_package_import_url; }
-void set_package_import_url(std::string url) { g_package_import_url = std::move(url); }
+const char *get_package_import_url() { return g_package_import_url; }
+void set_package_import_url(const char *url) { g_package_import_url = url; }
 
 }  // namespace dashboard_import
 }  // namespace esphome

--- a/esphome/components/dashboard_import/dashboard_import.h
+++ b/esphome/components/dashboard_import/dashboard_import.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <string>
-
 namespace esphome {
 namespace dashboard_import {
 
-const std::string &get_package_import_url();
-void set_package_import_url(std::string url);
+const char *get_package_import_url();
+void set_package_import_url(const char *url);
 
 }  // namespace dashboard_import
 }  // namespace esphome

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -135,8 +135,7 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
 
 #ifdef USE_DASHBOARD_IMPORT
     MDNS_STATIC_CONST_CHAR(TXT_PACKAGE_IMPORT_URL, "package_import_url");
-    txt_records.push_back(
-        {MDNS_STR(TXT_PACKAGE_IMPORT_URL), MDNS_STR(dashboard_import::get_package_import_url().c_str())});
+    txt_records.push_back({MDNS_STR(TXT_PACKAGE_IMPORT_URL), MDNS_STR(dashboard_import::get_package_import_url())});
 #endif
   }
 #endif  // USE_API


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `dashboard_import` to store the package import URL as a `const char*` pointer to `.rodata` instead of a `std::string` in RAM.

## Motivation

The package import URL is set once during `setup()` from a compile-time constant string literal and never modified. The previous implementation using `std::string` caused the URL to be stored twice:
1. String literal in `.rodata` (flash/ROM)
2. `std::string` heap-allocated copy in RAM

Since mDNS advertises this value during startup and it's a compile-time constant from YAML configuration, there's no reason to keep a mutable copy in RAM.

## Why This Wasn't Optimized Before

I initially avoided this optimization thinking an external component might need to set the URL at runtime. However, this doesn't make sense because:
- mDNS needs the URL by `setup()` time to advertise it
- Setting it after `setup()` would be too late for discovery
- The value comes from YAML configuration (compile-time constant)

Therefore, runtime mutability serves no purpose and we can safely use `.rodata` storage.

## Implementation Notes

The string literal generated by codegen (e.g., `"github://esphome/example-configs/test.yaml@main"`) is automatically stored in flash (`.rodata` section). The global now just holds a pointer to this flash location instead of making a heap copy.

On ESP8266, `.rodata` is accessed via flash reads (not consuming RAM). On ESP32, the string is in flash and accessed via XIP (execute-in-place). Either way, only the 4-byte pointer consumes RAM.

## Why Not PROGMEM?

For a single string, the PROGMEM complexity on ESP8266 isn't worth it since:
- Would need `FPSTR()` to read from PROGMEM
- Would need to copy to RAM buffer anyway to use with APIs
- Defeats the purpose of the optimization

The simple `const char*` approach provides most of the benefit with minimal complexity.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [x] Other (memory optimization)

**Related issue or feature (if applicable):**

- Part of ongoing embedded systems memory optimization efforts

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a transparent optimization

esphome:
  name: test
  project:
    name: test.project
    version: "1.0"

esp32:
  board: esp32dev
  framework:
    type: esp-idf

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:

dashboard_import:
  package_import_url: github://esphome/example-configs/test.yaml@main
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
