### PR TITLE
[esp32] Use the IDF I2C implementation on Arduino

### DIFF
--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -47,18 +47,23 @@ MULTI_CONF = True
 
 
 def _bus_declare_type(value):
+    if CORE.is_esp32:
+        return cv.declare_id(IDFI2CBus)(value)
     if CORE.using_arduino:
         return cv.declare_id(ArduinoI2CBus)(value)
-    if CORE.using_esp_idf:
-        return cv.declare_id(IDFI2CBus)(value)
     if CORE.using_zephyr:
         return cv.declare_id(ZephyrI2CBus)(value)
     raise NotImplementedError
 
 
 def validate_config(config):
-    if CORE.using_esp_idf:
-        return cv.require_framework_version(esp_idf=cv.Version(5, 4, 2))(config)
+    if CORE.is_esp32:
+        # ESP32 uses ESP-IDF I2C driver for both frameworks
+        # Arduino 3.2.0+ is based on ESP-IDF 5.4.1+ which has the new i2c_master driver
+        return cv.require_framework_version(
+            esp_idf=cv.Version(5, 4, 2),
+            esp32_arduino=cv.Version(3, 2, 0),
+        )(config)
     return config
 
 
@@ -67,12 +72,12 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): _bus_declare_type,
             cv.Optional(CONF_SDA, default="SDA"): pins.internal_gpio_pin_number,
-            cv.SplitDefault(CONF_SDA_PULLUP_ENABLED, esp32_idf=True): cv.All(
-                cv.only_with_esp_idf, cv.boolean
+            cv.SplitDefault(CONF_SDA_PULLUP_ENABLED, esp32=True): cv.All(
+                cv.only_on_esp32, cv.boolean
             ),
             cv.Optional(CONF_SCL, default="SCL"): pins.internal_gpio_pin_number,
-            cv.SplitDefault(CONF_SCL_PULLUP_ENABLED, esp32_idf=True): cv.All(
-                cv.only_with_esp_idf, cv.boolean
+            cv.SplitDefault(CONF_SCL_PULLUP_ENABLED, esp32=True): cv.All(
+                cv.only_on_esp32, cv.boolean
             ),
             cv.SplitDefault(
                 CONF_FREQUENCY,
@@ -151,7 +156,7 @@ async def to_code(config):
     cg.add(var.set_scan(config[CONF_SCAN]))
     if CONF_TIMEOUT in config:
         cg.add(var.set_timeout(int(config[CONF_TIMEOUT].total_microseconds)))
-    if CORE.using_arduino:
+    if CORE.using_arduino and not CORE.is_esp32:
         cg.add_library("Wire", None)
 
 
@@ -248,14 +253,16 @@ def final_validate_device_schema(
 FILTER_SOURCE_FILES = filter_source_files_from_platform(
     {
         "i2c_bus_arduino.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
             PlatformFramework.ESP8266_ARDUINO,
             PlatformFramework.RP2040_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,
             PlatformFramework.LN882X_ARDUINO,
         },
-        "i2c_bus_esp_idf.cpp": {PlatformFramework.ESP32_IDF},
+        "i2c_bus_esp_idf.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
         "i2c_bus_zephyr.cpp": {PlatformFramework.NRF52_ZEPHYR},
     }
 )

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -59,8 +59,7 @@ def _bus_declare_type(value):
 def validate_config(config):
     if CORE.is_esp32:
         return cv.require_framework_version(
-            esp_idf=cv.Version(5, 4, 2),
-            esp32_arduino=cv.Version(3, 2, 1),
+            esp_idf=cv.Version(5, 4, 2), esp32_arduino=cv.Version(3, 2, 1)
         )(config)
     return config
 

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -58,11 +58,9 @@ def _bus_declare_type(value):
 
 def validate_config(config):
     if CORE.is_esp32:
-        # ESP32 uses ESP-IDF I2C driver for both frameworks
-        # Arduino 3.2.0+ is based on ESP-IDF 5.4.1+ which has the new i2c_master driver
         return cv.require_framework_version(
             esp_idf=cv.Version(5, 4, 2),
-            esp32_arduino=cv.Version(3, 2, 0),
+            esp32_arduino=cv.Version(3, 2, 1),
         )(config)
     return config
 

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -1,4 +1,6 @@
-#ifdef USE_ARDUINO
+// Arduino I2C implementation for non-ESP32 platforms
+// ESP32 uses ESP-IDF I2C driver for all frameworks (see i2c_bus_esp_idf.cpp)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 #include "i2c_bus_arduino.h"
 #include <Arduino.h>
@@ -15,16 +17,7 @@ static const char *const TAG = "i2c.arduino";
 void ArduinoI2CBus::setup() {
   recover_();
 
-#if defined(USE_ESP32)
-  static uint8_t next_bus_num = 0;
-  if (next_bus_num == 0) {
-    wire_ = &Wire;
-  } else {
-    wire_ = new TwoWire(next_bus_num);  // NOLINT(cppcoreguidelines-owning-memory)
-  }
-  this->port_ = next_bus_num;
-  next_bus_num++;
-#elif defined(USE_ESP8266)
+#if defined(USE_ESP8266)
   wire_ = new TwoWire();  // NOLINT(cppcoreguidelines-owning-memory)
 #elif defined(USE_RP2040)
   static bool first = true;
@@ -54,10 +47,7 @@ void ArduinoI2CBus::set_pins_and_clock_() {
   wire_->begin(static_cast<int>(sda_pin_), static_cast<int>(scl_pin_));
 #endif
   if (timeout_ > 0) {  // if timeout specified in yaml
-#if defined(USE_ESP32)
-    // https://github.com/espressif/arduino-esp32/blob/master/libraries/Wire/src/Wire.cpp
-    wire_->setTimeOut(timeout_ / 1000);  // unit: ms
-#elif defined(USE_ESP8266)
+#if defined(USE_ESP8266)
     // https://github.com/esp8266/Arduino/blob/master/libraries/Wire/Wire.h
     wire_->setClockStretchLimit(timeout_);  // unit: us
 #elif defined(USE_RP2040)
@@ -76,9 +66,7 @@ void ArduinoI2CBus::dump_config() {
                 "  Frequency: %u Hz",
                 this->sda_pin_, this->scl_pin_, this->frequency_);
   if (timeout_ > 0) {
-#if defined(USE_ESP32)
-    ESP_LOGCONFIG(TAG, "  Timeout: %u ms", this->timeout_ / 1000);
-#elif defined(USE_ESP8266)
+#if defined(USE_ESP8266)
     ESP_LOGCONFIG(TAG, "  Timeout: %u us", this->timeout_);
 #elif defined(USE_RP2040)
     ESP_LOGCONFIG(TAG, "  Timeout: %u ms", this->timeout_ / 1000);
@@ -275,4 +263,4 @@ void ArduinoI2CBus::recover_() {
 }  // namespace i2c
 }  // namespace esphome
 
-#endif  // USE_ESP_IDF
+#endif  // defined(USE_ARDUINO) && !defined(USE_ESP32)

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -1,5 +1,3 @@
-// Arduino I2C implementation for non-ESP32 platforms
-// ESP32 uses ESP-IDF I2C driver for all frameworks (see i2c_bus_esp_idf.cpp)
 #if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 #include "i2c_bus_arduino.h"

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -29,6 +29,8 @@ class ArduinoI2CBus : public InternalI2CBus, public Component {
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
 
+  int get_port() const override { return 0; }
+
  private:
   void recover_();
   void set_pins_and_clock_();

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+// Arduino I2C implementation for non-ESP32 platforms
+// ESP32 uses ESP-IDF I2C driver for all frameworks (see i2c_bus_esp_idf.h)
+#if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 #include <Wire.h>
 #include "esphome/core/component.h"
@@ -29,15 +31,12 @@ class ArduinoI2CBus : public InternalI2CBus, public Component {
   void set_frequency(uint32_t frequency) { frequency_ = frequency; }
   void set_timeout(uint32_t timeout) { timeout_ = timeout; }
 
-  int get_port() const override { return this->port_; }
-
  private:
   void recover_();
   void set_pins_and_clock_();
   RecoveryCode recovery_result_;
 
  protected:
-  int8_t port_{-1};
   TwoWire *wire_;
   uint8_t sda_pin_;
   uint8_t scl_pin_;
@@ -49,4 +48,4 @@ class ArduinoI2CBus : public InternalI2CBus, public Component {
 }  // namespace i2c
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // defined(USE_ARDUINO) && !defined(USE_ESP32)

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// Arduino I2C implementation for non-ESP32 platforms
-// ESP32 uses ESP-IDF I2C driver for all frameworks (see i2c_bus_esp_idf.h)
 #if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 #include <Wire.h>

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 
 #include "i2c_bus_esp_idf.h"
 
@@ -299,4 +299,4 @@ void IDFI2CBus::recover_() {
 
 }  // namespace i2c
 }  // namespace esphome
-#endif  // USE_ESP_IDF
+#endif  // USE_ESP32

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 
 #include "esphome/core/component.h"
 #include "i2c_bus.h"
@@ -53,4 +53,4 @@ class IDFI2CBus : public InternalI2CBus, public Component {
 }  // namespace i2c
 }  // namespace esphome
 
-#endif  // USE_ESP_IDF
+#endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Use the IDF I2C implementation on ESP32 Arduino:
- the Arduino one seems to be causing issues
- simplifies the codebase

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11907

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5671

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
