### PR TITLE
[api] Reduce heap allocations in DeviceInfoResponse

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1451,8 +1451,11 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
 #ifdef USE_AREAS
   resp.set_suggested_area(StringRef(App.get_area()));
 #endif
-  // mac_address must store temporary string - will be valid during send_message call
-  std::string mac_address = get_mac_address_pretty();
+  // Stack buffer for MAC address (XX:XX:XX:XX:XX:XX\0 = 18 bytes)
+  char mac_address[18];
+  uint8_t mac[6];
+  get_mac_address_raw(mac);
+  format_mac_addr_upper(mac, mac_address);
   resp.set_mac_address(StringRef(mac_address));
 
   resp.set_esphome_version(ESPHOME_VERSION_REF);
@@ -1493,8 +1496,9 @@ bool APIConnection::send_device_info_response(const DeviceInfoRequest &msg) {
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   resp.bluetooth_proxy_feature_flags = bluetooth_proxy::global_bluetooth_proxy->get_feature_flags();
-  // bt_mac must store temporary string - will be valid during send_message call
-  std::string bluetooth_mac = bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty();
+  // Stack buffer for Bluetooth MAC address (XX:XX:XX:XX:XX:XX\0 = 18 bytes)
+  char bluetooth_mac[18];
+  bluetooth_proxy::global_bluetooth_proxy->get_bluetooth_mac_address_pretty(bluetooth_mac);
   resp.set_bluetooth_mac_address(StringRef(bluetooth_mac));
 #endif
 #ifdef USE_VOICE_ASSISTANT

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -130,11 +130,9 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
     return flags;
   }
 
-  std::string get_bluetooth_mac_address_pretty() {
+  void get_bluetooth_mac_address_pretty(std::span<char, 18> output) {
     const uint8_t *mac = esp_bt_dev_get_address();
-    char buf[18];
-    format_mac_addr_upper(mac, buf);
-    return std::string(buf);
+    format_mac_addr_upper(mac, output.data());
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations when responding to DeviceInfoResponse API calls by using stack buffers instead of heap-allocated strings for MAC addresses.

## Changes

This PR eliminates two heap allocations per DeviceInfoResponse:

1. **Device MAC address**: Changed from `std::string mac_address = get_mac_address_pretty()` to stack buffer
2. **Bluetooth MAC address**: Changed `get_bluetooth_mac_address_pretty()` to write into a provided buffer instead of allocating a string

**Impact**: DeviceInfoResponse is called during Home Assistant's config flow probing for every ESPHome device discovery and connection. Reducing heap churn here improves connection reliability and performance, especially on ESP8266 and other memory-constrained devices.

**Implementation details**:
- Added compile-time safe `std::span<char, 18>` parameter to `get_bluetooth_mac_address_pretty()`
- Uses stack-allocated `char[18]` buffers (size for "XX:XX:XX:XX:XX:XX\0")
- Buffers remain valid during `send_message()` call via `StringRef`

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Reduces heap fragmentation during config flow probing

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
