### PR TITLE
[core] Move Color::gradient to cpp to avoid duplicate code

### DIFF
--- a/esphome/core/color.cpp
+++ b/esphome/core/color.cpp
@@ -6,4 +6,18 @@ namespace esphome {
 constinit const Color Color::BLACK(0, 0, 0, 0);
 constinit const Color Color::WHITE(255, 255, 255, 255);
 
+Color Color::gradient(const Color &to_color, uint8_t amnt) {
+  Color new_color;
+  float amnt_f = float(amnt) / 255.0f;
+  new_color.r = amnt_f * (to_color.r - this->r) + this->r;
+  new_color.g = amnt_f * (to_color.g - this->g) + this->g;
+  new_color.b = amnt_f * (to_color.b - this->b) + this->b;
+  new_color.w = amnt_f * (to_color.w - this->w) + this->w;
+  return new_color;
+}
+
+Color Color::fade_to_white(uint8_t amnt) { return this->gradient(Color::WHITE, amnt); }
+
+Color Color::fade_to_black(uint8_t amnt) { return this->gradient(Color::BLACK, amnt); }
+
 }  // namespace esphome

--- a/esphome/core/color.h
+++ b/esphome/core/color.h
@@ -174,17 +174,9 @@ struct Color {
                  uint8_t((uint16_t(b) * 255U / max_rgb)), w);
   }
 
-  Color gradient(const Color &to_color, uint8_t amnt) {
-    Color new_color;
-    float amnt_f = float(amnt) / 255.0f;
-    new_color.r = amnt_f * (to_color.r - (*this).r) + (*this).r;
-    new_color.g = amnt_f * (to_color.g - (*this).g) + (*this).g;
-    new_color.b = amnt_f * (to_color.b - (*this).b) + (*this).b;
-    new_color.w = amnt_f * (to_color.w - (*this).w) + (*this).w;
-    return new_color;
-  }
-  Color fade_to_white(uint8_t amnt) { return (*this).gradient(Color::WHITE, amnt); }
-  Color fade_to_black(uint8_t amnt) { return (*this).gradient(Color::BLACK, amnt); }
+  Color gradient(const Color &to_color, uint8_t amnt);
+  Color fade_to_white(uint8_t amnt);
+  Color fade_to_black(uint8_t amnt);
 
   Color lighten(uint8_t delta) { return *this + delta; }
   Color darken(uint8_t delta) { return *this - delta; }


### PR DESCRIPTION
# What does this implement/fix?

Move `Color::gradient`, `Color::fade_to_white`, and `Color::fade_to_black` from inline definitions in `color.h` to out-of-line definitions in `color.cpp`.

When these methods were defined inline in the header, each translation unit that included `color.h` and called these functions got its own compiled copy. GCC's ISRA (Interprocedural Scalar Replacement of Aggregates) optimization created separate clones for each call site, and the linker did not merge them.

By moving the implementations to `color.cpp`, there is now only one copy of each function in the binary.

**Measured savings:** 482 bytes of flash on ESP32

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
