### PR TITLE
[core] Fix status_set_error() dangling pointer by accepting std::string

### DIFF
--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -19,7 +19,7 @@ void CST816Touchscreen::continue_setup_() {
       case CST816T_CHIP_ID:
         break;
       default:
-        this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());
+        this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_));
         this->mark_failed();
         return;
     }

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -51,7 +51,7 @@ void HttpRequestUpdate::update_task(void *params) {
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
     std::string msg = str_sprintf("Failed to fetch manifest from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     UPDATE_RETURN;
   }
 
@@ -60,7 +60,7 @@ void HttpRequestUpdate::update_task(void *params) {
   if (data == nullptr) {
     std::string msg = str_sprintf("Failed to allocate %zu bytes for manifest", container->content_length);
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     container->end();
     UPDATE_RETURN;
   }
@@ -123,7 +123,7 @@ void HttpRequestUpdate::update_task(void *params) {
   if (!valid) {
     std::string msg = str_sprintf("Failed to parse JSON from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     UPDATE_RETURN;
   }
 

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -49,7 +49,7 @@ void HttpRequestUpdate::update_task(void *params) {
   auto container = this_update->request_parent_->get(this_update->source_url_);
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
-    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_.c_str());
+    std::string msg = str_sprintf("Failed to fetch manifest from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     UPDATE_RETURN;
@@ -58,7 +58,7 @@ void HttpRequestUpdate::update_task(void *params) {
   RAMAllocator<uint8_t> allocator;
   uint8_t *data = allocator.allocate(container->content_length);
   if (data == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate %zu bytes for manifest", container->content_length);
+    std::string msg = str_sprintf("Failed to allocate %zu bytes for manifest", container->content_length);
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     container->end();
@@ -121,7 +121,7 @@ void HttpRequestUpdate::update_task(void *params) {
   }
 
   if (!valid) {
-    ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
+    std::string msg = str_sprintf("Failed to parse JSON from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
     this_update->defer([this_update, msg]() { this_update->status_set_error(msg); });
     UPDATE_RETURN;

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -35,7 +35,7 @@ static const char *const TAG = "component";
 namespace {
 struct ComponentErrorMessage {
   const Component *component;
-  const char *message;
+  std::string message;
 };
 
 struct ComponentPriorityOverride {
@@ -146,7 +146,7 @@ void Component::call_dump_config() {
     if (component_error_messages) {
       for (const auto &entry : *component_error_messages) {
         if (entry.component == this) {
-          error_msg = entry.message;
+          error_msg = entry.message.c_str();
           break;
         }
       }
@@ -307,28 +307,33 @@ void Component::status_set_warning(const LogString *message) {
   ESP_LOGW(TAG, "%s set Warning flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
-void Component::status_set_error(const char *message) {
+void Component::status_set_error(const std::string &message) {
   if ((this->component_state_ & STATUS_LED_ERROR) != 0)
     return;
   this->component_state_ |= STATUS_LED_ERROR;
   App.app_state_ |= STATUS_LED_ERROR;
-  ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()),
-           message ? message : LOG_STR_LITERAL("unspecified"));
-  if (message != nullptr) {
-    // Lazy allocate the error messages vector if needed
-    if (!component_error_messages) {
-      component_error_messages = std::make_unique<std::vector<ComponentErrorMessage>>();
-    }
-    // Check if this component already has an error message
-    for (auto &entry : *component_error_messages) {
-      if (entry.component == this) {
-        entry.message = message;
-        return;
-      }
-    }
-    // Add new error message
-    component_error_messages->emplace_back(ComponentErrorMessage{this, message});
+  ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()), message.c_str());
+  // Lazy allocate the error messages vector if needed
+  if (!component_error_messages) {
+    component_error_messages = std::make_unique<std::vector<ComponentErrorMessage>>();
   }
+  // Check if this component already has an error message
+  for (auto &entry : *component_error_messages) {
+    if (entry.component == this) {
+      entry.message = message;
+      return;
+    }
+  }
+  // Add new error message
+  component_error_messages->emplace_back(ComponentErrorMessage{this, message});
+}
+void Component::status_set_error() {
+  // No message version - just set the error flag
+  if ((this->component_state_ & STATUS_LED_ERROR) != 0)
+    return;
+  this->component_state_ |= STATUS_LED_ERROR;
+  App.app_state_ |= STATUS_LED_ERROR;
+  ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()), LOG_STR_LITERAL("unspecified"));
 }
 void Component::status_clear_warning() {
   if ((this->component_state_ & STATUS_LED_WARNING) == 0)

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -216,7 +216,8 @@ class Component {
   void status_set_warning(const char *message = nullptr);
   void status_set_warning(const LogString *message);
 
-  void status_set_error(const char *message = nullptr);
+  void status_set_error(const std::string &message);
+  void status_set_error();
 
   void status_clear_warning();
 


### PR DESCRIPTION
## 🔀 Two Solutions Available - Decision Needed

This PR is one of two approaches to fix the `status_set_error()` dangling pointer bug:

| Aspect | **#12021 - LogString** | **#12020 - std::string** |
|--------|------------------------|--------------------------|
| **Compatibility** | Breaking (6mo deprecation) | Fully backward compatible |
| **Flash Impact** | +288 bytes → 0 after removal | +664 bytes permanently |
| **RAM Impact** | 0 (strings in flash/PROGMEM) | Heap allocation per message |
| **ESP8266 RAM** | Strings stay in flash | Strings stored in RAM |
| **Dynamic strings** | Not supported | Supported |
| **Migration effort** | 38 call sites need `LOG_STR()` | Zero changes needed |

### Key Trade-offs

**#12021 (LogString):**
- Temporary +288 bytes becomes 0 after deprecation removal
- Keeps strings in flash, critical for ESP8266 RAM constraints
- Preserves original design intent (static error messages)
- Requires migration effort and breaking change process
- Dynamic error details logged at error time (requires logger connection to capture)

**#12020 (std::string):**
- Permanent +664 bytes flash overhead
- RAM usage for string storage (problematic on ESP8266)
- Zero migration effort, fully backward compatible
- Enables dynamic error context in status messages (new capability, persists in status)

### Context

This feature has existed for years with only static strings. **Dynamic error messages have never actually worked** - they were always dangling pointers that either crashed or displayed garbage. 4 instances exist in the codebase.

**Key question:** Should we add proper support for dynamic error messages (new capability, requires permanent overhead) or preserve the static-only design (zero long-term cost) but with the cost of a breaking change to make it safer?

**Note:** With #12021, dynamic details are logged via `ESP_LOGE()` when errors occur, but this requires logger connection at the time of failure. If a device fails while disconnected, only the static status message is available.

---

# What does this implement/fix?

Fixes dangling pointer bugs in `Component::status_set_error()` by changing the API to accept `const std::string &` instead of `const char *`.

## Problem

The `status_set_error(const char *message)` API stored raw pointers in a global vector. When components passed temporary strings (e.g., `str_sprintf("Error 0x%02X", value).c_str()`), the pointer would dangle after the temporary was destroyed, causing the error message to be corrupted or crash when accessed later during `dump_config()`.

**Buggy code examples:**
```cpp
// cst816_touchscreen.cpp - temporary string destroyed after call
this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());

// http_request_update.cpp - lambda captures string but pointer dangles
std::string msg = str_sprintf("Failed to fetch manifest from %s", url.c_str());
this->defer([this, msg]() { this->status_set_error(msg.c_str()); });
```

## Solution

Changed the API to `status_set_error(const std::string &message)`, which:
1. Makes a copy of the string and stores it in the global error message vector
2. Prevents dangling pointer bugs entirely
3. **Fully backward compatible** - all existing code continues to work due to implicit `const char*` to `std::string` conversion
4. Provides clear ownership semantics (the function owns a copy)

**Changes:**
- `ComponentErrorMessage::message`: Changed from `const char*` to `std::string`
- `status_set_error(const std::string &message)`: New primary API
- `status_set_error()`: No-argument overload (replaces `nullptr` default parameter)
- All existing usage patterns remain compatible (string literals, `const char*`, `.c_str()` all work)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered during code review of components using `status_set_error()` with dynamically generated strings

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal API change, not user-facing

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This is an internal API change that doesn't affect user configuration.

## Backward Compatibility

This change is **fully backward compatible**. All existing usage patterns continue to work:

```cpp
// String literals - works (implicit conversion)
this->status_set_error("Error message");

// const char* variables - works (implicit conversion)
const char* msg = "Error";
this->status_set_error(msg);

// std::string objects - works
std::string msg = "Error";
this->status_set_error(msg);

// .c_str() calls - works (implicit conversion, though now unnecessary)
this->status_set_error(some_string.c_str());

// No argument - works (new overload)
this->status_set_error();
```

**Code cleanup in this PR:** The PR removes `.c_str()` calls from the fixed components since they're now unnecessary, but they would still work if left in place.

## Trade-offs

**Pros:**
- ✅ Eliminates entire class of dangling pointer bugs
- ✅ Type-safe and clear ownership semantics
- ✅ **Fully backward compatible** - all existing code continues to work
- ✅ Simpler for component developers (no lifetime management needed)

**Cons:**
- ❌ ~500 bytes flash overhead for std::string reallocation machinery (one-time cost)
- ❌ Small heap allocation on errors (acceptable - errors are rare and system is already broken)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

