### PR TITLE
[tests] Fix clang-tidy warnings in custom_api_device_component fixture

### DIFF
--- a/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.cpp
+++ b/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.cpp
@@ -52,7 +52,7 @@ void CustomAPIDeviceComponent::on_service_with_arrays(std::vector<bool> bool_arr
   }
 }
 
-void CustomAPIDeviceComponent::on_ha_state_changed(std::string entity_id, std::string state) {
+void CustomAPIDeviceComponent::on_ha_state_changed(const std::string &entity_id, const std::string &state) {
   ESP_LOGI(TAG, "Home Assistant state changed for %s: %s", entity_id.c_str(), state.c_str());
   ESP_LOGI(TAG, "This subscription uses std::string API for backward compatibility");
 }

--- a/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.cpp
+++ b/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.cpp
@@ -52,7 +52,8 @@ void CustomAPIDeviceComponent::on_service_with_arrays(std::vector<bool> bool_arr
   }
 }
 
-void CustomAPIDeviceComponent::on_ha_state_changed(const std::string &entity_id, const std::string &state) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+void CustomAPIDeviceComponent::on_ha_state_changed(std::string entity_id, std::string state) {
   ESP_LOGI(TAG, "Home Assistant state changed for %s: %s", entity_id.c_str(), state.c_str());
   ESP_LOGI(TAG, "This subscription uses std::string API for backward compatibility");
 }

--- a/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.h
+++ b/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.h
@@ -24,7 +24,8 @@ class CustomAPIDeviceComponent : public Component, public CustomAPIDevice {
                               std::vector<float> float_array, std::vector<std::string> string_array);
 
   // Test Home Assistant state subscription with std::string API
-  void on_ha_state_changed(const std::string &entity_id, const std::string &state);
+  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+  void on_ha_state_changed(std::string entity_id, std::string state);
 };
 
 }  // namespace custom_api_device_component

--- a/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.h
+++ b/tests/integration/fixtures/external_components/custom_api_device_component/custom_api_device_component.h
@@ -24,7 +24,7 @@ class CustomAPIDeviceComponent : public Component, public CustomAPIDevice {
                               std::vector<float> float_array, std::vector<std::string> string_array);
 
   // Test Home Assistant state subscription with std::string API
-  void on_ha_state_changed(std::string entity_id, std::string state);
+  void on_ha_state_changed(const std::string &entity_id, const std::string &state);
 };
 
 }  // namespace custom_api_device_component


### PR DESCRIPTION
# What does this implement/fix?

Fix clang-tidy `performance-unnecessary-value-param` warnings in the `custom_api_device_component` test fixture by adding `NOLINTNEXTLINE` comments.

The `on_ha_state_changed` callback must use `std::string` by value (not by const reference) because the `subscribe_homeassistant_state` template in `custom_api_device.h` expects this exact signature. This is intentional for backward compatibility with the std::string API, so the warning is suppressed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - CI clang-tidy fix

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - test fixture only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - test fixture code only, verified by clang-tidy in CI

## Example entry for `config.yaml`:

N/A - test fixture only

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
