### PR TITLE
[api] Optimize APINoiseContext memory usage by removing shared_ptr overhead

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -90,8 +90,8 @@ static const int CAMERA_STOP_STREAM = 5000;
 APIConnection::APIConnection(std::unique_ptr<socket::Socket> sock, APIServer *parent)
     : parent_(parent), initial_state_iterator_(this), list_entities_iterator_(this) {
 #if defined(USE_API_PLAINTEXT) && defined(USE_API_NOISE)
-  auto noise_ctx = parent->get_noise_ctx();
-  if (noise_ctx->has_psk()) {
+  auto &noise_ctx = parent->get_noise_ctx();
+  if (noise_ctx.has_psk()) {
     this->helper_ =
         std::unique_ptr<APIFrameHelper>{new APINoiseFrameHelper(std::move(sock), noise_ctx, &this->client_info_)};
   } else {

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -527,7 +527,7 @@ APIError APINoiseFrameHelper::init_handshake_() {
   if (aerr != APIError::OK)
     return aerr;
 
-  const auto &psk = ctx_->get_psk();
+  const auto &psk = this->ctx_.get_psk();
   err = noise_handshakestate_set_pre_shared_key(handshake_, psk.data(), psk.size());
   aerr = handle_noise_error_(err, LOG_STR("noise_handshakestate_set_pre_shared_key"),
                              APIError::HANDSHAKESTATE_SETUP_FAILED);

--- a/esphome/components/api/api_frame_helper_noise.h
+++ b/esphome/components/api/api_frame_helper_noise.h
@@ -9,9 +9,8 @@ namespace esphome::api {
 
 class APINoiseFrameHelper final : public APIFrameHelper {
  public:
-  APINoiseFrameHelper(std::unique_ptr<socket::Socket> socket, std::shared_ptr<APINoiseContext> ctx,
-                      const ClientInfo *client_info)
-      : APIFrameHelper(std::move(socket), client_info), ctx_(std::move(ctx)) {
+  APINoiseFrameHelper(std::unique_ptr<socket::Socket> socket, APINoiseContext &ctx, const ClientInfo *client_info)
+      : APIFrameHelper(std::move(socket), client_info), ctx_(ctx) {
     // Noise header structure:
     // Pos 0: indicator (0x01)
     // Pos 1-2: encrypted payload size (16-bit big-endian)
@@ -41,8 +40,8 @@ class APINoiseFrameHelper final : public APIFrameHelper {
   NoiseCipherState *send_cipher_{nullptr};
   NoiseCipherState *recv_cipher_{nullptr};
 
-  // Shared pointer (8 bytes on 32-bit = 4 bytes control block pointer + 4 bytes object pointer)
-  std::shared_ptr<APINoiseContext> ctx_;
+  // Reference to noise context (4 bytes on 32-bit)
+  APINoiseContext &ctx_;
 
   // Vector (12 bytes on 32-bit)
   std::vector<uint8_t> prologue_;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -227,8 +227,8 @@ void APIServer::dump_config() {
                 "  Max connections: %u",
                 network::get_use_address(), this->port_, this->listen_backlog_, this->max_connections_);
 #ifdef USE_API_NOISE
-  ESP_LOGCONFIG(TAG, "  Noise encryption: %s", YESNO(this->noise_ctx_->has_psk()));
-  if (!this->noise_ctx_->has_psk()) {
+  ESP_LOGCONFIG(TAG, "  Noise encryption: %s", YESNO(this->noise_ctx_.has_psk()));
+  if (!this->noise_ctx_.has_psk()) {
     ESP_LOGCONFIG(TAG, "  Supports encryption: YES");
   }
 #else
@@ -493,7 +493,7 @@ bool APIServer::save_noise_psk(psk_t psk, bool make_active) {
   ESP_LOGW(TAG, "Key set in YAML");
   return false;
 #else
-  auto &old_psk = this->noise_ctx_->get_psk();
+  auto &old_psk = this->noise_ctx_.get_psk();
   if (std::equal(old_psk.begin(), old_psk.end(), psk.begin())) {
     ESP_LOGW(TAG, "New PSK matches old");
     return true;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -54,8 +54,8 @@ class APIServer : public Component, public Controller {
 #ifdef USE_API_NOISE
   bool save_noise_psk(psk_t psk, bool make_active = true);
   bool clear_noise_psk(bool make_active = true);
-  void set_noise_psk(psk_t psk) { noise_ctx_->set_psk(psk); }
-  std::shared_ptr<APINoiseContext> get_noise_ctx() { return noise_ctx_; }
+  void set_noise_psk(psk_t psk) { this->noise_ctx_.set_psk(psk); }
+  APINoiseContext &get_noise_ctx() { return this->noise_ctx_; }
 #endif  // USE_API_NOISE
 
   void handle_disconnect(APIConnection *conn);
@@ -228,7 +228,7 @@ class APIServer : public Component, public Controller {
   // 7 bytes used, 1 byte padding
 
 #ifdef USE_API_NOISE
-  std::shared_ptr<APINoiseContext> noise_ctx_ = std::make_shared<APINoiseContext>();
+  APINoiseContext noise_ctx_;
   ESPPreferenceObject noise_pref_;
 #endif  // USE_API_NOISE
 };

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -119,7 +119,7 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
     MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION, "api_encryption");
     MDNS_STATIC_CONST_CHAR(TXT_API_ENCRYPTION_SUPPORTED, "api_encryption_supported");
     MDNS_STATIC_CONST_CHAR(NOISE_ENCRYPTION, "Noise_NNpsk0_25519_ChaChaPoly_SHA256");
-    bool has_psk = api::global_api_server->get_noise_ctx()->has_psk();
+    bool has_psk = api::global_api_server->get_noise_ctx().has_psk();
     const char *encryption_key = has_psk ? TXT_API_ENCRYPTION : TXT_API_ENCRYPTION_SUPPORTED;
     txt_records.push_back({MDNS_STR(encryption_key), MDNS_STR(NOISE_ENCRYPTION)});
 #endif

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -140,7 +140,7 @@ void MQTTClientComponent::send_device_info_() {
 #endif
 
 #ifdef USE_API_NOISE
-        root[api::global_api_server->get_noise_ctx()->has_psk() ? "api_encryption" : "api_encryption_supported"] =
+        root[api::global_api_server->get_noise_ctx().has_psk() ? "api_encryption" : "api_encryption_supported"] =
             "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
 #endif
       },


### PR DESCRIPTION
# What does this implement/fix?

Optimizes memory usage in the API component by removing unnecessary `std::shared_ptr` overhead for `APINoiseContext`.

## Problem

The `APINoiseContext` was stored as a `std::shared_ptr`, which provided **zero value** because:

1. **`APIServer` has program lifetime**: Created once in `main.cpp`, stored in `global_api_server`, never destroyed until program termination
2. **The reference count would never reach zero**: With 1 reference from `APIServer` + N from active connections, the context would only be destroyed when the entire program exits
3. **No actual shared ownership**: `APIServer` exclusively owns the context; connections just need temporary access during handshake

The `std::shared_ptr` was doing pointless atomic reference counting and wasting memory for a singleton that lives for the entire program.

## Changes

Replace `std::shared_ptr<APINoiseContext>` with direct ownership and reference semantics:

1. **`APIServer` owns the context**: Direct member instead of shared_ptr (program lifetime guaranteed)
2. **Connections borrow via reference**: `APINoiseFrameHelper` stores `APINoiseContext &` instead of shared_ptr
3. **Lifetime safety**: Connections are destroyed before `APIServer` (via member destruction order)

### Before:
- `APIServer::noise_ctx_`: `std::shared_ptr<APINoiseContext>` (8 bytes)
- `APINoiseFrameHelper::ctx_`: `std::shared_ptr<APINoiseContext>` (8 bytes per connection)

### After:
- `APIServer::noise_ctx_`: `APINoiseContext` (direct member, ~33 bytes)
- `APINoiseFrameHelper::ctx_`: `APINoiseContext &` (reference, 4 bytes per connection)

### Memory savings:
- **Shared_ptr control block**: ~16-24 bytes (heap freed)
- **APINoiseContext heap allocation**: 33 bytes (heap freed, now in .bss)
- **APIServer**: 4 bytes (shared_ptr pointer removed)
- **Per connection**: 4 bytes (shared_ptr → reference)
- **Total heap saved**: ~57-65 bytes
- **Static RAM trade-off**: +36 bytes (APINoiseContext moved from heap to .bss)
  - **Net RAM improvement**: The +36 static RAM is more than offset by ~57-65 bytes freed from heap
  - Static RAM is less critical than heap on ESP8266 (reduces fragmentation)
- **Flash**: -316 bytes (template instantiations and ref-counting code removed)
- **Runtime**: Eliminates atomic ref-count increment/decrement on every connection create/destroy

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization effort for ESP8266 and constrained devices

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing changes - internal optimization only.

```yaml
# Existing API configuration works unchanged
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Implementation Details

### Files changed:
1. `esphome/components/api/api_server.h`
   - Changed `noise_ctx_` from `std::shared_ptr<APINoiseContext>` to direct member `APINoiseContext`
   - Changed `get_noise_ctx()` return type from `std::shared_ptr<APINoiseContext>` to `APINoiseContext &`

2. `esphome/components/api/api_frame_helper_noise.h`
   - Changed constructor parameter from `std::shared_ptr<APINoiseContext>` to `APINoiseContext &`
   - Changed `ctx_` member from `std::shared_ptr<APINoiseContext>` to `APINoiseContext &`

3. `esphome/components/api/api_connection.cpp`
   - Updated call sites to use reference instead of shared_ptr

4. `esphome/components/api/api_server.cpp`
   - Updated member access from `noise_ctx_->` to `noise_ctx_.`

5. `esphome/components/mdns/mdns_component.cpp`
   - Updated to use reference return value

6. `esphome/components/mqtt/mqtt_client.cpp`
   - Updated to use reference return value

### Correctness verification:

**Why this is safe**:

1. **Program lifetime**: `APIServer` is created once in `main.cpp`, stored in `global_api_server`, and never destroyed until program exit
2. **Member destruction order**: Even if `APIServer` were destroyed, C++ guarantees members are destroyed in reverse declaration order:
   ```cpp
   class APIServer {
     std::vector<std::unique_ptr<APIConnection>> clients_;  // Line 201 - destroyed FIRST
     // ... other members ...
     APINoiseContext noise_ctx_;  // Line 231 - destroyed LAST
   };
   ```
3. **Ownership hierarchy**:
   - `APIServer` owns `clients_` → owns all `APIConnection` → owns all `APINoiseFrameHelper`
   - All `APINoiseFrameHelper` instances (which hold `APINoiseContext &`) are destroyed before `noise_ctx_`

**Why the old code was unnecessary**:
- The shared_ptr ref count pattern was: 1 (APIServer) + N (active connections)
- Since `APIServer` lives forever, ref count never reaches 0 until program exit
- The atomic reference counting was pure overhead with zero benefit
- Classic case of over-engineering with smart pointers when simple ownership semantics suffice
