### PR TITLE
[sht4x] Read and store a serial number of SHT4x sensors

### DIFF
--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -7,6 +7,7 @@ namespace sht4x {
 static const char *const TAG = "sht4x";
 
 static const uint8_t MEASURECOMMANDS[] = {0xFD, 0xF6, 0xE0};
+static const uint8_t SERIAL_NUMBER_COMMAND = 0x89;
 
 void SHT4XComponent::start_heater_() {
   uint8_t cmd[] = {MEASURECOMMANDS[this->heater_command_]};
@@ -17,12 +18,27 @@ void SHT4XComponent::start_heater_() {
   }
 }
 
+void SHT4XComponent::read_serial_numer_() {
+  ESP_LOGD(TAG, "Read serial number");
+  uint16_t buffer[2];
+
+  if (!this->get_8bit_register(SERIAL_NUMBER_COMMAND, buffer, 2, 1)) {
+    ESP_LOGE(TAG, "Get serial number failed");
+    this->serial_number_ = 0;
+    return;
+  }
+  this->serial_number_ = (uint32_t(buffer[0]) << 16) | (uint64_t(buffer[1]));
+  ESP_LOGD(TAG, "Serial number: %" PRIu32, this->serial_number_);
+}
+
 void SHT4XComponent::setup() {
   auto err = this->write(nullptr, 0);
   if (err != i2c::ERROR_OK) {
     this->mark_failed();
     return;
   }
+
+  this->read_serial_numer_();
 
   if (std::isfinite(this->duty_cycle_) && this->duty_cycle_ > 0.0f) {
     uint32_t heater_interval = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
@@ -54,10 +70,17 @@ void SHT4XComponent::setup() {
 }
 
 void SHT4XComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "SHT4x:");
+  ESP_LOGCONFIG(TAG,
+                "SHT4x:\n"
+                "  Serial number: %" PRIu32 "\n",
+                this->serial_number_);
+
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+  }
+  if (this->serial_number_ == 0) {
+    ESP_LOGW(TAG, "Get serial number failed");
   }
 }
 

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -19,7 +19,6 @@ void SHT4XComponent::start_heater_() {
 }
 
 void SHT4XComponent::read_serial_number_() {
-  ESP_LOGD(TAG, "Read serial number");
   uint16_t buffer[2];
 
   if (!this->get_8bit_register(SERIAL_NUMBER_COMMAND, buffer, 2, 1)) {

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -27,7 +27,7 @@ void SHT4XComponent::read_serial_numer_() {
     this->serial_number_ = 0;
     return;
   }
-  this->serial_number_ = (uint32_t(buffer[0]) << 16) | (uint64_t(buffer[1]));
+  this->serial_number_ = (uint32_t(buffer[0]) << 16) | (uint32_t(buffer[1]));
   ESP_LOGD(TAG, "Serial number: %" PRIu32, this->serial_number_);
 }
 

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -20,7 +20,6 @@ void SHT4XComponent::start_heater_() {
 
 void SHT4XComponent::read_serial_number_() {
   uint16_t buffer[2];
-
   if (!this->get_8bit_register(SERIAL_NUMBER_COMMAND, buffer, 2, 1)) {
     ESP_LOGE(TAG, "Get serial number failed");
     this->serial_number_ = 0;

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -70,7 +70,7 @@ void SHT4XComponent::setup() {
 void SHT4XComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "SHT4x:\n"
-                "  Serial number: %08" PRIx32 "\n",
+                "  Serial number: %08" PRIx32,
                 this->serial_number_);
 
   LOG_I2C_DEVICE(this);

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -18,7 +18,7 @@ void SHT4XComponent::start_heater_() {
   }
 }
 
-void SHT4XComponent::read_serial_numer_() {
+void SHT4XComponent::read_serial_number_() {
   ESP_LOGD(TAG, "Read serial number");
   uint16_t buffer[2];
 
@@ -28,7 +28,7 @@ void SHT4XComponent::read_serial_numer_() {
     return;
   }
   this->serial_number_ = (uint32_t(buffer[0]) << 16) | (uint32_t(buffer[1]));
-  ESP_LOGD(TAG, "Serial number: %" PRIu32, this->serial_number_);
+  ESP_LOGD(TAG, "Serial number: %08" PRIx32, this->serial_number_);
 }
 
 void SHT4XComponent::setup() {
@@ -38,7 +38,7 @@ void SHT4XComponent::setup() {
     return;
   }
 
-  this->read_serial_numer_();
+  this->read_serial_number_();
 
   if (std::isfinite(this->duty_cycle_) && this->duty_cycle_ > 0.0f) {
     uint32_t heater_interval = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
@@ -72,7 +72,7 @@ void SHT4XComponent::setup() {
 void SHT4XComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "SHT4x:\n"
-                "  Serial number: %" PRIu32 "\n",
+                "  Serial number: %08" PRIx32 "\n",
                 this->serial_number_);
 
   LOG_I2C_DEVICE(this);

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -36,7 +36,9 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   float duty_cycle_;
 
   void start_heater_();
+  void read_serial_numer_();
   uint8_t heater_command_;
+  uint32_t serial_number_;
 
   sensor::Sensor *temp_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -36,7 +36,7 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   float duty_cycle_;
 
   void start_heater_();
-  void read_serial_numer_();
+  void read_serial_number_();
   uint8_t heater_command_;
   uint32_t serial_number_;
 


### PR DESCRIPTION
# What does this implement/fix?

Add a read of a serial number of SHT4x sensors and output it in dump_config.
It can be helpful for calibrated sensors to request calibration details from Sensirion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
