### PR TITLE
[ble_client] Convert to C++17 namespace style

### DIFF
--- a/esphome/components/ble_client/automation.cpp
+++ b/esphome/components/ble_client/automation.cpp
@@ -2,12 +2,10 @@
 
 #include "automation.h"
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 const char *const Automation::TAG = "ble_client.automation";
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -9,8 +9,7 @@
 #include "esphome/components/ble_client/ble_client.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 // placeholder class for static TAG .
 class Automation {
@@ -391,7 +390,6 @@ template<typename... Ts> class BLEClientDisconnectAction : public Action<Ts...>,
   BLEClient *ble_client_;
   std::tuple<Ts...> var_{};
 };
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/ble_client.cpp
+++ b/esphome/components/ble_client/ble_client.cpp
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_client";
 
@@ -82,7 +81,6 @@ bool BLEClient::all_nodes_established_() {
   return true;
 }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/ble_client.h
+++ b/esphome/components/ble_client/ble_client.h
@@ -15,8 +15,7 @@
 #include <string>
 #include <vector>
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -75,7 +74,6 @@ class BLEClient : public BLEClientBase {
   std::vector<BLEClientNode *> nodes_;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/output/ble_binary_output.cpp
+++ b/esphome/components/ble_client/output/ble_binary_output.cpp
@@ -3,8 +3,7 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 
 #ifdef USE_ESP32
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_binary_output";
 
@@ -75,6 +74,5 @@ void BLEBinaryOutput::write_state(bool state) {
     ESP_LOGW(TAG, "[%s] Write error, err=%d", this->char_uuid_.to_string().c_str(), err);
 }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/output/ble_binary_output.h
+++ b/esphome/components/ble_client/output/ble_binary_output.h
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -36,7 +35,6 @@ class BLEBinaryOutput : public output::BinaryOutput, public BLEClientNode, publi
   esp_gatt_write_type_t write_type_{};
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/sensor/automation.h
+++ b/esphome/components/ble_client/sensor/automation.h
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 class BLESensorNotifyTrigger : public Trigger<float>, public BLESensor {
  public:
@@ -35,7 +34,6 @@ class BLESensorNotifyTrigger : public Trigger<float>, public BLESensor {
   BLESensor *sensor_;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_rssi_sensor";
 
@@ -78,6 +77,5 @@ void BLEClientRSSISensor::get_rssi_() {
   }
 }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.h
@@ -8,8 +8,7 @@
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -29,6 +28,5 @@ class BLEClientRSSISensor : public sensor::Sensor, public PollingComponent, publ
   bool should_update_{false};
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -6,8 +6,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_sensor";
 
@@ -147,6 +146,5 @@ void BLESensor::update() {
   }
 }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/sensor/ble_sensor.h
+++ b/esphome/components/ble_client/sensor/ble_sensor.h
@@ -10,8 +10,7 @@
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -48,6 +47,5 @@ class BLESensor : public sensor::Sensor, public PollingComponent, public BLEClie
   espbt::ESPBTUUID descr_uuid_;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/switch/ble_switch.cpp
+++ b/esphome/components/ble_client/switch/ble_switch.cpp
@@ -4,8 +4,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_switch";
 
@@ -31,6 +30,5 @@ void BLEClientSwitch::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 
 void BLEClientSwitch::dump_config() { LOG_SWITCH("", "BLE Client Switch", this); }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/switch/ble_switch.h
+++ b/esphome/components/ble_client/switch/ble_switch.h
@@ -8,8 +8,7 @@
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -24,6 +23,5 @@ class BLEClientSwitch : public switch_::Switch, public Component, public BLEClie
   void write_state(bool state) override;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/text_sensor/automation.h
+++ b/esphome/components/ble_client/text_sensor/automation.h
@@ -5,8 +5,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 class BLETextSensorNotifyTrigger : public Trigger<std::string>, public BLETextSensor {
  public:
@@ -33,7 +32,6 @@ class BLETextSensorNotifyTrigger : public Trigger<std::string>, public BLETextSe
   BLETextSensor *sensor_;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 
 #endif

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
@@ -7,8 +7,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 static const char *const TAG = "ble_text_sensor";
 
@@ -138,6 +137,5 @@ void BLETextSensor::update() {
   }
 }
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.h
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.h
@@ -8,8 +8,7 @@
 #ifdef USE_ESP32
 #include <esp_gattc_api.h>
 
-namespace esphome {
-namespace ble_client {
+namespace esphome::ble_client {
 
 namespace espbt = esphome::esp32_ble_tracker;
 
@@ -40,6 +39,5 @@ class BLETextSensor : public text_sensor::TextSensor, public PollingComponent, p
   espbt::ESPBTUUID descr_uuid_;
 };
 
-}  // namespace ble_client
-}  // namespace esphome
+}  // namespace esphome::ble_client
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Convert the `ble_client` component from nested namespaces to C++17 style combined namespace declarations.

This changes:
```cpp
namespace esphome {
namespace ble_client {
```

to:
```cpp
namespace esphome::ble_client {
```

This is a code modernization change that improves readability and reduces indentation depth.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no functional changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
