### PR TITLE
[fan] Use uint8_t for speed_count and fix tuya max=256 validation bug

### DIFF
--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -65,7 +65,7 @@ void FanCall::validate_() {
   auto traits = this->parent_.get_traits();
 
   if (this->speed_.has_value()) {
-    this->speed_ = clamp(*this->speed_, 1, traits.supported_speed_count());
+    this->speed_ = clamp(*this->speed_, 1, static_cast<int>(traits.supported_speed_count()));
 
     // https://developers.home-assistant.io/docs/core/entity/fan/#preset-modes
     // "Manually setting a speed must disable any set preset mode"

--- a/esphome/components/fan/fan_traits.h
+++ b/esphome/components/fan/fan_traits.h
@@ -11,7 +11,7 @@ namespace fan {
 class FanTraits {
  public:
   FanTraits() = default;
-  FanTraits(bool oscillation, bool speed, bool direction, int speed_count)
+  FanTraits(bool oscillation, bool speed, bool direction, uint8_t speed_count)
       : oscillation_(oscillation), speed_(speed), direction_(direction), speed_count_(speed_count) {}
 
   /// Return if this fan supports oscillation.
@@ -23,9 +23,9 @@ class FanTraits {
   /// Set whether this fan supports speed levels.
   void set_speed(bool speed) { this->speed_ = speed; }
   /// Return how many speed levels the fan has
-  int supported_speed_count() const { return this->speed_count_; }
+  uint8_t supported_speed_count() const { return this->speed_count_; }
   /// Set how many speed levels this fan has.
-  void set_supported_speed_count(int speed_count) { this->speed_count_ = speed_count; }
+  void set_supported_speed_count(uint8_t speed_count) { this->speed_count_ = speed_count; }
   /// Return if this fan supports changing direction
   bool supports_direction() const { return this->direction_; }
   /// Set whether this fan supports changing direction
@@ -61,7 +61,7 @@ class FanTraits {
   bool oscillation_{false};
   bool speed_{false};
   bool direction_{false};
-  int speed_count_{};
+  uint8_t speed_count_{};
   std::vector<const char *> preset_modes_{};
 };
 

--- a/esphome/components/hbridge/fan/__init__.py
+++ b/esphome/components/hbridge/fan/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_DECAY_MODE, default="SLOW"): cv.enum(
                 DECAY_MODE_OPTIONS, upper=True
             ),
-            cv.Optional(CONF_SPEED_COUNT, default=100): cv.int_range(min=1),
+            cv.Optional(CONF_SPEED_COUNT, default=100): cv.int_range(min=1, max=255),
             cv.Optional(CONF_ENABLE_PIN): cv.use_id(output.FloatOutput),
             cv.Optional(CONF_PRESET_MODES): validate_preset_modes,
         }

--- a/esphome/components/hbridge/fan/hbridge_fan.h
+++ b/esphome/components/hbridge/fan/hbridge_fan.h
@@ -15,7 +15,7 @@ enum DecayMode {
 
 class HBridgeFan : public Component, public fan::Fan {
  public:
-  HBridgeFan(int speed_count, DecayMode decay_mode) : speed_count_(speed_count), decay_mode_(decay_mode) {}
+  HBridgeFan(uint8_t speed_count, DecayMode decay_mode) : speed_count_(speed_count), decay_mode_(decay_mode) {}
 
   void set_pin_a(output::FloatOutput *pin_a) { pin_a_ = pin_a; }
   void set_pin_b(output::FloatOutput *pin_b) { pin_b_ = pin_b; }
@@ -33,7 +33,7 @@ class HBridgeFan : public Component, public fan::Fan {
   output::FloatOutput *pin_b_;
   output::FloatOutput *enable_{nullptr};
   output::BinaryOutput *oscillating_{nullptr};
-  int speed_count_{};
+  uint8_t speed_count_{};
   DecayMode decay_mode_{DECAY_MODE_SLOW};
   fan::FanTraits traits_;
   std::vector<const char *> preset_modes_{};

--- a/esphome/components/speed/fan/__init__.py
+++ b/esphome/components/speed/fan/__init__.py
@@ -25,7 +25,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_SPEED): cv.invalid(
                 "Configuring individual speeds is deprecated."
             ),
-            cv.Optional(CONF_SPEED_COUNT, default=100): cv.int_range(min=1),
+            cv.Optional(CONF_SPEED_COUNT, default=100): cv.int_range(min=1, max=255),
             cv.Optional(CONF_PRESET_MODES): validate_preset_modes,
         }
     )

--- a/esphome/components/speed/fan/speed_fan.h
+++ b/esphome/components/speed/fan/speed_fan.h
@@ -10,7 +10,7 @@ namespace speed {
 
 class SpeedFan : public Component, public fan::Fan {
  public:
-  SpeedFan(int speed_count) : speed_count_(speed_count) {}
+  SpeedFan(uint8_t speed_count) : speed_count_(speed_count) {}
   void setup() override;
   void dump_config() override;
   void set_output(output::FloatOutput *output) { this->output_ = output; }
@@ -26,7 +26,7 @@ class SpeedFan : public Component, public fan::Fan {
   output::FloatOutput *output_;
   output::BinaryOutput *oscillating_{nullptr};
   output::BinaryOutput *direction_{nullptr};
-  int speed_count_{};
+  uint8_t speed_count_{};
   fan::FanTraits traits_;
   std::vector<const char *> preset_modes_{};
 };

--- a/esphome/components/template/fan/__init__.py
+++ b/esphome/components/template/fan/__init__.py
@@ -19,7 +19,7 @@ CONFIG_SCHEMA = (
         {
             cv.Optional(CONF_HAS_DIRECTION, default=False): cv.boolean,
             cv.Optional(CONF_HAS_OSCILLATING, default=False): cv.boolean,
-            cv.Optional(CONF_SPEED_COUNT): cv.int_range(min=1),
+            cv.Optional(CONF_SPEED_COUNT): cv.int_range(min=1, max=255),
             cv.Optional(CONF_PRESET_MODES): validate_preset_modes,
         }
     )

--- a/esphome/components/template/fan/template_fan.h
+++ b/esphome/components/template/fan/template_fan.h
@@ -13,7 +13,7 @@ class TemplateFan final : public Component, public fan::Fan {
   void dump_config() override;
   void set_has_direction(bool has_direction) { this->has_direction_ = has_direction; }
   void set_has_oscillating(bool has_oscillating) { this->has_oscillating_ = has_oscillating; }
-  void set_speed_count(int count) { this->speed_count_ = count; }
+  void set_speed_count(uint8_t count) { this->speed_count_ = count; }
   void set_preset_modes(std::initializer_list<const char *> presets) { this->preset_modes_ = presets; }
   fan::FanTraits get_traits() override { return this->traits_; }
 
@@ -22,7 +22,7 @@ class TemplateFan final : public Component, public fan::Fan {
 
   bool has_oscillating_{false};
   bool has_direction_{false};
-  int speed_count_{0};
+  uint8_t speed_count_{0};
   fan::FanTraits traits_;
   std::vector<const char *> preset_modes_{};
 };

--- a/esphome/components/tuya/fan/__init__.py
+++ b/esphome/components/tuya/fan/__init__.py
@@ -22,7 +22,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SPEED_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_DIRECTION_DATAPOINT): cv.uint8_t,
-            cv.Optional(CONF_SPEED_COUNT, default=3): cv.int_range(min=1, max=256),
+            cv.Optional(CONF_SPEED_COUNT, default=3): cv.int_range(min=1, max=255),
         }
     )
     .extend(cv.COMPONENT_SCHEMA),

--- a/esphome/components/tuya/fan/tuya_fan.h
+++ b/esphome/components/tuya/fan/tuya_fan.h
@@ -9,7 +9,7 @@ namespace tuya {
 
 class TuyaFan : public Component, public fan::Fan {
  public:
-  TuyaFan(Tuya *parent, int speed_count) : parent_(parent), speed_count_(speed_count) {}
+  TuyaFan(Tuya *parent, uint8_t speed_count) : parent_(parent), speed_count_(speed_count) {}
   void setup() override;
   void dump_config() override;
   void set_speed_id(uint8_t speed_id) { this->speed_id_ = speed_id; }
@@ -27,7 +27,7 @@ class TuyaFan : public Component, public fan::Fan {
   optional<uint8_t> switch_id_{};
   optional<uint8_t> oscillation_id_{};
   optional<uint8_t> direction_id_{};
-  int speed_count_{};
+  uint8_t speed_count_{};
   TuyaDatapointType speed_type_{};
   TuyaDatapointType oscillation_type_{};
 };


### PR DESCRIPTION
# What does this implement/fix?

Reduces memory usage by changing `speed_count_` from `int` (4 bytes) to `uint8_t` (1 byte) across all fan components. Fan speed counts are realistically limited to 1-255 (typically 1-100), so a full `int` is unnecessary.

Also adds `max=255` validation to all fan component schemas to match the storage type. This fixes an off-by-one bug in `tuya/fan` which previously allowed `max=256`, but the underlying `set_enum_datapoint_value()` only accepts `uint8_t` values (0-255).

## Changes

**C++ headers:**
- `fan/fan_traits.h`: `speed_count_` from `int` to `uint8_t`
- `speed/fan/speed_fan.h`: `speed_count_` from `int` to `uint8_t`
- `template/fan/template_fan.h`: `speed_count_` from `int` to `uint8_t`
- `hbridge/fan/hbridge_fan.h`: `speed_count_` from `int` to `uint8_t`
- `tuya/fan/tuya_fan.h`: `speed_count_` from `int` to `uint8_t`

**Python validation:**
- `speed/fan/__init__.py`: Added `max=255`
- `template/fan/__init__.py`: Added `max=255`
- `hbridge/fan/__init__.py`: Added `max=255`
- `tuya/fan/__init__.py`: Changed `max=256` to `max=255` (bugfix)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No changes to user configuration - existing configs continue to work
fan:
  - platform: speed
    output: my_output
    name: "Living Room Fan"
    speed_count: 100  # Valid range: 1-255
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
