### PR TITLE
[lvgl] Number saves value on interactive change

### DIFF
--- a/esphome/components/lvgl/number/lvgl_number.h
+++ b/esphome/components/lvgl/number/lvgl_number.h
@@ -29,14 +29,17 @@ class LVGLNumber : public number::Number, public Component {
     this->publish_state(value);
   }
 
-  void on_value() { this->publish_state(this->value_lambda_()); }
+  void on_value() { this->publish_(this->value_lambda_()); }
 
  protected:
-  void control(float value) override {
-    this->control_lambda_(value);
+  void publish_(float value) {
     this->publish_state(value);
     if (this->restore_)
       this->pref_.save(&value);
+  }
+  void control(float value) override {
+    this->control_lambda_(value);
+    this->publish_(value);
   }
   std::function<void(float)> control_lambda_;
   std::function<float()> value_lambda_;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When an LVGL `number` is changed by user interaction, the value was not being saved to prefs
even when `restore_value` was set.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10988

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
