### PR TITLE
[api] Release prologue memory after noise handshake completes

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -539,7 +539,8 @@ APIError APINoiseFrameHelper::init_handshake_() {
   if (aerr != APIError::OK)
     return aerr;
   // set_prologue copies it into handshakestate, so we can get rid of it now
-  prologue_ = {};
+  // Use swap idiom to actually release memory (= {} only clears size, not capacity)
+  std::vector<uint8_t>().swap(prologue_);
 
   err = noise_handshakestate_start(handshake_);
   aerr = handle_noise_error_(err, LOG_STR("noise_handshakestate_start"), APIError::HANDSHAKESTATE_SETUP_FAILED);


### PR DESCRIPTION
# What does this implement/fix?

Release `prologue_` vector memory after noise handshake completes.

The prologue data is only needed during the noise handshake. After `noise_handshakestate_set_prologue()` copies the data into the handshake state, the code cleared the vector with:

```cpp
prologue_ = {};
```

This sets `size()` to 0 but doesn't release the allocated `capacity()`. The vector holds onto its memory (~14-50+ bytes depending on client hello size) for the entire connection lifetime.

The fix uses the swap idiom to actually release the memory:

```cpp
std::vector<uint8_t>().swap(prologue_);
```

This creates a temporary empty vector, swaps it with `prologue_`, and the temporary (now holding the allocated memory) is immediately destroyed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
