### PR TITLE
[cst816][http_request] Fix status_set_error() dangling pointer bugs

### DIFF
--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -19,7 +19,8 @@ void CST816Touchscreen::continue_setup_() {
       case CST816T_CHIP_ID:
         break;
       default:
-        this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());
+        ESP_LOGE(TAG, "Unknown chip ID: 0x%02X", this->chip_id_);
+        this->status_set_error("Unknown chip ID");
         this->mark_failed();
         return;
     }

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -49,18 +49,18 @@ void HttpRequestUpdate::update_task(void *params) {
   auto container = this_update->request_parent_->get(this_update->source_url_);
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
-    std::string msg = str_sprintf("Failed to fetch manifest from %s", this_update->source_url_.c_str());
+    ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update]() { this_update->status_set_error("Failed to fetch manifest"); });
     UPDATE_RETURN;
   }
 
   RAMAllocator<uint8_t> allocator;
   uint8_t *data = allocator.allocate(container->content_length);
   if (data == nullptr) {
-    std::string msg = str_sprintf("Failed to allocate %zu bytes for manifest", container->content_length);
+    ESP_LOGE(TAG, "Failed to allocate %zu bytes for manifest", container->content_length);
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update]() { this_update->status_set_error("Failed to allocate memory for manifest"); });
     container->end();
     UPDATE_RETURN;
   }
@@ -121,9 +121,9 @@ void HttpRequestUpdate::update_task(void *params) {
   }
 
   if (!valid) {
-    std::string msg = str_sprintf("Failed to parse JSON from %s", this_update->source_url_.c_str());
+    ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update, msg]() { this_update->status_set_error(msg.c_str()); });
+    this_update->defer([this_update]() { this_update->status_set_error("Failed to parse manifest JSON"); });
     UPDATE_RETURN;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes dangling pointers in `status_set_error()` calls by moving dynamic error details to log statements and passing only static strings to the status API.

## Problem

Four instances in the codebase were passing temporary strings to `status_set_error()`, which stores raw `const char*` pointers globally:

1. **CST816 touchscreen**: `str_sprintf("Unknown chip ID 0x%02X", chip_id).c_str()` - temporary destroyed after call
2. **HTTP Request Update** (3 instances): Lambda captures `std::string msg` by value, then calls `msg.c_str()` - pointer becomes invalid when lambda copy is destroyed

These created dangling pointers that corrupted error messages or caused crashes during `dump_config()`.

## Solution

Applied the pattern of logging dynamic details with `ESP_LOGE()` and passing static strings to `status_set_error()`:

**Before:**
```cpp
this->status_set_error(str_sprintf("Unknown chip ID 0x%02X", this->chip_id_).c_str());
```

**After:**
```cpp
ESP_LOGE(TAG, "Unknown chip ID: 0x%02X", this->chip_id_);
this->status_set_error("Unknown chip ID");
```

## Why This Approach?

This is a minimal fix that:
- ✅ Eliminates all dangling pointer bugs without API changes
- ✅ No memory overhead or architectural changes
- ✅ Users still get full diagnostic details via logs
- ✅ Doesn't block future API improvements (PRs #12020 and #12021 are under consideration)

This fix addresses the immediate safety issue while the community decides on the long-term API direction.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #12020 and #12021 (alternative architectural approaches)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
# Existing CST816 touchscreen and HTTP Request Update configs work unchanged

touchscreen:
  - platform: cst816
    id: my_touchscreen
    # ... existing config ...

update:
  - platform: http_request
    # ... existing config ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
