### PR TITLE
[light] Modernize namespace declarations to C++17 syntax

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -1,8 +1,7 @@
 #include "addressable_light.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 static const char *const TAG = "light.addressable";
 
@@ -112,5 +111,4 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   return {};
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -14,8 +14,7 @@
 #include "esphome/components/power_supply/power_supply.h"
 #endif
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 /// Convert the color information from a `LightColorValues` object to a `Color` object (does not apply brightness).
 Color color_from_light_color_values(LightColorValues val);
@@ -116,5 +115,4 @@ class AddressableLightTransformer : public LightTransformer {
   Color target_color_{};
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -7,8 +7,7 @@
 #include "esphome/components/light/light_state.h"
 #include "esphome/components/light/addressable_light.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 inline static int16_t sin16_c(uint16_t theta) {
   static const uint16_t BASE[] = {0, 6393, 12539, 18204, 23170, 27245, 30273, 32137};
@@ -371,5 +370,4 @@ class AddressableFlickerEffect : public AddressableLightEffect {
   uint8_t intensity_{13};
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "addressable_light.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class AddressableLightWrapper : public light::AddressableLight {
  public:
@@ -123,5 +122,4 @@ class AddressableLightWrapper : public light::AddressableLight {
   ColorMode color_mode_{ColorMode::UNKNOWN};
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/automation.cpp
+++ b/esphome/components/light/automation.cpp
@@ -1,8 +1,7 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 static const char *const TAG = "light.automation";
 
@@ -11,5 +10,4 @@ void addressableset_warn_about_scale(const char *field) {
            field);
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -4,8 +4,7 @@
 #include "light_state.h"
 #include "addressable_light.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 enum class LimitMode { CLAMP, DO_NOTHING };
 
@@ -216,5 +215,4 @@ template<typename... Ts> class AddressableSet : public Action<Ts...> {
   }
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -6,8 +6,7 @@
 #include "esphome/core/helpers.h"
 #include "light_effect.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 inline static float random_cubic_float() {
   const float r = random_float() * 2.0f - 1.0f;
@@ -235,5 +234,4 @@ class FlickerLightEffect : public LightEffect {
   float alpha_{};
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/color_mode.h
+++ b/esphome/components/light/color_mode.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include "esphome/core/finite_set_mask.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 /// Color capabilities are the various outputs that a light has and that can be independently controlled by the user.
 enum class ColorCapability : uint8_t {
@@ -210,5 +209,4 @@ inline bool has_capability(const ColorModeMask &mask, ColorCapability capability
   return (mask.get_mask() & CAPABILITY_BITMASKS[capability_to_index(capability)]) != 0;
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_color_correction.cpp
+++ b/esphome/components/light/esp_color_correction.cpp
@@ -2,8 +2,7 @@
 #include "light_color_values.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 void ESPColorCorrection::calculate_gamma_table(float gamma) {
   for (uint16_t i = 0; i < 256; i++) {
@@ -23,5 +22,4 @@ void ESPColorCorrection::calculate_gamma_table(float gamma) {
   }
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_color_correction.h
+++ b/esphome/components/light/esp_color_correction.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/color.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class ESPColorCorrection {
  public:
@@ -73,5 +72,4 @@ class ESPColorCorrection {
   uint8_t local_brightness_{255};
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_color_view.h
+++ b/esphome/components/light/esp_color_view.h
@@ -4,8 +4,7 @@
 #include "esp_hsv_color.h"
 #include "esp_color_correction.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class ESPColorSettable {
  public:
@@ -106,5 +105,4 @@ class ESPColorView : public ESPColorSettable {
   const ESPColorCorrection *color_correction_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_hsv_color.cpp
+++ b/esphome/components/light/esp_hsv_color.cpp
@@ -1,7 +1,6 @@
 #include "esp_hsv_color.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 Color ESPHSVColor::to_rgb() const {
   // based on FastLED's hsv rainbow to rgb
@@ -70,5 +69,4 @@ Color ESPHSVColor::to_rgb() const {
   return rgb;
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_hsv_color.h
+++ b/esphome/components/light/esp_hsv_color.h
@@ -3,8 +3,7 @@
 #include "esphome/core/color.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 struct ESPHSVColor {
   union {
@@ -32,5 +31,4 @@ struct ESPHSVColor {
   Color to_rgb() const;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_range_view.cpp
+++ b/esphome/components/light/esp_range_view.cpp
@@ -1,8 +1,7 @@
 #include "esp_range_view.h"
 #include "addressable_light.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 int32_t HOT interpret_index(int32_t index, int32_t size) {
   if (index < 0)
@@ -92,5 +91,4 @@ ESPRangeView &ESPRangeView::operator=(const ESPRangeView &rhs) {  // NOLINT
 
 ESPColorView ESPRangeIterator::operator*() const { return this->range_.parent_->get(this->i_); }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/esp_range_view.h
+++ b/esphome/components/light/esp_range_view.h
@@ -3,8 +3,7 @@
 #include "esp_color_view.h"
 #include "esp_hsv_color.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 int32_t interpret_index(int32_t index, int32_t size);
 
@@ -76,5 +75,4 @@ class ESPRangeIterator {
   int32_t i_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 static const char *const TAG = "light";
 
@@ -647,5 +646,4 @@ LightCall &LightCall::set_rgbw(float red, float green, float blue, float white) 
   return *this;
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -4,8 +4,7 @@
 #include "color_mode.h"
 #include <cmath>
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 inline static uint8_t to_uint8_scale(float x) { return static_cast<uint8_t>(roundf(x * 255.0f)); }
 
@@ -310,5 +309,4 @@ class LightColorValues {
   ColorMode color_mode_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_effect.cpp
+++ b/esphome/components/light/light_effect.cpp
@@ -1,8 +1,7 @@
 #include "light_effect.h"
 #include "light_state.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 uint32_t LightEffect::get_index() const {
   if (this->state_ == nullptr) {
@@ -32,5 +31,4 @@ uint32_t LightEffect::get_index_in_parent_() const {
   return 0;  // Not found
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_effect.h
+++ b/esphome/components/light/light_effect.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class LightState;
 
@@ -55,5 +54,4 @@ class LightEffect {
   uint32_t get_index_in_parent_() const;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_JSON
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 // See https://www.home-assistant.io/integrations/light.mqtt/#json-schema for documentation on the schema
 
@@ -169,7 +168,6 @@ void LightJSONSchema::parse_json(LightState &state, LightCall &call, JsonObject 
   }
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light
 
 #endif

--- a/esphome/components/light/light_json_schema.h
+++ b/esphome/components/light/light_json_schema.h
@@ -8,8 +8,7 @@
 #include "light_call.h"
 #include "light_state.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class LightJSONSchema {
  public:
@@ -22,7 +21,6 @@ class LightJSONSchema {
   static void parse_color_json(LightState &state, LightCall &call, JsonObject root);
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light
 
 #endif

--- a/esphome/components/light/light_output.cpp
+++ b/esphome/components/light/light_output.cpp
@@ -1,12 +1,10 @@
 #include "light_output.h"
 #include "transformers.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 std::unique_ptr<LightTransformer> LightOutput::create_default_transition() {
   return make_unique<LightTransitionTransformer>();
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_output.h
+++ b/esphome/components/light/light_output.h
@@ -5,8 +5,7 @@
 #include "light_state.h"
 #include "light_transformer.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 /// Interface to write LightStates to hardware.
 class LightOutput {
@@ -29,5 +28,4 @@ class LightOutput {
   virtual void write_state(LightState *state) = 0;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -5,8 +5,7 @@
 #include "light_output.h"
 #include "transformers.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 static const char *const TAG = "light";
 
@@ -304,5 +303,4 @@ void LightState::save_remote_values_() {
   this->rtc_.save(&saved);
 }
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -15,8 +15,7 @@
 #include <strings.h>
 #include <vector>
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class LightOutput;
 
@@ -298,5 +297,4 @@ class LightState : public EntityBase, public Component {
   LightRestoreMode restore_mode_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "light_color_values.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 /// Base class for all light color transformers, such as transitions or flashes.
 class LightTransformer {
@@ -59,5 +58,4 @@ class LightTransformer {
   LightColorValues target_values_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -6,8 +6,7 @@
 #include "light_state.h"
 #include "light_transformer.h"
 
-namespace esphome {
-namespace light {
+namespace esphome::light {
 
 class LightTransitionTransformer : public LightTransformer {
  public:
@@ -118,5 +117,4 @@ class LightFlashTransformer : public LightTransformer {
   bool begun_lightstate_restore_;
 };
 
-}  // namespace light
-}  // namespace esphome
+}  // namespace esphome::light


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the `light` component by updating namespace declarations to use C++17 nested namespace syntax, following the same pattern as PR #11982 (lock component).

**Changes:**
- Converted `namespace esphome { namespace light {` to `namespace esphome::light {`
- Updated closing comments from `}  // namespace light }  // namespace esphome` to `}  // namespace esphome::light`
- Applied to all header (.h) and implementation (.cpp) files in the light component
- Special cases (`light_call.h` and `light_traits.h`) retain traditional syntax due to forward declarations in the esphome namespace

**Benefits:**
- Code reduction: Eliminates 40+ lines of code while preserving functionality
- Standards alignment: Leverages C++17 features (ESPHome uses gnu++20)
- Consistency: Matches ongoing modernization across components (binary_sensor, cover, lock, number)
- Readability: More concise and cleaner namespace syntax

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Continues modernization effort from #11982

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a code modernization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
