### PR TITLE
[rtl87xx] Fix FreeRTOS version for RTL8720C boards

### DIFF
--- a/esphome/components/rtl87xx/__init__.py
+++ b/esphome/components/rtl87xx/__init__.py
@@ -10,7 +10,9 @@ import esphome.codegen as cg
 from esphome.components import libretiny
 from esphome.components.libretiny.const import (
     COMPONENT_RTL87XX,
+    FAMILY_RTL8710B,
     KEY_COMPONENT_DATA,
+    KEY_FAMILY,
     KEY_LIBRETINY,
     LibreTinyComponent,
 )
@@ -48,7 +50,9 @@ CONFIG_SCHEMA.prepend_extra(_set_core_data)
 async def to_code(config):
     # Use FreeRTOS 8.2.3+ for xTaskNotifyGive/ulTaskNotifyTake required by AsyncTCP 3.4.3+
     # https://github.com/esphome/esphome/issues/10220
-    cg.add_platformio_option("custom_versions.freertos", "8.2.3")
+    # Only for RTL8710B (ambz) - RTL8720C (ambz2) requires FreeRTOS 10.x
+    if CORE.data[KEY_LIBRETINY][KEY_FAMILY] == FAMILY_RTL8710B:
+        cg.add_platformio_option("custom_versions.freertos", "8.2.3")
     return await libretiny.component_to_code(config)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation failure for RTL8720C (ambz2) boards introduced by #12230.

The recent FreeRTOS 8.2.3 upgrade was applied unconditionally to all RTL87xx boards, but RTL8720C boards use the realtek-ambz2 framework which requires FreeRTOS 10.x. The ambz2 heap_5.c port checks for configSUPPORT_DYNAMIC_ALLOCATION, a config option that doesn't exist in FreeRTOS 8.2.3 (added in 9.0.0), causing compilation to fail with: `#error This file must not be used if configSUPPORT_DYNAMIC_ALLOCATION is 0`

This PR makes the FreeRTOS version override conditional:
- RTL8710B (ambz) boards: Use FreeRTOS 8.2.3 (for AsyncTCP compatibility)
- RTL8720C (ambz2) boards: Use default FreeRTOS 10.0.1 (required by freertos-port)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
