### PR TITLE
[api] Eliminate rx_buf heap churn and release buffers after initial sync

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -169,8 +169,7 @@ void APIConnection::loop() {
       } else {
         this->last_traffic_ = now;
         // read a packet
-        this->read_message(buffer.data_len, buffer.type,
-                           buffer.data_len > 0 ? &buffer.container[buffer.data_offset] : nullptr);
+        this->read_message(buffer.data_len, buffer.type, buffer.data);
         if (this->flags_.remove)
           return;
       }
@@ -195,6 +194,9 @@ void APIConnection::loop() {
       }
       // Now that everything is sent, enable immediate sending for future state changes
       this->flags_.should_try_send_immediately = true;
+      // Release excess memory from buffers that grew during initial sync
+      this->deferred_batch_.release_buffer();
+      this->helper_->release_buffers();
     }
   }
 

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -576,6 +576,15 @@ class APIConnection final : public APIServerConnection {
     bool empty() const { return items.empty(); }
     size_t size() const { return items.size(); }
     const BatchItem &operator[](size_t index) const { return items[index]; }
+    // Release excess capacity - only releases if items already empty
+    void release_buffer() {
+      // Safe to call: batch is processed before release_buffer is called,
+      // and if any items remain (partial processing), we must not clear them.
+      // Use swap trick since shrink_to_fit() is non-binding and may be ignored.
+      if (items.empty()) {
+        std::vector<BatchItem>().swap(items);
+      }
+    }
   };
 
   // DeferredBatch here (16 bytes, 4-byte aligned)

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -554,10 +554,8 @@ class APIConnection final : public APIServerConnection {
     std::vector<BatchItem> items;
     uint32_t batch_start_time{0};
 
-    DeferredBatch() {
-      // Pre-allocate capacity for typical batch sizes to avoid reallocation
-      items.reserve(8);
-    }
+    // No pre-allocation - log connections never use batching, and for
+    // connections that do, buffers are released after initial sync anyway
 
     // Add item to the batch
     void add_item(EntityBase *entity, MessageCreator creator, uint8_t message_type, uint8_t estimated_size);

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -407,8 +407,7 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
     return APIError::BAD_DATA_PACKET;
   }
 
-  buffer->container = std::move(this->rx_buf_);
-  buffer->data_offset = 4;
+  buffer->data = msg_data + 4;  // Skip 4-byte header (type + length)
   buffer->data_len = data_len;
   buffer->type = type;
   return APIError::OK;

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -210,8 +210,7 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
     return aerr;
   }
 
-  buffer->container = std::move(this->rx_buf_);
-  buffer->data_offset = 0;
+  buffer->data = this->rx_buf_.data();
   buffer->data_len = this->rx_header_parsed_len_;
   buffer->type = this->rx_header_parsed_type_;
   return APIError::OK;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -13,7 +13,7 @@ void APIServerConnectionBase::log_send_message_(const char *name, const std::str
 }
 #endif
 
-void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
+void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) {
   switch (msg_type) {
     case HelloRequest::MESSAGE_TYPE: {
       HelloRequest msg;
@@ -827,7 +827,7 @@ void APIServerConnection::on_z_wave_proxy_frame(const ZWaveProxyFrame &msg) { th
 void APIServerConnection::on_z_wave_proxy_request(const ZWaveProxyRequest &msg) { this->zwave_proxy_request(msg); }
 #endif
 
-void APIServerConnection::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {
+void APIServerConnection::read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) {
   // Check authentication/connection requirements for messages
   switch (msg_type) {
     case HelloRequest::MESSAGE_TYPE:  // No setup required

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -218,7 +218,7 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_z_wave_proxy_request(const ZWaveProxyRequest &value){};
 #endif
  protected:
-  void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
+  void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) override;
 };
 
 class APIServerConnection : public APIServerConnectionBase {
@@ -480,7 +480,7 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_ZWAVE_PROXY
   void on_z_wave_proxy_request(const ZWaveProxyRequest &msg) override;
 #endif
-  void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;
+  void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) override;
 };
 
 }  // namespace esphome::api

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -846,7 +846,7 @@ class ProtoService {
    */
   virtual ProtoWriteBuffer create_buffer(uint32_t reserve_size) = 0;
   virtual bool send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) = 0;
-  virtual void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) = 0;
+  virtual void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) = 0;
 
   // Optimized method that pre-allocates buffer based on message size
   bool send_message_(const ProtoMessage &msg, uint8_t message_type) {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2769,8 +2769,8 @@ static const char *const TAG = "api.service";
     cases = list(RECEIVE_CASES.items())
     cases.sort()
     hpp += " protected:\n"
-    hpp += "  void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;\n"
-    out = f"void {class_name}::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {{\n"
+    hpp += "  void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) override;\n"
+    out = f"void {class_name}::read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) {{\n"
     out += "  switch (msg_type) {\n"
     for i, (case, ifdef, message_name) in cases:
         if ifdef is not None:
@@ -2878,9 +2878,9 @@ static const char *const TAG = "api.service";
                     result += "#endif\n"
             return result
 
-        hpp_protected += "  void read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) override;\n"
+        hpp_protected += "  void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) override;\n"
 
-        cpp += f"\nvoid {class_name}::read_message(uint32_t msg_size, uint32_t msg_type, uint8_t *msg_data) {{\n"
+        cpp += f"\nvoid {class_name}::read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) {{\n"
         cpp += "  // Check authentication/connection requirements for messages\n"
         cpp += "  switch (msg_type) {\n"
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes API connection memory usage by reusing the receive buffer instead of moving it on every packet, and releases excess buffer capacity after initial sync completes.

## Problem

Previously, every API packet received would `std::move` the `rx_buf_` to the caller, which transfers ownership of the buffer. Testing on ESP32 confirms that after `std::move`, the source vector has `capacity=0`:

```
Before move: src size=100, capacity=100
After move:
  src: size=0, capacity=0   <-- capacity is zero
  dst: size=100, capacity=100
After src.resize(50): src size=50, capacity=50  <-- new allocation required
```

This means every packet received required a new heap allocation for `rx_buf_`, causing constant malloc/free churn.

This change keeps the buffer in place and returns a pointer to it instead, allowing the buffer to be reused across reads.

## Solution

1. **Change `ReadPacketBuffer` to pointer-based**: Instead of owning a `std::vector<uint8_t>`, it now holds a `const uint8_t*` pointer directly into the frame helper's internal `rx_buf_`. This is safe because:
   - The buffer is only used synchronously within `read_message()`
   - The next `read_packet()` call won't overwrite until processing is complete

2. **Reuse `rx_buf_` across reads**: The buffer retains its capacity and is reused for subsequent packets. Allocations only happen when a larger message is received.

3. **Release buffers after initial sync**: After the initial entity list and state sync completes, we release excess capacity from:
   - `deferred_batch_.items` - grows during batched initial sync (up to 32 items)
   - `rx_buf_` - may have held large ListEntities responses
   - `reusable_iovs_` - grows during batched writes (up to 24 iovecs)

   Uses the swap trick (`std::vector<T>().swap(vec)`) since `shrink_to_fit()` is non-binding and ignored by ESP32's libstdc++.

4. **Remove batch pre-allocation**: Previously `DeferredBatch` would `reserve(8)` in its constructor. This wastes memory for log connections (like `esphome logs`) which never subscribe to entities and never use batching. Now the vector grows naturally only when needed.

## Results

| Device | Platform | Heap Before | Heap After | Improvement |
|--------|----------|-------------|------------|-------------|
| Small (few entities) | ESP32 | - | - | +136 bytes |
| Large (Apollo R Pro) | ESP32 | 261,624 | 263,272 | +1,648 bytes |
| neargaragedoor | ESP8266 | 26,852 | 27,424 | +572 bytes |

**Buffer release on large device (before → after):**
```
Before release: batch=0/32, rx_buf=31/35, iovs=11/24
After release:  batch=0/0,  rx_buf=0/0,   iovs=0/0
```

**Additional benefits:**
- Eliminates malloc/free on every packet received - reduces heap fragmentation
- Buffers regrow to smaller steady-state sizes for runtime operation
- Devices with many entities benefit most - the large buffers needed for initial sync (ListEntities responses) are released and in practice almost never needed again during the lifetime of the connection, so the memory savings persist

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Performance optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
