### PR TITLE
[scheduler] Fix use-after-move crash in heap operations

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -359,8 +359,7 @@ void HOT Scheduler::call(uint32_t now) {
       std::unique_ptr<SchedulerItem> item;
       {
         LockGuard guard{this->lock_};
-        item = std::move(this->items_[0]);
-        this->pop_raw_();
+        item = this->pop_raw_();
       }
 
       const char *name = item->get_name();
@@ -401,7 +400,7 @@ void HOT Scheduler::call(uint32_t now) {
     // Don't run on failed components
     if (item->component != nullptr && item->component->is_failed()) {
       LockGuard guard{this->lock_};
-      this->pop_raw_();
+      this->recycle_item_(this->pop_raw_());
       continue;
     }
 
@@ -414,7 +413,7 @@ void HOT Scheduler::call(uint32_t now) {
     {
       LockGuard guard{this->lock_};
       if (is_item_removed_(item.get())) {
-        this->pop_raw_();
+        this->recycle_item_(this->pop_raw_());
         this->to_remove_--;
         continue;
       }
@@ -423,7 +422,7 @@ void HOT Scheduler::call(uint32_t now) {
     // Single-threaded or multi-threaded with atomics: can check without lock
     if (is_item_removed_(item.get())) {
       LockGuard guard{this->lock_};
-      this->pop_raw_();
+      this->recycle_item_(this->pop_raw_());
       this->to_remove_--;
       continue;
     }
@@ -443,14 +442,14 @@ void HOT Scheduler::call(uint32_t now) {
 
     LockGuard guard{this->lock_};
 
-    auto executed_item = std::move(this->items_[0]);
     // Only pop after function call, this ensures we were reachable
     // during the function call and know if we were cancelled.
-    this->pop_raw_();
+    auto executed_item = this->pop_raw_();
 
     if (executed_item->remove) {
-      // We were removed/cancelled in the function call, stop
+      // We were removed/cancelled in the function call, recycle and continue
       this->to_remove_--;
+      this->recycle_item_(std::move(executed_item));
       continue;
     }
 
@@ -510,17 +509,18 @@ size_t HOT Scheduler::cleanup_() {
     if (!item->remove)
       break;
     this->to_remove_--;
-    this->pop_raw_();
+    this->recycle_item_(this->pop_raw_());
   }
   return this->items_.size();
 }
-void HOT Scheduler::pop_raw_() {
+std::unique_ptr<Scheduler::SchedulerItem> HOT Scheduler::pop_raw_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
 
-  // Instead of destroying, recycle the item
-  this->recycle_item_(std::move(this->items_.back()));
+  // Move the item out before popping - this is the item that was at the front of the heap
+  auto item = std::move(this->items_.back());
 
   this->items_.pop_back();
+  return item;
 }
 
 // Helper to execute a scheduler item

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -359,7 +359,7 @@ void HOT Scheduler::call(uint32_t now) {
       std::unique_ptr<SchedulerItem> item;
       {
         LockGuard guard{this->lock_};
-        item = this->pop_raw_();
+        item = this->pop_raw_locked_();
       }
 
       const char *name = item->get_name();
@@ -400,7 +400,7 @@ void HOT Scheduler::call(uint32_t now) {
     // Don't run on failed components
     if (item->component != nullptr && item->component->is_failed()) {
       LockGuard guard{this->lock_};
-      this->recycle_item_(this->pop_raw_());
+      this->recycle_item_(this->pop_raw_locked_());
       continue;
     }
 
@@ -413,7 +413,7 @@ void HOT Scheduler::call(uint32_t now) {
     {
       LockGuard guard{this->lock_};
       if (is_item_removed_(item.get())) {
-        this->recycle_item_(this->pop_raw_());
+        this->recycle_item_(this->pop_raw_locked_());
         this->to_remove_--;
         continue;
       }
@@ -422,7 +422,7 @@ void HOT Scheduler::call(uint32_t now) {
     // Single-threaded or multi-threaded with atomics: can check without lock
     if (is_item_removed_(item.get())) {
       LockGuard guard{this->lock_};
-      this->recycle_item_(this->pop_raw_());
+      this->recycle_item_(this->pop_raw_locked_());
       this->to_remove_--;
       continue;
     }
@@ -444,7 +444,7 @@ void HOT Scheduler::call(uint32_t now) {
 
     // Only pop after function call, this ensures we were reachable
     // during the function call and know if we were cancelled.
-    auto executed_item = this->pop_raw_();
+    auto executed_item = this->pop_raw_locked_();
 
     if (executed_item->remove) {
       // We were removed/cancelled in the function call, recycle and continue
@@ -496,7 +496,7 @@ size_t HOT Scheduler::cleanup_() {
     return this->items_.size();
 
   // We must hold the lock for the entire cleanup operation because:
-  // 1. We're modifying items_ (via pop_raw_) which requires exclusive access
+  // 1. We're modifying items_ (via pop_raw_locked_) which requires exclusive access
   // 2. We're decrementing to_remove_ which is also modified by other threads
   //    (though all modifications are already under lock)
   // 3. Other threads read items_ when searching for items to cancel in cancel_item_locked_()
@@ -509,11 +509,11 @@ size_t HOT Scheduler::cleanup_() {
     if (!item->remove)
       break;
     this->to_remove_--;
-    this->recycle_item_(this->pop_raw_());
+    this->recycle_item_(this->pop_raw_locked_());
   }
   return this->items_.size();
 }
-std::unique_ptr<Scheduler::SchedulerItem> HOT Scheduler::pop_raw_() {
+std::unique_ptr<Scheduler::SchedulerItem> HOT Scheduler::pop_raw_locked_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
 
   // Move the item out before popping - this is the item that was at the front of the heap

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -219,7 +219,9 @@ class Scheduler {
   // Returns the number of items remaining after cleanup
   // IMPORTANT: This method should only be called from the main thread (loop task).
   size_t cleanup_();
-  void pop_raw_();
+  // Remove and return the front item from the heap
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
+  std::unique_ptr<SchedulerItem> pop_raw_();
 
  private:
   // Helper to cancel items by name - must be called with lock held

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -221,7 +221,7 @@ class Scheduler {
   size_t cleanup_();
   // Remove and return the front item from the heap
   // IMPORTANT: Caller must hold the scheduler lock before calling this function.
-  std::unique_ptr<SchedulerItem> pop_raw_();
+  std::unique_ptr<SchedulerItem> pop_raw_locked_();
 
  private:
   // Helper to cancel items by name - must be called with lock held


### PR DESCRIPTION
# What does this implement/fix?

Addresses a potential crash (Guru Meditation Error: LoadProhibited) reported in #12120 where a nullptr appears in the scheduler heap during `pop_heap` operations.

## Background

A user reported a crash with this stack trace pointing to `SchedulerItem::cmp()` being called with a nullptr during `std::pop_heap()`:

```
0x40178d64: esphome::Scheduler::SchedulerItem::cmp(...) at scheduler.cpp:748
0x400e8465: std::__adjust_heap<...> at stl_heap.h:232
0x400e859e: esphome::Scheduler::pop_raw_() at scheduler.cpp:518
0x400e8724: esphome::Scheduler::call(unsigned long) at scheduler.cpp:449
```

The crash address `0x00000020` corresponds to accessing the `next_execution_high_` field offset from a null pointer.

## Analysis

I was unable to reproduce the crash despite extensive testing. The root cause could be:
1. **Heap corruption** - Memory being overwritten from elsewhere
2. **Thread safety issue** - A race condition in multi-threaded scenarios
3. **Use-after-move** - The original code pattern of moving `items_[0]` before calling `pop_heap`

## The Change

This PR makes the scheduler heap operations safer by:

1. Renaming `pop_raw_()` to `pop_raw_locked_()` to make the locking requirement explicit
2. Changing `pop_raw_locked_()` to return the popped item rather than having callers move it out first
3. Ensuring `pop_heap` always operates on valid pointers before any item is moved out

The new pattern:
```cpp
// Before: move then pop (potential issue if items_[0] becomes nullptr)
auto item = std::move(items_[0]);
pop_raw_();

// After: pop returns the item atomically
auto item = pop_raw_locked_();
```

**Note:** I cannot guarantee this fixes the reported issue #12120 without a reproducer, but this change makes the code safer and eliminates one potential source of the nullptr.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/12120 (may or may not fix it)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal change, no documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
