### PR TITLE
[esp8266] Allow use of recvfrom for esphome sockets

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -334,6 +334,12 @@ class LWIPRawImpl : public Socket {
     }
     return ret;
   }
+
+  ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) override {
+    errno = ENOTSUP;
+    return -1;
+  }
+
   ssize_t internal_write(const void *buf, size_t len) {
     if (pcb_ == nullptr) {
       errno = ECONNRESET;

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -113,6 +113,9 @@ class LwIPSocketImpl : public Socket {
   }
   int listen(int backlog) override { return lwip_listen(fd_, backlog); }
   ssize_t read(void *buf, size_t len) override { return lwip_read(fd_, buf, len); }
+  ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) override {
+    return lwip_recvfrom(fd_, buf, len, 0, addr, addr_len);
+  }
   ssize_t readv(const struct iovec *iov, int iovcnt) override { return lwip_readv(fd_, iov, iovcnt); }
   ssize_t write(const void *buf, size_t len) override { return lwip_write(fd_, buf, len); }
   ssize_t send(void *buf, size_t len, int flags) { return lwip_send(fd_, buf, len, flags); }

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -39,9 +39,7 @@ class Socket {
   virtual int setsockopt(int level, int optname, const void *optval, socklen_t optlen) = 0;
   virtual int listen(int backlog) = 0;
   virtual ssize_t read(void *buf, size_t len) = 0;
-#ifdef USE_SOCKET_IMPL_BSD_SOCKETS
   virtual ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) = 0;
-#endif
   virtual ssize_t readv(const struct iovec *iov, int iovcnt) = 0;
   virtual ssize_t write(const void *buf, size_t len) = 0;
   virtual ssize_t writev(const struct iovec *iov, int iovcnt) = 0;


### PR DESCRIPTION
For standard tcp/udp sockets, lwip is used as backend where recvfrom is perfectly supported. So hook that up for these platforms.

The raw version will just return an error code since it does not make sense for raw sockts.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
