### PR TITLE
[sx1509] Change setup priority from HARDWARE to IO

### DIFF
--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -40,7 +40,7 @@ class SX1509Component : public Component,
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  float get_setup_priority() const override { return setup_priority::IO; }
   void loop() override;
 
   uint16_t read_key_data();


### PR DESCRIPTION
With the current priority of "HARDWARE" binary-sensors have precedence. That causes pins, configured via sx1509, to not have mode settings applied, such as e.g. pullups.
Maybe that priority should even be changed to BUS, however then it's equal to I2C's, which might cause its own set of issues.

Related to GitHub issues:
 - https://github.com/esphome/esphome/issues/12367
 - https://github.com/esphome/issues/issues/7085

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue) **well, I hope, could very well have side effects**
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12367
- 
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

See https://github.com/esphome/esphome/issues/12367

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
