### PR TITLE
[api] Use StringRef for ActionResponse error message to avoid copy

### DIFF
--- a/tests/integration/fixtures/api_homeassistant.yaml
+++ b/tests/integration/fixtures/api_homeassistant.yaml
@@ -17,6 +17,7 @@ api:
         - button.press: test_all_empty_service
         - button.press: test_rapid_service_calls
         - button.press: test_read_ha_states
+        - button.press: test_action_response_error
         - number.set:
             id: ha_number
             value: 42.5
@@ -309,3 +310,24 @@ button:
           } else {
             ESP_LOGI("test", "HA Empty State has no value (expected)");
           }
+
+  # Test 9: Action response error handling (tests StringRef error message)
+  - platform: template
+    name: "Test Action Response Error"
+    id: test_action_response_error
+    on_press:
+      - logger.log: "Testing action response error handling"
+      - homeassistant.action:
+          action: nonexistent.action_for_error_test
+          data:
+            test_field: "test_value"
+          on_error:
+            - lambda: |-
+                // This tests that StringRef error message works correctly
+                // The error variable is std::string (converted from StringRef)
+                ESP_LOGI("test", "Action error received: %s", error.c_str());
+            - logger.log:
+                format: "Action failed with error message length: %d"
+                args: ['error.size()']
+          on_success:
+            - logger.log: "Action succeeded unexpectedly"

--- a/tests/integration/test_api_homeassistant.py
+++ b/tests/integration/test_api_homeassistant.py
@@ -81,7 +81,14 @@ async def test_api_homeassistant(
         "input_number.set_value": loop.create_future(),  # ha_number_service_call
         "switch.turn_on": loop.create_future(),  # ha_switch_on_service_call
         "switch.turn_off": loop.create_future(),  # ha_switch_off_service_call
+        "nonexistent.action_for_error_test": loop.create_future(),  # error_test_call
     }
+
+    # Future for error message test
+    action_error_received_future = loop.create_future()
+
+    # Store client reference for use in callback
+    client_ref: list = []  # Use list to allow modification in nested function
 
     def on_service_call(service_call: HomeassistantServiceCall) -> None:
         """Capture HomeAssistant service calls."""
@@ -92,6 +99,17 @@ async def test_api_homeassistant(
             future = service_call_futures[service_call.service]
             if not future.done():
                 future.set_result(service_call)
+
+        # Immediately respond to the error test call so the test can proceed
+        # This needs to happen synchronously so ESPHome receives the response
+        # before logging "=== All tests completed ==="
+        if service_call.service == "nonexistent.action_for_error_test" and client_ref:
+            test_error_message = "Test error: action not found"
+            client_ref[0].send_homeassistant_action_response(
+                call_id=service_call.call_id,
+                success=False,
+                error_message=test_error_message,
+            )
 
     def check_output(line: str) -> None:
         """Check log output for expected messages."""
@@ -131,7 +149,12 @@ async def test_api_homeassistant(
             if match:
                 ha_number_future.set_result(match.group(1))
 
-        elif not tests_complete_future.done() and tests_complete_pattern.search(line):
+        # Check for action error message (tests StringRef -> std::string conversion)
+        # Use separate if (not elif) since this can come after tests_complete
+        if not action_error_received_future.done() and "Action error received:" in line:
+            action_error_received_future.set_result(line)
+
+        if not tests_complete_future.done() and tests_complete_pattern.search(line):
             tests_complete_future.set_result(True)
 
     # Run with log monitoring
@@ -143,6 +166,9 @@ async def test_api_homeassistant(
         device_info = await client.device_info()
         assert device_info is not None
         assert device_info.name == "test-ha-api"
+
+        # Store client reference for use in service call callback
+        client_ref.append(client)
 
         # Subscribe to HomeAssistant service calls
         client.subscribe_service_calls(on_service_call)
@@ -291,6 +317,17 @@ async def test_api_homeassistant(
             )
             assert switch_off_call.service == "switch.turn_off"
             assert switch_off_call.data["entity_id"] == "switch.test_switch"
+
+            # 9. Action response error test (tests StringRef error message)
+            # The error response is sent automatically in on_service_call callback
+            # Wait for the error to be logged (proves StringRef -> std::string works)
+            error_log_line = await asyncio.wait_for(
+                action_error_received_future, timeout=2.0
+            )
+            test_error_message = "Test error: action not found"
+            assert test_error_message in error_log_line, (
+                f"Expected error message '{test_error_message}' not found in: {error_log_line}"
+            )
 
         except TimeoutError as e:
             # Show recent log lines for debugging


### PR DESCRIPTION
# What does this implement/fix?

Use `StringRef` instead of `std::string` for `ActionResponse::error_message_` to eliminate an unnecessary string copy when handling Home Assistant action responses.

When an action response is received from Home Assistant, the error message was being copied from the protobuf message into `ActionResponse`. Since the protobuf message outlives the entire callback chain (it's stack-allocated and the callback is synchronous), we can use `StringRef` to reference the original string without copying.

**Savings per action response:**
- Eliminates 1 heap allocation in the common success case
- Reduces `ActionResponse` size by ~8-16 bytes (StringRef is 16 bytes vs std::string's 24-32 bytes)
- Removes std::string copy constructor code instantiation

| Scenario | Before | After | Savings |
|----------|--------|-------|---------|
| Success (common case) | 2 allocations | 1 allocation | 1 allocation saved |
| Error with handler | 2 allocations | 2 allocations | 0 (converts at trigger) |
| Error without handler | 2 allocations | 1 allocation | 1 allocation saved |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing homeassistant.action with on_error continues to work:
button:
  - platform: template
    name: "Test Action"
    on_press:
      - homeassistant.action:
          action: light.turn_on
          data:
            entity_id: light.test
          on_error:
            - logger.log:
                format: "Action failed: %s"
                args: ['error.c_str()']
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
