### PR TITLE
[rtl87xx] Fix AsyncTCP compilation by upgrading FreeRTOS to 8.2.3

### DIFF
--- a/esphome/components/rtl87xx/__init__.py
+++ b/esphome/components/rtl87xx/__init__.py
@@ -6,6 +6,7 @@
 # in schema.py file in this directory.
 
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import libretiny
 from esphome.components.libretiny.const import (
     COMPONENT_RTL87XX,
@@ -45,6 +46,9 @@ CONFIG_SCHEMA.prepend_extra(_set_core_data)
 
 
 async def to_code(config):
+    # Use FreeRTOS 8.2.3+ for xTaskNotifyGive/ulTaskNotifyTake required by AsyncTCP 3.4.3+
+    # https://github.com/esphome/esphome/issues/10220
+    cg.add_platformio_option("custom_versions.freertos", "8.2.3")
     return await libretiny.component_to_code(config)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes RTL87XX (LibreTiny) compilation failure with AsyncTCP 3.4.5 by upgrading FreeRTOS from 8.1.2 to 8.2.3.

Problem: Since ESPHome 2025.7.0, RTL87XX devices fail to compile with errors:
- error: 'xTaskNotifyGive' was not declared in this scope
- error: 'ulTaskNotifyTake' was not declared in this scope

Cause: AsyncTCP 3.4.3+ uses xTaskNotifyGive() and ulTaskNotifyTake() FreeRTOS macros that were introduced in FreeRTOS 8.2.0, but LibreTiny's default FreeRTOS version for RTL87XX is 8.1.2.

Fix: Add custom_versions.freertos: 8.2.3 PlatformIO option for RTL87XX devices, as suggested by @kuba2k2.

Closes #10220

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10220

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
