### PR TITLE
[psram] Add C5 support

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -11,6 +11,7 @@ from esphome.components.esp32 import (
     get_esp32_variant,
 )
 from esphome.components.esp32.const import (
+    VARIANT_ESP32C5,
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
@@ -55,6 +56,7 @@ SPIRAM_MODES = {
     VARIANT_ESP32: (TYPE_QUAD,),
     VARIANT_ESP32S2: (TYPE_QUAD,),
     VARIANT_ESP32S3: (TYPE_QUAD, TYPE_OCTAL),
+    VARIANT_ESP32C5: (TYPE_QUAD,),
     VARIANT_ESP32P4: (TYPE_HEX,),
 }
 
@@ -63,6 +65,7 @@ SPIRAM_SPEEDS = {
     VARIANT_ESP32: (40, 80, 120),
     VARIANT_ESP32S2: (40, 80, 120),
     VARIANT_ESP32S3: (40, 80, 120),
+    VARIANT_ESP32C5: (40, 80, 120),
     VARIANT_ESP32P4: (20, 100, 200),
 }
 

--- a/tests/component_tests/psram/test_psram.py
+++ b/tests/component_tests/psram/test_psram.py
@@ -23,22 +23,23 @@ from tests.component_tests.types import SetCoreConfigCallable
 UNSUPPORTED_PSRAM_VARIANTS = [
     VARIANT_ESP32C2,
     VARIANT_ESP32C3,
-    VARIANT_ESP32C5,
     VARIANT_ESP32C6,
     VARIANT_ESP32H2,
 ]
 
 SUPPORTED_PSRAM_VARIANTS = [
     VARIANT_ESP32,
+    VARIANT_ESP32C5,
+    VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
-    VARIANT_ESP32P4,
 ]
 SUPPORTED_PSRAM_MODES = {
     VARIANT_ESP32: ["quad"],
+    VARIANT_ESP32C5: ["quad"],
+    VARIANT_ESP32P4: ["hex"],
     VARIANT_ESP32S2: ["quad"],
     VARIANT_ESP32S3: ["quad", "octal"],
-    VARIANT_ESP32P4: ["hex"],
 }
 
 

--- a/tests/components/psram/test.esp32-c5-idf.yaml
+++ b/tests/components/psram/test.esp32-c5-idf.yaml
@@ -1,0 +1,8 @@
+esp32:
+  cpu_frequency: 240MHz
+  framework:
+    type: esp-idf
+
+psram:
+  speed: 120MHz
+  ignore_not_found: false

--- a/tests/test_build_components/build_components_base.esp32-c5-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c5-idf.yaml
@@ -1,0 +1,17 @@
+esphome:
+  name: componenttestesp32c5idf
+  friendly_name: $component_name
+
+esp32:
+  board: esp32-c5-devkitc-1
+  framework:
+    type: esp-idf
+
+logger:
+  level: VERY_VERBOSE
+
+packages:
+  component_under_test: !include
+    file: $component_test_file
+    vars:
+      component_test_file: $component_test_file


### PR DESCRIPTION
# What does this implement/fix?

Add PSRAM support for ESP32-C5 with:
- Quad mode only (no octal support)
- Speed options: 40, 80, 120 MHz

Also adds C5 test infrastructure with base config and psram test.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5708

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
