### PR TITLE
[ld24xx] Modernize namespace declarations to C++17 syntax

### DIFF
--- a/esphome/components/ld2410/automation.h
+++ b/esphome/components/ld2410/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 template<typename... Ts> class BluetoothPasswordSetAction : public Action<Ts...> {
  public:
@@ -18,5 +17,4 @@ template<typename... Ts> class BluetoothPasswordSetAction : public Action<Ts...>
   LD2410Component *ld2410_comp_;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/factory_reset_button.cpp
+++ b/esphome/components/ld2410/button/factory_reset_button.cpp
@@ -1,9 +1,7 @@
 #include "factory_reset_button.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void FactoryResetButton::press_action() { this->parent_->factory_reset(); }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/factory_reset_button.h
+++ b/esphome/components/ld2410/button/factory_reset_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class FactoryResetButton : public button::Button, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class FactoryResetButton : public button::Button, public Parented<LD2410Componen
   void press_action() override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/query_button.cpp
+++ b/esphome/components/ld2410/button/query_button.cpp
@@ -1,9 +1,7 @@
 #include "query_button.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void QueryButton::press_action() { this->parent_->read_all_info(); }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/query_button.h
+++ b/esphome/components/ld2410/button/query_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class QueryButton : public button::Button, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class QueryButton : public button::Button, public Parented<LD2410Component> {
   void press_action() override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/restart_button.cpp
+++ b/esphome/components/ld2410/button/restart_button.cpp
@@ -1,9 +1,7 @@
 #include "restart_button.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void RestartButton::press_action() { this->parent_->restart_and_read_all_info(); }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/button/restart_button.h
+++ b/esphome/components/ld2410/button/restart_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class RestartButton : public button::Button, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class RestartButton : public button::Button, public Parented<LD2410Component> {
   void press_action() override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -9,8 +9,7 @@
 
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 static const char *const TAG = "ld2410";
 
@@ -782,5 +781,4 @@ void LD2410Component::set_gate_still_sensor(uint8_t gate, sensor::Sensor *s) {
 }
 #endif
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -29,8 +29,7 @@
 
 #include <array>
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 using namespace ld24xx;
 
@@ -133,5 +132,4 @@ class LD2410Component : public Component, public uart::UARTDevice {
 #endif
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/gate_threshold_number.cpp
+++ b/esphome/components/ld2410/number/gate_threshold_number.cpp
@@ -1,7 +1,6 @@
 #include "gate_threshold_number.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 GateThresholdNumber::GateThresholdNumber(uint8_t gate) : gate_(gate) {}
 
@@ -10,5 +9,4 @@ void GateThresholdNumber::control(float value) {
   this->parent_->set_gate_threshold(this->gate_);
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/gate_threshold_number.h
+++ b/esphome/components/ld2410/number/gate_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class GateThresholdNumber : public number::Number, public Parented<LD2410Component> {
  public:
@@ -15,5 +14,4 @@ class GateThresholdNumber : public number::Number, public Parented<LD2410Compone
   void control(float value) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/light_threshold_number.cpp
+++ b/esphome/components/ld2410/number/light_threshold_number.cpp
@@ -1,12 +1,10 @@
 #include "light_threshold_number.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void LightThresholdNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_light_out_control();
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/light_threshold_number.h
+++ b/esphome/components/ld2410/number/light_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class LightThresholdNumber : public number::Number, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class LightThresholdNumber : public number::Number, public Parented<LD2410Compon
   void control(float value) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/max_distance_timeout_number.cpp
+++ b/esphome/components/ld2410/number/max_distance_timeout_number.cpp
@@ -1,12 +1,10 @@
 #include "max_distance_timeout_number.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void MaxDistanceTimeoutNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_max_distances_timeout();
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/number/max_distance_timeout_number.h
+++ b/esphome/components/ld2410/number/max_distance_timeout_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class MaxDistanceTimeoutNumber : public number::Number, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class MaxDistanceTimeoutNumber : public number::Number, public Parented<LD2410Co
   void control(float value) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/baud_rate_select.cpp
+++ b/esphome/components/ld2410/select/baud_rate_select.cpp
@@ -1,12 +1,10 @@
 #include "baud_rate_select.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void BaudRateSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_baud_rate(this->option_at(index));
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/baud_rate_select.h
+++ b/esphome/components/ld2410/select/baud_rate_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class BaudRateSelect : public select::Select, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class BaudRateSelect : public select::Select, public Parented<LD2410Component> {
   void control(size_t index) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/distance_resolution_select.cpp
+++ b/esphome/components/ld2410/select/distance_resolution_select.cpp
@@ -1,12 +1,10 @@
 #include "distance_resolution_select.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void DistanceResolutionSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_distance_resolution(this->option_at(index));
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/distance_resolution_select.h
+++ b/esphome/components/ld2410/select/distance_resolution_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class DistanceResolutionSelect : public select::Select, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class DistanceResolutionSelect : public select::Select, public Parented<LD2410Co
   void control(size_t index) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/light_out_control_select.cpp
+++ b/esphome/components/ld2410/select/light_out_control_select.cpp
@@ -1,12 +1,10 @@
 #include "light_out_control_select.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void LightOutControlSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_light_out_control();
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/select/light_out_control_select.h
+++ b/esphome/components/ld2410/select/light_out_control_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class LightOutControlSelect : public select::Select, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class LightOutControlSelect : public select::Select, public Parented<LD2410Compo
   void control(size_t index) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/switch/bluetooth_switch.cpp
+++ b/esphome/components/ld2410/switch/bluetooth_switch.cpp
@@ -1,12 +1,10 @@
 #include "bluetooth_switch.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void BluetoothSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_bluetooth(state);
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/switch/bluetooth_switch.h
+++ b/esphome/components/ld2410/switch/bluetooth_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class BluetoothSwitch : public switch_::Switch, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class BluetoothSwitch : public switch_::Switch, public Parented<LD2410Component>
   void write_state(bool state) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/switch/engineering_mode_switch.cpp
+++ b/esphome/components/ld2410/switch/engineering_mode_switch.cpp
@@ -1,12 +1,10 @@
 #include "engineering_mode_switch.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 void EngineeringModeSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_engineering_mode(state);
 }
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2410/switch/engineering_mode_switch.h
+++ b/esphome/components/ld2410/switch/engineering_mode_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2410.h"
 
-namespace esphome {
-namespace ld2410 {
+namespace esphome::ld2410 {
 
 class EngineeringModeSwitch : public switch_::Switch, public Parented<LD2410Component> {
  public:
@@ -14,5 +13,4 @@ class EngineeringModeSwitch : public switch_::Switch, public Parented<LD2410Comp
   void write_state(bool state) override;
 };
 
-}  // namespace ld2410
-}  // namespace esphome
+}  // namespace esphome::ld2410

--- a/esphome/components/ld2412/button/factory_reset_button.cpp
+++ b/esphome/components/ld2412/button/factory_reset_button.cpp
@@ -1,9 +1,7 @@
 #include "factory_reset_button.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void FactoryResetButton::press_action() { this->parent_->factory_reset(); }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/factory_reset_button.h
+++ b/esphome/components/ld2412/button/factory_reset_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class FactoryResetButton : public button::Button, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class FactoryResetButton : public button::Button, public Parented<LD2412Componen
   void press_action() override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/query_button.cpp
+++ b/esphome/components/ld2412/button/query_button.cpp
@@ -1,9 +1,7 @@
 #include "query_button.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void QueryButton::press_action() { this->parent_->read_all_info(); }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/query_button.h
+++ b/esphome/components/ld2412/button/query_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class QueryButton : public button::Button, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class QueryButton : public button::Button, public Parented<LD2412Component> {
   void press_action() override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/restart_button.cpp
+++ b/esphome/components/ld2412/button/restart_button.cpp
@@ -1,9 +1,7 @@
 #include "restart_button.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void RestartButton::press_action() { this->parent_->restart_and_read_all_info(); }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/restart_button.h
+++ b/esphome/components/ld2412/button/restart_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class RestartButton : public button::Button, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class RestartButton : public button::Button, public Parented<LD2412Component> {
   void press_action() override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/start_dynamic_background_correction_button.cpp
+++ b/esphome/components/ld2412/button/start_dynamic_background_correction_button.cpp
@@ -2,10 +2,8 @@
 
 #include "restart_button.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void StartDynamicBackgroundCorrectionButton::press_action() { this->parent_->start_dynamic_background_correction(); }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/button/start_dynamic_background_correction_button.h
+++ b/esphome/components/ld2412/button/start_dynamic_background_correction_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class StartDynamicBackgroundCorrectionButton : public button::Button, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class StartDynamicBackgroundCorrectionButton : public button::Button, public Par
   void press_action() override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -10,8 +10,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 static const char *const TAG = "ld2412";
 
@@ -855,5 +854,4 @@ void LD2412Component::set_gate_still_sensor(uint8_t gate, sensor::Sensor *s) {
 }
 #endif
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -29,8 +29,7 @@
 
 #include <array>
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 using namespace ld24xx;
 
@@ -137,5 +136,4 @@ class LD2412Component : public Component, public uart::UARTDevice {
 #endif
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/gate_threshold_number.cpp
+++ b/esphome/components/ld2412/number/gate_threshold_number.cpp
@@ -1,7 +1,6 @@
 #include "gate_threshold_number.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 GateThresholdNumber::GateThresholdNumber(uint8_t gate) : gate_(gate) {}
 
@@ -10,5 +9,4 @@ void GateThresholdNumber::control(float value) {
   this->parent_->set_gate_threshold();
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/gate_threshold_number.h
+++ b/esphome/components/ld2412/number/gate_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class GateThresholdNumber : public number::Number, public Parented<LD2412Component> {
  public:
@@ -15,5 +14,4 @@ class GateThresholdNumber : public number::Number, public Parented<LD2412Compone
   void control(float value) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/light_threshold_number.cpp
+++ b/esphome/components/ld2412/number/light_threshold_number.cpp
@@ -1,12 +1,10 @@
 #include "light_threshold_number.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void LightThresholdNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_light_out_control();
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/light_threshold_number.h
+++ b/esphome/components/ld2412/number/light_threshold_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class LightThresholdNumber : public number::Number, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class LightThresholdNumber : public number::Number, public Parented<LD2412Compon
   void control(float value) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/max_distance_timeout_number.cpp
+++ b/esphome/components/ld2412/number/max_distance_timeout_number.cpp
@@ -1,12 +1,10 @@
 #include "max_distance_timeout_number.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void MaxDistanceTimeoutNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_basic_config();
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/number/max_distance_timeout_number.h
+++ b/esphome/components/ld2412/number/max_distance_timeout_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class MaxDistanceTimeoutNumber : public number::Number, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class MaxDistanceTimeoutNumber : public number::Number, public Parented<LD2412Co
   void control(float value) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/baud_rate_select.cpp
+++ b/esphome/components/ld2412/select/baud_rate_select.cpp
@@ -1,12 +1,10 @@
 #include "baud_rate_select.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void BaudRateSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_baud_rate(this->option_at(index));
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/baud_rate_select.h
+++ b/esphome/components/ld2412/select/baud_rate_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class BaudRateSelect : public select::Select, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class BaudRateSelect : public select::Select, public Parented<LD2412Component> {
   void control(size_t index) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/distance_resolution_select.cpp
+++ b/esphome/components/ld2412/select/distance_resolution_select.cpp
@@ -1,12 +1,10 @@
 #include "distance_resolution_select.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void DistanceResolutionSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_distance_resolution(this->option_at(index));
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/distance_resolution_select.h
+++ b/esphome/components/ld2412/select/distance_resolution_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class DistanceResolutionSelect : public select::Select, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class DistanceResolutionSelect : public select::Select, public Parented<LD2412Co
   void control(size_t index) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/light_out_control_select.cpp
+++ b/esphome/components/ld2412/select/light_out_control_select.cpp
@@ -1,12 +1,10 @@
 #include "light_out_control_select.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void LightOutControlSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_light_out_control();
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/select/light_out_control_select.h
+++ b/esphome/components/ld2412/select/light_out_control_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class LightOutControlSelect : public select::Select, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class LightOutControlSelect : public select::Select, public Parented<LD2412Compo
   void control(size_t index) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/switch/bluetooth_switch.cpp
+++ b/esphome/components/ld2412/switch/bluetooth_switch.cpp
@@ -1,12 +1,10 @@
 #include "bluetooth_switch.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void BluetoothSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_bluetooth(state);
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/switch/bluetooth_switch.h
+++ b/esphome/components/ld2412/switch/bluetooth_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class BluetoothSwitch : public switch_::Switch, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class BluetoothSwitch : public switch_::Switch, public Parented<LD2412Component>
   void write_state(bool state) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/switch/engineering_mode_switch.cpp
+++ b/esphome/components/ld2412/switch/engineering_mode_switch.cpp
@@ -1,12 +1,10 @@
 #include "engineering_mode_switch.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 void EngineeringModeSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_engineering_mode(state);
 }
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2412/switch/engineering_mode_switch.h
+++ b/esphome/components/ld2412/switch/engineering_mode_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2412.h"
 
-namespace esphome {
-namespace ld2412 {
+namespace esphome::ld2412 {
 
 class EngineeringModeSwitch : public switch_::Switch, public Parented<LD2412Component> {
  public:
@@ -14,5 +13,4 @@ class EngineeringModeSwitch : public switch_::Switch, public Parented<LD2412Comp
   void write_state(bool state) override;
 };
 
-}  // namespace ld2412
-}  // namespace esphome
+}  // namespace esphome::ld2412

--- a/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.cpp
+++ b/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const char *const TAG = "ld2420.binary_sensor";
 
@@ -12,5 +11,4 @@ void LD2420BinarySensor::dump_config() {
   LOG_BINARY_SENSOR("  ", "Presence", this->presence_bsensor_);
 }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.h
+++ b/esphome/components/ld2420/binary_sensor/ld2420_binary_sensor.h
@@ -3,8 +3,7 @@
 #include "../ld2420.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420BinarySensor : public LD2420Listener, public Component, binary_sensor::BinarySensor {
  public:
@@ -21,5 +20,4 @@ class LD2420BinarySensor : public LD2420Listener, public Component, binary_senso
   binary_sensor::BinarySensor *presence_bsensor_{nullptr};
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/button/reconfig_buttons.cpp
+++ b/esphome/components/ld2420/button/reconfig_buttons.cpp
@@ -4,13 +4,11 @@
 
 static const char *const TAG = "ld2420.button";
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 void LD2420ApplyConfigButton::press_action() { this->parent_->apply_config_action(); }
 void LD2420RevertConfigButton::press_action() { this->parent_->revert_config_action(); }
 void LD2420RestartModuleButton::press_action() { this->parent_->restart_module_action(); }
 void LD2420FactoryResetButton::press_action() { this->parent_->factory_reset_action(); }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/button/reconfig_buttons.h
+++ b/esphome/components/ld2420/button/reconfig_buttons.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2420.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420ApplyConfigButton : public button::Button, public Parented<LD2420Component> {
  public:
@@ -38,5 +37,4 @@ class LD2420FactoryResetButton : public button::Button, public Parented<LD2420Co
   void press_action() override;
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -58,8 +58,7 @@ Gate 0 high thresh = 10 00 uint16_t 0x0010, Threshold value = 60 EA 00 00 uint32
 Gate 0 low thresh = 20 00 uint16_t 0x0020, Threshold value = 60 EA 00 00 uint32_t 0x0000EA60
 */
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const char *const TAG = "ld2420";
 
@@ -880,5 +879,4 @@ void LD2420Component::refresh_gate_config_numbers() {
 
 #endif
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -17,8 +17,7 @@
 #include "esphome/components/button/button.h"
 #endif
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const uint8_t CALIBRATE_SAMPLES = 64;
 static const uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
@@ -193,5 +192,4 @@ class LD2420Component : public Component, public uart::UARTDevice {
   std::vector<LD2420Listener *> listeners_{};
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/number/gate_config_number.cpp
+++ b/esphome/components/ld2420/number/gate_config_number.cpp
@@ -4,8 +4,7 @@
 
 static const char *const TAG = "ld2420.number";
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 void LD2420TimeoutNumber::control(float timeout) {
   this->publish_state(timeout);
@@ -69,5 +68,4 @@ void LD2420StillThresholdNumbers::control(float still_threshold) {
   }
 }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/number/gate_config_number.h
+++ b/esphome/components/ld2420/number/gate_config_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2420.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420TimeoutNumber : public number::Number, public Parented<LD2420Component> {
  public:
@@ -74,5 +73,4 @@ class LD2420MoveThresholdNumbers : public number::Number, public Parented<LD2420
   void control(float move_threshold) override;
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/select/operating_mode_select.cpp
+++ b/esphome/components/ld2420/select/operating_mode_select.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const char *const TAG = "ld2420.select";
 
@@ -12,5 +11,4 @@ void LD2420Select::control(size_t index) {
   this->parent_->set_operating_mode(this->option_at(index));
 }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/select/operating_mode_select.h
+++ b/esphome/components/ld2420/select/operating_mode_select.h
@@ -3,8 +3,7 @@
 #include "../ld2420.h"
 #include "esphome/components/select/select.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420Select : public Component, public select::Select, public Parented<LD2420Component> {
  public:
@@ -14,5 +13,4 @@ class LD2420Select : public Component, public select::Select, public Parented<LD
   void control(size_t index) override;
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/sensor/ld2420_sensor.cpp
+++ b/esphome/components/ld2420/sensor/ld2420_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const char *const TAG = "ld2420.sensor";
 
@@ -12,5 +11,4 @@ void LD2420Sensor::dump_config() {
   LOG_SENSOR("  ", "Distance", this->distance_sensor_);
 }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/sensor/ld2420_sensor.h
+++ b/esphome/components/ld2420/sensor/ld2420_sensor.h
@@ -3,8 +3,7 @@
 #include "../ld2420.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420Sensor : public LD2420Listener, public Component, sensor::Sensor {
  public:
@@ -30,5 +29,4 @@ class LD2420Sensor : public LD2420Listener, public Component, sensor::Sensor {
   std::vector<sensor::Sensor *> energy_sensors_ = std::vector<sensor::Sensor *>(TOTAL_GATES);
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/text_sensor/ld2420_text_sensor.cpp
+++ b/esphome/components/ld2420/text_sensor/ld2420_text_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 static const char *const TAG = "ld2420.text_sensor";
 
@@ -12,5 +11,4 @@ void LD2420TextSensor::dump_config() {
   LOG_TEXT_SENSOR("  ", "Firmware", this->fw_version_text_sensor_);
 }
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2420/text_sensor/ld2420_text_sensor.h
+++ b/esphome/components/ld2420/text_sensor/ld2420_text_sensor.h
@@ -3,8 +3,7 @@
 #include "../ld2420.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace ld2420 {
+namespace esphome::ld2420 {
 
 class LD2420TextSensor : public LD2420Listener, public Component, text_sensor::TextSensor {
  public:
@@ -20,5 +19,4 @@ class LD2420TextSensor : public LD2420Listener, public Component, text_sensor::T
   text_sensor::TextSensor *fw_version_text_sensor_{nullptr};
 };
 
-}  // namespace ld2420
-}  // namespace esphome
+}  // namespace esphome::ld2420

--- a/esphome/components/ld2450/button/factory_reset_button.cpp
+++ b/esphome/components/ld2450/button/factory_reset_button.cpp
@@ -1,9 +1,7 @@
 #include "factory_reset_button.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void FactoryResetButton::press_action() { this->parent_->factory_reset(); }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/button/factory_reset_button.h
+++ b/esphome/components/ld2450/button/factory_reset_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class FactoryResetButton : public button::Button, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class FactoryResetButton : public button::Button, public Parented<LD2450Componen
   void press_action() override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/button/restart_button.cpp
+++ b/esphome/components/ld2450/button/restart_button.cpp
@@ -1,9 +1,7 @@
 #include "restart_button.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void RestartButton::press_action() { this->parent_->restart_and_read_all_info(); }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/button/restart_button.h
+++ b/esphome/components/ld2450/button/restart_button.h
@@ -3,8 +3,7 @@
 #include "esphome/components/button/button.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class RestartButton : public button::Button, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class RestartButton : public button::Button, public Parented<LD2450Component> {
   void press_action() override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -13,8 +13,7 @@
 #include <cmath>
 #include <numbers>
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 static const char *const TAG = "ld2450";
 
@@ -939,5 +938,4 @@ float LD2450Component::restore_from_flash_() {
 }
 #endif
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -31,8 +31,7 @@
 
 #include <array>
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 using namespace ld24xx;
 
@@ -193,5 +192,4 @@ class LD2450Component : public Component, public uart::UARTDevice {
 #endif
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/number/presence_timeout_number.cpp
+++ b/esphome/components/ld2450/number/presence_timeout_number.cpp
@@ -1,12 +1,10 @@
 #include "presence_timeout_number.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void PresenceTimeoutNumber::control(float value) {
   this->publish_state(value);
   this->parent_->set_presence_timeout();
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/number/presence_timeout_number.h
+++ b/esphome/components/ld2450/number/presence_timeout_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class PresenceTimeoutNumber : public number::Number, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class PresenceTimeoutNumber : public number::Number, public Parented<LD2450Compo
   void control(float value) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/number/zone_coordinate_number.cpp
+++ b/esphome/components/ld2450/number/zone_coordinate_number.cpp
@@ -1,7 +1,6 @@
 #include "zone_coordinate_number.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 ZoneCoordinateNumber::ZoneCoordinateNumber(uint8_t zone) : zone_(zone) {}
 
@@ -10,5 +9,4 @@ void ZoneCoordinateNumber::control(float value) {
   this->parent_->set_zone_coordinate(this->zone_);
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/number/zone_coordinate_number.h
+++ b/esphome/components/ld2450/number/zone_coordinate_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class ZoneCoordinateNumber : public number::Number, public Parented<LD2450Component> {
  public:
@@ -15,5 +14,4 @@ class ZoneCoordinateNumber : public number::Number, public Parented<LD2450Compon
   void control(float value) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/select/baud_rate_select.cpp
+++ b/esphome/components/ld2450/select/baud_rate_select.cpp
@@ -1,12 +1,10 @@
 #include "baud_rate_select.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void BaudRateSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_baud_rate(this->option_at(index));
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/select/baud_rate_select.h
+++ b/esphome/components/ld2450/select/baud_rate_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class BaudRateSelect : public select::Select, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class BaudRateSelect : public select::Select, public Parented<LD2450Component> {
   void control(size_t index) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/select/zone_type_select.cpp
+++ b/esphome/components/ld2450/select/zone_type_select.cpp
@@ -1,12 +1,10 @@
 #include "zone_type_select.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void ZoneTypeSelect::control(size_t index) {
   this->publish_state(index);
   this->parent_->set_zone_type(this->option_at(index));
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/select/zone_type_select.h
+++ b/esphome/components/ld2450/select/zone_type_select.h
@@ -3,8 +3,7 @@
 #include "esphome/components/select/select.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class ZoneTypeSelect : public select::Select, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class ZoneTypeSelect : public select::Select, public Parented<LD2450Component> {
   void control(size_t index) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/switch/bluetooth_switch.cpp
+++ b/esphome/components/ld2450/switch/bluetooth_switch.cpp
@@ -1,12 +1,10 @@
 #include "bluetooth_switch.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void BluetoothSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_bluetooth(state);
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/switch/bluetooth_switch.h
+++ b/esphome/components/ld2450/switch/bluetooth_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class BluetoothSwitch : public switch_::Switch, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class BluetoothSwitch : public switch_::Switch, public Parented<LD2450Component>
   void write_state(bool state) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/switch/multi_target_switch.cpp
+++ b/esphome/components/ld2450/switch/multi_target_switch.cpp
@@ -1,12 +1,10 @@
 #include "multi_target_switch.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 void MultiTargetSwitch::write_state(bool state) {
   this->publish_state(state);
   this->parent_->set_multi_target(state);
 }
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld2450/switch/multi_target_switch.h
+++ b/esphome/components/ld2450/switch/multi_target_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "../ld2450.h"
 
-namespace esphome {
-namespace ld2450 {
+namespace esphome::ld2450 {
 
 class MultiTargetSwitch : public switch_::Switch, public Parented<LD2450Component> {
  public:
@@ -14,5 +13,4 @@ class MultiTargetSwitch : public switch_::Switch, public Parented<LD2450Componen
   void write_state(bool state) override;
 };
 
-}  // namespace ld2450
-}  // namespace esphome
+}  // namespace esphome::ld2450

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -37,8 +37,7 @@
 #define highbyte(val) (uint8_t)((val) >> 8)
 #define lowbyte(val) (uint8_t)((val) &0xff)
 
-namespace esphome {
-namespace ld24xx {
+namespace esphome::ld24xx {
 
 static const char *const UNKNOWN_MAC = "unknown";
 static const char *const VERSION_FMT = "%u.%02X.%02X%02X%02X%02X";
@@ -83,5 +82,4 @@ template<typename T> class SensorWithDedup {
   Deduplicator<T> publish_dedup;
 };
 #endif
-}  // namespace ld24xx
-}  // namespace esphome
+}  // namespace esphome::ld24xx


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the namespace declarations for all LD24xx radar sensor components (LD2410, LD2412, LD2420, LD2450, and the shared LD24xx base) to use C++17 nested namespace syntax.

**Changes:**
- Converts traditional nested namespace syntax `namespace esphome { namespace ld2410 {` to modern C++17 syntax `namespace esphome::ld2410 {`
- Updates closing namespace comments from dual-line to single-line format
- Applies changes consistently across 84 files in all LD24xx components

**Benefits:**
- Reduces code verbosity and improves readability
- Aligns with ongoing ESPHome modernization initiative (following #11982, #11986)
- Leverages C++17 features already supported by the project
- Zero functional changes or memory impact

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing namespace modernization effort (see #11982, #11986)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is purely internal refactoring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
