### PR TITLE
[core] Document threading model rationale in ThreadModel enum

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -262,9 +262,9 @@ async def component_to_code(config):
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", FAMILY_FRIENDLY[config[CONF_FAMILY]])
     # LibreTiny uses MULTI_NO_ATOMICS because platforms like BK7231N (ARM968E-S) lack
-    # atomic instructions (no LDREX/STREX). Even if libatomic were linked, it would report
-    # ATOMIC_INT_LOCK_FREE=1 (sometimes), meaning atomics would use locks internally anyway.
-    # Direct FreeRTOS mutex locking is simpler and avoids 4-8KB libatomic overhead.
+    # exclusive load/store (no LDREX/STREX). std::atomic RMW operations require libatomic,
+    # which is not linked to save flash (4-8KB). Even if linked, libatomic would use locks
+    # (ATOMIC_INT_LOCK_FREE=1), so explicit FreeRTOS mutexes are simpler and equivalent.
     cg.add_define(ThreadModel.MULTI_NO_ATOMICS)
 
     # force using arduino framework

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -261,6 +261,10 @@ async def component_to_code(config):
     cg.add_build_flag(f"-DUSE_LIBRETINY_VARIANT_{config[CONF_FAMILY]}")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     cg.add_define("ESPHOME_VARIANT", FAMILY_FRIENDLY[config[CONF_FAMILY]])
+    # LibreTiny uses MULTI_NO_ATOMICS because platforms like BK7231N (ARM968E-S) lack
+    # atomic instructions (no LDREX/STREX). Even if libatomic were linked, it would report
+    # ATOMIC_INT_LOCK_FREE=1 (sometimes), meaning atomics would use locks internally anyway.
+    # Direct FreeRTOS mutex locking is simpler and avoids 4-8KB libatomic overhead.
     cg.add_define(ThreadModel.MULTI_NO_ATOMICS)
 
     # force using arduino framework

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -36,7 +36,28 @@ class Framework(StrEnum):
 
 
 class ThreadModel(StrEnum):
-    """Threading model identifiers for ESPHome scheduler."""
+    """Threading model identifiers for ESPHome scheduler.
+
+    ESPHome supports three threading models based on platform capabilities:
+
+    SINGLE: Single-threaded platforms (ESP8266, RP2040)
+        - No FreeRTOS or other RTOS
+        - No concurrent access to scheduler data structures
+        - No atomics or locks needed
+        - Minimal overhead
+
+    MULTI_NO_ATOMICS: Multi-threaded platforms without hardware atomic support (LibreTiny)
+        - Uses FreeRTOS or other RTOS with multiple tasks
+        - CPU lacks atomic instructions (e.g., ARM968E-S has no LDREX/STREX)
+        - libatomic is not linked (would add 4-8KB flash overhead)
+        - Uses explicit FreeRTOS mutex locking for synchronization
+
+    MULTI_ATOMICS: Multi-threaded platforms with hardware atomic support (ESP32, Host)
+        - Uses FreeRTOS or other RTOS with multiple tasks
+        - CPU has native atomic instructions (e.g., ESP32 has S32C1I, ARM Cortex has LDREX/STREX)
+        - Uses std::atomic for lock-free synchronization
+        - Better performance through reduced lock contention
+    """
 
     SINGLE = "ESPHOME_THREAD_SINGLE"
     MULTI_NO_ATOMICS = "ESPHOME_THREAD_MULTI_NO_ATOMICS"

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -38,25 +38,27 @@ class Framework(StrEnum):
 class ThreadModel(StrEnum):
     """Threading model identifiers for ESPHome scheduler.
 
-    ESPHome supports three threading models based on platform capabilities:
+    ESPHome currently uses three threading models based on platform capabilities:
 
-    SINGLE: Single-threaded platforms (ESP8266, RP2040)
-        - No FreeRTOS or other RTOS
+    SINGLE:
+        - Single-threaded platforms (ESP8266, RP2040)
+        - No RTOS task switching
         - No concurrent access to scheduler data structures
-        - No atomics or locks needed
+        - No atomics or locks required
         - Minimal overhead
 
-    MULTI_NO_ATOMICS: Multi-threaded platforms without hardware atomic support (LibreTiny)
-        - Uses FreeRTOS or other RTOS with multiple tasks
-        - CPU lacks atomic instructions (e.g., ARM968E-S has no LDREX/STREX)
-        - libatomic is not linked (would add 4-8KB flash overhead)
-        - Uses explicit FreeRTOS mutex locking for synchronization
+    MULTI_NO_ATOMICS:
+        - Multi-threaded platforms without hardware atomic RMW support (e.g. LibreTiny BK7231N)
+        - Uses FreeRTOS or another RTOS with multiple tasks
+        - CPU lacks exclusive load/store instructions (ARM968E-S has no LDREX/STREX)
+        - std::atomic cannot provide lock-free RMW; libatomic is avoided to save flash (4–8 KB)
+        - Scheduler uses explicit FreeRTOS mutexes for synchronization
 
-    MULTI_ATOMICS: Multi-threaded platforms with hardware atomic support (ESP32, Host)
-        - Uses FreeRTOS or other RTOS with multiple tasks
-        - CPU has native atomic instructions (e.g., ESP32 has S32C1I, ARM Cortex has LDREX/STREX)
-        - Uses std::atomic for lock-free synchronization
-        - Better performance through reduced lock contention
+    MULTI_ATOMICS:
+        - Multi-threaded platforms with hardware atomic RMW support (ESP32, Cortex-M, Host)
+        - CPU provides native atomic instructions (ESP32 S32C1I, ARM LDREX/STREX)
+        - std::atomic is used for lock-free synchronization
+        - Reduced contention and better performance
     """
 
     SINGLE = "ESPHOME_THREAD_SINGLE"


### PR DESCRIPTION
## What does this implement/fix?

Adds documentation to the `ThreadModel` enum in `esphome/const.py` and `esphome/components/libretiny/__init__.py` to explain why `ESPHOME_THREAD_MULTI_NO_ATOMICS` exists and why it cannot be eliminated.

**Background:** While investigating whether LibreTiny platforms could be switched to use `ESPHOME_THREAD_MULTI_ATOMICS` to simplify the codebase, testing revealed that:

1. LibreTiny platforms like BK7231N use ARM968E-S (ARMv5TE) which lacks exclusive load/store instructions (no LDREX/STREX)
2. Runtime tests show `ATOMIC_INT_LOCK_FREE=1` (sometimes), meaning atomic RMW operations would require locks even if libatomic were linked
3. Attempting to compile with `std::atomic` RMW operations produces linker errors for undefined `__atomic_*` functions
4. libatomic is not linked in LibreTiny (would add 4-8KB flash overhead for no benefit)

**Conclusion:** `ESPHOME_THREAD_MULTI_NO_ATOMICS` is the correct threading model for platforms without hardware atomic RMW support. This PR documents why it exists to prevent future confusion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (documentation improvement)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code documentation only)

## Test Environment

- [x] ESP32 (uses MULTI_ATOMICS - no change)
- [x] ESP8266 (uses SINGLE - no change)
- [x] BK72xx (uses MULTI_NO_ATOMICS - verified via atomic tests)
- [ ] RTL87xx (uses MULTI_NO_ATOMICS - same reasoning applies)
- [ ] Other LibreTiny platforms

## Example entry for `config.yaml`:

N/A - This is internal documentation only, no user-facing configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Changes Made

### 1. `esphome/const.py`
Added comprehensive docstring to `ThreadModel` enum explaining:
- Three threading models and when each is used
- Platform-specific requirements (hardware atomic RMW vs mutex locking)
- Why MULTI_NO_ATOMICS exists (platforms lacking exclusive load/store instructions)

### 2. `esphome/components/libretiny/__init__.py`
Added comment explaining why LibreTiny uses MULTI_NO_ATOMICS:
- ARM968E-S lacks LDREX/STREX instructions
- ATOMIC_INT_LOCK_FREE=1 means atomics would use locks anyway
- Direct FreeRTOS mutex locking is simpler and avoids libatomic overhead

## Testing Performed

1. **Runtime atomic capability test** on BK7231N showing `ATOMIC_INT_LOCK_FREE=1`
2. **Compilation test** confirming `std::atomic` RMW operations require libatomic (linker errors)
3. **Architecture verification** confirming ARM968E-S is ARMv5TE without exclusive load/store instructions
4. **Existing behavior preserved** - no functional changes, only documentation

## Why This Matters

Without this documentation, it's natural to wonder "why do we have three threading models?" and "can we eliminate MULTI_NO_ATOMICS to simplify the code?" This PR answers those questions upfront to save future maintainers from rediscovering the same architectural limitations.

## Future Considerations

If LibreTiny adds support for newer ARM Cortex-M chips (M0+, M3, M4) with LDREX/STREX support:
- Could add platform detection logic
- Use MULTI_ATOMICS for newer chips with atomic RMW support
- Keep MULTI_NO_ATOMICS for ARM968E-S
- But this is not needed now, so not implemented
