### PR TITLE
[esp32] Fix Arduino build on some ESP32 S2 boards

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -931,6 +931,12 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
         add_idf_sdkconfig_option("CONFIG_ESP_PHY_REDUCE_TX_POWER", True)
 
+        # ESP32-S2 Arduino: Disable USB Serial on boot to avoid TinyUSB dependency
+        if get_esp32_variant() == VARIANT_ESP32S2:
+            cg.add_build_unflag("-DARDUINO_USB_CDC_ON_BOOT=1")
+            cg.add_build_unflag("-DARDUINO_USB_CDC_ON_BOOT=0")
+            cg.add_build_flag("-DARDUINO_USB_CDC_ON_BOOT=0")
+
     cg.add_build_flag("-Wno-nonnull-compare")
 
     add_idf_sdkconfig_option(f"CONFIG_IDF_TARGET_{variant}", True)


### PR DESCRIPTION
# What does this implement/fix?

Fixes some ESP32-S2 boards with Arduino framework by disabling USB Serial on boot, eliminating the TinyUSB dependency that causes build failures.

## Problem

Some ESP32-S2 boards are configured to use ARDUINO_USB_MODE=0 (TinyUSB mode) by default. When combined with ARDUINO_USB_CDC_ON_BOOT=1 in board definitions, this causes Arduino to define USB_SERIAL_IS_DEFINED and attempt to use native USB Serial.

However, TinyUSB is not available when using the Arduino framework as an ESP-IDF component in ESPHome's build system,  causing build failures.

Affected boards: 22 ESP32-S2 boards including popular boards like:
- Adafruit Feather ESP32-S2 (and variants)
- LOLIN S2 Mini / S2 Pico
- Unexpected Maker FeatherS2 / TinyS2
- And 16 more ESP32-S2 boards

## Solution

Instead of blocking users from using ESP32-S2 boards with Arduino framework, this PR fixes the issue by overriding the build flags to disable USB Serial on boot:

```
# ESP32-S2 Arduino: Disable USB Serial on boot to avoid TinyUSB dependency
if get_esp32_variant() == VARIANT_ESP32S2:
    cg.add_build_unflag("-DARDUINO_USB_CDC_ON_BOOT=1")
    cg.add_build_unflag("-DARDUINO_USB_CDC_ON_BOOT=0")
    cg.add_build_flag("-DARDUINO_USB_CDC_ON_BOOT=0")
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11742

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
