### PR TITLE
[libretiny] Fix WiFi scan timeout loop when scan fails

### DIFF
--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -445,6 +445,7 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
 }
 void WiFiComponent::wifi_scan_done_callback_() {
   this->scan_result_.clear();
+  this->scan_done_ = true;
 
   int16_t num = WiFi.scanComplete();
   if (num < 0)
@@ -463,7 +464,6 @@ void WiFiComponent::wifi_scan_done_callback_() {
                                     ssid.length() == 0);
   }
   WiFi.scanDelete();
-  this->scan_done_ = true;
 #ifdef USE_WIFI_LISTENERS
   for (auto *listener : this->scan_results_listeners_) {
     listener->on_wifi_scan_results(this->scan_result_);


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug in LibreTiny WiFi scan handling where `scan_done_` was not set when a scan failed.

The issue was that `wifi_scan_done_callback_()` only set `scan_done_ = true` at the end of the function, after processing results. If `WiFi.scanComplete()` returned a negative value (indicating scan failure), the function returned early without setting `scan_done_`, leaving the state machine stuck in SCANNING state.

This bug has existed since the original LibreTiny implementation was added to ESPHome (PR #3509), but only became serious after the WiFi retry logic changes in 2025.11.0 (#11805). Before those changes, the state machine could sometimes recover; after them, an unset `scan_done_` causes the 30-second scan timeout to fire repeatedly, spamming the log with "Scan timeout" errors indefinitely.

The fix moves `scan_done_ = true` to the beginning of the callback, matching the pattern used in the ESP-IDF implementation where `scan_done_` is always set regardless of whether the scan succeeded or returned results.

This fix should be combined with #12354 which addresses a related but separate issue in the common WiFi retry logic.

Before fix:
```
[E][wifi:984]: Scan timeout
[E][wifi:984]: Scan timeout
[E][wifi:984]: Scan timeout
... (spams indefinitely)
```

After fix: The state machine properly transitions and retries the scan or moves to the next connection phase.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12152

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any WiFi config on LibreTiny platform
wifi:
  ssid: "my-network"
  password: "my-password"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
