### PR TITLE
[web_server_base] Replace shared_ptr with unique_ptr for AsyncWebServer

### DIFF
--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -111,7 +111,7 @@ class WebServerBase : public Component {
       this->initialized_++;
       return;
     }
-    this->server_ = std::make_shared<AsyncWebServer>(this->port_);
+    this->server_ = std::make_unique<AsyncWebServer>(this->port_);
     // All content is controlled and created by user - so allowing all origins is fine here.
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
     this->server_->begin();
@@ -127,7 +127,7 @@ class WebServerBase : public Component {
       this->server_ = nullptr;
     }
   }
-  std::shared_ptr<AsyncWebServer> get_server() const { return server_; }
+  AsyncWebServer *get_server() const { return this->server_.get(); }
   float get_setup_priority() const override;
 
 #ifdef USE_WEBSERVER_AUTH
@@ -143,7 +143,7 @@ class WebServerBase : public Component {
  protected:
   int initialized_{0};
   uint16_t port_{80};
-  std::shared_ptr<AsyncWebServer> server_{nullptr};
+  std::unique_ptr<AsyncWebServer> server_{nullptr};
   std::vector<AsyncWebHandler *> handlers_;
 #ifdef USE_WEBSERVER_AUTH
   internal::Credentials credentials_;


### PR DESCRIPTION
# What does this implement/fix?

Optimizes memory usage in the web server base component by replacing unnecessary `std::shared_ptr` with `std::unique_ptr` for `AsyncWebServer`.

## Problem

The `AsyncWebServer` was stored as a `std::shared_ptr`, but this provided **zero value** because:

1. **Exclusive ownership**: `WebServerBase` is the sole owner of the `AsyncWebServer` instance
2. **No shared ownership needed**: All callers of `get_server()` just invoke methods immediately - none store the returned pointer
3. **Lifecycle managed differently**: The `init()/deinit()` pattern with `initialized_` counter manages the server lifecycle, not the shared_ptr reference count

The `std::shared_ptr` was wasting memory on a control block for reference counting that served no purpose.

### History

The `shared_ptr` was an overly-conservative fix to a clang-tidy warning:

- **2019-06-09** (#624): Original implementation used raw `new`/`delete` with manual memory management
- **2021-09-13** (#1891): Changed raw pointer → `shared_ptr` to fix clang-tidy warning
  - Commit: a4867a00e "Activate owning-memory clang-tidy check"
  - Purpose: Eliminate manual `new`/`delete` to satisfy `owning-memory` clang-tidy warnings
  - **Overkill**: Used `shared_ptr` when `unique_ptr` was the correct choice for exclusive ownership
  - Likely reason: `shared_ptr` is safer/easier when unsure, but unnecessary for this use case
- **2025-11-18** (this PR): Correcting to `unique_ptr` for proper exclusive ownership semantics

The `shared_ptr` was chosen as a **safe but wasteful** fix to the clang-tidy warning. This PR uses the appropriate smart pointer for exclusive ownership.

## Changes

Replace `std::shared_ptr<AsyncWebServer>` with `std::unique_ptr<AsyncWebServer>`:

1. **WebServerBase owns exclusively**: Use `std::unique_ptr` to express exclusive ownership
2. **Callers borrow via pointer**: `get_server()` returns raw pointer for temporary access
3. **Same semantics**: `init()/deinit()` pattern continues to work identically (setting to `nullptr` destroys the server)

### Before:
```cpp
std::shared_ptr<AsyncWebServer> server_{nullptr};
std::shared_ptr<AsyncWebServer> get_server() const { return server_; }
this->server_ = std::make_shared<AsyncWebServer>(this->port_);
```

### After:
```cpp
std::unique_ptr<AsyncWebServer> server_{nullptr};
AsyncWebServer *get_server() const { return this->server_.get(); }
this->server_ = std::make_unique<AsyncWebServer>(this->port_);
```

### Memory savings:
- **Shared_ptr control block**: ~16-24 bytes (heap allocation eliminated)
- **Better ownership semantics**: Code now clearly expresses that `WebServerBase` exclusively owns the server
- **No functional changes**: All existing code works unchanged (callers just invoke methods on the returned pointer)

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing memory optimization effort for ESP8266 and constrained devices
- Follows same pattern as API noise context optimization

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing changes - internal optimization only.

```yaml
# Existing web_server configuration works unchanged
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Implementation Details

### Files changed:
1. `esphome/components/web_server_base/web_server_base.h`
   - Changed `server_` from `std::shared_ptr<AsyncWebServer>` to `std::unique_ptr<AsyncWebServer>`
   - Changed `get_server()` return type from `std::shared_ptr<AsyncWebServer>` to `AsyncWebServer *`
   - Changed `std::make_shared` to `std::make_unique`

### Call site analysis:

All existing call sites work without modification:

**captive_portal component** (only user of `get_server()`):
```cpp
// Before and After - identical usage
this->base_->get_server()->set_lru_purge_enable(true);
this->base_->get_server()->set_lru_purge_enable(false);
```

The change from `shared_ptr` to raw pointer is transparent because:
- Both support `->` operator for method calls
- Callers never stored the result (always used immediately)
- Lifetime is guaranteed by `WebServerBase` owning the server

### Why this is safe:

1. **Exclusive ownership**: Only `WebServerBase` creates/destroys the `AsyncWebServer`
   - Created via `std::make_unique` in `init()`
   - Destroyed by setting to `nullptr` in `deinit()`

2. **No stored references**: Verified that all callers use the pattern:
   ```cpp
   get_server()->some_method();  // Temporary use only
   ```

3. **Lifetime guarantee**: The server exists between `init()` and `deinit()` calls
   - Captive portal correctly calls `deinit()` when done (line 47 in captive_portal.h)
   - No other components hold references beyond the call

### Why the old code was unnecessary:

- The `shared_ptr` suggested shared ownership, but only `WebServerBase` owned it
- The reference count would always be 1 (just `WebServerBase`)
- The control block allocation and atomic ref counting provided zero benefit
- `std::unique_ptr` better expresses the actual ownership model

### Root cause analysis:

The `shared_ptr` was an overly-conservative fix when addressing clang-tidy warnings in 2021 (commit a4867a00e). When fixing the `owning-memory` warning, `shared_ptr` was chosen instead of `unique_ptr` - likely because it's "safer" when unsure about ownership semantics. However, since `WebServerBase` has exclusive ownership, `unique_ptr` is both correct and more efficient. This is a common pattern: reaching for `shared_ptr` as a "safe default" even when exclusive ownership would suffice.

### Comparison with similar optimizations:

This follows the same pattern as the `APINoiseContext` optimization:
- Both were using `shared_ptr` for singleton-like objects
- Both had exclusive ownership by a single component
- Both returned shared_ptr from getter methods that callers used immediately
- Both wasted memory on unnecessary control blocks

The difference is that `WebServerBase` has dynamic lifecycle (can be created/destroyed via `init()/deinit()`), while `APIServer` has program lifetime. However, neither needed shared ownership.
