### PR TITLE
[graph] Added new set_sample_at_index for fixed graphs

### DIFF
--- a/esphome/components/graph/__init__.py
+++ b/esphome/components/graph/__init__.py
@@ -65,7 +65,7 @@ VALUE_POSITION_TYPE = {
 GRAPH_TRACE_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(GraphTrace),
-        cv.Required(CONF_SENSOR): cv.use_id(sensor.Sensor),
+        cv.Optional(CONF_SENSOR): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_NAME): cv.string,
         cv.Optional(CONF_LINE_THICKNESS): cv.positive_int,
         cv.Optional(CONF_LINE_TYPE): cv.enum(LINE_TYPE, upper=True),
@@ -174,11 +174,12 @@ async def to_code(config):
     # Trace options
     for trace in config[CONF_TRACES]:
         tr = cg.new_Pvariable(trace[CONF_ID], GraphTrace())
-        sens = await cg.get_variable(trace[CONF_SENSOR])
-        cg.add(tr.set_sensor(sens))
+        if CONF_SENSOR in trace:
+            sens = await cg.get_variable(trace[CONF_SENSOR])
+            cg.add(tr.set_sensor(sens))
         if CONF_NAME in trace:
             cg.add(tr.set_name(trace[CONF_NAME]))
-        else:
+        elif CONF_SENSOR in trace:
             cg.add(tr.set_name(trace[CONF_SENSOR].id))
         if CONF_LINE_THICKNESS in trace:
             cg.add(tr.set_line_thickness(trace[CONF_LINE_THICKNESS]))

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -46,10 +46,32 @@ void HistoryData::take_sample(float data) {
   }
 }
 
+void HistoryData::recalc_minmax() {
+  this->recent_min_ = NAN;
+  this->recent_max_ = NAN;
+  for (int i = 0; i < this->length_; i++) {
+    if (!std::isnan(this->samples_[i])) {
+      if (std::isnan(this->recent_min_) || this->recent_min_ > this->samples_[i])
+        this->recent_min_ = this->samples_[i];
+      if (std::isnan(this->recent_max_) || this->recent_max_ < this->samples_[i])
+        this->recent_max_ = this->samples_[i];
+    }
+  }
+}
+
+void HistoryData::set_sample_at_index(int idx, float value) {
+  if (idx >= 0 && idx < this->length_) {
+    this->samples_[idx] = value;
+    ESP_LOGI(TAG, "Set sample at index %d to value: %f", idx, value);
+  }
+}
+
 void GraphTrace::init(Graph *g) {
   ESP_LOGI(TAG, "Init trace for sensor %s", this->get_name().c_str());
   this->data_.init(g->get_width());
-  sensor_->add_on_state_callback([this](float state) { this->data_.take_sample(state); });
+  if (sensor_ != nullptr) {
+    sensor_->add_on_state_callback([this](float state) { this->data_.take_sample(state); });
+  }
   this->data_.set_update_time_ms(g->get_duration() * 1000 / g->get_width());
 }
 

--- a/esphome/components/graph/graph.cpp
+++ b/esphome/components/graph/graph.cpp
@@ -62,7 +62,8 @@ void HistoryData::recalc_minmax() {
 void HistoryData::set_sample_at_index(int idx, float value) {
   if (idx >= 0 && idx < this->length_) {
     this->samples_[idx] = value;
-    ESP_LOGI(TAG, "Set sample at index %d to value: %f", idx, value);
+    ESP_LOGD(TAG, "Set sample at index %d to value: %f", idx, value);
+    this->recalc_minmax();
   }
 }
 

--- a/esphome/components/graph/graph.h
+++ b/esphome/components/graph/graph.h
@@ -93,6 +93,8 @@ class HistoryData {
   float get_value(int idx) const { return samples_[(count_ + length_ - 1 - idx) % length_]; }
   float get_recent_max() const { return recent_max_; }
   float get_recent_min() const { return recent_min_; }
+  void set_sample_at_index(int idx, float value);
+  void recalc_minmax();
 
  protected:
   uint32_t last_sample_;
@@ -120,6 +122,7 @@ class GraphTrace {
   void set_continuous(bool continuous) { this->continuous_ = continuous; }
   std::string get_name() { return name_; }
   const HistoryData *get_tracedata() { return &data_; }
+  HistoryData *get_tracedata_mutable() { return &data_; }
 
  protected:
   sensor::Sensor *sensor_{nullptr};
@@ -163,6 +166,12 @@ class Graph : public Component {
   uint32_t get_height() { return height_; }
   float get_graph_limit_min() { return graph_limit_min_; }
   float get_graph_limit_max() { return graph_limit_max_; }
+  GraphTrace *get_trace(size_t index) {
+    if (index < traces_.size()) {
+      return traces_[index];
+    }
+    return nullptr;
+  }
 
  protected:
   uint32_t duration_;  /// in seconds


### PR DESCRIPTION
This adds a new way of setting datapoints on graphs, to enable something fancier than the classic moving buffer based on a sensor

It works by allowing us to set an exact value at a particular index:

```
        if (time.is_valid()) {
          int seconds_today = time.hour * 3600 + time.minute * 60 + time.second;
          int idx = (seconds_today * 1140) / 86400;  // 1140px width, 86400 seconds/day
          ESP_LOGI("solar", "Calculated index %d for production value %.0f", idx, val);

          // Write to graph trace at time-based index
          auto trace = id(solar_combined_graph).get_trace(0);
          if (trace != nullptr) {
            trace->get_tracedata_mutable()->set_sample_at_index(idx, val);
          }
        }
```

I think this is cool, and allows me to make the kind of `graph`s that I want for this particular application.

RFC?

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


![PXL_20251201_050343588](https://github.com/user-attachments/assets/d7f4f25c-4a65-46f9-8b3d-c301dff4482e)
