### PR TITLE
[wifi, captive_portal, web_server, wifi_info] Use stack allocation for MAC address formatting

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -13,14 +13,16 @@ static const char *const TAG = "captive_portal";
 void CaptivePortal::handle_config(AsyncWebServerRequest *request) {
   AsyncResponseStream *stream = request->beginResponseStream(ESPHOME_F("application/json"));
   stream->addHeader(ESPHOME_F("cache-control"), ESPHOME_F("public, max-age=0, must-revalidate"));
+  char mac_s[18];
+  const char *mac_str = get_mac_address_pretty_into_buffer(mac_s);
 #ifdef USE_ESP8266
   stream->print(ESPHOME_F("{\"mac\":\""));
-  stream->print(get_mac_address_pretty().c_str());
+  stream->print(mac_str);
   stream->print(ESPHOME_F("\",\"name\":\""));
   stream->print(App.get_name().c_str());
   stream->print(ESPHOME_F("\",\"aps\":[{}"));
 #else
-  stream->printf(R"({"mac":"%s","name":"%s","aps":[{})", get_mac_address_pretty().c_str(), App.get_name().c_str());
+  stream->printf(R"({"mac":"%s","name":"%s","aps":[{})", mac_str, App.get_name().c_str());
 #endif
 
   for (auto &scan : wifi::global_wifi_component->get_scan_result()) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -359,8 +359,8 @@ void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response = request->beginResponse(200, "");
   response->addHeader(HEADER_CORS_ALLOW_PNA, "true");
   response->addHeader(HEADER_PNA_NAME, App.get_name().c_str());
-  std::string mac = get_mac_address_pretty();
-  response->addHeader(HEADER_PNA_ID, mac.c_str());
+  char mac_s[18];
+  response->addHeader(HEADER_PNA_ID, get_mac_address_pretty_into_buffer(mac_s));
   request->send(response);
 }
 #endif

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -334,10 +334,11 @@ void WiFiComponent::setup() {
 }
 
 void WiFiComponent::start() {
+  char mac_s[18];
   ESP_LOGCONFIG(TAG,
                 "Starting\n"
                 "  Local MAC: %s",
-                get_mac_address_pretty().c_str());
+                get_mac_address_pretty_into_buffer(mac_s));
   this->last_connected_ = millis();
 
   uint32_t hash = this->has_sta() ? fnv1_hash(App.get_compilation_time()) : 88491487UL;
@@ -800,7 +801,8 @@ void WiFiComponent::print_connect_params_() {
   char bssid_s[18];
   format_mac_addr_upper(bssid.data(), bssid_s);
 
-  ESP_LOGCONFIG(TAG, "  Local MAC: %s", get_mac_address_pretty().c_str());
+  char mac_s[18];
+  ESP_LOGCONFIG(TAG, "  Local MAC: %s", get_mac_address_pretty_into_buffer(mac_s));
   if (this->is_disabled()) {
     ESP_LOGCONFIG(TAG, "  Disabled");
     return;

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -126,7 +126,10 @@ class BSSIDWiFiInfo : public PollingComponent, public text_sensor::TextSensor {
 
 class MacAddressWifiInfo : public Component, public text_sensor::TextSensor {
  public:
-  void setup() override { this->publish_state(get_mac_address_pretty()); }
+  void setup() override {
+    char mac_s[18];
+    this->publish_state(get_mac_address_pretty_into_buffer(mac_s));
+  }
   void dump_config() override;
 };
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -638,9 +638,8 @@ std::string get_mac_address() {
 }
 
 std::string get_mac_address_pretty() {
-  uint8_t mac[6];
-  get_mac_address_raw(mac);
-  return format_mac_address_pretty(mac);
+  char buf[18];
+  return std::string(get_mac_address_pretty_into_buffer(buf));
 }
 
 void get_mac_address_into_buffer(std::span<char, 13> buf) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -648,6 +648,13 @@ void get_mac_address_into_buffer(std::span<char, 13> buf) {
   format_mac_addr_lower_no_sep(mac, buf.data());
 }
 
+const char *get_mac_address_pretty_into_buffer(std::span<char, 18> buf) {
+  uint8_t mac[6];
+  get_mac_address_raw(mac);
+  format_mac_addr_upper(mac, buf.data());
+  return buf.data();
+}
+
 #ifndef USE_ESP32
 bool has_custom_mac_address() { return false; }
 #endif

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1055,12 +1055,7 @@ void get_mac_address_into_buffer(std::span<char, 13> buf);
 /// Get the device MAC address into the given buffer, in colon-separated uppercase hex notation.
 /// Buffer must be exactly 18 bytes (17 for "XX:XX:XX:XX:XX:XX" + null terminator).
 /// Returns pointer to the buffer for convenience.
-inline const char *get_mac_address_pretty_into_buffer(std::span<char, 18> buf) {
-  uint8_t mac[6];
-  get_mac_address_raw(mac);
-  format_mac_addr_upper(mac, buf.data());
-  return buf.data();
-}
+const char *get_mac_address_pretty_into_buffer(std::span<char, 18> buf);
 
 #ifdef USE_ESP32
 /// Set the MAC address to use from the provided byte array (6 bytes).

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1052,6 +1052,16 @@ std::string get_mac_address_pretty();
 /// Assumes buffer length is 13 (12 digits for hexadecimal representation followed by null terminator).
 void get_mac_address_into_buffer(std::span<char, 13> buf);
 
+/// Get the device MAC address into the given buffer, in colon-separated uppercase hex notation.
+/// Buffer must be exactly 18 bytes (17 for "XX:XX:XX:XX:XX:XX" + null terminator).
+/// Returns pointer to the buffer for convenience.
+inline const char *get_mac_address_pretty_into_buffer(std::span<char, 18> buf) {
+  uint8_t mac[6];
+  get_mac_address_raw(mac);
+  format_mac_addr_upper(mac, buf.data());
+  return buf.data();
+}
+
 #ifdef USE_ESP32
 /// Set the MAC address to use from the provided byte array (6 bytes).
 void set_mac_address(uint8_t *mac);


### PR DESCRIPTION
# What does this implement/fix?

This PR eliminates heap allocations from MAC address formatting in core components (WiFi, captive_portal, web_server, wifi_info) by introducing a new stack-based helper function with compile-time buffer size safety.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Continues MAC address formatting optimization from commit 29a50da6
- Related to ld24xx optimization
- Part of ongoing memory optimization efforts for embedded targets

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization only
# All existing configurations work unchanged

wifi:
  ssid: "MyNetwork"
  password: "password"

captive_portal:

web_server:
  port: 80

text_sensor:
  - platform: wifi_info
    mac_address:
      name: "MAC Address"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
