### PR TITLE
[ci-custom] Fix after switch from string to path

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -554,10 +554,10 @@ def convert_path_to_relative(abspath, current):
         "esphome/components/web_server/__init__.py",
     ],
 )
-def lint_relative_py_import(fname, line, col, content):
+def lint_relative_py_import(fname: Path, line, col, content):
     import_line = content.splitlines()[line]
     abspath = import_line[col:].split(" ")[0]
-    current = fname.removesuffix(".py").replace(os.path.sep, ".")
+    current = fname.name.removesuffix(".py").replace(os.path.sep, ".")
     replacement = convert_path_to_relative(abspath, current)
     newline = import_line.replace(abspath, replacement)
     return (

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -557,7 +557,7 @@ def convert_path_to_relative(abspath, current):
 def lint_relative_py_import(fname: Path, line, col, content):
     import_line = content.splitlines()[line]
     abspath = import_line[col:].split(" ")[0]
-    current = fname.name.removesuffix(".py").replace(os.path.sep, ".")
+    current = str(fname).removesuffix(".py").replace(os.path.sep, ".")
     replacement = convert_path_to_relative(abspath, current)
     newline = import_line.replace(abspath, replacement)
     return (


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `scripts/ci-custom.py` script had changes from strings to Path for file names, at least one place was missed in the conversion.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
