### PR TITLE
[es8311] Remove MIN and MAX from mic_gain enum options

### DIFF
--- a/esphome/components/es8311/audio_dac.py
+++ b/esphome/components/es8311/audio_dac.py
@@ -22,7 +22,6 @@ ES8311_BITS_PER_SAMPLE_ENUM = {
 
 es8311_mic_gain = es8311_ns.enum("ES8311MicGain")
 ES8311_MIC_GAIN_ENUM = {
-    "MIN": es8311_mic_gain.ES8311_MIC_GAIN_MIN,
     "0DB": es8311_mic_gain.ES8311_MIC_GAIN_0DB,
     "6DB": es8311_mic_gain.ES8311_MIC_GAIN_6DB,
     "12DB": es8311_mic_gain.ES8311_MIC_GAIN_12DB,
@@ -31,7 +30,6 @@ ES8311_MIC_GAIN_ENUM = {
     "30DB": es8311_mic_gain.ES8311_MIC_GAIN_30DB,
     "36DB": es8311_mic_gain.ES8311_MIC_GAIN_36DB,
     "42DB": es8311_mic_gain.ES8311_MIC_GAIN_42DB,
-    "MAX": es8311_mic_gain.ES8311_MIC_GAIN_MAX,
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

MIN and MAX are sentinel values for enum bounds (-1 and 9) and should not be used as actual configuration values. Writing these values to the ADC register could result in undefined behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-docs/issues/5140

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5723

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
