### PR TITLE
Add support for Telaire T3022 CO2 sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -476,6 +476,7 @@ esphome/components/switch/binary_sensor/* @ssieb
 esphome/components/sx126x/* @swoboda1337
 esphome/components/sx127x/* @swoboda1337
 esphome/components/syslog/* @clydebarrow
+esphome/components/t3022/* @aomi
 esphome/components/t6615/* @tylermenezes
 esphome/components/tc74/* @sethgirvan
 esphome/components/tca9548a/* @andreashergert1984

--- a/esphome/components/t3022/sensor.py
+++ b/esphome/components/t3022/sensor.py
@@ -1,0 +1,44 @@
+import esphome.codegen as cg
+from esphome.components import i2c, sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CO2,
+    CONF_ID,
+    DEVICE_CLASS_CARBON_DIOXIDE,
+    ICON_MOLECULE_CO2,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PARTS_PER_MILLION,
+)
+
+DEPENDENCIES = ["i2c"]
+CODEOWNERS = ["@aomi"]
+
+t3022_ns = cg.esphome_ns.namespace("t3022")
+T3022Component = t3022_ns.class_("T3022Component", cg.PollingComponent, i2c.I2CDevice)
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(T3022Component),
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PARTS_PER_MILLION,
+                icon=ICON_MOLECULE_CO2,
+                accuracy_decimals=0,  # Accuracy: +/- 75 ppm or 10% of reading (whichever is greater)
+                device_class=DEVICE_CLASS_CARBON_DIOXIDE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x15))  # Default I2C address for T3022/T67xx series
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if CONF_CO2 in config:
+        sens = await sensor.new_sensor(config[CONF_CO2])
+        cg.add(var.set_co2_sensor(sens))

--- a/esphome/components/t3022/t3022.cpp
+++ b/esphome/components/t3022/t3022.cpp
@@ -1,0 +1,151 @@
+#include "t3022.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+namespace esphome {
+namespace t3022 {
+
+static const char *const TAG = "t3022";
+
+// Command definitions based on T67xx/T3022 protocol
+// Function codes: 0x03=Read Holding Registers, 0x04=Read Input Registers,
+//                 0x05=Read Holding Registers (alternate), 0x06=Write Single Register
+
+// Measure command: Read Holding Register 0x03F3, 1 word
+static const uint8_t CMD_MEASURE[] = {0x05, 0x03, 0xF3, 0x00, 0x00};
+
+// Read CO2 PPM: Read Input Register 0x138B, 1 word
+static const uint8_t CMD_READ_CO2[] = {0x04, 0x13, 0x8B, 0x00, 0x01};
+
+// Status register: Read Input Register 0x138A, 1 word
+static const uint8_t CMD_STATUS[] = {0x04, 0x13, 0x8A, 0x00, 0x01};
+
+bool T3022Component::send_command_(const uint8_t *command, size_t len) {
+  i2c::ErrorCode err = this->write(command, len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGE(TAG, "Failed to send command: %d", err);
+    return false;
+  }
+  delay(READ_DELAY);
+  return true;
+}
+
+bool T3022Component::read_response_(uint8_t *data, size_t len) {
+  i2c::ErrorCode err = this->read(data, len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGE(TAG, "Failed to read response: %d", err);
+    return false;
+  }
+  return true;
+}
+
+bool T3022Component::check_status_() {
+  uint8_t data[4];
+
+  if (!send_command_(CMD_STATUS, sizeof(CMD_STATUS))) {
+    return false;
+  }
+
+  if (!read_response_(data, sizeof(data))) {
+    return false;
+  }
+
+  // Status is OK if data[0] == 0x04 && data[3] == 0x00 (per sample.ino)
+  return (data[0] == 0x04 && data[3] == 0x00);
+}
+
+void T3022Component::read_co2_value_() {
+  uint8_t data[4];
+
+  // Read CO2 value
+  if (!send_command_(CMD_READ_CO2, sizeof(CMD_READ_CO2))) {
+    ESP_LOGE(TAG, "Failed to send read CO2 command");
+    this->status_set_warning();
+    this->publish_nan_();
+    return;
+  }
+
+  if (!read_response_(data, 4)) {
+    ESP_LOGE(TAG, "Failed to read CO2 response");
+    this->status_set_warning();
+    this->publish_nan_();
+    return;
+  }
+
+  // CO2 value is in bytes 2-3, with upper 2 bits of byte 2 masked
+  int16_t co2_value = ((data[2] & 0x3F) << 8) | data[3];
+
+  if (this->co2_sensor_ != nullptr) {
+    this->co2_sensor_->publish_state(co2_value);
+  }
+  this->status_clear_warning();
+}
+
+void T3022Component::publish_nan_() {
+  if (this->co2_sensor_ != nullptr) {
+    this->co2_sensor_->publish_state(NAN);
+  }
+}
+
+void T3022Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up T3022...");
+
+  // Check if sensor is responding by reading status register
+  if (!this->check_status_()) {
+    ESP_LOGE(TAG, "Communication with T3022 failed! Sensor not responding.");
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGCONFIG(TAG, "T3022 sensor detected and responding");
+}
+
+void T3022Component::update() {
+  if (this->co2_sensor_ == nullptr) {
+    return;
+  }
+
+  uint8_t data[5];
+
+  // Send measure command
+  if (!send_command_(CMD_MEASURE, sizeof(CMD_MEASURE))) {
+    ESP_LOGE(TAG, "Failed to send measure command");
+    this->status_set_warning();
+    this->publish_nan_();
+    return;
+  }
+
+  // Read response to measure command
+  if (!read_response_(data, sizeof(data))) {
+    ESP_LOGE(TAG, "Failed to read measure response");
+    this->status_set_warning();
+    this->publish_nan_();
+    return;
+  }
+
+  // Validate response - check if sensor responded correctly
+  if (data[1] != 0x03 || data[4] != 0x00) {
+    ESP_LOGE(TAG, "Measure command failed - invalid response");
+    this->status_set_warning();
+    this->publish_nan_();
+    return;
+  }
+
+  // Schedule reading after measurement delay (non-blocking)
+  this->set_timeout(MEASURE_DELAY, [this]() { this->read_co2_value_(); });
+}
+
+void T3022Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "T3022 CO2 Sensor:");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, "Communication with T3022 failed!");
+  }
+  LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+}
+
+float T3022Component::get_setup_priority() const { return setup_priority::DATA; }
+
+}  // namespace t3022
+}  // namespace esphome

--- a/esphome/components/t3022/t3022.h
+++ b/esphome/components/t3022/t3022.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace t3022 {
+
+class T3022Component : public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_co2_sensor(sensor::Sensor *co2) { co2_sensor_ = co2; }
+
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+ protected:
+  sensor::Sensor *co2_sensor_{nullptr};
+
+  // Helper methods for I2C communication
+  bool send_command_(const uint8_t *command, size_t len);
+  bool read_response_(uint8_t *data, size_t len);
+  bool check_status_();
+  void read_co2_value_();
+  void publish_nan_();
+
+  // Timing constants (in milliseconds)
+  static constexpr uint8_t READ_DELAY = 5;         // Delay between I2C write & read
+  static constexpr uint16_t MEASURE_DELAY = 2250;  // Delay between measure and read PPM (minimum recommended)
+};
+
+}  // namespace t3022
+}  // namespace esphome

--- a/tests/components/t3022/common.yaml
+++ b/tests/components/t3022/common.yaml
@@ -1,0 +1,6 @@
+sensor:
+  - platform: t3022
+    i2c_id: i2c_bus
+    co2:
+      name: T3022 CO2
+    address: 0x15

--- a/tests/components/t3022/test.esp32-ard.yaml
+++ b/tests/components/t3022/test.esp32-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/t3022/test.esp32-idf.yaml
+++ b/tests/components/t3022/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/t3022/test.esp8266-ard.yaml
+++ b/tests/components/t3022/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/t3022/test.rp2040-ard.yaml
+++ b/tests/components/t3022/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

- Add a new Telaire T3022 CO2 sensor component over I2C.
- Implement non-blocking measurement scheduling with `set_timeout()` and startup status check.
- Publish NAN on failures, include `LOG_UPDATE_INTERVAL`, and add multi-platform tests.
- Data sheet for [Telaire T3022](https://4donline.ihs.com/images/VipMasterIC/IC/AMPH/AMPH-S-A0010543784/AMPH-S-A0010543953-1.pdf?hkey=6D3A4C79FDBF58556ACFDE234799DDF0)
- Application Guide for [Telaire T67XX](https://f.hubspotusercontent40.net/hubfs/9035299/Documents/AAS-916-142A-Telaire-T67xx-CO2-Sensor-022719-web.pdf)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5797

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:

sensor:
  - platform: t3022
    address: 0x15
    update_interval: 60s
    co2:
      name: "CO2 Level"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
