### PR TITLE
[core] Prevent compiler unrolling of action chain traversal to reduce flash

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -239,7 +239,11 @@ template<typename... Ts> class Action {
   template<typename... Us> friend class ContinuationAction;
 
   virtual void play(const Ts &...x) = 0;
-  void play_next_(const Ts &...x) {
+
+  /// Continue to the next action in the chain.
+  /// Marked noinline to prevent compiler from inlining this into every play_complex caller,
+  /// which can cause significant code bloat when templates are instantiated many times.
+  void __attribute__((noinline)) play_next_(const Ts &...x) {
     if (this->num_running_ > 0) {
       this->num_running_--;
       if (this->next_ != nullptr) {
@@ -255,13 +259,19 @@ template<typename... Ts> class Action {
   }
 
   virtual void stop() {}
-  void stop_next_() {
+
+  /// Stop the next action in the chain.
+  /// Marked noinline to prevent compiler from unrolling the recursive chain traversal,
+  /// which can cause massive code bloat (500+ bytes per template instantiation).
+  void __attribute__((noinline)) stop_next_() {
     if (this->next_ != nullptr) {
       this->next_->stop_complex();
     }
   }
 
-  bool is_running_next_() {
+  /// Check if next action in chain is running.
+  /// Marked noinline to prevent compiler from unrolling the recursive chain traversal.
+  bool __attribute__((noinline)) is_running_next_() {
     if (this->next_ == nullptr)
       return false;
     return this->next_->is_running();


### PR DESCRIPTION
# What does this implement/fix?

Prevents compiler from unrolling recursive action chain traversal in the automation system, saving ~4.3 KB of flash.

The `Action` template class has methods that traverse linked action chains (`play_next_`, `stop_next_`, `is_running_next_`). Without `noinline`, the compiler aggressively inlines these recursive calls, generating duplicate code for every template instantiation (e.g., `Action<>`, `Action<int>`, `Action<float>`, `Action<string>`, `Action<string,string>`, etc.).

By marking these chain-traversal methods as `noinline`, we force the compiler to generate a single function body per template instantiation rather than duplicating the traversal code at every call site.

**Results (ESP32 test config):**
- Flash savings: **4,272 bytes** (1,310,383 → 1,306,111)
- Symbols >100B reduced from 58 to 46

**Eliminated from >100B symbol list:**
- `IfAction<>::stop()` (463 B)
- `ActionList<>::stop()` (259 B)
- `WhileAction<>::stop()` (258 B)
- `Action<string>::stop_complex()` (154 B)
- `Action<float>::stop_complex()` (154 B)
- `Action<>::stop_complex()` (154 B)
- `Action<string,string>::stop_complex()` (127 B)
- `Action<>::play_complex()` (127 B)
- Multiple other `Action<*>::play_complex()` instantiations

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (flash optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
