### PR TITLE
[nRF52] Add USE_ZEPHYR_NETWORKING feature flag

### DIFF
--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -300,6 +300,7 @@
 #define USE_NRF52_UICR_ERASE
 #define USE_SOFTDEVICE_ID 7
 #define USE_SOFTDEVICE_VERSION 1
+#define USE_ZEPHYR_NETWORKING
 #endif
 
 // Disabled feature flags


### PR DESCRIPTION
# What does this implement/fix?
Add `USE_ZEPHYR_NETWORKING` feature flag in preparation for enabling Zephyr networking stack support on nRF52 devices.

Not sure if I should extract this from the following request because it's outside the components but directly in `core`:
- https://github.com/esphome/esphome/pull/11764

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5741

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
