### PR TITLE
[esp32_hosted] Fix build and bump IDF component version to 2.7.0

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -93,9 +93,9 @@ async def to_code(config):
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"
     if framework_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.1.5")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.2.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.3")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.6.1")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.7.0")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")


### PR DESCRIPTION
# What does this implement/fix?

It appears all versions of esp_hosted from the last 4 months vanished from the repository including 2.6.1: https://components.espressif.com/components/espressif/esp_hosted/versions/2.7.0/versions?language=en

Bump to 2.70 as its the only available version that will build:
- esp_wifi_remote: 1.1.5 -> 1.2.2
- esp_hosted: 2.6.1 -> 2.7.0

Hopefully they these versions get restored but for now the build is broken. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
