### PR TITLE
[lock] Modernize to C++17 nested namespaces

### DIFF
--- a/esphome/components/lock/automation.h
+++ b/esphome/components/lock/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace lock {
+namespace esphome::lock {
 
 template<typename... Ts> class LockAction : public Action<Ts...> {
  public:
@@ -72,5 +71,4 @@ class LockUnlockTrigger : public Trigger<> {
   }
 };
 
-}  // namespace lock
-}  // namespace esphome
+}  // namespace esphome::lock

--- a/esphome/components/lock/lock.cpp
+++ b/esphome/components/lock/lock.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace lock {
+namespace esphome::lock {
 
 static const char *const TAG = "lock";
 
@@ -108,5 +107,4 @@ LockCall &LockCall::set_state(const std::string &state) {
 }
 const optional<LockState> &LockCall::get_state() const { return this->state_; }
 
-}  // namespace lock
-}  // namespace esphome
+}  // namespace esphome::lock

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -7,8 +7,7 @@
 #include "esphome/core/preferences.h"
 #include <initializer_list>
 
-namespace esphome {
-namespace lock {
+namespace esphome::lock {
 
 class Lock;
 
@@ -177,5 +176,4 @@ class Lock : public EntityBase {
   ESPPreferenceObject rtc_;
 };
 
-}  // namespace lock
-}  // namespace esphome
+}  // namespace esphome::lock


### PR DESCRIPTION
# What does this implement/fix?

Modernizes the `lock` component to use C++17 nested namespace syntax, replacing the traditional multi-line namespace declarations with the more concise `namespace esphome::lock {` format.

This change:
- Converts `namespace esphome { namespace lock {` to `namespace esphome::lock {`
- Updates closing namespace comments accordingly
- Reduces code by 6 lines while maintaining identical functionality
- Aligns with modern C++ standards (ESPHome uses gnu++20)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing C++17 modernization effort (similar to #11945 for number, #11935 for cover, #11929 for binary_sensor)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is a purely syntactic modernization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
