### PR TITLE
[select] Modernize namespace declarations to C++17 syntax

### DIFF
--- a/esphome/components/select/automation.h
+++ b/esphome/components/select/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "select.h"
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 class SelectStateTrigger : public Trigger<std::string, size_t> {
  public:
@@ -63,5 +62,4 @@ template<typename... Ts> class SelectOperationAction : public Action<Ts...> {
   Select *select_;
 };
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select.cpp
+++ b/esphome/components/select/select.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <cstring>
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 static const char *const TAG = "select";
 
@@ -86,5 +85,4 @@ optional<std::string> Select::at(size_t index) const {
 
 const char *Select::option_at(size_t index) const { return traits.get_options().at(index); }
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -6,8 +6,7 @@
 #include "select_call.h"
 #include "select_traits.h"
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -114,5 +113,4 @@ class Select : public EntityBase {
   CallbackManager<void(std::string, size_t)> state_callback_;
 };
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -2,8 +2,7 @@
 #include "select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 static const char *const TAG = "select";
 
@@ -125,5 +124,4 @@ void SelectCall::perform() {
   parent->control(idx);
 }
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select_call.h
+++ b/esphome/components/select/select_call.h
@@ -2,8 +2,7 @@
 
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 class Select;
 
@@ -45,5 +44,4 @@ class SelectCall {
   bool cycle_;
 };
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select_traits.cpp
+++ b/esphome/components/select/select_traits.cpp
@@ -1,7 +1,6 @@
 #include "select_traits.h"
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 void SelectTraits::set_options(const std::initializer_list<const char *> &options) { this->options_ = options; }
 
@@ -14,5 +13,4 @@ void SelectTraits::set_options(const FixedVector<const char *> &options) {
 
 const FixedVector<const char *> &SelectTraits::get_options() const { return this->options_; }
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select

--- a/esphome/components/select/select_traits.h
+++ b/esphome/components/select/select_traits.h
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include <initializer_list>
 
-namespace esphome {
-namespace select {
+namespace esphome::select {
 
 class SelectTraits {
  public:
@@ -16,5 +15,4 @@ class SelectTraits {
   FixedVector<const char *> options_;
 };
 
-}  // namespace select
-}  // namespace esphome
+}  // namespace esphome::select


### PR DESCRIPTION
# What does this implement/fix?

This PR modernizes the C++ namespace declarations in the select component to use C++17 syntax, improving code readability and consistency with ongoing ESPHome modernization efforts.

**Changes:**
- Converts nested namespace syntax to modern C++17 format
- Updates closing namespace comments to single-line format
- Zero functional changes - purely cosmetic refactoring

**Before:**
```cpp
namespace esphome {
namespace select {
...
}  // namespace select
}  // namespace esphome
```

**After:**
```cpp
namespace esphome::select {
...
}  // namespace esphome::select
```

This follows similar modernization work in other components (ld24xx #11988, lock #11982, light #11986).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing C++17 modernization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

All platforms supported (no platform-specific code changes)

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a refactoring PR
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

