### PR TITLE
2025.11.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,10 +219,19 @@ jobs:
       - init
       - deploy-manifest
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: esphome
+          repositories: home-assistant-addon
+
       - name: Trigger Workflow
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ secrets.DEPLOY_HA_ADDON_REPO_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             let description = "ESPHome";
             if (context.eventName == "release") {
@@ -245,15 +254,55 @@ jobs:
     needs: [init]
     environment: ${{ needs.init.outputs.deploy_env }}
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: esphome
+          repositories: esphome-schema
+
       - name: Trigger Workflow
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
-          github-token: ${{ secrets.DEPLOY_ESPHOME_SCHEMA_REPO_TOKEN }}
+          github-token: ${{ steps.generate-token.outputs.token }}
           script: |
             github.rest.actions.createWorkflowDispatch({
               owner: "esphome",
               repo: "esphome-schema",
               workflow_id: "generate-schemas.yml",
+              ref: "main",
+              inputs: {
+                version: "${{ needs.init.outputs.tag }}",
+              }
+            })
+
+  version-notifier:
+    if: github.repository == 'esphome/esphome' && needs.init.outputs.branch_build == 'false'
+    runs-on: ubuntu-latest
+    needs:
+      - init
+      - deploy-manifest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@7e473efe3cb98aa54f8d4bac15400b15fad77d94 # v2.2.0
+        with:
+          app-id: ${{ secrets.ESPHOME_GITHUB_APP_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          owner: esphome
+          repositories: version-notifier
+
+      - name: Trigger Workflow
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: "esphome",
+              repo: "version-notifier",
+              workflow_id: "notify.yml",
               ref: "main",
               inputs: {
                 version: "${{ needs.init.outputs.tag }}",

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.11.3
+PROJECT_NUMBER         = 2025.11.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/es8311/audio_dac.py
+++ b/esphome/components/es8311/audio_dac.py
@@ -22,7 +22,6 @@ ES8311_BITS_PER_SAMPLE_ENUM = {
 
 es8311_mic_gain = es8311_ns.enum("ES8311MicGain")
 ES8311_MIC_GAIN_ENUM = {
-    "MIN": es8311_mic_gain.ES8311_MIC_GAIN_MIN,
     "0DB": es8311_mic_gain.ES8311_MIC_GAIN_0DB,
     "6DB": es8311_mic_gain.ES8311_MIC_GAIN_6DB,
     "12DB": es8311_mic_gain.ES8311_MIC_GAIN_12DB,
@@ -31,7 +30,6 @@ ES8311_MIC_GAIN_ENUM = {
     "30DB": es8311_mic_gain.ES8311_MIC_GAIN_30DB,
     "36DB": es8311_mic_gain.ES8311_MIC_GAIN_36DB,
     "42DB": es8311_mic_gain.ES8311_MIC_GAIN_42DB,
-    "MAX": es8311_mic_gain.ES8311_MIC_GAIN_MAX,
 }
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -860,6 +860,7 @@ async def to_code(config):
     )
     cg.set_cpp_standard("gnu++20")
     cg.add_build_flag("-DUSE_ESP32")
+    cg.add_build_flag("-Wl,-z,noexecstack")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     variant = config[CONF_VARIANT]
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -93,9 +93,9 @@ async def to_code(config):
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"
     if framework_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.1.5")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.2.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.3")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.6.1")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.7.0")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -740,9 +740,10 @@ def has_at_most_one_key(*keys):
         if not isinstance(obj, dict):
             raise Invalid("expected dictionary")
 
-        number = sum(k in keys for k in obj)
-        if number > 1:
-            raise Invalid(f"Cannot specify more than one of {', '.join(keys)}.")
+        used = set(obj) & set(keys)
+        if len(used) > 1:
+            msg = "Cannot specify more than one of '" + "', '".join(used) + "'."
+            raise MultipleInvalid([Invalid(msg, path=[k]) for k in used])
         return obj
 
     return validate

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.11.3"
+__version__ = "2025.11.4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32] Add build flag to suppress noexecstack message [esphome#12272](https://github.com/esphome/esphome/pull/12272)
- [ld2420] Add missing USE_SELECT ifdefs [esphome#12275](https://github.com/esphome/esphome/pull/12275)
- [config] Provide path for `has_at_most_one_of` messages [esphome#12277](https://github.com/esphome/esphome/pull/12277)
- [es8311] Remove MIN and MAX from mic_gain enum options [esphome#12281](https://github.com/esphome/esphome/pull/12281)
- [esp32_hosted] Fix build and bump IDF component version to 2.7.0 [esphome#12282](https://github.com/esphome/esphome/pull/12282)
- [CI] Trigger generic version notifier job on release [esphome#12292](https://github.com/esphome/esphome/pull/12292)
- [scheduler] Fix use-after-free when cancelling timeouts from non-main-loop threads [esphome#12288](https://github.com/esphome/esphome/pull/12288)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
