### PR TITLE
[datetime] Convert to C++17 nested namespace style

### DIFF
--- a/esphome/components/datetime/date_entity.cpp
+++ b/esphome/components/datetime/date_entity.cpp
@@ -5,8 +5,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 static const char *const TAG = "datetime.date_entity";
 
@@ -129,7 +128,6 @@ void DateEntityRestoreState::apply(DateEntity *date) {
   date->publish_state();
 }
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_DATE

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -10,8 +10,7 @@
 
 #include "datetime_base.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -111,7 +110,6 @@ template<typename... Ts> class DateSetAction : public Action<Ts...>, public Pare
   }
 };
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_DATE

--- a/esphome/components/datetime/datetime_base.h
+++ b/esphome/components/datetime/datetime_base.h
@@ -8,8 +8,7 @@
 #include "esphome/components/time/real_time_clock.h"
 #endif
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 class DateTimeBase : public EntityBase {
  public:
@@ -37,5 +36,4 @@ class DateTimeStateTrigger : public Trigger<ESPTime> {
   }
 };
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime

--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -5,8 +5,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 static const char *const TAG = "datetime.datetime_entity";
 
@@ -250,7 +249,6 @@ bool OnDateTimeTrigger::matches_(const ESPTime &time) const {
 }
 #endif
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_TIME

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -10,8 +10,7 @@
 
 #include "datetime_base.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -146,7 +145,6 @@ class OnDateTimeTrigger : public Trigger<>, public Component, public Parented<Da
 };
 #endif
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_DATETIME

--- a/esphome/components/datetime/time_entity.cpp
+++ b/esphome/components/datetime/time_entity.cpp
@@ -5,8 +5,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 static const char *const TAG = "datetime.time_entity";
 
@@ -152,7 +151,6 @@ bool OnTimeTrigger::matches_(const ESPTime &time) const {
 }
 #endif
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_TIME

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -10,8 +10,7 @@
 
 #include "datetime_base.h"
 
-namespace esphome {
-namespace datetime {
+namespace esphome::datetime {
 
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -125,7 +124,6 @@ class OnTimeTrigger : public Trigger<>, public Component, public Parented<TimeEn
 };
 #endif
 
-}  // namespace datetime
-}  // namespace esphome
+}  // namespace esphome::datetime
 
 #endif  // USE_DATETIME_TIME


### PR DESCRIPTION
# What does this implement/fix?

Convert the datetime component to use C++17 nested namespace syntax.

- `namespace esphome { namespace datetime {` → `namespace esphome::datetime {`
- Updated closing comments to match: `}  // namespace esphome::datetime`


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code style update only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
