### PR TITLE
[core] Fix status_momentary API misuse and optimize parameter type

### DIFF
--- a/esphome/components/demo/demo_alarm_control_panel.h
+++ b/esphome/components/demo/demo_alarm_control_panel.h
@@ -33,7 +33,7 @@ class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
       case ACP_STATE_ARMED_AWAY:
         if (this->get_requires_code_to_arm() && call.get_code().has_value()) {
           if (call.get_code().value() != "1234") {
-            this->status_momentary_error("Invalid code", 5000);
+            this->status_momentary_error("invalid_code", 5000);
             return;
           }
         }
@@ -42,7 +42,7 @@ class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
       case ACP_STATE_DISARMED:
         if (this->get_requires_code() && call.get_code().has_value()) {
           if (call.get_code().value() != "1234") {
-            this->status_momentary_error("Invalid code", 5000);
+            this->status_momentary_error("invalid_code", 5000);
             return;
           }
         }

--- a/esphome/components/es8388/es8388.cpp
+++ b/esphome/components/es8388/es8388.cpp
@@ -225,7 +225,7 @@ bool ES8388::set_dac_output(DacOutputLine line) {
 optional<DacOutputLine> ES8388::get_dac_power() {
   uint8_t dac_power;
   if (!this->read_byte(ES8388_DACPOWER, &dac_power)) {
-    this->status_momentary_warning("Failed to read ES8388_DACPOWER");
+    this->status_momentary_warning("dacpower_read");
     return {};
   }
   switch (dac_power) {
@@ -268,7 +268,7 @@ bool ES8388::set_adc_input_mic(AdcInputMicLine line) {
 optional<AdcInputMicLine> ES8388::get_mic_input() {
   uint8_t mic_input;
   if (!this->read_byte(ES8388_ADCCONTROL2, &mic_input)) {
-    this->status_momentary_warning("Failed to read ES8388_ADCCONTROL2");
+    this->status_momentary_warning("adccontrol2_read");
     return {};
   }
   switch (mic_input) {

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -402,7 +402,7 @@ error:
     this->backend_->abort();
   }
 
-  this->status_momentary_error("onerror", 5000);
+  this->status_momentary_error("err", 5000);
 #ifdef USE_OTA_STATE_CALLBACK
   this->state_callback_.call(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif

--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -298,8 +298,7 @@ void MicroWakeWord::loop() {
         // uses floating point operations.
         if (!FrontendPopulateState(&this->frontend_config_, &this->frontend_state_,
                                    this->microphone_source_->get_audio_stream_info().get_sample_rate())) {
-          this->status_momentary_error(
-              "Failed to allocate buffers for spectrogram feature processor, attempting again in 1 second", 1000);
+          this->status_momentary_error("frontend_alloc", 1000);
           return;
         }
 
@@ -308,7 +307,7 @@ void MicroWakeWord::loop() {
 
         if (this->inference_task_handle_ == nullptr) {
           FrontendFreeStateContents(&this->frontend_state_);  // Deallocate frontend state
-          this->status_momentary_error("Task failed to start, attempting again in 1 second", 1000);
+          this->status_momentary_error("task_start", 1000);
         }
       }
       break;

--- a/esphome/components/sound_level/sound_level.cpp
+++ b/esphome/components/sound_level/sound_level.cpp
@@ -167,7 +167,7 @@ bool SoundLevelComponent::start_() {
   this->audio_buffer_ = audio::AudioSourceTransferBuffer::create(
       this->microphone_source_->get_audio_stream_info().ms_to_bytes(AUDIO_BUFFER_DURATION_MS));
   if (this->audio_buffer_ == nullptr) {
-    this->status_momentary_error("Failed to allocate transfer buffer", 15000);
+    this->status_momentary_error("transfer_buffer", 15000);
     return false;
   }
 
@@ -176,7 +176,7 @@ bool SoundLevelComponent::start_() {
   std::shared_ptr<RingBuffer> temp_ring_buffer =
       RingBuffer::create(this->microphone_source_->get_audio_stream_info().ms_to_bytes(RING_BUFFER_DURATION_MS));
   if (temp_ring_buffer.use_count() == 0) {
-    this->status_momentary_error("Failed to allocate ring buffer", 15000);
+    this->status_momentary_error("ring_buffer", 15000);
     this->stop_();
     return false;
   } else {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -369,11 +369,11 @@ void Component::status_clear_error() {
   this->component_state_ &= ~STATUS_LED_ERROR;
   ESP_LOGE(TAG, "%s cleared Error flag", LOG_STR_ARG(this->get_component_log_str()));
 }
-void Component::status_momentary_warning(const std::string &name, uint32_t length) {
+void Component::status_momentary_warning(const char *name, uint32_t length) {
   this->status_set_warning();
   this->set_timeout(name, length, [this]() { this->status_clear_warning(); });
 }
-void Component::status_momentary_error(const std::string &name, uint32_t length) {
+void Component::status_momentary_error(const char *name, uint32_t length) {
   this->status_set_error();
   this->set_timeout(name, length, [this]() { this->status_clear_error(); });
 }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -241,9 +241,23 @@ class Component {
 
   void status_clear_error();
 
-  void status_momentary_warning(const std::string &name, uint32_t length = 5000);
+  /** Set warning status flag and automatically clear it after a timeout.
+   *
+   * @param name Identifier for the timeout (used to cancel/replace existing timeouts with the same name).
+   *             Must be a static string literal (stored in flash/rodata), not a temporary or dynamic string.
+   *             This is NOT a message to display - use status_set_warning() with a message if logging is needed.
+   * @param length Duration in milliseconds before the warning is automatically cleared.
+   */
+  void status_momentary_warning(const char *name, uint32_t length = 5000);
 
-  void status_momentary_error(const std::string &name, uint32_t length = 5000);
+  /** Set error status flag and automatically clear it after a timeout.
+   *
+   * @param name Identifier for the timeout (used to cancel/replace existing timeouts with the same name).
+   *             Must be a static string literal (stored in flash/rodata), not a temporary or dynamic string.
+   *             This is NOT a message to display - use status_set_error() with a message if logging is needed.
+   * @param length Duration in milliseconds before the error is automatically cleared.
+   */
+  void status_momentary_error(const char *name, uint32_t length = 5000);
 
   bool has_overridden_loop() const;
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes misuse of `status_momentary_warning` and `status_momentary_error` where the `name` parameter was being treated as a log message instead of a timeout identifier.

The `name` parameter is passed to `set_timeout` to identify the timeout (allowing it to be cancelled/replaced). Several components were passing descriptive messages like `"Task failed to start, attempting again in 1 second"` instead of short identifiers like `"task_start"`.

Also changes the parameter type from `const std::string &` to `const char *` since `set_timeout` already has a `const char *` overload, avoiding unnecessary string construction.

## Changes

- Fixed components passing messages instead of identifiers
- Changed parameter type to `const char *`
- Added documentation clarifying correct usage

## Results (ESP8266)

- **RAM:** -4 bytes
- **Flash:** -180 bytes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal API documentation only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal API change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
