### PR TITLE
[button] Convert to C++17 nested namespace style

### DIFF
--- a/esphome/components/button/automation.h
+++ b/esphome/components/button/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace button {
+namespace esphome::button {
 
 template<typename... Ts> class PressAction : public Action<Ts...> {
  public:
@@ -24,5 +23,4 @@ class ButtonPressTrigger : public Trigger<> {
   }
 };
 
-}  // namespace button
-}  // namespace esphome
+}  // namespace esphome::button

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -1,8 +1,7 @@
 #include "button.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace button {
+namespace esphome::button {
 
 static const char *const TAG = "button";
 
@@ -26,5 +25,4 @@ void Button::press() {
 }
 void Button::add_on_press_callback(std::function<void()> &&callback) { this->press_callback_.add(std::move(callback)); }
 
-}  // namespace button
-}  // namespace esphome
+}  // namespace esphome::button

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -4,8 +4,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace button {
+namespace esphome::button {
 
 class Button;
 void log_button(const char *tag, const char *prefix, const char *type, Button *obj);
@@ -45,5 +44,4 @@ class Button : public EntityBase, public EntityBase_DeviceClass {
   CallbackManager<void()> press_callback_{};
 };
 
-}  // namespace button
-}  // namespace esphome
+}  // namespace esphome::button


### PR DESCRIPTION
# What does this implement/fix?

Convert the button component to use C++17 nested namespace syntax.

- `namespace esphome { namespace button {` → `namespace esphome::button {`
- Updated closing comments to match: `}  // namespace esphome::button`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code style update only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
