### PR TITLE
[spi] Use ESP-IDF driver for ESP32 Arduino

### DIFF
--- a/esphome/components/spi/spi.cpp
+++ b/esphome/components/spi/spi.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace spi {
+namespace esphome::spi {
 
 const char *const TAG = "spi";
 
@@ -119,5 +118,4 @@ uint16_t SPIDelegateBitBash::transfer_(uint16_t data, size_t num_bits) {
   return out_data;
 }
 
-}  // namespace spi
-}  // namespace esphome
+}  // namespace esphome::spi

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -1,4 +1,5 @@
 #pragma once
+#ifndef USE_ZEPHYR
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
@@ -25,16 +26,10 @@ using SPIInterface = SPIClass *;
 
 #endif  // USE_ESP32 / USE_ARDUINO
 
-#ifdef USE_ZEPHYR
-// TODO supprse clang-tidy. Remove after SPI driver for nrf52 is added.
-using SPIInterface = void *;
-#endif
-
 /**
  * Implementation of SPI Controller mode.
  */
-namespace esphome {
-namespace spi {
+namespace esphome::spi {
 
 /// The bit-order for SPI devices. This defines how the data read from and written to the device is interpreted.
 enum SPIBitOrder {
@@ -507,5 +502,5 @@ class SPIDevice : public SPIClient {
   template<size_t N> void transfer_array(std::array<uint8_t, N> &data) { this->transfer_array(data.data(), N); }
 };
 
-}  // namespace spi
-}  // namespace esphome
+}  // namespace esphome::spi
+#endif  // USE_ZEPHYR

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -7,7 +7,13 @@
 #include <utility>
 #include <vector>
 
-#ifdef USE_ARDUINO
+#ifdef USE_ESP32
+
+#include "driver/spi_master.h"
+
+using SPIInterface = spi_host_device_t;
+
+#elif defined(USE_ARDUINO)
 
 #include <SPI.h>
 
@@ -17,15 +23,7 @@ using SPIInterface = SPIClassRP2040 *;
 using SPIInterface = SPIClass *;
 #endif
 
-#endif
-
-#ifdef USE_ESP_IDF
-
-#include "driver/spi_master.h"
-
-using SPIInterface = spi_host_device_t;
-
-#endif  // USE_ESP_IDF
+#endif  // USE_ESP32 / USE_ARDUINO
 
 #ifdef USE_ZEPHYR
 // TODO supprse clang-tidy. Remove after SPI driver for nrf52 is added.

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -1,8 +1,7 @@
 #include "spi.h"
 #include <vector>
 
-namespace esphome {
-namespace spi {
+namespace esphome::spi {
 #if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 static const char *const TAG = "spi-esp-arduino";
@@ -102,5 +101,4 @@ SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo
 }
 
 #endif  // USE_ARDUINO && !USE_ESP32
-}  // namespace spi
-}  // namespace esphome
+}  // namespace esphome::spi

--- a/esphome/components/spi/spi_arduino.cpp
+++ b/esphome/components/spi/spi_arduino.cpp
@@ -3,7 +3,7 @@
 
 namespace esphome {
 namespace spi {
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 static const char *const TAG = "spi-esp-arduino";
 class SPIDelegateHw : public SPIDelegate {
@@ -101,6 +101,6 @@ SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo
   return new SPIBusHw(clk, sdo, sdi, interface);
 }
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO && !USE_ESP32
 }  // namespace spi
 }  // namespace esphome

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -1,8 +1,7 @@
 #include "spi.h"
 #include <vector>
 
-namespace esphome {
-namespace spi {
+namespace esphome::spi {
 
 #ifdef USE_ESP32
 static const char *const TAG = "spi-esp-idf";
@@ -267,5 +266,4 @@ SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo
 }
 
 #endif  // USE_ESP32
-}  // namespace spi
-}  // namespace esphome
+}  // namespace esphome::spi

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace spi {
 
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 static const char *const TAG = "spi-esp-idf";
 static const size_t MAX_TRANSFER_SIZE = 4092;  // dictated by ESP-IDF API.
 
@@ -266,6 +266,6 @@ SPIBus *SPIComponent::get_bus(SPIInterface interface, GPIOPin *clk, GPIOPin *sdo
   return new SPIBusHw(clk, sdo, sdi, interface, data_pins);
 }
 
-#endif
+#endif  // USE_ESP32
 }  // namespace spi
 }  // namespace esphome


### PR DESCRIPTION
## What does this implement/fix?

Uses the ESP-IDF SPI driver for ESP32 when using the Arduino framework, instead of the Arduino SPI library. This unifies ESP32 SPI handling to always use the ESP-IDF driver regardless of framework.

## Summary
- ESP32 now uses ESP-IDF SPI driver for both Arduino and ESP-IDF frameworks
- Removes Arduino SPI library dependency for ESP32 builds
- Updates `spi_arduino.cpp` to exclude ESP32 (handled by `spi_esp_idf.cpp`)
- Updates `spi_esp_idf.cpp` to handle both ESP32 Arduino and ESP-IDF
- Adds Zephyr guard to header for clang-tidy compatibility
- Uses C++17 nested namespace syntax

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/5767

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an automatic behavior improvement
# The update component will now silently skip checks until network is ready
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing config changes)