### PR TITLE
[scheduler] Avoid std::string allocation in RetryArgs

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -138,7 +138,16 @@ void Component::set_retry(const std::string &name, uint32_t initial_wait_time, u
   App.scheduler.set_retry(this, name, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
 }
 
+void Component::set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
+                          std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor) {  // NOLINT
+  App.scheduler.set_retry(this, name, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+}
+
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
+  return App.scheduler.cancel_retry(this, name);
+}
+
+bool Component::cancel_retry(const char *name) {  // NOLINT
   return App.scheduler.cancel_retry(this, name);
 }
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -367,6 +367,9 @@ class Component {
   void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,       // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
+  void set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,              // NOLINT
+                 std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
+
   void set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,  // NOLINT
                  float backoff_increase_factor = 1.0f);                                                      // NOLINT
 
@@ -376,6 +379,7 @@ class Component {
    * @return Whether a retry function was deleted.
    */
   bool cancel_retry(const std::string &name);  // NOLINT
+  bool cancel_retry(const char *name);         // NOLINT
 
   /** Set a timeout function with a unique name.
    *


### PR DESCRIPTION
# What does this implement/fix?

Aligns `RetryArgs` name storage with how `SchedulerItem` handles names: using `const char*` with a `name_is_dynamic` flag instead of `std::string`.

`SchedulerItem` uses:
- `const char*` for string literals stored in rodata (program lifetime, no allocation)
- `char*` for caller-owned strings (copied with `new char[]`)
- `bool name_is_dynamic` flag to track ownership and know whether to `delete[]` in destructor

Previously, `RetryArgs` stored the name as `std::string`, which always allocated heap memory even when the caller passed a string literal. Now `RetryArgs` uses the same approach:

- `const char* name` to store the pointer
- `bool name_is_dynamic` flag to track ownership
- For static strings (the common case): store the pointer directly, no allocation
- For dynamic strings: make a copy with `new char[]`, cleaned up in destructor

The struct fields are also reordered to minimize padding on 32-bit systems (grouping 4-byte fields together, then 1-byte fields at the end).

Also adds `const char*` overloads for `Component::set_retry()` and `Component::cancel_retry()` to match the existing pattern used by `set_timeout()` and `cancel_interval()`. This allows components using string literals to avoid unnecessary `std::string` conversion and heap allocation.

For example, the ratgdo component calls `set_retry("position_sync_while_moving", ...)` which retries every few hundred milliseconds while the garage door is moving. Previously each retry iteration allocated a new `std::string` when scheduling the next timeout - causing heap churn throughout the entire door movement (and likely contributing to out-of-memory crashes that were observed during door movement before recent ESPHome optimizations). Now it just stores the pointer to the rodata string literal.

**Flash savings:** 224 bytes on ESP8266 (tested with ratgdo component).

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Part of ongoing scheduler memory optimization work

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Host platform tested via integration tests.

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Existing scheduler retry integration tests (`tests/integration/test_scheduler_retry_test.py`) cover static string names. Test 10 ("Mixed string/const char*") exercises the dynamic `std::string` allocation path for cancellation.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal change)
