### PR TITLE
[ltr501][ltr_als_ps] Rename enum to avoid collision with lwip defines

### DIFF
--- a/esphome/components/ltr501/ltr501.cpp
+++ b/esphome/components/ltr501/ltr501.cpp
@@ -174,7 +174,7 @@ void LTRAlsPs501Component::loop() {
       break;
 
     case State::WAITING_FOR_DATA:
-      if (this->is_als_data_ready_(this->als_readings_) == DataAvail::DATA_OK) {
+      if (this->is_als_data_ready_(this->als_readings_) == LtrDataAvail::LTR_DATA_OK) {
         tries = 0;
         ESP_LOGV(TAG, "Reading sensor data assuming gain = %.0fx, time = %d ms",
                  get_gain_coeff(this->als_readings_.gain), get_itime_ms(this->als_readings_.integration_time));
@@ -379,18 +379,18 @@ void LTRAlsPs501Component::configure_integration_time_(IntegrationTime501 time) 
   }
 }
 
-DataAvail LTRAlsPs501Component::is_als_data_ready_(AlsReadings &data) {
+LtrDataAvail LTRAlsPs501Component::is_als_data_ready_(AlsReadings &data) {
   AlsPsStatusRegister als_status{0};
   als_status.raw = this->reg((uint8_t) CommandRegisters::ALS_PS_STATUS).get();
   if (!als_status.als_new_data)
-    return DataAvail::NO_DATA;
+    return LtrDataAvail::LTR_NO_DATA;
   ESP_LOGV(TAG, "Data ready, reported gain is %.0fx", get_gain_coeff(als_status.gain));
   if (data.gain != als_status.gain) {
     ESP_LOGW(TAG, "Actual gain differs from requested (%.0f)", get_gain_coeff(data.gain));
-    return DataAvail::BAD_DATA;
+    return LtrDataAvail::LTR_BAD_DATA;
   }
   data.gain = als_status.gain;
-  return DataAvail::DATA_OK;
+  return LtrDataAvail::LTR_DATA_OK;
 }
 
 void LTRAlsPs501Component::read_sensor_data_(AlsReadings &data) {

--- a/esphome/components/ltr501/ltr501.h
+++ b/esphome/components/ltr501/ltr501.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace ltr501 {
 
-enum DataAvail : uint8_t { NO_DATA, BAD_DATA, DATA_OK };
+enum LtrDataAvail : uint8_t { LTR_NO_DATA, LTR_BAD_DATA, LTR_DATA_OK };
 
 enum LtrType : uint8_t {
   LTR_TYPE_UNKNOWN = 0,
@@ -106,7 +106,7 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
   void configure_als_();
   void configure_integration_time_(IntegrationTime501 time);
   void configure_gain_(AlsGain501 gain);
-  DataAvail is_als_data_ready_(AlsReadings &data);
+  LtrDataAvail is_als_data_ready_(AlsReadings &data);
   void read_sensor_data_(AlsReadings &data);
   bool are_adjustments_required_(AlsReadings &data);
   void apply_lux_calculation_(AlsReadings &data);

--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -165,7 +165,7 @@ void LTRAlsPsComponent::loop() {
       break;
 
     case State::WAITING_FOR_DATA:
-      if (this->is_als_data_ready_(this->als_readings_) == DataAvail::DATA_OK) {
+      if (this->is_als_data_ready_(this->als_readings_) == LtrDataAvail::LTR_DATA_OK) {
         tries = 0;
         ESP_LOGV(TAG, "Reading sensor data having gain = %.0fx, time = %d ms", get_gain_coeff(this->als_readings_.gain),
                  get_itime_ms(this->als_readings_.integration_time));
@@ -376,23 +376,23 @@ void LTRAlsPsComponent::configure_integration_time_(IntegrationTime time) {
   }
 }
 
-DataAvail LTRAlsPsComponent::is_als_data_ready_(AlsReadings &data) {
+LtrDataAvail LTRAlsPsComponent::is_als_data_ready_(AlsReadings &data) {
   AlsPsStatusRegister als_status{0};
 
   als_status.raw = this->reg((uint8_t) CommandRegisters::ALS_PS_STATUS).get();
   if (!als_status.als_new_data)
-    return DataAvail::NO_DATA;
+    return LtrDataAvail::LTR_NO_DATA;
 
   if (als_status.data_invalid) {
     ESP_LOGW(TAG, "Data available but not valid");
-    return DataAvail::BAD_DATA;
+    return LtrDataAvail::LTR_BAD_DATA;
   }
   ESP_LOGV(TAG, "Data ready, reported gain is %.0f", get_gain_coeff(als_status.gain));
   if (data.gain != als_status.gain) {
     ESP_LOGW(TAG, "Actual gain differs from requested (%.0f)", get_gain_coeff(data.gain));
-    return DataAvail::BAD_DATA;
+    return LtrDataAvail::LTR_BAD_DATA;
   }
-  return DataAvail::DATA_OK;
+  return LtrDataAvail::LTR_DATA_OK;
 }
 
 void LTRAlsPsComponent::read_sensor_data_(AlsReadings &data) {

--- a/esphome/components/ltr_als_ps/ltr_als_ps.h
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.h
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace ltr_als_ps {
 
-enum DataAvail : uint8_t { NO_DATA, BAD_DATA, DATA_OK };
+enum LtrDataAvail : uint8_t { LTR_NO_DATA, LTR_BAD_DATA, LTR_DATA_OK };
 
 enum LtrType : uint8_t {
   LTR_TYPE_UNKNOWN = 0,
@@ -106,7 +106,7 @@ class LTRAlsPsComponent : public PollingComponent, public i2c::I2CDevice {
   void configure_als_();
   void configure_integration_time_(IntegrationTime time);
   void configure_gain_(AlsGain gain);
-  DataAvail is_als_data_ready_(AlsReadings &data);
+  LtrDataAvail is_als_data_ready_(AlsReadings &data);
   void read_sensor_data_(AlsReadings &data);
   bool are_adjustments_required_(AlsReadings &data);
   void apply_lux_calculation_(AlsReadings &data);


### PR DESCRIPTION
# What does this implement/fix?

Rename enum to avoid collision with lwip defines:
```
### File /home/runner/work/esphome/esphome/.temp/all-include.cpp

Error: /home/runner/work/esphome/esphome/esphome/components/ltr501/ltr501.h:14:28: error: expected identifier [clang-diagnostic-error]
   14 | enum DataAvail : uint8_t { NO_DATA, BAD_DATA, DATA_OK };
      |                            ^
/home/runner/.platformio/packages/framework-espidf/components/lwip/lwip/src/include/lwip/netdb.h:75:25: note: expanded from macro 'NO_DATA'
   75 | #define NO_DATA         211
      |                         ^
Error: /home/runner/work/esphome/esphome/esphome/components/ltr_als_ps/ltr_als_ps.h:14:28: error: expected identifier [clang-diagnostic-error]
   14 | enum DataAvail : uint8_t { NO_DATA, BAD_DATA, DATA_OK };
      |                            ^
/home/runner/.platformio/packages/framework-espidf/components/lwip/lwip/src/include/lwip/netdb.h:75:25: note: expanded from macro 'NO_DATA'
   75 | #define NO_DATA         211
      |                         ^`
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
