### PR TITLE
[mdns] Bump mDNS component to 1.9.1

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -165,7 +165,7 @@ async def to_code(config):
             cg.add_library("LEAmDNS", None)
 
     if CORE.using_esp_idf:
-        add_idf_component(name="espressif/mdns", ref="1.8.2")
+        add_idf_component(name="espressif/mdns", ref="1.9.1")
 
     cg.add_define("USE_MDNS")
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   espressif/esp32-camera:
     version: 2.1.1
   espressif/mdns:
-    version: 1.8.2
+    version: 1.9.1
   espressif/esp_wifi_remote:
     version: 1.1.5
     rules:


### PR DESCRIPTION
# What does this implement/fix?

Upgrade mDNS for ESP-IDF to 1.9.1

Changelog:
- [1.9.0](https://github.com/espressif/esp-protocols/releases/tag/mdns-v1.9.0)
- [1.9.1](https://github.com/espressif/esp-protocols/releases/tag/mdns-v1.9.1)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
