### PR TITLE
[esp8266] Allow IN&OUT pin config for ESP8266

### DIFF
--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -8,7 +8,7 @@ namespace esphome::esp8266 {
 static const char *const TAG = "esp8266";
 
 static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
-  if (flags == gpio::FLAG_OUTPUT) {  // NOLINT(bugprone-branch-clone)
+  if (flags == gpio::FLAG_OUTPUT || flags == (gpio::FLAG_OUTPUT | gpio::FLAG_INPUT)) {  // NOLINT(bugprone-branch-clone)
     return OUTPUT;
   } else if (flags == gpio::FLAG_INPUT) {
     return INPUT;

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -10,9 +10,13 @@ static const char *const TAG = "esp8266";
 static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
   if (flags == gpio::FLAG_OUTPUT || flags == (gpio::FLAG_OUTPUT | gpio::FLAG_INPUT)) {
     return OUTPUT;
-  } else if (flags == gpio::FLAG_INPUT) {
+  }
+
+  if (flags == gpio::FLAG_INPUT) {
     return INPUT;
-  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
+  }
+
+  if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     if (pin == 16) {
       // GPIO16 doesn't have a pullup, so pinMode would fail.
       // However, sometimes this method is called with pullup mode anyway
@@ -21,13 +25,17 @@ static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
       return INPUT;
     }
     return INPUT_PULLUP;
-  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN)) {
-    return INPUT_PULLDOWN_16;
-  } else if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
-    return OUTPUT_OPEN_DRAIN;
-  } else {
-    return 0;
   }
+
+  if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN)) {
+    return INPUT_PULLDOWN_16;
+  }
+
+  if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
+    return OUTPUT_OPEN_DRAIN;
+  }
+
+  return INPUT;
 }
 
 struct ISRPinArg {

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -8,10 +8,10 @@ namespace esphome::esp8266 {
 static const char *const TAG = "esp8266";
 
 static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
-  if (flags == gpio::FLAG_INPUT) {  // NOLINT(bugprone-branch-clone)
-    return INPUT;
-  } else if (flags == gpio::FLAG_OUTPUT) {
+  if (flags == gpio::FLAG_OUTPUT) {  // NOLINT(bugprone-branch-clone)
     return OUTPUT;
+  } else if (flags == gpio::FLAG_INPUT) {
+    return INPUT;
   } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     if (pin == 16) {
       // GPIO16 doesn't have a pullup, so pinMode would fail.

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -8,7 +8,7 @@ namespace esphome::esp8266 {
 static const char *const TAG = "esp8266";
 
 static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
-  if (flags == gpio::FLAG_OUTPUT || flags == (gpio::FLAG_OUTPUT | gpio::FLAG_INPUT)) {  // NOLINT(bugprone-branch-clone)
+  if (flags == gpio::FLAG_OUTPUT || flags == (gpio::FLAG_OUTPUT | gpio::FLAG_INPUT)) {
     return OUTPUT;
   } else if (flags == gpio::FLAG_INPUT) {
     return INPUT;

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -11,11 +11,9 @@ static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
   if (flags == gpio::FLAG_OUTPUT || flags == (gpio::FLAG_OUTPUT | gpio::FLAG_INPUT)) {
     return OUTPUT;
   }
-
   if (flags == gpio::FLAG_INPUT) {
     return INPUT;
   }
-
   if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     if (pin == 16) {
       // GPIO16 doesn't have a pullup, so pinMode would fail.
@@ -26,15 +24,12 @@ static int flags_to_mode(gpio::Flags flags, uint8_t pin) {
     }
     return INPUT_PULLUP;
   }
-
   if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN)) {
     return INPUT_PULLDOWN_16;
   }
-
   if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
     return OUTPUT_OPEN_DRAIN;
   }
-
   return INPUT;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

SSIA, if python config contains both input and output mode for pin schema, pin is set to input and couldnt be used as output. This fixes it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Issue found out while developing https://github.com/esphome/esphome/pull/8899

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
