### PR TITLE
[mdns] Modernize to C++17 nested namespace syntax

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -21,8 +21,7 @@
 #include "esphome/components/dashboard_import/dashboard_import.h"
 #endif
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 static const char *const TAG = "mdns";
 
@@ -189,6 +188,5 @@ void MDNSComponent::dump_config() {
 #endif
 }
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 #endif

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 // Helper struct that identifies strings that may be stored in flash storage (similar to LogString)
 struct MDNSString;
@@ -79,6 +78,5 @@ class MDNSComponent : public Component {
   void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services);
 };
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 #endif

--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -7,8 +7,7 @@
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 static const char *const TAG = "mdns";
 
@@ -56,7 +55,6 @@ void MDNSComponent::on_shutdown() {
   delay(40);  // Allow the mdns packets announcing service removal to be sent
 }
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 
 #endif  // USE_ESP32

--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -9,8 +9,7 @@
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 void MDNSComponent::setup() {
 #ifdef USE_MDNS_STORE_SERVICES
@@ -52,7 +51,6 @@ void MDNSComponent::on_shutdown() {
   delay(10);
 }
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 
 #endif

--- a/esphome/components/mdns/mdns_host.cpp
+++ b/esphome/components/mdns/mdns_host.cpp
@@ -6,8 +6,7 @@
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 void MDNSComponent::setup() {
   // Host platform doesn't have actual mDNS implementation
@@ -15,7 +14,6 @@ void MDNSComponent::setup() {
 
 void MDNSComponent::on_shutdown() {}
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 
 #endif

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -9,8 +9,7 @@
 
 #include <mDNS.h>
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 void MDNSComponent::setup() {
 #ifdef USE_MDNS_STORE_SERVICES
@@ -46,7 +45,6 @@ void MDNSComponent::setup() {
 
 void MDNSComponent::on_shutdown() {}
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 
 #endif

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -9,8 +9,7 @@
 
 #include <ESP8266mDNS.h>
 
-namespace esphome {
-namespace mdns {
+namespace esphome::mdns {
 
 void MDNSComponent::setup() {
 #ifdef USE_MDNS_STORE_SERVICES
@@ -51,7 +50,6 @@ void MDNSComponent::on_shutdown() {
   delay(40);
 }
 
-}  // namespace mdns
-}  // namespace esphome
+}  // namespace esphome::mdns
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the `mdns` component to use C++17 nested namespace syntax.

**Changes:**
- Updated all namespace declarations from nested blocks to C++17 single-line syntax
- Affects 6 files: mdns_component.h, mdns_component.cpp, mdns_esp32.cpp, mdns_esp8266.cpp, mdns_rp2040.cpp, mdns_libretiny.cpp, mdns_host.cpp

**Before:**
```cpp
namespace esphome {
namespace mdns {
  // code
}  // namespace mdns
}  // namespace esphome
```

**After:**
```cpp
namespace esphome::mdns {
  // code
}  // namespace esphome::mdns
```

This is a purely syntactic improvement with no functional changes, aligning the codebase with modern C++ standards (C++17 and later).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing C++17 modernization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
