### PR TITLE
[light] Replace sparse enum switch with linear search to save 156 bytes RAM

### DIFF
--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -7,30 +7,29 @@ namespace esphome::light {
 
 // See https://www.home-assistant.io/integrations/light.mqtt/#json-schema for documentation on the schema
 
-// Lookup table for color mode strings
-static constexpr const char *get_color_mode_json_str(ColorMode mode) {
-  switch (mode) {
-    case ColorMode::ON_OFF:
-      return "onoff";
-    case ColorMode::BRIGHTNESS:
-      return "brightness";
-    case ColorMode::WHITE:
-      return "white";  // not supported by HA in MQTT
-    case ColorMode::COLOR_TEMPERATURE:
-      return "color_temp";
-    case ColorMode::COLD_WARM_WHITE:
-      return "cwww";  // not supported by HA
-    case ColorMode::RGB:
-      return "rgb";
-    case ColorMode::RGB_WHITE:
-      return "rgbw";
-    case ColorMode::RGB_COLOR_TEMPERATURE:
-      return "rgbct";  // not supported by HA
-    case ColorMode::RGB_COLD_WARM_WHITE:
-      return "rgbww";
-    default:
-      return nullptr;
+// Get JSON string for color mode using linear search (avoids large switch jump table)
+static const char *get_color_mode_json_str(ColorMode mode) {
+  // Parallel arrays: mode values and their corresponding strings
+  // Uses less RAM than a switch jump table on sparse enum values
+  static constexpr ColorMode MODES[] = {
+      ColorMode::ON_OFF,
+      ColorMode::BRIGHTNESS,
+      ColorMode::WHITE,
+      ColorMode::COLOR_TEMPERATURE,
+      ColorMode::COLD_WARM_WHITE,
+      ColorMode::RGB,
+      ColorMode::RGB_WHITE,
+      ColorMode::RGB_COLOR_TEMPERATURE,
+      ColorMode::RGB_COLD_WARM_WHITE,
+  };
+  static constexpr const char *STRINGS[] = {
+      "onoff", "brightness", "white", "color_temp", "cwww", "rgb", "rgbw", "rgbct", "rgbww",
+  };
+  for (size_t i = 0; i < sizeof(MODES) / sizeof(MODES[0]); i++) {
+    if (MODES[i] == mode)
+      return STRINGS[i];
   }
+  return nullptr;
 }
 
 void LightJSONSchema::dump_json(LightState &state, JsonObject root) {


### PR DESCRIPTION
# What does this implement/fix?

Saves 156 bytes of RAM and 124 bytes of flash on ESP8266 by replacing a switch statement with a linear search lookup for color mode JSON strings.

The `ColorMode` enum values are sparse bitmask combinations (1, 3, 7, 11, 19, 35, 39, 47, 55), not sequential integers. The compiler generates a large 204-byte jump table to handle all possible values up to the highest enum value.

By using parallel arrays with a simple linear search over just 9 elements, we avoid the jump table entirely. The lookup is called rarely (only when serializing light state to JSON), so the O(n) search has negligible performance impact.

Before:
```cpp
switch (mode) {
  case ColorMode::ON_OFF: return "onoff";
  case ColorMode::BRIGHTNESS: return "brightness";
  // ... generates 204-byte jump table
}
```

After:
```cpp
static constexpr ColorMode MODES[] = { ColorMode::ON_OFF, ... };  // 9 bytes
static constexpr const char *STRINGS[] = { "onoff", ... };        // 36 bytes
// Linear search over 9 elements
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - RAM/flash optimization for ESP8266

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
light:
  - platform: rgb
    name: "RGB Light"
    red: output_red
    green: output_green
    blue: output_blue
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Memory Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| RAM | 35,800 bytes | 35,644 bytes | -156 bytes |
| Flash | 500,141 bytes | 500,017 bytes | -124 bytes |
