### PR TITLE
[http_request] Use ESP-IDF for ESP32 Arduino

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -69,9 +69,6 @@ def validate_url(value):
 def validate_ssl_verification(config):
     error_message = ""
 
-    if CORE.is_esp32 and not CORE.using_esp_idf and config[CONF_VERIFY_SSL]:
-        error_message = "ESPHome supports certificate verification only via ESP-IDF"
-
     if CORE.is_rp2040 and config[CONF_VERIFY_SSL]:
         error_message = "ESPHome does not support certificate verification on RP2040"
 
@@ -93,9 +90,9 @@ def validate_ssl_verification(config):
 def _declare_request_class(value):
     if CORE.is_host:
         return cv.declare_id(HttpRequestHost)(value)
-    if CORE.using_esp_idf:
+    if CORE.is_esp32:
         return cv.declare_id(HttpRequestIDF)(value)
-    if CORE.is_esp8266 or CORE.is_esp32 or CORE.is_rp2040:
+    if CORE.is_esp8266 or CORE.is_rp2040:
         return cv.declare_id(HttpRequestArduino)(value)
     return NotImplementedError
 
@@ -121,11 +118,11 @@ CONFIG_SCHEMA = cv.All(
                 cv.positive_not_null_time_period,
                 cv.positive_time_period_milliseconds,
             ),
-            cv.SplitDefault(CONF_BUFFER_SIZE_RX, esp32_idf=512): cv.All(
-                cv.uint16_t, cv.only_with_esp_idf
+            cv.SplitDefault(CONF_BUFFER_SIZE_RX, esp32=512): cv.All(
+                cv.uint16_t, cv.only_on_esp32
             ),
-            cv.SplitDefault(CONF_BUFFER_SIZE_TX, esp32_idf=512): cv.All(
-                cv.uint16_t, cv.only_with_esp_idf
+            cv.SplitDefault(CONF_BUFFER_SIZE_TX, esp32=512): cv.All(
+                cv.uint16_t, cv.only_on_esp32
             ),
             cv.Optional(CONF_CA_CERTIFICATE_PATH): cv.All(
                 cv.file_,
@@ -158,25 +155,21 @@ async def to_code(config):
         cg.add(var.set_watchdog_timeout(timeout_ms))
 
     if CORE.is_esp32:
-        if CORE.using_esp_idf:
-            cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
-            cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
+        cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
+        cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
 
-            esp32.add_idf_sdkconfig_option(
-                "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",
-                config.get(CONF_VERIFY_SSL),
-            )
-            esp32.add_idf_sdkconfig_option(
-                "CONFIG_ESP_TLS_INSECURE",
-                not config.get(CONF_VERIFY_SSL),
-            )
-            esp32.add_idf_sdkconfig_option(
-                "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
-                not config.get(CONF_VERIFY_SSL),
-            )
-        else:
-            cg.add_library("NetworkClientSecure", None)
-            cg.add_library("HTTPClient", None)
+        esp32.add_idf_sdkconfig_option(
+            "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",
+            config.get(CONF_VERIFY_SSL),
+        )
+        esp32.add_idf_sdkconfig_option(
+            "CONFIG_ESP_TLS_INSECURE",
+            not config.get(CONF_VERIFY_SSL),
+        )
+        esp32.add_idf_sdkconfig_option(
+            "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
+            not config.get(CONF_VERIFY_SSL),
+        )
     if CORE.is_esp8266:
         cg.add_library("ESP8266HTTPClient", None)
     if CORE.is_rp2040 and CORE.using_arduino:
@@ -327,13 +320,15 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
     {
         "http_request_host.cpp": {PlatformFramework.HOST_NATIVE},
         "http_request_arduino.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
             PlatformFramework.ESP8266_ARDUINO,
             PlatformFramework.RP2040_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,
             PlatformFramework.LN882X_ARDUINO,
         },
-        "http_request_idf.cpp": {PlatformFramework.ESP32_IDF},
+        "http_request_idf.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
     }
 )

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -158,10 +158,9 @@ async def to_code(config):
         cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
         cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
 
-        esp32.add_idf_sdkconfig_option(
-            "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE",
-            config.get(CONF_VERIFY_SSL),
-        )
+        if config.get(CONF_VERIFY_SSL):
+            esp32.add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+
         esp32.add_idf_sdkconfig_option(
             "CONFIG_ESP_TLS_INSECURE",
             not config.get(CONF_VERIFY_SSL),

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 static const char *const TAG = "http_request";
 
@@ -42,5 +41,4 @@ std::string HttpContainer::get_response_header(const std::string &header_name) {
   }
 }
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -15,8 +15,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 struct Header {
   std::string name;
@@ -302,5 +301,4 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   size_t max_response_buffer_size_{SIZE_MAX};
 };
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -9,8 +9,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 static const char *const TAG = "http_request.arduino";
 
@@ -172,7 +171,6 @@ void HttpContainerArduino::end() {
   this->client_.end();
 }
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_ARDUINO && !USE_ESP32

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -1,6 +1,6 @@
 #include "http_request_arduino.h"
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
 #include "esphome/components/network/util.h"
 #include "esphome/components/watchdog/watchdog.h"
@@ -75,8 +75,6 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     container->client_.setInsecure();
   }
   bool status = container->client_.begin(url.c_str());
-#elif defined(USE_ESP32)
-  bool status = container->client_.begin(url.c_str());
 #endif
 
   App.feed_wdt();
@@ -90,9 +88,6 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
 
   container->client_.setReuse(true);
   container->client_.setTimeout(this->timeout_);
-#if defined(USE_ESP32)
-  container->client_.setConnectTimeout(this->timeout_);
-#endif
 
   if (this->useragent_ != nullptr) {
     container->client_.setUserAgent(this->useragent_);
@@ -180,4 +175,4 @@ void HttpContainerArduino::end() {
 }  // namespace http_request
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO && !USE_ESP32

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -15,8 +15,7 @@
 #endif
 #endif
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 class HttpRequestArduino;
 class HttpContainerArduino : public HttpContainer {
@@ -36,7 +35,6 @@ class HttpRequestArduino : public HttpRequestComponent {
                                          const std::set<std::string> &collect_headers) override;
 };
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_ARDUINO && !USE_ESP32

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -2,9 +2,9 @@
 
 #include "http_request.h"
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && !defined(USE_ESP32)
 
-#if defined(USE_ESP32) || defined(USE_RP2040)
+#if defined(USE_RP2040)
 #include <HTTPClient.h>
 #include <WiFiClient.h>
 #endif
@@ -39,4 +39,4 @@ class HttpRequestArduino : public HttpRequestComponent {
 }  // namespace http_request
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO && !USE_ESP32

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -12,8 +12,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 static const char *const TAG = "http_request.host";
 
@@ -139,7 +138,6 @@ void HttpContainerHost::end() {
   this->bytes_read_ = 0;
 }
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_HOST

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -2,8 +2,8 @@
 
 #ifdef USE_HOST
 #include "http_request.h"
-namespace esphome {
-namespace http_request {
+
+namespace esphome::http_request {
 
 class HttpRequestHost;
 class HttpContainerHost : public HttpContainer {
@@ -27,7 +27,6 @@ class HttpRequestHost : public HttpRequestComponent {
   const char *ca_path_{};
 };
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_HOST

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -14,8 +14,7 @@
 
 #include "esp_task_wdt.h"
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 static const char *const TAG = "http_request.idf";
 
@@ -245,7 +244,6 @@ void HttpContainerIDF::feed_wdt() {
   }
 }
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_ESP32

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -1,6 +1,6 @@
 #include "http_request_idf.h"
 
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 
 #include "esphome/components/network/util.h"
 #include "esphome/components/watchdog/watchdog.h"
@@ -248,4 +248,4 @@ void HttpContainerIDF::feed_wdt() {
 }  // namespace http_request
 }  // namespace esphome
 
-#endif  // USE_ESP_IDF
+#endif  // USE_ESP32

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -2,7 +2,7 @@
 
 #include "http_request.h"
 
-#ifdef USE_ESP_IDF
+#ifdef USE_ESP32
 
 #include <esp_event.h>
 #include <esp_http_client.h>
@@ -51,4 +51,4 @@ class HttpRequestIDF : public HttpRequestComponent {
 }  // namespace http_request
 }  // namespace esphome
 
-#endif  // USE_ESP_IDF
+#endif  // USE_ESP32

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -9,8 +9,7 @@
 #include <esp_netif.h>
 #include <esp_tls.h>
 
-namespace esphome {
-namespace http_request {
+namespace esphome::http_request {
 
 class HttpContainerIDF : public HttpContainer {
  public:
@@ -48,7 +47,6 @@ class HttpRequestIDF : public HttpRequestComponent {
   static esp_err_t http_event_handler(esp_http_client_event_t *evt);
 };
 
-}  // namespace http_request
-}  // namespace esphome
+}  // namespace esphome::http_request
 
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Switch ESP32 Arduino to use the ESP-IDF HTTP client instead of the Arduino HTTPClient library. This provides consistent behavior across both ESP32 frameworks and enables SSL certificate verification on ESP32 Arduino.

Changes:
- ESP32 Arduino now uses `esp_http_client` (ESP-IDF) instead of Arduino `HTTPClient`
- SSL certificate verification (`verify_ssl: true`) now works on ESP32 Arduino
- Buffer size options (`buffer_size_rx`, `buffer_size_tx`) now available for ESP32 Arduino
- Modernized all component files to use C++17 nested namespace syntax

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5768

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  verify_ssl: true  # Now works on ESP32 Arduino!
  buffer_size_rx: 1024
  buffer_size_tx: 1024
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)