### PR TITLE
[wifi] Save 112 bytes BSS on ESP8266 by calling SDK directly for BSSID

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -878,7 +878,7 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
 
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};
-  struct station_config conf;
+  struct station_config conf{};
   if (wifi_station_get_config(&conf)) {
     std::copy_n(conf.bssid, bssid.size(), bssid.begin());
   }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -878,7 +878,7 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
 
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};
-  struct station_config conf{};
+  struct station_config conf {};
   if (wifi_station_get_config(&conf)) {
     std::copy_n(conf.bssid, bssid.size(), bssid.begin());
   }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -878,10 +878,9 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() {
 
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};
-  uint8_t *raw_bssid = WiFi.BSSID();
-  if (raw_bssid != nullptr) {
-    for (size_t i = 0; i < bssid.size(); i++)
-      bssid[i] = raw_bssid[i];
+  struct station_config conf;
+  if (wifi_station_get_config(&conf)) {
+    std::copy_n(conf.bssid, bssid.size(), bssid.begin());
   }
   return bssid;
 }


### PR DESCRIPTION
# What does this implement/fix?

Saves 112 bytes of BSS RAM on ESP8266 by calling the SDK's `wifi_station_get_config()` directly instead of using Arduino's `WiFi.BSSID()` wrapper.

The Arduino ESP8266 WiFi library's `BSSID()` method uses a static `station_config` struct (112 bytes) just to return a pointer to the 6-byte BSSID field:

```cpp
// Arduino's implementation (wastes 112 bytes in .bss)
uint8_t* ESP8266WiFiSTAClass::BSSID(void) {
    static struct station_config conf;  // 112 bytes in .bss!
    wifi_station_get_config(&conf);
    return reinterpret_cast<uint8_t*>(conf.bssid);
}
```

ESPHome immediately copies the BSSID into its own `bssid_t` array, so we don't need the static variable at all. By calling the SDK directly with a stack-allocated struct, we avoid pulling in Arduino's static allocation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - RAM optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
