### PR TITLE
[Tuya] Fixed missing brightness mode for CT dimmer

### DIFF
--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -115,13 +115,13 @@ light::LightTraits TuyaLight::get_traits() {
   if (this->color_temperature_id_.has_value() && this->dimmer_id_.has_value()) {
     if (this->color_id_.has_value()) {
       if (this->color_interlock_) {
-        traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE});
+        traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
       } else {
         traits.set_supported_color_modes(
-            {light::ColorMode::RGB_COLOR_TEMPERATURE, light::ColorMode::COLOR_TEMPERATURE});
+            {light::ColorMode::RGB_COLOR_TEMPERATURE, light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
       }
     } else {
-      traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE});
+      traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
     }
     traits.set_min_mireds(this->cold_white_temperature_);
     traits.set_max_mireds(this->warm_white_temperature_);

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -115,10 +115,11 @@ light::LightTraits TuyaLight::get_traits() {
   if (this->color_temperature_id_.has_value() && this->dimmer_id_.has_value()) {
     if (this->color_id_.has_value()) {
       if (this->color_interlock_) {
-        traits.set_supported_color_modes({light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
-      } else {
         traits.set_supported_color_modes(
-            {light::ColorMode::RGB_COLOR_TEMPERATURE, light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
+            {light::ColorMode::RGB, light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});
+      } else {
+        traits.set_supported_color_modes({light::ColorMode::RGB_COLOR_TEMPERATURE, light::ColorMode::COLOR_TEMPERATURE,
+                                          light::ColorMode::BRIGHTNESS});
       }
     } else {
       traits.set_supported_color_modes({light::ColorMode::COLOR_TEMPERATURE, light::ColorMode::BRIGHTNESS});


### PR DESCRIPTION
# What does this implement/fix?

I have a tuyamcu desk lamp with cold and warm white and dimming possibility. Although flashed with esphome (see yaml) the behavior was not as expected - any state changes done to the light from HA were quickly "reverted" by the lamp.
In the logs I noticed this error:

[W][light:023]: 'Light': brightness not supported

After some debugging I found that the tuya_light does not set the BRIGHTNESS mode correctly. Setting it has fixed the issue.
I assume that if a light has a valid dimmer datapoint set, then it always needs the BRIGHTNESS mode, so I added it also in two other places.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: "tuya"
    id: tuya_light
    name: Light
    switch_datapoint: 1
    dimmer_datapoint: 3
    min_value: 25
    color_temperature_datapoint: 4
    restore_mode: RESTORE_DEFAULT_OFF
    cold_white_color_temperature: 6500 K
    warm_white_color_temperature: 2700 K
    color_temperature_invert: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
