### PR TITLE
[api] Use shared static string for reboot timeout scheduler name

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -117,9 +117,11 @@ void APIServer::setup() {
 #endif
 }
 
+static const char *const REBOOT_TIMEOUT = "reboot";
+
 void APIServer::schedule_reboot_timeout_() {
   this->status_set_warning();
-  this->set_timeout("api_reboot", this->reboot_timeout_, []() {
+  this->set_timeout(REBOOT_TIMEOUT, this->reboot_timeout_, []() {
     if (!global_api_server->is_connected()) {
       ESP_LOGE(TAG, "No clients; rebooting");
       App.reboot();
@@ -155,7 +157,7 @@ void APIServer::loop() {
       // Clear warning status and cancel reboot when first client connects
       if (this->clients_.size() == 1 && this->reboot_timeout_ != 0) {
         this->status_clear_warning();
-        this->cancel_timeout("api_reboot");
+        this->cancel_timeout(REBOOT_TIMEOUT);
       }
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Use a shared static string constant for the API reboot timeout scheduler name.

On ESP8266, string literals are stored in RAM by default. The string `"api_reboot"` was duplicated at two call sites (`set_timeout` and `cancel_timeout`). This change:

1. Uses a shorter name `"reboot"` (timeout names are per-component, so no conflict)
2. Stores it in a single `static const char *const` so only one copy exists

Saves ~10 bytes of RAM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
api:
  reboot_timeout: 15min
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
