### PR TITLE
[bme68x] Print error when no sensors are configured

### DIFF
--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -70,6 +70,9 @@ void BME68xBSEC2Component::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication failed (BSEC2 status: %d, BME68X status: %d)", this->bsec_status_,
              this->bme68x_status_);
+    if (this->bsec_status_ == BSEC_E_SU_SUBSCRIBEDOUTPUTGATES) {
+      ESP_LOGE(TAG, "No sensors, add at least one sensor to the config");
+    }
   }
 
   if (this->algorithm_output_ != ALGORITHM_OUTPUT_IAQ) {

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -70,7 +70,7 @@ void BME68xBSEC2Component::dump_config() {
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Communication failed (BSEC2 status: %d, BME68X status: %d)", this->bsec_status_,
              this->bme68x_status_);
-    if (this->bsec_status_ == BSEC_E_SU_SUBSCRIBEDOUTPUTGATES) {
+    if (this->bsec_status_ == BSEC_I_SU_SUBSCRIBEDOUTPUTGATES) {
       ESP_LOGE(TAG, "No sensors, add at least one sensor to the config");
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Print error when no sensors are configured, component will fail with zero senors

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11608

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
