### PR TITLE
[hub75] fix id conflict

### DIFF
--- a/tests/components/hub75/test.esp32-idf.yaml
+++ b/tests/components/hub75/test.esp32-idf.yaml
@@ -25,15 +25,15 @@ display:
     oe_pin: GPIO15
     clk_pin: GPIO16
     pages:
-      - id: page1
+      - id: page1_hub75
         lambda: |-
           it.rectangle(0, 0, it.get_width(), it.get_height());
-      - id: page2
+      - id: page2_hub75
         lambda: |-
           it.rectangle(0, 0, it.get_width(), it.get_height());
     on_page_change:
-      from: page1
-      to: page2
+      from: page1_hub75
+      to: page2_hub75
       then:
         lambda: |-
           ESP_LOGD("display", "1 -> 2");


### PR DESCRIPTION
The id must be unique in the grouped test script

# What does this implement/fix?

The test components 
batch (tmp1075 tmp117 tof10120 tsl2561 tsl2591 tt21100 ttp229_lsf ufire_ec ufire_ise veml3235 veml7700 vl53l0x xgzp68xx xl9535 zio_ultrasonic chsc6x cst226 cst816 wk2132_i2c i2s_audio mipi_rgb st7701s bluetooth_proxy esp32_ble esp32_ble_beacon esp32_ble_server esp32_can esp32_dac esp32_improv esp32_rmt_led_strip esp32_touch hub75 ledc psram rpi_dpi_rgb usb_host usb_uart wk2168_i2c wk2204_i2c wk2212_i2c) 
is failing because of a duplicate page id in the hub75 and chsc6x.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
