### PR TITLE
[mdns] Extract common Arduino mDNS registration to shared header

### DIFF
--- a/esphome/components/mdns/mdns_arduino.h
+++ b/esphome/components/mdns/mdns_arduino.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "esphome/core/defines.h"
+
+// Common Arduino mDNS registration for RP2040 and LibreTiny
+#if defined(USE_MDNS) && (defined(USE_RP2040) || defined(USE_LIBRETINY))
+
+#include "esphome/core/application.h"
+#include "mdns_component.h"
+
+namespace esphome::mdns {
+
+/// Register mDNS services using Arduino-style mDNS library (RP2040/LibreTiny)
+/// @param services The services to register
+inline void register_arduino_mdns(MDNSComponent *, StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services) {
+  MDNS.begin(App.get_name().c_str());
+
+  for (const auto &service : services) {
+    // Strip the leading underscore from the proto and service_type. While it is
+    // part of the wire protocol to have an underscore, and for example ESP-IDF
+    // expects the underscore to be there, the RP2040/LibreTiny mDNS
+    // implementations always add the underscore themselves.
+    auto *proto = MDNS_STR_ARG(service.proto);
+    while (*proto == '_') {
+      proto++;
+    }
+
+    auto *service_type = MDNS_STR_ARG(service.service_type);
+    while (*service_type == '_') {
+      service_type++;
+    }
+
+    uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
+    MDNS.addService(service_type, proto, port);
+    for (const auto &record : service.txt_records) {
+      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key), MDNS_STR_ARG(record.value));
+    }
+  }
+}
+
+}  // namespace esphome::mdns
+
+#endif

--- a/esphome/components/mdns/mdns_arduino.h
+++ b/esphome/components/mdns/mdns_arduino.h
@@ -1,8 +1,8 @@
 #pragma once
-#include "esphome/core/defines.h"
 
 // Common Arduino mDNS registration for RP2040 and LibreTiny
-#if defined(USE_MDNS) && (defined(USE_RP2040) || defined(USE_LIBRETINY))
+// NOTE: The platform's mDNS header (e.g., <mDNS.h> or <ESP8266mDNS.h>) must be
+// included BEFORE this header to make the MDNS global available.
 
 #include "esphome/core/application.h"
 #include "mdns_component.h"
@@ -38,5 +38,3 @@ inline void register_arduino_mdns(MDNSComponent *, StaticVector<MDNSService, MDN
 }
 
 }  // namespace esphome::mdns
-
-#endif

--- a/esphome/components/mdns/mdns_libretiny.cpp
+++ b/esphome/components/mdns/mdns_libretiny.cpp
@@ -1,41 +1,13 @@
 #include "esphome/core/defines.h"
 #if defined(USE_LIBRETINY) && defined(USE_MDNS)
 
-#include "esphome/components/network/ip_address.h"
-#include "esphome/components/network/util.h"
-#include "esphome/core/application.h"
-#include "esphome/core/log.h"
-#include "mdns_component.h"
-
 #include <mDNS.h>
+
+#include "mdns_arduino.h"
 
 namespace esphome::mdns {
 
-static void register_libretiny(MDNSComponent *, StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services) {
-  MDNS.begin(App.get_name().c_str());
-
-  for (const auto &service : services) {
-    // Strip the leading underscore from the proto and service_type. While it is
-    // part of the wire protocol to have an underscore, and for example ESP-IDF
-    // expects the underscore to be there, the ESP8266 implementation always adds
-    // the underscore itself.
-    auto *proto = MDNS_STR_ARG(service.proto);
-    while (*proto == '_') {
-      proto++;
-    }
-    auto *service_type = MDNS_STR_ARG(service.service_type);
-    while (*service_type == '_') {
-      service_type++;
-    }
-    uint16_t port_ = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    MDNS.addService(service_type, proto, port_);
-    for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key), MDNS_STR_ARG(record.value));
-    }
-  }
-}
-
-void MDNSComponent::setup() { this->setup_buffers_and_register_(register_libretiny); }
+void MDNSComponent::setup() { this->setup_buffers_and_register_(register_arduino_mdns); }
 
 void MDNSComponent::on_shutdown() {}
 

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -1,41 +1,13 @@
 #include "esphome/core/defines.h"
 #if defined(USE_RP2040) && defined(USE_MDNS)
 
-#include "esphome/components/network/ip_address.h"
-#include "esphome/components/network/util.h"
-#include "esphome/core/application.h"
-#include "esphome/core/log.h"
-#include "mdns_component.h"
-
 #include <ESP8266mDNS.h>
+
+#include "mdns_arduino.h"
 
 namespace esphome::mdns {
 
-static void register_rp2040(MDNSComponent *, StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services) {
-  MDNS.begin(App.get_name().c_str());
-
-  for (const auto &service : services) {
-    // Strip the leading underscore from the proto and service_type. While it is
-    // part of the wire protocol to have an underscore, and for example ESP-IDF
-    // expects the underscore to be there, the ESP8266 implementation always adds
-    // the underscore itself.
-    auto *proto = MDNS_STR_ARG(service.proto);
-    while (*proto == '_') {
-      proto++;
-    }
-    auto *service_type = MDNS_STR_ARG(service.service_type);
-    while (*service_type == '_') {
-      service_type++;
-    }
-    uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
-    MDNS.addService(service_type, proto, port);
-    for (const auto &record : service.txt_records) {
-      MDNS.addServiceTxt(service_type, proto, MDNS_STR_ARG(record.key), MDNS_STR_ARG(record.value));
-    }
-  }
-}
-
-void MDNSComponent::setup() { this->setup_buffers_and_register_(register_rp2040); }
+void MDNSComponent::setup() { this->setup_buffers_and_register_(register_arduino_mdns); }
 
 void MDNSComponent::loop() { MDNS.update(); }
 


### PR DESCRIPTION
# What does this implement/fix?

Consolidates duplicate mDNS registration code between RP2040 and LibreTiny platforms into a shared header file.

Both `mdns_rp2040.cpp` and `mdns_libretiny.cpp` had nearly identical implementations of the service registration logic (~30 lines each). This PR extracts the common code into `mdns_arduino.h` with a single `register_arduino_mdns()` function.

**Changes:**
- New `mdns_arduino.h` with shared `register_arduino_mdns()` inline function
- `mdns_rp2040.cpp` reduced from 49 to 21 lines
- `mdns_libretiny.cpp` reduced from 44 to 16 lines

Platform-specific code (loop behavior, shutdown delays) remains in the individual files.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactoring only)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
