### PR TITLE
[esp_ldo,mipi_dsi,mipi_rgb] Fix dangling pointer bugs in mark_failed()

### DIFF
--- a/esphome/components/esp_ldo/esp_ldo.cpp
+++ b/esphome/components/esp_ldo/esp_ldo.cpp
@@ -14,8 +14,8 @@ void EspLdo::setup() {
   config.flags.adjustable = this->adjustable_;
   auto err = esp_ldo_acquire_channel(&config, &this->handle_);
   if (err != ESP_OK) {
-    auto msg = str_sprintf("Failed to acquire LDO channel %d with voltage %fV", this->channel_, this->voltage_);
-    this->mark_failed(msg.c_str());
+    ESP_LOGE(TAG, "Failed to acquire LDO channel %d with voltage %fV", this->channel_, this->voltage_);
+    this->mark_failed("Failed to acquire LDO channel");
   } else {
     ESP_LOGD(TAG, "Acquired LDO channel %d with voltage %fV", this->channel_, this->voltage_);
   }

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -11,6 +11,12 @@ static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel
   xSemaphoreGiveFromISR(sem, &need_yield);
   return (need_yield == pdTRUE);
 }
+
+void MIPI_DSI::smark_failed(const char *message, esp_err_t err) {
+  ESP_LOGE(TAG, "%s: %s", message, esp_err_to_name(err));
+  this->mark_failed(message);
+}
+
 void MIPI_DSI::setup() {
   ESP_LOGCONFIG(TAG, "Running Setup");
 

--- a/esphome/components/mipi_dsi/mipi_dsi.h
+++ b/esphome/components/mipi_dsi/mipi_dsi.h
@@ -62,10 +62,7 @@ class MIPI_DSI : public display::Display {
   void set_lanes(uint8_t lanes) { this->lanes_ = lanes; }
   void set_madctl(uint8_t madctl) { this->madctl_ = madctl; }
 
-  void smark_failed(const char *message, esp_err_t err) {
-    auto str = str_sprintf("Setup failed: %s: %s", message, esp_err_to_name(err));
-    this->mark_failed(str.c_str());
-  }
+  void smark_failed(const char *message, esp_err_t err);
 
   void update() override;
 

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -164,8 +164,8 @@ void MipiRgb::common_setup_() {
   if (err == ESP_OK)
     err = esp_lcd_panel_init(this->handle_);
   if (err != ESP_OK) {
-    auto msg = str_sprintf("lcd setup failed: %s", esp_err_to_name(err));
-    this->mark_failed(msg.c_str());
+    ESP_LOGE(TAG, "lcd setup failed: %s", esp_err_to_name(err));
+    this->mark_failed("lcd setup failed");
   }
   ESP_LOGCONFIG(TAG, "MipiRgb setup complete");
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes critical dangling pointer bugs in `Component::mark_failed()` where temporary strings were being stored as raw `const char*` pointers, causing corrupted error messages or crashes during `dump_config()`.

This is a minimal, backport-safe version of #12021 that fixes the dangling pointer bugs without changing the API or adding deprecation warnings.

## Problem

Three components were passing temporary strings to `mark_failed()`:

1. **esp_ldo.cpp**: `str_sprintf("Failed to acquire LDO channel %d with voltage %fV", ...).c_str()` - temporary destroyed immediately
2. **mipi_rgb.cpp**: `str_sprintf("lcd setup failed: %s", esp_err_to_name(err)).c_str()` - temporary destroyed immediately
3. **mipi_dsi.h**: `smark_failed()` helper used `str_sprintf().c_str()` pattern - temporary destroyed immediately

When the temporary `std::string` is destroyed, the `const char*` pointer becomes invalid (dangling), causing error messages to be corrupted or crash when accessed later during `dump_config()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered during code review - subset of fixes from #12021
- This PR contains only the critical dangling pointer fixes without API changes

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal bug fix, not user-facing

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This is an internal bug fix that doesn't affect user configuration. The affected components (esp_ldo, mipi_dsi, mipi_rgb) are ESP32-P4 specific display/power components.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
