### PR TITLE
[openthread] channel range, fix typo, use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -91,7 +91,7 @@ def set_sdkconfig_options(config):
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT_MAX_SERVICES", 5)
 
-    # TODO: Add suport for synchronized sleepy end devices (SSED)
+    # TODO: Add support for synchronized sleepy end devices (SSED)
     add_idf_sdkconfig_option(f"CONFIG_OPENTHREAD_{config.get(CONF_DEVICE_TYPE)}", True)
 
 
@@ -102,7 +102,7 @@ OpenThreadSrpComponent = openthread_ns.class_("OpenThreadSrpComponent", cg.Compo
 _CONNECTION_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_PAN_ID): cv.hex_int,
-        cv.Optional(CONF_CHANNEL): cv.int_,
+        cv.Optional(CONF_CHANNEL): cv.int_range(min=11, max=26),
         cv.Optional(CONF_NETWORK_KEY): cv.hex_int,
         cv.Optional(CONF_EXT_PAN_ID): cv.hex_int,
         cv.Optional(CONF_NETWORK_NAME): cv.string_strict,

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -21,8 +21,7 @@
 
 static const char *const TAG = "openthread";
 
-namespace esphome {
-namespace openthread {
+namespace esphome::openthread {
 
 OpenThreadComponent *global_openthread_component =  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
     nullptr;                                        // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -275,7 +274,5 @@ const char *OpenThreadComponent::get_use_address() const { return this->use_addr
 
 void OpenThreadComponent::set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
-}  // namespace openthread
-}  // namespace esphome
-
+}  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -13,8 +13,7 @@
 #include <optional>
 #include <vector>
 
-namespace esphome {
-namespace openthread {
+namespace esphome::openthread {
 
 class InstanceLock;
 
@@ -91,6 +90,5 @@ class InstanceLock {
   InstanceLock() {}
 };
 
-}  // namespace openthread
-}  // namespace esphome
+}  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -24,8 +24,7 @@
 
 static const char *const TAG = "openthread";
 
-namespace esphome {
-namespace openthread {
+namespace esphome::openthread {
 
 void OpenThreadComponent::setup() {
   // Used eventfds:
@@ -209,6 +208,5 @@ otInstance *InstanceLock::get_instance() { return esp_openthread_get_instance();
 
 InstanceLock::~InstanceLock() { esp_openthread_lock_release(); }
 
-}  // namespace openthread
-}  // namespace esphome
+}  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread_info/openthread_info_text_sensor.cpp
+++ b/esphome/components/openthread_info/openthread_info_text_sensor.cpp
@@ -3,8 +3,7 @@
 #ifdef USE_OPENTHREAD
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace openthread_info {
+namespace esphome::openthread_info {
 
 static const char *const TAG = "openthread_info";
 
@@ -19,6 +18,5 @@ void NetworkKeyOpenThreadInfo::dump_config() { LOG_TEXT_SENSOR("", "Network Key"
 void PanIdOpenThreadInfo::dump_config() { LOG_TEXT_SENSOR("", "PAN ID", this); }
 void ExtPanIdOpenThreadInfo::dump_config() { LOG_TEXT_SENSOR("", "Extended PAN ID", this); }
 
-}  // namespace openthread_info
-}  // namespace esphome
+}  // namespace esphome::openthread_info
 #endif

--- a/esphome/components/openthread_info/openthread_info_text_sensor.h
+++ b/esphome/components/openthread_info/openthread_info_text_sensor.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #ifdef USE_OPENTHREAD
 
-namespace esphome {
-namespace openthread_info {
+namespace esphome::openthread_info {
 
 using esphome::openthread::InstanceLock;
 
@@ -213,6 +212,5 @@ class ExtPanIdOpenThreadInfo : public DatasetOpenThreadInfo, public text_sensor:
   std::array<uint8_t, 8> last_extpanid_{};
 };
 
-}  // namespace openthread_info
-}  // namespace esphome
+}  // namespace esphome::openthread_info
 #endif


### PR DESCRIPTION
# What does this implement/fix?

- set channel range
- fix typo
- use C++17 nested namespace syntax

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
