### PR TITLE
[wifi_info] Fix compilation error when using only mac_address sensor, add tests

### DIFF
--- a/esphome/components/wifi_info/wifi_info_text_sensor.cpp
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.cpp
@@ -6,6 +6,8 @@ namespace esphome::wifi_info {
 
 static const char *const TAG = "wifi_info";
 
+#ifdef USE_WIFI_LISTENERS
+
 static constexpr size_t MAX_STATE_LENGTH = 255;
 
 /********************
@@ -97,6 +99,8 @@ void BSSIDWiFiInfo::on_wifi_connect_state(const std::string &ssid, const wifi::b
   }
   this->publish_state(buf);
 }
+
+#endif
 
 /*********************
  * MacAddressWifiInfo

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -9,6 +9,7 @@
 
 namespace esphome::wifi_info {
 
+#ifdef USE_WIFI_LISTENERS
 class IPAddressWiFiInfo final : public Component, public text_sensor::TextSensor, public wifi::WiFiIPStateListener {
  public:
   void setup() override;
@@ -62,6 +63,7 @@ class BSSIDWiFiInfo final : public Component, public text_sensor::TextSensor, pu
   // WiFiConnectStateListener interface
   void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override;
 };
+#endif
 
 class MacAddressWifiInfo final : public Component, public text_sensor::TextSensor {
  public:

--- a/tests/components/wifi_info/common-mac.yaml
+++ b/tests/components/wifi_info/common-mac.yaml
@@ -1,0 +1,8 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+text_sensor:
+  - platform: wifi_info
+    mac_address:
+      name: MAC Address

--- a/tests/components/wifi_info/common.yaml
+++ b/tests/components/wifi_info/common.yaml
@@ -13,6 +13,6 @@ text_sensor:
     bssid:
       name: BSSID
     mac_address:
-      name: Mac Address
+      name: MAC Address
     dns_address:
       name: DNS ADdress

--- a/tests/components/wifi_info/test-mac.esp32-idf.yaml
+++ b/tests/components/wifi_info/test-mac.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common-mac.yaml

--- a/tests/components/wifi_info/test-mac.esp8266-ard.yaml
+++ b/tests/components/wifi_info/test-mac.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common-mac.yaml

--- a/tests/components/wifi_info/test-mac.rp2040-ard.yaml
+++ b/tests/components/wifi_info/test-mac.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common-mac.yaml


### PR DESCRIPTION
# What does this implement/fix?

Small fix to avoid a compilation error when using only mac_address sensor.
Also adds tests to avoid this issue in the future; the new tests check building when only `mac_address` is used since it does not use the wifi listener architecture, unlike all other sensor types supported.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
