### PR TITLE
[api] Use loop-based reboot timeout check to avoid scheduler heap churn

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -108,6 +108,10 @@ void APIServer::setup() {
 
   // Initialize last_connected_ for reboot timeout tracking
   this->last_connected_ = App.get_loop_component_start_time();
+  // Set warning status if reboot timeout is enabled
+  if (this->reboot_timeout_ != 0) {
+    this->status_set_warning();
+  }
 }
 
 void APIServer::loop() {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -107,7 +107,7 @@ void APIServer::setup() {
 #endif
 
   // Initialize last_connected_ for reboot timeout tracking
-  this->last_connected_ = millis();
+  this->last_connected_ = App.get_loop_component_start_time();
 }
 
 void APIServer::loop() {
@@ -149,7 +149,7 @@ void APIServer::loop() {
     if (this->reboot_timeout_ != 0) {
       const uint32_t now = App.get_loop_component_start_time();
       if (now - this->last_connected_ > this->reboot_timeout_) {
-        ESP_LOGE(TAG, "No client connected; rebooting");
+        ESP_LOGE(TAG, "No clients; rebooting");
         App.reboot();
       }
     }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -105,6 +105,9 @@ void APIServer::setup() {
     camera::Camera::instance()->add_listener(this);
   }
 #endif
+
+  // Initialize last_connected_ for reboot timeout tracking
+  this->last_connected_ = millis();
 }
 
 void APIServer::loop() {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -52,11 +52,6 @@ void APIServer::setup() {
 #endif
 #endif
 
-  // Schedule reboot if no clients connect within timeout
-  if (this->reboot_timeout_ != 0) {
-    this->schedule_reboot_timeout_();
-  }
-
   this->socket_ = socket::socket_ip_loop_monitored(SOCK_STREAM, 0);  // monitored for incoming connections
   if (this->socket_ == nullptr) {
     ESP_LOGW(TAG, "Could not create socket");
@@ -112,16 +107,6 @@ void APIServer::setup() {
 #endif
 }
 
-void APIServer::schedule_reboot_timeout_() {
-  this->status_set_warning();
-  this->set_timeout("api_reboot", this->reboot_timeout_, []() {
-    if (!global_api_server->is_connected()) {
-      ESP_LOGE(TAG, "No clients; rebooting");
-      App.reboot();
-    }
-  });
-}
-
 void APIServer::loop() {
   // Accept new clients only if the socket exists and has incoming connections
   if (this->socket_ && this->socket_->ready()) {
@@ -147,15 +132,24 @@ void APIServer::loop() {
       this->clients_.emplace_back(conn);
       conn->start();
 
-      // Clear warning status and cancel reboot when first client connects
+      // First client connected - clear warning and update timestamp
       if (this->clients_.size() == 1 && this->reboot_timeout_ != 0) {
         this->status_clear_warning();
-        this->cancel_timeout("api_reboot");
+        this->last_connected_ = App.get_loop_component_start_time();
       }
     }
   }
 
   if (this->clients_.empty()) {
+    // Check reboot timeout - done in loop to avoid scheduler heap churn
+    // (cancelled scheduler items sit in heap memory until their scheduled time)
+    if (this->reboot_timeout_ != 0) {
+      const uint32_t now = App.get_loop_component_start_time();
+      if (now - this->last_connected_ > this->reboot_timeout_) {
+        ESP_LOGE(TAG, "No client connected; rebooting");
+        App.reboot();
+      }
+    }
     return;
   }
 
@@ -194,9 +188,10 @@ void APIServer::loop() {
     }
     this->clients_.pop_back();
 
-    // Schedule reboot when last client disconnects
+    // Last client disconnected - set warning and start tracking for reboot timeout
     if (this->clients_.empty() && this->reboot_timeout_ != 0) {
-      this->schedule_reboot_timeout_();
+      this->status_set_warning();
+      this->last_connected_ = App.get_loop_component_start_time();
     }
     // Don't increment client_index since we need to process the swapped element
   }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -202,7 +202,6 @@ class APIServer : public Component,
 #endif
 
  protected:
-  void schedule_reboot_timeout_();
 #ifdef USE_API_NOISE
   bool update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg, const LogString *fail_log_msg,
                          const psk_t &active_psk, bool make_active);
@@ -218,6 +217,7 @@ class APIServer : public Component,
 
   // 4-byte aligned types
   uint32_t reboot_timeout_{300000};
+  uint32_t last_connected_{0};
 
   // Vectors and strings (12 bytes each on 32-bit)
   std::vector<std::unique_ptr<APIConnection>> clients_;


### PR DESCRIPTION
# What does this implement/fix?

Reverts the API reboot timeout from using the scheduler back to an improved loop-based check.

## Background

In #12288, we fixed a use-after-free race condition in the scheduler by removing an optimization that immediately recycled cancelled items. However, this means cancelled scheduler items now sit in the heap until their scheduled execution time passes.

For the API reboot timeout (typically 5-15 minutes), this means a cancelled `api_reboot` timeout item would occupy memory for the full timeout duration after a client connects:

```
[D][scheduler:367]:   timeout 'api/api_reboot' interval=0 next_execution in 756676ms at 901240 [CANCELLED]
```

## Solution

Switch back to a loop-based design, but improved over the original:

**Original loop-based design:**
- Updated `last_connected_` timestamp every loop iteration
- Called `status_set_warning()`/`status_clear_warning()` every loop

**New improved design:**
- Update `last_connected_` only on connect/disconnect transitions
- Set/clear warning status only on state transitions
- Zero overhead when clients are connected - only a single `clients_.empty()` check which was already in the code path

## Trade-offs

| Approach | Memory when connected | Loop overhead when connected |
|----------|----------------------|------------------------------|
| Scheduler | ~80+ bytes for cancelled item sitting in heap | None |
| Original loop-based | 4 bytes | `millis()` call + timestamp update every loop |
| **New loop-based** | 4 bytes | None - just existing `empty()` check |

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #12288

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
