### PR TITLE
[cst816][packet_transport][udp][wake_on_lan] Fix error messages

### DIFF
--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -19,8 +19,8 @@ void CST816Touchscreen::continue_setup_() {
       case CST816T_CHIP_ID:
         break;
       default:
-        this->mark_failed();
         this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());
+        this->mark_failed();
         return;
     }
     this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -195,8 +195,8 @@ static void add(std::vector<uint8_t> &vec, const char *str) {
 void PacketTransport::setup() {
   this->name_ = App.get_name().c_str();
   if (strlen(this->name_) > 255) {
-    this->mark_failed();
     this->status_set_error("Device name exceeds 255 chars");
+    this->mark_failed();
     return;
   }
   this->resend_ping_key_ = this->ping_pong_enable_;

--- a/esphome/components/udp/udp_component.cpp
+++ b/esphome/components/udp/udp_component.cpp
@@ -21,8 +21,8 @@ void UDPComponent::setup() {
   if (this->should_broadcast_) {
     this->broadcast_socket_ = socket::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
     if (this->broadcast_socket_ == nullptr) {
-      this->mark_failed();
       this->status_set_error("Could not create socket");
+      this->mark_failed();
       return;
     }
     int enable = 1;
@@ -41,15 +41,15 @@ void UDPComponent::setup() {
   if (this->should_listen_) {
     this->listen_socket_ = socket::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
     if (this->listen_socket_ == nullptr) {
-      this->mark_failed();
       this->status_set_error("Could not create socket");
+      this->mark_failed();
       return;
     }
     auto err = this->listen_socket_->setblocking(false);
     if (err < 0) {
       ESP_LOGE(TAG, "Unable to set nonblocking: errno %d", errno);
-      this->mark_failed();
       this->status_set_error("Unable to set nonblocking");
+      this->mark_failed();
       return;
     }
     int enable = 1;
@@ -73,8 +73,8 @@ void UDPComponent::setup() {
       err = this->listen_socket_->setsockopt(IPPROTO_IP, IP_ADD_MEMBERSHIP, &imreq, sizeof(imreq));
       if (err < 0) {
         ESP_LOGE(TAG, "Failed to set IP_ADD_MEMBERSHIP. Error %d", errno);
-        this->mark_failed();
         this->status_set_error("Failed to set IP_ADD_MEMBERSHIP");
+        this->mark_failed();
         return;
       }
     }
@@ -82,8 +82,8 @@ void UDPComponent::setup() {
     err = this->listen_socket_->bind((struct sockaddr *) &server, sizeof(server));
     if (err != 0) {
       ESP_LOGE(TAG, "Socket unable to bind: errno %d", errno);
-      this->mark_failed();
       this->status_set_error("Unable to bind socket");
+      this->mark_failed();
       return;
     }
   }

--- a/esphome/components/wake_on_lan/wake_on_lan.cpp
+++ b/esphome/components/wake_on_lan/wake_on_lan.cpp
@@ -67,8 +67,8 @@ void WakeOnLanButton::setup() {
 #if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   this->broadcast_socket_ = socket::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
   if (this->broadcast_socket_ == nullptr) {
-    this->mark_failed();
     this->status_set_error("Could not create socket");
+    this->mark_failed();
     return;
   }
   int enable = 1;


### PR DESCRIPTION
# What does this implement/fix?

Calling `mark_failed` will set an empty error message and mark the component as failed. The component code would ignore the actual error message as it was already set. Fix the order of these calls. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
