### PR TITLE
[epaper_spi] Set reasonable default update interval

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -91,7 +91,8 @@ def model_schema(config):
                 cv.Optional(CONF_ROTATION, default=0): validate_rotation,
                 cv.Required(CONF_MODEL): cv.one_of(model.name, upper=True),
                 cv.Optional(
-                    CONF_UPDATE_INTERVAL, default=cv.UNDEFINED
+                    CONF_UPDATE_INTERVAL,
+                    default="5min",
                 ): update_interval,
                 cv.Optional(CONF_TRANSFORM): cv.Schema(
                     {

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -41,6 +41,7 @@ AUTO_LOAD = ["split_buffer"]
 DEPENDENCIES = ["spi"]
 
 CONF_INIT_SEQUENCE_ID = "init_sequence_id"
+CONF_MINIMUM_UPDATE_INTERVAL = "minimum_update_interval"
 
 epaper_spi_ns = cg.esphome_ns.namespace("epaper_spi")
 EPaperBase = epaper_spi_ns.class_(
@@ -71,6 +72,9 @@ TRANSFORM_OPTIONS = {CONF_MIRROR_X, CONF_MIRROR_Y, CONF_SWAP_XY}
 def model_schema(config):
     model = MODELS[config[CONF_MODEL]]
     class_name = epaper_spi_ns.class_(model.class_name, EPaperBase)
+    minimum_update_interval = update_interval(
+        model.get_default(CONF_MINIMUM_UPDATE_INTERVAL, "1s")
+    )
     cv_dimensions = cv.Optional if model.get_default(CONF_WIDTH) else cv.Required
     return (
         display.FULL_DISPLAY_SCHEMA.extend(
@@ -90,10 +94,9 @@ def model_schema(config):
             {
                 cv.Optional(CONF_ROTATION, default=0): validate_rotation,
                 cv.Required(CONF_MODEL): cv.one_of(model.name, upper=True),
-                cv.Optional(
-                    CONF_UPDATE_INTERVAL,
-                    default="5min",
-                ): cv.All(update_interval, cv.Range(min=core.TimePeriod(seconds=30))),
+                cv.Optional(CONF_UPDATE_INTERVAL, default=cv.UNDEFINED): cv.All(
+                    update_interval, cv.Range(min=minimum_update_interval)
+                ),
                 cv.Optional(CONF_TRANSFORM): cv.Schema(
                     {
                         cv.Required(CONF_MIRROR_X): cv.boolean,
@@ -154,9 +157,8 @@ def _final_validate(config):
         else:
             # If no drawing methods are configured, and LVGL is not enabled, show a test card
             config[CONF_SHOW_TEST_CARD] = True
-            config[CONF_UPDATE_INTERVAL] = core.TimePeriod(
-                seconds=60
-            ).total_milliseconds
+    elif CONF_UPDATE_INTERVAL not in config:
+        config[CONF_UPDATE_INTERVAL] = update_interval("1min")
     return config
 
 

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -93,7 +93,7 @@ def model_schema(config):
                 cv.Optional(
                     CONF_UPDATE_INTERVAL,
                     default="5min",
-                ): update_interval,
+                ): cv.All(update_interval, cv.Range(min=core.TimePeriod(seconds=30))),
                 cv.Optional(CONF_TRANSFORM): cv.Schema(
                     {
                         cv.Required(CONF_MIRROR_X): cv.boolean,

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -286,7 +286,7 @@ void EPaperBase::initialise_() {
  * @param y
  * @return false if the coordinates are out of bounds
  */
-bool EPaperBase::rotate_coordinates_(int &x, int &y) const {
+bool EPaperBase::rotate_coordinates_(int &x, int &y) {
   if (!this->get_clipping().inside(x, y))
     return false;
   if (this->transform_ & SWAP_XY)
@@ -297,6 +297,10 @@ bool EPaperBase::rotate_coordinates_(int &x, int &y) const {
     y = this->height_ - y - 1;
   if (x >= this->width_ || y >= this->height_ || x < 0 || y < 0)
     return false;
+  this->x_low_ = clamp_at_most(this->x_low_, x);
+  this->x_high_ = clamp_at_least(this->x_high_, x + 1);
+  this->y_low_ = clamp_at_most(this->y_low_, y);
+  this->y_high_ = clamp_at_least(this->y_high_, y + 1);
   return true;
 }
 
@@ -319,10 +323,6 @@ void HOT EPaperBase::draw_pixel_at(int x, int y, Color color) {
   } else {
     this->buffer_[byte_position] = original | pixel_bit;
   }
-  this->x_low_ = clamp_at_most(this->x_low_, x);
-  this->x_high_ = clamp_at_least(this->x_high_, x + 1);
-  this->y_low_ = clamp_at_most(this->y_low_, y);
-  this->y_high_ = clamp_at_least(this->y_high_, y + 1);
 }
 
 void EPaperBase::dump_config() {

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -106,7 +106,7 @@ class EPaperBase : public Display,
   void initialise_();
   void wait_for_idle_(bool should_wait);
   bool init_buffer_(size_t buffer_length);
-  bool rotate_coordinates_(int &x, int &y) const;
+  bool rotate_coordinates_(int &x, int &y);
 
   /**
    * Methods that must be implemented by concrete classes to control the display

--- a/esphome/components/epaper_spi/models/spectra_e6.py
+++ b/esphome/components/epaper_spi/models/spectra_e6.py
@@ -4,8 +4,8 @@ from . import EpaperModel
 
 
 class SpectraE6(EpaperModel):
-    def __init__(self, name, class_name="EPaperSpectraE6", **kwargs):
-        super().__init__(name, class_name, **kwargs)
+    def __init__(self, name, class_name="EPaperSpectraE6", **defaults):
+        super().__init__(name, class_name, **defaults)
 
     # fmt: off
     def get_init_sequence(self, config: dict):
@@ -30,7 +30,7 @@ class SpectraE6(EpaperModel):
         return self.defaults.get(key, fallback)
 
 
-spectra_e6 = SpectraE6("spectra-e6")
+spectra_e6 = SpectraE6("spectra-e6", minimum_update_interval="30s")
 
 spectra_e6_7p3 = spectra_e6.extend(
     "7.3in-Spectra-E6",

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -498,12 +498,12 @@ void LvglComponent::setup() {
     buf_bytes /= MIN_BUFFER_FRAC;
     buffer = lv_custom_mem_alloc(buf_bytes);  // NOLINT
   }
+  this->buffer_frac_ = frac;
   if (buffer == nullptr) {
     this->status_set_error(LOG_STR("Memory allocation failure"));
     this->mark_failed();
     return;
   }
-  this->buffer_frac_ = frac;
   lv_disp_draw_buf_init(&this->draw_buf_, buffer, nullptr, buffer_pixels);
   this->disp_drv_.hor_res = display->get_width();
   this->disp_drv_.ver_res = display->get_height();


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `epaper_spi` component needs a proper default for `update_interval` as it currently defaults to 0 which is a Bad Idea.

This adds a model-specific minimum time, and a sensible default.

Also fix some bugs:

* LVGL crashed with divide-by-zero exception if the buffer allocation failed;
* Display updates for Spectra E6 were not happening with LVGL after the initial draw

 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Relates to https://github.com/esphome/esphome/issues/12322

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
