### PR TITLE
[api] Use stack buffer for MAC address in Noise handshake

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -239,12 +239,13 @@ APIError APINoiseFrameHelper::state_action_() {
   }
   if (state_ == State::SERVER_HELLO) {
     // send server hello
+    constexpr size_t mac_len = 13;  // 12 hex chars + null terminator
     const std::string &name = App.get_name();
-    const std::string &mac = get_mac_address();
+    char mac[mac_len];
+    get_mac_address_into_buffer(mac);
 
     // Calculate positions and sizes
     size_t name_len = name.size() + 1;  // including null terminator
-    size_t mac_len = mac.size() + 1;    // including null terminator
     size_t name_offset = 1;
     size_t mac_offset = name_offset + name_len;
     size_t total_size = 1 + name_len + mac_len;
@@ -257,7 +258,7 @@ APIError APINoiseFrameHelper::state_action_() {
     // node name, terminated by null byte
     std::memcpy(msg.get() + name_offset, name.c_str(), name_len);
     // node mac, terminated by null byte
-    std::memcpy(msg.get() + mac_offset, mac.c_str(), mac_len);
+    std::memcpy(msg.get() + mac_offset, mac, mac_len);
 
     aerr = write_frame_(msg.get(), total_size);
     if (aerr != APIError::OK)


### PR DESCRIPTION
## What does this implement/fix?

Reduces heap allocations in the API Noise frame helper by using a stack buffer for MAC address formatting instead of allocating a temporary `std::string`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Problem Description

During the API Noise handshake `SERVER_HELLO` phase, the code was calling `get_mac_address()` which allocates a temporary `std::string` on the heap. This allocation is unnecessary since:

1. The MAC address is always exactly 12 hex characters (fixed size)
2. The value is only used once to copy into the message buffer
3. A stack buffer can be used instead

## Solution

Changed the implementation to use `get_mac_address_into_buffer()` with a stack-allocated buffer:

**Before:**
```cpp
const std::string &mac = get_mac_address();  // Heap allocation
size_t mac_len = mac.size() + 1;
std::memcpy(msg.get() + mac_offset, mac.c_str(), mac_len);
```

**After:**
```cpp
constexpr size_t mac_len = 13;  // 12 hex chars + null terminator
char mac[mac_len];              // Stack allocation
get_mac_address_into_buffer(mac);
std::memcpy(msg.get() + mac_offset, mac, mac_len);
```

## Benefits

- Eliminates one heap allocation per API connection handshake
- Uses compile-time constant for buffer size (more optimal code generation)
- Maintains identical behavior (verified with test)

## Related PRs/Issues

Part of ongoing effort to reduce heap allocations in the API components.
