### PR TITLE
[micronova] Add FINAL_VALIDATE_SCHEMA to validate uart

### DIFF
--- a/esphome/components/micronova/__init__.py
+++ b/esphome/components/micronova/__init__.py
@@ -8,12 +8,13 @@ CODEOWNERS = ["@jorre05"]
 
 DEPENDENCIES = ["uart"]
 
-CONF_MICRONOVA_ID = "micronova_id"
+DOMAIN = "micronova"
+CONF_MICRONOVA_ID = f"{DOMAIN}_id"
 CONF_ENABLE_RX_PIN = "enable_rx_pin"
 CONF_MEMORY_LOCATION = "memory_location"
 CONF_MEMORY_ADDRESS = "memory_address"
 
-micronova_ns = cg.esphome_ns.namespace("micronova")
+micronova_ns = cg.esphome_ns.namespace(DOMAIN)
 
 MicroNovaFunctions = micronova_ns.enum("MicroNovaFunctions", is_class=True)
 MICRONOVA_FUNCTIONS_ENUM = {
@@ -42,6 +43,16 @@ CONFIG_SCHEMA = (
     )
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(cv.polling_component_schema("60s"))
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    DOMAIN,
+    baud_rate=1200,
+    require_rx=True,
+    require_tx=True,
+    data_bits=8,
+    parity="NONE",
+    stop_bits=2,
 )
 
 

--- a/tests/components/micronova/test.esp32-idf.yaml
+++ b/tests/components/micronova/test.esp32-idf.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO13
 
 packages:
-  uart: !include ../../test_build_components/common/uart/esp32-idf.yaml
+  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/micronova/test.esp8266-ard.yaml
+++ b/tests/components/micronova/test.esp8266-ard.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO15
 
 packages:
-  uart: !include ../../test_build_components/common/uart/esp8266-ard.yaml
+  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/micronova/test.rp2040-ard.yaml
+++ b/tests/components/micronova/test.rp2040-ard.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO3
 
 packages:
-  uart: !include ../../test_build_components/common/uart/rp2040-ard.yaml
+  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/rp2040-ard.yaml
 
 <<: !include common.yaml

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-ard.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-ard.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for ESP32 Arduino tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-c3-ard.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-c3-ard.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for ESP32-C3 Arduino tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO20
+  rx_pin: GPIO21
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-c3-idf.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-c3-idf.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for ESP32-C3 IDF tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO20
+  rx_pin: GPIO21
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-idf.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/esp32-idf.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for ESP32 IDF tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/esp8266-ard.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/esp8266-ard.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for ESP8266 Arduino tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO4
+  rx_pin: GPIO5
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2

--- a/tests/test_build_components/common/uart_1200_none_2stopbits/rp2040-ard.yaml
+++ b/tests/test_build_components/common/uart_1200_none_2stopbits/rp2040-ard.yaml
@@ -1,0 +1,13 @@
+# Common UART configuration for RP2040 Arduino tests - 1200 baud NONE parity 2 stop bits
+
+substitutions:
+  tx_pin: GPIO0
+  rx_pin: GPIO1
+
+uart:
+  - id: uart_bus
+    tx_pin: ${tx_pin}
+    rx_pin: ${rx_pin}
+    baud_rate: 1200
+    parity: NONE
+    stop_bits: 2


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Add FINAL_VALIDATE_SCHEMA to validate uart config

CI revealed that tests used the wrong UART config. Added the required UART config to test_build_components, so in the future, other components can use it

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
