### PR TITLE
[lvgl] Fix position of errors in widget config

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -1,8 +1,7 @@
-from contextlib import contextmanager
-
 from esphome import config_validation as cv
 from esphome.automation import Trigger, validate_automation
 from esphome.components.time import RealTimeClock
+from esphome.config_validation import prepend_path
 from esphome.const import (
     CONF_ARGS,
     CONF_FORMAT,
@@ -408,17 +407,6 @@ def container_schema(widget_type: WidgetType, extras=None):
     return validator
 
 
-@contextmanager
-def append_path(path):
-    """A contextmanager helper to append a path to all voluptuous errors."""
-    if not isinstance(path, (list, tuple)):
-        path = [path]
-    try:
-        yield
-    except cv.Invalid as e:
-        raise cv.Invalid(str(e), path=path + e.path) from e
-
-
 def any_widget_schema(extras=None):
     """
     Dynamically generate schemas for all possible LVGL widgets. This is what implements the ability to have a list of any kind of
@@ -460,7 +448,7 @@ def any_widget_schema(extras=None):
             # Apply custom validation
             value = widget_type.validate(value or {})
             path = [key] if isdict else [index, key]
-            with append_path(path):
+            with prepend_path(path):
                 result.append({key: container_validator(value)})
         return result
 

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from esphome import config_validation as cv
 from esphome.automation import Trigger, validate_automation
 from esphome.components.time import RealTimeClock
@@ -406,6 +408,17 @@ def container_schema(widget_type: WidgetType, extras=None):
     return validator
 
 
+@contextmanager
+def append_path(path):
+    """A contextmanager helper to append a path to all voluptuous errors."""
+    if not isinstance(path, (list, tuple)):
+        path = [path]
+    try:
+        yield
+    except cv.Invalid as e:
+        raise cv.Invalid(str(e), path=path + e.path) from e
+
+
 def any_widget_schema(extras=None):
     """
     Dynamically generate schemas for all possible LVGL widgets. This is what implements the ability to have a list of any kind of
@@ -422,7 +435,10 @@ def any_widget_schema(extras=None):
     def validator(value):
         if isinstance(value, dict):
             # Convert to list
+            isdict = True
             value = [{k: v} for k, v in value.items()]
+        else:
+            isdict = False
         if not isinstance(value, list):
             raise cv.Invalid("Expected a list of widgets")
         result = []
@@ -443,7 +459,9 @@ def any_widget_schema(extras=None):
                 )
             # Apply custom validation
             value = widget_type.validate(value or {})
-            result.append({key: container_validator(value)})
+            path = [key] if isdict else [index, key]
+            with append_path(path):
+                result.append({key: container_validator(value)})
         return result
 
     return validator

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -423,10 +423,10 @@ def any_widget_schema(extras=None):
     def validator(value):
         if isinstance(value, dict):
             # Convert to list
-            isdict = True
+            is_dict = True
             value = [{k: v} for k, v in value.items()]
         else:
-            isdict = False
+            is_dict = False
         if not isinstance(value, list):
             raise cv.Invalid("Expected a list of widgets")
         result = []
@@ -447,7 +447,7 @@ def any_widget_schema(extras=None):
                 )
             # Apply custom validation
             value = widget_type.validate(value or {})
-            path = [key] if isdict else [index, key]
+            path = [key] if is_dict else [index, key]
             with prepend_path(path):
                 result.append({key: container_validator(value)})
         return result


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Earlier change broke the path resolution for errors in widget configs. Messages like this were being produced:

```
Failed config

lvgl: [source ../esp/my-devices/valid.yaml:26]

  value must be at least 0.
  widgets:
    arc:
      change_rate: -10
```

With this fix the message now appears in the right place:

```
lvgl: [source valid.yaml:26]
  widgets:
    arc:

      value must be at least 0.
      change_rate: -10
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
lvgl:
  widgets:
    arc: # Clock container
      change_rate: -10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
