### PR TITLE
2025.11.3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.11.2
+PROJECT_NUMBER         = 2025.11.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/ade7953_base/ade7953_base.cpp
+++ b/esphome/components/ade7953_base/ade7953_base.cpp
@@ -25,7 +25,8 @@ void ADE7953::setup() {
     this->ade_write_8(PGA_V_8, pga_v_);
     this->ade_write_8(PGA_IA_8, pga_ia_);
     this->ade_write_8(PGA_IB_8, pga_ib_);
-    this->ade_write_32(AVGAIN_32, vgain_);
+    this->ade_write_32(AVGAIN_32, avgain_);
+    this->ade_write_32(BVGAIN_32, bvgain_);
     this->ade_write_32(AIGAIN_32, aigain_);
     this->ade_write_32(BIGAIN_32, bigain_);
     this->ade_write_32(AWGAIN_32, awgain_);
@@ -34,7 +35,8 @@ void ADE7953::setup() {
     this->ade_read_8(PGA_V_8, &pga_v_);
     this->ade_read_8(PGA_IA_8, &pga_ia_);
     this->ade_read_8(PGA_IB_8, &pga_ib_);
-    this->ade_read_32(AVGAIN_32, &vgain_);
+    this->ade_read_32(AVGAIN_32, &avgain_);
+    this->ade_read_32(BVGAIN_32, &bvgain_);
     this->ade_read_32(AIGAIN_32, &aigain_);
     this->ade_read_32(BIGAIN_32, &bigain_);
     this->ade_read_32(AWGAIN_32, &awgain_);
@@ -63,13 +65,14 @@ void ADE7953::dump_config() {
                 "  PGA_V_8: 0x%X\n"
                 "  PGA_IA_8: 0x%X\n"
                 "  PGA_IB_8: 0x%X\n"
-                "  VGAIN_32: 0x%08jX\n"
+                "  AVGAIN_32: 0x%08jX\n"
+                "  BVGAIN_32: 0x%08jX\n"
                 "  AIGAIN_32: 0x%08jX\n"
                 "  BIGAIN_32: 0x%08jX\n"
                 "  AWGAIN_32: 0x%08jX\n"
                 "  BWGAIN_32: 0x%08jX",
-                this->use_acc_energy_regs_, pga_v_, pga_ia_, pga_ib_, (uintmax_t) vgain_, (uintmax_t) aigain_,
-                (uintmax_t) bigain_, (uintmax_t) awgain_, (uintmax_t) bwgain_);
+                this->use_acc_energy_regs_, pga_v_, pga_ia_, pga_ib_, (uintmax_t) avgain_, (uintmax_t) bvgain_,
+                (uintmax_t) aigain_, (uintmax_t) bigain_, (uintmax_t) awgain_, (uintmax_t) bwgain_);
 }
 
 #define ADE_PUBLISH_(name, val, factor) \

--- a/esphome/components/ade7953_base/ade7953_base.h
+++ b/esphome/components/ade7953_base/ade7953_base.h
@@ -46,7 +46,12 @@ class ADE7953 : public PollingComponent, public sensor::Sensor {
   void set_pga_ib(uint8_t pga_ib) { pga_ib_ = pga_ib; }
 
   // Set input gains
-  void set_vgain(uint32_t vgain) { vgain_ = vgain; }
+  void set_vgain(uint32_t vgain) {
+    // Datasheet says: "to avoid discrepancies in other registers,
+    // if AVGAIN is set then BVGAIN should be set to the same value."
+    avgain_ = vgain;
+    bvgain_ = vgain;
+  }
   void set_aigain(uint32_t aigain) { aigain_ = aigain; }
   void set_bigain(uint32_t bigain) { bigain_ = bigain; }
   void set_awgain(uint32_t awgain) { awgain_ = awgain; }
@@ -100,7 +105,8 @@ class ADE7953 : public PollingComponent, public sensor::Sensor {
   uint8_t pga_v_;
   uint8_t pga_ia_;
   uint8_t pga_ib_;
-  uint32_t vgain_;
+  uint32_t avgain_;
+  uint32_t bvgain_;
   uint32_t aigain_;
   uint32_t bigain_;
   uint32_t awgain_;

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -20,6 +20,7 @@ class AnalogThresholdBinarySensor : public Component, public binary_sensor::Bina
   sensor::Sensor *sensor_{nullptr};
   TemplatableValue<float> upper_threshold_{};
   TemplatableValue<float> lower_threshold_{};
+  bool raw_state_{false};  // Pre-filter state for hysteresis logic
 };
 
 }  // namespace analog_threshold

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -10,6 +10,7 @@
 
 #include <esp_event.h>
 #include <esp_mac.h>
+#include <esp_netif.h>
 #include <esp_now.h>
 #include <esp_random.h>
 #include <esp_wifi.h>
@@ -157,6 +158,12 @@ bool ESPNowComponent::is_wifi_enabled() {
 }
 
 void ESPNowComponent::setup() {
+#ifndef USE_WIFI
+  // Initialize LwIP stack for wake_loop_threadsafe() socket support
+  // When WiFi component is present, it handles esp_netif_init()
+  ESP_ERROR_CHECK(esp_netif_init());
+#endif
+
   if (this->enable_on_boot_) {
     this->enable_();
   } else {

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -189,7 +189,7 @@ template<typename... Ts> class EnrollmentAction : public Action<Ts...>, public P
   TEMPLATABLE_VALUE(std::string, name)
   TEMPLATABLE_VALUE(uint8_t, direction)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     auto name = this->name_.value(x...);
     auto direction = (HlkFm22xFaceDirection) this->direction_.value(x...);
     this->parent_->enroll_face(name, direction);
@@ -200,7 +200,7 @@ template<typename... Ts> class DeleteAction : public Action<Ts...>, public Paren
  public:
   TEMPLATABLE_VALUE(int16_t, face_id)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     auto face_id = this->face_id_.value(x...);
     this->parent_->delete_face(face_id);
   }
@@ -208,17 +208,17 @@ template<typename... Ts> class DeleteAction : public Action<Ts...>, public Paren
 
 template<typename... Ts> class DeleteAllAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->delete_all_faces(); }
+  void play(const Ts &...x) override { this->parent_->delete_all_faces(); }
 };
 
 template<typename... Ts> class ScanAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->scan_face(); }
+  void play(const Ts &...x) override { this->parent_->scan_face(); }
 };
 
 template<typename... Ts> class ResetAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->reset(); }
+  void play(const Ts &...x) override { this->parent_->reset(); }
 };
 
 }  // namespace esphome::hlk_fm22x

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -116,7 +116,7 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   // Get temperature of sensor
   if (this->temperature_ != nullptr) {
-    uint8_t temp_in_c = this->parse_temperature_(manu_data.data);
+    int8_t temp_in_c = this->parse_temperature_(manu_data.data);
     this->temperature_->publish_state(temp_in_c);
   }
 
@@ -145,7 +145,7 @@ uint32_t MopekaProCheck::parse_distance_(const std::vector<uint8_t> &message) {
                      (MOPEKA_LPG_COEF[0] + MOPEKA_LPG_COEF[1] * raw_t + MOPEKA_LPG_COEF[2] * raw_t * raw_t));
 }
 
-uint8_t MopekaProCheck::parse_temperature_(const std::vector<uint8_t> &message) { return (message[2] & 0x7F) - 40; }
+int8_t MopekaProCheck::parse_temperature_(const std::vector<uint8_t> &message) { return (message[2] & 0x7F) - 40; }
 
 SensorReadQuality MopekaProCheck::parse_read_quality_(const std::vector<uint8_t> &message) {
   // Since a 8 bit value is being shifted and truncated to 2 bits all possible values are defined as enumeration

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.h
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.h
@@ -61,7 +61,7 @@ class MopekaProCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
 
   uint8_t parse_battery_level_(const std::vector<uint8_t> &message);
   uint32_t parse_distance_(const std::vector<uint8_t> &message);
-  uint8_t parse_temperature_(const std::vector<uint8_t> &message);
+  int8_t parse_temperature_(const std::vector<uint8_t> &message);
   SensorReadQuality parse_read_quality_(const std::vector<uint8_t> &message);
 };
 

--- a/esphome/components/rtl87xx/__init__.py
+++ b/esphome/components/rtl87xx/__init__.py
@@ -6,6 +6,7 @@
 # in schema.py file in this directory.
 
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import libretiny
 from esphome.components.libretiny.const import (
     COMPONENT_RTL87XX,
@@ -45,6 +46,9 @@ CONFIG_SCHEMA.prepend_extra(_set_core_data)
 
 
 async def to_code(config):
+    # Use FreeRTOS 8.2.3+ for xTaskNotifyGive/ulTaskNotifyTake required by AsyncTCP 3.4.3+
+    # https://github.com/esphome/esphome/issues/10220
+    cg.add_platformio_option("custom_versions.freertos", "8.2.3")
     return await libretiny.component_to_code(config)
 
 

--- a/esphome/components/rtl87xx/__init__.py
+++ b/esphome/components/rtl87xx/__init__.py
@@ -10,7 +10,9 @@ import esphome.codegen as cg
 from esphome.components import libretiny
 from esphome.components.libretiny.const import (
     COMPONENT_RTL87XX,
+    FAMILY_RTL8710B,
     KEY_COMPONENT_DATA,
+    KEY_FAMILY,
     KEY_LIBRETINY,
     LibreTinyComponent,
 )
@@ -48,7 +50,9 @@ CONFIG_SCHEMA.prepend_extra(_set_core_data)
 async def to_code(config):
     # Use FreeRTOS 8.2.3+ for xTaskNotifyGive/ulTaskNotifyTake required by AsyncTCP 3.4.3+
     # https://github.com/esphome/esphome/issues/10220
-    cg.add_platformio_option("custom_versions.freertos", "8.2.3")
+    # Only for RTL8710B (ambz) - RTL8720C (ambz2) requires FreeRTOS 10.x
+    if CORE.data[KEY_LIBRETINY][KEY_FAMILY] == FAMILY_RTL8710B:
+        cg.add_platformio_option("custom_versions.freertos", "8.2.3")
     return await libretiny.component_to_code(config)
 
 

--- a/esphome/components/usb_uart/__init__.py
+++ b/esphome/components/usb_uart/__init__.py
@@ -1,4 +1,5 @@
 import esphome.codegen as cg
+from esphome.components import socket
 from esphome.components.uart import (
     CONF_DATA_BITS,
     CONF_PARITY,
@@ -17,7 +18,7 @@ from esphome.const import (
 )
 from esphome.cpp_types import Component
 
-AUTO_LOAD = ["uart", "usb_host", "bytebuffer"]
+AUTO_LOAD = ["uart", "usb_host", "bytebuffer", "socket"]
 CODEOWNERS = ["@clydebarrow"]
 
 usb_uart_ns = cg.esphome_ns.namespace("usb_uart")
@@ -116,6 +117,10 @@ CONFIG_SCHEMA = cv.ensure_list(
 
 
 async def to_code(config):
+    # Enable wake_loop_threadsafe for low-latency USB data processing
+    # The USB task queues data events that need immediate processing
+    socket.require_wake_loop_threadsafe()
+
     for device in config:
         var = await register_usb_client(device)
         for index, channel in enumerate(device[CONF_CHANNELS]):

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -2,6 +2,7 @@
 #if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3) || defined(USE_ESP32_VARIANT_ESP32P4)
 #include "usb_uart.h"
 #include "esphome/core/log.h"
+#include "esphome/core/application.h"
 #include "esphome/components/uart/uart_debugger.h"
 
 #include <cinttypes>
@@ -262,6 +263,11 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
       // Push to lock-free queue for main loop processing
       // Push always succeeds because pool size == queue size
       this->usb_data_queue_.push(chunk);
+
+      // Wake main loop immediately to process USB data instead of waiting for select() timeout
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+      App.wake_loop_threadsafe();
+#endif
     }
 
     // On success, restart input immediately from USB task for performance

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.11.2"
+__version__ = "2025.11.3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -225,6 +225,9 @@ template<typename T> class FixedVector {
     other.reset_();
   }
 
+  // Allow conversion to std::vector
+  operator std::vector<T>() const { return {data_, data_ + size_}; }
+
   FixedVector &operator=(FixedVector &&other) noexcept {
     if (this != &other) {
       // Delete our current data

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -1,8 +1,12 @@
+from collections.abc import Callable
 import importlib
 import logging
 import os
 from pathlib import Path
 import re
+import shutil
+import stat
+from types import TracebackType
 
 from esphome import loader
 from esphome.config import iter_component_configs, iter_components
@@ -301,9 +305,24 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def clean_build(clear_pio_cache: bool = True):
-    import shutil
+def _rmtree_error_handler(
+    func: Callable[[str], object],
+    path: str,
+    exc_info: tuple[type[BaseException], BaseException, TracebackType | None],
+) -> None:
+    """Error handler for shutil.rmtree to handle read-only files on Windows.
 
+    On Windows, git pack files and other files may be marked read-only,
+    causing shutil.rmtree to fail with "Access is denied". This handler
+    removes the read-only flag and retries the deletion.
+    """
+    if os.access(path, os.W_OK):
+        raise exc_info[1].with_traceback(exc_info[2])
+    os.chmod(path, stat.S_IWUSR | stat.S_IRUSR)
+    func(path)
+
+
+def clean_build(clear_pio_cache: bool = True):
     # Allow skipping cache cleaning for integration tests
     if os.environ.get("ESPHOME_SKIP_CLEAN_BUILD"):
         _LOGGER.warning("Skipping build cleaning (ESPHOME_SKIP_CLEAN_BUILD set)")
@@ -312,11 +331,11 @@ def clean_build(clear_pio_cache: bool = True):
     pioenvs = CORE.relative_pioenvs_path()
     if pioenvs.is_dir():
         _LOGGER.info("Deleting %s", pioenvs)
-        shutil.rmtree(pioenvs)
+        shutil.rmtree(pioenvs, onerror=_rmtree_error_handler)
     piolibdeps = CORE.relative_piolibdeps_path()
     if piolibdeps.is_dir():
         _LOGGER.info("Deleting %s", piolibdeps)
-        shutil.rmtree(piolibdeps)
+        shutil.rmtree(piolibdeps, onerror=_rmtree_error_handler)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
@@ -337,12 +356,10 @@ def clean_build(clear_pio_cache: bool = True):
         cache_dir = Path(config.get("platformio", "cache_dir"))
         if cache_dir.is_dir():
             _LOGGER.info("Deleting PlatformIO cache %s", cache_dir)
-            shutil.rmtree(cache_dir)
+            shutil.rmtree(cache_dir, onerror=_rmtree_error_handler)
 
 
 def clean_all(configuration: list[str]):
-    import shutil
-
     data_dirs = []
     for config in configuration:
         item = Path(config)
@@ -364,7 +381,7 @@ def clean_all(configuration: list[str]):
                 if item.is_file() and not item.name.endswith(".json"):
                     item.unlink()
                 elif item.is_dir() and item.name != "storage":
-                    shutil.rmtree(item)
+                    shutil.rmtree(item, onerror=_rmtree_error_handler)
 
     # Clean PlatformIO project files
     try:
@@ -378,7 +395,7 @@ def clean_all(configuration: list[str]):
             path = Path(config.get("platformio", pio_dir))
             if path.is_dir():
                 _LOGGER.info("Deleting PlatformIO %s %s", pio_dir, path)
-                shutil.rmtree(path)
+                shutil.rmtree(path, onerror=_rmtree_error_handler)
 
 
 GITIGNORE_CONTENT = """# Gitignore settings for ESPHome

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -121,7 +121,7 @@ def update_storage_json() -> None:
             )
         else:
             _LOGGER.info("Core config or version changed, cleaning build files...")
-        clean_build()
+        clean_build(clear_pio_cache=False)
     elif storage_should_update_cmake_cache(old, new):
         _LOGGER.info("Integrations changed, cleaning cmake cache...")
         clean_cmake_cache()
@@ -301,7 +301,7 @@ def clean_cmake_cache():
             pioenvs_cmake_path.unlink()
 
 
-def clean_build():
+def clean_build(clear_pio_cache: bool = True):
     import shutil
 
     # Allow skipping cache cleaning for integration tests
@@ -321,6 +321,9 @@ def clean_build():
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)
         dependencies_lock.unlink()
+
+    if not clear_pio_cache:
+        return
 
     # Clean PlatformIO cache to resolve CMake compiler detection issues
     # This helps when toolchain paths change or get corrupted


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [build] Don't clear pio cache unless requested [esphome#11966](https://github.com/esphome/esphome/pull/11966)
- [usb_uart] Wake main loop immediately when USB data arrives [esphome#12148](https://github.com/esphome/esphome/pull/12148)
- [espnow] Initialize LwIP stack when running without WiFi component [esphome#12169](https://github.com/esphome/esphome/pull/12169)
- [helpers] Add conversion from FixedVector to std::vector [esphome#12179](https://github.com/esphome/esphome/pull/12179)
- [hlk_fm22x] Fix Action::play method signatures [esphome#12192](https://github.com/esphome/esphome/pull/12192)
- [mopeka_pro_check] Fix negative temperatures [esphome#12198](https://github.com/esphome/esphome/pull/12198)
- [ade7953] Apply voltage_gain setting to both channels [esphome#12180](https://github.com/esphome/esphome/pull/12180)
- [core] Fix clean all on windows [esphome#12217](https://github.com/esphome/esphome/pull/12217)
- [rtl87xx] Fix AsyncTCP compilation by upgrading FreeRTOS to 8.2.3 [esphome#12230](https://github.com/esphome/esphome/pull/12230)
- [analog_threshold] Fix oscillation when using invert filter [esphome#12251](https://github.com/esphome/esphome/pull/12251)
- [rtl87xx] Fix FreeRTOS version for RTL8720C boards [esphome#12261](https://github.com/esphome/esphome/pull/12261)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
