### PR TITLE
[light] Store log_percent parameter strings in flash on ESP8266

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -74,11 +74,11 @@ static const LogString *color_mode_to_human(ColorMode color_mode) {
 
 // Helper to log percentage values
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
-static void log_percent(const char *name, const char *param, float value) {
-  ESP_LOGD(TAG, "  %s: %.0f%%", param, value * 100.0f);
+static void log_percent(const LogString *param, float value) {
+  ESP_LOGD(TAG, "  %s: %.0f%%", LOG_STR_ARG(param), value * 100.0f);
 }
 #else
-#define log_percent(name, param, value)
+#define log_percent(param, value)
 #endif
 
 void LightCall::perform() {
@@ -104,11 +104,11 @@ void LightCall::perform() {
     }
 
     if (this->has_brightness()) {
-      log_percent(name, "Brightness", v.get_brightness());
+      log_percent(LOG_STR("Brightness"), v.get_brightness());
     }
 
     if (this->has_color_brightness()) {
-      log_percent(name, "Color brightness", v.get_color_brightness());
+      log_percent(LOG_STR("Color brightness"), v.get_color_brightness());
     }
     if (this->has_red() || this->has_green() || this->has_blue()) {
       ESP_LOGD(TAG, "  Red: %.0f%%, Green: %.0f%%, Blue: %.0f%%", v.get_red() * 100.0f, v.get_green() * 100.0f,
@@ -116,7 +116,7 @@ void LightCall::perform() {
     }
 
     if (this->has_white()) {
-      log_percent(name, "White", v.get_white());
+      log_percent(LOG_STR("White"), v.get_white());
     }
     if (this->has_color_temperature()) {
       ESP_LOGD(TAG, "  Color temperature: %.1f mireds", v.get_color_temperature());


### PR DESCRIPTION
# What does this implement/fix?

Move debug log parameter strings in `light_call.cpp` to flash memory on ESP8266 by using `LOG_STR()` macro.

The `log_percent` helper function was using regular `const char*` string literals which are stored in rodata (consuming RAM on ESP8266). This change updates the function to use `const LogString*` with `LOG_STR()` macro, moving strings like "Brightness", "Color brightness", and "White" to flash.

Also removes an unused `name` parameter from the `log_percent` function.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). n/a
