### PR TITLE
[light] Fix schedule_show not enabling loop for idle addressable lights

### DIFF
--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -70,7 +70,7 @@ class AddressableLight : public LightOutput, public Component {
     this->state_parent_ = state;
   }
   void update_state(LightState *state) override;
-  void schedule_show() { this->state_parent_->next_write_ = true; }
+  void schedule_show() { this->state_parent_->schedule_write_(); }
 
 #ifdef USE_POWER_SUPPLY
   void set_power_supply(power_supply::PowerSupply *power_supply) { this->power_.set_parent(power_supply); }

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -305,8 +305,7 @@ void LightState::set_immediately_(const LightColorValues &target, bool set_remot
     this->remote_values = target;
   }
   this->output_->update_state(this);
-  this->next_write_ = true;
-  this->enable_loop();
+  this->schedule_write_();
 }
 
 void LightState::disable_loop_if_idle_() {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -277,6 +277,12 @@ class LightState : public EntityBase, public Component {
   /// Disable loop if neither transformer nor effect is active
   void disable_loop_if_idle_();
 
+  /// Schedule a write to the light output and enable the loop to process it
+  void schedule_write_() {
+    this->next_write_ = true;
+    this->enable_loop();
+  }
+
   /// Store the output to allow effects to have more access.
   LightOutput *output_;
   /// The currently active transformer for this light (transition/flash).


### PR DESCRIPTION
# What does this implement/fix?

Fixes addressable lights not updating when `schedule_show()` is called while the light's loop is disabled.

## Problem

After #11881 introduced dynamic loop disabling for idle lights, `schedule_show()` would set `next_write_ = true` but the light's `loop()` would never run to process it because the loop was disabled.

This affected:
- Partition lights calling `schedule_show()` on underlying addressable lights
- Effects calling `schedule_show()` on addressable lights
- Any external code using `schedule_show()` to trigger a light update

## Solution

Add a `schedule_write_()` helper method that both sets `next_write_ = true` AND enables the loop to ensure the write is processed. Update `schedule_show()` and `set_immediately_()` to use this helper.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #11881
- Reported by KevinA on Discord: https://ptb.discord.com/channels/429907082951524364/524177279270780928/1446488243838386419

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (bugfix, no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This fix affects partition lights and addressable light effects
# Example: Voice PE light ring with partition light
light:
  - platform: esp32_rmt_led_strip
    id: leds_internal
    pin: 21
    chipset: WS2812
    num_leds: 12
    restore_mode: ALWAYS_OFF

  - platform: partition
    id: voice_assistant_leds
    segments:
      - id: leds_internal
        from: 0
        to: 11
    effects:
      - addressable_rainbow:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
