### PR TITLE
[tuya] Add fan support for string DPs

### DIFF
--- a/esphome/components/tuya/fan/tuya_fan.cpp
+++ b/esphome/components/tuya/fan/tuya_fan.cpp
@@ -21,6 +21,15 @@ void TuyaFan::setup() {
         ESP_LOGV(TAG, "MCU reported speed of: %d", datapoint.value_int);
         this->speed = datapoint.value_int;
         this->publish_state();
+      } else if (datapoint.type == TuyaDatapointType::STRING) {
+        char *endptr;
+        this->speed = strtol(datapoint.value_string.c_str(), &endptr, 10);
+        if (*endptr != '\0') {
+          ESP_LOGE(TAG, "Speed has invalid value '%s'", datapoint.value_string.c_str());
+        } else {
+          ESP_LOGV(TAG, "MCU reported speed of: %d '%s'", this->speed, datapoint.value_string.c_str());
+          this->publish_state();
+        }
       }
       this->speed_type_ = datapoint.type;
     });
@@ -95,10 +104,13 @@ void TuyaFan::control(const fan::FanCall &call) {
     this->parent_->set_enum_datapoint_value(*this->direction_id_, enable);
   }
   if (this->speed_id_.has_value() && call.get_speed().has_value()) {
+    int speed = *call.get_speed();
     if (this->speed_type_ == TuyaDatapointType::ENUM) {
-      this->parent_->set_enum_datapoint_value(*this->speed_id_, *call.get_speed() - 1);
+      this->parent_->set_enum_datapoint_value(*this->speed_id_, speed - 1);
     } else if (this->speed_type_ == TuyaDatapointType::INTEGER) {
-      this->parent_->set_integer_datapoint_value(*this->speed_id_, *call.get_speed());
+      this->parent_->set_integer_datapoint_value(*this->speed_id_, speed);
+    } else if (this->speed_type_ == TuyaDatapointType::STRING) {
+      this->parent_->set_string_datapoint_value(*this->speed_id_, to_string(speed));
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

~~Fix the MQTT handling of fan speeds to use a percentage, as documented in the HA MQTT docs.~~
Add support for Tuya fans with the speed in a string DP.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
.fan:
  - platform: tuya
    name: "Cooker fan"
    id: cooker_fan
    tuya_id: my_tuya_tcp
    switch_datapoint: 1
    speed_datapoint: 2
    speed_count: 4

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation not needed in [esphome-docs](https://github.com/esphome/esphome-docs).
