### PR TITLE
[micronova] Move STOVE_STATES to text sensor file as it's used only there

### DIFF
--- a/esphome/components/micronova/micronova.h
+++ b/esphome/components/micronova/micronova.h
@@ -13,18 +13,6 @@ namespace esphome::micronova {
 static const char *const TAG = "micronova";
 static const int STOVE_REPLY_DELAY = 60;
 
-static const std::string STOVE_STATES[11] = {"Off",
-                                             "Start",
-                                             "Pellets loading",
-                                             "Ignition",
-                                             "Working",
-                                             "Brazier Cleaning",
-                                             "Final Cleaning",
-                                             "Standby",
-                                             "No pellets alarm",
-                                             "No ignition alarm",
-                                             "Undefined alarm"};
-
 enum class MicroNovaFunctions {
   STOVE_FUNCTION_VOID = 0,
   STOVE_FUNCTION_SWITCH = 1,

--- a/esphome/components/micronova/text_sensor/micronova_text_sensor.h
+++ b/esphome/components/micronova/text_sensor/micronova_text_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::micronova {
 
-static const std::string STOVE_STATES[11] = {"Off",
+static const char *const STOVE_STATES[11] = {"Off",
                                              "Start",
                                              "Pellets loading",
                                              "Ignition",

--- a/esphome/components/micronova/text_sensor/micronova_text_sensor.h
+++ b/esphome/components/micronova/text_sensor/micronova_text_sensor.h
@@ -5,6 +5,18 @@
 
 namespace esphome::micronova {
 
+static const std::string STOVE_STATES[11] = {"Off",
+                                             "Start",
+                                             "Pellets loading",
+                                             "Ignition",
+                                             "Working",
+                                             "Brazier Cleaning",
+                                             "Final Cleaning",
+                                             "Standby",
+                                             "No pellets alarm",
+                                             "No ignition alarm",
+                                             "Undefined alarm"};
+
 class MicroNovaTextSensor : public text_sensor::TextSensor, public MicroNovaSensorListener {
  public:
   MicroNovaTextSensor(MicroNova *m) : MicroNovaSensorListener(m) {}

--- a/tests/components/micronova/common.yaml
+++ b/tests/components/micronova/common.yaml
@@ -41,3 +41,8 @@ switch:
   - platform: micronova
     stove:
       name: Stove on/off
+
+text_sensor:
+  - platform: micronova
+    stove_state:
+      name: Stove state


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Move STOVE_STATES to text sensor file as it's used only there

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
