### PR TITLE
[api] Fix potential buffer overflow in noise PSK base64 decode

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1669,7 +1669,7 @@ bool APIConnection::send_noise_encryption_set_key_response(const NoiseEncryption
     } else {
       ESP_LOGW(TAG, "Failed to clear encryption key");
     }
-  } else if (base64_decode(msg.key, psk.data(), msg.key.size()) != psk.size()) {
+  } else if (base64_decode(msg.key, psk.data(), psk.size()) != psk.size()) {
     ESP_LOGW(TAG, "Invalid encryption key length");
   } else if (!this->parent_->save_noise_psk(psk, true)) {
     ESP_LOGW(TAG, "Failed to save encryption key");

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -480,22 +480,13 @@ std::string base64_encode(const uint8_t *buf, size_t buf_len) {
 }
 
 size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf_len) {
-  std::vector<uint8_t> decoded = base64_decode(encoded_string);
-  if (decoded.size() > buf_len) {
-    ESP_LOGW(TAG, "Base64 decode: buffer too small, truncating");
-    decoded.resize(buf_len);
-  }
-  memcpy(buf, decoded.data(), decoded.size());
-  return decoded.size();
-}
-
-std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
   int in_len = encoded_string.size();
   int i = 0;
   int j = 0;
   int in = 0;
+  size_t out = 0;
   uint8_t char_array_4[4], char_array_3[3];
-  std::vector<uint8_t> ret;
+  bool truncated = false;
 
   // SAFETY: The loop condition checks is_base64() before processing each character.
   // This ensures base64_find_char() is only called on valid base64 characters,
@@ -511,8 +502,13 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
       char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
       char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
-      for (i = 0; (i < 3); i++)
-        ret.push_back(char_array_3[i]);
+      for (i = 0; i < 3; i++) {
+        if (out < buf_len) {
+          buf[out++] = char_array_3[i];
+        } else {
+          truncated = true;
+        }
+      }
       i = 0;
     }
   }
@@ -528,10 +524,28 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
     char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
     char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
 
-    for (j = 0; (j < i - 1); j++)
-      ret.push_back(char_array_3[j]);
+    for (j = 0; j < i - 1; j++) {
+      if (out < buf_len) {
+        buf[out++] = char_array_3[j];
+      } else {
+        truncated = true;
+      }
+    }
   }
 
+  if (truncated) {
+    ESP_LOGW(TAG, "Base64 decode: buffer too small, truncating");
+  }
+
+  return out;
+}
+
+std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
+  // Calculate maximum decoded size: every 4 base64 chars = 3 bytes
+  size_t max_len = (encoded_string.size() / 4 + 1) * 3;
+  std::vector<uint8_t> ret(max_len);
+  size_t actual_len = base64_decode(encoded_string, ret.data(), max_len);
+  ret.resize(actual_len);
   return ret;
 }
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -542,7 +542,7 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
 
 std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
   // Calculate maximum decoded size: every 4 base64 chars = 3 bytes
-  size_t max_len = (encoded_string.size() / 4 + 1) * 3;
+  size_t max_len = ((encoded_string.size() + 3) / 4) * 3;
   std::vector<uint8_t> ret(max_len);
   size_t actual_len = base64_decode(encoded_string, ret.data(), max_len);
   ret.resize(actual_len);


### PR DESCRIPTION
# What does this implement/fix?

Fix potential buffer overflow in `base64_decode` call for noise PSK and refactor to eliminate unnecessary heap allocation.

**Bug:** The call in `api_connection.cpp` was passing `msg.key.size()` (~44 for a 32-byte key) as the buffer length instead of `psk.size()` (32). This told `base64_decode` it had a 44-byte buffer when it only had 32 bytes, creating a potential overflow if a malicious client sent an oversized base64 string.

```cpp
// Before (bug):
base64_decode(msg.key, psk.data(), msg.key.size())

// After (fixed):
base64_decode(msg.key, psk.data(), psk.size())
```

**Refactor:** While fixing this, also refactored `base64_decode` to decode directly into the provided buffer instead of allocating a temporary `std::vector` and copying.

**Changes:**
- Fix buffer length parameter in `api_connection.cpp` to use `psk.size()` instead of `msg.key.size()`
- Make the buffer-based `base64_decode(string, buf, len)` the primary implementation that decodes directly into the provided buffer
- The vector-returning `base64_decode(string)` now calls the buffer version instead of vice versa
- Preserve the `ESP_LOGW` warning when the buffer is too small and truncation occurs

**Additional benefits:**
- **No heap allocation** for the API noise PSK decoding
- **No temporary vector** construction/destruction overhead
- **No memcpy** - data goes directly to the destination buffer
- Saves ~16 bytes of flash

**Future optimization:** A follow-up PR could make `msg.key` zero-copy by accepting `const char *` and length instead of `const std::string &`, avoiding the string construction entirely. Not done in this PR.

**Testing:** Existing integration tests in `test_noise_encryption_key_protection.py` exercise `noise_encryption_set_key` which calls `base64_decode`. Both tests pass with these changes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal API only

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no user-facing changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
