### PR TITLE
[core] Add constexpr parse_hex_char helper and simplify parse_hex

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -266,19 +266,12 @@ std::string make_name_with_suffix(const std::string &name, char sep, const char 
 // Parsing & formatting
 
 size_t parse_hex(const char *str, size_t length, uint8_t *data, size_t count) {
-  uint8_t val;
   size_t chars = std::min(length, 2 * count);
   for (size_t i = 2 * count - chars; i < 2 * count; i++, str++) {
-    if (*str >= '0' && *str <= '9') {
-      val = *str - '0';
-    } else if (*str >= 'A' && *str <= 'F') {
-      val = 10 + (*str - 'A');
-    } else if (*str >= 'a' && *str <= 'f') {
-      val = 10 + (*str - 'a');
-    } else {
+    uint8_t val = parse_hex_char(*str);
+    if (val > 15)
       return 0;
-    }
-    data[i >> 1] = !(i & 1) ? val << 4 : data[i >> 1] | val;
+    data[i >> 1] = (i & 1) ? data[i >> 1] | val : val << 4;
   }
   return chars;
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -624,6 +624,17 @@ template<typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0> optional<
   return parse_hex<T>(str.c_str(), str.length());
 }
 
+/// Parse a hex character to its nibble value (0-15), returns 255 on invalid input
+constexpr uint8_t parse_hex_char(char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'A' && c <= 'F')
+    return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  return 255;
+}
+
 /// Convert a nibble (0-15) to lowercase hex char
 inline char format_hex_char(uint8_t v) { return v >= 10 ? 'a' + (v - 10) : '0' + v; }
 


### PR DESCRIPTION
# What does this implement/fix?

Refactor `parse_hex` to use a new `constexpr` helper function `parse_hex_char` for converting hex characters to nibbles.

**Changes:**
- Add `constexpr uint8_t parse_hex_char(char c)` helper that converts a single hex character ('0'-'9', 'A'-'F', 'a'-'f') to its nibble value (0-15), returning 255 on invalid input
- Simplify `parse_hex()` implementation to use this helper, improving readability
- Being `constexpr`, the helper can be evaluated at compile time when the input is a constant

**Benefits:**
- More readable code - hex char parsing logic is factored out
- Reusable helper for other code that needs to parse single hex characters
- `constexpr` enables compile-time evaluation where applicable
- Saves ~4 bytes of flash

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal API only

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
