### PR TITLE
[esp8266] Eliminate up to 16ms socket latency

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -23,6 +23,7 @@ namespace socket {
 
 #ifdef USE_ESP8266
 // Flag to signal socket activity - checked by socket_delay() to exit early
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static volatile bool s_socket_woke = false;
 
 void socket_delay(uint32_t ms) {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -21,6 +21,24 @@
 namespace esphome {
 namespace socket {
 
+#ifdef USE_ESP8266
+// Flag to signal socket activity - checked by socket_delay() to exit early
+static volatile bool s_socket_woke = false;
+
+void socket_delay(uint32_t ms) {
+  // Use esp_delay with a callback that checks if socket data arrived.
+  // This allows the delay to exit early when socket_wake() is called by
+  // lwip recv_fn/accept_fn callbacks, reducing socket latency.
+  s_socket_woke = false;
+  esp_delay(ms, []() { return !s_socket_woke; });
+}
+
+void socket_wake() {
+  s_socket_woke = true;
+  esp_schedule();
+}
+#endif
+
 static const char *const TAG = "socket.lwip";
 
 // set to 1 to enable verbose lwip logging
@@ -483,8 +501,7 @@ class LWIPRawImpl : public Socket {
     }
 #ifdef USE_ESP8266
     // Wake the main loop immediately so it can process the received data.
-    // esp_schedule() wakes the context blocked in delay() -> esp_suspend().
-    esp_schedule();
+    socket_wake();
 #endif
     return ERR_OK;
   }
@@ -648,7 +665,7 @@ class LWIPRawListenImpl : public LWIPRawImpl {
     LWIP_LOG("Accepted connection, queue size: %d", accepted_socket_count_);
 #ifdef USE_ESP8266
     // Wake the main loop immediately so it can accept the new connection.
-    esp_schedule();
+    socket_wake();
 #endif
     return ERR_OK;
   }

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -24,7 +24,7 @@ namespace socket {
 static const char *const TAG = "socket.lwip";
 
 // set to 1 to enable verbose lwip logging
-#if 0
+#if 0  // NOLINT(readability-avoid-unconditional-preprocessor-if)
 #define LWIP_LOG(msg, ...) ESP_LOGVV(TAG, "socket %p: " msg, this, ##__VA_ARGS__)
 #else
 #define LWIP_LOG(msg, ...)
@@ -327,9 +327,10 @@ class LWIPRawImpl : public Socket {
     for (int i = 0; i < iovcnt; i++) {
       ssize_t err = read(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);
       if (err == -1) {
-        if (ret != 0)
+        if (ret != 0) {
           // if we already read some don't return an error
           break;
+        }
         return err;
       }
       ret += err;
@@ -397,9 +398,10 @@ class LWIPRawImpl : public Socket {
     ssize_t written = internal_write(buf, len);
     if (written == -1)
       return -1;
-    if (written == 0)
+    if (written == 0) {
       // no need to output if nothing written
       return 0;
+    }
     if (nodelay_) {
       int err = internal_output();
       if (err == -1)
@@ -412,18 +414,20 @@ class LWIPRawImpl : public Socket {
     for (int i = 0; i < iovcnt; i++) {
       ssize_t err = internal_write(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);
       if (err == -1) {
-        if (written != 0)
+        if (written != 0) {
           // if we already read some don't return an error
           break;
+        }
         return err;
       }
       written += err;
       if ((size_t) err != iov[i].iov_len)
         break;
     }
-    if (written == 0)
+    if (written == 0) {
       // no need to output if nothing written
       return 0;
+    }
     if (nodelay_) {
       int err = internal_output();
       if (err == -1)

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -621,7 +621,7 @@ class LWIPRawListenImpl : public LWIPRawImpl {
   }
 
  private:
-  err_t accept_fn(struct tcp_pcb *newpcb, err_t err) {
+  err_t accept_fn_(struct tcp_pcb *newpcb, err_t err) {
     LWIP_LOG("accept(newpcb=%p err=%d)", newpcb, err);
     if (err != ERR_OK || newpcb == nullptr) {
       // "An error code if there has been an error accepting. Only return ERR_ABRT if you have
@@ -651,7 +651,7 @@ class LWIPRawListenImpl : public LWIPRawImpl {
 
   static err_t s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err) {
     LWIPRawListenImpl *arg_this = reinterpret_cast<LWIPRawListenImpl *>(arg);
-    return arg_this->accept_fn(newpcb, err);
+    return arg_this->accept_fn_(newpcb, err);
   }
 
   // Accept queue - holds incoming connections briefly until the event loop calls accept()

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -14,6 +14,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_ESP8266
+#include <coredecls.h>  // For esp_schedule()
+#endif
+
 namespace esphome {
 namespace socket {
 
@@ -473,6 +477,11 @@ class LWIPRawImpl : public Socket {
     } else {
       pbuf_cat(rx_buf_, pb);
     }
+#ifdef USE_ESP8266
+    // Wake the main loop immediately so it can process the received data.
+    // esp_schedule() wakes the context blocked in delay() -> esp_suspend().
+    esp_schedule();
+#endif
     return ERR_OK;
   }
 
@@ -633,6 +642,10 @@ class LWIPRawListenImpl : public LWIPRawImpl {
     sock->init();
     accepted_sockets_[accepted_socket_count_++] = std::move(sock);
     LWIP_LOG("Accepted connection, queue size: %d", accepted_socket_count_);
+#ifdef USE_ESP8266
+    // Wake the main loop immediately so it can accept the new connection.
+    esp_schedule();
+#endif
     return ERR_OK;
   }
 

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -82,6 +82,15 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
 /// Set a sockaddr to the any address and specified port for the IP version used by socket_ip().
 socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port);
 
+#if defined(USE_ESP8266) && defined(USE_SOCKET_IMPL_LWIP_TCP)
+/// Delay that can be woken early by socket activity.
+/// On ESP8266, lwip callbacks set a flag and call esp_schedule() to wake the delay.
+void socket_delay(uint32_t ms);
+
+/// Called by lwip callbacks to signal socket activity and wake delay.
+void socket_wake();
+#endif
+
 }  // namespace socket
 }  // namespace esphome
 #endif

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -12,6 +12,10 @@
 #include "esphome/components/status_led/status_led.h"
 #endif
 
+#if defined(USE_ESP8266) && defined(USE_SOCKET_IMPL_LWIP_TCP)
+#include "esphome/components/socket/socket.h"
+#endif
+
 #ifdef USE_SOCKET_SELECT_SUPPORT
 #include <cerrno>
 
@@ -627,6 +631,9 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     // No sockets registered, use regular delay
     delay(delay_ms);
   }
+#elif defined(USE_ESP8266) && defined(USE_SOCKET_IMPL_LWIP_TCP)
+  // No select support but can wake on socket activity via esp_schedule()
+  socket::socket_delay(delay_ms);
 #else
   // No select support, use regular delay
   delay(delay_ms);


### PR DESCRIPTION
# What does this implement/fix?

**Brings ESP8266 socket responsiveness to parity with ESP32 and LibreTiny platforms.**

On ESP32 and LibreTiny, the main loop uses `select()` to wake immediately when socket data arrives. But ESP8266 uses the lwip raw TCP implementation which doesn't support `select()`, so it had to poll - sleeping for up to 16ms (the default loop interval) before discovering that data had arrived.

This 16ms latency affected every new connection and every incoming data packet - meaning every API request, every Home Assistant command, and every network interaction. Users on ESP8266 experienced noticeably slower response times compared to ESP32 devices.

**This PR eliminates that latency.** The loop now wakes within microseconds of data arriving, matching the behavior of ESP32 and LibreTiny.

## How it works

ESP8266 Arduino provides `esp_delay(timeout_ms, callback)` which loops calling `esp_try_delay()` → `esp_suspend()`. The callback is checked after each resume - if it returns `false`, the delay exits early.

The key mechanism: `esp_schedule()` posts an event via `ets_post()` which immediately wakes `esp_suspend()`. The flow is:

```
esp_delay(ms, callback)
  └─► while (!esp_try_delay(...) && callback()) { }
        └─► esp_delay(grain_ms)
              └─► esp_suspend()  ◄── woken by esp_schedule()
```

When `esp_schedule()` is called:
1. `ets_post()` queues an event to the SDK task dispatcher
2. The dispatcher calls `loop_task()` → `cont_run()` which resumes the suspended continuation
3. `esp_try_delay()` returns (timeout not expired)
4. The while loop checks `callback()` - if it returns `false`, the delay exits immediately

This PR leverages that mechanism:
1. Adds `socket_delay(ms)` - uses `esp_delay(ms, []() { return !s_socket_woke; })`
2. Adds `socket_wake()` - sets `s_socket_woke = true` and calls `esp_schedule()`
3. Calls `socket_wake()` from lwip callbacks when:
   - TCP data is received (`recv_fn`)
   - A new TCP connection is accepted (`accept_fn`)
4. Uses `socket_delay()` in the main loop instead of regular `delay()` on ESP8266

This is the same pattern used by the Arduino ESP8266 WiFi library's `ClientContext` class.

## Safety

`esp_schedule()` only calls `ets_post()` to queue an event - it does NOT immediately switch context. The flow is:
1. lwip calls `recv_fn()`
2. We process the pbuf, call `socket_wake()` which sets flag and queues event
3. We return `ERR_OK` from `recv_fn()`
4. lwip finishes its packet processing
5. `esp_delay()` callback sees the flag, returns `false`, loop exits early

No context switch happens until after we return from the callback, so lwip is never left in an inconsistent state.

## Testing

Added temporary debug logging to verify the implementation works. The log shows:
- `early` - number of times delay exited early due to socket activity
- `total` - total delay calls in the 10 second window

Example log output while pressing a button via the Home Assistant API:
```
[03:52:47.824][D][button:022]: 'Test Button' Pressed.
[03:52:47.948][D][main:213]: Button pressed
[03:52:48.127][D][button:022]: 'Test Button' Pressed.
[03:52:48.127][D][main:213]: Button pressed
[03:52:48.127][D][app:652]: Loop wake stats: early=8 total=1060 (delay_ms=11 actual=11)
[03:52:48.254][D][button:022]: 'Test Button' Pressed.
[03:52:48.254][D][main:213]: Button pressed
[03:52:48.397][D][button:022]: 'Test Button' Pressed.
[03:52:48.397][D][main:213]: Button pressed
[03:52:58.003][D][app:652]: Loop wake stats: early=2 total=1218 (delay_ms=14 actual=14)
[03:53:08.018][D][app:652]: Loop wake stats: early=0 total=1221 (delay_ms=5 actual=5)
```

The `early=8` and `early=2` counts confirm the loop is waking immediately when API commands arrive. When idle (`early=0`), the delay runs to completion as expected - no CPU overhead when there's no socket activity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration needed - this is automatic for all ESP8266 devices
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
