### PR TITLE
[helpers] Add conversion from FixedVector to std::vector

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -242,6 +242,9 @@ template<typename T> class FixedVector {
     other.reset_();
   }
 
+  // Allow conversion to std::vector
+  operator std::vector<T>() const { return {data_, data_ + size_}; }
+
   FixedVector &operator=(FixedVector &&other) noexcept {
     if (this != &other) {
       // Delete our current data


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add a conversion operator to turn a FixedVector into a std::vector, useful where a fixed vector gets returned in a lambda and needs to be provided to something else expecting a std::vector


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes https://community.home-assistant.io/t/unable-to-build-in-2025-11-using-remote-transmitter-transmit-raw-error-could-not-convert-keycode-from-const-esphome-fixedvector-int-to-std-vector-int/956168

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
