### PR TITLE
[text_sensor] Add deprecation warning for raw_state member access

### DIFF
--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -25,11 +25,11 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
 }
 
 void TextSensor::publish_state(const std::string &state) {
-  // Only store raw_state_ separately when filters exist
-  // When no filters, raw_state == state, so we avoid the duplicate storage
-  if (this->filter_list_ != nullptr) {
-    this->raw_state_ = state;
-  }
+// Suppress deprecation warning - we need to populate raw_state for backwards compatibility
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  this->raw_state = state;
+#pragma GCC diagnostic pop
   if (this->raw_callback_) {
     this->raw_callback_->call(state);
   }
@@ -85,9 +85,11 @@ void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> call
 
 std::string TextSensor::get_state() const { return this->state; }
 std::string TextSensor::get_raw_state() const {
-  // When no filters exist, raw_state == state, so return state to avoid
-  // requiring separate storage
-  return this->filter_list_ != nullptr ? this->raw_state_ : this->state;
+// Suppress deprecation warning - get_raw_state() is the replacement API
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return this->raw_state;
+#pragma GCC diagnostic pop
 }
 void TextSensor::internal_send_state_to_frontend(const std::string &state) {
   this->state = state;

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -51,6 +51,13 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
 
   std::string state;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  /// @deprecated Use get_raw_state() instead. This member will be removed in ESPHome 2026.6.0.
+  ESPDEPRECATED("Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0", "2025.12.0")
+  std::string raw_state;
+#pragma GCC diagnostic pop
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
 
@@ -62,10 +69,6 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   CallbackManager<void(std::string)> callback_;  ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
-
-  /// Raw state (before filters). Only populated when filters are configured.
-  /// When no filters exist, get_raw_state() returns state directly.
-  std::string raw_state_;
 };
 
 }  // namespace text_sensor


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #12205. This restores the public `raw_state` member with a deprecation warning, giving users a 6-month migration window to switch from `.raw_state` to `.get_raw_state()`.

#12205 removed `raw_state` as a breaking change. While `raw_state` was never documented, users may have discovered it through IDE autocomplete or by looking at the sensor base class. This PR follows the pattern established by `Select.state` deprecation to provide a smoother migration path.

**Changes:**
- Restore `raw_state` as a public member with `ESPDEPRECATED` warning
- Use `#pragma GCC diagnostic` to suppress warnings in internal code
- `get_raw_state()` remains the recommended API
- `raw_state` will be removed in ESPHome 2026.6.0

**Migration for users:**
```cpp
// Before (deprecated, will warn)
id(my_text_sensor).raw_state

// After (recommended)
id(my_text_sensor).get_raw_state()
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #12205

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this adds compiler deprecation warnings
# Users accessing .raw_state in lambdas will see a warning like:
# warning: 'raw_state' is deprecated: Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0

text_sensor:
  - platform: template
    name: "Test Sensor"
    id: test_sensor
    lambda: |-
      // This will now show a deprecation warning:
      // return id(test_sensor).raw_state;

      // Use this instead (no warning):
      return id(test_sensor).get_raw_state();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
