### PR TITLE
[esp32] Place FreeRTOS functions in flash by default (prep for IDF 6.0)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1008,10 +1008,17 @@ async def to_code(config):
     # Place non-ISR FreeRTOS functions into flash instead of IRAM
     # This saves up to 8KB of IRAM. ISR-safe functions (FromISR variants) stay in IRAM.
     # In ESP-IDF 6.0 this becomes the default and CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH
-    # is removed. We enable this now to match IDF 6.0 behavior and catch any issues early.
+    # is removed (replaced by CONFIG_FREERTOS_IN_IRAM to restore old behavior).
+    # We enable this now to match IDF 6.0 behavior and catch any issues early.
     # Users can set freertos_in_iram: true as an escape hatch if they encounter problems
     # with code that incorrectly calls FreeRTOS functions from ISRs with cache disabled.
-    if not conf[CONF_ADVANCED][CONF_FREERTOS_IN_IRAM]:
+    if conf[CONF_ADVANCED][CONF_FREERTOS_IN_IRAM]:
+        # IDF 5.x: don't set the flash option (keeps functions in IRAM)
+        # IDF 6.0+: will need CONFIG_FREERTOS_IN_IRAM=y to restore IRAM placement
+        add_idf_sdkconfig_option("CONFIG_FREERTOS_IN_IRAM", True)
+    else:
+        # IDF 5.x: explicitly place functions in flash
+        # IDF 6.0+: this is the default, option no longer exists
         add_idf_sdkconfig_option("CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH", True)
 
     # Setup watchdog

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -584,6 +584,7 @@ CONF_DISABLE_LIBC_LOCKS_IN_IRAM = "disable_libc_locks_in_iram"
 CONF_DISABLE_VFS_SUPPORT_TERMIOS = "disable_vfs_support_termios"
 CONF_DISABLE_VFS_SUPPORT_SELECT = "disable_vfs_support_select"
 CONF_DISABLE_VFS_SUPPORT_DIR = "disable_vfs_support_dir"
+CONF_FREERTOS_IN_IRAM = "freertos_in_iram"
 CONF_LOOP_TASK_STACK_SIZE = "loop_task_stack_size"
 
 # VFS requirement tracking
@@ -677,6 +678,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_TERMIOS, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_SELECT, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
+                cv.Optional(CONF_FREERTOS_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_EXECUTE_FROM_PSRAM, default=False): cv.boolean,
                 cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
                     min=8192, max=32768
@@ -1002,6 +1004,15 @@ async def to_code(config):
 
     # Increase freertos tick speed from 100Hz to 1kHz so that delay() resolution is 1ms
     add_idf_sdkconfig_option("CONFIG_FREERTOS_HZ", 1000)
+
+    # Place non-ISR FreeRTOS functions into flash instead of IRAM
+    # This saves up to 8KB of IRAM. ISR-safe functions (FromISR variants) stay in IRAM.
+    # In ESP-IDF 6.0 this becomes the default and CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH
+    # is removed. We enable this now to match IDF 6.0 behavior and catch any issues early.
+    # Users can set freertos_in_iram: true as an escape hatch if they encounter problems
+    # with code that incorrectly calls FreeRTOS functions from ISRs with cache disabled.
+    if not conf[CONF_ADVANCED][CONF_FREERTOS_IN_IRAM]:
+        add_idf_sdkconfig_option("CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH", True)
 
     # Setup watchdog
     add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT", True)


### PR DESCRIPTION
# What does this implement/fix?

Place FreeRTOS functions into flash instead of IRAM by default to save up to 8KB of IRAM.

This change enables `CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH` by default, which moves non-ISR FreeRTOS functions from IRAM to flash. ISR-safe functions (`FromISR` variants) remain in IRAM.

**Performance impact:** Testing on ESP-IDF 5.5 with Bluetooth proxies shows no functional difference thanks to fast XIP (execute in place) from flash. Bluetooth proxies are one of the most IRAM-intensive and timing-sensitive use cases, which is likely why Espressif felt confident making this the default in IDF 6.0.

**Why now?** In [ESP-IDF 6.0](https://github.com/espressif/esp-idf/issues/17052), this becomes the default behavior and the `CONFIG_FREERTOS_PLACE_FUNCTIONS_INTO_FLASH` option is removed entirely, replaced by `CONFIG_FREERTOS_IN_IRAM` to restore the old behavior (see [migration guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-6.x/6.0/system.html#memory-placement)). By enabling this now, we can:
1. Save ~8KB of IRAM immediately on ESP-IDF 5.x
2. Catch any issues early before IDF 6.0 forces this change
3. Give users an escape hatch (`freertos_in_iram: true`) if they encounter problems

The only reason this could cause issues is if code incorrectly calls FreeRTOS functions from ISRs. ESPHome itself doesn't do this, but external components might.

**Note:** This change doesn't adjust `CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH` since ESPHome uses ring buffer functions quite a bit and we may want to leave them in IRAM for performance reasons (particularly for voice assistants). A future PR will be needed for that decision (see [IDF 6.0 ring buffer migration](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-6.x/6.0/system.html#id1)).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Preparation for ESP-IDF 6.0: https://github.com/espressif/esp-idf/issues/17052

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5693

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default behavior - FreeRTOS functions in flash (saves ~8KB IRAM)
esp32:
  board: esp32dev
  framework:
    type: esp-idf

# Escape hatch if issues occur - revert to FreeRTOS functions in IRAM
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      freertos_in_iram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
