### PR TITLE
make thermostat humidification_action public

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -654,7 +654,7 @@ void ThermostatClimate::trigger_supplemental_action_() {
 
 void ThermostatClimate::switch_to_humidity_control_action_(HumidificationAction action) {
   // setup_complete_ helps us ensure an action is called immediately after boot
-  if ((action == this->humidification_action_) && this->setup_complete_) {
+  if ((action == this->humidification_action) && this->setup_complete_) {
     // already in target mode
     return;
   }
@@ -683,7 +683,7 @@ void ThermostatClimate::switch_to_humidity_control_action_(HumidificationAction 
     this->prev_humidity_control_trigger_->stop_action();
     this->prev_humidity_control_trigger_ = nullptr;
   }
-  this->humidification_action_ = action;
+  this->humidification_action = action;
   this->prev_humidity_control_trigger_ = trig;
   if (trig != nullptr) {
     trig->trigger();
@@ -1114,7 +1114,7 @@ bool ThermostatClimate::dehumidification_required_() {
   }
   // if we get here, the current humidity is between target + hysteresis and target - hysteresis,
   //  so the action should not change
-  return this->humidification_action_ == THERMOSTAT_HUMIDITY_CONTROL_ACTION_DEHUMIDIFY;
+  return this->humidification_action == THERMOSTAT_HUMIDITY_CONTROL_ACTION_DEHUMIDIFY;
 }
 
 bool ThermostatClimate::humidification_required_() {
@@ -1127,7 +1127,7 @@ bool ThermostatClimate::humidification_required_() {
   }
   // if we get here, the current humidity is between target - hysteresis and target + hysteresis,
   //  so the action should not change
-  return this->humidification_action_ == THERMOSTAT_HUMIDITY_CONTROL_ACTION_HUMIDIFY;
+  return this->humidification_action == THERMOSTAT_HUMIDITY_CONTROL_ACTION_HUMIDIFY;
 }
 
 void ThermostatClimate::dump_preset_config_(const char *preset_name, const ThermostatClimateTargetTempConfig &config) {

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -207,6 +207,9 @@ class ThermostatClimate : public climate::Climate, public Component {
   void validate_target_temperature_high();
   void validate_target_humidity();
 
+  /// The current humidification action
+  HumidificationAction humidification_action{THERMOSTAT_HUMIDITY_CONTROL_ACTION_NONE};
+
  protected:
   /// Override control to change settings of the climate device.
   void control(const climate::ClimateCall &call) override;
@@ -300,9 +303,6 @@ class ThermostatClimate : public climate::Climate, public Component {
 
   /// The current supplemental action
   climate::ClimateAction supplemental_action_{climate::CLIMATE_ACTION_OFF};
-
-  /// The current humidification action
-  HumidificationAction humidification_action_{THERMOSTAT_HUMIDITY_CONTROL_ACTION_NONE};
 
   /// Default standard preset to use on start up
   climate::ClimatePreset default_preset_{};


### PR DESCRIPTION
# What does this implement/fix?

The thermostat attribute humidification_action was originally defined as protected. This PR makes it public, so that it can be accessed to determine current humidification status. This makes HumidificationAction more aligned with ClimateAction.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Discussion in discord:
https://discord.com/channels/429907082951524364/1441091530705211412

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bool humidifying = id(tstat).humidification_action == thermostat::THERMOSTAT_HUMIDITY_CONTROL_ACTION_HUMIDIFY;
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
