### PR TITLE
[core] Improve CORE.data documentation with dataclass pattern

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -434,7 +434,7 @@ This document provides essential context for AI models interacting with this pro
             _get_data().items.append(item)
         ```
 
-        See `esphome/components/zephyr/__init__.py` for a real-world example.
+        If you need a real-world example, search for components that use `@dataclass` with `CORE.data` in the codebase. Note: Some components may use `TypedDict` for dictionary-based storage; both patterns are acceptable depending on your needs.
 
         **Why this matters:**
         - Module-level globals persist between compilation runs if the dashboard doesn't fork/exec

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -402,35 +402,45 @@ This document provides essential context for AI models interacting with this pro
             _use_feature = True
         ```
 
-        **Good Pattern (CORE.data with Helpers):**
+        **Bad Pattern (Flat Keys):**
         ```python
+        # Don't do this - keys should be namespaced under component domain
+        MY_FEATURE_KEY = "my_component_feature"
+        CORE.data[MY_FEATURE_KEY] = True
+        ```
+
+        **Good Pattern (dataclass):**
+        ```python
+        from dataclasses import dataclass, field
         from esphome.core import CORE
 
-        # Keys for CORE.data storage
-        COMPONENT_STATE_KEY = "my_component_state"
-        USE_FEATURE_KEY = "my_component_use_feature"
+        DOMAIN = "my_component"
 
-        def _get_component_state() -> list:
-            """Get component state from CORE.data."""
-            return CORE.data.setdefault(COMPONENT_STATE_KEY, [])
+        @dataclass
+        class MyComponentData:
+            feature_enabled: bool = False
+            item_count: int = 0
+            items: list[str] = field(default_factory=list)
 
-        def _get_use_feature() -> bool | None:
-            """Get feature flag from CORE.data."""
-            return CORE.data.get(USE_FEATURE_KEY)
+        def _get_data() -> MyComponentData:
+            if DOMAIN not in CORE.data:
+                CORE.data[DOMAIN] = MyComponentData()
+            return CORE.data[DOMAIN]
 
-        def _set_use_feature(value: bool) -> None:
-            """Set feature flag in CORE.data."""
-            CORE.data[USE_FEATURE_KEY] = value
+        def request_feature() -> None:
+            _get_data().feature_enabled = True
 
-        def enable_feature():
-            _set_use_feature(True)
+        def add_item(item: str) -> None:
+            _get_data().items.append(item)
         ```
+
+        See `esphome/components/zephyr/__init__.py` for a real-world example.
 
         **Why this matters:**
         - Module-level globals persist between compilation runs if the dashboard doesn't fork/exec
         - `CORE.data` automatically clears between runs
-        - Typed helper functions provide better IDE support and maintainability
-        - Encapsulation makes state management explicit and testable
+        - Namespacing under `DOMAIN` prevents key collisions between components
+        - `@dataclass` provides type safety and cleaner attribute access
 
 *   **Security:** Be mindful of security when making changes to the API, web server, or any other network-related code. Do not hardcode secrets or keys.
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -541,8 +541,23 @@ class EsphomeCore:
         self.friendly_name: str | None = None
         # The area / zone of the node
         self.area: str | None = None
-        # Additional data components can store temporary data in
-        # The first key to this dict should always be the integration name
+        # Additional data components can store temporary data in.
+        # This dict is cleared between compilation runs.
+        #
+        # Usage pattern (use @dataclass for type safety):
+        #   DOMAIN = "my_component"
+        #
+        #   @dataclass
+        #   class MyComponentData:
+        #       feature_enabled: bool = False
+        #
+        #   def _get_data() -> MyComponentData:
+        #       if DOMAIN not in CORE.data:
+        #           CORE.data[DOMAIN] = MyComponentData()
+        #       return CORE.data[DOMAIN]
+        #
+        # The first key should always be the component domain name (DOMAIN constant).
+        # See esphome/components/zephyr/__init__.py for a real-world example.
         self.data = {}
         # The relative path to the configuration YAML
         self.config_path: Path | None = None

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -557,7 +557,6 @@ class EsphomeCore:
         #       return CORE.data[DOMAIN]
         #
         # The first key should always be the component domain name (DOMAIN constant).
-        # See esphome/components/zephyr/__init__.py for a real-world example.
         self.data = {}
         # The relative path to the configuration YAML
         self.config_path: Path | None = None


### PR DESCRIPTION
# What does this implement/fix?

Improves documentation for `CORE.data` usage patterns in both the AI instructions (`CLAUDE.md`) and inline code documentation (`esphome/core/__init__.py`).

The documentation now clearly shows:
- **Bad patterns**: Module-level globals and flat keys without namespacing
- **Good pattern**: Using `@dataclass` with `DOMAIN` constant for type-safe, namespaced state storage
- Reference to `esphome/components/zephyr/__init__.py` as a real-world example

This helps ensure consistent patterns across components and prevents key collisions in `CORE.data`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal developer documentation)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

(Documentation-only change, no runtime testing needed)

## Example entry for `config.yaml`:

```yaml
# N/A - documentation only change
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal developer docs)
