### PR TITLE
[socket] Fix IPv6 address parsing for BSD sockets

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -61,9 +61,18 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
     server->sin6_family = AF_INET6;
     server->sin6_port = htons(port);
 
+#ifdef USE_SOCKET_IMPL_BSD_SOCKETS
+    // Use standard inet_pton for BSD sockets
+    if (inet_pton(AF_INET6, ip_address.c_str(), &server->sin6_addr) != 1) {
+      errno = EINVAL;
+      return 0;
+    }
+#else
+    // Use LWIP-specific functions
     ip6_addr_t ip6;
     inet6_aton(ip_address.c_str(), &ip6);
     memcpy(server->sin6_addr.un.u32_addr, ip6.addr, sizeof(ip6.addr));
+#endif
     return sizeof(sockaddr_in6);
   }
 #endif /* USE_NETWORK_IPV6 */


### PR DESCRIPTION
Use standard inet_pton() for BSD sockets instead of LWIP-specific inet6_aton(). This fixes IPv6 support on host platform and other BSD socket implementations.

# What does this implement/fix?

Fixes a build failure when host code tries to use `socket::set_sockaddr()`:
```
src/esphome/components/socket/socket.cpp: In function ‘socklen_t esphome::socket::set_sockaddr(sockaddr*, socklen_t, const std::string&, uint16_t)’:
src/esphome/components/socket/socket.cpp:64:5: error: ‘ip6_addr_t’ was not declared in this scope; did you mean ‘in_addr_t’?
   64 |     ip6_addr_t ip6;
      |     ^~~~~~~~~~
      |     in_addr_t
src/esphome/components/socket/socket.cpp:65:37: error: ‘ip6’ was not declared in this scope; did you mean ‘ip’?
   65 |     inet6_aton(ip_address.c_str(), &ip6);
      |                                     ^~~
      |                                     ip
src/esphome/components/socket/socket.cpp:65:5: error: ‘inet6_aton’ was not declared in this scope; did you mean ‘inet_aton’?
   65 |     inet6_aton(ip_address.c_str(), &ip6);
      |     ^~~~~~~~~~
      |     inet_aton
src/esphome/components/socket/socket.cpp:66:30: error: ‘struct in6_addr’ has no member named ‘un’
   66 |     memcpy(server->sin6_addr.un.u32_addr, ip6.addr, sizeof(ip6.addr));
      |                              ^~
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host


## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
