### PR TITLE
[wifi_signal] Update signal strength immediately on WiFi connect/disconnect

### DIFF
--- a/esphome/components/wifi_signal/sensor.py
+++ b/esphome/components/wifi_signal/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import sensor
+from esphome.components import sensor, wifi
 import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
@@ -25,5 +25,6 @@ CONFIG_SCHEMA = sensor.sensor_schema(
 
 
 async def to_code(config):
+    wifi.request_wifi_listeners()
     var = await sensor.new_sensor(config)
     await cg.register_component(var, config)

--- a/esphome/components/wifi_signal/wifi_signal_sensor.cpp
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.cpp
@@ -2,13 +2,11 @@
 #ifdef USE_WIFI
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace wifi_signal {
+namespace esphome::wifi_signal {
 
 static const char *const TAG = "wifi_signal.sensor";
 
 void WiFiSignalSensor::dump_config() { LOG_SENSOR("", "WiFi Signal", this); }
 
-}  // namespace wifi_signal
-}  // namespace esphome
+}  // namespace esphome::wifi_signal
 #endif

--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -5,17 +5,19 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/wifi/wifi_component.h"
 #ifdef USE_WIFI
-namespace esphome {
-namespace wifi_signal {
+namespace esphome::wifi_signal {
 
-class WiFiSignalSensor : public sensor::Sensor, public PollingComponent {
+class WiFiSignalSensor : public sensor::Sensor, public PollingComponent, public wifi::WiFiConnectStateListener {
  public:
+  void setup() override { wifi::global_wifi_component->add_connect_state_listener(this); }
   void update() override { this->publish_state(wifi::global_wifi_component->wifi_rssi()); }
   void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  // WiFiConnectStateListener interface - update RSSI immediately on connect
+  void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override { this->update(); }
 };
 
-}  // namespace wifi_signal
-}  // namespace esphome
+}  // namespace esphome::wifi_signal
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Update WiFi signal sensor immediately when WiFi connects or disconnects instead of waiting for the next polling interval.

Previously, the wifi_signal sensor only updated on its polling interval (default 60s), which meant that on first boot the sensor would report -127 dBm / 0% until the first poll after connection. This caused confusing initial readings in Home Assistant.

Now the sensor implements `WiFiConnectStateListener` to receive immediate notifications when WiFi state changes, providing accurate signal strength readings as soon as the connection is established.

Also converts the component to use C++17 nested namespace syntax.

This is particularly important for devices that cycle through deep sleep, where the brief window of stale values could result in spurious -127/-128 dBm readings being reported. See [forum discussion](https://community.home-assistant.io/t/wi-fi-signal-strength-of-128db-being-reported-since-21-november/959674/2).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: wifi_signal
    name: "WiFi Signal"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no config changes)
