### PR TITLE
[core] Fix error on invalid id extend/remove

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -355,6 +355,8 @@ def _get_item_id(item: Any) -> str | Extend | Remove | None:
     if isinstance(item_id, Extend):
         # Remove instances of Extend so they don't overwrite the original item when merging:
         del item[CONF_ID]
+    if not isinstance(item_id, (str, Extend, Remove)):
+        return None
     return item_id
 
 

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -355,7 +355,7 @@ def _get_item_id(item: Any) -> str | Extend | Remove | None:
     if isinstance(item_id, Extend):
         # Remove instances of Extend so they don't overwrite the original item when merging:
         del item[CONF_ID]
-    if not isinstance(item_id, (str, Extend, Remove)):
+    elif not isinstance(item_id, (str, Remove)):
         return None
     return item_id
 

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.approved.yaml
@@ -31,3 +31,9 @@ lvgl:
             id: object5
             x: 10
             y: 11
+        - obj:
+            id:
+              - Invalid ID
+        - obj:
+            id:
+              invalid: id

--- a/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/05-extend-remove.input.yaml
@@ -37,6 +37,10 @@ packages:
                 id: object5
                 x: 10
                 y: 11
+            - obj:
+                id: ["Invalid ID"]
+            - obj:
+                id: {"invalid": "id"}
 
 some_component:
   - id: !extend ${A}


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes an error in the `_get_item_id()` function when parsing the configuration where the function was returning a value that was impossible for an id, contradicting its own typings. This made the indexer crash.

The problem has been fixed and a test case added to prevent it from happening in the future.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#12061

## Test Environment

- [x] all (config)

## Example entry for `config.yaml`:

```yaml
packages:
  - lvgl:
      pages:
        - id: scr_test
          on_load:
            - lvgl.widget.update:
                id: 
                  - lbl_clock
                bg_color: 0x00BBCC
          widgets:
            - label:
                id: lbl_test
                text: "test"

esphome:
  name: esphome-lvgl

host:

touchscreen:
  platform: sdl
  id: touch

display:
    id: screen
    platform: sdl
    dimensions:
      width: 800
      height: 480
    update_interval: never

lvgl:
  displays: screen
  touchscreens: touch
  bg_color: 0x55AAFF
  pages:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
