### PR TITLE
[climate] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/climate/automation.h
+++ b/esphome/components/climate/automation.h
@@ -3,8 +3,7 @@
 #include "esphome/core/automation.h"
 #include "climate.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 template<typename... Ts> class ControlAction : public Action<Ts...> {
  public:
@@ -58,5 +57,4 @@ class StateTrigger : public Trigger<Climate &> {
   }
 };
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/macros.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 static const char *const TAG = "climate";
 
@@ -762,5 +761,4 @@ void Climate::dump_traits_(const char *tag) {
   }
 }
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -8,8 +8,7 @@
 #include "climate_mode.h"
 #include "climate_traits.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 #define LOG_CLIMATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -345,5 +344,4 @@ class Climate : public EntityBase {
   const char *custom_preset_{nullptr};
 };
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate_mode.cpp
+++ b/esphome/components/climate/climate_mode.cpp
@@ -1,7 +1,6 @@
 #include "climate_mode.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 const LogString *climate_mode_to_string(ClimateMode mode) {
   switch (mode) {
@@ -107,5 +106,4 @@ const LogString *climate_preset_to_string(ClimatePreset preset) {
   }
 }
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate_mode.h
+++ b/esphome/components/climate/climate_mode.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 /// Enum for all modes a climate device can be in.
 /// NOTE: If adding values, update ClimateModeMask in climate_traits.h to use the new last value
@@ -132,5 +131,4 @@ const LogString *climate_swing_mode_to_string(ClimateSwingMode mode);
 /// Convert the given PresetMode to a human-readable string.
 const LogString *climate_preset_to_string(ClimatePreset preset);
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate_traits.cpp
+++ b/esphome/components/climate/climate_traits.cpp
@@ -1,7 +1,6 @@
 #include "climate_traits.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 int8_t ClimateTraits::get_target_temperature_accuracy_decimals() const {
   return step_to_accuracy_decimals(this->visual_target_temperature_step_);
@@ -11,5 +10,4 @@ int8_t ClimateTraits::get_current_temperature_accuracy_decimals() const {
   return step_to_accuracy_decimals(this->visual_current_temperature_step_);
 }
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate

--- a/esphome/components/climate/climate_traits.h
+++ b/esphome/components/climate/climate_traits.h
@@ -6,8 +6,7 @@
 #include "esphome/core/finite_set_mask.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace climate {
+namespace esphome::climate {
 
 // Type aliases for climate enum bitmasks
 // These replace std::set<EnumType> to eliminate red-black tree overhead
@@ -292,5 +291,4 @@ class ClimateTraits {
   std::vector<const char *> supported_custom_presets_;
 };
 
-}  // namespace climate
-}  // namespace esphome
+}  // namespace esphome::climate


### PR DESCRIPTION
# What does this implement/fix?

Convert climate component to use C++17 nested namespace syntax.

Changes `namespace esphome { namespace climate {` to `namespace esphome::climate {` across all climate component files

This is a purely syntactic modernization with no functional changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
