### PR TITLE
[esp32_ble_client] Use stack-based MAC formatting in auth logging

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -524,7 +524,7 @@ void BLEClientBase::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_
     case ESP_GAP_BLE_AUTH_CMPL_EVT:
       if (!this->check_addr(param->ble_security.auth_cmpl.bd_addr))
         return;
-      char addr_str[18];
+      char addr_str[MAC_ADDR_STR_LEN];
       format_mac_addr_upper(param->ble_security.auth_cmpl.bd_addr, addr_str);
       ESP_LOGI(TAG, "[%d] [%s] auth complete addr: %s", this->connection_index_, this->address_str_, addr_str);
       if (!param->ble_security.auth_cmpl.success) {

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -524,10 +524,9 @@ void BLEClientBase::gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_
     case ESP_GAP_BLE_AUTH_CMPL_EVT:
       if (!this->check_addr(param->ble_security.auth_cmpl.bd_addr))
         return;
-      esp_bd_addr_t bd_addr;
-      memcpy(bd_addr, param->ble_security.auth_cmpl.bd_addr, sizeof(esp_bd_addr_t));
-      ESP_LOGI(TAG, "[%d] [%s] auth complete addr: %s", this->connection_index_, this->address_str_,
-               format_hex(bd_addr, 6).c_str());
+      char addr_str[18];
+      format_mac_addr_upper(param->ble_security.auth_cmpl.bd_addr, addr_str);
+      ESP_LOGI(TAG, "[%d] [%s] auth complete addr: %s", this->connection_index_, this->address_str_, addr_str);
       if (!param->ble_security.auth_cmpl.success) {
         this->log_error_("auth fail reason", param->ble_security.auth_cmpl.fail_reason);
       } else {


### PR DESCRIPTION
# What does this implement/fix?

Use stack-based MAC address formatting in BLE client auth complete logging.

This change replaces heap-allocated `std::string` formatting with inline stack-based formatting for the Bluetooth address logged during authentication completion.

**Before:**
```cpp
esp_bd_addr_t bd_addr;
memcpy(bd_addr, param->ble_security.auth_cmpl.bd_addr, sizeof(esp_bd_addr_t));
ESP_LOGI(TAG, "... addr: %s", format_hex(bd_addr, 6).c_str());
```

**After:**
```cpp
char addr_str[18];
format_mac_addr_upper(param->ble_security.auth_cmpl.bd_addr, addr_str);
ESP_LOGI(TAG, "... addr: %s", addr_str);
```

**Benefits:**
- Saves 162 bytes of flash by eliminating `format_hex(uint8_t*, size_t)` instantiation
- Removes unnecessary `memcpy` to temporary buffer
- No heap allocation for the formatted string
- Output format is more readable: `XX:XX:XX:XX:XX:XX` instead of `xxxxxxxxxxxx`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
