### PR TITLE
[lvgl] Fix lambda return types for coord and font validators

### DIFF
--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -40,7 +40,7 @@ from .helpers import (
     lv_fonts_used,
     requires_component,
 )
-from .types import lv_font_t, lv_gradient_t
+from .types import lv_gradient_t
 
 opacity_consts = LvConstant("LV_OPA_", "TRANSP", "COVER")
 
@@ -498,7 +498,9 @@ class LvFont(LValidator):
             esphome_fonts_used.add(fontval)
             return requires_component("font")(fontval)
 
-        super().__init__(validator, lv_font_t)
+        # Use font::Font* as return type for lambdas returning ESPHome fonts
+        # The inline overloads in lvgl_esphome.h handle conversion to lv_font_t*
+        super().__init__(validator, Font.operator("ptr"))
 
     async def process(self, value, args=()):
         if is_lv_font(value):

--- a/esphome/components/lvgl/widgets/line.py
+++ b/esphome/components/lvgl/widgets/line.py
@@ -6,7 +6,7 @@ from esphome.core import Lambda
 from ..defines import CONF_MAIN, call_lambda
 from ..lvcode import lv_add
 from ..schemas import point_schema
-from ..types import LvCompound, LvType
+from ..types import LvCompound, LvType, lv_coord_t
 from . import Widget, WidgetType
 
 CONF_LINE = "line"
@@ -23,9 +23,7 @@ LINE_SCHEMA = {
 
 async def process_coord(coord):
     if isinstance(coord, Lambda):
-        coord = call_lambda(
-            await cg.process_lambda(coord, [], return_type="lv_coord_t")
-        )
+        coord = call_lambda(await cg.process_lambda(coord, [], return_type=lv_coord_t))
         if not coord.endswith("()"):
             coord = f"static_cast<lv_coord_t>({coord})"
         return cg.RawExpression(coord)


### PR DESCRIPTION
# What does this implement/fix?

Fixes incorrect return types in LVGL lambda code generation that caused compilation failures after #11918 (lambda deduplication).

## Problem

Two return type issues in LVGL code generation were exposed by #11918:

### 1. `lv_coord_t` passed as string literal
In `widgets/line.py`, the return type was passed as a string `"lv_coord_t"` instead of the proper type object `lv_coord_t`. When `safe_exp()` processes a string, it wraps it in `StringLiteral` which adds quotes, generating invalid C++:

```cpp
// Generated (broken):
"lv_coord_t" shared_lambda_14() { ... }

// Expected:
lv_coord_t shared_lambda_14() { ... }
```

### 2. Font type mismatch
In `lv_validation.py`, `LvFont` declared `lv_font_t` as the return type, but lambdas actually return `font::Font*` (ESPHome font pointers). The generated code tried to return a `Font*` from a function declared to return `lv_font_t` (a struct by value).

## Why this was hidden before #11918

Before lambda deduplication, the `call_lambda()` function in LVGL's `defines.py` would **inline** simple lambda expressions directly into the call site. For a lambda like:

```yaml
x: !lambda return random_uint32() % 100;
```

The code would extract just `random_uint32() % 100` and inline it directly:

```cpp
// Before dedup - inlined expression, return type never used in function signature
lv_line_id->set_points({{5, 5}, {static_cast<lv_coord_t>(random_uint32() % 100), ...}});
```

With lambda deduplication (#11918), identical stateless lambdas are extracted into shared standalone functions. Now the declared return type is actually used in a function signature:

```cpp
// After dedup - shared function, return type matters
lv_coord_t shared_lambda_14() {
  return random_uint32() % 100;
}
// ... later ...
lv_line_id->set_points({{5, 5}, {shared_lambda_14(), ...}});
```

This exposed the latent bugs where return types were incorrectly specified.

## Changes

1. **`widgets/line.py`**: Use proper `lv_coord_t` type object instead of string literal
2. **`lv_validation.py`**: Use `Font.operator("ptr")` (i.e., `font::Font*`) as return type for font lambdas, matching what the lambda actually returns

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes compilation failure after #11918

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal code fix, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes internal code generation
# Test with any LVGL config that uses line points with lambdas or font lambdas:

lvgl:
  displays:
    - display_id: my_display
  widgets:
    - line:
        points:
          - x: !lambda return random_uint32() % 100;
            y: !lambda return random_uint32() % 100;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
