### PR TITLE
fix(MQTT): Reduce topic length

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -231,7 +231,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PORT, default=1883): cv.port,
             cv.Optional(CONF_USERNAME, default=""): cv.string,
             cv.Optional(CONF_PASSWORD, default=""): cv.string,
-            cv.Optional(CONF_CLEAN_SESSION, default=False): cv.boolean,
+            cv.Optional(CONF_CLEAN_SESSION, default=True): cv.boolean,
             cv.Optional(CONF_CLIENT_ID): cv.string,
             cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32_idf=False): cv.All(
                 cv.boolean, cv.only_with_esp_idf

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -312,6 +312,8 @@ void MQTTClientComponent::check_connected() {
   // MQTT Client needs some time to be fully set up.
   delay(100);  // NOLINT
 
+  // Startup subscriptions
+  // TODO: Get the session_present flag from the backend
   this->resubscribe_subscriptions_();
   this->send_device_info_();
 
@@ -388,6 +390,7 @@ void MQTTClientComponent::loop() {
         }
 
         this->last_connected_ = now;
+        // Try to resubscribe subscriptions that failed
         this->resubscribe_subscriptions_();
       }
       break;
@@ -427,10 +430,18 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub) {
   if (do_resub) {
     sub->subscribed = this->subscribe_(sub->topic.c_str(), sub->qos);
     sub->resubscribe_timeout = now;
+    // We are in a persistent session and have subscribed successfully
+    if (!this->credentials_.clean_session && sub->subscribed) {
+      // TODO: Store the topic and QOS to non-volatile memory
+    }
   }
 }
-void MQTTClientComponent::resubscribe_subscriptions_() {
+void MQTTClientComponent::resubscribe_subscriptions_(bool session_present) {
   for (auto &subscription : this->subscriptions_) {
+    // If the session is present, check if we had already subscribed
+    if (session_present && !subscription.subscribed) {
+      // TODO: Check if we have stored the subscription before and set subscribed = true
+    }
     this->resubscribe_subscription_(&subscription);
   }
 }

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -426,7 +426,12 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub, bool 
     return;
   // If the session is present, check if we had already subscribed
   if (check_persistence) {
-    // TODO: Check if we have stored the subscription before and set subscribed = true if so
+    if (is_subscription_stored(*sub)) {
+      ESP_LOGV(TAG, "Subscription to topic='%s' qos=%d already present in persistent session, skipping subscribe",
+               sub->topic.c_str(), sub->qos);
+      sub->subscribed = true;
+      return;
+    }
   }
 
   const uint32_t now = millis();
@@ -437,7 +442,7 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub, bool 
     sub->resubscribe_timeout = now;
     // We are in a persistent session and have subscribed successfully
     if (!this->credentials_.clean_session && sub->subscribed) {
-      // TODO: Store the topic and QOS to non-volatile memory
+      store_subscription(*sub);
     }
   }
 }
@@ -478,7 +483,6 @@ void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_js
 }
 
 void MQTTClientComponent::unsubscribe(const std::string &topic) {
-  // TODO: Remove from persistent storage if needed
   bool ret = this->mqtt_backend_.unsubscribe(topic.c_str());
   yield();
   if (ret) {
@@ -493,6 +497,7 @@ void MQTTClientComponent::unsubscribe(const std::string &topic) {
   while (it != subscriptions_.end()) {
     if (it->topic == topic) {
       it = subscriptions_.erase(it);
+      remove_subscription(*it);
     } else {
       ++it;
     }
@@ -556,6 +561,68 @@ void MQTTClientComponent::disable() {
   ESP_LOGD(TAG, "Disabling");
   this->state_ = MQTT_CLIENT_DISABLED;
   this->on_shutdown();
+}
+
+/** Generate a 32-bit hash for an MQTT subscription
+ *
+ * Combines the FNV-1 hash of the topic with the QoS value to create a unique identifier
+ * for the subscription that can be used for persistence checks.
+ *
+ * @param sub The MQTT subscription to hash.
+ * @return A 32-bit hash value combining topic and QoS.
+ */
+static uint32_t hash_subscription(const MQTTSubscription &sub) {
+  uint32_t hash = fnv1_hash(sub.topic.c_str());
+  // Mix in the QoS by XOR'ing it into the hash (shifted to spread bits)
+  hash ^= (static_cast<uint32_t>(sub.qos) << 24);
+  return hash;
+}
+
+/** Store a subscription in persistent storage
+ *
+ * Saves the subscription hash to non-volatile memory so it can be checked
+ * on reconnect to determine if the subscription is already active on the broker.
+ *
+ * @param sub The MQTT subscription to store.
+ * @return true if the subscription was successfully stored, false otherwise.
+ */
+static bool store_subscription(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
+  return pref.save(&hash);
+}
+
+/** Check if a subscription is stored in persistent storage
+ *
+ * Retrieves the subscription hash from non-volatile memory to determine if
+ * this subscription was previously stored (indicating it may still be active
+ * on the broker in a persistent session).
+ *
+ * @param sub The MQTT subscription to check.
+ * @return true if the subscription was found in storage, false otherwise.
+ */
+static bool is_subscription_stored(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
+  uint32_t stored_hash = 0;
+  if (!pref.load(&stored_hash))
+    return false;
+  return stored_hash == hash;
+}
+
+/** Remove a subscription from persistent storage
+ *
+ * Deletes the subscription hash from non-volatile memory, typically when
+ * unsubscribing from a topic or cleaning up after a clean session.
+ *
+ * @param sub The MQTT subscription to remove.
+ * @return true if the subscription was successfully removed, false otherwise.
+ */
+static bool remove_subscription(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
+  uint32_t zero_hash = 0;
+  return pref.save(&zero_hash);
 }
 
 /** Check if the message topic matches the given subscription topic

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -624,7 +624,6 @@ void MQTTClientComponent::disable() {
   this->on_shutdown();
 }
 
-
 /** Check if the message topic matches the given subscription topic
  *
  * INFO: MQTT spec mandates that topics must not be empty and must be valid NULL-terminated UTF-8 strings.

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -314,7 +314,7 @@ void MQTTClientComponent::check_connected() {
 
   // Startup subscriptions
   // TODO: Get the session_present flag from the backend
-  this->resubscribe_subscriptions_();
+  this->resubscribe_subscriptions_(this->session_present_ && !this->credentials_.clean_session);
   this->send_device_info_();
 
   for (MQTTComponent *component : this->children_)
@@ -436,10 +436,10 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub) {
     }
   }
 }
-void MQTTClientComponent::resubscribe_subscriptions_(bool session_present) {
+void MQTTClientComponent::resubscribe_subscriptions_(bool check_persistence) {
   for (auto &subscription : this->subscriptions_) {
     // If the session is present, check if we had already subscribed
-    if (session_present && !subscription.subscribed) {
+    if (check_persistence && !subscription.subscribed) {
       // TODO: Check if we have stored the subscription before and set subscribed = true
     }
     this->resubscribe_subscription_(&subscription);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -404,6 +404,69 @@ void MQTTClientComponent::loop() {
 }
 float MQTTClientComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 
+/** Generate a 32-bit hash for an MQTT subscription topic
+ *
+ * Creates a unique identifier for the subscription topic that can be used
+ * as a key for persistence storage.
+ *
+ * @param sub The MQTT subscription to hash.
+ * @return A 32-bit hash value based on the topic.
+ */
+static uint32_t hash_subscription(const MQTTSubscription &sub) { return fnv1_hash(sub.topic.c_str()); }
+
+/** Store a subscription in persistent storage
+ *
+ * Saves the subscription QoS to non-volatile memory so it can be checked
+ * on reconnect to determine if the subscription is already active on the broker.
+ * Stores QoS + 34 as a magic value to distinguish from uninitialized storage.
+ *
+ * @param sub The MQTT subscription to store.
+ * @return true if the subscription was successfully stored, false otherwise.
+ */
+static bool store_subscription(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t stored_value = sub.qos + 34;
+  return pref.save(&stored_value);
+}
+
+/** Check if a subscription is stored in persistent storage
+ *
+ * Retrieves the subscription QoS from non-volatile memory to determine if
+ * this subscription was previously stored (indicating it may still be active
+ * on the broker in a persistent session).
+ *
+ * @param sub The MQTT subscription to check.
+ * @return true if the subscription was found in storage, false otherwise.
+ */
+static bool is_subscription_stored(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t stored_value = 0;
+  if (!pref.load(&stored_value))
+    return false;
+  return stored_value == (sub.qos + 34);
+}
+
+/** Remove a subscription from persistent storage
+ *
+ * Deletes the subscription from non-volatile memory, typically when
+ * unsubscribing from a topic or cleaning up after a clean session.
+ *
+ * @param sub The MQTT subscription to remove.
+ * @return true if the subscription was successfully removed, false otherwise.
+ */
+static bool remove_subscription(const MQTTSubscription &sub) {
+  uint32_t hash = hash_subscription(sub);
+  // Check if it exists first
+  if (!is_subscription_stored(sub)) {
+    return true;
+  }
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t zero_value = 0;
+  return pref.save(&zero_value);
+}
+
 // Subscribe
 bool MQTTClientComponent::subscribe_(const char *topic, uint8_t qos) {
   if (!this->is_connected())
@@ -565,68 +628,6 @@ void MQTTClientComponent::disable() {
   this->on_shutdown();
 }
 
-/** Generate a 32-bit hash for an MQTT subscription topic
- *
- * Creates a unique identifier for the subscription topic that can be used
- * as a key for persistence storage.
- *
- * @param sub The MQTT subscription to hash.
- * @return A 32-bit hash value based on the topic.
- */
-static uint32_t hash_subscription(const MQTTSubscription &sub) { return fnv1_hash(sub.topic.c_str()); }
-
-/** Store a subscription in persistent storage
- *
- * Saves the subscription QoS to non-volatile memory so it can be checked
- * on reconnect to determine if the subscription is already active on the broker.
- * Stores QoS + 34 as a magic value to distinguish from uninitialized storage.
- *
- * @param sub The MQTT subscription to store.
- * @return true if the subscription was successfully stored, false otherwise.
- */
-static bool store_subscription(const MQTTSubscription &sub) {
-  uint32_t hash = hash_subscription(sub);
-  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
-  uint8_t stored_value = sub.qos + 34;
-  return pref.save(&stored_value);
-}
-
-/** Check if a subscription is stored in persistent storage
- *
- * Retrieves the subscription QoS from non-volatile memory to determine if
- * this subscription was previously stored (indicating it may still be active
- * on the broker in a persistent session).
- *
- * @param sub The MQTT subscription to check.
- * @return true if the subscription was found in storage, false otherwise.
- */
-static bool is_subscription_stored(const MQTTSubscription &sub) {
-  uint32_t hash = hash_subscription(sub);
-  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
-  uint8_t stored_value = 0;
-  if (!pref.load(&stored_value))
-    return false;
-  return stored_value == (sub.qos + 34);
-}
-
-/** Remove a subscription from persistent storage
- *
- * Deletes the subscription from non-volatile memory, typically when
- * unsubscribing from a topic or cleaning up after a clean session.
- *
- * @param sub The MQTT subscription to remove.
- * @return true if the subscription was successfully removed, false otherwise.
- */
-static bool remove_subscription(const MQTTSubscription &sub) {
-  uint32_t hash = hash_subscription(sub);
-  // Check if it exists first
-  if (!is_subscription_stored(sub)) {
-    return true;
-  }
-  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
-  uint8_t zero_value = 0;
-  return pref.save(&zero_value);
-}
 
 /** Check if the message topic matches the given subscription topic
  *

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -420,9 +420,13 @@ bool MQTTClientComponent::subscribe_(const char *topic, uint8_t qos) {
   }
   return ret != 0;
 }
-void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub) {
+void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub, bool check_persistence) {
   if (sub->subscribed)
     return;
+  // If the session is present, check if we had already subscribed
+  if (check_persistence) {
+    // TODO: Check if we have stored the subscription before and set subscribed = true if so
+  }
 
   const uint32_t now = millis();
   bool do_resub = sub->resubscribe_timeout == 0 || now - sub->resubscribe_timeout > 1000;
@@ -438,11 +442,7 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub) {
 }
 void MQTTClientComponent::resubscribe_subscriptions_(bool check_persistence) {
   for (auto &subscription : this->subscriptions_) {
-    // If the session is present, check if we had already subscribed
-    if (check_persistence && !subscription.subscribed) {
-      // TODO: Check if we have stored the subscription before and set subscribed = true
-    }
-    this->resubscribe_subscription_(&subscription);
+    this->resubscribe_subscription_(&subscription, check_persistence);
   }
 }
 

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -56,9 +56,7 @@ void MQTTClientComponent::setup() {
     this->disconnect_reason_ = reason;
     this->session_present_ = false;
   });
-  this->mqtt_backend_.set_on_connect([this](bool session_present) {
-    this->session_present_ = session_present;
-  });
+  this->mqtt_backend_.set_on_connect([this](bool session_present) { this->session_present_ = session_present; });
 #ifdef USE_LOGGER
   if (this->is_log_message_enabled() && logger::global_logger != nullptr) {
     logger::global_logger->add_log_listener(this);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -54,6 +54,10 @@ void MQTTClientComponent::setup() {
       return;
     this->state_ = MQTT_CLIENT_DISCONNECTED;
     this->disconnect_reason_ = reason;
+    this->session_present_ = false;
+  });
+  this->mqtt_backend_.set_on_connect([this](bool session_present) {
+    this->session_present_ = session_present;
   });
 #ifdef USE_LOGGER
   if (this->is_log_message_enabled() && logger::global_logger != nullptr) {
@@ -313,7 +317,6 @@ void MQTTClientComponent::check_connected() {
   delay(100);  // NOLINT
 
   // Startup subscriptions
-  // TODO: Get the session_present flag from the backend
   this->resubscribe_subscriptions_(this->session_present_ && !this->credentials_.clean_session);
   this->send_device_info_();
 

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -488,13 +488,9 @@ void MQTTClientComponent::resubscribe_subscription_(MQTTSubscription *sub, bool 
   if (sub->subscribed)
     return;
   // If the session is present, check if we had already subscribed
-  if (check_persistence) {
-    if (is_subscription_stored(*sub)) {
-      ESP_LOGV(TAG, "Subscription to topic='%s' qos=%d already present in persistent session, skipping subscribe",
-               sub->topic.c_str(), sub->qos);
-      sub->subscribed = true;
-      return;
-    }
+  if (check_persistence && is_subscription_stored(*sub)) {
+    sub->subscribed = true;
+    return;
   }
 
   const uint32_t now = millis();

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -477,6 +477,7 @@ void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_js
 }
 
 void MQTTClientComponent::unsubscribe(const std::string &topic) {
+  // TODO: Remove from persistent storage if needed
   bool ret = this->mqtt_backend_.unsubscribe(topic.c_str());
   yield();
   if (ret) {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -497,7 +497,9 @@ void MQTTClientComponent::unsubscribe(const std::string &topic) {
   while (it != subscriptions_.end()) {
     if (it->topic == topic) {
       it = subscriptions_.erase(it);
-      remove_subscription(*it);
+      if (!this->credentials_.clean_session) {
+        remove_subscription(*it);
+      }
     } else {
       ++it;
     }
@@ -563,38 +565,35 @@ void MQTTClientComponent::disable() {
   this->on_shutdown();
 }
 
-/** Generate a 32-bit hash for an MQTT subscription
+/** Generate a 32-bit hash for an MQTT subscription topic
  *
- * Combines the FNV-1 hash of the topic with the QoS value to create a unique identifier
- * for the subscription that can be used for persistence checks.
+ * Creates a unique identifier for the subscription topic that can be used
+ * as a key for persistence storage.
  *
  * @param sub The MQTT subscription to hash.
- * @return A 32-bit hash value combining topic and QoS.
+ * @return A 32-bit hash value based on the topic.
  */
-static uint32_t hash_subscription(const MQTTSubscription &sub) {
-  uint32_t hash = fnv1_hash(sub.topic.c_str());
-  // Mix in the QoS by XOR'ing it into the hash (shifted to spread bits)
-  hash ^= (static_cast<uint32_t>(sub.qos) << 24);
-  return hash;
-}
+static uint32_t hash_subscription(const MQTTSubscription &sub) { return fnv1_hash(sub.topic.c_str()); }
 
 /** Store a subscription in persistent storage
  *
- * Saves the subscription hash to non-volatile memory so it can be checked
+ * Saves the subscription QoS to non-volatile memory so it can be checked
  * on reconnect to determine if the subscription is already active on the broker.
+ * Stores QoS + 34 as a magic value to distinguish from uninitialized storage.
  *
  * @param sub The MQTT subscription to store.
  * @return true if the subscription was successfully stored, false otherwise.
  */
 static bool store_subscription(const MQTTSubscription &sub) {
   uint32_t hash = hash_subscription(sub);
-  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
-  return pref.save(&hash);
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t stored_value = sub.qos + 34;
+  return pref.save(&stored_value);
 }
 
 /** Check if a subscription is stored in persistent storage
  *
- * Retrieves the subscription hash from non-volatile memory to determine if
+ * Retrieves the subscription QoS from non-volatile memory to determine if
  * this subscription was previously stored (indicating it may still be active
  * on the broker in a persistent session).
  *
@@ -603,16 +602,16 @@ static bool store_subscription(const MQTTSubscription &sub) {
  */
 static bool is_subscription_stored(const MQTTSubscription &sub) {
   uint32_t hash = hash_subscription(sub);
-  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
-  uint32_t stored_hash = 0;
-  if (!pref.load(&stored_hash))
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t stored_value = 0;
+  if (!pref.load(&stored_value))
     return false;
-  return stored_hash == hash;
+  return stored_value == (sub.qos + 34);
 }
 
 /** Remove a subscription from persistent storage
  *
- * Deletes the subscription hash from non-volatile memory, typically when
+ * Deletes the subscription from non-volatile memory, typically when
  * unsubscribing from a topic or cleaning up after a clean session.
  *
  * @param sub The MQTT subscription to remove.
@@ -620,9 +619,13 @@ static bool is_subscription_stored(const MQTTSubscription &sub) {
  */
 static bool remove_subscription(const MQTTSubscription &sub) {
   uint32_t hash = hash_subscription(sub);
-  auto pref = global_preferences->make_preference<uint32_t>(hash, true);
-  uint32_t zero_hash = 0;
-  return pref.save(&zero_hash);
+  // Check if it exists first
+  if (!is_subscription_stored(sub)) {
+    return true;
+  }
+  auto pref = global_preferences->make_preference<uint8_t>(hash, true);
+  uint8_t zero_value = 0;
+  return pref.save(&zero_value);
 }
 
 /** Check if the message topic matches the given subscription topic

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -299,7 +299,7 @@ class MQTTClientComponent : public Component
   void recalculate_availability_();
 
   bool subscribe_(const char *topic, uint8_t qos);
-  void resubscribe_subscription_(MQTTSubscription *sub);
+  void resubscribe_subscription_(MQTTSubscription *sub, bool check_persistence = false);
   void resubscribe_subscriptions_(bool check_persistence = false);
 
   MQTTCredentials credentials_;

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -300,7 +300,7 @@ class MQTTClientComponent : public Component
 
   bool subscribe_(const char *topic, uint8_t qos);
   void resubscribe_subscription_(MQTTSubscription *sub);
-  void resubscribe_subscriptions_(bool session_present = false);
+  void resubscribe_subscriptions_(bool check_persistence = false);
 
   MQTTCredentials credentials_;
   /// The last will message. Disabled optional denotes it being default and
@@ -351,6 +351,7 @@ class MQTTClientComponent : public Component
 
   bool publish_nan_as_none_{false};
   bool wait_for_connection_{false};
+  bool session_present_{false};
 };
 
 extern MQTTClientComponent *global_mqtt_client;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -300,7 +300,7 @@ class MQTTClientComponent : public Component
 
   bool subscribe_(const char *topic, uint8_t qos);
   void resubscribe_subscription_(MQTTSubscription *sub);
-  void resubscribe_subscriptions_();
+  void resubscribe_subscriptions_(bool session_present = false);
 
   MQTTCredentials credentials_;
   /// The last will message. Disabled optional denotes it being default and

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -201,7 +201,7 @@ void MQTTComponent::subscribe_json(const std::string &topic, const mqtt_json_cal
 
 MQTTComponent::MQTTComponent() = default;
 
-float MQTTComponent::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
+float MQTTComponent::get_setup_priority() const { return setup_priority::BEFORE_CONNECTION; }
 void MQTTComponent::disable_discovery() { this->discovery_enabled_ = false; }
 void MQTTComponent::set_custom_state_topic(const char *custom_state_topic) {
   this->custom_state_topic_ = StringRef(custom_state_topic);


### PR DESCRIPTION
# What does this implement/fix?

Reduce default MQTT component topic lengths:
* `/config` -> `/c` (5 bytes saved)
* `/state` -> `/s` (4 bytes saved)
* `/command` -> `/cm` (5 bytes saved)

Note, this might break external APIs that rely on hard-coded topics (and not on HA auto-discovery). 

## Benefits

* **Bandwidth savings and energy savings**: reduction in data usage for MQTT components. On a device with 10 sensors, this saves 40 bytes per batch of publish messages, a reduction of 57 KB/day if they publish every minute. This is critical for battery-powered devices where WiFi transmission can consume 70-100mA vs <1mA in deep sleep.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
