### PR TITLE
[text_sensor] Fix infinite loop in substitute filter

### DIFF
--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -66,10 +66,14 @@ SubstituteFilter::SubstituteFilter(const std::initializer_list<Substitution> &su
     : substitutions_(substitutions) {}
 
 optional<std::string> SubstituteFilter::new_value(std::string value) {
-  std::size_t pos;
   for (const auto &sub : this->substitutions_) {
-    while ((pos = value.find(sub.from)) != std::string::npos)
+    std::size_t pos = 0;
+    while ((pos = value.find(sub.from, pos)) != std::string::npos) {
       value.replace(pos, sub.from.size(), sub.to);
+      // Advance past the replacement to avoid infinite loop when
+      // the replacement contains the search pattern (e.g., f -> foo)
+      pos += sub.to.size();
+    }
   }
   return value;
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix infinite loop in substitute filter

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11425

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
