### PR TITLE
optimization(MQTT): reduce topic length

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -201,7 +201,7 @@ void MQTTComponent::subscribe_json(const std::string &topic, const mqtt_json_cal
 
 MQTTComponent::MQTTComponent() = default;
 
-float MQTTComponent::get_setup_priority() const { return setup_priority::BEFORE_CONNECTION; }
+float MQTTComponent::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
 void MQTTComponent::disable_discovery() { this->discovery_enabled_ = false; }
 void MQTTComponent::set_custom_state_topic(const char *custom_state_topic) {
   this->custom_state_topic_ = StringRef(custom_state_topic);

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -45,7 +45,7 @@ std::string MQTTComponent::get_state_topic_() const {
 std::string MQTTComponent::get_command_topic_() const {
   if (this->has_custom_command_topic_)
     return this->custom_command_topic_.str();
-  return this->get_default_topic_for_("cm");
+  return this->get_default_topic_for_("x");
 }
 
 bool MQTTComponent::publish(const std::string &topic, const std::string &payload) {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -23,7 +23,7 @@ void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
   std::string sanitized_name = str_sanitize(App.get_name());
   return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
-         this->get_default_object_id_() + "/c";
+         this->get_default_object_id_() + "/config";
 }
 
 std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) const {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -23,7 +23,7 @@ void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
   std::string sanitized_name = str_sanitize(App.get_name());
   return discovery_info.prefix + "/" + this->component_type() + "/" + sanitized_name + "/" +
-         this->get_default_object_id_() + "/config";
+         this->get_default_object_id_() + "/c";
 }
 
 std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) const {
@@ -39,13 +39,13 @@ std::string MQTTComponent::get_default_topic_for_(const std::string &suffix) con
 std::string MQTTComponent::get_state_topic_() const {
   if (this->has_custom_state_topic_)
     return this->custom_state_topic_.str();
-  return this->get_default_topic_for_("state");
+  return this->get_default_topic_for_("s");
 }
 
 std::string MQTTComponent::get_command_topic_() const {
   if (this->has_custom_command_topic_)
     return this->custom_command_topic_.str();
-  return this->get_default_topic_for_("command");
+  return this->get_default_topic_for_("cm");
 }
 
 bool MQTTComponent::publish(const std::string &topic, const std::string &payload) {
@@ -201,7 +201,7 @@ void MQTTComponent::subscribe_json(const std::string &topic, const mqtt_json_cal
 
 MQTTComponent::MQTTComponent() = default;
 
-float MQTTComponent::get_setup_priority() const { return setup_priority::AFTER_CONNECTION; }
+float MQTTComponent::get_setup_priority() const { return setup_priority::BEFORE_CONNECTION; }
 void MQTTComponent::disable_discovery() { this->discovery_enabled_ = false; }
 void MQTTComponent::set_custom_state_topic(const char *custom_state_topic) {
   this->custom_state_topic_ = StringRef(custom_state_topic);


### PR DESCRIPTION
# What does this implement/fix?

Reduce default MQTT component topic lengths:
* `/state` -> `/s` (4 bytes saved)
* `/command` -> `/x` (6 bytes saved)

Note, this might break external APIs that rely on hard-coded topics (and not on HA auto-discovery). 

## Benefits

* **Bandwidth savings and energy savings**: reduction in data usage for MQTT components. On a device with 10 sensors, this saves 40 bytes per batch of publish messages, a reduction of 57 KB/day if they publish every minute. This is critical for battery-powered devices where WiFi transmission can consume 70-100mA vs <1mA in deep sleep.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.