### PR TITLE
[cst816] Fix CST826 & CST836

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+example/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-example/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -17,14 +17,16 @@ void CST816Touchscreen::continue_setup_() {
       return;
     }
   }
-  // CST826/CST836 return 0 for chip ID, need to read from factory ID register
+
   if (this->chip_id_ == 0) {
+    // CST826/CST836 return 0 for chip ID, need to read from factory ID register
     if (!this->read_byte(REG_FACTORY_ID, &this->chip_id_) && !this->skip_probe_) {
       this->status_set_error(LOG_STR("Failed to read chip ID"));
       this->mark_failed();
       return;
     }
   }
+
   switch (this->chip_id_) {
     case CST716_CHIP_ID:
     case CST816S_CHIP_ID:

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -22,7 +22,7 @@ void CST816Touchscreen::continue_setup_() {
         if (this->read_byte(REG_CHIP_TYPE, &this->chip_type_)) {
           switch (this->chip_type_) {
             case CST826_CHIP_ID:
-            case CST846_CHIP_ID:
+            case CST836_CHIP_ID:
               break;
             default:
               ESP_LOGE(TAG, "Unknown chip type: 0x%02X", this->chip_type_);
@@ -122,7 +122,7 @@ void CST816Touchscreen::dump_config() {
           case CST826_CHIP_ID:
             name = "CST826";
             break;
-          case CST846_CHIP_ID:
+          case CST836_CHIP_ID:
             name = "CST836";
             break;
         }

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -18,8 +18,8 @@ void CST816Touchscreen::continue_setup_() {
     }
   }
 
+  // CST826/CST836 return 0 for chip ID, need to read from factory ID register
   if (this->chip_id_ == 0) {
-    // CST826/CST836 return 0 for chip ID, need to read from factory ID register
     if (!this->read_byte(REG_FACTORY_ID, &this->chip_id_) && !this->skip_probe_) {
       this->status_set_error(LOG_STR("Failed to read chip ID"));
       this->mark_failed();

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -9,14 +9,32 @@ void CST816Touchscreen::continue_setup_() {
     this->interrupt_pin_->setup();
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
+
   if (this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
     switch (this->chip_id_) {
       case CST820_CHIP_ID:
-      case CST826_CHIP_ID:
       case CST716_CHIP_ID:
       case CST816S_CHIP_ID:
       case CST816D_CHIP_ID:
       case CST816T_CHIP_ID:
+        break;
+      case 0x00:
+        if (this->read_byte(REG_CHIP_TYPE, &this->chip_type_)) {
+          switch (this->chip_type_) {
+            case CST826_CHIP_ID:
+            case CST846_CHIP_ID:
+              break;
+            default:
+              ESP_LOGE(TAG, "Unknown chip type: 0x%02X", this->chip_type_);
+              this->status_set_error(LOG_STR("Unknown chip type"));
+              this->mark_failed();
+              return;
+          }
+        } else if (!this->skip_probe_) {
+          this->status_set_error(LOG_STR("Failed to read chip type"));
+          this->mark_failed();
+          return;
+        }
         break;
       default:
         ESP_LOGE(TAG, "Unknown chip ID: 0x%02X", this->chip_id_);
@@ -97,6 +115,18 @@ void CST816Touchscreen::dump_config() {
       break;
     case CST816T_CHIP_ID:
       name = "CST816T";
+      break;
+    case 0x00:
+      if (this->chip_type_) {
+        switch (this->chip_type_) {
+          case CST826_CHIP_ID:
+            name = "CST826";
+            break;
+          case CST846_CHIP_ID:
+            name = "CST836";
+            break;
+        }
+      }
       break;
     default:
       name = "Unknown";

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -10,44 +10,39 @@ void CST816Touchscreen::continue_setup_() {
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
 
-  if (this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
-    switch (this->chip_id_) {
-      case CST820_CHIP_ID:
-      case CST716_CHIP_ID:
-      case CST816S_CHIP_ID:
-      case CST816D_CHIP_ID:
-      case CST816T_CHIP_ID:
-        break;
-      case 0x00:
-        if (this->read_byte(REG_CHIP_TYPE, &this->chip_type_)) {
-          switch (this->chip_type_) {
-            case CST826_CHIP_ID:
-            case CST836_CHIP_ID:
-              break;
-            default:
-              ESP_LOGE(TAG, "Unknown chip type: 0x%02X", this->chip_type_);
-              this->status_set_error(LOG_STR("Unknown chip type"));
-              this->mark_failed();
-              return;
-          }
-        } else if (!this->skip_probe_) {
-          this->status_set_error(LOG_STR("Failed to read chip type"));
-          this->mark_failed();
-          return;
-        }
-        break;
-      default:
+  if (!this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
+    if (!this->skip_probe_) {
+      this->status_set_error(LOG_STR("Failed to read chip ID"));
+      this->mark_failed();
+      return;
+    }
+  }
+  // CST826/CST836 return 0 for chip ID, need to read from factory ID register
+  if (this->chip_id_ == 0) {
+    if (!this->read_byte(REG_FACTORY_ID, &this->chip_id_) && !this->skip_probe_) {
+      this->status_set_error(LOG_STR("Failed to read chip ID"));
+      this->mark_failed();
+      return;
+    }
+  }
+  switch (this->chip_id_) {
+    case CST716_CHIP_ID:
+    case CST816S_CHIP_ID:
+    case CST816D_CHIP_ID:
+    case CST816T_CHIP_ID:
+    case CST820_CHIP_ID:
+    case CST826_CHIP_ID:
+    case CST836_CHIP_ID:
+      break;
+    default:
+      if (!this->skip_probe_) {
         ESP_LOGE(TAG, "Unknown chip ID: 0x%02X", this->chip_id_);
         this->status_set_error(LOG_STR("Unknown chip ID"));
         this->mark_failed();
         return;
-    }
-    this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);
-  } else if (!this->skip_probe_) {
-    this->status_set_error(LOG_STR("Failed to read chip id"));
-    this->mark_failed();
-    return;
+      }
   }
+  this->write_byte(REG_IRQ_CTL, IRQ_EN_MOTION);
   if (this->x_raw_max_ == this->x_raw_min_) {
     this->x_raw_max_ = this->display_->get_native_width();
   }
@@ -98,11 +93,8 @@ void CST816Touchscreen::dump_config() {
                 this->x_raw_min_, this->x_raw_max_, this->y_raw_min_, this->y_raw_max_);
   const char *name;
   switch (this->chip_id_) {
-    case CST820_CHIP_ID:
-      name = "CST820";
-      break;
-    case CST826_CHIP_ID:
-      name = "CST826";
+    case CST716_CHIP_ID:
+      name = "CST716";
       break;
     case CST816S_CHIP_ID:
       name = "CST816S";
@@ -110,23 +102,17 @@ void CST816Touchscreen::dump_config() {
     case CST816D_CHIP_ID:
       name = "CST816D";
       break;
-    case CST716_CHIP_ID:
-      name = "CST716";
-      break;
     case CST816T_CHIP_ID:
       name = "CST816T";
       break;
-    case 0x00:
-      if (this->chip_type_) {
-        switch (this->chip_type_) {
-          case CST826_CHIP_ID:
-            name = "CST826";
-            break;
-          case CST836_CHIP_ID:
-            name = "CST836";
-            break;
-        }
-      }
+    case CST820_CHIP_ID:
+      name = "CST820";
+      break;
+    case CST826_CHIP_ID:
+      name = "CST826";
+      break;
+    case CST836_CHIP_ID:
+      name = "CST836";
       break;
     default:
       name = "Unknown";

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.cpp
@@ -10,12 +10,10 @@ void CST816Touchscreen::continue_setup_() {
     this->attach_interrupt_(this->interrupt_pin_, gpio::INTERRUPT_FALLING_EDGE);
   }
 
-  if (!this->read_byte(REG_CHIP_ID, &this->chip_id_)) {
-    if (!this->skip_probe_) {
-      this->status_set_error(LOG_STR("Failed to read chip ID"));
-      this->mark_failed();
-      return;
-    }
+  if (!this->read_byte(REG_CHIP_ID, &this->chip_id_) && !this->skip_probe_) {
+    this->status_set_error(LOG_STR("Failed to read chip ID"));
+    this->mark_failed();
+    return;
   }
 
   // CST826/CST836 return 0 for chip ID, need to read from factory ID register

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -19,7 +19,7 @@ static const uint8_t REG_YPOS_HIGH = 0x05;
 static const uint8_t REG_YPOS_LOW = 0x06;
 static const uint8_t REG_DIS_AUTOSLEEP = 0xFE;
 static const uint8_t REG_CHIP_ID = 0xA7;
-static const uint8_t REG_CHIP_TYPE = 0xAA;
+static const uint8_t REG_FACTORY_ID = 0xAA;
 static const uint8_t REG_FW_VERSION = 0xA9;
 static const uint8_t REG_SLEEP = 0xE5;
 static const uint8_t REG_IRQ_CTL = 0xFA;
@@ -54,7 +54,6 @@ class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   InternalGPIOPin *interrupt_pin_{};
   GPIOPin *reset_pin_{};
   uint8_t chip_id_{};
-  uint8_t chip_type_{};
   bool skip_probe_{};  // if set, do not expect to be able to probe the controller on the i2c bus.
 };
 

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -19,12 +19,14 @@ static const uint8_t REG_YPOS_HIGH = 0x05;
 static const uint8_t REG_YPOS_LOW = 0x06;
 static const uint8_t REG_DIS_AUTOSLEEP = 0xFE;
 static const uint8_t REG_CHIP_ID = 0xA7;
+static const uint8_t REG_CHIP_TYPE = 0xAA;
 static const uint8_t REG_FW_VERSION = 0xA9;
 static const uint8_t REG_SLEEP = 0xE5;
 static const uint8_t REG_IRQ_CTL = 0xFA;
 static const uint8_t IRQ_EN_MOTION = 0x70;
 
 static const uint8_t CST826_CHIP_ID = 0x11;
+static const uint8_t CST846_CHIP_ID = 0x13;
 static const uint8_t CST820_CHIP_ID = 0xB7;
 static const uint8_t CST816S_CHIP_ID = 0xB4;
 static const uint8_t CST816D_CHIP_ID = 0xB6;
@@ -52,6 +54,7 @@ class CST816Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice
   InternalGPIOPin *interrupt_pin_{};
   GPIOPin *reset_pin_{};
   uint8_t chip_id_{};
+  uint8_t chip_type_{};
   bool skip_probe_{};  // if set, do not expect to be able to probe the controller on the i2c bus.
 };
 

--- a/esphome/components/cst816/touchscreen/cst816_touchscreen.h
+++ b/esphome/components/cst816/touchscreen/cst816_touchscreen.h
@@ -26,7 +26,7 @@ static const uint8_t REG_IRQ_CTL = 0xFA;
 static const uint8_t IRQ_EN_MOTION = 0x70;
 
 static const uint8_t CST826_CHIP_ID = 0x11;
-static const uint8_t CST846_CHIP_ID = 0x13;
+static const uint8_t CST836_CHIP_ID = 0x13;
 static const uint8_t CST820_CHIP_ID = 0xB7;
 static const uint8_t CST816S_CHIP_ID = 0xB4;
 static const uint8_t CST816D_CHIP_ID = 0xB6;


### PR DESCRIPTION
# What does this implement/fix?

CST826 and CST836 return 0x00 in the 0xA7 register, so you have to look at the 0xAA register for chip_type. This change reflects that behavior in the continue_setup_ () and dump_config() methods.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5718

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
touchscreen:
  platform: cst816
  id: touch
  display: round_display
  update_interval: 50ms
  reset_pin:
    pcf8574: pcf8574_hub
    number: 0
  skip_probe: true
  i2c_id: i2c_touch
  on_touch:
    - logger.log:
        format: Touch at (%d, %d)
        args: [touch.x, touch.y]
    - lambda: |-
        ESP_LOGI("cal", "x=%d, y=%d, x_raw=%d, y_raw=%0d",
            touch.x,
            touch.y,
            touch.x_raw,
            touch.y_raw
            );
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
