### PR TITLE
[psram] Fix boot failure with 120MHz Octal flash

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -197,7 +197,6 @@ async def to_code(config):
     add_idf_sdkconfig_option("CONFIG_SPIRAM_SPEED", speed)
     if config[CONF_MODE] == TYPE_OCTAL and speed == 120:
         add_idf_sdkconfig_option("CONFIG_ESPTOOLPY_FLASHFREQ_120M", True)
-        add_idf_sdkconfig_option("CONFIG_BOOTLOADER_FLASH_DC_AWARE", True)
         if CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] >= cv.Version(5, 4, 0):
             add_idf_sdkconfig_option(
                 "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR", True


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using octal flash on an esp32s3 at 120MHz, the psram component is setting the sdk config option `CONFIG_BOOTLOADER_FLASH_DC_AWARE`.

This appears to be having the effect of boot failure when resetting the chip by anything other than an external hardware reset (e.g. USB reset, software reset after OTA.) The effect is that after the soft reset the log shows:

```
[19:46:50.483]SPIWP:0xee
[19:46:50.483]mode:DIO, clock div:1
[19:46:50.483]load:0x3fce2820,len:0x158c
[19:46:50.483]load:0x3c870040,len:0xc84ff
[19:46:50.483]Invalid image block, can't boot.
[19:46:50.483]ets_main.c 329
[19:46:51.652]ESP-ROM:esp32s3-20210327
[19:46:51.652]Build:Mar 27 2021
[19:46:51.653]rst:0x7 (TG0WDT_SYS_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
[19:46:51.653]Saved PC:0x40043ac8
[19:46:51.661]SPIWP:0xee
[19:46:51.661]mode:DIO, clock div:1
[19:46:51.661]load:0x3fce2820,len:0x158c
[19:46:51.661]load:0x3c870040,len:0xc84ff
[19:46:51.662]Invalid image block, can't boot.
[19:46:51.663]ets_main.c 329
```

ad infinitum. A hardware reset restores normal operation. This behaviour has been reproduced on several different ESP32-S3 boards.

The esp-idf docs only discuss that the config option in question is applicable to quad PSRAM chips, so this PR removes that setting. It remains an open question whether it should be set for quad psram at 120MHz.

Testing shows that the problem is gone after this change.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esp32:
  variant: esp32s3
  flash_size: 16MB
  cpu_frequency: 240MHz
  framework:
    type: esp-idf
    advanced:
      enable_idf_experimental_features: true

psram:
  mode: octal
  speed: 120MHz

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
