### PR TITLE
[bluetooth_proxy] Fix crash due to null pointer

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -135,7 +135,7 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
     if (mac != nullptr) {
       format_mac_addr_upper(mac, output.data());
     } else {
-        output[0] = '\0';
+      output[0] = '\0';
     }
   }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -134,6 +134,8 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
     const uint8_t *mac = esp_bt_dev_get_address();
     if (mac != nullptr) {
       format_mac_addr_upper(mac, output.data());
+    } else {
+        output[0] = '\0';
     }
   }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -132,7 +132,9 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
 
   void get_bluetooth_mac_address_pretty(std::span<char, 18> output) {
     const uint8_t *mac = esp_bt_dev_get_address();
-    format_mac_addr_upper(mac, output.data());
+    if (mac != nullptr) {
+      format_mac_addr_upper(mac, output.data());
+    }
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

`esp_bt_dev_get_address()` can return NULL if Bluetooth is disabled when a client connects resulting in a crash like:

```
[15:01:44.422][D][api:161]: Accept 10.x.y.z
[15:01:44.428][W][component:364]: api cleared Warning flag
[15:01:44.433][D][api.connection:1386]: zwave-js (10.x.y.z) connected
[15:01:44.486]Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

[15:01:44.489]Core  1 register dump:
[15:01:44.497]PC      : 0x420a334e  PS      : 0x00060430  A0      : 0x8200314e  A1      : 0x3fcee0f0  
WARNING Decoded 0x420a334e: esphome::format_mac_addr_upper(unsigned char const*, char*) at /.../src/esphome/core/helpers.h:623
[15:01:44.524]A2      : 0x00000000  A3      : 0x3fcee160  A4      : 0x000000ff  A5      : 0x0000ff00  
[15:01:44.524]A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x00000000  A9      : 0x3fcee160  
[15:01:44.524]A10     : 0x00000000  A11     : 0x00000034  A12     : 0x00000009  A13     : 0x00000039  
[15:01:44.528]A14     : 0x0000003a  A15     : 0x3fca0320  SAR     : 0x00000000  EXCCAUSE: 0x0000001c  
[15:01:44.536]EXCVADDR: 0x00000000  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xfffffffa  


[15:01:44.606]Backtrace: 0x420a334b:0x3fcee0f0 0x4200314b:0x3fcee110 0x42005e25:0x3fcee1b0 0x42005be9:0x3fcee1d0 0x42005e71:0x3fcee210 0x42003b1f:0x3fcee230 0x420063b4:0x3fcee270 0x420a43ad:0x3fcee2d0 0x4200eaa1:0x\x80\x80\x80\x80xxxxxx\x80\x80\x80\x80x\x80\x80\x80x\xf8\x80\x80\x80\x80\x80\x80x\x80x\x80\x80\x80\xf8\x80\x80\x80\x80\x80\xf8\x80\x80x\x80\x80\x80\x80xxxxxx\x80\x80x\x80\x80\x80\x80x\xf8\x80\x80\x80\x80\x80x\x80\x80\xf8\xf8\x80\x80\x80\x80x\x80x\xf8\x80\x80x\x80\x80\x80\x80xxxxxx\x80\x80\xf8\x80\x80\x80\x80x\xf8\x80\x80\x80\x80\x80\x80\xf8\xf8\x80\x80xx\xf8\x80\x80\xf8\x80\x80x\x80\x80\x80\x80xxxxxx\x80\x80\x80\xf8\x80\x80x\x80xx\x80xx\x80xx\x80xx\x80xxx\x80xx\x80\x80\x80x\x80\xf8x\xf8xxx\x80\xf8\x80x\x80xx\x80\x80x\xf8\x80\x80\xf8\x80\x80\xf8\x80\x80\x80\x80x\x80\x80xx\xf8\x80\xf8x\x80\x80\x80x\x80\x80x\x80xx\x80x\x80\x80xx\x80xx\xf8x\xf8x\xf8x\x80\xf8x\xf8x\x80xx\x80x\x80xx\x80xESP-ROM:esp32s3-20210327
WARNING Found stack trace! Trying to decode it
WARNING Decoded 0x420a334b: esphome::format_mac_addr_upper(unsigned char const*, char*) at /.../src/esphome/core/helpers.h:623
WARNING Decoded 0x4200314b: esphome::bluetooth_proxy::BluetoothProxy::get_bluetooth_mac_address_pretty(std::span<char, 18u>) at /.../src/esphome/components/bluetooth_proxy/bluetooth_proxy.h:135 (discriminator 1)
 (inlined by) esphome::api::APIConnection::send_device_info_response(esphome::api::DeviceInfoRequest const&) at /.../src/esphome/components/api/api_connection.cpp:1501 (discriminator 1)
WARNING Decoded 0x42005e25: esphome::api::APIServerConnection::on_device_info_request(esphome::api::DeviceInfoRequest const&) at /.../src/esphome/components/api/api_pb2_service.cpp:653
WARNING Decoded 0x42005be9: esphome::api::APIServerConnectionBase::read_message(unsigned long, unsigned long, unsigned char*) at /.../src/esphome/components/api/api_pb2_service.cpp:610
WARNING Decoded 0x42005e71: esphome::api::APIServerConnection::read_message(unsigned long, unsigned long, unsigned char*) at /.../src/esphome/components/api/api_pb2_service.cpp:854
WARNING Decoded 0x42003b1f: esphome::api::APIConnection::loop() at /.../src/esphome/components/api/api_connection.cpp:172 (discriminator 2)
WARNING Decoded 0x420063b4: esphome::api::APIServer::loop() at /.../src/esphome/components/api/api_server.cpp:197 (discriminator 1)
WARNING Decoded 0x420a43ad: esphome::Component::call_loop() at /.../src/esphome/core/component.cpp:161
WARNING Decoded 0x4200eaa1: esphome::Component::call() at /.../src/esphome/core/component.cpp:210
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
