### PR TITLE
[prometheus] Use current_option() instead of deprecated .state for select entities

### DIFF
--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -726,7 +726,7 @@ void PrometheusHandler::select_row_(AsyncResponseStream *stream, select::Select 
     stream->print(ESPHOME_F("\",name=\""));
     stream->print(relabel_name_(obj).c_str());
     stream->print(ESPHOME_F("\",value=\""));
-    stream->print(obj->state.c_str());
+    stream->print(obj->current_option());
     stream->print(ESPHOME_F("\"} "));
     stream->print(ESPHOME_F("1.0"));
     stream->print(ESPHOME_F("\n"));


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the Prometheus handler to use `current_option()` instead of the deprecated `.state` member for select entities.

The select component's `.state` member was deprecated in favor of `current_option()` which returns a `const char*` pointer to the option string stored in flash memory. The Prometheus handler was missed in the original deprecation change and was still accessing the deprecated `.state.c_str()`.

**Changes:**
- `esphome/components/prometheus/prometheus_handler.cpp:729`: Changed `obj->state.c_str()` to `obj->current_option()`

This aligns with the select API changes where `current_option()` is the preferred method for retrieving the currently selected option.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Cleanup of deprecated API usage

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No documentation changes needed

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config showing prometheus with select component
prometheus:

select:
  - platform: template
    name: "My Select"
    options:
      - Option A
      - Option B
      - Option C
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
