### PR TITLE
[analog_threshold] Fix oscillation when using invert filter

### DIFF
--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -20,6 +20,7 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   sensor::Sensor *sensor_{nullptr};
   TemplatableValue<float> upper_threshold_{};
   TemplatableValue<float> lower_threshold_{};
+  bool raw_state_{false};  // Pre-filter state for hysteresis logic
 };
 
 }  // namespace analog_threshold


### PR DESCRIPTION
# What does this implement/fix?

 The analog_threshold binary sensor oscillates between on/off states when an invert filter is applied and the sensor value falls within the hysteresis zone (between lower and upper thresholds).

Root cause: The hysteresis logic used this->state (the post-filter state) to determine which threshold to compare against. When an invert filter is applied, the inverted state incorrectly influences the next threshold selection, causing the sensor to flip back and forth on each reading.

Fix: Added a raw_state_ member to track the pre-filter state. The hysteresis logic now uses this raw state to decide whether to compare against the upper or lower threshold, ensuring filters don't interfere with the threshold logic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12248

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
