### PR TITLE
[uart] Convert to C++17 namespace style

### DIFF
--- a/esphome/components/uart/automation.h
+++ b/esphome/components/uart/automation.h
@@ -5,8 +5,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 template<typename... Ts> class UARTWriteAction : public Action<Ts...>, public Parented<UARTComponent> {
  public:
@@ -41,5 +40,4 @@ template<typename... Ts> class UARTWriteAction : public Action<Ts...>, public Pa
   } code_;
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/button/uart_button.cpp
+++ b/esphome/components/uart/button/uart_button.cpp
@@ -1,8 +1,7 @@
 #include "uart_button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.button";
 
@@ -13,5 +12,4 @@ void UARTButton::press_action() {
 
 void UARTButton::dump_config() { LOG_BUTTON("", "UART Button", this); }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/button/uart_button.h
+++ b/esphome/components/uart/button/uart_button.h
@@ -6,8 +6,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class UARTButton : public button::Button, public UARTDevice, public Component {
  public:
@@ -21,5 +20,4 @@ class UARTButton : public button::Button, public UARTDevice, public Component {
   std::vector<uint8_t> data_;
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/packet_transport/uart_transport.cpp
+++ b/esphome/components/uart/packet_transport/uart_transport.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/application.h"
 #include "uart_transport.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart_transport";
 
@@ -84,5 +83,5 @@ void UARTTransport::send_packet(const std::vector<uint8_t> &buf) const {
   this->write_byte_(crc >> 8);
   this->parent_->write_byte(FLAG_BYTE);
 }
-}  // namespace uart
-}  // namespace esphome
+
+}  // namespace esphome::uart

--- a/esphome/components/uart/packet_transport/uart_transport.h
+++ b/esphome/components/uart/packet_transport/uart_transport.h
@@ -5,8 +5,7 @@
 #include <vector>
 #include "../uart.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 /**
  * A transport protocol for sending and receiving packets over a UART connection.
@@ -37,5 +36,4 @@ class UARTTransport : public packet_transport::PacketTransport, public UARTDevic
   bool rx_control_{};
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/switch/uart_switch.cpp
+++ b/esphome/components/uart/switch/uart_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.switch";
 
@@ -58,5 +57,4 @@ void UARTSwitch::dump_config() {
   }
 }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/switch/uart_switch.h
+++ b/esphome/components/uart/switch/uart_switch.h
@@ -7,8 +7,7 @@
 #include <cinttypes>
 #include <vector>
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class UARTSwitch : public switch_::Switch, public UARTDevice, public Component {
  public:
@@ -33,5 +32,4 @@ class UARTSwitch : public switch_::Switch, public UARTDevice, public Component {
   uint32_t last_transmission_;
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart";
 
@@ -43,5 +42,4 @@ const LogString *parity_to_str(UARTParityOptions parity) {
   }
 }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -6,8 +6,7 @@
 #include "esphome/core/log.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class UARTDevice {
  public:
@@ -74,5 +73,4 @@ class UARTDevice {
   UARTComponent *parent_{nullptr};
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -1,7 +1,6 @@
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart";
 
@@ -28,5 +27,4 @@ void UARTComponent::set_rx_full_threshold_ms(uint8_t time) {
   this->set_rx_full_threshold(val);
 }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -11,8 +11,7 @@
 #include "esphome/core/automation.h"
 #endif
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 enum UARTParityOptions {
   UART_CONFIG_PARITY_NONE,
@@ -199,5 +198,4 @@ class UARTComponent {
 #endif
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -9,8 +9,7 @@
 #include "esphome/components/logger/logger.h"
 #endif
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.arduino_esp8266";
 bool ESP8266UartComponent::serial0_in_use = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -331,6 +330,5 @@ int ESP8266SoftwareSerial::available() {
   return avail;
 }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart
 #endif  // USE_ESP8266

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -9,8 +9,7 @@
 #include "esphome/core/log.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class ESP8266SoftwareSerial {
  public:
@@ -88,7 +87,5 @@ class ESP8266UartComponent : public UARTComponent, public Component {
   static bool serial0_in_use;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 };
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_ESP8266

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -14,8 +14,8 @@
 #include "esphome/components/logger/logger.h"
 #endif
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
+
 static const char *const TAG = "uart.idf";
 
 uart_config_t IDFUARTComponent::get_config_() {
@@ -405,7 +405,5 @@ void IDFUARTComponent::rx_event_task_func(void *param) {
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class IDFUARTComponent : public UARTComponent, public Component {
  public:
@@ -63,7 +62,5 @@ class IDFUARTComponent : public UARTComponent, public Component {
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 };
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -96,8 +96,7 @@ speed_t get_baud(int baud) {
 
 }  // namespace
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.host";
 
@@ -296,7 +295,5 @@ void HostUartComponent::update_error_(const std::string &error) {
   ESP_LOGE(TAG, "Port error: %s", error.c_str());
 }
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_HOST

--- a/esphome/components/uart/uart_component_host.h
+++ b/esphome/components/uart/uart_component_host.h
@@ -6,8 +6,7 @@
 #include "esphome/core/log.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class HostUartComponent : public UARTComponent, public Component {
  public:
@@ -32,7 +31,5 @@ class HostUartComponent : public UARTComponent, public Component {
   uint8_t peek_byte_;
 };
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_HOST

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -14,8 +14,7 @@
 #include <SoftwareSerial.h>
 #endif
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.lt";
 
@@ -187,7 +186,5 @@ void LibreTinyUARTComponent::check_logger_conflict() {
 #endif
 }
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_LIBRETINY

--- a/esphome/components/uart/uart_component_libretiny.h
+++ b/esphome/components/uart/uart_component_libretiny.h
@@ -8,8 +8,7 @@
 #include "esphome/core/log.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class LibreTinyUARTComponent : public UARTComponent, public Component {
  public:
@@ -37,7 +36,5 @@ class LibreTinyUARTComponent : public UARTComponent, public Component {
   int8_t hardware_idx_{-1};
 };
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_LIBRETINY

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -11,8 +11,7 @@
 #include "esphome/components/logger/logger.h"
 #endif
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart.arduino_rp2040";
 
@@ -193,7 +192,5 @@ void RP2040UartComponent::flush() {
   this->serial_->flush();
 }
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_RP2040

--- a/esphome/components/uart/uart_component_rp2040.h
+++ b/esphome/components/uart/uart_component_rp2040.h
@@ -11,8 +11,7 @@
 #include "esphome/core/log.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 class RP2040UartComponent : public UARTComponent, public Component {
  public:
@@ -40,7 +39,5 @@ class RP2040UartComponent : public UARTComponent, public Component {
   HardwareSerial *serial_{nullptr};
 };
 
-}  // namespace uart
-}  // namespace esphome
-
+}  // namespace esphome::uart
 #endif  // USE_RP2040

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -6,8 +6,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 static const char *const TAG = "uart_debug";
 
@@ -197,6 +196,5 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
   delay(10);
 }
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart
 #endif

--- a/esphome/components/uart/uart_debugger.h
+++ b/esphome/components/uart/uart_debugger.h
@@ -8,8 +8,7 @@
 #include "uart.h"
 #include "uart_component.h"
 
-namespace esphome {
-namespace uart {
+namespace esphome::uart {
 
 /// The UARTDebugger class adds debugging support to a UART bus.
 ///
@@ -96,6 +95,5 @@ class UARTDebug {
   static void log_binary(UARTDirection direction, std::vector<uint8_t> bytes, uint8_t separator);
 };
 
-}  // namespace uart
-}  // namespace esphome
+}  // namespace esphome::uart
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Convert the `uart` component from nested namespaces to C++17 style combined namespace declarations.

This changes:
```cpp
namespace esphome {
namespace uart {
```

to:
```cpp
namespace esphome::uart {
```

This is a code modernization change that improves readability and reduces indentation depth.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
