### PR TITLE
[web_server_idf] Fix pbuf_free crash by moving shutdown before close

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -209,6 +209,7 @@ class AsyncWebServer {
   static esp_err_t request_handler(httpd_req_t *r);
   static esp_err_t request_post_handler(httpd_req_t *r);
   esp_err_t request_handler_(AsyncWebServerRequest *request) const;
+  static void safe_close_with_shutdown(httpd_handle_t hd, int sockfd);
 #ifdef USE_WEBSERVER_OTA
   esp_err_t handle_multipart_upload_(httpd_req_t *r, const char *content_type);
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes a race condition in ESP-IDF's httpd that causes `pbuf_free` assertion crashes when closing EventSource connections during webpage reloads.

## The Problem

PR #11937 attempted to fix lwIP race conditions by calling `shutdown()` in the `destroy()` callback, but this approach was **too late** - the socket was already closed by the time `destroy()` was called.

The race condition occurs because ESP-IDF's `httpd_sess_delete()` calls `close(fd)` **before** calling the `free_ctx` callback:

1. `httpd_sess_delete()` calls `close(fd)`
2. `close()` initiates lwIP teardown (`netconn_prepare_delete`)
3. lwIP's TCP/IP thread can **still** receive packets and call `recv_tcp()`
4. **Later**, the `free_ctx` callback (`destroy()`) is called
5. PR #11937's `shutdown()` call happens here - but it's too late!

By this point, `recv_tcp()` has already seen partially-torn-down connection state and triggered assertions like `pbuf_free: p->ref > 0`.

## The Solution

This PR moves the `shutdown()` call to the **correct location** - inside a custom `close_fn` that executes **before** `close()` is called:

1. ESP-IDF calls our custom `close_fn`
2. We call `shutdown(sockfd, SHUT_RD)` to stop lwIP from accepting new data
3. We call `close(sockfd)` to cleanly tear down the connection
4. Later, `free_ctx` callback runs (no race window anymore)

By shutting down the receive side before closing, lwIP stops delivering packets **before** the teardown begins, eliminating the race window. We use `SHUT_RD` (not `SHUT_RDWR`) to allow the FIN packet to be sent cleanly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-webserver/issues/163
- fixes https://github.com/esphome/esphome/issues/11993
- supersedes #11937 (PR #11937's approach was correct but implemented in the wrong place)

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal fix
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
