### PR TITLE
[ade7953_base] Add missing CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,7 @@ esphome/components/adc128s102/* @DeerMaximum
 esphome/components/addressable_light/* @justfalter
 esphome/components/ade7880/* @kpfleming
 esphome/components/ade7953/* @angelnu
+esphome/components/ade7953_base/* @angelnu
 esphome/components/ade7953_i2c/* @angelnu
 esphome/components/ade7953_spi/* @angelnu
 esphome/components/ads1118/* @solomondg1

--- a/esphome/components/ade7953_base/__init__.py
+++ b/esphome/components/ade7953_base/__init__.py
@@ -24,6 +24,8 @@ from esphome.const import (
     UNIT_WATT,
 )
 
+CODEOWNERS = ["@angelnu"]
+
 CONF_CURRENT_A = "current_a"
 CONF_CURRENT_B = "current_b"
 CONF_ACTIVE_POWER_A = "active_power_a"


### PR DESCRIPTION
# What does this implement/fix?

Adds missing owner (@angelnu) for `ade7953_base` to the `CODEOWNERS` file.

I submitted a PR (#12180) for ade7953_base, but the code owner was not notified because this entry was missing from `CODEOWNERS`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Other

**Related issue or feature (if applicable):**

* None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

* None

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

* Not applicable.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
