### PR TITLE
[ci] Isolate usb_cdc_acm in component tests due to tinyusb/usb_host conflict

### DIFF
--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -87,6 +87,7 @@ ISOLATED_COMPONENTS = {
     "neopixelbus": "RMT type conflict with ESP32 Arduino/ESP-IDF headers (enum vs struct rmt_channel_t)",
     "packages": "cannot merge packages",
     "tinyusb": "Conflicts with usb_host component - cannot be used together",
+    "usb_cdc_acm": "Depends on tinyusb which conflicts with usb_host",
 }
 
 


### PR DESCRIPTION
# What does this implement/fix?

Add `usb_cdc_acm` to the `ISOLATED_COMPONENTS` list in the test build script.

The `usb_cdc_acm` component depends on `tinyusb`, which has `CONFLICTS_WITH = ["usb_host"]`. When the test script tries to group `usb_cdc_acm` with `usb_host` or `usb_uart` (which auto-loads `usb_host`), the configuration validation fails because `tinyusb` and `usb_host` cannot be used together.

By marking `usb_cdc_acm` as isolated, it will be tested separately from components that use `usb_host`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

N/A - This is a CI/test infrastructure change only.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
