### PR TITLE
[ci] Allow memory impact target branch build to fail without blocking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,13 +959,13 @@ jobs:
       - memory-impact-comment
     if: always()
     steps:
-      - name: Success
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-      - name: Failure
-        if: ${{ contains(needs.*.result, 'failure') }}
+      - name: Check job results
         env:
-          JSON_DOC: ${{ toJSON(needs) }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          echo $JSON_DOC | jq
-          exit 1
+          # memory-impact-target-branch is allowed to fail without blocking CI.
+          # This job builds the target branch (dev/beta/release) which may fail because:
+          # 1. The target branch has a build issue independent of this PR
+          # 2. This PR fixes a build issue on the target branch
+          # In either case, we only care that the PR branch builds successfully.
+          echo "$NEEDS_JSON" | jq -e 'del(.["memory-impact-target-branch"]) | all(.result != "failure")'

--- a/script/templates/ci_memory_impact_target_unavailable.j2
+++ b/script/templates/ci_memory_impact_target_unavailable.j2
@@ -1,0 +1,19 @@
+{{ comment_marker }}
+## Memory Impact Analysis
+
+**Components:** {{ components_str }}
+**Platform:** `{{ platform }}`
+
+| Metric | This PR |
+|--------|---------|
+| **RAM** | {{ pr_ram }} |
+| **Flash** | {{ pr_flash }} |
+
+> ⚠️ **Target branch comparison unavailable** - The target branch failed to build.
+> This can happen when the target branch has a build issue, or when this PR fixes a build issue on the target branch.
+> The PR branch compiled successfully with the memory usage shown above.
+
+---
+> **Note:** This analysis measures **static RAM and Flash usage** only (compile-time allocation).
+
+*This analysis runs automatically when components change.*


### PR DESCRIPTION
# What does this implement/fix?

Allow the memory impact target branch build to fail without blocking CI.

The `memory-impact-target-branch` job builds the target branch (dev/beta/release) to compare memory usage against the PR. This job can fail for reasons unrelated to the PR:

1. The target branch has a build issue independent of this PR
2. This PR fixes a build issue on the target branch
3. The target branch doesn't support something the PR branch does (ie new platform support)

In either case, we only care that the PR branch builds successfully. The target branch comparison is informational - if it fails, we still post a comment showing the PR's memory usage with a note explaining the comparison is unavailable.

## Changes

- **ci.yml**: Modified `ci-status` job to exclude `memory-impact-target-branch` from the failure check using jq to filter job results
- **ci_memory_impact_comment.py**: Handle missing target data gracefully by posting a limited comment instead of failing
- **ci_memory_impact_target_unavailable.j2**: New template for the "target unavailable" case
- Added `format_components_str()` helper to reduce code duplication

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - CI workflow change

## Example entry for `config.yaml`:

N/A - CI workflow change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

The jq expression was tested with a shell script covering 8 test cases:
1. All jobs pass - CI succeeds
2. Only target branch fails - CI succeeds
4. PR branch fails - CI fails
5. Other job fails - CI fails
6. Target branch and other job both fail - CI fails
7. Jobs skipped - CI succeeds
8. Jobs cancelled - CI succeeds
9. Full realistic needs object - CI succeeds

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

N/A - Internal CI change
