### PR TITLE
[text_sensor] Fix spurious raw_state deprecation warnings

### DIFF
--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -24,7 +24,17 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
 
 class TextSensor : public EntityBase, public EntityBase_DeviceClass {
  public:
+  std::string state;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  /// @deprecated Use get_raw_state() instead. This member will be removed in ESPHome 2026.6.0.
+  ESPDEPRECATED("Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0", "2025.12.0")
+  std::string raw_state;
+
   TextSensor() = default;
+  ~TextSensor() = default;
+#pragma GCC diagnostic pop
 
   /// Getter-syntax for .state.
   std::string get_state() const;
@@ -48,15 +58,6 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   void add_on_state_callback(std::function<void(std::string)> callback);
   /// Add a callback that will be called every time the sensor sends a raw value.
   void add_on_raw_state_callback(std::function<void(std::string)> callback);
-
-  std::string state;
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  /// @deprecated Use get_raw_state() instead. This member will be removed in ESPHome 2026.6.0.
-  ESPDEPRECATED("Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0", "2025.12.0")
-  std::string raw_state;
-#pragma GCC diagnostic pop
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)


### PR DESCRIPTION
# What does this implement/fix?

Fixes spurious deprecation warnings during `TextSensor` construction by wrapping both the deprecated `raw_state` field and the default constructor in a single `#pragma GCC diagnostic` block.

The default constructor was triggering deprecation warnings when the compiler generated code to initialize the deprecated `raw_state` member. This fix follows the same pattern used in `select.h` for its deprecated `state` field.

**Before:** Component tests showed repeated warnings:
```
warning: 'esphome::text_sensor::TextSensor::raw_state' is deprecated: Use get_raw_state() instead of .raw_state. Will be removed in 2026.6.0 [-Wdeprecated-declarations]
```

**After:** Clean compilation without spurious warnings. The field remains properly deprecated for external users.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported by @swoboda1337 in Discord

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal fix only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
