### PR TITLE
[media_player] Add more commands to support Sendspin

### DIFF
--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -72,15 +72,16 @@ CONF_ON_PAUSE = "on_pause"
 CONF_ON_ANNOUNCEMENT = "on_announcement"
 CONF_MEDIA_URL = "media_url"
 
-StateTrigger = media_player_ns.class_("StateTrigger", automation.Trigger.template())
-IdleTrigger = media_player_ns.class_("IdleTrigger", automation.Trigger.template())
-PlayTrigger = media_player_ns.class_("PlayTrigger", automation.Trigger.template())
-PauseTrigger = media_player_ns.class_("PauseTrigger", automation.Trigger.template())
-AnnoucementTrigger = media_player_ns.class_(
-    "AnnouncementTrigger", automation.Trigger.template()
-)
-OnTrigger = media_player_ns.class_("OnTrigger", automation.Trigger.template())
-OffTrigger = media_player_ns.class_("OffTrigger", automation.Trigger.template())
+# State triggers: (config_key, C++ class name)
+_STATE_TRIGGERS = [
+    (CONF_ON_STATE, "StateTrigger"),
+    (CONF_ON_IDLE, "IdleTrigger"),
+    (CONF_ON_PLAY, "PlayTrigger"),
+    (CONF_ON_PAUSE, "PauseTrigger"),
+    (CONF_ON_ANNOUNCEMENT, "AnnouncementTrigger"),
+    (CONF_ON_TURN_ON, "OnTrigger"),
+    (CONF_ON_TURN_OFF, "OffTrigger"),
+]
 # State conditions that all share the same schema and codegen handler
 # Maps YAML condition name suffix to C++ class name
 _STATE_CONDITIONS = [
@@ -96,27 +97,10 @@ _STATE_CONDITIONS = [
 
 async def setup_media_player_core_(var, config):
     await setup_entity(var, config, "media_player")
-    for conf in config.get(CONF_ON_STATE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_IDLE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_PLAY, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_PAUSE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_ANNOUNCEMENT, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_TURN_ON, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
-    for conf in config.get(CONF_ON_TURN_OFF, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+    for conf_key, _ in _STATE_TRIGGERS:
+        for conf in config.get(conf_key, []):
+            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+            await automation.build_automation(trigger, [], conf)
 
 
 async def register_media_player(var, config):
@@ -135,41 +119,14 @@ async def new_media_player(config, *args):
 
 _MEDIA_PLAYER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
     {
-        cv.Optional(CONF_ON_STATE): automation.validate_automation(
+        cv.Optional(conf_key): automation.validate_automation(
             {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(StateTrigger),
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                    media_player_ns.class_(class_name, automation.Trigger.template())
+                ),
             }
-        ),
-        cv.Optional(CONF_ON_IDLE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(IdleTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_PLAY): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PlayTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_PAUSE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PauseTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_ANNOUNCEMENT): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(AnnoucementTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_TURN_ON): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnTrigger),
-            }
-        ),
-        cv.Optional(CONF_ON_TURN_OFF): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OffTrigger),
-            }
-        ),
+        )
+        for conf_key, class_name in _STATE_TRIGGERS
     }
 )
 

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -188,42 +188,48 @@ async def media_player_play_media_action(config, action_id, template_arg, args):
     return var
 
 
-async def _media_player_command_action(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
-    cg.add(var.set_announcement(announcement))
-    return var
-
-
 def _snake_to_camel(name):
     return "".join(word.capitalize() for word in name.split("_"))
 
 
-for _action_name in _COMMAND_ACTIONS:
-    _class_name = f"{_snake_to_camel(_action_name)}Action"
-    _action_class = media_player_ns.class_(
-        _class_name, automation.Action, cg.Parented.template(MediaPlayer)
-    )
-    automation.register_action(
-        f"media_player.{_action_name}", _action_class, MEDIA_PLAYER_ACTION_SCHEMA
-    )(_media_player_command_action)
+def _register_command_actions():
+    async def handler(config, action_id, template_arg, args):
+        var = cg.new_Pvariable(action_id, template_arg)
+        await cg.register_parented(var, config[CONF_ID])
+        announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
+        cg.add(var.set_announcement(announcement))
+        return var
+
+    for action_name in _COMMAND_ACTIONS:
+        class_name = f"{_snake_to_camel(action_name)}Action"
+        action_class = media_player_ns.class_(
+            class_name, automation.Action, cg.Parented.template(MediaPlayer)
+        )
+        automation.register_action(
+            f"media_player.{action_name}", action_class, MEDIA_PLAYER_ACTION_SCHEMA
+        )(handler)
 
 
-async def _media_player_condition(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    return var
+_register_command_actions()
 
 
-for _condition_name in _STATE_CONDITIONS:
-    _class_name = f"Is{_snake_to_camel(_condition_name)}Condition"
-    _condition_class = media_player_ns.class_(_class_name, automation.Condition)
-    automation.register_condition(
-        f"media_player.is_{_condition_name}",
-        _condition_class,
-        MEDIA_PLAYER_CONDITION_SCHEMA,
-    )(_media_player_condition)
+def _register_state_conditions():
+    async def handler(config, action_id, template_arg, args):
+        var = cg.new_Pvariable(action_id, template_arg)
+        await cg.register_parented(var, config[CONF_ID])
+        return var
+
+    for condition_name in _STATE_CONDITIONS:
+        class_name = f"Is{_snake_to_camel(condition_name)}Condition"
+        condition_class = media_player_ns.class_(class_name, automation.Condition)
+        automation.register_condition(
+            f"media_player.is_{condition_name}",
+            condition_class,
+            MEDIA_PLAYER_CONDITION_SCHEMA,
+        )(handler)
+
+
+_register_state_conditions()
 
 
 @automation.register_action(

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -62,6 +62,7 @@ _COMMAND_ACTIONS = [
     "shuffle",
     "unshuffle",
     "group_join",
+    "clear_playlist",
 ]
 
 # State triggers: (config_key, C++ class name)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -36,66 +36,35 @@ MEDIA_PLAYER_FORMAT_PURPOSE_ENUM = {
 }
 
 
-PlayAction = media_player_ns.class_(
-    "PlayAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
 PlayMediaAction = media_player_ns.class_(
     "PlayMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-ToggleAction = media_player_ns.class_(
-    "ToggleAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-PauseAction = media_player_ns.class_(
-    "PauseAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-StopAction = media_player_ns.class_(
-    "StopAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-VolumeUpAction = media_player_ns.class_(
-    "VolumeUpAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-VolumeDownAction = media_player_ns.class_(
-    "VolumeDownAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
 VolumeSetAction = media_player_ns.class_(
     "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
-TurnOnAction = media_player_ns.class_(
-    "TurnOnAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-TurnOffAction = media_player_ns.class_(
-    "TurnOffAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-NextAction = media_player_ns.class_(
-    "NextAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-PreviousAction = media_player_ns.class_(
-    "PreviousAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-MuteAction = media_player_ns.class_(
-    "MuteAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-UnmuteAction = media_player_ns.class_(
-    "UnmuteAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-RepeatOffAction = media_player_ns.class_(
-    "RepeatOffAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-RepeatOneAction = media_player_ns.class_(
-    "RepeatOneAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-RepeatAllAction = media_player_ns.class_(
-    "RepeatAllAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-ShuffleAction = media_player_ns.class_(
-    "ShuffleAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-UnshuffleAction = media_player_ns.class_(
-    "UnshuffleAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-GroupJoinAction = media_player_ns.class_(
-    "GroupJoinAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
+
+# Command actions that all share the same schema and codegen handler
+# Maps YAML action name suffix to C++ class name
+_COMMAND_ACTIONS = [
+    "play",
+    "pause",
+    "stop",
+    "toggle",
+    "volume_up",
+    "volume_down",
+    "turn_on",
+    "turn_off",
+    "next",
+    "previous",
+    "mute",
+    "unmute",
+    "repeat_off",
+    "repeat_one",
+    "repeat_all",
+    "shuffle",
+    "unshuffle",
+    "group_join",
+]
 
 CONF_ANNOUNCEMENT = "announcement"
 CONF_ON_PLAY = "on_play"
@@ -112,15 +81,17 @@ AnnoucementTrigger = media_player_ns.class_(
 )
 OnTrigger = media_player_ns.class_("OnTrigger", automation.Trigger.template())
 OffTrigger = media_player_ns.class_("OffTrigger", automation.Trigger.template())
-IsIdleCondition = media_player_ns.class_("IsIdleCondition", automation.Condition)
-IsPausedCondition = media_player_ns.class_("IsPausedCondition", automation.Condition)
-IsPlayingCondition = media_player_ns.class_("IsPlayingCondition", automation.Condition)
-IsAnnouncingCondition = media_player_ns.class_(
-    "IsAnnouncingCondition", automation.Condition
-)
-IsOnCondition = media_player_ns.class_("IsOnCondition", automation.Condition)
-IsOffCondition = media_player_ns.class_("IsOffCondition", automation.Condition)
-IsMutedCondition = media_player_ns.class_("IsMutedCondition", automation.Condition)
+# State conditions that all share the same schema and codegen handler
+# Maps YAML condition name suffix to C++ class name
+_STATE_CONDITIONS = [
+    "idle",
+    "paused",
+    "playing",
+    "announcing",
+    "on",
+    "off",
+    "muted",
+]
 
 
 async def setup_media_player_core_(var, config):
@@ -259,53 +230,7 @@ async def media_player_play_media_action(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("media_player.play", PlayAction, MEDIA_PLAYER_ACTION_SCHEMA)
-@automation.register_action(
-    "media_player.toggle", ToggleAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.pause", PauseAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action("media_player.stop", StopAction, MEDIA_PLAYER_ACTION_SCHEMA)
-@automation.register_action(
-    "media_player.volume_up", VolumeUpAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.volume_down", VolumeDownAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.turn_on", TurnOnAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.turn_off", TurnOffAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action("media_player.next", NextAction, MEDIA_PLAYER_ACTION_SCHEMA)
-@automation.register_action(
-    "media_player.previous", PreviousAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action("media_player.mute", MuteAction, MEDIA_PLAYER_ACTION_SCHEMA)
-@automation.register_action(
-    "media_player.unmute", UnmuteAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.repeat_off", RepeatOffAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.repeat_one", RepeatOneAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.repeat_all", RepeatAllAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.shuffle", ShuffleAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.unshuffle", UnshuffleAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-@automation.register_action(
-    "media_player.group_join", GroupJoinAction, MEDIA_PLAYER_ACTION_SCHEMA
-)
-async def media_player_action(config, action_id, template_arg, args):
+async def _media_player_command_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
@@ -313,31 +238,34 @@ async def media_player_action(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_condition(
-    "media_player.is_idle", IsIdleCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_paused", IsPausedCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_playing", IsPlayingCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_announcing", IsAnnouncingCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_on", IsOnCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_off", IsOffCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-@automation.register_condition(
-    "media_player.is_muted", IsMutedCondition, MEDIA_PLAYER_CONDITION_SCHEMA
-)
-async def media_player_condition(config, action_id, template_arg, args):
+def _snake_to_camel(name):
+    return "".join(word.capitalize() for word in name.split("_"))
+
+
+for _action_name in _COMMAND_ACTIONS:
+    _class_name = f"{_snake_to_camel(_action_name)}Action"
+    _action_class = media_player_ns.class_(
+        _class_name, automation.Action, cg.Parented.template(MediaPlayer)
+    )
+    automation.register_action(
+        f"media_player.{_action_name}", _action_class, MEDIA_PLAYER_ACTION_SCHEMA
+    )(_media_player_command_action)
+
+
+async def _media_player_condition(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
+
+
+for _condition_name in _STATE_CONDITIONS:
+    _class_name = f"Is{_snake_to_camel(_condition_name)}Condition"
+    _condition_class = media_player_ns.class_(_class_name, automation.Condition)
+    automation.register_condition(
+        f"media_player.is_{_condition_name}",
+        _condition_class,
+        MEDIA_PLAYER_CONDITION_SCHEMA,
+    )(_media_player_condition)
 
 
 @automation.register_action(

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -66,6 +66,36 @@ TurnOnAction = media_player_ns.class_(
 TurnOffAction = media_player_ns.class_(
     "TurnOffAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
+NextAction = media_player_ns.class_(
+    "NextAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+PreviousAction = media_player_ns.class_(
+    "PreviousAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+MuteAction = media_player_ns.class_(
+    "MuteAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+UnmuteAction = media_player_ns.class_(
+    "UnmuteAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+RepeatOffAction = media_player_ns.class_(
+    "RepeatOffAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+RepeatOneAction = media_player_ns.class_(
+    "RepeatOneAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+RepeatAllAction = media_player_ns.class_(
+    "RepeatAllAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+ShuffleAction = media_player_ns.class_(
+    "ShuffleAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+UnshuffleAction = media_player_ns.class_(
+    "UnshuffleAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+GroupJoinAction = media_player_ns.class_(
+    "GroupJoinAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
 
 CONF_ANNOUNCEMENT = "announcement"
 CONF_ON_PLAY = "on_play"
@@ -247,6 +277,32 @@ async def media_player_play_media_action(config, action_id, template_arg, args):
 )
 @automation.register_action(
     "media_player.turn_off", TurnOffAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action("media_player.next", NextAction, MEDIA_PLAYER_ACTION_SCHEMA)
+@automation.register_action(
+    "media_player.previous", PreviousAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action("media_player.mute", MuteAction, MEDIA_PLAYER_ACTION_SCHEMA)
+@automation.register_action(
+    "media_player.unmute", UnmuteAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.repeat_off", RepeatOffAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.repeat_one", RepeatOneAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.repeat_all", RepeatAllAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.shuffle", ShuffleAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.unshuffle", UnshuffleAction, MEDIA_PLAYER_ACTION_SCHEMA
+)
+@automation.register_action(
+    "media_player.group_join", GroupJoinAction, MEDIA_PLAYER_ACTION_SCHEMA
 )
 async def media_player_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -35,16 +35,14 @@ MEDIA_PLAYER_FORMAT_PURPOSE_ENUM = {
     "announcement": MediaPlayerFormatPurpose.PURPOSE_ANNOUNCEMENT,
 }
 
-
-PlayMediaAction = media_player_ns.class_(
-    "PlayMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
-VolumeSetAction = media_player_ns.class_(
-    "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
-)
+# Local config key constants
+CONF_ANNOUNCEMENT = "announcement"
+CONF_ON_PLAY = "on_play"
+CONF_ON_PAUSE = "on_pause"
+CONF_ON_ANNOUNCEMENT = "on_announcement"
+CONF_MEDIA_URL = "media_url"
 
 # Command actions that all share the same schema and codegen handler
-# Maps YAML action name suffix to C++ class name
 _COMMAND_ACTIONS = [
     "play",
     "pause",
@@ -66,12 +64,6 @@ _COMMAND_ACTIONS = [
     "group_join",
 ]
 
-CONF_ANNOUNCEMENT = "announcement"
-CONF_ON_PLAY = "on_play"
-CONF_ON_PAUSE = "on_pause"
-CONF_ON_ANNOUNCEMENT = "on_announcement"
-CONF_MEDIA_URL = "media_url"
-
 # State triggers: (config_key, C++ class name)
 _STATE_TRIGGERS = [
     (CONF_ON_STATE, "StateTrigger"),
@@ -82,8 +74,8 @@ _STATE_TRIGGERS = [
     (CONF_ON_TURN_ON, "OnTrigger"),
     (CONF_ON_TURN_OFF, "OffTrigger"),
 ]
+
 # State conditions that all share the same schema and codegen handler
-# Maps YAML condition name suffix to C++ class name
 _STATE_CONDITIONS = [
     "idle",
     "paused",
@@ -93,6 +85,14 @@ _STATE_CONDITIONS = [
     "off",
     "muted",
 ]
+
+# Special action classes with custom schemas/handlers
+PlayMediaAction = media_player_ns.class_(
+    "PlayMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
+VolumeSetAction = media_player_ns.class_(
+    "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
 
 
 async def setup_media_player_core_(var, config):

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -120,6 +120,7 @@ IsAnnouncingCondition = media_player_ns.class_(
 )
 IsOnCondition = media_player_ns.class_("IsOnCondition", automation.Condition)
 IsOffCondition = media_player_ns.class_("IsOffCondition", automation.Condition)
+IsMutedCondition = media_player_ns.class_("IsMutedCondition", automation.Condition)
 
 
 async def setup_media_player_core_(var, config):
@@ -329,6 +330,9 @@ async def media_player_action(config, action_id, template_arg, args):
 )
 @automation.register_condition(
     "media_player.is_off", IsOffCondition, MEDIA_PLAYER_CONDITION_SCHEMA
+)
+@automation.register_condition(
+    "media_player.is_muted", IsMutedCondition, MEDIA_PLAYER_CONDITION_SCHEMA
 )
 async def media_player_condition(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -52,6 +52,8 @@ template<typename... Ts>
 using UnshuffleAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNSHUFFLE, Ts...>;
 template<typename... Ts>
 using GroupJoinAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_GROUP_JOIN, Ts...>;
+template<typename... Ts>
+using ClearPlaylistAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_CLEAR_PLAYLIST, Ts...>;
 
 template<typename... Ts> class PlayMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(std::string, media_url)

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -32,6 +32,26 @@ template<typename... Ts>
 using TurnOnAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_TURN_ON, Ts...>;
 template<typename... Ts>
 using TurnOffAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_TURN_OFF, Ts...>;
+template<typename... Ts>
+using NextAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_NEXT, Ts...>;
+template<typename... Ts>
+using PreviousAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_PREVIOUS, Ts...>;
+template<typename... Ts>
+using MuteAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_MUTE, Ts...>;
+template<typename... Ts>
+using UnmuteAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNMUTE, Ts...>;
+template<typename... Ts>
+using RepeatOffAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_OFF, Ts...>;
+template<typename... Ts>
+using RepeatOneAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_ONE, Ts...>;
+template<typename... Ts>
+using RepeatAllAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_REPEAT_ALL, Ts...>;
+template<typename... Ts>
+using ShuffleAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_SHUFFLE, Ts...>;
+template<typename... Ts>
+using UnshuffleAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_UNSHUFFLE, Ts...>;
+template<typename... Ts>
+using GroupJoinAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_GROUP_JOIN, Ts...>;
 
 template<typename... Ts> class PlayMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(std::string, media_url)

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -125,5 +125,10 @@ template<typename... Ts> class IsOffCondition : public Condition<Ts...>, public 
   bool check(const Ts &...x) override { return this->parent_->state == MediaPlayerState::MEDIA_PLAYER_STATE_OFF; }
 };
 
+template<typename... Ts> class IsMutedCondition : public Condition<Ts...>, public Parented<MediaPlayer> {
+ public:
+  bool check(const Ts &...x) override { return this->parent_->is_muted(); }
+};
+
 }  // namespace media_player
 }  // namespace esphome

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -77,6 +77,22 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
   }
 }
 
+void MediaPlayerTraits::set_supports_pause(bool supports_pause) {
+  if (supports_pause) {
+    this->features_ |= MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY;
+  } else {
+    this->features_ &= ~(MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY);
+  }
+}
+
+void MediaPlayerTraits::set_supports_turn_off_on(bool supports_turn_off_on) {
+  if (supports_turn_off_on) {
+    this->features_ |= MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON;
+  } else {
+    this->features_ &= ~(MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON);
+  }
+}
+
 void MediaPlayerCall::validate_() {
   if (this->media_url_.has_value()) {
     if (this->command_.has_value() && this->command_.value() != MEDIA_PLAYER_COMMAND_ENQUEUE) {

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -60,6 +60,18 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
       return "TURN_ON";
     case MEDIA_PLAYER_COMMAND_TURN_OFF:
       return "TURN_OFF";
+    case MEDIA_PLAYER_COMMAND_NEXT:
+      return "NEXT";
+    case MEDIA_PLAYER_COMMAND_PREVIOUS:
+      return "PREVIOUS";
+    case MEDIA_PLAYER_COMMAND_REPEAT_ALL:
+      return "REPEAT_ALL";
+    case MEDIA_PLAYER_COMMAND_SHUFFLE:
+      return "SHUFFLE";
+    case MEDIA_PLAYER_COMMAND_UNSHUFFLE:
+      return "UNSHUFFLE";
+    case MEDIA_PLAYER_COMMAND_GROUP_JOIN:
+      return "GROUP_JOIN";
     default:
       return "UNKNOWN";
   }

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -153,6 +153,30 @@ MediaPlayerCall &MediaPlayerCall::set_command(const char *command) {
     this->set_command(MEDIA_PLAYER_COMMAND_TURN_ON);
   } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TURN_OFF")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_TURN_OFF);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("VOLUME_UP")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_VOLUME_UP);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("VOLUME_DOWN")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_VOLUME_DOWN);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("ENQUEUE")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_ENQUEUE);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("REPEAT_ONE")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_REPEAT_ONE);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("REPEAT_OFF")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_REPEAT_OFF);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("REPEAT_ALL")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_REPEAT_ALL);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("CLEAR_PLAYLIST")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_CLEAR_PLAYLIST);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("NEXT")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_NEXT);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("PREVIOUS")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_PREVIOUS);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("SHUFFLE")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_SHUFFLE);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("UNSHUFFLE")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_UNSHUFFLE);
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("GROUP_JOIN")) == 0) {
+    this->set_command(MEDIA_PLAYER_COMMAND_GROUP_JOIN);
   } else {
     ESP_LOGW(TAG, "'%s' - Unrecognized command %s", this->parent_->get_name().c_str(), command);
   }

--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -79,17 +79,17 @@ const char *media_player_command_to_string(MediaPlayerCommand command) {
 
 void MediaPlayerTraits::set_supports_pause(bool supports_pause) {
   if (supports_pause) {
-    this->features_ |= MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY;
+    this->feature_flags_ |= MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY;
   } else {
-    this->features_ &= ~(MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY);
+    this->feature_flags_ &= ~(MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY);
   }
 }
 
 void MediaPlayerTraits::set_supports_turn_off_on(bool supports_turn_off_on) {
   if (supports_turn_off_on) {
-    this->features_ |= MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON;
+    this->feature_flags_ |= MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON;
   } else {
-    this->features_ &= ~(MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON);
+    this->feature_flags_ &= ~(MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON);
   }
 }
 

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -95,7 +95,10 @@ class MediaPlayerTraits {
   uint32_t get_feature_flags() const { return this->feature_flags_; }
   void add_feature_flags(uint32_t feature_flags) { this->feature_flags_ |= feature_flags; }
   void clear_feature_flags(uint32_t feature_flags) { this->feature_flags_ &= ~feature_flags; }
-  bool has_feature_flags(uint32_t feature_flags) const { return this->feature_flags_ & feature_flags; }
+  // Returns true only if all specified flags are set
+  bool has_feature_flags(uint32_t feature_flags) const {
+    return (this->feature_flags_ & feature_flags) == feature_flags;
+  }
 
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -86,64 +86,29 @@ class MediaPlayerTraits {
  public:
   MediaPlayerTraits() = default;
 
-  void set_supports_pause(bool supports_pause) { this->supports_pause_ = supports_pause; }
-  bool get_supports_pause() const { return this->supports_pause_; }
+  // Base features always reported for all media players
+  static constexpr uint32_t BASE_FEATURES =
+      MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA | MediaPlayerEntityFeature::STOP |
+      MediaPlayerEntityFeature::VOLUME_SET | MediaPlayerEntityFeature::VOLUME_MUTE |
+      MediaPlayerEntityFeature::MEDIA_ANNOUNCE;
 
-  void set_supports_turn_off_on(bool supports_turn_off_on) { this->supports_turn_off_on_ = supports_turn_off_on; }
-  bool get_supports_turn_off_on() const { return this->supports_turn_off_on_; }
-
-  void set_supports_next_previous(bool supports_next_previous) {
-    this->supports_next_previous_ = supports_next_previous;
-  }
-  bool get_supports_next_previous() const { return this->supports_next_previous_; }
-
-  void set_supports_repeat(bool supports_repeat) { this->supports_repeat_ = supports_repeat; }
-  bool get_supports_repeat() const { return this->supports_repeat_; }
-
-  void set_supports_shuffle(bool supports_shuffle) { this->supports_shuffle_ = supports_shuffle; }
-  bool get_supports_shuffle() const { return this->supports_shuffle_; }
-
-  void set_supports_clear_playlist(bool supports_clear_playlist) {
-    this->supports_clear_playlist_ = supports_clear_playlist;
-  }
-  bool get_supports_clear_playlist() const { return this->supports_clear_playlist_; }
+  void set_feature(MediaPlayerEntityFeature feature) { this->features_ |= feature; }
+  void clear_feature(MediaPlayerEntityFeature feature) { this->features_ &= ~feature; }
+  bool supports(MediaPlayerEntityFeature feature) const { return (this->features_ & feature) != 0; }
+  uint32_t get_feature_flags() const { return BASE_FEATURES | this->features_; }
 
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 
-  uint32_t get_feature_flags() const {
-    uint32_t flags = 0;
-    flags |= MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA |
-             MediaPlayerEntityFeature::STOP | MediaPlayerEntityFeature::VOLUME_SET |
-             MediaPlayerEntityFeature::VOLUME_MUTE | MediaPlayerEntityFeature::MEDIA_ANNOUNCE;
-    if (this->get_supports_pause()) {
-      flags |= MediaPlayerEntityFeature::PAUSE | MediaPlayerEntityFeature::PLAY;
-    }
-    if (this->get_supports_turn_off_on()) {
-      flags |= MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON;
-    }
-    if (this->get_supports_next_previous()) {
-      flags |= MediaPlayerEntityFeature::NEXT_TRACK | MediaPlayerEntityFeature::PREVIOUS_TRACK;
-    }
-    if (this->get_supports_repeat()) {
-      flags |= MediaPlayerEntityFeature::REPEAT_SET;
-    }
-    if (this->get_supports_shuffle()) {
-      flags |= MediaPlayerEntityFeature::SHUFFLE_SET;
-    }
-    if (this->get_supports_clear_playlist()) {
-      flags |= MediaPlayerEntityFeature::CLEAR_PLAYLIST;
-    }
-    return flags;
-  }
+  // Legacy setters/getters — kept for backward compatibility
+  void set_supports_pause(bool supports_pause);
+  bool get_supports_pause() const { return this->supports(MediaPlayerEntityFeature::PAUSE); }
+
+  void set_supports_turn_off_on(bool supports_turn_off_on);
+  bool get_supports_turn_off_on() const { return this->supports(MediaPlayerEntityFeature::TURN_ON); }
 
  protected:
   std::vector<MediaPlayerSupportedFormat> supported_formats_{};
-  bool supports_pause_{false};
-  bool supports_turn_off_on_{false};
-  bool supports_next_previous_{false};
-  bool supports_repeat_{false};
-  bool supports_shuffle_{false};
-  bool supports_clear_playlist_{false};
+  uint32_t features_{0};
 };
 
 class MediaPlayerCall {

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -81,7 +81,7 @@ struct MediaPlayerSupportedFormat {
 };
 
 // Base features always reported for all media players
-static const uint32_t BASE_MEDIA_PLAYER_FEATURES =
+static constexpr uint32_t BASE_MEDIA_PLAYER_FEATURES =
     MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA | MediaPlayerEntityFeature::STOP |
     MediaPlayerEntityFeature::VOLUME_SET | MediaPlayerEntityFeature::VOLUME_MUTE |
     MediaPlayerEntityFeature::MEDIA_ANNOUNCE;

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -80,22 +80,22 @@ struct MediaPlayerSupportedFormat {
   uint32_t sample_bytes;
 };
 
+// Base features always reported for all media players
+static constexpr uint32_t BASE_MEDIA_PLAYER_FEATURES =
+    MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA | MediaPlayerEntityFeature::STOP |
+    MediaPlayerEntityFeature::VOLUME_SET | MediaPlayerEntityFeature::VOLUME_MUTE |
+    MediaPlayerEntityFeature::MEDIA_ANNOUNCE;
+
 class MediaPlayer;
 
 class MediaPlayerTraits {
  public:
   MediaPlayerTraits() = default;
 
-  // Base features always reported for all media players
-  static constexpr uint32_t BASE_FEATURES =
-      MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA | MediaPlayerEntityFeature::STOP |
-      MediaPlayerEntityFeature::VOLUME_SET | MediaPlayerEntityFeature::VOLUME_MUTE |
-      MediaPlayerEntityFeature::MEDIA_ANNOUNCE;
-
   void set_feature(MediaPlayerEntityFeature feature) { this->features_ |= feature; }
   void clear_feature(MediaPlayerEntityFeature feature) { this->features_ &= ~feature; }
   bool supports(MediaPlayerEntityFeature feature) const { return (this->features_ & feature) != 0; }
-  uint32_t get_feature_flags() const { return BASE_FEATURES | this->features_; }
+  uint32_t get_feature_flags() const { return BASE_MEDIA_PLAYER_FEATURES | this->features_; }
 
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -104,7 +104,9 @@ class MediaPlayerTraits {
   bool get_supports_pause() const { return this->has_feature_flags(MediaPlayerEntityFeature::PAUSE); }
 
   void set_supports_turn_off_on(bool supports_turn_off_on);
-  bool get_supports_turn_off_on() const { return this->has_feature_flags(MediaPlayerEntityFeature::TURN_ON); }
+  bool get_supports_turn_off_on() const {
+    return this->has_feature_flags(MediaPlayerEntityFeature::TURN_ON | MediaPlayerEntityFeature::TURN_OFF);
+  }
 
  protected:
   std::vector<MediaPlayerSupportedFormat> supported_formats_{};

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -92,23 +92,23 @@ class MediaPlayerTraits {
  public:
   MediaPlayerTraits() = default;
 
-  void set_feature(MediaPlayerEntityFeature feature) { this->features_ |= feature; }
-  void clear_feature(MediaPlayerEntityFeature feature) { this->features_ &= ~feature; }
-  bool supports(MediaPlayerEntityFeature feature) const { return (this->features_ & feature) != 0; }
-  uint32_t get_feature_flags() const { return BASE_MEDIA_PLAYER_FEATURES | this->features_; }
+  uint32_t get_feature_flags() const { return this->feature_flags_; }
+  void add_feature_flags(uint32_t feature_flags) { this->feature_flags_ |= feature_flags; }
+  void clear_feature_flags(uint32_t feature_flags) { this->feature_flags_ &= ~feature_flags; }
+  bool has_feature_flags(uint32_t feature_flags) const { return this->feature_flags_ & feature_flags; }
 
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 
   // Legacy setters/getters are kept for backward compatibility
   void set_supports_pause(bool supports_pause);
-  bool get_supports_pause() const { return this->supports(MediaPlayerEntityFeature::PAUSE); }
+  bool get_supports_pause() const { return this->has_feature_flags(MediaPlayerEntityFeature::PAUSE); }
 
   void set_supports_turn_off_on(bool supports_turn_off_on);
-  bool get_supports_turn_off_on() const { return this->supports(MediaPlayerEntityFeature::TURN_ON); }
+  bool get_supports_turn_off_on() const { return this->has_feature_flags(MediaPlayerEntityFeature::TURN_ON); }
 
  protected:
   std::vector<MediaPlayerSupportedFormat> supported_formats_{};
-  uint32_t features_{0};
+  uint32_t feature_flags_{BASE_MEDIA_PLAYER_FEATURES};
 };
 
 class MediaPlayerCall {

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -81,7 +81,7 @@ struct MediaPlayerSupportedFormat {
 };
 
 // Base features always reported for all media players
-static constexpr uint32_t BASE_MEDIA_PLAYER_FEATURES =
+static const uint32_t BASE_MEDIA_PLAYER_FEATURES =
     MediaPlayerEntityFeature::PLAY_MEDIA | MediaPlayerEntityFeature::BROWSE_MEDIA | MediaPlayerEntityFeature::STOP |
     MediaPlayerEntityFeature::VOLUME_SET | MediaPlayerEntityFeature::VOLUME_MUTE |
     MediaPlayerEntityFeature::MEDIA_ANNOUNCE;
@@ -99,7 +99,7 @@ class MediaPlayerTraits {
 
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 
-  // Legacy setters/getters — kept for backward compatibility
+  // Legacy setters/getters are kept for backward compatibility
   void set_supports_pause(bool supports_pause);
   bool get_supports_pause() const { return this->supports(MediaPlayerEntityFeature::PAUSE); }
 

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -58,6 +58,12 @@ enum MediaPlayerCommand : uint8_t {
   MEDIA_PLAYER_COMMAND_CLEAR_PLAYLIST = 11,
   MEDIA_PLAYER_COMMAND_TURN_ON = 12,
   MEDIA_PLAYER_COMMAND_TURN_OFF = 13,
+  MEDIA_PLAYER_COMMAND_NEXT = 14,
+  MEDIA_PLAYER_COMMAND_PREVIOUS = 15,
+  MEDIA_PLAYER_COMMAND_REPEAT_ALL = 16,
+  MEDIA_PLAYER_COMMAND_SHUFFLE = 17,
+  MEDIA_PLAYER_COMMAND_UNSHUFFLE = 18,
+  MEDIA_PLAYER_COMMAND_GROUP_JOIN = 19,
 };
 const char *media_player_command_to_string(MediaPlayerCommand command);
 
@@ -86,6 +92,22 @@ class MediaPlayerTraits {
   void set_supports_turn_off_on(bool supports_turn_off_on) { this->supports_turn_off_on_ = supports_turn_off_on; }
   bool get_supports_turn_off_on() const { return this->supports_turn_off_on_; }
 
+  void set_supports_next_previous(bool supports_next_previous) {
+    this->supports_next_previous_ = supports_next_previous;
+  }
+  bool get_supports_next_previous() const { return this->supports_next_previous_; }
+
+  void set_supports_repeat(bool supports_repeat) { this->supports_repeat_ = supports_repeat; }
+  bool get_supports_repeat() const { return this->supports_repeat_; }
+
+  void set_supports_shuffle(bool supports_shuffle) { this->supports_shuffle_ = supports_shuffle; }
+  bool get_supports_shuffle() const { return this->supports_shuffle_; }
+
+  void set_supports_clear_playlist(bool supports_clear_playlist) {
+    this->supports_clear_playlist_ = supports_clear_playlist;
+  }
+  bool get_supports_clear_playlist() const { return this->supports_clear_playlist_; }
+
   std::vector<MediaPlayerSupportedFormat> &get_supported_formats() { return this->supported_formats_; }
 
   uint32_t get_feature_flags() const {
@@ -99,6 +121,18 @@ class MediaPlayerTraits {
     if (this->get_supports_turn_off_on()) {
       flags |= MediaPlayerEntityFeature::TURN_OFF | MediaPlayerEntityFeature::TURN_ON;
     }
+    if (this->get_supports_next_previous()) {
+      flags |= MediaPlayerEntityFeature::NEXT_TRACK | MediaPlayerEntityFeature::PREVIOUS_TRACK;
+    }
+    if (this->get_supports_repeat()) {
+      flags |= MediaPlayerEntityFeature::REPEAT_SET;
+    }
+    if (this->get_supports_shuffle()) {
+      flags |= MediaPlayerEntityFeature::SHUFFLE_SET;
+    }
+    if (this->get_supports_clear_playlist()) {
+      flags |= MediaPlayerEntityFeature::CLEAR_PLAYLIST;
+    }
     return flags;
   }
 
@@ -106,6 +140,10 @@ class MediaPlayerTraits {
   std::vector<MediaPlayerSupportedFormat> supported_formats_{};
   bool supports_pause_{false};
   bool supports_turn_off_on_{false};
+  bool supports_next_previous_{false};
+  bool supports_repeat_{false};
+  bool supports_shuffle_{false};
+  bool supports_clear_playlist_{false};
 };
 
 class MediaPlayerCall {

--- a/tests/components/media_player/common.yaml
+++ b/tests/components/media_player/common.yaml
@@ -37,6 +37,7 @@ media_player:
       - media_player.shuffle:
       - media_player.unshuffle:
       - media_player.group_join:
+      - media_player.clear_playlist:
       - wait_until:
           media_player.is_idle:
       - wait_until:

--- a/tests/components/media_player/common.yaml
+++ b/tests/components/media_player/common.yaml
@@ -23,6 +23,8 @@ media_player:
       - media_player.stop:
       - media_player.stop:
           announcement: true
+    on_announcement:
+      - media_player.play:
     on_pause:
       - media_player.toggle:
       - media_player.turn_on:

--- a/tests/components/media_player/common.yaml
+++ b/tests/components/media_player/common.yaml
@@ -25,6 +25,18 @@ media_player:
           announcement: true
     on_pause:
       - media_player.toggle:
+      - media_player.turn_on:
+      - media_player.turn_off:
+      - media_player.next:
+      - media_player.previous:
+      - media_player.mute:
+      - media_player.unmute:
+      - media_player.repeat_off:
+      - media_player.repeat_one:
+      - media_player.repeat_all:
+      - media_player.shuffle:
+      - media_player.unshuffle:
+      - media_player.group_join:
       - wait_until:
           media_player.is_idle:
       - wait_until:
@@ -33,6 +45,12 @@ media_player:
           media_player.is_announcing:
       - wait_until:
           media_player.is_paused:
+      - wait_until:
+          media_player.is_on:
+      - wait_until:
+          media_player.is_off:
+      - wait_until:
+          media_player.is_muted:
       - media_player.volume_up:
       - media_player.volume_down:
       - media_player.volume_set: 50%

--- a/tests/components/media_player/common.yaml
+++ b/tests/components/media_player/common.yaml
@@ -25,6 +25,10 @@ media_player:
           announcement: true
     on_announcement:
       - media_player.play:
+    on_turn_on:
+      - media_player.play:
+    on_turn_off:
+      - media_player.stop:
     on_pause:
       - media_player.toggle:
       - media_player.turn_on:


### PR DESCRIPTION
# What does this implement/fix?

Updates the base media_player platform component with more actions and conditions to support the upcoming Sendspin component.

- Adds several new media player commands along with YAML actions for each: ``next``, ``previous``, ``repeat_all``, ``shuffle``, ``unshuffle``, ``group_join``, and ``clear_playlist``
- Adds a new ``media_player.is_muted`` YAML condition
- Updates the tests to include all the new (and previously missing) actions, conditions, and triggers
- Refactors the ``MediaPlayerTraits`` class:
  - Uses a single uint32_t feature flag member variable that the setters/getters manipulate directly. This is in place of using a bool member variable for each feature flag. 
  - Adds generalized ``add_feature_flags``, ``clear_feature_flags``, and ``has_feature_flags`` helpers based on the ClimateTraits example. Keeps the existing setters/getters for pause and on/off for backwards compatibility (in the future, we should mark these as deprecated)
  - Adds a ``BASE_MEDIA_PLAYER_FEATURES`` constant variable that matches the current defaults (this should be revisited in the future, as newer media players may not support all of these features)
 - Refactors the codegen for building the actions, conditions, and triggers to reduce boilerplate repetition. All of them are setup in a list and are processed one-by-one in a loop

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#6101

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: i2s_audio
    name: None
    dac_type: external
    i2s_dout_pin: 18
    mute_pin: 19
    on_state:
      - media_player.play:
      - media_player.play_media: http://localhost/media.mp3
      - media_player.play_media: !lambda 'return "http://localhost/media.mp3";'
    on_idle:
      - media_player.pause:
    on_play:
      - media_player.stop:
      - media_player.stop:
          announcement: true
    on_pause:
      - media_player.toggle:
      - media_player.turn_on:
      - media_player.turn_off:
      - media_player.next:
      - media_player.previous:
      - media_player.mute:
      - media_player.unmute:
      - media_player.repeat_off:
      - media_player.repeat_one:
      - media_player.repeat_all:
      - media_player.shuffle:
      - media_player.unshuffle:
      - media_player.group_join:
      - wait_until:
          media_player.is_idle:
      - wait_until:
          media_player.is_playing:
      - wait_until:
          media_player.is_announcing:
      - wait_until:
          media_player.is_paused:
      - wait_until:
          media_player.is_on:
      - wait_until:
          media_player.is_off:
      - wait_until:
          media_player.is_muted:
      - media_player.volume_up:
      - media_player.volume_down:
      - media_player.volume_set: 50%

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
