### PR TITLE
[wifi] Fix captive portal unusable when WiFi credentials are wrong

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -74,9 +74,10 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     # Register socket needs for DNS server and additional HTTP connections
     # - 1 UDP socket for DNS server
-    # - 3 additional TCP sockets for captive portal HTTP connections
-    #   OS captive portal detection makes multiple simultaneous probe requests.
-    #   LRU purging will reclaim idle sockets, but we need enough for the initial burst.
+    # - 3 additional TCP sockets for captive portal detection probes + configuration requests
+    #   OS captive portal detection makes multiple probe requests that stay in TIME_WAIT.
+    #   Need headroom for actual user configuration requests.
+    #   LRU purging will reclaim idle sockets to prevent exhaustion from repeated attempts.
     from esphome.components import socket
 
     socket.consume_sockets(4, "captive_portal")(config)

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -72,10 +72,14 @@ def _final_validate(config: ConfigType) -> ConfigType:
             "Add 'ap:' to your WiFi configuration to enable the captive portal."
         )
 
-    # Register socket needs for DNS server (1 UDP socket)
+    # Register socket needs for DNS server and additional HTTP connections
+    # - 1 UDP socket for DNS server
+    # - 2 additional TCP sockets for captive portal detection probes + configuration requests
+    #   (OS captive portal detection makes multiple probe requests that stay in TIME_WAIT,
+    #    need headroom for actual user configuration requests)
     from esphome.components import socket
 
-    socket.consume_sockets(1, "captive_portal")(config)
+    socket.consume_sockets(3, "captive_portal")(config)
 
     return config
 

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -72,6 +72,11 @@ def _final_validate(config: ConfigType) -> ConfigType:
             "Add 'ap:' to your WiFi configuration to enable the captive portal."
         )
 
+    # Register socket needs for DNS server (1 UDP socket)
+    from esphome.components import socket
+
+    socket.consume_sockets(1, "captive_portal")(config)
+
     return config
 
 

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -74,9 +74,9 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     # Register socket needs for DNS server and additional HTTP connections
     # - 1 UDP socket for DNS server
-    # - 3 additional TCP sockets for captive portal detection probes + configuration requests
-    #   (OS captive portal detection makes multiple probe requests that stay in TIME_WAIT,
-    #    need headroom for actual user configuration requests)
+    # - 3 additional TCP sockets for captive portal HTTP connections
+    #   OS captive portal detection makes multiple simultaneous probe requests.
+    #   LRU purging will reclaim idle sockets, but we need enough for the initial burst.
     from esphome.components import socket
 
     socket.consume_sockets(4, "captive_portal")(config)

--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -74,12 +74,12 @@ def _final_validate(config: ConfigType) -> ConfigType:
 
     # Register socket needs for DNS server and additional HTTP connections
     # - 1 UDP socket for DNS server
-    # - 2 additional TCP sockets for captive portal detection probes + configuration requests
+    # - 3 additional TCP sockets for captive portal detection probes + configuration requests
     #   (OS captive portal detection makes multiple probe requests that stay in TIME_WAIT,
     #    need headroom for actual user configuration requests)
     from esphome.components import socket
 
-    socket.consume_sockets(3, "captive_portal")(config)
+    socket.consume_sockets(4, "captive_portal")(config)
 
     return config
 

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -63,7 +63,7 @@ void CaptivePortal::start() {
   this->base_->init();
   if (!this->initialized_) {
     this->base_->add_handler(this);
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
     // Enable LRU socket purging to handle captive portal detection probe bursts
     // OS captive portal detection makes many simultaneous HTTP requests which can
     // exhaust sockets. LRU purging automatically closes oldest idle connections.

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -51,7 +51,8 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  SSID='%s'", ssid.c_str());
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   wifi::global_wifi_component->save_wifi_sta(ssid, psk);
-  wifi::global_wifi_component->start_scanning();
+  // Don't call start_scanning() from HTTP thread - WiFi operations must happen on main loop
+  // The force_scan_after_provision_ flag will trigger scan on next retry cycle
   request->redirect(ESPHOME_F("/?save"));
 }
 

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -50,9 +50,8 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "Requested WiFi Settings Change:");
   ESP_LOGI(TAG, "  SSID='%s'", ssid.c_str());
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
-  wifi::global_wifi_component->save_wifi_sta(ssid, psk);
-  // Don't call start_scanning() from HTTP thread - WiFi operations must happen on main loop
-  // The force_scan_after_provision_ flag will trigger scan on next retry cycle
+  // Defer save to main loop thread to avoid NVS operations from HTTP thread
+  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
   request->redirect(ESPHOME_F("/?save"));
 }
 

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -63,6 +63,12 @@ void CaptivePortal::start() {
   this->base_->init();
   if (!this->initialized_) {
     this->base_->add_handler(this);
+#ifdef USE_ESP_IDF
+    // Enable LRU socket purging to handle captive portal detection probe bursts
+    // OS captive portal detection makes many simultaneous HTTP requests which can
+    // exhaust sockets. LRU purging automatically closes oldest idle connections.
+    this->base_->get_server()->set_lru_purge_enable(true);
+#endif
   }
 
   network::IPAddress ip = wifi::global_wifi_component->wifi_soft_ap_ip();

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -53,8 +53,8 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
   this->defer([ssid, psk]() {
     wifi::global_wifi_component->save_wifi_sta(ssid, psk);
-    // Trigger immediate retry to attempt connection with new credentials
-    wifi::global_wifi_component->retry_connect();
+    // Trigger connection attempt (exits cooldown if needed)
+    wifi::global_wifi_component->connect_soon();
   });
   request->redirect(ESPHOME_F("/?save"));
 }

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -51,11 +51,7 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  SSID='%s'", ssid.c_str());
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
-  this->defer([ssid, psk]() {
-    wifi::global_wifi_component->save_wifi_sta(ssid, psk);
-    // Trigger connection attempt (exits cooldown if needed)
-    wifi::global_wifi_component->connect_soon();
-  });
+  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
   request->redirect(ESPHOME_F("/?save"));
 }
 

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -51,7 +51,11 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  SSID='%s'", ssid.c_str());
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
-  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
+  this->defer([ssid, psk]() {
+    wifi::global_wifi_component->save_wifi_sta(ssid, psk);
+    // Trigger immediate retry to attempt connection with new credentials
+    wifi::global_wifi_component->retry_connect();
+  });
   request->redirect(ESPHOME_F("/?save"));
 }
 

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -52,13 +52,7 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   wifi::global_wifi_component->save_wifi_sta(ssid, psk);
   wifi::global_wifi_component->start_scanning();
-
-  // Add Connection: close header to ensure socket is released immediately
-  // Without this, sockets can stay in TIME_WAIT and exhaust the socket pool
-  auto *response = request->beginResponse(302, ESPHOME_F("text/plain"), ESPHOME_F(""));
-  response->addHeader(ESPHOME_F("Location"), ESPHOME_F("/?save"));
-  response->addHeader(ESPHOME_F("Connection"), ESPHOME_F("close"));
-  request->send(response);
+  request->redirect(ESPHOME_F("/?save"));
 }
 
 void CaptivePortal::setup() {

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -52,7 +52,13 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   ESP_LOGI(TAG, "  Password=" LOG_SECRET("'%s'"), psk.c_str());
   wifi::global_wifi_component->save_wifi_sta(ssid, psk);
   wifi::global_wifi_component->start_scanning();
-  request->redirect(ESPHOME_F("/?save"));
+
+  // Add Connection: close header to ensure socket is released immediately
+  // Without this, sockets can stay in TIME_WAIT and exhaust the socket pool
+  auto *response = request->beginResponse(302, ESPHOME_F("text/plain"), ESPHOME_F(""));
+  response->addHeader(ESPHOME_F("Location"), ESPHOME_F("/?save"));
+  response->addHeader(ESPHOME_F("Connection"), ESPHOME_F("close"));
+  request->send(response);
 }
 
 void CaptivePortal::setup() {

--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -40,6 +40,10 @@ class CaptivePortal : public AsyncWebHandler, public Component {
   void end() {
     this->active_ = false;
     this->disable_loop();  // Stop processing DNS requests
+#ifdef USE_ESP_IDF
+    // Disable LRU socket purging now that captive portal is done
+    this->base_->get_server()->set_lru_purge_enable(false);
+#endif
     this->base_->deinit();
     if (this->dns_server_ != nullptr) {
       this->dns_server_->stop();

--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -40,7 +40,7 @@ class CaptivePortal : public AsyncWebHandler, public Component {
   void end() {
     this->active_ = false;
     this->disable_loop();  // Stop processing DNS requests
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
     // Disable LRU socket purging now that captive portal is done
     this->base_->get_server()->set_lru_purge_enable(false);
 #endif

--- a/esphome/components/esp32_improv/__init__.py
+++ b/esphome/components/esp32_improv/__init__.py
@@ -20,6 +20,10 @@ CONF_ON_STOP = "on_stop"
 CONF_STATUS_INDICATOR = "status_indicator"
 CONF_WIFI_TIMEOUT = "wifi_timeout"
 
+# Default WiFi timeout - aligned with WiFi component ap_timeout
+# Allows sufficient time to try all BSSIDs before starting provisioning mode
+DEFAULT_WIFI_TIMEOUT = "90s"
+
 
 improv_ns = cg.esphome_ns.namespace("improv")
 Error = improv_ns.enum("Error")
@@ -59,7 +63,7 @@ CONFIG_SCHEMA = (
                 CONF_AUTHORIZED_DURATION, default="1min"
             ): cv.positive_time_period_milliseconds,
             cv.Optional(
-                CONF_WIFI_TIMEOUT, default="1min"
+                CONF_WIFI_TIMEOUT, default=DEFAULT_WIFI_TIMEOUT
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_ON_PROVISIONED): automation.validate_automation(
                 {

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -127,6 +127,7 @@ void ESP32ImprovComponent::loop() {
           // Set initial state based on whether we have an authorizer
           this->set_state_(this->get_initial_state_(), false);
           this->set_error_(improv::ERROR_NONE);
+          this->should_start_ = false;  // Clear flag after starting
           ESP_LOGD(TAG, "Service started!");
         }
       }

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -381,8 +381,8 @@ void ESP32ImprovComponent::check_wifi_connection_() {
 
   if (this->state_ == improv::STATE_PROVISIONING) {
     wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(), this->connecting_sta_.get_password());
-    // Trigger immediate retry to attempt connection with new credentials
-    wifi::global_wifi_component->retry_connect();
+    // Trigger connection attempt (exits cooldown if needed, no-op if already connected)
+    wifi::global_wifi_component->connect_soon();
     this->connecting_sta_ = {};
     this->cancel_timeout("wifi-connect-timeout");
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -381,8 +381,6 @@ void ESP32ImprovComponent::check_wifi_connection_() {
 
   if (this->state_ == improv::STATE_PROVISIONING) {
     wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(), this->connecting_sta_.get_password());
-    // Trigger connection attempt (exits cooldown if needed, no-op if already connected)
-    wifi::global_wifi_component->connect_soon();
     this->connecting_sta_ = {};
     this->cancel_timeout("wifi-connect-timeout");
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -381,6 +381,8 @@ void ESP32ImprovComponent::check_wifi_connection_() {
 
   if (this->state_ == improv::STATE_PROVISIONING) {
     wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(), this->connecting_sta_.get_password());
+    // Trigger immediate retry to attempt connection with new credentials
+    wifi::global_wifi_component->retry_connect();
     this->connecting_sta_ = {};
     this->cancel_timeout("wifi-connect-timeout");
 

--- a/esphome/components/esp32_improv/esp32_improv_component.h
+++ b/esphome/components/esp32_improv/esp32_improv_component.h
@@ -45,6 +45,7 @@ class ESP32ImprovComponent : public Component, public improv_base::ImprovBase {
   void start();
   void stop();
   bool is_active() const { return this->state_ != improv::STATE_STOPPED; }
+  bool should_start() const { return this->should_start_; }
 
 #ifdef USE_ESP32_IMPROV_STATE_CALLBACK
   void add_on_state_callback(std::function<void(improv::State, improv::Error)> &&callback) {

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -50,6 +50,8 @@ void ImprovSerialComponent::loop() {
     if (wifi::global_wifi_component->is_connected()) {
       wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(),
                                                  this->connecting_sta_.get_password());
+      // Trigger immediate retry to attempt connection with new credentials
+      wifi::global_wifi_component->retry_connect();
       this->connecting_sta_ = {};
       this->cancel_timeout("wifi-connect-timeout");
       this->set_state_(improv::STATE_PROVISIONED);

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -50,8 +50,6 @@ void ImprovSerialComponent::loop() {
     if (wifi::global_wifi_component->is_connected()) {
       wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(),
                                                  this->connecting_sta_.get_password());
-      // Trigger connection attempt (exits cooldown if needed, no-op if already connected)
-      wifi::global_wifi_component->connect_soon();
       this->connecting_sta_ = {};
       this->cancel_timeout("wifi-connect-timeout");
       this->set_state_(improv::STATE_PROVISIONED);

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -50,8 +50,8 @@ void ImprovSerialComponent::loop() {
     if (wifi::global_wifi_component->is_connected()) {
       wifi::global_wifi_component->save_wifi_sta(this->connecting_sta_.get_ssid(),
                                                  this->connecting_sta_.get_password());
-      // Trigger immediate retry to attempt connection with new credentials
-      wifi::global_wifi_component->retry_connect();
+      // Trigger connection attempt (exits cooldown if needed, no-op if already connected)
+      wifi::global_wifi_component->connect_soon();
       this->connecting_sta_ = {};
       this->cancel_timeout("wifi-connect-timeout");
       this->set_state_(improv::STATE_PROVISIONED);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -242,6 +242,7 @@ void AsyncWebServerRequest::send(int code, const char *content_type, const char 
 void AsyncWebServerRequest::redirect(const std::string &url) {
   httpd_resp_set_status(*this, "302 Found");
   httpd_resp_set_hdr(*this, "Location", url.c_str());
+  httpd_resp_set_hdr(*this, "Connection", "close");
   httpd_resp_send(*this, nullptr, 0);
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -101,6 +101,9 @@ void AsyncWebServer::begin() {
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
+  // Enable LRU purging to close oldest idle connections when socket limit is reached
+  // This prevents socket exhaustion when multiple clients connect (e.g., captive portal probes)
+  config.lru_purge_enable = true;
   if (httpd_start(&this->server_, &config) == ESP_OK) {
     const httpd_uri_t handler_get = {
         .uri = "",

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -94,6 +94,18 @@ void AsyncWebServer::end() {
   }
 }
 
+void AsyncWebServer::set_lru_purge_enable(bool enable) {
+  if (this->lru_purge_enable_ == enable) {
+    return;  // No change needed
+  }
+  this->lru_purge_enable_ = enable;
+  // If server is already running, restart it with new config
+  if (this->server_) {
+    this->end();
+    this->begin();
+  }
+}
+
 void AsyncWebServer::begin() {
   if (this->server_) {
     this->end();
@@ -101,9 +113,8 @@ void AsyncWebServer::begin() {
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
-  // Enable LRU purging to close oldest idle connections when socket limit is reached
-  // This prevents socket exhaustion when multiple clients connect (e.g., captive portal probes)
-  config.lru_purge_enable = true;
+  // Enable LRU purging if requested (e.g., by captive portal to handle probe bursts)
+  config.lru_purge_enable = this->lru_purge_enable_;
   if (httpd_start(&this->server_, &config) == ESP_OK) {
     const httpd_uri_t handler_get = {
         .uri = "",

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -199,9 +199,13 @@ class AsyncWebServer {
     return *handler;
   }
 
+  void set_lru_purge_enable(bool enable);
+  httpd_handle_t get_server() { return this->server_; }
+
  protected:
   uint16_t port_{};
   httpd_handle_t server_{};
+  bool lru_purge_enable_{false};
   static esp_err_t request_handler(httpd_req_t *r);
   static esp_err_t request_post_handler(httpd_req_t *r);
   esp_err_t request_handler_(AsyncWebServerRequest *request) const;

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -69,6 +69,12 @@ CONF_MIN_AUTH_MODE = "min_auth_mode"
 # Limited to 127 because selected_sta_index_ is int8_t in C++
 MAX_WIFI_NETWORKS = 127
 
+# Default AP timeout - allows sufficient time to try all BSSIDs during initial connection
+# After AP starts, WiFi scanning is skipped to avoid disrupting the AP, so we only
+# get best-effort connection attempts. Longer timeout ensures we exhaust all options
+# before falling back to AP mode.
+DEFAULT_AP_TIMEOUT = "2min"
+
 wifi_ns = cg.esphome_ns.namespace("wifi")
 EAPAuth = wifi_ns.struct("EAPAuth")
 ManualIP = wifi_ns.struct("ManualIP")
@@ -177,7 +183,7 @@ CONF_AP_TIMEOUT = "ap_timeout"
 WIFI_NETWORK_AP = WIFI_NETWORK_BASE.extend(
     {
         cv.Optional(
-            CONF_AP_TIMEOUT, default="1min"
+            CONF_AP_TIMEOUT, default=DEFAULT_AP_TIMEOUT
         ): cv.positive_time_period_milliseconds,
     }
 )

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -72,8 +72,8 @@ MAX_WIFI_NETWORKS = 127
 # Default AP timeout - allows sufficient time to try all BSSIDs during initial connection
 # After AP starts, WiFi scanning is skipped to avoid disrupting the AP, so we only
 # get best-effort connection attempts. Longer timeout ensures we exhaust all options
-# before falling back to AP mode.
-DEFAULT_AP_TIMEOUT = "2min"
+# before falling back to AP mode. Aligned with improv wifi_timeout default.
+DEFAULT_AP_TIMEOUT = "90s"
 
 wifi_ns = cg.esphome_ns.namespace("wifi")
 EAPAuth = wifi_ns.struct("EAPAuth")

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1232,9 +1232,16 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       return WiFiRetryPhase::RESTARTING_ADAPTER;
 
     case WiFiRetryPhase::RESTARTING_ADAPTER:
-      // After restart, go back to explicit hidden if we went through it initially, otherwise scan
-      return this->went_through_explicit_hidden_phase_() ? WiFiRetryPhase::EXPLICIT_HIDDEN
-                                                         : WiFiRetryPhase::SCAN_CONNECTING;
+      // After restart, go back to explicit hidden if we went through it initially
+      if (this->went_through_explicit_hidden_phase_()) {
+        return WiFiRetryPhase::EXPLICIT_HIDDEN;
+      }
+      // Skip scanning when captive portal/improv is active to avoid disrupting AP
+      // Even passive scans can cause brief AP disconnections on ESP32
+      if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
+        return WiFiRetryPhase::RETRY_HIDDEN;
+      }
+      return WiFiRetryPhase::SCAN_CONNECTING;
   }
 
   // Should never reach here

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -501,7 +501,8 @@ void WiFiComponent::loop() {
 #endif  // USE_WIFI_AP
 
 #ifdef USE_IMPROV
-    if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active()) {
+    if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active() &&
+        !esp32_improv::global_improv_component->should_start()) {
       if (now - this->last_connected_ > esp32_improv::global_improv_component->get_wifi_timeout()) {
         if (this->wifi_mode_(true, {}))
           esp32_improv::global_improv_component->start();

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -669,6 +669,10 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
   sta.set_ssid(ssid);
   sta.set_password(password);
   this->set_sta(sta);
+
+  // Force scan on next attempt even if captive portal is still active
+  // This ensures new credentials are tried with proper BSSID selection after provisioning
+  this->force_scan_after_provision_ = true;
 }
 
 void WiFiComponent::start_connecting(const WiFiAP &ap) {
@@ -867,6 +871,8 @@ void WiFiComponent::start_scanning() {
   ESP_LOGD(TAG, "Starting scan");
   this->wifi_scan_start_(this->passive_scan_);
   this->state_ = WIFI_COMPONENT_STATE_STA_SCANNING;
+  // Clear the force scan flag after starting the scan
+  this->force_scan_after_provision_ = false;
 }
 
 /// Comparator for WiFi scan result sorting - determines which network should be tried first
@@ -1238,7 +1244,9 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // Skip scanning when captive portal/improv is active to avoid disrupting AP
       // Even passive scans can cause brief AP disconnections on ESP32
-      if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
+      // UNLESS new credentials were just provisioned - then we need to scan
+      if ((this->is_captive_portal_active_() || this->is_esp32_improv_active_()) &&
+          !this->force_scan_after_provision_) {
         return WiFiRetryPhase::RETRY_HIDDEN;
       }
       return WiFiRetryPhase::SCAN_CONNECTING;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -444,6 +444,12 @@ void WiFiComponent::loop() {
     switch (this->state_) {
       case WIFI_COMPONENT_STATE_COOLDOWN: {
         this->status_set_warning(LOG_STR("waiting to reconnect"));
+        // Skip cooldown if new credentials were provided while connecting
+        if (this->skip_cooldown_next_cycle_) {
+          this->skip_cooldown_next_cycle_ = false;
+          this->check_connecting_finished();
+          break;
+        }
         // Use longer cooldown when captive portal/improv is active to avoid disrupting user config
         bool portal_active = this->is_captive_portal_active_() || this->is_esp32_improv_active_();
         uint32_t cooldown_duration = portal_active ? WIFI_COOLDOWN_WITH_AP_ACTIVE_MS : WIFI_COOLDOWN_DURATION_MS;
@@ -612,6 +618,9 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->init_sta(1);
   this->add_sta(ap);
   this->selected_sta_index_ = 0;
+  // Force scan on next attempt even if captive portal is still active
+  // This ensures new credentials are tried with proper BSSID selection after provisioning
+  this->force_scan_after_provision_ = true;
 }
 
 WiFiAP WiFiComponent::build_params_for_current_phase_() {
@@ -691,6 +700,14 @@ void WiFiComponent::connect_soon_() {
 }
 
 void WiFiComponent::start_connecting(const WiFiAP &ap) {
+  // If already connecting/connected, set flag to skip cooldown on next cycle
+  // Caller (e.g., improv) already called set_sta() with new credentials, state machine will retry
+  if (this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTING || this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED) {
+    ESP_LOGD(TAG, "Already connecting, will retry on next cycle");
+    this->skip_cooldown_next_cycle_ = true;
+    return;
+  }
+
   // Log connection attempt at INFO level with priority
   char bssid_s[18];
   int8_t priority = 0;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -503,6 +503,7 @@ void WiFiComponent::loop() {
 #ifdef USE_IMPROV
     if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active()) {
       if (now - this->last_connected_ > esp32_improv::global_improv_component->get_wifi_timeout()) {
+        ESP_LOGI(TAG, "Starting Improv");
         if (this->wifi_mode_(true, {}))
           esp32_improv::global_improv_component->start();
       }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -896,8 +896,6 @@ void WiFiComponent::start_scanning() {
   ESP_LOGD(TAG, "Starting scan");
   this->wifi_scan_start_(this->passive_scan_);
   this->state_ = WIFI_COMPONENT_STATE_STA_SCANNING;
-  // Clear the force scan flag after starting the scan
-  this->force_scan_after_provision_ = false;
 }
 
 /// Comparator for WiFi scan result sorting - determines which network should be tried first

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -676,10 +676,10 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
   this->force_scan_after_provision_ = true;
 
   // Trigger connection attempt (exits cooldown if needed, no-op if already connecting/connected)
-  this->connect_soon();
+  this->connect_soon_();
 }
 
-void WiFiComponent::connect_soon() {
+void WiFiComponent::connect_soon_() {
   // Only trigger retry if we're in cooldown - if already connecting/connected, do nothing
   if (this->state_ == WIFI_COMPONENT_STATE_COOLDOWN) {
     ESP_LOGD(TAG, "Exiting cooldown early due to new WiFi credentials");

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -199,7 +199,11 @@ static constexpr uint8_t WIFI_RETRY_COUNT_PER_AP = 1;
 
 /// Cooldown duration in milliseconds after adapter restart or repeated failures
 /// Allows WiFi hardware to stabilize before next connection attempt
-static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 1000;
+static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
+
+/// Cooldown duration when fallback AP is active and captive portal may be running
+/// Longer interval prevents scanning from disrupting AP connections and blocking captive portal
+static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 30000;
 
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {
@@ -417,10 +421,6 @@ void WiFiComponent::start() {
 void WiFiComponent::restart_adapter() {
   ESP_LOGW(TAG, "Restarting adapter");
   this->wifi_mode_(false, {});
-  // Enter cooldown state to allow WiFi hardware to stabilize after restart
-  // Don't set retry_phase_ or num_retried_ here - state machine handles transitions
-  this->state_ = WIFI_COMPONENT_STATE_COOLDOWN;
-  this->action_started_ = millis();
   this->error_from_callback_ = false;
 }
 
@@ -441,7 +441,10 @@ void WiFiComponent::loop() {
     switch (this->state_) {
       case WIFI_COMPONENT_STATE_COOLDOWN: {
         this->status_set_warning(LOG_STR("waiting to reconnect"));
-        if (now - this->action_started_ > WIFI_COOLDOWN_DURATION_MS) {
+        // Use longer cooldown when captive portal/improv is active to avoid disrupting user config
+        bool portal_active = this->is_captive_portal_active_() || this->is_esp32_improv_active_();
+        uint32_t cooldown_duration = portal_active ? WIFI_COOLDOWN_WITH_AP_ACTIVE_MS : WIFI_COOLDOWN_DURATION_MS;
+        if (now - this->action_started_ > cooldown_duration) {
           // After cooldown we either restarted the adapter because of
           // a failure, or something tried to connect over and over
           // so we entered cooldown. In both cases we call
@@ -1319,6 +1322,10 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
       if (!this->is_captive_portal_active_() && !this->is_esp32_improv_active_()) {
         this->restart_adapter();
       }
+      // Always enter cooldown after restart (or skip-restart) to allow stabilization
+      // Use extended cooldown when AP is active to avoid constant scanning that blocks DNS
+      this->state_ = WIFI_COMPONENT_STATE_COOLDOWN;
+      this->action_started_ = millis();
       // Return true to indicate we should wait (go to COOLDOWN) instead of immediately connecting
       return true;
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -618,9 +618,6 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->init_sta(1);
   this->add_sta(ap);
   this->selected_sta_index_ = 0;
-  // Force scan on next attempt even if captive portal is still active
-  // This ensures new credentials are tried with proper BSSID selection after provisioning
-  this->force_scan_after_provision_ = true;
 }
 
 WiFiAP WiFiComponent::build_params_for_current_phase_() {
@@ -682,10 +679,6 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
   sta.set_ssid(ssid);
   sta.set_password(password);
   this->set_sta(sta);
-
-  // Force scan on next attempt even if captive portal is still active
-  // This ensures new credentials are tried with proper BSSID selection after provisioning
-  this->force_scan_after_provision_ = true;
 
   // Trigger connection attempt (exits cooldown if needed, no-op if already connecting/connected)
   this->connect_soon_();

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -202,8 +202,8 @@ static constexpr uint8_t WIFI_RETRY_COUNT_PER_AP = 1;
 static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
 
 /// Cooldown duration when fallback AP is active and captive portal may be running
-/// Longer interval prevents scanning from disrupting AP connections and blocking captive portal
-static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 30000;
+/// Longer interval gives users time to configure WiFi without constant connection attempts
+static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 5000;
 
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -280,7 +280,9 @@ int8_t WiFiComponent::find_next_hidden_sta_(int8_t start_index) {
       }
     }
 
-    if (!this->ssid_was_seen_in_scan_(sta.get_ssid())) {
+    // If we didn't scan this cycle, treat all networks as potentially hidden
+    // Otherwise, only retry networks that weren't seen in the scan
+    if (!this->did_scan_this_cycle_ || !this->ssid_was_seen_in_scan_(sta.get_ssid())) {
       ESP_LOGD(TAG, "Hidden candidate " LOG_SECRET("'%s'") " at index %d", sta.get_ssid().c_str(), static_cast<int>(i));
       return static_cast<int8_t>(i);
     }
@@ -984,6 +986,7 @@ void WiFiComponent::check_scanning_finished() {
     return;
   }
   this->scan_done_ = false;
+  this->did_scan_this_cycle_ = true;
 
   if (this->scan_result_.empty()) {
     ESP_LOGW(TAG, "No networks found");
@@ -1349,6 +1352,8 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
       if (!this->is_captive_portal_active_() && !this->is_esp32_improv_active_()) {
         this->restart_adapter();
       }
+      // Clear scan flag - we're starting a new retry cycle
+      this->did_scan_this_cycle_ = false;
       // Always enter cooldown after restart (or skip-restart) to allow stabilization
       // Use extended cooldown when AP is active to avoid constant scanning that blocks DNS
       this->state_ = WIFI_COMPONENT_STATE_COOLDOWN;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -203,7 +203,8 @@ static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
 
 /// Cooldown duration when fallback AP is active and captive portal may be running
 /// Longer interval gives users time to configure WiFi without constant connection attempts
-static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 5000;
+/// While connecting, WiFi can't beacon the AP properly, so needs longer cooldown
+static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 30000;
 
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -676,6 +676,14 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
   this->force_scan_after_provision_ = true;
 }
 
+void WiFiComponent::connect_soon() {
+  // Only trigger retry if we're in cooldown - if already connecting/connected, do nothing
+  if (this->state_ == WIFI_COMPONENT_STATE_COOLDOWN) {
+    ESP_LOGD(TAG, "Exiting cooldown early due to new WiFi credentials");
+    this->retry_connect();
+  }
+}
+
 void WiFiComponent::start_connecting(const WiFiAP &ap) {
   // Log connection attempt at INFO level with priority
   char bssid_s[18];

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -674,6 +674,9 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
   // Force scan on next attempt even if captive portal is still active
   // This ensures new credentials are tried with proper BSSID selection after provisioning
   this->force_scan_after_provision_ = true;
+
+  // Trigger connection attempt (exits cooldown if needed, no-op if already connecting/connected)
+  this->connect_soon();
 }
 
 void WiFiComponent::connect_soon() {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1268,9 +1268,7 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // Skip scanning when captive portal/improv is active to avoid disrupting AP
       // Even passive scans can cause brief AP disconnections on ESP32
-      // UNLESS new credentials were just provisioned - then we need to scan
-      if ((this->is_captive_portal_active_() || this->is_esp32_improv_active_()) &&
-          !this->force_scan_after_provision_) {
+      if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
         return WiFiRetryPhase::RETRY_HIDDEN;
       }
       return WiFiRetryPhase::SCAN_CONNECTING;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -503,7 +503,6 @@ void WiFiComponent::loop() {
 #ifdef USE_IMPROV
     if (esp32_improv::global_improv_component != nullptr && !esp32_improv::global_improv_component->is_active()) {
       if (now - this->last_connected_ > esp32_improv::global_improv_component->get_wifi_timeout()) {
-        ESP_LOGI(TAG, "Starting Improv");
         if (this->wifi_mode_(true, {}))
           esp32_improv::global_improv_component->start();
       }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -618,6 +618,8 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->init_sta(1);
   this->add_sta(ap);
   this->selected_sta_index_ = 0;
+  // When new credentials are set (e.g., from improv), skip cooldown to retry immediately
+  this->skip_cooldown_next_cycle_ = true;
 }
 
 WiFiAP WiFiComponent::build_params_for_current_phase_() {
@@ -693,14 +695,6 @@ void WiFiComponent::connect_soon_() {
 }
 
 void WiFiComponent::start_connecting(const WiFiAP &ap) {
-  // If already connecting/connected, set flag to skip cooldown on next cycle
-  // Caller (e.g., improv) already called set_sta() with new credentials, state machine will retry
-  if (this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTING || this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED) {
-    ESP_LOGD(TAG, "Already connecting, will retry on next cycle");
-    this->skip_cooldown_next_cycle_ = true;
-    return;
-  }
-
   // Log connection attempt at INFO level with priority
   char bssid_s[18];
   int8_t priority = 0;

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -291,6 +291,7 @@ class WiFiComponent : public Component {
   void set_passive_scan(bool passive);
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   /// Setup WiFi interface.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -532,7 +532,6 @@ class WiFiComponent : public Component {
   bool enable_on_boot_;
   bool got_ipv4_address_{false};
   bool keep_scan_results_{false};
-  bool force_scan_after_provision_{false};
   bool did_scan_this_cycle_{false};
   bool skip_cooldown_next_cycle_{false};
 

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -534,6 +534,7 @@ class WiFiComponent : public Component {
   bool keep_scan_results_{false};
   bool force_scan_after_provision_{false};
   bool did_scan_this_cycle_{false};
+  bool skip_cooldown_next_cycle_{false};
 
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -292,6 +292,9 @@ class WiFiComponent : public Component {
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
 
+  /// Trigger connection attempt soon (exits cooldown if needed, otherwise no-op if already connecting/connected)
+  void connect_soon();
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   /// Setup WiFi interface.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -292,9 +292,6 @@ class WiFiComponent : public Component {
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
 
-  /// Trigger connection attempt soon (exits cooldown if needed, otherwise no-op if already connecting/connected)
-  void connect_soon();
-
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   /// Setup WiFi interface.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -425,6 +425,8 @@ class WiFiComponent : public Component {
     return true;
   }
 
+  void connect_soon_();
+
   void wifi_loop_();
   bool wifi_mode_(optional<bool> sta, optional<bool> ap);
   bool wifi_sta_pre_setup_();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -533,6 +533,7 @@ class WiFiComponent : public Component {
   bool got_ipv4_address_{false};
   bool keep_scan_results_{false};
   bool force_scan_after_provision_{false};
+  bool did_scan_this_cycle_{false};
 
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -529,6 +529,7 @@ class WiFiComponent : public Component {
   bool enable_on_boot_;
   bool got_ipv4_address_{false};
   bool keep_scan_results_{false};
+  bool force_scan_after_provision_{false};
 
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};


### PR DESCRIPTION
# What does this implement/fix?

Fixes captive portal not working reliably when WiFi credentials are incorrect or WiFi is unavailable. Previously, constant WiFi scanning (every 1 second) was blocking the main loop and disrupting the captive portal's DNS server and web server, making it nearly impossible to configure new credentials. Additionally, socket exhaustion from captive portal probe requests was causing connection failures.

## Changes

1. **Reduced normal WiFi cooldown from 1000ms to 500ms** - Faster reconnection when captive portal is not active
2. **Added 30-second cooldown when captive portal/improv is active** - While WiFi is attempting to connect, it can't properly beacon the AP. Longer cooldown ensures AP remains stable and accessible for provisioning
3. **Fixed missing cooldown after adapter restart skip** - When captive portal was active, the adapter restart was skipped to avoid disruption, but the code forgot to enter cooldown state, causing immediate re-scanning in a tight loop
4. **Skip WiFi scanning when captive portal/improv is active** - Even passive scans cause brief AP disconnections on ESP32. When captive portal/improv is active, the WiFi component skips to the RETRY_HIDDEN phase instead of scanning, treating all configured networks as hidden. This keeps the AP stable for provisioning.
5. **Track whether scan occurred in current cycle** - Added `did_scan_this_cycle_` flag to track if WiFi scanned in the current retry cycle. When scan is skipped (captive portal/improv active), RETRY_HIDDEN phase treats all networks as potentially hidden and tries them. When scan occurred, only networks not found in scan results are retried as hidden. Fixes issue where skipping scan phase prevented hidden retry from trying configured networks.
6. **Immediate connection after provisioning** - `save_wifi_sta()` now automatically exits cooldown if WiFi is waiting, but does nothing if already connecting/connected. This allows provisioned credentials (via captive portal, esp32_improv, or improv_serial) to attempt connection immediately without waiting up to 30 seconds, while avoiding double-connection if already connected.
7. **Increased default AP timeout from 1 minute to 90 seconds** - Gives WiFi sufficient time to try all BSSIDs during initial connection before starting the fallback AP. Since WiFi scanning is skipped once AP is active, it's important to exhaust all connection options before falling back to AP mode. Also aligned esp32_improv `wifi_timeout` default to 90 seconds to keep both timeouts consistent.
8. **Added socket registration for captive portal** - Registers 4 sockets (1 UDP for DNS server + 3 TCP for HTTP connections) to prevent file handle exhaustion (ENFILE errors). OS captive portal detection makes multiple probe requests that stay in TIME_WAIT state, requiring additional socket headroom for actual user configuration requests.
9. **Added Connection: close header to redirects** - ESP-IDF web server redirect responses now include "Connection: close" header to ensure sockets are released immediately
10. **Enabled LRU socket purging during captive portal** - When captive portal is active (ESP32 only), the ESP-IDF HTTP server automatically closes the oldest idle connections when the socket limit is reached, preventing socket exhaustion from OS probe bursts. This is disabled when captive portal ends to maintain normal web server behavior.
11. **Fixed improv start tight loop** - Added `should_start()` getter to esp32_improv component and updated WiFi component to check both `is_active()` and `should_start()` before calling `start()`. This prevents repeatedly calling `start()` in a tight loop before improv's `loop()` has a chance to run and update its state.
12. **Fixed improv provisioning race during background retries** - Improv provisioning was unreliable when WiFi was retrying connection attempts in the background (from previously failed credentials). The `wifi_sta_connect_()` call in `start_connecting()` would fail with ESP-IDF error "sta is connecting, cannot set config", forcing users to retry provisioning multiple times until they got lucky with timing. Added `skip_cooldown_next_cycle_` flag to `set_sta()` so when new credentials are set, the WiFi state machine skips cooldown on the next cycle and immediately retries with the new credentials.

## Root Cause

Three issues were preventing the captive portal from working:

1. **WiFi scanning loop**: The WiFi state machine has a `RESTARTING_ADAPTER` phase that normally restarts the WiFi adapter and enters a cooldown state. However, when captive portal or improv is active, it skips the restart (to avoid disrupting the AP connection) but was not entering the cooldown state. This caused the state machine to immediately transition to `SCAN_CONNECTING` and start scanning again, creating a tight loop that blocked the main loop for 300-400ms every second, preventing the captive portal DNS and web servers from responding.

2. **Socket exhaustion**: The captive portal component did not register its socket usage with the ESP32 socket tracking system. Operating systems perform captive portal detection by making multiple HTTP probe requests simultaneously, which can leave several sockets in TIME_WAIT state. Without proper socket registration, `CONFIG_LWIP_MAX_SOCKETS` was too low, causing "error in accept (23)" (ENFILE - too many open files) when users tried to configure WiFi credentials.

3. **No socket reclamation**: The ESP-IDF HTTP server was not configured to reclaim idle sockets when the limit was reached. Even with increased socket allocation, repeated connection attempts (e.g., OS probes + user retries with wrong passwords) could still exhaust all available sockets since idle connections weren't being closed to make room for new ones.

## Solution

- Move cooldown setup out of `restart_adapter()` function and unconditionally enter cooldown state after the restart phase, whether the restart actually happens or not
- Use 30-second cooldown when captive portal/improv is active (detected via `is_captive_portal_active_()` / `is_esp32_improv_active_()`) - WiFi can't beacon the AP properly while connecting, so longer cooldown keeps AP stable
- Once credentials are configured and portal becomes inactive, automatically switch back to fast 500ms cooldown for quick connection
- Skip WiFi scanning phase when captive portal/improv is active - go directly to RETRY_HIDDEN phase to avoid AP disruption
- Add `did_scan_this_cycle_` flag to track whether WiFi performed a scan in the current retry cycle. Set to false at start of RESTARTING_ADAPTER phase, set to true after scan completes. RETRY_HIDDEN phase checks this flag: if false (scan was skipped), all networks are treated as potentially hidden and tried; if true (scan occurred), only networks not found in scan results are retried
- Fix thread safety in captive portal WiFi provisioning - use `defer()` to move `save_wifi_sta()` call (which writes to NVS) from HTTP handler thread to main loop thread
- Modify `save_wifi_sta()` to automatically call `retry_connect()` if in cooldown state, otherwise do nothing. This allows immediate connection attempts after provisioning without disrupting already-active connections, and works automatically for all provisioning methods (captive portal, esp32_improv, improv_serial)
- Increase default AP timeout from 1 minute to 90 seconds to allow WiFi component to try all BSSIDs during initial connection before starting fallback AP
- Align esp32_improv `wifi_timeout` default to 90 seconds to match WiFi AP timeout
- Register 4 sockets in captive portal's `_final_validate()` to properly account for DNS server and HTTP connections in `CONFIG_LWIP_MAX_SOCKETS` calculation
- Add "Connection: close" header to all redirect responses in ESP-IDF web server to ensure immediate socket cleanup
- Enable LRU (Least Recently Used) socket purging on the ESP-IDF HTTP server when captive portal starts (ESP32 only), automatically closing oldest idle connections when socket limit is reached
- Disable LRU purging when captive portal ends to return to normal web server behavior
- Add `should_start()` public getter to esp32_improv component to expose the `should_start_` flag
- Update WiFi component to check `should_start()` in addition to `is_active()` before calling improv's `start()` method, preventing tight loop where `start()` is called repeatedly before improv's `loop()` can run
- Add `skip_cooldown_next_cycle_` flag to WiFi component to handle improv provisioning during active connection
- In `set_sta()`, set the flag when new credentials are configured so state machine knows to skip cooldown
- In COOLDOWN state handler, check flag and skip cooldown to immediately retry with new credentials, then clear flag

This maintains backward compatibility while making the captive portal usable. When new WiFi credentials are provisioned via captive portal or improv, `save_wifi_sta()` automatically exits cooldown (if waiting), allowing fast connection with the new credentials without disrupting already-active connections.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (issue to be filed if not already existing)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5639

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - fix works automatically
wifi:
  ssid: "your_network"
  password: "wrong_password"  # Even with wrong credentials, captive portal now works

  ap:
    ssid: "Fallback Hotspot"

captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
