### PR TITLE
[tests] Fix SNTP time ID conflicts in component tests for grouped testing

### DIFF
--- a/tests/components/lvgl/common.yaml
+++ b/tests/components/lvgl/common.yaml
@@ -115,8 +115,8 @@ wifi:
   password: PASSWORD123
 
 time:
-  platform: sntp
-  id: time_id
+  - platform: sntp
+    id: sntp_time
 
 text:
   - id: lvgl_text

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -478,19 +478,19 @@ lvgl:
                   id: hello_label
                   text:
                     time_format: "%c"
-                    time: time_id
+                    time: sntp_time
               - lvgl.label.update:
                   id: hello_label
                   text:
                     time_format: "%c"
-                    time: !lambda return id(time_id).now();
+                    time: !lambda return id(sntp_time).now();
               - lvgl.label.update:
                   id: hello_label
                   text:
                     time_format: "%c"
                     time: !lambda |-
                         ESP_LOGD("label", "multi-line lambda");
-                        return id(time_id).now();
+                        return id(sntp_time).now();
             on_value:
               logger.log:
                 format: "state now %d"

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -4,6 +4,7 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 mqtt:
   broker: "192.168.178.84"

--- a/tests/components/uptime/common.yaml
+++ b/tests/components/uptime/common.yaml
@@ -3,6 +3,7 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 sensor:
   - platform: uptime

--- a/tests/components/wireguard/common.yaml
+++ b/tests/components/wireguard/common.yaml
@@ -4,8 +4,10 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 wireguard:
+  time_id: sntp_time
   address: 172.16.34.100
   netmask: 255.255.255.0
   # NEVER use the following keys for your VPN -- they are now public!


### PR DESCRIPTION
# What does this implement/fix?

Fixes component tests with inconsistent SNTP time IDs that were missed when PR #11904 was implemented.

## Background

PR #11904 fixed crashes and undefined behavior when multiple SNTP configurations existed. The solution was to automatically merge multiple SNTP instances into one. The merging logic requires all SNTP instances to use the same ID (`sntp_time`) to be merged together.

PR #11904 assumed all component tests already had consistent `sntp_time` IDs, which was true for most tests (bedjet, pvvx_mithermometer, sntp, template, time, total_daily_energy, uponor_smatrix), but **a few were missed**:
- `tests/components/mqtt/common.yaml` - missing ID
- `tests/components/uptime/common.yaml` - missing ID
- `tests/components/wireguard/common.yaml` - missing ID and missing `time_id` reference
- `tests/components/lvgl/common.yaml` - using wrong ID (`time_id` instead of `sntp_time`)
- `tests/components/lvgl/lvgl-package.yaml` - using wrong ID in lambdas

## The Issue

PR #11989 discovered these inconsistent IDs when grouped component testing triggered circular dependency errors. When component tests are grouped together, the SNTP instances with inconsistent IDs cannot be merged properly, causing code generation failures.

## The Fix

This PR completes the alignment work by updating the remaining test files to use `sntp_time`, allowing the SNTP merging feature to work correctly in all grouped test scenarios.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes test failure in grouped component testing for esp32-idf with components: airthings_wave_mini, airthings_wave_plus, am43, anova, bedjet, ble_client, ble_scanner, pvvx_mithermometer, radon_eye_rd200, bme68x_bsec2_i2c, ccs811, ezo_pmp, gdk101, msa3xx, wifi_info, wireguard, atm90e32, daly_bms, haier, hlk_fm22x, homeassistant, ld2410, ld2412, ld2420, ld2450, micronova, pipsolar, pylontech, sml, sun_gtil2, teleinfo, tuya, wl_134, copy, debug, demo, homeassistant

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - test-only change

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is a test infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
