### PR TITLE
[config] Provide path for `has_at_most_one_of` messages

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -742,7 +742,9 @@ def has_at_most_one_key(*keys):
 
         number = sum(k in keys for k in obj)
         if number > 1:
-            raise Invalid(f"Cannot specify more than one of {', '.join(keys)}.")
+            raise Invalid(
+                f"Cannot specify more than one of {', '.join(keys)}.", path=[keys[0]]
+            )
         return obj
 
     return validate

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -742,7 +742,7 @@ def has_at_most_one_key(*keys):
 
         used = set(obj) & set(keys)
         if len(used) > 1:
-            msg = f"Cannot specify more than one of {', '.join(used)}."
+            msg = "Cannot specify more than one of '" + "', '".join(used) + "'."
             raise MultipleInvalid([Invalid(msg, path=[k]) for k in used])
         return obj
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -740,11 +740,10 @@ def has_at_most_one_key(*keys):
         if not isinstance(obj, dict):
             raise Invalid("expected dictionary")
 
-        number = sum(k in keys for k in obj)
-        if number > 1:
-            raise Invalid(
-                f"Cannot specify more than one of {', '.join(keys)}.", path=[keys[0]]
-            )
+        used = set(obj) & set(keys)
+        if len(used) > 1:
+            msg = f"Cannot specify more than one of {', '.join(used)}."
+            raise MultipleInvalid([Invalid(msg, path=[k]) for k in used])
         return obj
 
     return validate


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Currently the validator `cv.has_at_most_one_of()` outputs the error message with the path of the enclosing config.

Instead add path information to point to at least one of the offending keys, thus improving the locality of the error message.


Old message:

```
            Cannot specify more than one of indicator, pivot.
            meter:
              on_boot:
                - delay: 5s
```

New message

```
          - meter:
              on_boot:
                - delay: 5s
              pivot:
                width: 40
                height: 60
                pad_all: 10px
                bg_color: blue
                radius: 5px

              Cannot specify more than one of pivot, indicator.
              pivot:
                width: 40
                height: 60
                pad_all: 10px
                bg_color: blue
                radius: 5px

              Cannot specify more than one of pivot, indicator.
              indicator:
                width: 40
                height: 60
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [ ] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
