### PR TITLE
Map `HEAT_COOL` to `MODE_AUTO` in HeatpumpIR component

### DIFF
--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -181,6 +181,9 @@ void HeatpumpIRClimate::transmit_state() {
       power_mode_cmd = POWER_ON;
       operating_mode_cmd = MODE_HEAT;
       break;
+    // treat HEAT_COOL as hardware AUTO / auto changeover
+    // see https://github.com/esphome/esphome/issues/11161
+    case climate::CLIMATE_MODE_HEAT_COOL:
     case climate::CLIMATE_MODE_AUTO:
       power_mode_cmd = POWER_ON;
       operating_mode_cmd = MODE_AUTO;

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -181,8 +181,10 @@ void HeatpumpIRClimate::transmit_state() {
       power_mode_cmd = POWER_ON;
       operating_mode_cmd = MODE_HEAT;
       break;
-    // treat HEAT_COOL as hardware AUTO / auto changeover
-    // see https://github.com/esphome/esphome/issues/11161
+    // Map HEAT_COOL to hardware AUTO mode (automatic heat/cool changeover based on temperature).
+    // In hardware AUTO mode, the device automatically switches between heating and cooling
+    // based on the current temperature versus the target temperature.
+    // See https://github.com/esphome/esphome/issues/11161 for further discussion.
     case climate::CLIMATE_MODE_HEAT_COOL:
     case climate::CLIMATE_MODE_AUTO:
       power_mode_cmd = POWER_ON;


### PR DESCRIPTION
# What does this implement/fix?

This PR implements explicit handling for `CLIMATE_MODE_HEAT_COOL` in the `heatpumpir` climate platform.  
As reported in [esphome/esphome#11161](https://github.com/esphome/esphome/issues/11161), when Home Assistant or ESPHome sends `HEAT_COOL` (e.g. when selecting “Auto”), the mode value falls through the switch in `transmit_state()` and reaches the `default` branch, resulting in a `POWER_OFF` frame being sent.

This change adds a dedicated `CLIMATE_MODE_HEAT_COOL` case and maps it to `POWER_ON` + `MODE_AUTO`, which is the correct IR representation for entering the heat pump’s built-in Auto/auto-changeover mode. The existing `CLIMATE_MODE_AUTO` branch is preserved for backwards compatibility.

No breaking changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- (partially) addresses https://github.com/esphome/esphome/issues/11161
  - does not address the CN105 implementation issue - only HeatpumpIR

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no configuration or user-visible changes)

## Test Environment

- [ ] ESP32  
- [ ] ESP32 IDF  
- [x] ESP8266  
- [ ] RP2040  
- [ ] BK72xx  
- [ ] RTL87xx  
- [ ] nRF52840  

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: heatpumpir
    id: aircon          
    protocol: mitsubishi_heavy_zmp
    name: "Control"
    max_temperature: 28.0
    min_temperature: 18.0
    horizontal_default: auto
    vertical_default: auto
    supports_heat: true
    supports_cool: true    
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] ~Tests have been added to verify that the new code works (under `tests/` folder).~ N/A

If user exposed functionality or configuration variables are added/changed:
- [ ] ~Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).~ N/A

## Local Testing:

Relevant YAML bits:
```yaml
external_components:
  - source: github://poolski/esphome@heatpumpir-map-heat-cool
    refresh: 0s
    components: [ 'heatpumpir' ]

climate:
  - platform: heatpumpir
    id: office_aircon_control
    protocol: mitsubishi_heavy_zmp
    name: "Control"
    max_temperature: 28.0
    min_temperature: 18.0
    horizontal_default: auto
    vertical_default: auto
    supports_heat: true
    supports_cool: true   
```
Firmware compiles

```
INFO Updating https://github.com/poolski/esphome.git@heatpumpir-map-heat-cool
...
linking... etc
```
Selecting `Heat/Cool` seems to set the correct mode/temperature (I've confirmed it with my custom IR frame decoder)

<img width="1090" height="1043" alt="PixelSnap 2025-11-23 at 11 59 41@2x" src="https://github.com/user-attachments/assets/fb560b5b-8e24-4aa2-a00b-3f373d968f29" />

```
[12:04:27.395][I][mhi_aeha:121]: Remote -> heatpumpir: power=on mode=1 temp=22 fan=2 swing=0 (b5=0xFF b6=0x00 b7=0xE5)
[12:04:27.407][D][climate:049]: 'Control' - Setting
[12:04:27.407][D][climate:053]:   Mode: HEAT_COOL
[12:04:27.407][D][climate:062]:   Fan: AUTO
[12:04:27.407][D][climate:075]:   Swing: OFF
[12:04:27.526][D][climate:078]:   Target Temperature: 22.00
[12:04:27.527][D][remote_transmitter:085]: Sending remote code
[12:04:27.539][D][climate:427]: 'Control' - Sending state:
[12:04:27.539][D][climate:430]:   Mode: HEAT_COOL
[12:04:27.539][D][climate:435]:   Fan Mode: AUTO
[12:04:27.540][D][climate:447]:   Swing Mode: OFF
[12:04:27.560][D][climate:457]:   Target Temperature: 22.00°C
[12:04:27.560][I][remote.aeha:098]: Received AEHA: address=0x4A75, data=[0xC3,0x64,0x9B,0xFF,0x00,0xFF,0x00,0xE5,0x1A]
[12:04:36.675][V][sensor:081]: 'Uptime': Received new state 1271.156006
[12:04:36.678][D][sensor:133]: 'Uptime': Sending state 1271.15601 s with 0 decimals of accuracy
```