### PR TITLE
[online_image] Fix some large PNGs causing watchdog timeout

### DIFF
--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -44,7 +44,7 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   // Feed every 1000 pixels to balance efficiency and responsiveness.
   uint32_t pixels = w * h;
   decoder->add_pixels(pixels);
-  if ((decoder->get_pixels_decoded() % 1000) < pixels) {
+  if ((decoder->get_pixels_decoded() % 1024) < pixels) {
     App.feed_wdt();
   }
 }

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -2,6 +2,7 @@
 #ifdef USE_ONLINE_IMAGE_PNG_SUPPORT
 
 #include "esphome/components/display/display_buffer.h"
+#include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -38,6 +39,14 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   PngDecoder *decoder = (PngDecoder *) pngle_get_user_data(pngle);
   Color color(rgba[0], rgba[1], rgba[2], rgba[3]);
   decoder->draw(x, y, w, h, color);
+
+  // Feed watchdog periodically to avoid triggering during long decode operations.
+  // Feed every 1000 pixels to balance efficiency and responsiveness.
+  uint32_t pixels = w * h;
+  decoder->add_pixels(pixels);
+  if ((decoder->get_pixels_decoded() % 1000) < pixels) {
+    App.feed_wdt();
+  }
 }
 
 PngDecoder::PngDecoder(OnlineImage *image) : ImageDecoder(image) {

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -41,7 +41,7 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   decoder->draw(x, y, w, h, color);
 
   // Feed watchdog periodically to avoid triggering during long decode operations.
-  // Feed every 1000 pixels to balance efficiency and responsiveness.
+  // Feed every 1024 pixels to balance efficiency and responsiveness.
   uint32_t pixels = w * h;
   decoder->add_pixels(pixels);
   if ((decoder->get_pixels_decoded() % 1024) < pixels) {

--- a/esphome/components/online_image/png_image.cpp
+++ b/esphome/components/online_image/png_image.cpp
@@ -43,7 +43,7 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
   // Feed watchdog periodically to avoid triggering during long decode operations.
   // Feed every 1024 pixels to balance efficiency and responsiveness.
   uint32_t pixels = w * h;
-  decoder->add_pixels(pixels);
+  decoder->increment_pixels_decoded(pixels);
   if ((decoder->get_pixels_decoded() % 1024) < pixels) {
     App.feed_wdt();
   }

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -25,7 +25,7 @@ class PngDecoder : public ImageDecoder {
   int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
 
-  void add_pixels(uint32_t count) { this->pixels_decoded_ += count; }
+  void increment_pixels_decoded(uint32_t count) { this->pixels_decoded_ += count; }
   uint32_t get_pixels_decoded() const { return this->pixels_decoded_; }
 
  protected:

--- a/esphome/components/online_image/png_image.h
+++ b/esphome/components/online_image/png_image.h
@@ -25,9 +25,13 @@ class PngDecoder : public ImageDecoder {
   int prepare(size_t download_size) override;
   int HOT decode(uint8_t *buffer, size_t size) override;
 
+  void add_pixels(uint32_t count) { this->pixels_decoded_ += count; }
+  uint32_t get_pixels_decoded() const { return this->pixels_decoded_; }
+
  protected:
   RAMAllocator<pngle_t> allocator_;
   pngle_t *pngle_;
+  uint32_t pixels_decoded_{0};
 };
 
 }  // namespace online_image


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11897

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
