### PR TITLE
[wifi] Fix scan timeout loop when scan returns zero networks

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1264,8 +1264,8 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
     }
 
     case WiFiRetryPhase::SCAN_CONNECTING:
-      // If scan found no matching networks, skip to hidden network mode
-      if (!this->scan_result_.empty() && !this->scan_result_[0].get_matches()) {
+      // If scan found no networks or no matching networks, skip to hidden network mode
+      if (this->scan_result_.empty() || !this->scan_result_[0].get_matches()) {
         return WiFiRetryPhase::RETRY_HIDDEN;
       }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes WiFi state machine getting stuck in an infinite "Scan timeout" loop when a scan completes but returns zero networks (e.g., due to PHY failure, interference, or the configured network being out of range).

The bug was introduced in 2025.11.0. When `scan_result_` is empty after a scan completes, `determine_next_phase_()` would keep returning `SCAN_CONNECTING` because the condition `!scan_result_.empty() && !scan_result_[0].get_matches()` was always false when the result was empty. This caused the state machine to stay in the scanning state without an active scan, eventually triggering the 30-second timeout repeatedly.

The fix changes the condition to `scan_result_.empty() || !scan_result_[0].get_matches()` so that empty scan results also trigger a transition to `RETRY_HIDDEN` phase, allowing the normal retry cycle to continue.

Before fix:
```
[18:37:38.110][W][wifi:1048]: No networks found
[18:38:05.918][E][wifi:1039]: Scan timeout
[18:38:05.920][E][wifi:1039]: Scan timeout
[18:38:05.934][E][wifi:1039]: Scan timeout
... (spams indefinitely)
```

After fix:
```
[W][wifi:1048]: No networks found
[D][wifi:1345]: Retry phase: SCAN_CONNECTING → RETRY_HIDDEN
[I][wifi:759]: Connecting to 'ssid' (any) (priority 0, attempt 1/1 in phase RETRY_HIDDEN)...
... (continues normal retry cycle)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12352

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any WiFi config will work - issue occurs when scan returns 0 networks
wifi:
  ssid: "my-network"
  password: "my-password"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
