### PR TITLE
[wifi] Fix ap_active condition

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -583,9 +583,9 @@ bool WiFiComponent::has_ap() const { return this->has_ap_; }
 bool WiFiComponent::is_ap_active() const {
 #ifdef USE_WIFI_AP
 #ifdef USE_ESP_IDF
-  return s_ap_started;
+  return wifi::s_ap_started;
 #else
-  return s_ap_mode;
+  return wifi::s_ap_mode;
 #endif  // USE_ESP_IDF
 #else
   return false;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -580,7 +580,17 @@ void WiFiComponent::loop() {
 WiFiComponent::WiFiComponent() { global_wifi_component = this; }
 
 bool WiFiComponent::has_ap() const { return this->has_ap_; }
-bool WiFiComponent::is_ap_active() const { return this->ap_setup_; }
+bool WiFiComponent::is_ap_active() const {
+#ifdef USE_WIFI_AP
+#ifdef USE_ESP_IDF
+  return s_ap_started;
+#else
+  return s_ap_mode;
+#endif  // USE_ESP_IDF
+#else
+  return false;
+#endif  // USE_WIFI_AP
+}
 bool WiFiComponent::has_sta() const { return !this->sta_.empty(); }
 #ifdef USE_WIFI_11KV_SUPPORT
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -580,7 +580,7 @@ void WiFiComponent::loop() {
 WiFiComponent::WiFiComponent() { global_wifi_component = this; }
 
 bool WiFiComponent::has_ap() const { return this->has_ap_; }
-bool WiFiComponent::is_ap_active() const { return this->state_ == WIFI_COMPONENT_STATE_AP; }
+bool WiFiComponent::is_ap_active() const { return this->ap_setup_; }
 bool WiFiComponent::has_sta() const { return !this->sta_.empty(); }
 #ifdef USE_WIFI_11KV_SUPPORT
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -580,17 +580,7 @@ void WiFiComponent::loop() {
 WiFiComponent::WiFiComponent() { global_wifi_component = this; }
 
 bool WiFiComponent::has_ap() const { return this->has_ap_; }
-bool WiFiComponent::is_ap_active() const {
-#ifdef USE_WIFI_AP
-#ifdef USE_ESP_IDF
-  return wifi::s_ap_started;
-#else
-  return wifi::s_ap_mode;
-#endif  // USE_ESP_IDF
-#else
-  return false;
-#endif  // USE_WIFI_AP
-}
+bool WiFiComponent::is_ap_active() const { return this->ap_started_; }
 bool WiFiComponent::has_sta() const { return !this->sta_.empty(); }
 #ifdef USE_WIFI_11KV_SUPPORT
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -616,6 +616,7 @@ class WiFiComponent : public Component {
   bool error_from_callback_{false};
   bool scan_done_{false};
   bool ap_setup_{false};
+  bool ap_started_{false};
   bool passive_scan_{false};
   bool has_saved_wifi_settings_{false};
 #ifdef USE_WIFI_11KV_SUPPORT

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -47,7 +47,6 @@ static bool s_sta_got_ip = false;             // NOLINT(cppcoreguidelines-avoid-
 static bool s_sta_connect_not_found = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connect_error = false;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connecting = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_ap_mode = false;                // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
@@ -68,10 +67,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (target_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
-    s_ap_mode = true;
+    this->ap_started_ = true;
   } else if (!target_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
-    s_ap_mode = false;
+    this->ap_started_ = false;
   }
 
   ETS_UART_INTR_DISABLE();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -47,6 +47,7 @@ static bool s_sta_got_ip = false;             // NOLINT(cppcoreguidelines-avoid-
 static bool s_sta_connect_not_found = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connect_error = false;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connecting = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_ap_mode = false;                // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
@@ -67,8 +68,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (target_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
+    s_ap_mode = true;
   } else if (!target_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
+    s_ap_mode = false;
   }
 
   ETS_UART_INTR_DISABLE();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -67,10 +67,8 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (target_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
-    this->ap_started_ = true;
   } else if (!target_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
-    this->ap_started_ = false;
   }
 
   ETS_UART_INTR_DISABLE();
@@ -84,7 +82,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   if (!ret) {
     ESP_LOGW(TAG, "Set mode failed");
+    return false;
   }
+
+  this->ap_started_ = target_ap;
 
   return ret;
 }

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -53,7 +53,6 @@ static esp_netif_t *s_ap_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-
 #endif                                        // USE_WIFI_AP
 static bool s_sta_started = false;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connected = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_ap_started = false;             // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connect_not_found = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connect_error = false;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_connecting = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -831,11 +830,11 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_START) {
     ESP_LOGV(TAG, "AP start");
-    s_ap_started = true;
+    this->ap_started_ = true;
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_STOP) {
     ESP_LOGV(TAG, "AP stop");
-    s_ap_started = false;
+    this->ap_started_ = false;
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_PROBEREQRECVED) {
     const auto &it = data->data.ap_probe_req_rx;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -20,6 +20,7 @@ namespace esphome::wifi {
 static const char *const TAG = "wifi_lt";
 
 static bool s_sta_connecting = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_ap_mode = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = WiFi.getMode();
@@ -37,8 +38,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (enable_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
+    s_ap_mode = true;
   } else if (!enable_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
+    s_ap_mode = false;
   }
 
   uint8_t mode = 0;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -37,10 +37,8 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (enable_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
-    this->ap_started_ = true;
   } else if (!enable_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
-    this->ap_started_ = false;
   }
 
   uint8_t mode = 0;
@@ -52,7 +50,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
 
   if (!ret) {
     ESP_LOGW(TAG, "Setting mode failed");
+    return false;
   }
+
+  this->ap_started_ = enable_ap;
 
   return ret;
 }

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -20,7 +20,6 @@ namespace esphome::wifi {
 static const char *const TAG = "wifi_lt";
 
 static bool s_sta_connecting = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_ap_mode = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = WiFi.getMode();
@@ -38,10 +37,10 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   }
   if (enable_ap && !current_ap) {
     ESP_LOGV(TAG, "Enabling AP");
-    s_ap_mode = true;
+    this->ap_started_ = true;
   } else if (!enable_ap && current_ap) {
     ESP_LOGV(TAG, "Disabling AP");
-    s_ap_mode = false;
+    this->ap_started_ = false;
   }
 
   uint8_t mode = 0;

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -23,12 +23,13 @@ static bool s_sta_was_connected = false;  // NOLINT(cppcoreguidelines-avoid-non-
 static bool s_sta_had_ip = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
-  bool ap_state = false;
   if (sta.has_value()) {
     if (sta.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
     }
   }
+
+  bool ap_state = false;
   if (ap.has_value()) {
     if (ap.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -21,16 +21,19 @@ static const char *const TAG = "wifi_pico_w";
 // Track previous state for detecting changes
 static bool s_sta_was_connected = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_had_ip = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_ap_mode = false;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   if (sta.has_value()) {
     if (sta.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
+      s_ap_mode = false;
     }
   }
   if (ap.has_value()) {
     if (ap.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);
+      s_ap_mode = true;
     }
   }
   return true;

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -21,21 +21,21 @@ static const char *const TAG = "wifi_pico_w";
 // Track previous state for detecting changes
 static bool s_sta_was_connected = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_had_ip = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_ap_mode = false;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
+  bool ap_state = false;
   if (sta.has_value()) {
     if (sta.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
-      s_ap_mode = false;
     }
   }
   if (ap.has_value()) {
     if (ap.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);
-      s_ap_mode = true;
+      ap_state = true;
     }
   }
+  this->ap_started_ = ap_state;
   return true;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Fixes a WiFi AP state condition issue introduced in #[11852](https://github.com/esphome/esphome/pull/11852) when captive portal is enabled and actively scanning.

**Problem:**
When captive portal performs network scanning, it changes the internal WiFi state from `WIFI_COMPONENT_STATE_AP ` to `WIFI_COMPONENT_STATE_STA_SCANNING`. This causes the condition from #[11852](https://github.com/esphome/esphome/pull/11852) to incorrectly evaluate the AP state, breaking functionality when both features are used together.

**Solution:**
Tracks AP enabled/disabled state using existing or new state variables across all WiFi component versions


This ensures the AP state condition remains accurate regardless of scanning activity and enables reliable detection of AP state changes for automation triggers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
on_...:
  - if:
      condition: wifi.ap_active
      then:
        - logger.log: WiFi AP is active!
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
