### PR TITLE
Support for waveshare 7.50in-hd

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -107,6 +107,9 @@ WaveshareEPaper7P5InV2alt = waveshare_epaper_ns.class_(
 WaveshareEPaper7P5InV2P = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InV2P", WaveshareEPaper
 )
+WaveshareEPaper7P5InHD = waveshare_epaper_ns.class_(
+    "WaveshareEPaper7P5InHD", WaveshareEPaper
+)
 WaveshareEPaper7P5InHDB = waveshare_epaper_ns.class_(
     "WaveshareEPaper7P5InHDB", WaveshareEPaper
 )
@@ -167,6 +170,7 @@ MODELS = {
     "7.50inv2": ("b", WaveshareEPaper7P5InV2),
     "7.50inv2alt": ("b", WaveshareEPaper7P5InV2alt),
     "7.50inv2p": ("c", WaveshareEPaper7P5InV2P),
+    "7.50in-hd": ("b", WaveshareEPaper7P5InHD),
     "7.50in-hd-b": ("b", WaveshareEPaper7P5InHDB),
     "2.13in-ttgo-dke": ("c", WaveshareEPaper2P13InDKE),
     "2.13inv3": ("c", WaveshareEPaper2P13InV3),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -4435,6 +4435,100 @@ void WaveshareEPaper7P5InBC::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+/* 7.50in-hd */
+void WaveshareEPaper7P5InHD::initialize() {
+  this->wait_until_idle_();
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  this->command(0x46);  // Auto Write Red RAM
+  this->data(0xf7);
+  this->wait_until_idle_();
+  this->command(0x47);  // Auto Write  B/W RAM
+  this->data(0xf7);
+  this->wait_until_idle_();
+
+  this->command(0x0C);  // Soft start setting
+  this->data(0xAE);
+  this->data(0xC7);
+  this->data(0xC3);
+  this->data(0xC0);
+  this->data(0x40);
+
+  this->command(0x01);  // Set MUX as 527
+  this->data(0xAF);
+  this->data(0x02);
+  this->data(0x01);
+
+  this->command(0x11);  // Data entry mode
+  this->data(0x01);
+
+  this->command(0x44);
+  this->data(0x00);  // RAM x address start at 0
+  this->data(0x00);
+  this->data(0x6F);
+  this->data(0x03);
+
+  this->command(0x45);
+  this->data(0xAF);
+  this->data(0x02);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x3C);  // VBD
+  this->data(0x05);     // LUT1, for white
+
+  this->command(0x18);
+  this->data(0x80);
+
+  this->command(0x22);
+  this->data(0xB1);  // Load Temperature and waveform setting.
+  this->command(0x20);
+  this->wait_until_idle_();
+
+  this->command(0x4E);  // set RAM x address count to 0;
+  this->data(0x00);
+  this->data(0x00);
+  this->command(0x4F);
+  this->data(0x00);
+  this->data(0x00);
+}
+
+void HOT WaveshareEPaper7P5InHD::display() {
+  this->command(0x4F);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  this->command(0x26);
+  this->start_data_();
+  for (size_t i = 0; i < this->get_buffer_length_(); i++)
+    this->write_byte(0xff);
+  this->end_data_();
+
+  this->command(0x22);
+  this->data(0xF7);  // Load LUT from MCU(0x32)
+  this->command(0x20);
+}
+
+int WaveshareEPaper7P5InHD::get_width_internal() { return 880; }
+
+int WaveshareEPaper7P5InHD::get_height_internal() { return 528; }
+
+void WaveshareEPaper7P5InHD::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 7.5in-HD");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+/* 7.50in-hdb */
 void WaveshareEPaper7P5InHDB::initialize() {
   this->command(0x12);  // SWRESET
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -993,6 +993,26 @@ class WaveshareEPaper7P5InV2P : public WaveshareEPaper {
   void turn_on_display_();
 };
 
+class WaveshareEPaper7P5InHD : public WaveshareEPaper {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    // deep sleep
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper7P5InHDB : public WaveshareEPaper {
  public:
   void initialize() override;

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -712,6 +712,24 @@ display:
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
   - platform: waveshare_epaper
+    id: epd_7_50hd
+    model: 7.50in-hd
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
+  - platform: waveshare_epaper
     id: epd_7_50hdb
     model: 7.50in-hd-b
     cs_pin:


### PR DESCRIPTION
# What does this implement/fix?

Adds support for waveshare 7.5HD (B/W, Non b) https://www.waveshare.com/7.5inch-hd-e-paper-hat.htm
Adds support using https://github.com/esphome/esphome/pull/3239 as the base for this change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5702

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: epaper-screen
  friendly_name: epaper_screen

esp32:
  board: esp32-c6-devkitc-1
  framework:
    type: esp-idf

# Enable logging
logger:

font:
  - file: "https://github.com/IdreesInc/Monocraft/releases/download/v3.0/Monocraft.ttf"
    id: font1
    size: 48

spi:
  clk_pin: 21
  mosi_pin: 22

display:
  - platform: waveshare_epaper
    id: epaper_display
    cs_pin: 2
    dc_pin: 3
    busy_pin: 6
    reset_pin: 5
    model: 7.50in-hd
    update_interval: 60s
    lambda: |
      it.print(0, 0, id(font1), "Hello World2!");


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
