### PR TITLE
[esp32] Improve IDF component support

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -37,6 +37,7 @@ from esphome.const import (
     __version__,
 )
 from esphome.core import CORE, HexInt, TimePeriod
+from esphome.coroutine import CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
 from esphome.helpers import copy_file_if_changed, write_file_if_changed
 from esphome.types import ConfigType
@@ -262,6 +263,7 @@ def add_idf_component(
             "deprecated and will be removed in ESPHome 2026.1. If you are seeing this, report "
             "an issue to the external_component author and ask them to update it."
         )
+
     if components:
         for comp in components:
             CORE.data[KEY_ESP32][KEY_COMPONENTS][comp] = {
@@ -592,6 +594,14 @@ def require_vfs_dir() -> None:
     CORE.data[KEY_VFS_DIR_REQUIRED] = True
 
 
+def _parse_idf_component(value: str) -> ConfigType:
+    """Parse IDF component shorthand syntax like 'owner/component^version'"""
+    if "^" not in value:
+        raise cv.Invalid(f"Invalid IDF component shorthand '{value}'")
+    name, ref = value.split("^", 1)
+    return {CONF_NAME: name, CONF_REF: ref}
+
+
 def _validate_idf_component(config: ConfigType) -> ConfigType:
     """Validate IDF component config and warn about deprecated options."""
     if CONF_REFRESH in config:
@@ -659,14 +669,19 @@ FRAMEWORK_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
             cv.All(
-                cv.Schema(
-                    {
-                        cv.Required(CONF_NAME): cv.string_strict,
-                        cv.Optional(CONF_SOURCE): cv.git_ref,
-                        cv.Optional(CONF_REF): cv.string,
-                        cv.Optional(CONF_PATH): cv.string,
-                        cv.Optional(CONF_REFRESH): cv.All(cv.string, cv.source_refresh),
-                    }
+                cv.Any(
+                    cv.All(cv.string_strict, _parse_idf_component),
+                    cv.Schema(
+                        {
+                            cv.Required(CONF_NAME): cv.string_strict,
+                            cv.Optional(CONF_SOURCE): cv.git_ref,
+                            cv.Optional(CONF_REF): cv.string,
+                            cv.Optional(CONF_PATH): cv.string,
+                            cv.Optional(CONF_REFRESH): cv.All(
+                                cv.string, cv.source_refresh
+                            ),
+                        }
+                    ),
                 ),
                 _validate_idf_component,
             )
@@ -849,6 +864,18 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
     )
 
     add_idf_sdkconfig_option("CONFIG_LWIP_MAX_SOCKETS", max_sockets)
+
+
+@coroutine_with_priority(CoroPriority.FINAL)
+async def _add_yaml_idf_components(components):
+    """Add IDF components from YAML config with final priority to override code-added components."""
+    for component in components:
+        add_idf_component(
+            name=component[CONF_NAME],
+            repo=component.get(CONF_SOURCE),
+            ref=component.get(CONF_REF),
+            path=component.get(CONF_PATH),
+        )
 
 
 async def to_code(config):
@@ -1097,13 +1124,10 @@ async def to_code(config):
     for name, value in conf[CONF_SDKCONFIG_OPTIONS].items():
         add_idf_sdkconfig_option(name, RawSdkconfigValue(value))
 
-    for component in conf[CONF_COMPONENTS]:
-        add_idf_component(
-            name=component[CONF_NAME],
-            repo=component.get(CONF_SOURCE),
-            ref=component.get(CONF_REF),
-            path=component.get(CONF_PATH),
-        )
+    # Components from YAML are added in a separate coroutine with FINAL priority
+    # Schedule it to run after all other components
+    if conf[CONF_COMPONENTS]:
+        CORE.add_job(_add_yaml_idf_components, conf[CONF_COMPONENTS])
 
 
 APP_PARTITION_SIZES = {

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -263,9 +263,10 @@ def add_idf_component(
             "deprecated and will be removed in ESPHome 2026.1. If you are seeing this, report "
             "an issue to the external_component author and ask them to update it."
         )
+    components_registry = CORE.data[KEY_ESP32][KEY_COMPONENTS]
     if components:
         for comp in components:
-            existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(comp)
+            existing = components_registry.get(comp)
             if existing and existing.get(KEY_REF) != ref:
                 _LOGGER.warning(
                     "IDF component %s version conflict %s replaced by %s",
@@ -273,13 +274,13 @@ def add_idf_component(
                     existing.get(KEY_REF),
                     ref,
                 )
-            CORE.data[KEY_ESP32][KEY_COMPONENTS][comp] = {
+            components_registry[comp] = {
                 KEY_REPO: repo,
                 KEY_REF: ref,
                 KEY_PATH: f"{path}/{comp}" if path else comp,
             }
     else:
-        existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(name)
+        existing = components_registry.get(name)
         if existing and existing.get(KEY_REF) != ref:
             _LOGGER.warning(
                 "IDF component %s version conflict %s replaced by %s",
@@ -287,7 +288,7 @@ def add_idf_component(
                 existing.get(KEY_REF),
                 ref,
             )
-        CORE.data[KEY_ESP32][KEY_COMPONENTS][name] = {
+        components_registry[name] = {
             KEY_REPO: repo,
             KEY_REF: ref,
             KEY_PATH: path,
@@ -882,7 +883,7 @@ def _configure_lwip_max_sockets(conf: dict) -> None:
 
 
 @coroutine_with_priority(CoroPriority.FINAL)
-async def _add_yaml_idf_components(components):
+async def _add_yaml_idf_components(components: list[ConfigType]):
     """Add IDF components from YAML config with final priority to override code-added components."""
     for component in components:
         add_idf_component(

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -268,7 +268,7 @@ def add_idf_component(
             existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(comp)
             if existing and existing.get(KEY_REF) != ref:
                 _LOGGER.warning(
-                    "IDF component %s version overridden from %s to %s.",
+                    "IDF component %s version conflict %s replaced by %s",
                     comp,
                     existing.get(KEY_REF),
                     ref,
@@ -282,7 +282,7 @@ def add_idf_component(
         existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(name)
         if existing and existing.get(KEY_REF) != ref:
             _LOGGER.warning(
-                "IDF component %s version overridden from %s to %s.",
+                "IDF component %s version conflict %s replaced by %s",
                 name,
                 existing.get(KEY_REF),
                 ref,

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -263,7 +263,6 @@ def add_idf_component(
             "deprecated and will be removed in ESPHome 2026.1. If you are seeing this, report "
             "an issue to the external_component author and ask them to update it."
         )
-
     if components:
         for comp in components:
             CORE.data[KEY_ESP32][KEY_COMPONENTS][comp] = {

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -265,12 +265,28 @@ def add_idf_component(
         )
     if components:
         for comp in components:
+            existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(comp)
+            if existing and existing.get(KEY_REF) != ref:
+                _LOGGER.warning(
+                    "IDF component %s version overridden from %s to %s.",
+                    comp,
+                    existing.get(KEY_REF),
+                    ref,
+                )
             CORE.data[KEY_ESP32][KEY_COMPONENTS][comp] = {
                 KEY_REPO: repo,
                 KEY_REF: ref,
                 KEY_PATH: f"{path}/{comp}" if path else comp,
             }
     else:
+        existing = CORE.data[KEY_ESP32][KEY_COMPONENTS].get(name)
+        if existing and existing.get(KEY_REF) != ref:
+            _LOGGER.warning(
+                "IDF component %s version overridden from %s to %s.",
+                name,
+                existing.get(KEY_REF),
+                ref,
+            )
         CORE.data[KEY_ESP32][KEY_COMPONENTS][name] = {
             KEY_REPO: repo,
             KEY_REF: ref,

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -4,6 +4,10 @@ esp32:
   cpu_frequency: 400MHz
   framework:
     type: esp-idf
+    components:
+      - espressif/mdns^1.8.2
+      - name: espressif/esp_hosted
+        ref: 2.6.6
     advanced:
       enable_idf_experimental_features: yes
 


### PR DESCRIPTION
# What does this implement/fix?

Improve IDF component support:
- Add shorthand support, ie `espressif/esp_hosted^2.6.6`
- Allow yaml to overwrite versions defined in the code
- Add warning if version of overridden 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5684

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
