### PR TITLE
[wifi_signal] Add ifdef guards for clang-tidy compatibility

### DIFF
--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -7,16 +7,24 @@
 #ifdef USE_WIFI
 namespace esphome::wifi_signal {
 
+#ifdef USE_WIFI_LISTENERS
 class WiFiSignalSensor : public sensor::Sensor, public PollingComponent, public wifi::WiFiConnectStateListener {
+#else
+class WiFiSignalSensor : public sensor::Sensor, public PollingComponent {
+#endif
  public:
+#ifdef USE_WIFI_LISTENERS
   void setup() override { wifi::global_wifi_component->add_connect_state_listener(this); }
+#endif
   void update() override { this->publish_state(wifi::global_wifi_component->wifi_rssi()); }
   void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
+#ifdef USE_WIFI_LISTENERS
   // WiFiConnectStateListener interface - update RSSI immediately on connect
   void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override { this->update(); }
+#endif
 };
 
 }  // namespace esphome::wifi_signal


### PR DESCRIPTION
# What does this implement/fix?

Add `#ifdef USE_WIFI_LISTENERS` guards to `wifi_signal_sensor.h` to fix clang-tidy errors.

The `add_connect_state_listener()` method and `WiFiConnectStateListener` base class are guarded by `USE_WIFI_LISTENERS` in the wifi component. When clang-tidy analyzes the wifi_signal header without this define present, it fails with:

```
error: no member named 'add_connect_state_listener' in 'esphome::wifi::WiFiComponent'
```

In practice, `USE_WIFI_LISTENERS` is always defined when this component is used because `sensor.py` calls `wifi.request_wifi_listeners()`. The ifdef guards are purely to satisfy clang-tidy's static analysis.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a clang-tidy fix only
sensor:
  - platform: wifi_signal
    name: "WiFi Signal"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
