### PR TITLE
[esp32] Fix C2 builds

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -884,6 +884,12 @@ async def to_code(config):
     )
 
     add_extra_script(
+        "pre",
+        "pre_build.py",
+        Path(__file__).parent / "pre_build.py.script",
+    )
+
+    add_extra_script(
         "post",
         "post_build.py",
         Path(__file__).parent / "post_build.py.script",

--- a/esphome/components/esp32/pre_build.py.script
+++ b/esphome/components/esp32/pre_build.py.script
@@ -1,0 +1,9 @@
+Import("env")  # noqa: F821
+
+# Remove custom_sdkconfig from the board config as it causes
+# pioarduino to enable some strange hybrid build mode that breaks IDF
+board = env.BoardConfig()
+if "espidf.custom_sdkconfig" in board:
+    del board._manifest["espidf"]["custom_sdkconfig"]
+    if not board._manifest["espidf"]:
+        del board._manifest["espidf"]


### PR DESCRIPTION
# What does this implement/fix?

If board files have `custom_sdkconfig` set:
```
  "espidf": {
    "custom_sdkconfig": [
      "CONFIG_IDF_TARGET=\"esp32c2\"" 
    ]
  },
```
it enables some hybrid thing in pioarduino which breaks standard IDF builds. Create a script to remove this setting as it is not useful to us. In both cases custom_sdkconfig contains dummy sdk configs that are only there to enable this mode. In this example CONFIG_IDF_TARGET which is already set by default and is not needed.

Only two board files have this setting `esp32-c2-devkitm-1.json` and `esp32-solo1.json`

Can probably revert https://github.com/esphome/esphome/pull/9578 as the c2 build now correctly builds bootloader.bin, that PR didn't fix the real issue, just worked around it to create an OTA image. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/7137

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
