### PR TITLE
[packages] Fix package schema validation

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -23,15 +23,36 @@ from esphome.core import EsphomeError
 DOMAIN = CONF_PACKAGES
 
 
-def validate_git_package(config: dict):
-    if CONF_URL not in config:
-        return config
-    config = BASE_SCHEMA(config)
-    new_config = config
+def valid_package_contents(package_config: dict):
+    """Validates that a package_config that will be merged looks as much as possible to a valid config
+    to fail early on obvious mistakes."""
+    if isinstance(package_config, dict):
+        if CONF_URL in package_config:
+            # If a URL key is found, then make sure the config conforms to a remote package schema:
+            return REMOTE_PACKAGE_SCHEMA(package_config)
+
+        # Validate manually since Voluptuous would regenerate dicts and lose metadata
+        # such as ESPHomeDataBase
+        for k, v in package_config.items():
+            if not isinstance(k, str):
+                raise cv.Invalid("Package content keys must be strings")
+            if isinstance(v, (dict, list)):
+                continue  # e.g. script: [] or logger: {level: debug}
+            if v is None:
+                continue  # e.g. web_server:
+            raise cv.Invalid("Invalid component content in package definition")
+        return package_config
+
+    raise cv.Invalid("Package contents must be a dict")
+
+
+def expand_file_to_files(config: dict):
     if CONF_FILE in config:
+        new_config = config
         new_config[CONF_FILES] = [config[CONF_FILE]]
         del new_config[CONF_FILE]
-    return new_config
+        return new_config
+    return config
 
 
 def validate_yaml_filename(value):
@@ -45,7 +66,7 @@ def validate_yaml_filename(value):
 
 def validate_source_shorthand(value):
     if not isinstance(value, str):
-        raise cv.Invalid("Shorthand only for strings")
+        raise cv.Invalid("Git URL shorthand only for strings")
 
     git_file = git.GitFile.from_shorthand(value)
 
@@ -56,10 +77,10 @@ def validate_source_shorthand(value):
     if git_file.ref:
         conf[CONF_REF] = git_file.ref
 
-    return BASE_SCHEMA(conf)
+    return REMOTE_PACKAGE_SCHEMA(conf)
 
 
-BASE_SCHEMA = cv.All(
+REMOTE_PACKAGE_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.Required(CONF_URL): cv.url,
@@ -90,23 +111,28 @@ BASE_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(CONF_FILE, CONF_FILES),
+    expand_file_to_files,
 )
 
-PACKAGE_SCHEMA = cv.All(
-    cv.Any(validate_source_shorthand, BASE_SCHEMA, dict), validate_git_package
+PACKAGE_SCHEMA = cv.Any(  # A package definition is either:
+    validate_source_shorthand,  # A git URL shorthand string that expands to a remote package schema, or
+    REMOTE_PACKAGE_SCHEMA,  # a valid remote package schema, or
+    valid_package_contents,  # Something that at least looks like an actual package, e.g. {wifi:{ssid: xxx}}
+    # which will have to be fully validated later as per each component's schema.
 )
 
-CONFIG_SCHEMA = cv.Any(
+CONFIG_SCHEMA = cv.Any(  # under `packages:` we can have either:
     cv.Schema(
         {
-            str: PACKAGE_SCHEMA,
+            str: PACKAGE_SCHEMA,  # a named dict of package definitions, or
         }
     ),
-    [PACKAGE_SCHEMA],
+    [PACKAGE_SCHEMA],  # a list of package definitions, or
+    cv.ensure_list(PACKAGE_SCHEMA),  # a single package definition
 )
 
 
-def _process_base_package(config: dict, skip_update: bool = False) -> dict:
+def _process_remote_package(config: dict, skip_update: bool = False) -> dict:
     # When skip_update is True, use NEVER_REFRESH to prevent updates
     actual_refresh = git.NEVER_REFRESH if skip_update else config[CONF_REFRESH]
     repo_dir, revert = git.clone_or_update(
@@ -185,7 +211,7 @@ def _process_base_package(config: dict, skip_update: bool = False) -> dict:
 def _process_package(package_config, config, skip_update: bool = False):
     recursive_package = package_config
     if CONF_URL in package_config:
-        package_config = _process_base_package(package_config, skip_update)
+        package_config = _process_remote_package(package_config, skip_update)
     if isinstance(package_config, dict):
         recursive_package = do_packages_pass(package_config, skip_update)
     return merge_config(recursive_package, config)

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from esphome import git, yaml_util
@@ -19,6 +20,8 @@ from esphome.const import (
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import EsphomeError
+
+_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = CONF_PACKAGES
 
@@ -80,6 +83,13 @@ def validate_source_shorthand(value):
     return REMOTE_PACKAGE_SCHEMA(conf)
 
 
+def deprecate_single_package(config):
+    _LOGGER.warning(
+        "Including a single package under `packages:` is deprecated. Use a list instead."
+    )
+    return config
+
+
 REMOTE_PACKAGE_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -128,7 +138,9 @@ CONFIG_SCHEMA = cv.Any(  # under `packages:` we can have either:
         }
     ),
     [PACKAGE_SCHEMA],  # a list of package definitions, or
-    cv.ensure_list(PACKAGE_SCHEMA),  # a single package definition
+    cv.All(  # a single package definition (deprecated)
+        cv.ensure_list(PACKAGE_SCHEMA), deprecate_single_package
+    ),
 )
 
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -95,7 +95,7 @@ def test_package_invalid_dict(basic_esphome, basic_wifi):
 
 
 @pytest.mark.parametrize(
-    "package",
+    "packages",
     [
         {"package1": "github://esphome/non-existant-repo/file1.yml@main"},
         {"package2": "github://esphome/non-existant-repo/file1.yml"},
@@ -107,12 +107,12 @@ def test_package_invalid_dict(basic_esphome, basic_wifi):
         ],
     ],
 )
-def test_package_shorthand(package):
-    CONFIG_SCHEMA(package)
+def test_package_shorthand(packages):
+    CONFIG_SCHEMA(packages)
 
 
 @pytest.mark.parametrize(
-    "package",
+    "packages",
     [
         # not github
         {"package1": "someplace://esphome/non-existant-repo/file1.yml@main"},
@@ -133,9 +133,9 @@ def test_package_shorthand(package):
         [3],
     ],
 )
-def test_package_invalid(package):
+def test_package_invalid(packages):
     with pytest.raises(cv.Invalid):
-        CONFIG_SCHEMA(package)
+        CONFIG_SCHEMA(packages)
 
 
 def test_package_include(basic_wifi, basic_esphome):

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -155,6 +155,21 @@ def test_package_include(basic_wifi, basic_esphome):
     assert actual == expected
 
 
+def test_single_package(basic_esphome, basic_wifi):
+    """
+    Tests the simple case where a single package is added to the top-level config as is.
+    In this test, the CONF_WIFI config is expected to be simply added to the top-level config.
+    This tests the case where the user just put packages: !include package.yaml, not
+    part of a list or mapping of packages.
+    """
+    config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: {CONF_WIFI: basic_wifi}}
+
+    expected = {CONF_ESPHOME: basic_esphome, CONF_WIFI: basic_wifi}
+
+    actual = packages_pass(config)
+    assert actual == expected
+
+
 def test_package_append(basic_wifi, basic_esphome):
     """
     Tests the case where a key is present in both a package and top-level config.

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -155,19 +155,31 @@ def test_package_include(basic_wifi, basic_esphome):
     assert actual == expected
 
 
-def test_single_package(basic_esphome, basic_wifi):
+def test_single_package(
+    basic_esphome,
+    basic_wifi,
+    caplog: pytest.LogCaptureFixture,
+):
     """
     Tests the simple case where a single package is added to the top-level config as is.
     In this test, the CONF_WIFI config is expected to be simply added to the top-level config.
     This tests the case where the user just put packages: !include package.yaml, not
     part of a list or mapping of packages.
+    This behavior is deprecated, the test also checks if a warning is issued.
     """
     config = {CONF_ESPHOME: basic_esphome, CONF_PACKAGES: {CONF_WIFI: basic_wifi}}
 
     expected = {CONF_ESPHOME: basic_esphome, CONF_WIFI: basic_wifi}
 
-    actual = packages_pass(config)
+    with caplog.at_level("WARNING"):
+        actual = packages_pass(config)
+
     assert actual == expected
+
+    assert (
+        "Including a single package under `packages:` is deprecated. Use a list instead."
+        in caplog.text
+    )
 
 
 def test_package_append(basic_wifi, basic_esphome):


### PR DESCRIPTION
# What does this implement/fix?

esphome/esphome#11584 introduced a regression (#12107) whereupon the following documented way to include a single package was removed with no tests failing:

```yaml
packages: !include package.yaml
```

esphome/esphome#11584's objective was to tighten package validation since obviously invalid package definitions such as `packages: {my_package: "github://bad-url"}` were let through, wrapped into a list and then reconsidered as if `my_package` was a component name instead of a package name.

While it is impossible to validate at package level if all components declared will be valid, this PR:

* Restores the previous functionality. Previous tests pass untouched.
* Adds a test to ensure a single package can be included in the documented way.
* Keeps a degree of tight package validation to fail early in case obvious mistakes
* Renames some functions in the package validation to match closer to the documentation.

At the same time, this PR issues a deprecation warning for single package inclusion (the restored functionality). This is because esphome/esphome#8688 inadvertently introduces hard to resolve ambiguity, for example, consider the following:

```yaml
# package.yaml
logger:
  on_message:
    then:
      - lambda: printf("%s\n", message);
```
```yaml
# main.yaml
esphome:
  name: myconfig

packages: !include package.yaml

host:
```

The user would expect the above to just include the single package, however the interpretation would be that a package named `logger` contains the `on_message` component. Thus, the resulting config becomes:

```yaml
esphome:
  name: myconfig
host:
on_message:
    then:
      - lambda: printf("%s\n", message);
```
Which fails downstream with a weird, hard to track validation error:
```
Failed config

on_message: [source package.yaml:4]
  
  Component not found: on_message.
  then: 
    - lambda: printf("%s\n", message);
```
Now, not all packages are like the one above so they won't trigger this error because they usually contain scalars in the first level of a component configuration and this PR can tell them out early, but in my opinion, with the introduction of lists of packages (esphome/esphome#8688), the single-include package option should be deprecated: To safely include a package, the user should use either the list or mapping methods.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome#12107

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5681

## Test Environment

- [x] all (config)
## Example entry for `config.yaml`:

```yaml
packages: !include common.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
