### PR TITLE
[scheduler] Fix missing lock when recycling items in defer queue processing

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -744,6 +744,10 @@ bool HOT Scheduler::SchedulerItem::cmp(const std::unique_ptr<SchedulerItem> &a,
                                                               : (a->next_execution_high_ > b->next_execution_high_);
 }
 
+// Recycle a SchedulerItem back to the pool for reuse.
+// IMPORTANT: Caller must hold the scheduler lock before calling this function.
+// This protects scheduler_item_pool_ from concurrent access by other threads
+// that may be acquiring items from the pool in set_timer_common_().
 void Scheduler::recycle_item_main_loop_(std::unique_ptr<SchedulerItem> item) {
   if (!item)
     return;


### PR DESCRIPTION
# What does this implement/fix?

Fix a race condition in the scheduler where `recycle_item_main_loop_()` was called without holding the lock in `process_defer_queue_()`. This caused a data race on `scheduler_item_pool_` between the main loop and other threads (e.g., the web server task calling `defer()`).

The race condition:
1. Main loop in `process_defer_queue_()`: releases lock after moving item from `defer_queue_`, then calls `recycle_item_main_loop_()` which does `scheduler_item_pool_.push_back()`
2. Web server task calls `set_timer_common_()`: acquires lock, then accesses `scheduler_item_pool_.back()` and `scheduler_item_pool_.pop_back()` to reuse a pooled item

Since the main loop didn't hold the lock while modifying `scheduler_item_pool_`, these operations could execute concurrently, corrupting the vector. The corrupted item would later be added to `items_` and cause a crash in `SchedulerItem::cmp()` during heap operations when it tried to dereference a corrupted/null pointer.

The fix:
1. Adds lock acquisition around the `recycle_item_main_loop_()` call in `process_defer_queue_()`
2. Documents in both the header and implementation that `recycle_item_main_loop_()` requires the caller to hold the lock

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12120

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a core scheduler bugfix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
