### PR TITLE
[template] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -6,8 +6,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 using namespace esphome::alarm_control_panel;
 
@@ -286,5 +285,4 @@ void TemplateAlarmControlPanel::control(const AlarmControlPanelCall &call) {
   }
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -14,8 +14,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #endif
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 #ifdef USE_BINARY_SENSOR
 enum BinarySensorFlags : uint16_t {
@@ -169,5 +168,4 @@ class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControl
   void arm_(optional<std::string> code, alarm_control_panel::AlarmControlPanelState state, uint32_t delay);
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -1,8 +1,7 @@
 #include "template_binary_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
@@ -23,5 +22,4 @@ void TemplateBinarySensor::loop() {
 
 void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateBinarySensor final : public Component, public binary_sensor::BinarySensor {
  public:
@@ -21,5 +20,4 @@ class TemplateBinarySensor final : public Component, public binary_sensor::Binar
   TemplateLambda<bool> f_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/button/template_button.h
+++ b/esphome/components/template/button/template_button.h
@@ -2,8 +2,7 @@
 
 #include "esphome/components/button/button.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateButton final : public button::Button {
  public:
@@ -11,5 +10,4 @@ class TemplateButton final : public button::Button {
   void press_action() override{};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/cover/template_cover.cpp
+++ b/esphome/components/template/cover/template_cover.cpp
@@ -1,8 +1,7 @@
 #include "template_cover.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 using namespace esphome::cover;
 
@@ -133,5 +132,4 @@ void TemplateCover::stop_prev_trigger_() {
   }
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/cover/template_cover.h
+++ b/esphome/components/template/cover/template_cover.h
@@ -5,8 +5,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/cover/cover.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 enum TemplateCoverRestoreMode {
   COVER_NO_RESTORE,
@@ -63,5 +62,4 @@ class TemplateCover final : public cover::Cover, public Component {
   bool has_tilt_{false};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/datetime/template_date.cpp
+++ b/esphome/components/template/datetime/template_date.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.date";
 
@@ -104,7 +103,6 @@ void TemplateDate::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_DATE

--- a/esphome/components/template/datetime/template_date.h
+++ b/esphome/components/template/datetime/template_date.h
@@ -11,8 +11,7 @@
 #include "esphome/core/time.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateDate final : public datetime::DateEntity, public PollingComponent {
  public:
@@ -41,7 +40,6 @@ class TemplateDate final : public datetime::DateEntity, public PollingComponent 
   ESPPreferenceObject pref_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_DATE

--- a/esphome/components/template/datetime/template_datetime.cpp
+++ b/esphome/components/template/datetime/template_datetime.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.datetime";
 
@@ -143,7 +142,6 @@ void TemplateDateTime::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_DATETIME

--- a/esphome/components/template/datetime/template_datetime.h
+++ b/esphome/components/template/datetime/template_datetime.h
@@ -11,8 +11,7 @@
 #include "esphome/core/time.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateDateTime final : public datetime::DateTimeEntity, public PollingComponent {
  public:
@@ -41,7 +40,6 @@ class TemplateDateTime final : public datetime::DateTimeEntity, public PollingCo
   ESPPreferenceObject pref_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_DATETIME

--- a/esphome/components/template/datetime/template_time.cpp
+++ b/esphome/components/template/datetime/template_time.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.time";
 
@@ -104,7 +103,6 @@ void TemplateTime::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_TIME

--- a/esphome/components/template/datetime/template_time.h
+++ b/esphome/components/template/datetime/template_time.h
@@ -11,8 +11,7 @@
 #include "esphome/core/time.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateTime final : public datetime::TimeEntity, public PollingComponent {
  public:
@@ -41,7 +40,6 @@ class TemplateTime final : public datetime::TimeEntity, public PollingComponent 
   ESPPreferenceObject pref_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_
 
 #endif  // USE_DATETIME_TIME

--- a/esphome/components/template/event/template_event.h
+++ b/esphome/components/template/event/template_event.h
@@ -3,10 +3,8 @@
 #include "esphome/core/component.h"
 #include "esphome/components/event/event.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateEvent final : public Component, public event::Event {};
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/fan/template_fan.cpp
+++ b/esphome/components/template/fan/template_fan.cpp
@@ -1,8 +1,7 @@
 #include "template_fan.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.fan";
 
@@ -34,5 +33,4 @@ void TemplateFan::control(const fan::FanCall &call) {
   this->publish_state();
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/fan/template_fan.h
+++ b/esphome/components/template/fan/template_fan.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/fan/fan.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateFan final : public Component, public fan::Fan {
  public:
@@ -27,5 +26,4 @@ class TemplateFan final : public Component, public fan::Fan {
   std::vector<const char *> preset_modes_{};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/lock/automation.h
+++ b/esphome/components/template/lock/automation.h
@@ -4,8 +4,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 template<typename... Ts> class TemplateLockPublishAction : public Action<Ts...>, public Parented<TemplateLock> {
  public:
@@ -14,5 +13,4 @@ template<typename... Ts> class TemplateLockPublishAction : public Action<Ts...>,
   void play(const Ts &...x) override { this->parent_->publish_state(this->state_.value(x...)); }
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/lock/template_lock.cpp
+++ b/esphome/components/template/lock/template_lock.cpp
@@ -1,8 +1,7 @@
 #include "template_lock.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 using namespace esphome::lock;
 
@@ -56,5 +55,4 @@ void TemplateLock::dump_config() {
   ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/lock/template_lock.h
+++ b/esphome/components/template/lock/template_lock.h
@@ -5,8 +5,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/lock/lock.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateLock final : public lock::Lock, public Component {
  public:
@@ -36,5 +35,4 @@ class TemplateLock final : public lock::Lock, public Component {
   Trigger<> *prev_trigger_{nullptr};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -1,8 +1,7 @@
 #include "template_number.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.number";
 
@@ -51,5 +50,4 @@ void TemplateNumber::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -6,8 +6,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateNumber final : public number::Number, public PollingComponent {
  public:
@@ -34,5 +33,4 @@ class TemplateNumber final : public number::Number, public PollingComponent {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/output/template_output.h
+++ b/esphome/components/template/output/template_output.h
@@ -4,8 +4,7 @@
 #include "esphome/components/output/binary_output.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateBinaryOutput final : public output::BinaryOutput {
  public:
@@ -27,5 +26,4 @@ class TemplateFloatOutput final : public output::FloatOutput {
   Trigger<float> *trigger_ = new Trigger<float>();
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -1,8 +1,7 @@
 #include "template_select.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.select";
 
@@ -63,5 +62,4 @@ void TemplateSelect::dump_config() {
                 YESNO(this->optimistic_), this->option_at(this->initial_option_index_), YESNO(this->restore_value_));
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/select/template_select.h
+++ b/esphome/components/template/select/template_select.h
@@ -6,8 +6,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateSelect final : public select::Select, public PollingComponent {
  public:
@@ -34,5 +33,4 @@ class TemplateSelect final : public select::Select, public PollingComponent {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/sensor/template_sensor.cpp
+++ b/esphome/components/template/sensor/template_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include <cmath>
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.sensor";
 
@@ -24,5 +23,4 @@ void TemplateSensor::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/sensor/template_sensor.h
+++ b/esphome/components/template/sensor/template_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateSensor final : public sensor::Sensor, public PollingComponent {
  public:
@@ -21,5 +20,4 @@ class TemplateSensor final : public sensor::Sensor, public PollingComponent {
   TemplateLambda<float> f_;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -1,8 +1,7 @@
 #include "template_switch.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.switch";
 
@@ -57,5 +56,4 @@ void TemplateSwitch::dump_config() {
 }
 void TemplateSwitch::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/switch/template_switch.h
+++ b/esphome/components/template/switch/template_switch.h
@@ -5,8 +5,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateSwitch final : public switch_::Switch, public Component {
  public:
@@ -37,5 +36,4 @@ class TemplateSwitch final : public switch_::Switch, public Component {
   Trigger<> *prev_trigger_{nullptr};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -1,8 +1,7 @@
 #include "template_text.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.text";
 
@@ -51,5 +50,4 @@ void TemplateText::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -6,8 +6,7 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/template_lambda.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 // We keep this separate so we don't have to template and duplicate
 // the text input for each different size flash allocation.
@@ -84,5 +83,4 @@ class TemplateText final : public text::Text, public PollingComponent {
   TemplateTextSaverBase *pref_ = nullptr;
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/text_sensor/template_text_sensor.cpp
+++ b/esphome/components/template/text_sensor/template_text_sensor.cpp
@@ -1,8 +1,7 @@
 #include "template_text_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 static const char *const TAG = "template.text_sensor";
 
@@ -20,5 +19,4 @@ float TemplateTextSensor::get_setup_priority() const { return setup_priority::HA
 
 void TemplateTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Template Sensor", this); }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/text_sensor/template_text_sensor.h
+++ b/esphome/components/template/text_sensor/template_text_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 class TemplateTextSensor final : public text_sensor::TextSensor, public PollingComponent {
  public:
@@ -22,5 +21,4 @@ class TemplateTextSensor final : public text_sensor::TextSensor, public PollingC
   TemplateLambda<std::string> f_{};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/valve/automation.h
+++ b/esphome/components/template/valve/automation.h
@@ -4,8 +4,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 template<typename... Ts> class TemplateValvePublishAction : public Action<Ts...>, public Parented<TemplateValve> {
   TEMPLATABLE_VALUE(float, position)
@@ -20,5 +19,4 @@ template<typename... Ts> class TemplateValvePublishAction : public Action<Ts...>
   }
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/valve/template_valve.cpp
+++ b/esphome/components/template/valve/template_valve.cpp
@@ -1,8 +1,7 @@
 #include "template_valve.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 using namespace esphome::valve;
 
@@ -127,5 +126,4 @@ void TemplateValve::stop_prev_trigger_() {
   }
 }
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_

--- a/esphome/components/template/valve/template_valve.h
+++ b/esphome/components/template/valve/template_valve.h
@@ -5,8 +5,7 @@
 #include "esphome/core/template_lambda.h"
 #include "esphome/components/valve/valve.h"
 
-namespace esphome {
-namespace template_ {
+namespace esphome::template_ {
 
 enum TemplateValveRestoreMode {
   VALVE_NO_RESTORE,
@@ -57,5 +56,4 @@ class TemplateValve final : public valve::Valve, public Component {
   bool has_position_{false};
 };
 
-}  // namespace template_
-}  // namespace esphome
+}  // namespace esphome::template_


### PR DESCRIPTION
# What does this implement/fix?

Modernize the template component to use C++17 nested namespace syntax.

This changes all files in `esphome/components/template/` from the legacy nested namespace style:

```cpp
namespace esphome {
namespace template_ {
...
}  // namespace template_
}  // namespace esphome
```

To the cleaner C++17 syntax:

```cpp
namespace esphome::template_ {
...
}  // namespace esphome::template_
```

This is a code style modernization with no functional changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a code style update only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
