### PR TITLE
[text] Add component tests with pattern coverage

### DIFF
--- a/tests/components/text/common.yaml
+++ b/tests/components/text/common.yaml
@@ -1,0 +1,25 @@
+text:
+  - platform: template
+    name: "Test Text"
+    id: test_text
+    optimistic: true
+    min_length: 0
+    max_length: 100
+    mode: text
+
+  - platform: template
+    name: "Test Text with Pattern"
+    id: test_text_pattern
+    optimistic: true
+    min_length: 1
+    max_length: 50
+    pattern: "[A-Za-z0-9 ]+"
+    mode: text
+
+  - platform: template
+    name: "Test Password"
+    id: test_password
+    optimistic: true
+    min_length: 8
+    max_length: 32
+    mode: password

--- a/tests/components/text/test.esp32-idf.yaml
+++ b/tests/components/text/test.esp32-idf.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/components/text/test.esp8266-ard.yaml
+++ b/tests/components/text/test.esp8266-ard.yaml
@@ -1,0 +1,2 @@
+packages:
+  common: !include common.yaml

--- a/tests/integration/fixtures/api_message_size_batching.yaml
+++ b/tests/integration/fixtures/api_message_size_batching.yaml
@@ -143,6 +143,7 @@ text:
     mode: text
     min_length: 0
     max_length: 255
+    pattern: "[A-Za-z0-9 ]+"
     initial_value: "Initial value"
     update_interval: 5.0s
 

--- a/tests/integration/test_api_message_size_batching.py
+++ b/tests/integration/test_api_message_size_batching.py
@@ -141,6 +141,9 @@ async def test_api_message_size_batching(
         assert text_input.max_length == 255, (
             f"Expected max_length 255, got {text_input.max_length}"
         )
+        assert text_input.pattern == "[A-Za-z0-9 ]+", (
+            f"Expected pattern '[A-Za-z0-9 ]+', got '{text_input.pattern}'"
+        )
 
         # Verify total entity count - messages of various sizes were batched successfully
         # We have: 3 selects + 3 text sensors + 1 text input + 1 number = 8 total


### PR DESCRIPTION
# What does this implement/fix?

Adds component tests for the `text` component, including coverage for the `pattern` field which was previously untested.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
text:
  - platform: template
    name: "Test Text with Pattern"
    optimistic: true
    min_length: 1
    max_length: 50
    pattern: "[A-Za-z0-9 ]+"
    mode: text
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
