### PR TITLE
[mqtt] Fix logger method case sensitivity error

### DIFF
--- a/esphome/mqtt.py
+++ b/esphome/mqtt.py
@@ -192,7 +192,7 @@ def get_esphome_device_ip(
 
             data = json.loads(payload)
             if "name" not in data or data["name"] != dev_name:
-                _LOGGER.Warn("Wrong device answer")
+                _LOGGER.warning("Wrong device answer")
                 return
 
             dev_ip = []


### PR DESCRIPTION
# What does this implement/fix?

Fix `AttributeError: 'Logger' object has no attribute 'Warn'` that occurs in MQTT message handling.

Python's logging module uses lowercase method names (`debug`, `info`, `warning`, `error`, `critical`). The code incorrectly used `_LOGGER.Warn()` with a capital 'W' instead of `_LOGGER.warning()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12378

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Note: This is a Python-only fix that doesn't require device testing.

## Example entry for `config.yaml`:

```yaml
# N/A - no configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)