### PR TITLE
[packages] Add more information and deprecation deadline for "single package" includes

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -91,7 +91,16 @@ def validate_source_shorthand(value):
 
 def deprecate_single_package(config):
     _LOGGER.warning(
-        "Including a single package under `packages:` is deprecated. Use a list instead."
+        """
+        Including a single package under `packages:`, i.e., `packages: !include mypackage.yaml` is deprecated.
+        This method for including packages will go away in 2026.7.0
+        Please use a list instead:
+
+        packages:
+          - !include mypackage.yaml
+
+        See https://github.com/esphome/esphome/pull/12116
+        """
     )
     return config
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -176,10 +176,7 @@ def test_single_package(
 
     assert actual == expected
 
-    assert (
-        "Including a single package under `packages:` is deprecated. Use a list instead."
-        in caplog.text
-    )
+    assert "This method for including packages will go away in 2026.7.0" in caplog.text
 
 
 def test_package_append(basic_wifi, basic_esphome):


### PR DESCRIPTION
# What does this implement/fix?

Following up on #12116 this PR indicates a clear deprecation deadline for single package inclusion and provides an easy migration path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] all (config)

## Example entry for `config.yaml`:

The following YAML should still work but will throw a warning:
```yaml
packages: !include mypackage.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
