### PR TITLE
[esp32] improve types and variable naming

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -117,8 +117,8 @@ ARDUINO_ALLOWED_VARIANTS = [
 ]
 
 
-def get_cpu_frequencies(*frequencies):
-    return [str(x) + "MHZ" for x in frequencies]
+def get_cpu_frequencies(*frequencies: int) -> list[str]:
+    return [f"{frequency}MHZ" for frequency in frequencies]
 
 
 CPU_FREQUENCIES = {
@@ -135,7 +135,7 @@ CPU_FREQUENCIES = {
 }
 
 # Make sure not missed here if a new variant added.
-assert all(v in CPU_FREQUENCIES for v in VARIANTS)
+assert all(variant in CPU_FREQUENCIES for variant in VARIANTS)
 
 FULL_CPU_FREQUENCIES = set(itertools.chain.from_iterable(CPU_FREQUENCIES.values()))
 
@@ -249,10 +249,10 @@ def add_idf_sdkconfig_option(name: str, value: SdkconfigValueType):
 def add_idf_component(
     *,
     name: str,
-    repo: str = None,
-    ref: str = None,
-    path: str = None,
-    refresh: TimePeriod = None,
+    repo: str | None = None,
+    ref: str | None = None,
+    path: str | None = None,
+    refresh: TimePeriod | None = None,
     components: list[str] | None = None,
     submodules: list[str] | None = None,
 ):
@@ -333,7 +333,7 @@ def _format_framework_espidf_version(ver: cv.Version, release: str) -> str:
     return f"pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v{str(ver)}/esp-idf-v{str(ver)}.{ext}"
 
 
-def _is_framework_url(source: str) -> str:
+def _is_framework_url(source: str) -> bool:
     # platformio accepts many URL schemes for framework repositories and archives including http, https, git, file, and symlink
     import urllib.parse
 
@@ -1189,7 +1189,7 @@ APP_PARTITION_SIZES = {
 }
 
 
-def get_arduino_partition_csv(flash_size):
+def get_arduino_partition_csv(flash_size: str):
     app_partition_size = APP_PARTITION_SIZES[flash_size]
     eeprom_partition_size = 0x1000  # 4 KB
     spiffs_partition_size = 0xF000  # 60 KB
@@ -1209,7 +1209,7 @@ spiffs,   data, spiffs,  0x{spiffs_partition_start:X}, 0x{spiffs_partition_size:
 """
 
 
-def get_idf_partition_csv(flash_size):
+def get_idf_partition_csv(flash_size: str):
     app_partition_size = APP_PARTITION_SIZES[flash_size]
 
     return f"""\


### PR DESCRIPTION
# What does this implement/fix?

- fix wrong return type of `_is_framework_url`
- improve other types
- variable naming

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
