### PR TITLE
[substitutions] Fix #12018 `!include` vars not propagated correctly beyond 2nd hierarchy level

### DIFF
--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -235,5 +235,5 @@ def do_substitution_pass(
     config.move_to_end(CONF_SUBSTITUTIONS, False)
 
     # Create a Jinja environment that will consider substitutions in scope:
-    jinja = Jinja(substitutions)
+    jinja = Jinja(substitutions, ignore_missing)
     _substitute_item(substitutions, config, [], jinja, ignore_missing)

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import jinja2 as jinja
 from jinja2.nativetypes import NativeCodeGenerator, NativeTemplate
+from jinja2.runtime import missing as Missing
 
 from esphome.yaml_util import ESPLiteralValue
 
@@ -106,6 +107,9 @@ class JinjaError(Exception):
 class TrackerContext(jinja.runtime.Context):
     def resolve_or_missing(self, key):
         val = super().resolve_or_missing(key)
+        if val is Missing and self.environment.ignore_missing:
+            # delay evaluation of this expression
+            raise UndefinedError(f"'{key}' is undefined")
         if isinstance(val, JinjaStr):
             self.environment.context_trace[key] = val
             val, _ = self.environment.expand(val)
@@ -168,7 +172,7 @@ class Jinja(jinja.Environment):
     code_generator_class = NativeCodeGenerator
     concat = staticmethod(_concat_nodes_override)
 
-    def __init__(self, context_vars: dict):
+    def __init__(self, context_vars: dict, ignore_missing=False):
         super().__init__(
             trim_blocks=True,
             lstrip_blocks=True,
@@ -180,6 +184,7 @@ class Jinja(jinja.Environment):
             variable_end_string="}",
             undefined=jinja.StrictUndefined,
         )
+        self.ignore_missing = ignore_missing
         self.context_class = TrackerContext
         self.add_extension("jinja2.ext.do")
         self.context_trace = {}

--- a/esphome/components/substitutions/jinja.py
+++ b/esphome/components/substitutions/jinja.py
@@ -1,4 +1,5 @@
 from ast import literal_eval
+from collections import ChainMap
 from collections.abc import Iterator
 from itertools import chain, islice
 import logging
@@ -67,13 +68,13 @@ class JinjaStr(str):
 
     Undefined = object()
 
-    def __new__(cls, value: str, upvalues=None):
+    def __new__(cls, value: str, upvalues: dict[str, Any] = None):
         if isinstance(value, JinjaStr):
             base = str(value)
             merged = {**value.upvalues, **(upvalues or {})}
         else:
             base = value
-            merged = dict(upvalues or {})
+            merged = upvalues or {}
         obj = super().__new__(cls, base)
         obj.upvalues = merged
         obj.result = JinjaStr.Undefined
@@ -112,7 +113,12 @@ class TrackerContext(jinja.runtime.Context):
             raise UndefinedError(f"'{key}' is undefined")
         if isinstance(val, JinjaStr):
             self.environment.context_trace[key] = val
-            val, _ = self.environment.expand(val)
+            val, err = self.environment.expand(
+                JinjaStr(str(val), ChainMap(val.upvalues, self.parent))
+            )
+            if isinstance(err, UndefinedError) and self.environment.ignore_missing:
+                # delay evaluation of this expression
+                raise err
         self.environment.context_trace[key] = val
         return val
 

--- a/tests/unit_tests/fixtures/substitutions/06-include_hierarchy.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/06-include_hierarchy.approved.yaml
@@ -1,0 +1,21 @@
+substitutions:
+  a: 10
+  b: 20
+  x: 79
+test_list:
+  - level1:
+      c: 10
+      d: 20
+      level2:
+        - level2:
+            e: 20
+            f: 40
+            level3:
+              - level3:
+                  g: 100
+                  h: 200
+                  i: ${undefined_variable}
+                  x: 79
+  - a: 10
+    b: 20
+    x: 79

--- a/tests/unit_tests/fixtures/substitutions/06-include_hierarchy.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/06-include_hierarchy.input.yaml
@@ -1,0 +1,14 @@
+substitutions:
+  a: 10
+  b: 20
+  x: 79
+
+test_list:
+  - !include
+    file: level1_package.yaml
+    vars:
+      c: ${a}
+      d: ${b}
+  - a: ${a}
+    b: ${b}
+    x: ${x}

--- a/tests/unit_tests/fixtures/substitutions/level1_package.yaml
+++ b/tests/unit_tests/fixtures/substitutions/level1_package.yaml
@@ -1,0 +1,9 @@
+level1:
+  c: ${c}
+  d: ${d}
+  level2:
+    - !include
+      file: level2_package.yaml
+      vars:
+        e: ${c*2}
+        f: ${d*2}

--- a/tests/unit_tests/fixtures/substitutions/level2_package.yaml
+++ b/tests/unit_tests/fixtures/substitutions/level2_package.yaml
@@ -1,0 +1,9 @@
+level2:
+  e: ${e}
+  f: ${f}
+  level3:
+    - !include
+      file: level3_package.yaml
+      vars:
+        g: ${e*5}
+        h: ${f*5}

--- a/tests/unit_tests/fixtures/substitutions/level3_package.yaml
+++ b/tests/unit_tests/fixtures/substitutions/level3_package.yaml
@@ -1,0 +1,5 @@
+level3:
+  g: ${g}
+  h: ${h}
+  i: ${undefined_variable}  # Does not exist, should be output as-is
+  x: ${x}  # Inherited from top-level substitutions


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes the case whereupon `!include` vars containing an expression would not be expanded correctly after a second `!include` that referenced it. The fix postpones evaluation of the expression until all referenced variables are available in a later pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#12018
- fixes esphome/esphome#9978

## Test Environment

- [x] all (config)

## Example entry for `config.yaml`:

See example in esphome/esphome#12018, which now works correctly after this fix.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
