### PR TITLE
Add api.disconnect_clients action

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -55,6 +55,9 @@ def AUTO_LOAD(config: ConfigType) -> list[str]:
 
 api_ns = cg.esphome_ns.namespace("api")
 APIServer = api_ns.class_("APIServer", cg.Component, cg.Controller)
+APIDiconnectClientsAction = api_ns.class_(
+    "APIDiconnectClientsAction", automation.Action
+)
 HomeAssistantServiceCallAction = api_ns.class_(
     "HomeAssistantServiceCallAction", automation.Action
 )
@@ -536,6 +539,25 @@ async def homeassistant_tag_scanned_to_code(config, action_id, template_arg, arg
     templ = await cg.templatable(config[CONF_TAG], args, cg.std_string)
     cg.add(var.add_data("tag_id", templ))
     return var
+
+
+API_DISCONNECT_CLIENTS_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(APIServer),
+        cv.Optional(CONF_STATE_SUBSCRIPTION_ONLY, default=False): cv.templatable(
+            cv.boolean
+        ),
+    }
+)
+
+
+@automation.register_action(
+    "api.disconnect_clients",
+    APIDiconnectClientsAction,
+    API_DISCONNECT_CLIENTS_ACTION_SCHEMA,
+)
+async def api_disconnect_clients_to_code(config, action_id, template_arg, args):
+    return cg.new_Pvariable(action_id, template_arg)
 
 
 API_CONNECTED_CONDITION_SCHEMA = cv.Schema(

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -255,6 +255,18 @@ bool APIServer::check_password(const uint8_t *password_data, size_t password_len
 
 void APIServer::handle_disconnect(APIConnection *conn) {}
 
+void APIServer::disconnect_clients() {
+  for (auto &c : this->clients_) {
+    DisconnectRequest req;
+    if (!c->send_message(req, DisconnectRequest::MESSAGE_TYPE)) {
+      // If we can't send the disconnect request directly (tx_buffer full),
+      // schedule it at the front of the batch so it will be sent with priority
+      c->schedule_message_front_(nullptr, &APIConnection::try_send_disconnect_request, DisconnectRequest::MESSAGE_TYPE,
+                                 DisconnectRequest::ESTIMATED_SIZE);
+    }
+  }
+}
+
 // Macro for controller update dispatch
 #define API_DISPATCH_UPDATE(entity_type, entity_name) \
   void APIServer::on_##entity_name##_update(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
@@ -462,10 +474,7 @@ bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString 
     this->set_timeout(100, [this, active_psk]() {
       ESP_LOGW(TAG, "Disconnecting all clients to reset PSK");
       this->set_noise_psk(active_psk);
-      for (auto &c : this->clients_) {
-        DisconnectRequest req;
-        c->send_message(req, DisconnectRequest::MESSAGE_TYPE);
-      }
+      this->disconnect_clients();
     });
   }
   return true;
@@ -563,15 +572,7 @@ void APIServer::on_shutdown() {
   this->batch_delay_ = 5;
 
   // Send disconnect requests to all connected clients
-  for (auto &c : this->clients_) {
-    DisconnectRequest req;
-    if (!c->send_message(req, DisconnectRequest::MESSAGE_TYPE)) {
-      // If we can't send the disconnect request directly (tx_buffer full),
-      // schedule it at the front of the batch so it will be sent with priority
-      c->schedule_message_front_(nullptr, &APIConnection::try_send_disconnect_request, DisconnectRequest::MESSAGE_TYPE,
-                                 DisconnectRequest::ESTIMATED_SIZE);
-    }
-  }
+  this->disconnect_clients();
 }
 
 bool APIServer::teardown() {

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -80,6 +80,8 @@ class APIServer : public Component,
   APINoiseContext &get_noise_ctx() { return this->noise_ctx_; }
 #endif  // USE_API_NOISE
 
+  void disconnect_clients();
+
   void handle_disconnect(APIConnection *conn);
 #ifdef USE_BINARY_SENSOR
   void on_binary_sensor_update(binary_sensor::BinarySensor *obj) override;
@@ -256,6 +258,11 @@ class APIServer : public Component,
 };
 
 extern APIServer *global_api_server;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+template<typename... Ts> class APIDisconnectClientsAction : public Action<Ts...> {
+ public:
+  bool play(const Ts &...x) override { return global_api_server->disconnect_clients(); }
+};
 
 template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
   TEMPLATABLE_VALUE(bool, state_subscription_only)

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -261,7 +261,7 @@ extern APIServer *global_api_server;  // NOLINT(cppcoreguidelines-avoid-non-cons
 
 template<typename... Ts> class APIDisconnectClientsAction : public Action<Ts...> {
  public:
-  bool play(const Ts &...x) override { return global_api_server->disconnect_clients(); }
+  void play(const Ts &...x) override { global_api_server->disconnect_clients(); }
 };
 
 template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -181,6 +181,10 @@ api:
             else:
               - logger.log: "Skipped loops"
         - logger.log: "After combined test"
+    - action: disconnect_clients
+      then:
+        - logger.log: "Requested to disconnect all api clients"
+        - api.disconnect_clients:
 
 event:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

This adds a new api action `api.disconnect_clients` to request all clients to connect.
With this action it's possible to refresh the connected clients entities after making changes to the internal state.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
