### PR TITLE
[esp32_ble_tracker] Replace scanner state callback with listener interface

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -27,11 +27,13 @@ void BluetoothProxy::setup() {
   // Capture the configured scan mode from YAML before any API changes
   this->configured_scan_active_ = this->parent_->get_scan_active();
 
-  this->parent_->add_scanner_state_callback([this](esp32_ble_tracker::ScannerState state) {
-    if (this->api_connection_ != nullptr) {
-      this->send_bluetooth_scanner_state_(state);
-    }
-  });
+  this->parent_->add_scanner_state_listener(this);
+}
+
+void BluetoothProxy::on_scanner_state(esp32_ble_tracker::ScannerState state) {
+  if (this->api_connection_ != nullptr) {
+    this->send_bluetooth_scanner_state_(state);
+  }
 }
 
 void BluetoothProxy::send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerState state) {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -52,7 +52,9 @@ enum BluetoothProxySubscriptionFlag : uint32_t {
   SUBSCRIPTION_RAW_ADVERTISEMENTS = 1 << 0,
 };
 
-class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, public Component {
+class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
+                             public esp32_ble_tracker::BLEScannerStateListener,
+                             public Component {
   friend class BluetoothConnection;  // Allow connection to update connections_free_response_
  public:
   BluetoothProxy();
@@ -107,6 +109,9 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener, publ
 
   void set_active(bool active) { this->active_ = active; }
   bool has_active() { return this->active_; }
+
+  /// BLEScannerStateListener interface
+  void on_scanner_state(esp32_ble_tracker::ScannerState state) override;
 
   uint32_t get_legacy_version() const {
     if (this->active_) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -373,7 +373,9 @@ void ESP32BLETracker::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 
 void ESP32BLETracker::set_scanner_state_(ScannerState state) {
   this->scanner_state_ = state;
-  this->scanner_state_callbacks_.call(state);
+  for (auto *listener : this->scanner_state_listeners_) {
+    listener->on_scanner_state(state);
+  }
 }
 
 #ifdef USE_ESP32_BLE_DEVICE


### PR DESCRIPTION
# What does this implement/fix?

Replace `CallbackManager` callback in the BLE tracker component with a lightweight virtual listener interface, following the same pattern established in PR #12153 (logger).

## Changes

- Add `BLEScannerStateListener` interface to `esp32_ble_tracker.h`
- Replace `CallbackManager<void(ScannerState)>` with `std::vector<BLEScannerStateListener*>`
- Update `bluetooth_proxy` to implement `BLEScannerStateListener` instead of using a lambda callback

## Benefits

- **Reduced flash usage**: Eliminates `std::function` type erasure machinery
- **Reduced heap usage**: 4-byte pointer vs 16-byte `std::function` object per listener
- **Faster dispatch**: Virtual call (~2 cycles) vs `std::function` indirection (~6+ cycles)
- **Explicit coupling**: Makes the relationship between BLE tracker and its consumers explicit

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Note:** Technically a breaking change to the internal API (`add_scanner_state_callback` -> `add_scanner_state_listener`), but this callback was added specifically for `bluetooth_proxy` and is only used internally. Unlikely to affect external components.

**Related issue or feature (if applicable):**

- Follows pattern from #12153 (logger LogListener)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, not user-facing)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal refactor
# bluetooth_proxy works exactly the same way
esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal API)
