### PR TITLE
[logger] Replace std::function callbacks with LogListener interface

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -101,19 +101,7 @@ void APIServer::setup() {
 
 #ifdef USE_LOGGER
   if (logger::global_logger != nullptr) {
-    logger::global_logger->add_on_log_callback(
-        [this](int level, const char *tag, const char *message, size_t message_len) {
-          if (this->shutting_down_) {
-            // Don't try to send logs during shutdown
-            // as it could result in a recursion and
-            // we would be filling a buffer we are trying to clear
-            return;
-          }
-          for (auto &c : this->clients_) {
-            if (!c->flags_.remove && c->get_log_subscription_level() >= level)
-              c->try_send_log_message(level, tag, message, message_len);
-          }
-        });
+    logger::global_logger->add_log_listener(this);
   }
 #endif
 
@@ -540,6 +528,21 @@ bool APIServer::is_connected(bool state_subscription_only) const {
   }
   return false;
 }
+
+#ifdef USE_LOGGER
+void APIServer::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
+  if (this->shutting_down_) {
+    // Don't try to send logs during shutdown
+    // as it could result in a recursion and
+    // we would be filling a buffer we are trying to clear
+    return;
+  }
+  for (auto &c : this->clients_) {
+    if (!c->flags_.remove && c->get_log_subscription_level() >= level)
+      c->try_send_log_message(level, tag, message, message_len);
+  }
+}
+#endif
 
 void APIServer::on_shutdown() {
   this->shutting_down_ = true;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -15,6 +15,9 @@
 #ifdef USE_API_USER_DEFINED_ACTIONS
 #include "user_services.h"
 #endif
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
 
 #include <map>
 #include <vector>
@@ -27,7 +30,13 @@ struct SavedNoisePsk {
 } PACKED;  // NOLINT
 #endif
 
-class APIServer : public Component, public Controller {
+class APIServer : public Component,
+                  public Controller
+#ifdef USE_LOGGER
+    ,
+                  public logger::LogListener
+#endif
+{
  public:
   APIServer();
   void setup() override;
@@ -37,6 +46,9 @@ class APIServer : public Component, public Controller {
   void dump_config() override;
   void on_shutdown() override;
   bool teardown() override;
+#ifdef USE_LOGGER
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
+#endif
 #ifdef USE_API_PASSWORD
   bool check_password(const uint8_t *password_data, size_t password_len) const;
   void set_password(const std::string &password);

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -87,16 +87,20 @@ void BLENUS::setup() {
   global_ble_nus = this;
 #ifdef USE_LOGGER
   if (logger::global_logger != nullptr && this->expose_log_) {
-    logger::global_logger->add_on_log_callback(
-        [this](int level, const char *tag, const char *message, size_t message_len) {
-          this->write_array(reinterpret_cast<const uint8_t *>(message), message_len);
-          const char c = '\n';
-          this->write_array(reinterpret_cast<const uint8_t *>(&c), 1);
-        });
+    logger::global_logger->add_log_listener(this);
   }
-
 #endif
 }
+
+#ifdef USE_LOGGER
+void BLENUS::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
+  (void) level;
+  (void) tag;
+  this->write_array(reinterpret_cast<const uint8_t *>(message), message_len);
+  const char c = '\n';
+  this->write_array(reinterpret_cast<const uint8_t *>(&c), 1);
+}
+#endif
 
 void BLENUS::dump_config() {
   ESP_LOGCONFIG(TAG, "ble nus:");

--- a/esphome/components/ble_nus/ble_nus.h
+++ b/esphome/components/ble_nus/ble_nus.h
@@ -2,12 +2,20 @@
 #ifdef USE_ZEPHYR
 #include "esphome/core/defines.h"
 #include "esphome/core/component.h"
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
 #include <shell/shell_bt_nus.h>
 #include <atomic>
 
 namespace esphome::ble_nus {
 
-class BLENUS : public Component {
+class BLENUS : public Component
+#ifdef USE_LOGGER
+    ,
+               public logger::LogListener
+#endif
+{
   enum TxStatus {
     TX_DISABLED,
     TX_ENABLED,
@@ -20,6 +28,9 @@ class BLENUS : public Component {
   void loop() override;
   size_t write_array(const uint8_t *data, size_t len);
   void set_expose_log(bool expose_log) { this->expose_log_ = expose_log; }
+#ifdef USE_LOGGER
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
+#endif
 
  protected:
   static void send_enabled_callback(bt_nus_send_status status);

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -36,6 +36,28 @@ struct device;
 
 namespace esphome::logger {
 
+/** Interface for receiving log messages without std::function overhead.
+ *
+ * Components can implement this interface instead of using lambdas with std::function
+ * to avoid the ~600 bytes per-type cost of std::function type erasure machinery.
+ *
+ * Usage:
+ *   class MyComponent : public Component, public LogListener {
+ *    public:
+ *     void setup() override {
+ *       if (logger::global_logger != nullptr)
+ *         logger::global_logger->add_log_listener(this);
+ *     }
+ *     void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override {
+ *       // Handle log message
+ *     }
+ *   };
+ */
+class LogListener {
+ public:
+  virtual void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) = 0;
+};
+
 #ifdef USE_LOGGER_RUNTIME_TAG_LEVELS
 // Comparison function for const char* keys in log_levels_ map
 struct CStrCompare {
@@ -168,8 +190,8 @@ class Logger : public Component {
 
   inline uint8_t level_for(const char *tag);
 
-  /// Register a callback that will be called for every log message sent
-  void add_on_log_callback(std::function<void(uint8_t, const char *, const char *, size_t)> &&callback);
+  /// Register a log listener to receive log messages
+  void add_log_listener(LogListener *listener) { this->log_listeners_.push_back(listener); }
 
   // add a listener for log level changes
   void add_listener(std::function<void(uint8_t)> &&callback) { this->level_callback_.add(std::move(callback)); }
@@ -240,7 +262,7 @@ class Logger : public Component {
     }
   }
 
-  // Helper to format and send a log message to both console and callbacks
+  // Helper to format and send a log message to both console and listeners
   inline void HOT log_message_to_buffer_and_send_(uint8_t level, const char *tag, int line, const char *format,
                                                   va_list args) {
     // Format to tx_buffer and prepare for output
@@ -248,8 +270,9 @@ class Logger : public Component {
     this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, this->tx_buffer_, &this->tx_buffer_at_,
                                                 this->tx_buffer_size_);
 
-    // Callbacks get message WITHOUT newline (for API/MQTT/syslog)
-    this->log_callback_.call(level, tag, this->tx_buffer_, this->tx_buffer_at_);
+    // Listeners get message WITHOUT newline (for API/MQTT/syslog)
+    for (auto *listener : this->log_listeners_)
+      listener->on_log(level, tag, this->tx_buffer_, this->tx_buffer_at_);
 
     // Console gets message WITH newline (if platform needs it)
     this->write_tx_buffer_to_console_();
@@ -301,7 +324,7 @@ class Logger : public Component {
 #ifdef USE_LOGGER_RUNTIME_TAG_LEVELS
   std::map<const char *, uint8_t, CStrCompare> log_levels_{};
 #endif
-  CallbackManager<void(uint8_t, const char *, const char *, size_t)> log_callback_{};
+  std::vector<LogListener *> log_listeners_;  // Log message listeners (API, MQTT, syslog, etc.)
   CallbackManager<void(uint8_t)> level_callback_{};
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   std::unique_ptr<logger::TaskLogBuffer> log_buffer_;  // Will be initialized with init_log_buffer
@@ -496,15 +519,14 @@ class Logger : public Component {
 };
 extern Logger *global_logger;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-class LoggerMessageTrigger : public Trigger<uint8_t, const char *, const char *> {
+class LoggerMessageTrigger : public Trigger<uint8_t, const char *, const char *>, public LogListener {
  public:
-  explicit LoggerMessageTrigger(Logger *parent, uint8_t level) {
-    this->level_ = level;
-    parent->add_on_log_callback([this](uint8_t level, const char *tag, const char *message, size_t message_len) {
-      if (level <= this->level_) {
-        this->trigger(level, tag, message);
-      }
-    });
+  explicit LoggerMessageTrigger(Logger *parent, uint8_t level) : level_(level) { parent->add_log_listener(this); }
+
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override {
+    if (level <= this->level_) {
+      this->trigger(level, tag, message);
+    }
   }
 
  protected:

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -39,7 +39,7 @@ namespace esphome::logger {
 /** Interface for receiving log messages without std::function overhead.
  *
  * Components can implement this interface instead of using lambdas with std::function
- * to avoid the ~600 bytes per-type cost of std::function type erasure machinery.
+ * to reduce flash usage from std::function type erasure machinery.
  *
  * Usage:
  *   class MyComponent : public Component, public LogListener {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -524,6 +524,7 @@ class LoggerMessageTrigger : public Trigger<uint8_t, const char *, const char *>
   explicit LoggerMessageTrigger(Logger *parent, uint8_t level) : level_(level) { parent->add_log_listener(this); }
 
   void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override {
+    (void) message_len;
     if (level <= this->level_) {
       this->trigger(level, tag, message);
     }

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -57,15 +57,7 @@ void MQTTClientComponent::setup() {
   });
 #ifdef USE_LOGGER
   if (this->is_log_message_enabled() && logger::global_logger != nullptr) {
-    logger::global_logger->add_on_log_callback(
-        [this](int level, const char *tag, const char *message, size_t message_len) {
-          if (level <= this->log_level_ && this->is_connected()) {
-            this->publish({.topic = this->log_message_.topic,
-                           .payload = std::string(message, message_len),
-                           .qos = this->log_message_.qos,
-                           .retain = this->log_message_.retain});
-          }
-        });
+    logger::global_logger->add_log_listener(this);
   }
 #endif
 
@@ -147,6 +139,18 @@ void MQTTClientComponent::send_device_info_() {
       2, this->discovery_info_.retain);
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
+
+#ifdef USE_LOGGER
+void MQTTClientComponent::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
+  (void) tag;
+  if (level <= this->log_level_ && this->is_connected()) {
+    this->publish({.topic = this->log_message_.topic,
+                   .payload = std::string(message, message_len),
+                   .qos = this->log_message_.qos,
+                   .retain = this->log_message_.retain});
+  }
+}
+#endif
 
 void MQTTClientComponent::dump_config() {
   ESP_LOGCONFIG(TAG,

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -10,6 +10,9 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
 #if defined(USE_ESP32)
 #include "mqtt_backend_esp32.h"
 #elif defined(USE_ESP8266)
@@ -97,7 +100,12 @@ enum MQTTClientState {
 
 class MQTTComponent;
 
-class MQTTClientComponent : public Component {
+class MQTTClientComponent : public Component
+#ifdef USE_LOGGER
+    ,
+                            public logger::LogListener
+#endif
+{
  public:
   MQTTClientComponent();
 
@@ -237,6 +245,10 @@ class MQTTClientComponent : public Component {
   void loop() override;
   /// MQTT client setup priority
   float get_setup_priority() const override;
+
+#ifdef USE_LOGGER
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
+#endif
 
   void on_message(const std::string &topic, const std::string &payload);
 

--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -19,11 +19,10 @@ constexpr int LOG_LEVEL_TO_SYSLOG_SEVERITY[] = {
     7   // VERY_VERBOSE
 };
 
-void Syslog::setup() {
-  logger::global_logger->add_on_log_callback(
-      [this](int level, const char *tag, const char *message, size_t message_len) {
-        this->log_(level, tag, message, message_len);
-      });
+void Syslog::setup() { logger::global_logger->add_log_listener(this); }
+
+void Syslog::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
+  this->log_(level, tag, message, message_len);
 }
 
 void Syslog::log_(const int level, const char *tag, const char *message, size_t message_len) const {

--- a/esphome/components/syslog/esphome_syslog.h
+++ b/esphome/components/syslog/esphome_syslog.h
@@ -2,16 +2,18 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/components/logger/logger.h"
 #include "esphome/components/udp/udp_component.h"
 #include "esphome/components/time/real_time_clock.h"
 
 #ifdef USE_NETWORK
 namespace esphome {
 namespace syslog {
-class Syslog : public Component, public Parented<udp::UDPComponent> {
+class Syslog : public Component, public Parented<udp::UDPComponent>, public logger::LogListener {
  public:
   Syslog(int level, time::RealTimeClock *time) : log_level_(level), time_(time) {}
   void setup() override;
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
   void set_strip(bool strip) { this->strip_ = strip; }
   void set_facility(int facility) { this->facility_ = facility; }
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -7,6 +7,9 @@
 #include "esphome/core/component.h"
 #include "esphome/core/controller.h"
 #include "esphome/core/entity_base.h"
+#ifdef USE_LOGGER
+#include "esphome/components/logger/logger.h"
+#endif
 
 #include <functional>
 #include <list>
@@ -170,7 +173,14 @@ class DeferredUpdateEventSourceList : public std::list<DeferredUpdateEventSource
  * under the '/light/...', '/sensor/...', ... URLs. A full documentation for this API
  * can be found under https://esphome.io/web-api/index.html.
  */
-class WebServer : public Controller, public Component, public AsyncWebHandler {
+class WebServer : public Controller,
+                  public Component,
+                  public AsyncWebHandler
+#ifdef USE_LOGGER
+    ,
+                  public logger::LogListener
+#endif
+{
 #if !defined(USE_ESP32) && defined(USE_ARDUINO)
   friend class DeferredUpdateEventSourceList;
 #endif
@@ -229,6 +239,10 @@ class WebServer : public Controller, public Component, public AsyncWebHandler {
   void loop() override;
 
   void dump_config() override;
+
+#ifdef USE_LOGGER
+  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
+#endif
 
   /// MQTT setup priority.
   float get_setup_priority() const override;


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::function` log callbacks with a virtual `LogListener` interface to reduce flash and heap usage.

## Background

The logger component previously used `CallbackManager<void(uint8_t, const char *, const char *, size_t)>` which stores `std::function` objects. Each component that registers a log callback (API, WebServer, MQTT, Syslog, BLE NUS) creates a unique lambda type, and each unique lambda type generates `std::_Function_handler` template instantiation code in flash.

Similar to #11772 (Controller Registry), we already have tight coupling here - all log consumers need to know about `logger::global_logger` anyway. The `std::function` indirection provides no decoupling benefit while adding significant overhead. Replacing it with a simple virtual interface makes the coupling explicit while eliminating the cost.

## Changes

- Add `LogListener` virtual interface with `on_log(uint8_t level, const char *tag, const char *message, size_t message_len)` method
- Replace `add_on_log_callback(std::function<...>)` with `add_log_listener(LogListener *)`
- Replace `CallbackManager<...> log_callback_` with `std::vector<LogListener *> log_listeners_`
- Migrate all log consumers to implement `LogListener`:
  - `APIServer`
  - `WebServer`
  - `MQTTClientComponent`
  - `Syslog`
  - `BLENUS`
  - `LoggerMessageTrigger`

## Measured Savings (API component, ESP32 classic)

| Resource | Before | After | Saved |
|----------|--------|-------|-------|
| Flash | 358,343 B | 358,151 B | **192 B** |
| Heap | 306,464 B | 306,700 B | **236 B** |

Savings scale with the number of log consumers in a build.

## Performance (ESP32 classic, ESP-IDF)

| Approach | ns/call |
|----------|---------|
| std::function | 363.3 ns |
| LogListener | 238.8 ns |

Virtual dispatch is ~1.5x faster than `std::function`, but the real benefit is the heap savings (16 bytes per callback → 4 bytes per pointer on ESP8266), followed by flash savings from eliminating `std::function` type erasure machinery.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Similar pattern to #11772 (Controller Registry)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API change)

## Breaking Change Notes

This removes the `add_on_log_callback()` method from `Logger`. External components that used this API must now:

1. Inherit from `logger::LogListener`
2. Implement `void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override`
3. Call `logger::global_logger->add_log_listener(this)` instead of `add_on_log_callback()`

**Before:**
```cpp
logger::global_logger->add_on_log_callback(
    [this](int level, const char *tag, const char *message, size_t message_len) {
      // handle log
    });
```

**After:**
```cpp
// In class declaration:
class MyComponent : public Component, public logger::LogListener {
  void on_log(uint8_t level, const char *tag, const char *message, size_t message_len) override;
};

// In setup():
logger::global_logger->add_log_listener(this);

// Implementation:
void MyComponent::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
  // handle log
}
```

This follows the precedent set by #9368 which changed the callback signature with minimal impact, and #11772 which used the same "make coupling explicit" pattern for controller state updates.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
logger:

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
