### PR TITLE
[esp32] Fix platformio flash size print

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -854,6 +854,10 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
 async def to_code(config):
     cg.add_platformio_option("board", config[CONF_BOARD])
     cg.add_platformio_option("board_upload.flash_size", config[CONF_FLASH_SIZE])
+    cg.add_platformio_option(
+        "board_upload.maximum_size",
+        int(config[CONF_FLASH_SIZE].rstrip("MB")) * 1024 * 1024,
+    )
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -856,7 +856,7 @@ async def to_code(config):
     cg.add_platformio_option("board_upload.flash_size", config[CONF_FLASH_SIZE])
     cg.add_platformio_option(
         "board_upload.maximum_size",
-        int(config[CONF_FLASH_SIZE].rstrip("MB")) * 1024 * 1024,
+        int(config[CONF_FLASH_SIZE].removesuffix("MB")) * 1024 * 1024,
     )
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")


### PR DESCRIPTION
# What does this implement/fix?

Set `board_upload.maximum_size` so platformio prints the correct size. 

No functional change but will avoid some confusion:
```
HARDWARE: ESP32P4 360MHz, 500KB RAM, 8MB Flash
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12056

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
