### PR TITLE
[ld24xx] Use stack allocation for MAC and version formatting

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -13,8 +13,6 @@ namespace esphome {
 namespace ld2410 {
 
 static const char *const TAG = "ld2410";
-static const char *const UNKNOWN_MAC = "unknown";
-static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
 enum BaudRate : uint8_t {
   BAUD_RATE_9600 = 1,
@@ -181,15 +179,15 @@ static inline bool validate_header_footer(const uint8_t *header_footer, const ui
 }
 
 void LD2410Component::dump_config() {
-  std::string mac_str =
-      mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-  std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                    this->version_[4], this->version_[3], this->version_[2]);
+  char mac_s[18];
+  char version_s[20];
+  const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+  ld24xx::format_version_str(this->version_, version_s);
   ESP_LOGCONFIG(TAG,
                 "LD2410:\n"
                 "  Firmware version: %s\n"
                 "  MAC address: %s",
-                version.c_str(), mac_str.c_str());
+                version_s, mac_str);
 #ifdef USE_BINARY_SENSOR
   ESP_LOGCONFIG(TAG, "Binary Sensors:");
   LOG_BINARY_SENSOR("  ", "Target", this->target_binary_sensor_);
@@ -448,12 +446,12 @@ bool LD2410Component::handle_ack_data_() {
 
     case CMD_QUERY_VERSION: {
       std::memcpy(this->version_, &this->buffer_data_[12], sizeof(this->version_));
-      std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                        this->version_[4], this->version_[3], this->version_[2]);
-      ESP_LOGV(TAG, "Firmware version: %s", version.c_str());
+      char version_s[20];
+      ld24xx::format_version_str(this->version_, version_s);
+      ESP_LOGV(TAG, "Firmware version: %s", version_s);
 #ifdef USE_TEXT_SENSOR
       if (this->version_text_sensor_ != nullptr) {
-        this->version_text_sensor_->publish_state(version);
+        this->version_text_sensor_->publish_state(version_s);
       }
 #endif
       break;
@@ -506,9 +504,9 @@ bool LD2410Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      std::string mac_str =
-          mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-      ESP_LOGV(TAG, "MAC address: %s", mac_str.c_str());
+      char mac_s[18];
+      const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+      ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR
       if (this->mac_text_sensor_ != nullptr) {
         this->mac_text_sensor_->publish_state(mac_str);

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -14,8 +14,6 @@ namespace esphome {
 namespace ld2412 {
 
 static const char *const TAG = "ld2412";
-static const char *const UNKNOWN_MAC = "unknown";
-static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
 enum BaudRate : uint8_t {
   BAUD_RATE_9600 = 1,
@@ -200,15 +198,15 @@ static inline bool validate_header_footer(const uint8_t *header_footer, const ui
 }
 
 void LD2412Component::dump_config() {
-  std::string mac_str =
-      mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-  std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                    this->version_[4], this->version_[3], this->version_[2]);
+  char mac_s[18];
+  char version_s[20];
+  const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+  ld24xx::format_version_str(this->version_, version_s);
   ESP_LOGCONFIG(TAG,
                 "LD2412:\n"
                 "  Firmware version: %s\n"
                 "  MAC address: %s",
-                version.c_str(), mac_str.c_str());
+                version_s, mac_str);
 #ifdef USE_BINARY_SENSOR
   ESP_LOGCONFIG(TAG, "Binary Sensors:");
   LOG_BINARY_SENSOR("  ", "DynamicBackgroundCorrectionStatus",
@@ -492,12 +490,12 @@ bool LD2412Component::handle_ack_data_() {
 
     case CMD_QUERY_VERSION: {
       std::memcpy(this->version_, &this->buffer_data_[12], sizeof(this->version_));
-      std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                        this->version_[4], this->version_[3], this->version_[2]);
-      ESP_LOGV(TAG, "Firmware version: %s", version.c_str());
+      char version_s[20];
+      ld24xx::format_version_str(this->version_, version_s);
+      ESP_LOGV(TAG, "Firmware version: %s", version_s);
 #ifdef USE_TEXT_SENSOR
       if (this->version_text_sensor_ != nullptr) {
-        this->version_text_sensor_->publish_state(version);
+        this->version_text_sensor_->publish_state(version_s);
       }
 #endif
       break;
@@ -544,9 +542,9 @@ bool LD2412Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      std::string mac_str =
-          mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-      ESP_LOGV(TAG, "MAC address: %s", mac_str.c_str());
+      char mac_s[18];
+      const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+      ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR
       if (this->mac_text_sensor_ != nullptr) {
         this->mac_text_sensor_->publish_state(mac_str);

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -17,8 +17,6 @@ namespace esphome {
 namespace ld2450 {
 
 static const char *const TAG = "ld2450";
-static const char *const UNKNOWN_MAC = "unknown";
-static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
 
 enum BaudRate : uint8_t {
   BAUD_RATE_9600 = 1,
@@ -192,15 +190,15 @@ void LD2450Component::setup() {
 }
 
 void LD2450Component::dump_config() {
-  std::string mac_str =
-      mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-  std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                    this->version_[4], this->version_[3], this->version_[2]);
+  char mac_s[18];
+  char version_s[20];
+  const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+  ld24xx::format_version_str(this->version_, version_s);
   ESP_LOGCONFIG(TAG,
                 "LD2450:\n"
                 "  Firmware version: %s\n"
                 "  MAC address: %s",
-                version.c_str(), mac_str.c_str());
+                version_s, mac_str);
 #ifdef USE_BINARY_SENSOR
   ESP_LOGCONFIG(TAG, "Binary Sensors:");
   LOG_BINARY_SENSOR("  ", "MovingTarget", this->moving_target_binary_sensor_);
@@ -642,12 +640,12 @@ bool LD2450Component::handle_ack_data_() {
 
     case CMD_QUERY_VERSION: {
       std::memcpy(this->version_, &this->buffer_data_[12], sizeof(this->version_));
-      std::string version = str_sprintf(VERSION_FMT, this->version_[1], this->version_[0], this->version_[5],
-                                        this->version_[4], this->version_[3], this->version_[2]);
-      ESP_LOGV(TAG, "Firmware version: %s", version.c_str());
+      char version_s[20];
+      ld24xx::format_version_str(this->version_, version_s);
+      ESP_LOGV(TAG, "Firmware version: %s", version_s);
 #ifdef USE_TEXT_SENSOR
       if (this->version_text_sensor_ != nullptr) {
-        this->version_text_sensor_->publish_state(version);
+        this->version_text_sensor_->publish_state(version_s);
       }
 #endif
       break;
@@ -663,9 +661,9 @@ bool LD2450Component::handle_ack_data_() {
         std::memcpy(this->mac_address_, &this->buffer_data_[10], sizeof(this->mac_address_));
       }
 
-      std::string mac_str =
-          mac_address_is_valid(this->mac_address_) ? format_mac_address_pretty(this->mac_address_) : UNKNOWN_MAC;
-      ESP_LOGV(TAG, "MAC address: %s", mac_str.c_str());
+      char mac_s[18];
+      const char *mac_str = ld24xx::format_mac_str(this->mac_address_, mac_s);
+      ESP_LOGV(TAG, "MAC address: %s", mac_str);
 #ifdef USE_TEXT_SENSOR
       if (this->mac_text_sensor_ != nullptr) {
         this->mac_text_sensor_->publish_state(mac_str);

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 
 #include <memory>
+#include <span>
 
 #ifdef USE_SENSOR
 #include "esphome/core/helpers.h"
@@ -38,6 +40,27 @@
 
 namespace esphome {
 namespace ld24xx {
+
+static const char *const UNKNOWN_MAC = "unknown";
+static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
+
+// Helper function to format MAC address with stack allocation
+// Returns pointer to UNKNOWN_MAC constant or formatted buffer
+// Buffer must be exactly 18 bytes (17 for "XX:XX:XX:XX:XX:XX" + null terminator)
+inline const char *format_mac_str(const uint8_t *mac_address, std::span<char, 18> buffer) {
+  if (mac_address_is_valid(mac_address)) {
+    format_mac_addr_upper(mac_address, buffer.data());
+    return buffer.data();
+  }
+  return UNKNOWN_MAC;
+}
+
+// Helper function to format firmware version with stack allocation
+// Buffer must be exactly 20 bytes (format: "x.xxXXXXXX" fits in 11 + null terminator, 20 for safety)
+inline void format_version_str(const uint8_t *version, std::span<char, 20> buffer) {
+  snprintf(buffer.data(), buffer.size(), VERSION_FMT, version[1], version[0], version[5], version[4], version[3],
+           version[2]);
+}
 
 #ifdef USE_SENSOR
 // Helper class to store a sensor with a deduplicator & publish state only when the value changes

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -7,7 +7,6 @@
 #include <span>
 
 #ifdef USE_SENSOR
-#include "esphome/core/helpers.h"
 #include "esphome/components/sensor/sensor.h"
 
 #define SUB_SENSOR_WITH_DEDUP(name, dedup_type) \


### PR DESCRIPTION
# What does this implement/fix?

This PR optimizes MAC address and firmware version formatting in the LD2410, LD2412, and LD2450 components by replacing heap-allocated strings with stack-allocated buffers. It also consolidates common code into shared helper functions in the `ld24xx` component.

**Changes:**
1. Created shared helper functions in `esphome/components/ld24xx/ld24xx.h`:
   - `format_mac_str()` - Formats MAC addresses using stack allocation with compile-time size safety via `std::span<char, 18>`
   - `format_version_str()` - Formats firmware versions using stack allocation with compile-time size safety via `std::span<char, 20>`
   - Moved `UNKNOWN_MAC` and `VERSION_FMT` constants to the shared `ld24xx` namespace to eliminate duplication

2. Updated LD2410, LD2412, and LD2450 components to:
   - Replace `format_mac_address_pretty()` (which returns `std::string`) with stack-based `format_mac_str()`
   - Replace `str_sprintf()` for version formatting (which returns `std::string`) with stack-based `format_version_str()`
   - Remove duplicate `UNKNOWN_MAC` and `VERSION_FMT` definitions from each component

**Benefits:**
- Eliminates 2 heap allocations per `dump_config()` call and 1-2 per MAC query
- Reduces memory fragmentation on resource-constrained devices
- Provides compile-time buffer size validation via fixed-size `std::span`
- Consolidates duplicate code across three components into reusable helpers
- Follows the same optimization pattern as the WiFi component (commit 29a50da6)

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Related to ongoing memory optimization efforts for embedded targets

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
# Existing LD2410, LD2412, and LD2450 configurations work unchanged

ld2410:
  # ... existing config

ld2412:
  # ... existing config

ld2450:
  # ... existing config
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
