### PR TITLE
2025.11.0b5

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.11.0b4
+PROJECT_NUMBER         = 2025.11.0b5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -102,7 +102,7 @@ def customise_schema(config):
     """
     config = cv.Schema(
         {
-            cv.Required(CONF_MODEL): cv.one_of(*MODELS, upper=True),
+            cv.Required(CONF_MODEL): cv.one_of(*MODELS, upper=True, space="-"),
         },
         extra=cv.ALLOW_EXTRA,
     )(config)

--- a/esphome/components/epaper_spi/models/spectra_e6.py
+++ b/esphome/components/epaper_spi/models/spectra_e6.py
@@ -32,11 +32,15 @@ class SpectraE6(EpaperModel):
 
 spectra_e6 = SpectraE6("spectra-e6")
 
-spectra_e6.extend(
-    "Seeed-reTerminal-E1002",
+spectra_e6_7p3 = spectra_e6.extend(
+    "7.3in-Spectra-E6",
     width=800,
     height=480,
     data_rate="20MHz",
+)
+
+spectra_e6_7p3.extend(
+    "Seeed-reTerminal-E1002",
     cs_pin=10,
     dc_pin=11,
     reset_pin=12,

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -66,10 +66,14 @@ SubstituteFilter::SubstituteFilter(const std::initializer_list<Substitution> &su
     : substitutions_(substitutions) {}
 
 optional<std::string> SubstituteFilter::new_value(std::string value) {
-  std::size_t pos;
   for (const auto &sub : this->substitutions_) {
-    while ((pos = value.find(sub.from)) != std::string::npos)
+    std::size_t pos = 0;
+    while ((pos = value.find(sub.from, pos)) != std::string::npos) {
       value.replace(pos, sub.from.size(), sub.to);
+      // Advance past the replacement to avoid infinite loop when
+      // the replacement contains the search pattern (e.g., f -> foo)
+      pos += sub.to.size();
+    }
   }
   return value;
 }

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -209,6 +209,7 @@ class AsyncWebServer {
   static esp_err_t request_handler(httpd_req_t *r);
   static esp_err_t request_post_handler(httpd_req_t *r);
   esp_err_t request_handler_(AsyncWebServerRequest *request) const;
+  static void safe_close_with_shutdown(httpd_handle_t hd, int sockfd);
 #ifdef USE_WEBSERVER_OTA
   esp_err_t handle_multipart_upload_(httpd_req_t *r, const char *content_type);
 #endif

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -870,7 +870,13 @@ bssid_t WiFiComponent::wifi_bssid() {
   return bssid;
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
-int8_t WiFiComponent::wifi_rssi() { return WiFi.status() == WL_CONNECTED ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
+int8_t WiFiComponent::wifi_rssi() {
+  if (WiFi.status() != WL_CONNECTED)
+    return WIFI_RSSI_DISCONNECTED;
+  int8_t rssi = WiFi.RSSI();
+  // Values >= 31 are error codes per NONOS SDK API, not valid RSSI readings
+  return rssi >= 31 ? WIFI_RSSI_DISCONNECTED : rssi;
+}
 int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 network::IPAddress WiFiComponent::wifi_subnet_mask_() { return {(const ip_addr_t *) WiFi.subnetMask()}; }
 network::IPAddress WiFiComponent::wifi_gateway_ip_() { return {(const ip_addr_t *) WiFi.gatewayIP()}; }

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.11.0b4"
+__version__ = "2025.11.0b5"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/components/lvgl/common.yaml
+++ b/tests/components/lvgl/common.yaml
@@ -115,8 +115,8 @@ wifi:
   password: PASSWORD123
 
 time:
-  platform: sntp
-  id: time_id
+  - platform: sntp
+    id: sntp_time
 
 text:
   - id: lvgl_text

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -478,19 +478,19 @@ lvgl:
                   id: hello_label
                   text:
                     time_format: "%c"
-                    time: time_id
+                    time: sntp_time
               - lvgl.label.update:
                   id: hello_label
                   text:
                     time_format: "%c"
-                    time: !lambda return id(time_id).now();
+                    time: !lambda return id(sntp_time).now();
               - lvgl.label.update:
                   id: hello_label
                   text:
                     time_format: "%c"
                     time: !lambda |-
                         ESP_LOGD("label", "multi-line lambda");
-                        return id(time_id).now();
+                        return id(sntp_time).now();
             on_value:
               logger.log:
                 format: "state now %d"

--- a/tests/components/mqtt/common.yaml
+++ b/tests/components/mqtt/common.yaml
@@ -4,6 +4,7 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 mqtt:
   broker: "192.168.178.84"

--- a/tests/components/uptime/common.yaml
+++ b/tests/components/uptime/common.yaml
@@ -3,6 +3,7 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 sensor:
   - platform: uptime

--- a/tests/components/wireguard/common.yaml
+++ b/tests/components/wireguard/common.yaml
@@ -4,8 +4,10 @@ wifi:
 
 time:
   - platform: sntp
+    id: sntp_time
 
 wireguard:
+  time_id: sntp_time
   address: 172.16.34.100
   netmask: 255.255.255.0
   # NEVER use the following keys for your VPN -- they are now public!


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [tests] Fix SNTP time ID conflicts in component tests for grouped testing [esphome#11990](https://github.com/esphome/esphome/pull/11990)
- [text_sensor] Fix infinite loop in substitute filter [esphome#11989](https://github.com/esphome/esphome/pull/11989)
- [wifi] Fix positive RSSI values on 8266 [esphome#11994](https://github.com/esphome/esphome/pull/11994)
- [web_server_idf] Fix pbuf_free crash by moving shutdown before close [esphome#11995](https://github.com/esphome/esphome/pull/11995)
- [epaper_spi] Add basic `7.3in-Spectra-E6` model [esphome#12001](https://github.com/esphome/esphome/pull/12001) (new-feature)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
