### PR TITLE
[lock] Refactor trigger classes to template and add integration tests

### DIFF
--- a/esphome/components/lock/automation.h
+++ b/esphome/components/lock/automation.h
@@ -49,26 +49,18 @@ template<typename... Ts> class LockCondition : public Condition<Ts...> {
   bool state_;
 };
 
-class LockLockTrigger : public Trigger<> {
+template<LockState State> class LockStateTrigger : public Trigger<> {
  public:
-  LockLockTrigger(Lock *a_lock) {
+  explicit LockStateTrigger(Lock *a_lock) {
     a_lock->add_on_state_callback([this, a_lock]() {
-      if (a_lock->state == LockState::LOCK_STATE_LOCKED) {
+      if (a_lock->state == State) {
         this->trigger();
       }
     });
   }
 };
 
-class LockUnlockTrigger : public Trigger<> {
- public:
-  LockUnlockTrigger(Lock *a_lock) {
-    a_lock->add_on_state_callback([this, a_lock]() {
-      if (a_lock->state == LockState::LOCK_STATE_UNLOCKED) {
-        this->trigger();
-      }
-    });
-  }
-};
+using LockLockTrigger = LockStateTrigger<LockState::LOCK_STATE_LOCKED>;
+using LockUnlockTrigger = LockStateTrigger<LockState::LOCK_STATE_UNLOCKED>;
 
 }  // namespace esphome::lock

--- a/tests/integration/fixtures/lock_automations.yaml
+++ b/tests/integration/fixtures/lock_automations.yaml
@@ -1,0 +1,17 @@
+esphome:
+  name: lock-automations-test
+
+host:
+api:  # Port will be automatically injected
+logger:
+  level: DEBUG
+
+lock:
+  - platform: template
+    id: test_lock
+    name: "Test Lock"
+    optimistic: true
+    on_lock:
+      - logger.log: "TRIGGER: on_lock fired"
+    on_unlock:
+      - logger.log: "TRIGGER: on_unlock fired"

--- a/tests/integration/test_lock_automations.py
+++ b/tests/integration/test_lock_automations.py
@@ -1,0 +1,58 @@
+"""Integration test for lock automation triggers.
+
+Tests that on_lock and on_unlock triggers work correctly.
+"""
+
+import asyncio
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_lock_automations(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test lock on_lock and on_unlock triggers."""
+    loop = asyncio.get_running_loop()
+
+    # Futures for log line detection
+    on_lock_future: asyncio.Future[bool] = loop.create_future()
+    on_unlock_future: asyncio.Future[bool] = loop.create_future()
+
+    def check_output(line: str) -> None:
+        """Check log output for trigger messages."""
+        if "TRIGGER: on_lock fired" in line and not on_lock_future.done():
+            on_lock_future.set_result(True)
+        elif "TRIGGER: on_unlock fired" in line and not on_unlock_future.done():
+            on_unlock_future.set_result(True)
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        # Import here to avoid import errors when aioesphomeapi is not installed
+        from aioesphomeapi import LockCommand
+
+        # Get entities
+        entities = await client.list_entities_services()
+        lock = next(e for e in entities[0] if e.object_id == "test_lock")
+
+        # Test 1: Lock - should trigger on_lock
+        client.lock_command(key=lock.key, command=LockCommand.LOCK)
+
+        try:
+            await asyncio.wait_for(on_lock_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("on_lock trigger did not fire")
+
+        # Test 2: Unlock - should trigger on_unlock
+        client.lock_command(key=lock.key, command=LockCommand.UNLOCK)
+
+        try:
+            await asyncio.wait_for(on_unlock_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("on_unlock trigger did not fire")


### PR DESCRIPTION
# What does this implement/fix?

Refactor lock automation triggers to use a template class and add integration tests.

The `LockLockTrigger` and `LockUnlockTrigger` classes were nearly identical, differing only in the `LockState` they check. This PR consolidates them into a single template class `LockStateTrigger<LockState State>` with type aliases to maintain full backward compatibility.

**Changes:**
- Consolidate duplicate trigger classes into `LockStateTrigger<LockState State>` template
- Add `using` aliases for `LockLockTrigger` and `LockUnlockTrigger` to preserve API compatibility
- Add `explicit` keyword to single-argument constructor (best practice)
- Add integration test to verify `on_lock` and `on_unlock` triggers work correctly

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a - no user-facing changes

## Test Environment

- [x] ESP32 IDF (host platform used for integration tests)

## Example entry for `config.yaml`:

```yaml
# No changes to user-facing configuration
lock:
  - platform: template
    id: my_lock
    name: "My Lock"
    optimistic: true
    on_lock:
      - logger.log: "Lock was locked"
    on_unlock:
      - logger.log: "Lock was unlocked"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a - no user-facing changes)
