### PR TITLE
[espnow] Initialize LwIP stack when running without WiFi component

### DIFF
--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -10,6 +10,7 @@
 
 #include <esp_event.h>
 #include <esp_mac.h>
+#include <esp_netif.h>
 #include <esp_now.h>
 #include <esp_random.h>
 #include <esp_wifi.h>
@@ -177,6 +178,8 @@ void ESPNowComponent::enable() {
 void ESPNowComponent::enable_() {
   if (!this->is_wifi_enabled()) {
     esp_event_loop_create_default();
+    // Initialize LwIP stack for wake_loop_threadsafe() socket support
+    ESP_ERROR_CHECK(esp_netif_init());
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -158,6 +158,12 @@ bool ESPNowComponent::is_wifi_enabled() {
 }
 
 void ESPNowComponent::setup() {
+#ifndef USE_WIFI
+  // Initialize LwIP stack for wake_loop_threadsafe() socket support
+  // When WiFi component is present, it handles esp_netif_init()
+  ESP_ERROR_CHECK(esp_netif_init());
+#endif
+
   if (this->enable_on_boot_) {
     this->enable_();
   } else {
@@ -178,8 +184,6 @@ void ESPNowComponent::enable() {
 void ESPNowComponent::enable_() {
   if (!this->is_wifi_enabled()) {
     esp_event_loop_create_default();
-    // Initialize LwIP stack for wake_loop_threadsafe() socket support
-    ESP_ERROR_CHECK(esp_netif_init());
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
 


### PR DESCRIPTION
# What does this implement/fix?

Initialize LwIP stack (`esp_netif_init()`) when ESP-NOW runs without the WiFi component. This fixes a crash on boot when ESP-NOW is used standalone (without WiFi) and `wake_loop_threadsafe()` support is enabled.

The crash occurred because `setup_wake_loop_threadsafe_()` calls `lwip_socket()` which requires the LwIP TCP/IP stack to be initialized. When the WiFi component is present, WiFi's setup calls `esp_netif_init()`. But when ESP-NOW runs standalone without the WiFi component, it only initialized the WiFi driver (`esp_wifi_init()`) without initializing LwIP, causing an assertion failure when trying to acquire the uninitialized `lock_tcpip_core` mutex.

The fix adds `esp_netif_init()` in ESP-NOW's `setup()` when `USE_WIFI` is not defined.

Stack trace from crash:
```
xQueueSemaphoreTake queue.c:1709 (( pxQueue ))  <- NULL mutex assertion
sys_mutex_lock at sys_arch.c:63
tcpip_send_msg_wait_sem at tcpip.c:446
lwip_socket at sockets.c:1759
esphome::Application::setup_wake_loop_threadsafe_()
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12157

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP-NOW without WiFi - previously crashed, now works
espnow:
  id: espnow_proto
  enable_on_boot: true
  auto_add_peer: true
  channel: 1

packet_transport:
  - platform: espnow
    id: pt_node
    espnow_id: espnow_proto
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
