### PR TITLE
[inkplate] Ignore strapping pin warnings on default pins

### DIFF
--- a/esphome/components/inkplate/display.py
+++ b/esphome/components/inkplate/display.py
@@ -6,10 +6,12 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_FULL_UPDATE_EVERY,
     CONF_ID,
+    CONF_IGNORE_STRAPPING_WARNING,
     CONF_LAMBDA,
     CONF_MIRROR_X,
     CONF_MIRROR_Y,
     CONF_MODEL,
+    CONF_NUMBER,
     CONF_OE_PIN,
     CONF_PAGES,
     CONF_TRANSFORM,
@@ -101,14 +103,21 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_SPV_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_VCOM_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_WAKEUP_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_CL_PIN, default=0): pins.internal_gpio_output_pin_schema,
-            cv.Optional(CONF_LE_PIN, default=2): pins.internal_gpio_output_pin_schema,
+            cv.Optional(
+                CONF_CL_PIN,
+                default={CONF_NUMBER: 0, CONF_IGNORE_STRAPPING_WARNING: True},
+            ): pins.internal_gpio_output_pin_schema,
+            cv.Optional(
+                CONF_LE_PIN,
+                default={CONF_NUMBER: 2, CONF_IGNORE_STRAPPING_WARNING: True},
+            ): pins.internal_gpio_output_pin_schema,
             # Data pins
             cv.Optional(
                 CONF_DISPLAY_DATA_0_PIN, default=4
             ): pins.internal_gpio_output_pin_schema,
             cv.Optional(
-                CONF_DISPLAY_DATA_1_PIN, default=5
+                CONF_DISPLAY_DATA_1_PIN,
+                default={CONF_NUMBER: 5, CONF_IGNORE_STRAPPING_WARNING: True},
             ): pins.internal_gpio_output_pin_schema,
             cv.Optional(
                 CONF_DISPLAY_DATA_2_PIN, default=18


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

These pins are set for the hardware, we dont need a warning

```
WARNING GPIO0 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO2 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
WARNING GPIO5 is a strapping PIN and should only be used for I/O with care.
Attaching external pullup/down resistors to strapping pins can cause unexpected failures.
See https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
