### PR TITLE
[uart] Automatically enable the socket wake infrastructure when RX wake requested

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -125,7 +125,16 @@ def request_wake_loop_on_rx() -> None:
     should call this function during their code generation.
     This enables the RX event task which wakes the main loop when data arrives.
     """
-    _get_data().wake_loop_on_rx = True
+    data = _get_data()
+    if not data.wake_loop_on_rx:
+        data.wake_loop_on_rx = True
+
+        # UART RX event task uses wake_loop_threadsafe() to notify the main loop
+        # Automatically enable the socket wake infrastructure when RX wake is requested
+        if CORE.is_esp32:
+            from esphome.components import socket
+
+            socket.require_wake_loop_threadsafe()
 
 
 def validate_raw_data(value):

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -45,7 +45,7 @@ DOMAIN = "uart"
 
 def AUTO_LOAD() -> list[str]:
     """Conditionally auto-load socket only when wake_loop_on_rx is requested."""
-    if _get_data().wake_loop_on_rx:
+    if CORE.is_esp32:
         return ["socket"]
     return []
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -44,7 +44,10 @@ DOMAIN = "uart"
 
 
 def AUTO_LOAD() -> list[str]:
-    """Conditionally auto-load socket only when wake_loop_on_rx is requested."""
+    """Ideally, we would only auto-load socket only when wake_loop_on_rx is requested;
+    however, AUTO_LOAD is examined before wake_loop_on_rx is set, so instead, since ESP32
+    always uses socket select support in the main app, we'll just ensure it's loaded here.
+    """
     if CORE.is_esp32:
         return ["socket"]
     return []

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -42,6 +42,14 @@ _LOGGER = getLogger(__name__)
 CODEOWNERS = ["@esphome/core"]
 DOMAIN = "uart"
 
+
+def AUTO_LOAD() -> list[str]:
+    """Conditionally auto-load socket only when wake_loop_on_rx is requested."""
+    if _get_data().wake_loop_on_rx:
+        return ["socket"]
+    return []
+
+
 uart_ns = cg.esphome_ns.namespace("uart")
 UARTComponent = uart_ns.class_("UARTComponent")
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -131,10 +131,9 @@ def request_wake_loop_on_rx() -> None:
 
         # UART RX event task uses wake_loop_threadsafe() to notify the main loop
         # Automatically enable the socket wake infrastructure when RX wake is requested
-        if CORE.is_esp32:
-            from esphome.components import socket
+        from esphome.components import socket
 
-            socket.require_wake_loop_threadsafe()
+        socket.require_wake_loop_threadsafe()
 
 
 def validate_raw_data(value):


### PR DESCRIPTION
# What does this implement/fix?

Small change which will automatically enable the socket wake infrastructure when RX wake is requested by another component.

See also #12172

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
