### PR TITLE
Document XFLIP handling in ST7701S

### DIFF
--- a/esphome/components/mipi_rgb/models/st7701s.py
+++ b/esphome/components/mipi_rgb/models/st7701s.py
@@ -24,6 +24,8 @@ class ST7701S(DriverChip):
         sdir = 0
         if transform.get(CONF_MIRROR_X):
             sdir |= 0x04
+            # XFLIP doesn't do anything in the ST7701S,
+            # it's set in the madctl byte just so it can be reported at runtime by logconfig
             madctl |= MADCTL_XFLIP
         sequence.append((SDIR_CMD, sdir))
         return madctl


### PR DESCRIPTION
Add comments explaining XFLIP behavior in ST7701S.

# What does this implement/fix?

After discussion in https://discord.com/channels/429907082951524364/1440775570219598006 I thought it worth adding just a small comment by @clydebarrow to explain to our future selfs why a flag is set and not output :)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
