### PR TITLE
[http_request] Skip update check when network not connected

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -36,6 +36,10 @@ void HttpRequestUpdate::setup() {
 }
 
 void HttpRequestUpdate::update() {
+  if (!network::is_connected()) {
+    ESP_LOGD(TAG, "Network not connected, skipping update check");
+    return;
+  }
 #ifdef USE_ESP32
   xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);
 #else


### PR DESCRIPTION
# What does this implement/fix?

Prevents noisy error logs on startup when the `http_request` update component attempts to fetch the manifest before WiFi is connected.

The scheduler triggers the first interval update within 0-5 seconds of setup (due to `MAX_INTERVAL_DELAY = 5000ms`), but WiFi typically takes 5-10+ seconds to connect. This causes the update component to fail with errors like:

```
[E][component:315]: http_request.update set Error flag: Failed to fetch manifest
[E][component:315][update_task]: http_request set Error flag: unspecified
[E][http_request.idf:061][update_task]: HTTP Request failed; Not connected to network
[E][http_request.update:052][update_task]: Failed to fetch manifest from https://...
```

This change adds a `network::is_connected()` check at the start of `update()` that silently skips the update check (with a DEBUG log) when the network isn't ready. The regular polling interval (default 6 hours) will check once connected, or users can trigger an immediate check via `wifi.on_connect` + `update.check` action.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12416

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an automatic behavior improvement
# The update component will now silently skip checks until network is ready

update:
  - platform: http_request
    name: Firmware Update
    source: "https://example.com/manifest.json"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing config changes)