### PR TITLE
[network] Fix IPAddress constructor causing comparison failures and garbage output

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -81,7 +81,12 @@ struct IPAddress {
     ip_addr_.type = IPADDR_TYPE_V6;
   }
 #endif /* LWIP_IPV6 */
-  IPAddress(esp_ip4_addr_t *other_ip) { memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(esp_ip4_addr_t)); }
+  IPAddress(esp_ip4_addr_t *other_ip) {
+    memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(esp_ip4_addr_t));
+#if LWIP_IPV6
+    ip_addr_.type = IPADDR_TYPE_V4;
+#endif
+  }
   IPAddress(esp_ip_addr_t *other_ip) {
 #if LWIP_IPV6
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(ip_addr_));


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `IPAddress(esp_ip4_addr_t *other_ip)` constructor to properly initialize the `type` field when `LWIP_IPV6` is enabled on ESP32. Without this fix, the type field contains uninitialized memory, causing multiple issues:

1. **Issue #10690 (`wifi_info`)**: IP address comparisons fail even when addresses are identical, causing continuous publishing every second
2. **Issue #11837 (`ethernet_info`)**: IP addresses display as garbage hex strings like `c0a8:320a:80e5:fc3f:6cc4:40:77c4:40` instead of proper IPv4 format

## Root Cause Analysis

When IPv6 support is enabled (`LWIP_IPV6`), the lwIP `ip_addr_t` struct includes a `type` field to distinguish between IPv4 (`IPADDR_TYPE_V4`) and IPv6 (`IPADDR_TYPE_V6`) addresses:

```c
// When LWIP_IPV6 is enabled:
typedef struct ip_addr {
  union {
    ip6_addr_t ip6;
    ip4_addr_t ip4;
  } u_addr;
  u8_t type;  // ← This field only exists when LWIP_IPV6 is enabled
} ip_addr_t;

// When LWIP_IPV6 is disabled:
typedef struct ip_addr {
  u32_t addr;  // Just a 32-bit IPv4 address, no type field
} ip_addr_t;
```

The `IPAddress(esp_ip4_addr_t *other_ip)` constructor was using `memcpy()` to copy only the IP address bytes without setting the type field, leaving it with uninitialized/garbage values. Since the `type` field only exists when `LWIP_IPV6` is enabled, the fix is conditionally compiled with `#if LWIP_IPV6` guards.

This causes two distinct symptoms:

1. **Comparison failures (#10690)**: The `operator==` uses `ip_addr_cmp()` which compares the type field first. When types don't match (garbage value vs expected value), the comparison fails even though the actual IP addresses are identical. This caused components like `wifi_info` to detect false positive changes on every poll cycle.

2. **String formatting failures (#11837)**: The `str()` method uses `ipaddr_ntoa()` which checks the type field to determine formatting. With garbage in the type field, it doesn't recognize the address as IPv4 or IPv6, so it falls back to dumping raw memory as hex, producing strings like `c0a8:320a:80e5:fc3f:6cc4:40:77c4:40` (note `c0a8` = 192.168 in hex).

**Debug evidence**:
- Issue #10690: Type field alternating between values 224 and 144 during consecutive comparisons
- Issue #11837: Initially shows correct IP `192.168.x.x`, then switches to garbage hex string on subsequent updates

## The Fix

Added missing type field initialization to match the pattern already used in the `IPAddress(ip4_addr_t *other_ip)` constructor:

```cpp
IPAddress(esp_ip4_addr_t *other_ip) {
  memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(esp_ip4_addr_t));
#if LWIP_IPV6
  ip_addr_.type = IPADDR_TYPE_V4;  // <-- Added this
#endif
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10690
- fixes https://github.com/esphome/esphome/issues/11837

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (bug fix, no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

**Note**: This bug affects ESP32 platforms where `LWIP_IPV6` is compiled in:

- **ESP32 Arduino framework (3.x)**: `LWIP_IPV6` is **always compiled in** (hardcoded to `True` in `esphome/components/network/__init__.py` lines 216-218), regardless of the `enable_ipv6` config setting. This affects **all ESP32 Arduino users**, even those with `enable_ipv6: false` explicitly set.

- **ESP32 IDF framework**: `LWIP_IPV6` respects the `enable_ipv6` config setting (defaults to `False`), so only users who enable IPv6 are affected.

- **ESP8266/RP2040/other platforms**: Typically don't have IPv6 compiled in due to memory constraints, so the `type` field doesn't exist and this bug doesn't occur.

**Critical clarification for ESP32 Arduino users**: Setting `enable_ipv6: false` does **not** prevent this bug. The config option only disables runtime IPv6 usage - the compile-time `LWIP_IPV6` flag (which adds the `type` field to the struct) remains enabled. This is why issue #11837 occurs even with `enable_ipv6: false` explicitly configured.

**Why Arduino always enables LWIP_IPV6**: Arduino 3.x is built as an ESP-IDF component and requires IPv6 support to be compiled in at the lwIP level, even when not actively used at runtime. ESPHome's network component reflects this requirement by hardcoding `CONFIG_LWIP_IPV6=True` for Arduino builds (see `network/__init__.py:217`).

## Example entry for `config.yaml`:

```yaml
# This config previously caused continuous IP address publishing every second
# After the fix, IP address is only published when it actually changes

esp32:
  board: esp32dev
  framework:
    type: arduino  # or esp-idf

text_sensor:
  - platform: wifi_info
    ip_address:
      name: "IP Address"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Notes

This is a one-line fix that resolves a critical bug affecting ESP32 users with IPv6 enabled. The fix follows the existing pattern established by the `IPAddress(ip4_addr_t *other_ip)` constructor (lines 61-66 in the same file).

### Bug History

1. **September 27, 2023** (PR #5252): The `IPAddress(esp_ip4_addr_t *)` constructor was added as part of refactoring IP address representation. It was modeled after the existing `IPAddress(ip4_addr_t *)` constructor, which at the time also lacked type field initialization.

2. **October 23, 2023** (PR #5583): The `IPAddress(ip4_addr_t *)` constructor was fixed to include `ip_addr_.type = IPADDR_TYPE_V4`. However, the `IPAddress(esp_ip4_addr_t *)` constructor (added less than a month earlier) was not updated at the same time.

This fix completes the pattern by applying the same type initialization to the `esp_ip4_addr_t` constructor that was already applied to the `ip4_addr_t` constructor in October 2023.

**Credit**: Big shoutout to @elbandi for the excellent detective work! They identified the root cause by instrumenting the `operator==` method and discovering the type field was swapping between uninitialized values (224 and 144) instead of the correct `IPADDR_TYPE_V4` constant. See their detailed analysis in https://github.com/esphome/esphome/issues/10690#issuecomment-3554994868 - nice work! 🎉
