### PR TITLE
[cover] Store cover state strings in flash on ESP8266

### DIFF
--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -13,25 +13,25 @@ static const char *const TAG = "cover";
 const float COVER_OPEN = 1.0f;
 const float COVER_CLOSED = 0.0f;
 
-const char *cover_command_to_str(float pos) {
+const LogString *cover_command_to_str(float pos) {
   if (pos == COVER_OPEN) {
-    return "OPEN";
+    return LOG_STR("OPEN");
   } else if (pos == COVER_CLOSED) {
-    return "CLOSE";
+    return LOG_STR("CLOSE");
   } else {
-    return "UNKNOWN";
+    return LOG_STR("UNKNOWN");
   }
 }
-const char *cover_operation_to_str(CoverOperation op) {
+const LogString *cover_operation_to_str(CoverOperation op) {
   switch (op) {
     case COVER_OPERATION_IDLE:
-      return "IDLE";
+      return LOG_STR("IDLE");
     case COVER_OPERATION_OPENING:
-      return "OPENING";
+      return LOG_STR("OPENING");
     case COVER_OPERATION_CLOSING:
-      return "CLOSING";
+      return LOG_STR("CLOSING");
     default:
-      return "UNKNOWN";
+      return LOG_STR("UNKNOWN");
   }
 }
 
@@ -87,7 +87,7 @@ void CoverCall::perform() {
     if (traits.get_supports_position()) {
       ESP_LOGD(TAG, "  Position: %.0f%%", *this->position_ * 100.0f);
     } else {
-      ESP_LOGD(TAG, "  Command: %s", cover_command_to_str(*this->position_));
+      ESP_LOGD(TAG, "  Command: %s", LOG_STR_ARG(cover_command_to_str(*this->position_)));
     }
   }
   if (this->tilt_.has_value()) {
@@ -169,7 +169,7 @@ void Cover::publish_state(bool save) {
   if (traits.get_supports_tilt()) {
     ESP_LOGD(TAG, "  Tilt: %.0f%%", this->tilt * 100.0f);
   }
-  ESP_LOGD(TAG, "  Current Operation: %s", cover_operation_to_str(this->current_operation));
+  ESP_LOGD(TAG, "  Current Operation: %s", LOG_STR_ARG(cover_operation_to_str(this->current_operation)));
 
   this->state_callback_.call();
 #if defined(USE_COVER) && defined(USE_CONTROLLER_REGISTRY)

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
 
 #include "cover_traits.h"
@@ -86,7 +87,7 @@ enum CoverOperation : uint8_t {
   COVER_OPERATION_CLOSING,
 };
 
-const char *cover_operation_to_str(CoverOperation op);
+const LogString *cover_operation_to_str(CoverOperation op);
 
 /** Base class for all cover devices.
  *

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -41,6 +41,10 @@ namespace web_server {
 
 static const char *const TAG = "web_server";
 
+// Longest: HORIZONTAL (10 chars + null terminator, rounded up)
+static constexpr size_t PSTR_LOCAL_SIZE = 16;
+#define PSTR_LOCAL(mode_s) ESPHOME_strncpy_P(buf, (ESPHOME_PGM_P) ((mode_s)), PSTR_LOCAL_SIZE - 1)
+
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 static const char *const HEADER_PNA_NAME = "Private-Network-Access-Name";
 static const char *const HEADER_PNA_ID = "Private-Network-Access-ID";
@@ -908,7 +912,8 @@ std::string WebServer::cover_json(cover::Cover *obj, JsonDetail start_config) {
 
   set_json_icon_state_value(root, obj, "cover", obj->is_fully_closed() ? "CLOSED" : "OPEN", obj->position,
                             start_config);
-  root["current_operation"] = cover::cover_operation_to_str(obj->current_operation);
+  char buf[PSTR_LOCAL_SIZE];
+  root["current_operation"] = PSTR_LOCAL(cover::cover_operation_to_str(obj->current_operation));
 
   if (obj->get_traits().get_supports_position())
     root["position"] = obj->position;
@@ -1271,9 +1276,6 @@ std::string WebServer::select_json(select::Select *obj, const char *value, JsonD
   return builder.serialize();
 }
 #endif
-
-// Longest: HORIZONTAL
-#define PSTR_LOCAL(mode_s) ESPHOME_strncpy_P(buf, (ESPHOME_PGM_P) ((mode_s)), 15)
 
 #ifdef USE_CLIMATE
 void WebServer::on_climate_update(climate::Climate *obj) {


### PR DESCRIPTION
# What does this implement/fix?

Store cover operation strings in flash on ESP8266 when `esp8266_store_log_strings_in_flash` is enabled.

This is a follow-up to #12163 which did the same for lock state strings. The cover component has two similar functions (`cover_command_to_str` and `cover_operation_to_str`) that return string literals which consume RAM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #12163

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test-cover

esp8266:
  board: d1_mini

logger:
  esp8266_store_log_strings_in_flash: true

cover:
  - platform: template
    name: "Test Cover"
    lambda: return COVER_OPEN;
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
