### PR TITLE
[update] Add check action to trigger update checks

### DIFF
--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -29,6 +29,9 @@ UpdateInfo = update_ns.struct("UpdateInfo")
 PerformAction = update_ns.class_(
     "PerformAction", automation.Action, cg.Parented.template(UpdateEntity)
 )
+CheckAction = update_ns.class_(
+    "CheckAction", automation.Action, cg.Parented.template(UpdateEntity)
+)
 IsAvailableCondition = update_ns.class_(
     "IsAvailableCondition", automation.Condition, cg.Parented.template(UpdateEntity)
 )
@@ -140,6 +143,21 @@ async def update_perform_action_to_code(config, action_id, template_arg, args):
 
     force = await cg.templatable(config[CONF_FORCE_UPDATE], args, cg.bool_)
     cg.add(var.set_force(force))
+    return var
+
+
+@automation.register_action(
+    "update.check",
+    CheckAction,
+    automation.maybe_simple_id(
+        {
+            cv.GenerateID(): cv.use_id(UpdateEntity),
+        }
+    ),
+)
+async def update_check_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
     return var
 
 

--- a/esphome/components/update/automation.h
+++ b/esphome/components/update/automation.h
@@ -14,6 +14,11 @@ template<typename... Ts> class PerformAction : public Action<Ts...>, public Pare
   void play(const Ts &...x) override { this->parent_->perform(this->force_.value(x...)); }
 };
 
+template<typename... Ts> class CheckAction : public Action<Ts...>, public Parented<UpdateEntity> {
+ public:
+  void play(const Ts &...x) override { this->parent_->check(); }
+};
+
 template<typename... Ts> class IsAvailableCondition : public Condition<Ts...>, public Parented<UpdateEntity> {
  public:
   bool check(const Ts &...x) override { return this->parent_->state == UPDATE_STATE_AVAILABLE; }

--- a/tests/components/update/common.yaml
+++ b/tests/components/update/common.yaml
@@ -9,6 +9,8 @@ esphome:
             update.is_available:
           then:
             - logger.log: "Update available"
+          else:
+            - update.check:
       - update.perform:
           force_update: true
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a new action `update.check` which can be used to trigger a check for updates from automations. Most notably, this is useful with the `http_request` update platform, either to manually trigger an update on startup after network connectivity is available, in response to an external system notifying the ESPHome device of an available firmware update, or other potential scenarios.

The specific use-case prompting this feature is the ability to have a CI/CD pipeline (which compiles and publishes the firmware manifests for my esphome based devices) trigger an immediate check for updates on relevant ESP devices when new firmware is available.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5763

## Test Environment

Tested this change locally on an ESP32-C6 device with a managed HTTP update component. 

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Trigger update check when network connection is available (on boot)
wifi:
  on_connect:
    - update.check:

# Trigger update check manually from Home Assistant
button:
  - platform: template
    name: "Check for Updates"
    on_press:
      - update.check:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
