### PR TITLE
[usb_uart] Wake main loop immediately when USB data arrives

### DIFF
--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -1,4 +1,5 @@
 import esphome.codegen as cg
+from esphome.components import socket
 from esphome.components.uart import (
     CONF_DATA_BITS,
     CONF_PARITY,
@@ -17,7 +18,7 @@ from esphome.const import (
 )
 from esphome.cpp_types import Component
 
-AUTO_LOAD = ["uart", "usb_host", "bytebuffer"]
+AUTO_LOAD = ["uart", "usb_host", "bytebuffer", "socket"]
 CODEOWNERS = ["@clydebarrow"]
 
 usb_uart_ns = cg.esphome_ns.namespace("usb_uart")
@@ -116,6 +117,10 @@ CONFIG_SCHEMA = cv.ensure_list(
 
 
 async def to_code(config):
+    # Enable wake_loop_threadsafe for low-latency USB data processing
+    # The USB task queues data events that need immediate processing
+    socket.require_wake_loop_threadsafe()
+
     for device in config:
         var = await register_usb_client(device)
         for index, channel in enumerate(device[CONF_CHANNELS]):

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -2,6 +2,7 @@
 #if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
 #include "usb_uart.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include "esphome/components/uart/uart_debugger.h"
 
 #include <cinttypes>
@@ -262,6 +263,11 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       // Push to lock-free queue for main loop processing
       // Push always succeeds because pool size == queue size
       this->usb_data_queue_.push(chunk);
+
+      // Wake main loop immediately to process USB data instead of waiting for select() timeout
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+      App.wake_loop_threadsafe();
+#endif
     }
 
     // On success, restart input immediately from USB task for performance


### PR DESCRIPTION
# What does this implement/fix?

Adds immediate main loop wake when USB UART data arrives, reducing latency from select() timeout (~100ms worst case) to ~12μs.

I should have done this in #11683 but I apparently lost the original version of this change when I was adding all the other`App.wake_loop_threadsafe()` due to an error keeping track of PRs on my part.

Previously, when USB data arrived:
1. USB task received data and pushed to lock-free queue
2. Main loop waited for select() timeout before processing

Now the USB task calls `App.wake_loop_threadsafe()` after queueing data, immediately waking the main loop via UDP socket notification.

This is the same pattern already used for USB device connect/disconnect events in `usb_host_client.cpp` and by other components like `zwave_proxy`, `mqtt`, and `micro_wake_word`.

This complements #12135 which adds `HighFrequencyLoopRequester` and RX notification APIs for hardware UARTs. Together they provide low-latency paths for both:
- Hardware UART (via `uart_set_select_notif_callback` / event queue)
- USB host CDC-ACM (via `wake_loop_threadsafe`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Complements https://github.com/esphome/esphome/pull/12135 (Z-Wave proxy latency improvements for hardware UARTs)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - improvement is automatic
usb_uart:
  - type: CDC_ACM
    channels:
      - id: my_usb_uart
        baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
