### PR TITLE
[core] Fix clean all on windows

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -3,6 +3,8 @@ import logging
 import os
 from pathlib import Path
 import re
+import shutil
+import stat
 
 from esphome import loader
 from esphome.config import iter_component_configs, iter_components
@@ -301,9 +303,26 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def clean_build(clear_pio_cache: bool = True):
-    import shutil
+def _rmtree(path: Path) -> None:
+    """Remove directory tree, handling read-only files on Windows.
 
+    On Windows, git pack files and other files may be marked read-only,
+    causing shutil.rmtree to fail with "Access is denied". This function
+    handles that by removing the read-only flag before retrying deletion.
+    """
+
+    def on_error(func, path, exc_info):
+        # If the error is due to read-only files, remove the flag and retry
+        if not os.access(path, os.W_OK):
+            os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+            func(path)
+        else:
+            raise exc_info[1].with_traceback(exc_info[2])
+
+    shutil.rmtree(path, onerror=on_error)
+
+
+def clean_build(clear_pio_cache: bool = True):
     # Allow skipping cache cleaning for integration tests
     if os.environ.get("ESPHOME_SKIP_CLEAN_BUILD"):
         _LOGGER.warning("Skipping build cleaning (ESPHOME_SKIP_CLEAN_BUILD set)")
@@ -312,11 +331,11 @@ def clean_build(clear_pio_cache: bool = True):
     pioenvs = CORE.relative_pioenvs_path()
     if pioenvs.is_dir():
         _LOGGER.info("Deleting %s", pioenvs)
-        shutil.rmtree(pioenvs)
+        _rmtree(pioenvs)
     piolibdeps = CORE.relative_piolibdeps_path()
     if piolibdeps.is_dir():
         _LOGGER.info("Deleting %s", piolibdeps)
-        shutil.rmtree(piolibdeps)
+        _rmtree(piolibdeps)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
@@ -337,12 +356,10 @@ def clean_build(clear_pio_cache: bool = True):
         cache_dir = Path(config.get("platformio", "cache_dir"))
         if cache_dir.is_dir():
             _LOGGER.info("Deleting PlatformIO cache %s", cache_dir)
-            shutil.rmtree(cache_dir)
+            _rmtree(cache_dir)
 
 
 def clean_all(configuration: list[str]):
-    import shutil
-
     data_dirs = []
     for config in configuration:
         item = Path(config)
@@ -364,7 +381,7 @@ def clean_all(configuration: list[str]):
                 if item.is_file() and not item.name.endswith(".json"):
                     item.unlink()
                 elif item.is_dir() and item.name != "storage":
-                    shutil.rmtree(item)
+                    _rmtree(item)
 
     # Clean PlatformIO project files
     try:
@@ -378,7 +395,7 @@ def clean_all(configuration: list[str]):
             path = Path(config.get("platformio", pio_dir))
             if path.is_dir():
                 _LOGGER.info("Deleting PlatformIO %s %s", pio_dir, path)
-                shutil.rmtree(path)
+                _rmtree(path)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import importlib
 import logging
 import os
@@ -5,6 +6,7 @@ from pathlib import Path
 import re
 import shutil
 import stat
+from types import TracebackType
 
 from esphome import loader
 from esphome.config import iter_component_configs, iter_components
@@ -303,18 +305,21 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def _rmtree_error_handler(func, path, exc_info):
+def _rmtree_error_handler(
+    func: Callable[[str], object],
+    path: str,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType | None],
+) -> None:
     """Error handler for shutil.rmtree to handle read-only files on Windows.
 
     On Windows, git pack files and other files may be marked read-only,
     causing shutil.rmtree to fail with "Access is denied". This handler
     removes the read-only flag and retries the deletion.
     """
-    if not os.access(path, os.W_OK):
-        os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
-        func(path)
-    else:
+    if os.access(path, os.W_OK):
         raise exc_info[1].with_traceback(exc_info[2])
+    os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+    func(path)
 
 
 def clean_build(clear_pio_cache: bool = True):

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -303,23 +303,18 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def _rmtree(path: Path) -> None:
-    """Remove directory tree, handling read-only files on Windows.
+def _rmtree_error_handler(func, path, exc_info):
+    """Error handler for shutil.rmtree to handle read-only files on Windows.
 
     On Windows, git pack files and other files may be marked read-only,
-    causing shutil.rmtree to fail with "Access is denied". This function
-    handles that by removing the read-only flag before retrying deletion.
+    causing shutil.rmtree to fail with "Access is denied". This handler
+    removes the read-only flag and retries the deletion.
     """
-
-    def on_error(func, path, exc_info):
-        # If the error is due to read-only files, remove the flag and retry
-        if not os.access(path, os.W_OK):
-            os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
-            func(path)
-        else:
-            raise exc_info[1].with_traceback(exc_info[2])
-
-    shutil.rmtree(path, onerror=on_error)
+    if not os.access(path, os.W_OK):
+        os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+        func(path)
+    else:
+        raise exc_info[1].with_traceback(exc_info[2])
 
 
 def clean_build(clear_pio_cache: bool = True):
@@ -331,11 +326,11 @@ def clean_build(clear_pio_cache: bool = True):
     pioenvs = CORE.relative_pioenvs_path()
     if pioenvs.is_dir():
         _LOGGER.info("Deleting %s", pioenvs)
-        _rmtree(pioenvs)
+        shutil.rmtree(pioenvs, onerror=_rmtree_error_handler)
     piolibdeps = CORE.relative_piolibdeps_path()
     if piolibdeps.is_dir():
         _LOGGER.info("Deleting %s", piolibdeps)
-        _rmtree(piolibdeps)
+        shutil.rmtree(piolibdeps, onerror=_rmtree_error_handler)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
@@ -356,7 +351,7 @@ def clean_build(clear_pio_cache: bool = True):
         cache_dir = Path(config.get("platformio", "cache_dir"))
         if cache_dir.is_dir():
             _LOGGER.info("Deleting PlatformIO cache %s", cache_dir)
-            _rmtree(cache_dir)
+            shutil.rmtree(cache_dir, onerror=_rmtree_error_handler)
 
 
 def clean_all(configuration: list[str]):
@@ -381,7 +376,7 @@ def clean_all(configuration: list[str]):
                 if item.is_file() and not item.name.endswith(".json"):
                     item.unlink()
                 elif item.is_dir() and item.name != "storage":
-                    _rmtree(item)
+                    shutil.rmtree(item, onerror=_rmtree_error_handler)
 
     # Clean PlatformIO project files
     try:
@@ -395,7 +390,7 @@ def clean_all(configuration: list[str]):
             path = Path(config.get("platformio", pio_dir))
             if path.is_dir():
                 _LOGGER.info("Deleting PlatformIO %s %s", pio_dir, path)
-                _rmtree(path)
+                shutil.rmtree(path, onerror=_rmtree_error_handler)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -1070,7 +1070,6 @@ def test_clean_all_preserves_json_files(
 def test_clean_build_handles_readonly_files(
     mock_core: MagicMock,
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test clean_build handles read-only files (e.g., git pack files on Windows)."""
     # Create directory structure with read-only files
@@ -1093,8 +1092,7 @@ def test_clean_build_handles_readonly_files(
     assert not os.access(readonly_file, os.W_OK)
 
     # Call the function - should not crash
-    with caplog.at_level("INFO"):
-        clean_build()
+    clean_build()
 
     # Verify directory was removed despite read-only files
     assert not pioenvs_dir.exists()

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -1062,3 +1062,78 @@ def test_clean_all_preserves_json_files(
     # Verify logging mentions cleaning
     assert "Cleaning" in caplog.text
     assert str(build_dir) in caplog.text
+
+
+@patch("esphome.writer.CORE")
+def test_clean_build_handles_readonly_files(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_build handles read-only files (e.g., git pack files on Windows)."""
+    import os
+    import stat
+
+    # Create directory structure with read-only files
+    pioenvs_dir = tmp_path / ".pioenvs"
+    pioenvs_dir.mkdir()
+    git_dir = pioenvs_dir / ".git" / "objects" / "pack"
+    git_dir.mkdir(parents=True)
+
+    # Create a read-only file (simulating git pack files on Windows)
+    readonly_file = git_dir / "pack-abc123.pack"
+    readonly_file.write_text("pack data")
+    os.chmod(readonly_file, stat.S_IRUSR)  # Read-only
+
+    # Setup mocks
+    mock_core.relative_pioenvs_path.return_value = pioenvs_dir
+    mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
+    mock_core.relative_build_path.return_value = tmp_path / "dependencies.lock"
+
+    # Verify file is read-only
+    assert not os.access(readonly_file, os.W_OK)
+
+    # Call the function - should not crash
+    with caplog.at_level("INFO"):
+        clean_build()
+
+    # Verify directory was removed despite read-only files
+    assert not pioenvs_dir.exists()
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_handles_readonly_files(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all handles read-only files."""
+    import os
+    import stat
+
+    from esphome.writer import clean_all
+
+    # Create config directory
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+
+    # Create a subdirectory with read-only files
+    subdir = build_dir / "subdir"
+    subdir.mkdir()
+    readonly_file = subdir / "readonly.txt"
+    readonly_file.write_text("content")
+    os.chmod(readonly_file, stat.S_IRUSR)  # Read-only
+
+    # Verify file is read-only
+    assert not os.access(readonly_file, os.W_OK)
+
+    # Call the function - should not crash
+    with caplog.at_level("INFO"):
+        clean_all([str(config_dir)])
+
+    # Verify directory was removed despite read-only files
+    assert not subdir.exists()
+    assert build_dir.exists()  # .esphome dir itself is preserved

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -15,6 +15,7 @@ from esphome.writer import (
     CPP_INCLUDE_BEGIN,
     CPP_INCLUDE_END,
     GITIGNORE_CONTENT,
+    _rmtree_error_handler,
     clean_build,
     clean_cmake_cache,
     storage_should_clean,
@@ -1137,3 +1138,20 @@ def test_clean_all_handles_readonly_files(
     # Verify directory was removed despite read-only files
     assert not subdir.exists()
     assert build_dir.exists()  # .esphome dir itself is preserved
+
+
+def test_rmtree_error_handler_reraises_for_writable_files() -> None:
+    """Test _rmtree_error_handler re-raises exception for writable files."""
+    # Create a mock exception
+    original_error = PermissionError("Some other permission error")
+    exc_info = (type(original_error), original_error, original_error.__traceback__)
+
+    # Patch os.access to return True (file is writable)
+    with (
+        patch("esphome.writer.os.access", return_value=True),
+        pytest.raises(PermissionError) as exc_info_caught,
+    ):
+        _rmtree_error_handler(lambda p: None, "/some/path", exc_info)
+
+    # Verify the original exception was re-raised
+    assert exc_info_caught.value is original_error

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -1,7 +1,9 @@
 """Test writer module functionality."""
 
 from collections.abc import Callable
+import os
 from pathlib import Path
+import stat
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +17,6 @@ from esphome.writer import (
     CPP_INCLUDE_BEGIN,
     CPP_INCLUDE_END,
     GITIGNORE_CONTENT,
-    _rmtree_error_handler,
     clean_build,
     clean_cmake_cache,
     storage_should_clean,
@@ -1072,9 +1073,6 @@ def test_clean_build_handles_readonly_files(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test clean_build handles read-only files (e.g., git pack files on Windows)."""
-    import os
-    import stat
-
     # Create directory structure with read-only files
     pioenvs_dir = tmp_path / ".pioenvs"
     pioenvs_dir.mkdir()
@@ -1109,9 +1107,6 @@ def test_clean_all_handles_readonly_files(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test clean_all handles read-only files."""
-    import os
-    import stat
-
     from esphome.writer import clean_all
 
     # Create config directory
@@ -1140,18 +1135,38 @@ def test_clean_all_handles_readonly_files(
     assert build_dir.exists()  # .esphome dir itself is preserved
 
 
-def test_rmtree_error_handler_reraises_for_writable_files() -> None:
-    """Test _rmtree_error_handler re-raises exception for writable files."""
-    # Create a mock exception
-    original_error = PermissionError("Some other permission error")
-    exc_info = (type(original_error), original_error, original_error.__traceback__)
+@patch("esphome.writer.CORE")
+def test_clean_build_reraises_for_other_errors(
+    mock_core: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test clean_build re-raises errors that are not read-only permission issues."""
+    # Create directory structure with a read-only subdirectory
+    # This prevents file deletion and triggers the error handler
+    pioenvs_dir = tmp_path / ".pioenvs"
+    pioenvs_dir.mkdir()
+    subdir = pioenvs_dir / "subdir"
+    subdir.mkdir()
+    test_file = subdir / "test.txt"
+    test_file.write_text("content")
 
-    # Patch os.access to return True (file is writable)
-    with (
-        patch("esphome.writer.os.access", return_value=True),
-        pytest.raises(PermissionError) as exc_info_caught,
-    ):
-        _rmtree_error_handler(lambda p: None, "/some/path", exc_info)
+    # Make subdir read-only so files inside can't be deleted
+    os.chmod(subdir, stat.S_IRUSR | stat.S_IXUSR)
 
-    # Verify the original exception was re-raised
-    assert exc_info_caught.value is original_error
+    # Setup mocks
+    mock_core.relative_pioenvs_path.return_value = pioenvs_dir
+    mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
+    mock_core.relative_build_path.return_value = tmp_path / "dependencies.lock"
+
+    try:
+        # Mock os.access in writer module to return True (writable)
+        # This simulates a case where the error is NOT due to read-only permissions
+        # so the error handler should re-raise instead of trying to fix permissions
+        with (
+            patch("esphome.writer.os.access", return_value=True),
+            pytest.raises(PermissionError),
+        ):
+            clean_build()
+    finally:
+        # Cleanup - restore write permission so tmp_path cleanup works
+        os.chmod(subdir, stat.S_IRWXU)

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -17,6 +17,7 @@ from esphome.writer import (
     CPP_INCLUDE_BEGIN,
     CPP_INCLUDE_END,
     GITIGNORE_CONTENT,
+    clean_all,
     clean_build,
     clean_cmake_cache,
     storage_should_clean,
@@ -1102,11 +1103,8 @@ def test_clean_build_handles_readonly_files(
 def test_clean_all_handles_readonly_files(
     mock_core: MagicMock,
     tmp_path: Path,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test clean_all handles read-only files."""
-    from esphome.writer import clean_all
-
     # Create config directory
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -1125,8 +1123,7 @@ def test_clean_all_handles_readonly_files(
     assert not os.access(readonly_file, os.W_OK)
 
     # Call the function - should not crash
-    with caplog.at_level("INFO"):
-        clean_all([str(config_dir)])
+    clean_all([str(config_dir)])
 
     # Verify directory was removed despite read-only files
     assert not subdir.exists()


### PR DESCRIPTION
# What does this implement/fix?

Fix clean all windows. On Windows, git pack files and other files may be marked read-only, causing shutil.rmtree to fail with "Access is denied". 

Add a handler to remove the read-only flag and retry the deletion.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
