### PR TITLE
[micronova] Fix test UART package key to match directory name

### DIFF
--- a/tests/components/micronova/test.esp32-idf.yaml
+++ b/tests/components/micronova/test.esp32-idf.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO13
 
 packages:
-  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp32-idf.yaml
+  uart_1200_none_2stopbits: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/micronova/test.esp8266-ard.yaml
+++ b/tests/components/micronova/test.esp8266-ard.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO15
 
 packages:
-  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp8266-ard.yaml
+  uart_1200_none_2stopbits: !include ../../test_build_components/common/uart_1200_none_2stopbits/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/micronova/test.rp2040-ard.yaml
+++ b/tests/components/micronova/test.rp2040-ard.yaml
@@ -2,6 +2,6 @@ substitutions:
   enable_rx_pin: GPIO3
 
 packages:
-  uart: !include ../../test_build_components/common/uart_1200_none_2stopbits/rp2040-ard.yaml
+  uart_1200_none_2stopbits: !include ../../test_build_components/common/uart_1200_none_2stopbits/rp2040-ard.yaml
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fix micronova test UART package key to match directory name.

The micronova component uses a custom UART configuration (1200 baud, NONE parity, 2 stop bits) but the test files used `uart` as the package key while pointing to the `uart_1200_none_2stopbits` directory. This caused the CI component grouping logic to incorrectly identify micronova as compatible with other UART components that use standard 9600 baud configuration.

The fix changes the package key from `uart` to `uart_1200_none_2stopbits` to match the actual directory name, allowing the grouping logic to properly identify components with different UART configurations as incompatible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure change only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
