### PR TITLE
[build] Don't clear pio cache unless requested

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -121,7 +121,7 @@ def update_storage_json() -> None:
             )
         else:
             _LOGGER.info("Core config or version changed, cleaning build files...")
-        clean_build()
+        clean_build(clear_pio_cache=False)
     elif storage_should_update_cmake_cache(old, new):
         _LOGGER.info("Integrations changed, cleaning cmake cache...")
         clean_cmake_cache()
@@ -301,7 +301,7 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def clean_build():
+def clean_build(clear_pio_cache: bool = True):
     import shutil
 
     # Allow skipping cache cleaning for integration tests
@@ -321,6 +321,9 @@ def clean_build():
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
         dependencies_lock.unlink()
+
+    if not clear_pio_cache:
+        return
 
     # Clean PlatformIO cache to resolve CMake compiler detection issues
     # This helps when toolchain paths change or get corrupted


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `clean` action in esphome deletes the Platformio cache, requiring files to be downloaded
again. This is appropriate for a user-initiated clean since a corrupted cache could cause
problems, but currently this is also triggered when the build system detects that config
has changed, requiring object files to be deleted.

* Add a parameter to the `clean_build()` function to allow skipping the cache clear when
the clean is a side-effect of config changes. 
* Retain the cache clear for a user-requested clean.
* 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1439850611318325410

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
