### PR TITLE
[espnow] implemented support for ESP-NOW encryption

### DIFF
--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -58,6 +58,8 @@ OnBroadcastedTrigger = espnow_ns.class_(
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
 CONF_PMK = "pmk"
+CONF_PEER_ADDRESS = "address"
+CONF_PEER_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
@@ -80,7 +82,17 @@ CONFIG_SCHEMA = cv.All(
             cv.OnlyWithout(CONF_CHANNEL, CONF_WIFI): validate_channel,
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_AUTO_ADD_PEER, default=False): cv.boolean,
-            cv.Optional(CONF_PEERS): cv.ensure_list(cv.mac_address),
+            cv.Optional(CONF_PEERS): cv.ensure_list(
+                cv.Any(
+                    cv.mac_address,
+                    cv.Schema(
+                        {
+                            cv.Required(CONF_PEER_ADDRESS): cv.mac_address,
+                            cv.Optional(CONF_PEER_LMK): cv.templatable(cv.string)
+                        }
+                    )
+                )
+            ),
             cv.Optional(CONF_PMK): cv.templatable(cv.string),
             cv.Optional(CONF_ON_UNKNOWN_PEER): automation.validate_automation(
                 {
@@ -140,7 +152,14 @@ async def to_code(config):
     cg.add(var.set_auto_add_peer(config[CONF_AUTO_ADD_PEER]))
 
     for peer in config.get(CONF_PEERS, []):
-        cg.add(var.add_peer(peer.parts))
+        if isinstance(peer, core.MACAddress):
+            cg.add(var.add_peer(peer.parts))
+        else:
+            lmk = peer.get(CONF_PEER_LMK, None)
+            if lmk:
+                cg.add(var.add_peer(peer.get(CONF_PEER_ADDRESS).parts, lmk))
+            else:
+                cg.add(var.add_peer(peer.get(CONF_PEER_ADDRESS).parts))
 
     if pmk := config.get(CONF_PMK):
         cg.add(var.set_pmk(pmk))

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -131,7 +131,9 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_ADDRESS): cv.mac_address,
                 }
             ),
-            cv.Optional(CONF_ESPNOW_ON_START): automation.validate_automation(single=True),
+            cv.Optional(CONF_ESPNOW_ON_START): automation.validate_automation(
+                single=True
+            ),
         },
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -72,6 +72,7 @@ CONF_WAIT_FOR_SENT = "wait_for_sent"
 
 MAX_ESPNOW_PACKET_SIZE = 250  # Maximum size of the payload in bytes
 
+
 def _validate_master_key(value):
     if isinstance(value, str):
         value = list(bytes(value.encode()))
@@ -80,6 +81,7 @@ def _validate_master_key(value):
     if len(value) != ESPNOW_MASTER_KEY_SIZE:
         raise cv.Invalid(f"Key must be {ESPNOW_MASTER_KEY_SIZE} bytes in size, got {len(value)}")
     return cv.Schema([cv.hex_uint8_t])(value)
+
 
 PEER_SCHEMA = cv.Schema(
     {
@@ -230,7 +232,7 @@ async def register_peer(var, config, args):
     cg.add(var.set_address(template_))
 
     # only for espnow.peer.add
-    if lmk:= config.get(CONF_LMK):
+    if lmk := config.get(CONF_LMK):
         template_ = await cg.templatable(lmk, args, master_address_t, master_address_t)
         cg.add(var.set_lmk(template_))
 

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -58,6 +58,7 @@ OnBroadcastedTrigger = espnow_ns.class_(
     "OnBroadcastedTrigger", ESPNowHandlerTrigger, ESPNowBroadcastedHandler
 )
 
+
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
 CONF_PMK = "pmk"
@@ -70,23 +71,6 @@ CONF_CONTINUE_ON_ERROR = "continue_on_error"
 CONF_WAIT_FOR_SENT = "wait_for_sent"
 
 MAX_ESPNOW_PACKET_SIZE = 250  # Maximum size of the payload in bytes
-
-def _validate_raw_data(value):
-    if isinstance(value, str):
-        if len(value) >= MAX_ESPNOW_PACKET_SIZE:
-            raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
-            )
-        return value
-    if isinstance(value, list):
-        if len(value) > MAX_ESPNOW_PACKET_SIZE:
-            raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
-            )
-        return cv.Schema([cv.hex_uint8_t])(value)
-    raise cv.Invalid(
-        f"'{CONF_DATA}' must either be a string wrapped in quotes or a list of bytes"
-    )
 
 def _validate_master_key(value):
     if isinstance(value, str):
@@ -105,15 +89,6 @@ PEER_SCHEMA = cv.Schema(
     }
 )
 
-SEND_SCHEMA = PEER_SCHEMA.extend(
-    {
-        cv.Required(CONF_DATA): cv.templatable(_validate_raw_data),
-        cv.Optional(CONF_ON_SENT): automation.validate_action_list,
-        cv.Optional(CONF_ON_ERROR): automation.validate_action_list,
-        cv.Optional(CONF_WAIT_FOR_SENT, default=True): cv.boolean,
-        cv.Optional(CONF_CONTINUE_ON_ERROR, default=True): cv.boolean,
-    }
-)
 
 def validate_channel(value):
     if value is None:
@@ -193,12 +168,10 @@ async def to_code(config):
     for peer in config.get(CONF_PEERS, []):
         if isinstance(peer, core.MACAddress):
             cg.add(var.add_peer(peer.parts))
+        elif lmk := peer.get(CONF_LMK):
+            cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts, lmk))
         else:
-            lmk = peer.get(CONF_LMK, None)
-            if lmk:
-                cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts, lmk))
-            else:
-                cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts))
+            cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts))
 
     if pmk := config.get(CONF_PMK):
         cg.add(var.set_pmk(pmk))
@@ -230,6 +203,24 @@ def validate_peer(value):
     return cv.mac_address(value)
 
 
+def _validate_raw_data(value):
+    if isinstance(value, str):
+        if len(value) >= MAX_ESPNOW_PACKET_SIZE:
+            raise cv.Invalid(
+                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
+            )
+        return value
+    if isinstance(value, list):
+        if len(value) > MAX_ESPNOW_PACKET_SIZE:
+            raise cv.Invalid(
+                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
+            )
+        return cv.Schema([cv.hex_uint8_t])(value)
+    raise cv.Invalid(
+        f"'{CONF_DATA}' must either be a string wrapped in quotes or a list of bytes"
+    )
+
+
 async def register_peer(var, config, args):
     peer = config[CONF_ADDRESS]
     if isinstance(peer, core.MACAddress):
@@ -239,9 +230,21 @@ async def register_peer(var, config, args):
     cg.add(var.set_address(template_))
 
     # only for espnow.peer.add
-    if lmk:= config.get(CONF_LMK, None):
+    if lmk:= config.get(CONF_LMK):
         template_ = await cg.templatable(lmk, args, master_address_t, master_address_t)
         cg.add(var.set_lmk(template_))
+
+
+SEND_SCHEMA = PEER_SCHEMA.extend(
+    {
+        cv.Required(CONF_DATA): cv.templatable(_validate_raw_data),
+        cv.Optional(CONF_ON_SENT): automation.validate_action_list,
+        cv.Optional(CONF_ON_ERROR): automation.validate_action_list,
+        cv.Optional(CONF_WAIT_FOR_SENT, default=True): cv.boolean,
+        cv.Optional(CONF_CONTINUE_ON_ERROR, default=True): cv.boolean,
+    }
+)
+
 
 def _validate_send_action(config):
     if not config[CONF_WAIT_FOR_SENT] and not config[CONF_CONTINUE_ON_ERROR]:
@@ -251,7 +254,9 @@ def _validate_send_action(config):
         )
     return config
 
+
 SEND_SCHEMA.add_extra(_validate_send_action)
+
 
 @automation.register_action(
     "espnow.send",

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -17,10 +17,14 @@ from esphome.core import CORE, HexInt
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
-AUTO_LOAD = ["socket", "md5"]
+AUTO_LOAD = ["socket"]
+
+# fixed size of ESP-NOW master keys (both Primary and Local)
+ESPNOW_MASTER_KEY_SIZE = 16
 
 byte_vector = cg.std_vector.template(cg.uint8)
 peer_address_t = cg.std_ns.class_("array").template(cg.uint8, 6)
+master_address_t = cg.std_ns.class_("array").template(cg.uint8, ESPNOW_MASTER_KEY_SIZE)
 
 espnow_ns = cg.esphome_ns.namespace("espnow")
 ESPNowComponent = espnow_ns.class_("ESPNowComponent", cg.Component)
@@ -57,7 +61,7 @@ OnBroadcastedTrigger = espnow_ns.class_(
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
 CONF_PMK = "pmk"
-CONF_PEER_LMK = "lmk"
+CONF_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
@@ -84,11 +88,20 @@ def _validate_raw_data(value):
         f"'{CONF_DATA}' must either be a string wrapped in quotes or a list of bytes"
     )
 
+def _validate_master_key(value):
+    if isinstance(value, str):
+        value = list(bytes(value.encode()))
+    elif not isinstance(value, list):
+        raise cv.Invalid("Key must either be a string wrapped in quotes or a list of bytes")
+    if len(value) != ESPNOW_MASTER_KEY_SIZE:
+        raise cv.Invalid(f"Key must be {ESPNOW_MASTER_KEY_SIZE} bytes in size, got {len(value)}")
+    return cv.Schema([cv.hex_uint8_t])(value)
+
 PEER_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.use_id(ESPNowComponent),
         cv.Required(CONF_ADDRESS): cv.templatable(cv.mac_address),
-        cv.Optional(CONF_PEER_LMK): cv.templatable(cv.string),
+        cv.Optional(CONF_LMK): cv.templatable(_validate_master_key),
     }
 )
 
@@ -118,7 +131,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PEERS): cv.ensure_list(
                 cv.Any(cv.mac_address, PEER_SCHEMA)
             ),
-            cv.Optional(CONF_PMK): cv.templatable(cv.string),
+            cv.Optional(CONF_PMK): cv.templatable(_validate_master_key),
             cv.Optional(CONF_ON_UNKNOWN_PEER): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnUnknownPeerTrigger),
@@ -181,7 +194,7 @@ async def to_code(config):
         if isinstance(peer, core.MACAddress):
             cg.add(var.add_peer(peer.parts))
         else:
-            lmk = peer.get(CONF_PEER_LMK, None)
+            lmk = peer.get(CONF_LMK, None)
             if lmk:
                 cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts, lmk))
             else:
@@ -226,8 +239,8 @@ async def register_peer(var, config, args):
     cg.add(var.set_address(template_))
 
     # only for espnow.peer.add
-    if lmk:= config.get(CONF_PEER_LMK, None):
-        template_ = await cg.templatable(lmk, args, cg.std_string)
+    if lmk:= config.get(CONF_LMK, None):
+        template_ = await cg.templatable(lmk, args, master_address_t, master_address_t)
         cg.add(var.set_lmk(template_))
 
 def _validate_send_action(config):

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -66,7 +66,7 @@ CONF_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
-CONF_ESPNOW_ON_START = "on_start"
+CONF_ON_START = "on_start"
 CONF_CONTINUE_ON_ERROR = "continue_on_error"
 CONF_WAIT_FOR_SENT = "wait_for_sent"
 
@@ -131,9 +131,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_ADDRESS): cv.mac_address,
                 }
             ),
-            cv.Optional(CONF_ESPNOW_ON_START): automation.validate_automation(
-                single=True
-            ),
+            cv.Optional(CONF_ON_START): automation.validate_automation(single=True),
         },
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,
@@ -196,9 +194,9 @@ async def to_code(config):
         trigger = await _trigger_to_code(on_receive)
         cg.add(var.register_broadcasted_handler(trigger))
 
-    if CONF_ESPNOW_ON_START in config:
+    if CONF_ON_START in config:
         await automation.build_automation(
-            var.get_start_trigger(), [], config[CONF_ESPNOW_ON_START]
+            var.get_start_trigger(), [], config[CONF_ON_START]
         )
 
 

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -221,7 +221,7 @@ async def register_peer(var, config, args):
 
     # only for espnow.peer.add
     if lmk:= config.get(CONF_PEER_LMK, None):
-        template_ = await cg.templatable(lmk, args, cv.string, cv.string)
+        template_ = await cg.templatable(lmk, args, cg.std_string)
         cg.add(var.set_lmk(template_))
 
 def _validate_send_action(config):
@@ -232,9 +232,7 @@ def _validate_send_action(config):
         )
     return config
 
-
 SEND_SCHEMA.add_extra(_validate_send_action)
-
 
 @automation.register_action(
     "espnow.send",

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -54,7 +54,6 @@ OnBroadcastedTrigger = espnow_ns.class_(
     "OnBroadcastedTrigger", ESPNowHandlerTrigger, ESPNowBroadcastedHandler
 )
 
-
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
 CONF_PMK = "pmk"
@@ -62,6 +61,7 @@ CONF_PEER_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
+CONF_ON_START = "on_start"
 CONF_CONTINUE_ON_ERROR = "continue_on_error"
 CONF_WAIT_FOR_SENT = "wait_for_sent"
 
@@ -137,6 +137,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_ADDRESS): cv.mac_address,
                 }
             ),
+            cv.Optional(CONF_ON_START): automation.validate_automation(single=True),
         },
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,
@@ -200,6 +201,11 @@ async def to_code(config):
     for on_receive in config.get(CONF_ON_BROADCAST, []):
         trigger = await _trigger_to_code(on_receive)
         cg.add(var.register_broadcasted_handler(trigger))
+
+    if CONF_ON_START in config:
+        await automation.build_automation(
+            var.get_start_trigger(), [], config[CONF_ON_START]
+        )
 
 
 # ========================================== A C T I O N S ================================================

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -66,7 +66,7 @@ CONF_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
-CONF_ON_START = "on_start"
+CONF_ESPNOW_ON_START = "on_start"
 CONF_CONTINUE_ON_ERROR = "continue_on_error"
 CONF_WAIT_FOR_SENT = "wait_for_sent"
 
@@ -131,7 +131,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_ADDRESS): cv.mac_address,
                 }
             ),
-            cv.Optional(CONF_ON_START): automation.validate_automation(single=True),
+            cv.Optional(CONF_ESPNOW_ON_START): automation.validate_automation(single=True),
         },
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on_esp32,
@@ -194,9 +194,9 @@ async def to_code(config):
         trigger = await _trigger_to_code(on_receive)
         cg.add(var.register_broadcasted_handler(trigger))
 
-    if CONF_ON_START in config:
+    if CONF_ESPNOW_ON_START in config:
         await automation.build_automation(
-            var.get_start_trigger(), [], config[CONF_ON_START]
+            var.get_start_trigger(), [], config[CONF_ESPNOW_ON_START]
         )
 
 

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -58,7 +58,6 @@ OnBroadcastedTrigger = espnow_ns.class_(
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
 CONF_PMK = "pmk"
-CONF_PEER_ADDRESS = "address"
 CONF_PEER_LMK = "lmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
@@ -68,6 +67,40 @@ CONF_WAIT_FOR_SENT = "wait_for_sent"
 
 MAX_ESPNOW_PACKET_SIZE = 250  # Maximum size of the payload in bytes
 
+def _validate_raw_data(value):
+    if isinstance(value, str):
+        if len(value) >= MAX_ESPNOW_PACKET_SIZE:
+            raise cv.Invalid(
+                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
+            )
+        return value
+    if isinstance(value, list):
+        if len(value) > MAX_ESPNOW_PACKET_SIZE:
+            raise cv.Invalid(
+                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
+            )
+        return cv.Schema([cv.hex_uint8_t])(value)
+    raise cv.Invalid(
+        f"'{CONF_DATA}' must either be a string wrapped in quotes or a list of bytes"
+    )
+
+PEER_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(ESPNowComponent),
+        cv.Required(CONF_ADDRESS): cv.templatable(cv.mac_address),
+        cv.Optional(CONF_PEER_LMK): cv.templatable(cv.string),
+    }
+)
+
+SEND_SCHEMA = PEER_SCHEMA.extend(
+    {
+        cv.Required(CONF_DATA): cv.templatable(_validate_raw_data),
+        cv.Optional(CONF_ON_SENT): automation.validate_action_list,
+        cv.Optional(CONF_ON_ERROR): automation.validate_action_list,
+        cv.Optional(CONF_WAIT_FOR_SENT, default=True): cv.boolean,
+        cv.Optional(CONF_CONTINUE_ON_ERROR, default=True): cv.boolean,
+    }
+)
 
 def validate_channel(value):
     if value is None:
@@ -83,15 +116,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_AUTO_ADD_PEER, default=False): cv.boolean,
             cv.Optional(CONF_PEERS): cv.ensure_list(
-                cv.Any(
-                    cv.mac_address,
-                    cv.Schema(
-                        {
-                            cv.Required(CONF_PEER_ADDRESS): cv.mac_address,
-                            cv.Optional(CONF_PEER_LMK): cv.templatable(cv.string)
-                        }
-                    )
-                )
+                cv.Any(cv.mac_address, PEER_SCHEMA)
             ),
             cv.Optional(CONF_PMK): cv.templatable(cv.string),
             cv.Optional(CONF_ON_UNKNOWN_PEER): automation.validate_automation(
@@ -157,9 +182,9 @@ async def to_code(config):
         else:
             lmk = peer.get(CONF_PEER_LMK, None)
             if lmk:
-                cg.add(var.add_peer(peer.get(CONF_PEER_ADDRESS).parts, lmk))
+                cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts, lmk))
             else:
-                cg.add(var.add_peer(peer.get(CONF_PEER_ADDRESS).parts))
+                cg.add(var.add_peer(peer.get(CONF_ADDRESS).parts))
 
     if pmk := config.get(CONF_PMK):
         cg.add(var.set_pmk(pmk))
@@ -186,24 +211,6 @@ def validate_peer(value):
     return cv.mac_address(value)
 
 
-def _validate_raw_data(value):
-    if isinstance(value, str):
-        if len(value) >= MAX_ESPNOW_PACKET_SIZE:
-            raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
-            )
-        return value
-    if isinstance(value, list):
-        if len(value) > MAX_ESPNOW_PACKET_SIZE:
-            raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
-            )
-        return cv.Schema([cv.hex_uint8_t])(value)
-    raise cv.Invalid(
-        f"'{CONF_DATA}' must either be a string wrapped in quotes or a list of bytes"
-    )
-
-
 async def register_peer(var, config, args):
     peer = config[CONF_ADDRESS]
     if isinstance(peer, core.MACAddress):
@@ -212,24 +219,10 @@ async def register_peer(var, config, args):
     template_ = await cg.templatable(peer, args, peer_address_t, peer_address_t)
     cg.add(var.set_address(template_))
 
-
-PEER_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.use_id(ESPNowComponent),
-        cv.Required(CONF_ADDRESS): cv.templatable(cv.mac_address),
-    }
-)
-
-SEND_SCHEMA = PEER_SCHEMA.extend(
-    {
-        cv.Required(CONF_DATA): cv.templatable(_validate_raw_data),
-        cv.Optional(CONF_ON_SENT): automation.validate_action_list,
-        cv.Optional(CONF_ON_ERROR): automation.validate_action_list,
-        cv.Optional(CONF_WAIT_FOR_SENT, default=True): cv.boolean,
-        cv.Optional(CONF_CONTINUE_ON_ERROR, default=True): cv.boolean,
-    }
-)
-
+    # only for espnow.peer.add
+    if lmk:= config.get(CONF_PEER_LMK, None):
+        template_ = await cg.templatable(lmk, args, cv.string, cv.string)
+        cg.add(var.set_lmk(template_))
 
 def _validate_send_action(config):
     if not config[CONF_WAIT_FOR_SENT] and not config[CONF_CONTINUE_ON_ERROR]:
@@ -294,10 +287,7 @@ async def send_action(
 @automation.register_action(
     "espnow.peer.add",
     AddPeerAction,
-    cv.maybe_simple_value(
-        PEER_SCHEMA,
-        key=CONF_ADDRESS,
-    ),
+    PEER_SCHEMA
 )
 @automation.register_action(
     "espnow.peer.delete",

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -77,9 +77,13 @@ def _validate_master_key(value):
     if isinstance(value, str):
         value = list(bytes(value.encode()))
     elif not isinstance(value, list):
-        raise cv.Invalid("Key must either be a string wrapped in quotes or a list of bytes")
+        raise cv.Invalid(
+            "Key must either be a string wrapped in quotes or a list of bytes"
+        )
     if len(value) != ESPNOW_MASTER_KEY_SIZE:
-        raise cv.Invalid(f"Key must be {ESPNOW_MASTER_KEY_SIZE} bytes in size, got {len(value)}")
+        raise cv.Invalid(
+            f"Key must be {ESPNOW_MASTER_KEY_SIZE} bytes in size, got {len(value)}"
+        )
     return cv.Schema([cv.hex_uint8_t])(value)
 
 
@@ -308,11 +312,7 @@ async def send_action(
     return var
 
 
-@automation.register_action(
-    "espnow.peer.add",
-    AddPeerAction,
-    PEER_SCHEMA
-)
+@automation.register_action("espnow.peer.add", AddPeerAction, PEER_SCHEMA)
 @automation.register_action(
     "espnow.peer.delete",
     DeletePeerAction,

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -17,7 +17,7 @@ from esphome.core import CORE, HexInt
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@jesserockz"]
-AUTO_LOAD = ["socket"]
+AUTO_LOAD = ["socket", "md5"]
 
 byte_vector = cg.std_vector.template(cg.uint8)
 peer_address_t = cg.std_ns.class_("array").template(cg.uint8, 6)
@@ -57,6 +57,7 @@ OnBroadcastedTrigger = espnow_ns.class_(
 
 CONF_AUTO_ADD_PEER = "auto_add_peer"
 CONF_PEERS = "peers"
+CONF_PMK = "pmk"
 CONF_ON_SENT = "on_sent"
 CONF_ON_UNKNOWN_PEER = "on_unknown_peer"
 CONF_ON_BROADCAST = "on_broadcast"
@@ -80,6 +81,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_AUTO_ADD_PEER, default=False): cv.boolean,
             cv.Optional(CONF_PEERS): cv.ensure_list(cv.mac_address),
+            cv.Optional(CONF_PMK): cv.templatable(cv.string),
             cv.Optional(CONF_ON_UNKNOWN_PEER): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnUnknownPeerTrigger),
@@ -139,6 +141,9 @@ async def to_code(config):
 
     for peer in config.get(CONF_PEERS, []):
         cg.add(var.add_peer(peer.parts))
+
+    if pmk := config.get(CONF_PMK):
+        cg.add(var.set_pmk(pmk))
 
     if on_receive := config.get(CONF_ON_UNKNOWN_PEER):
         trigger = await _trigger_to_code(on_receive)

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -88,11 +88,14 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
 
 template<typename... Ts> class AddPeerAction : public Action<Ts...>, public Parented<ESPNowComponent> {
   TEMPLATABLE_VALUE(peer_address_t, address);
+  TEMPLATABLE_VALUE(std::string, lmk);
 
  public:
   void play(const Ts &...x) override {
-    peer_address_t address = this->address_.value(x...);
-    this->parent_->add_peer(address.data());
+    auto address = this->address_.value(x...);
+    auto lmk     = this->lmk_.value(x...);
+
+    this->parent_->add_peer(address.data(), lmk.data());
   }
 };
 

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -88,7 +88,7 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
 
 template<typename... Ts> class AddPeerAction : public Action<Ts...>, public Parented<ESPNowComponent> {
   TEMPLATABLE_VALUE(peer_address_t, address);
-  TEMPLATABLE_VALUE(std::string, lmk);
+  TEMPLATABLE_VALUE(master_key_t, lmk);
 
  public:
   void play(const Ts &...x) override {

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -93,7 +93,7 @@ template<typename... Ts> class AddPeerAction : public Action<Ts...>, public Pare
  public:
   void play(const Ts &...x) override {
     auto address = this->address_.value(x...);
-    auto lmk     = this->lmk_.value(x...);
+    auto lmk = this->lmk_.value(x...);
 
     this->parent_->add_peer(address.data(), lmk.data());
   }

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -9,10 +9,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_MD5
-#include "esphome/core/helpers.h"
-#endif
-
 #include <esp_event.h>
 #include <esp_mac.h>
 #include <esp_netif.h>
@@ -166,40 +162,18 @@ void ESPNowComponent::setup() {
   }
 }
 
-void ESPNowComponent::set_pmk(const std::string& pmk) {
-  this->pmk = pmk;
+void ESPNowComponent::set_pmk(const master_key_t& pmk) {
+  this->pmk_ = std::move(pmk);
 }
 
 bool ESPNowComponent::has_pmk() {
-  return ! this->pmk.empty();
-}
-
-// PMK's and LMK's are 16 bytes. To allow for any string to serve as MK,
-// we'll hash it and use that to fill the MK byte array.
-void ESPNowComponent::hash_mk(const std::string& mk, const uint8_t* out) {
-#ifdef USE_MD5
-  md5::MD5Digest hasher;
-  hasher.init();
-  hasher.add(mk.c_str(), mk.size());
-  hasher.calculate();
-  hasher.get_bytes((uint8_t*) out);
-#else
-  // better than nothing
-  uint32_t hash = fnv1_hash(mk);
-  *((uint32_t*)(&mk[0]))  = hash;
-  *((uint32_t*)(&mk[4]))  = hash;
-  *((uint32_t*)(&mk[8]))  = hash;
-  *((uint32_t*)(&mk[12])) = hash;
-#endif
+  return this->pmk_.has_value();
 }
 
 void ESPNowComponent::set_espnow_pmk() {
   if (! this->has_pmk()) return;
 
-  const uint8_t* pmk[ESP_NOW_KEY_LEN];
-  this->hash_mk(this->pmk, (const uint8_t*) pmk);
-
-  esp_err_t err = esp_now_set_pmk((const uint8_t*) pmk);
+  esp_err_t err = esp_now_set_pmk((const uint8_t*) this->pmk_->data());
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to set Primary Master Key - %s", LOG_STR_ARG(espnow_error_to_str(err)));
     return;

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -271,6 +271,8 @@ void ESPNowComponent::enable_() {
   for (auto peer : this->peers_) {
     this->add_peer(peer.address, peer.encrypt ? peer.lmk : nullptr);
   }
+
+  this->defer([this]() { this->start_trigger_->trigger(); });
 }
 
 void ESPNowComponent::disable() {

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -162,18 +162,15 @@ void ESPNowComponent::setup() {
   }
 }
 
-void ESPNowComponent::set_pmk(const master_key_t& pmk) {
-  this->pmk_ = std::move(pmk);
-}
+void ESPNowComponent::set_pmk(const master_key_t &pmk) { this->pmk_ = std::move(pmk); }
 
-bool ESPNowComponent::has_pmk() {
-  return this->pmk_.has_value();
-}
+bool ESPNowComponent::has_pmk() { return this->pmk_.has_value(); }
 
 void ESPNowComponent::set_espnow_pmk() {
-  if (! this->has_pmk()) return;
+  if (!this->has_pmk())
+    return;
 
-  esp_err_t err = esp_now_set_pmk((const uint8_t*) this->pmk_->data());
+  esp_err_t err = esp_now_set_pmk((const uint8_t *) this->pmk_->data());
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "Failed to set Primary Master Key - %s", LOG_STR_ARG(espnow_error_to_str(err)));
     return;
@@ -441,7 +438,7 @@ void ESPNowComponent::send_() {
   }
 }
 
-esp_err_t ESPNowComponent::add_peer(const uint8_t *peer, const uint8_t* lmk) {
+esp_err_t ESPNowComponent::add_peer(const uint8_t *peer, const uint8_t *lmk) {
   if (this->state_ != ESPNOW_STATE_ENABLED || this->is_failed()) {
     return ESP_ERR_ESPNOW_NOT_INIT;
   }

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -174,6 +174,8 @@ bool ESPNowComponent::has_pmk() {
   return ! this->pmk.empty();
 }
 
+// PMK's and LMK's are 16 bytes. To allow for any string to serve as MK,
+// we'll hash it and use that to fill the MK byte array.
 void ESPNowComponent::hash_mk(const std::string& mk, const uint8_t* out) {
 #ifdef USE_MD5
   md5::MD5Digest hasher;
@@ -184,7 +186,6 @@ void ESPNowComponent::hash_mk(const std::string& mk, const uint8_t* out) {
 #else
   // better than nothing
   uint32_t hash = fnv1_hash(mk);
-
   *((uint32_t*)(&mk[0]))  = hash;
   *((uint32_t*)(&mk[4]))  = hash;
   *((uint32_t*)(&mk[8]))  = hash;
@@ -195,8 +196,6 @@ void ESPNowComponent::hash_mk(const std::string& mk, const uint8_t* out) {
 void ESPNowComponent::set_espnow_pmk() {
   if (! this->has_pmk()) return;
 
-  // PMK's are 16 bytes. To allow for any string to serve as PMK, we'll hash it
-  // and use that to fill the byte array
   const uint8_t* pmk[ESP_NOW_KEY_LEN];
   this->hash_mk(this->pmk, (const uint8_t*) pmk);
 
@@ -270,7 +269,7 @@ void ESPNowComponent::enable_() {
   }
 
   for (auto peer : this->peers_) {
-    this->add_peer(peer.address, peer.lmk);
+    this->add_peer(peer.address, peer.encrypt ? peer.lmk : nullptr);
   }
 }
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -174,27 +174,31 @@ bool ESPNowComponent::has_pmk() {
   return ! this->pmk.empty();
 }
 
+void ESPNowComponent::hash_mk(const std::string& mk, const uint8_t* out) {
+#ifdef USE_MD5
+  md5::MD5Digest hasher;
+  hasher.init();
+  hasher.add(mk.c_str(), mk.size());
+  hasher.calculate();
+  hasher.get_bytes((uint8_t*) out);
+#else
+  // better than nothing
+  uint32_t hash = fnv1_hash(mk);
+
+  *((uint32_t*)(&mk[0]))  = hash;
+  *((uint32_t*)(&mk[4]))  = hash;
+  *((uint32_t*)(&mk[8]))  = hash;
+  *((uint32_t*)(&mk[12])) = hash;
+#endif
+}
+
 void ESPNowComponent::set_espnow_pmk() {
   if (! this->has_pmk()) return;
 
   // PMK's are 16 bytes. To allow for any string to serve as PMK, we'll hash it
   // and use that to fill the byte array
-  const uint8_t* pmk[16];
-#ifdef USE_MD5
-  md5::MD5Digest hasher;
-  hasher.init();
-  hasher.add(this->pmk.c_str(), this->pmk.size());
-  hasher.calculate();
-  hasher.get_bytes((uint8_t*) pmk);
-#else
-  // better than nothing
-  uint32_t hash = fnv1_hash(this->pmk);
-
-  *((uint32_t*)(&pmk[0]))  = hash;
-  *((uint32_t*)(&pmk[4]))  = hash;
-  *((uint32_t*)(&pmk[8]))  = hash;
-  *((uint32_t*)(&pmk[12])) = hash;
-#endif
+  const uint8_t* pmk[ESP_NOW_KEY_LEN];
+  this->hash_mk(this->pmk, (const uint8_t*) pmk);
 
   esp_err_t err = esp_now_set_pmk((const uint8_t*) pmk);
   if (err != ESP_OK) {
@@ -266,7 +270,7 @@ void ESPNowComponent::enable_() {
   }
 
   for (auto peer : this->peers_) {
-    this->add_peer(peer.address);
+    this->add_peer(peer.address, peer.lmk);
   }
 }
 
@@ -462,7 +466,7 @@ void ESPNowComponent::send_() {
   }
 }
 
-esp_err_t ESPNowComponent::add_peer(const uint8_t *peer) {
+esp_err_t ESPNowComponent::add_peer(const uint8_t *peer, const uint8_t* lmk) {
   if (this->state_ != ESPNOW_STATE_ENABLED || this->is_failed()) {
     return ESP_ERR_ESPNOW_NOT_INIT;
   }
@@ -477,6 +481,13 @@ esp_err_t ESPNowComponent::add_peer(const uint8_t *peer) {
     memset(&peer_info, 0, sizeof(esp_now_peer_info_t));
     peer_info.ifidx = WIFI_IF_STA;
     memcpy(peer_info.peer_addr, peer, ESP_NOW_ETH_ALEN);
+
+    // Add (optional) Local Master Key
+    if (lmk != nullptr) {
+      memcpy(peer_info.lmk, lmk, ESP_NOW_KEY_LEN);
+      peer_info.encrypt = true;
+    }
+
     esp_err_t err = esp_now_add_peer(&peer_info);
 
     if (err != ESP_OK) {

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -9,6 +9,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_MD5
+#include "esphome/core/helpers.h"
+#endif
+
 #include <esp_event.h>
 #include <esp_mac.h>
 #include <esp_netif.h>
@@ -162,6 +166,44 @@ void ESPNowComponent::setup() {
   }
 }
 
+void ESPNowComponent::set_pmk(const std::string& pmk) {
+  this->pmk = pmk;
+}
+
+bool ESPNowComponent::has_pmk() {
+  return ! this->pmk.empty();
+}
+
+void ESPNowComponent::set_espnow_pmk() {
+  if (! this->has_pmk()) return;
+
+  // PMK's are 16 bytes. To allow for any string to serve as PMK, we'll hash it
+  // and use that to fill the byte array
+  const uint8_t* pmk[16];
+#ifdef USE_MD5
+  md5::MD5Digest hasher;
+  hasher.init();
+  hasher.add(this->pmk.c_str(), this->pmk.size());
+  hasher.calculate();
+  hasher.get_bytes((uint8_t*) pmk);
+#else
+  // better than nothing
+  uint32_t hash = fnv1_hash(this->pmk);
+
+  *((uint32_t*)(&pmk[0]))  = hash;
+  *((uint32_t*)(&pmk[4]))  = hash;
+  *((uint32_t*)(&pmk[8]))  = hash;
+  *((uint32_t*)(&pmk[12])) = hash;
+#endif
+
+  esp_err_t err = esp_now_set_pmk((const uint8_t*) pmk);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to set Primary Master Key - %s", LOG_STR_ARG(espnow_error_to_str(err)));
+    return;
+  }
+  ESP_LOGV(TAG, "Set Primary Master Key");
+}
+
 void ESPNowComponent::enable() {
   if (this->state_ == ESPNOW_STATE_ENABLED)
     return;
@@ -218,6 +260,10 @@ void ESPNowComponent::enable_() {
 #endif
 
   this->state_ = ESPNOW_STATE_ENABLED;
+
+  if (this->has_pmk()) {
+    this->set_espnow_pmk();
+  }
 
   for (auto peer : this->peers_) {
     this->add_peer(peer.address);

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -480,6 +480,12 @@ esp_err_t ESPNowComponent::add_peer(const uint8_t *peer, const uint8_t *lmk) {
   if (!found) {
     ESPNowPeer new_peer;
     memcpy(new_peer.address, peer, ESP_NOW_ETH_ALEN);
+    if (lmk != nullptr) {
+      memcpy(new_peer.lmk, lmk, ESP_NOW_KEY_LEN);
+      new_peer.encrypt = true;
+    } else {
+      new_peer.encrypt = false;
+    }
     this->peers_.push_back(new_peer);
   }
 

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -55,6 +55,7 @@ enum ESPNowState : uint8_t {
 struct ESPNowPeer {
   uint8_t address[ESP_NOW_ETH_ALEN];  // MAC address of the peer
   uint8_t lmk[ESP_NOW_KEY_LEN]; // Local Master Key (optional)
+  bool    encrypt = false;
 
   bool operator==(const ESPNowPeer &other) const { return memcmp(this->address, other.address, ESP_NOW_ETH_ALEN) == 0; }
   bool operator==(const uint8_t *other) const { return memcmp(this->address, other, ESP_NOW_ETH_ALEN) == 0; }
@@ -116,6 +117,7 @@ class ESPNowComponent : public Component {
     memset(&peer, 0, sizeof(ESPNowPeer));
     memcpy(peer.address, address.data(), ESP_NOW_ETH_ALEN);
     if (! lmk.empty()) {
+      peer.encrypt = true;
       this->hash_mk(lmk, (const uint8_t*) peer.lmk);
     }
     this->peers_.push_back(peer);

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -169,6 +169,8 @@ class ESPNowComponent : public Component {
     this->broadcasted_handlers_.push_back(handler);
   }
 
+  Trigger<> *get_start_trigger() const { return this->start_trigger_; }
+
  protected:
   friend void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
@@ -202,6 +204,8 @@ class ESPNowComponent : public Component {
 
   bool auto_add_peer_{false};
   bool enable_on_boot_{true};
+
+  Trigger<> *start_trigger_ = new Trigger<>();
 };
 
 extern ESPNowComponent *global_esp_now;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -3,6 +3,10 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
+#ifdef USE_MD5
+#include "esphome/components/md5/md5.h"
+#endif
+
 #ifdef USE_ESP32
 
 #include "esphome/core/event_pool.h"
@@ -97,6 +101,11 @@ class ESPNowComponent : public Component {
 
   float get_setup_priority() const override { return setup_priority::LATE; }
 
+  // Handle Primary Master Key (PMK)
+  void set_pmk(const std::string& pmk);
+  bool has_pmk();
+  void set_espnow_pmk();
+
   // Add a peer to the internal list of peers
   void add_peer(peer_address_t address) {
     ESPNowPeer peer;
@@ -171,6 +180,9 @@ class ESPNowComponent : public Component {
 
   uint8_t wifi_channel_{0};
   ESPNowState state_{ESPNOW_STATE_OFF};
+
+  // Primary Master Key (optional)
+  std::string pmk;
 
   bool auto_add_peer_{false};
   bool enable_on_boot_{true};

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -52,7 +52,7 @@ enum ESPNowState : uint8_t {
 
 struct ESPNowPeer {
   uint8_t address[ESP_NOW_ETH_ALEN];  // MAC address of the peer
-  uint8_t lmk[ESP_NOW_KEY_LEN]; // Local Master Key (optional)
+  uint8_t lmk[ESP_NOW_KEY_LEN];       // Local Master Key (optional)
   bool encrypt{false};
 
   bool operator==(const ESPNowPeer &other) const { return memcmp(this->address, other.address, ESP_NOW_ETH_ALEN) == 0; }
@@ -104,19 +104,17 @@ class ESPNowComponent : public Component {
   float get_setup_priority() const override { return setup_priority::LATE; }
 
   // Handle Primary Master Key (PMK)
-  void set_pmk(const master_key_t& pmk);
+  void set_pmk(const master_key_t &pmk);
   bool has_pmk();
   void set_espnow_pmk();
 
   // Add a peer with the esp_now api and add to the internal list if doesnt exist already
-  esp_err_t add_peer(const uint8_t *peer, const uint8_t* lmk = nullptr);
+  esp_err_t add_peer(const uint8_t *peer, const uint8_t *lmk = nullptr);
 
   // Overloaded add_peer's
-  void add_peer(peer_address_t address, const master_key_t& lmk) {
-    this->add_peer(address, lmk.data());
-  }
+  void add_peer(peer_address_t address, const master_key_t &lmk) { this->add_peer(address, lmk.data()); }
 
-  void add_peer(peer_address_t address, const uint8_t* lmk = nullptr) {
+  void add_peer(peer_address_t address, const uint8_t *lmk = nullptr) {
     ESPNowPeer peer;
     memcpy(peer.address, address.data(), ESP_NOW_ETH_ALEN);
     if (lmk) {
@@ -128,9 +126,7 @@ class ESPNowComponent : public Component {
     this->peers_.push_back(peer);
   }
 
-  esp_err_t add_peer(const uint8_t *peer, const master_key_t& lmk) {
-    return this->add_peer(peer, lmk.data());
-  }
+  esp_err_t add_peer(const uint8_t *peer, const master_key_t &lmk) { return this->add_peer(peer, lmk.data()); }
 
   // Remove a peer with the esp_now api and remove from the internal list if exists
   esp_err_t del_peer(const uint8_t *peer);

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -3,10 +3,6 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-#ifdef USE_MD5
-#include "esphome/components/md5/md5.h"
-#endif
-
 #ifdef USE_ESP32
 
 #include "esphome/core/event_pool.h"
@@ -23,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 namespace esphome::espnow {
 
@@ -33,6 +30,7 @@ static constexpr size_t MAX_ESP_NOW_SEND_QUEUE_SIZE = 16;
 static constexpr size_t MAX_ESP_NOW_RECEIVE_QUEUE_SIZE = 16;
 
 using peer_address_t = std::array<uint8_t, ESP_NOW_ETH_ALEN>;
+using master_key_t = std::array<uint8_t, ESP_NOW_KEY_LEN>;
 
 enum class ESPNowTriggers : uint8_t {
   TRIGGER_NONE = 0,
@@ -55,7 +53,7 @@ enum ESPNowState : uint8_t {
 struct ESPNowPeer {
   uint8_t address[ESP_NOW_ETH_ALEN];  // MAC address of the peer
   uint8_t lmk[ESP_NOW_KEY_LEN]; // Local Master Key (optional)
-  bool    encrypt = false;
+  bool encrypt{false};
 
   bool operator==(const ESPNowPeer &other) const { return memcmp(this->address, other.address, ESP_NOW_ETH_ALEN) == 0; }
   bool operator==(const uint8_t *other) const { return memcmp(this->address, other, ESP_NOW_ETH_ALEN) == 0; }
@@ -106,30 +104,34 @@ class ESPNowComponent : public Component {
   float get_setup_priority() const override { return setup_priority::LATE; }
 
   // Handle Primary Master Key (PMK)
-  void set_pmk(const std::string& pmk);
+  void set_pmk(const master_key_t& pmk);
   bool has_pmk();
-  void hash_mk(const std::string& mk, const uint8_t* out);
   void set_espnow_pmk();
 
-  // Add a peer to the internal list of peers
-  void add_peer(peer_address_t address, const std::string& lmk = EMPTY_STRING) {
+  // Add a peer with the esp_now api and add to the internal list if doesnt exist already
+  esp_err_t add_peer(const uint8_t *peer, const uint8_t* lmk = nullptr);
+
+  // Overloaded add_peer's
+  void add_peer(peer_address_t address, const master_key_t& lmk) {
+    this->add_peer(address, lmk.data());
+  }
+
+  void add_peer(peer_address_t address, const uint8_t* lmk = nullptr) {
     ESPNowPeer peer;
-    memset(&peer, 0, sizeof(ESPNowPeer));
     memcpy(peer.address, address.data(), ESP_NOW_ETH_ALEN);
-    if (! lmk.empty()) {
+    if (lmk) {
+      memcpy(peer.lmk, lmk, ESP_NOW_KEY_LEN);
       peer.encrypt = true;
-      this->hash_mk(lmk, (const uint8_t*) peer.lmk);
+    } else {
+      peer.encrypt = false;
     }
     this->peers_.push_back(peer);
   }
-  // Add a peer with a string LMK that needs to be hashed first
-  esp_err_t add_peer(const uint8_t *peer, const std::string& lmk) {
-    uint8_t hash[ESP_NOW_KEY_LEN];
-    this->hash_mk(lmk, (const uint8_t*) hash);
-    return this->add_peer(peer, (const uint8_t*) hash);
+
+  esp_err_t add_peer(const uint8_t *peer, const master_key_t& lmk) {
+    return this->add_peer(peer, lmk.data());
   }
-  // Add a peer with the esp_now api and add to the internal list if doesnt exist already
-  esp_err_t add_peer(const uint8_t *peer, const uint8_t* lmk = nullptr);
+
   // Remove a peer with the esp_now api and remove from the internal list if exists
   esp_err_t del_peer(const uint8_t *peer);
 
@@ -200,7 +202,7 @@ class ESPNowComponent : public Component {
   ESPNowState state_{ESPNOW_STATE_OFF};
 
   // Primary Master Key (optional)
-  std::string pmk;
+  std::optional<master_key_t> pmk_{};
 
   bool auto_add_peer_{false};
   bool enable_on_boot_{true};

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -26,6 +26,8 @@
 
 namespace esphome::espnow {
 
+static const std::string EMPTY_STRING = std::string();
+
 // Maximum size of the ESPNow event queue - must be power of 2 for lock-free queue
 static constexpr size_t MAX_ESP_NOW_SEND_QUEUE_SIZE = 16;
 static constexpr size_t MAX_ESP_NOW_RECEIVE_QUEUE_SIZE = 16;
@@ -52,6 +54,7 @@ enum ESPNowState : uint8_t {
 
 struct ESPNowPeer {
   uint8_t address[ESP_NOW_ETH_ALEN];  // MAC address of the peer
+  uint8_t lmk[ESP_NOW_KEY_LEN]; // Local Master Key (optional)
 
   bool operator==(const ESPNowPeer &other) const { return memcmp(this->address, other.address, ESP_NOW_ETH_ALEN) == 0; }
   bool operator==(const uint8_t *other) const { return memcmp(this->address, other, ESP_NOW_ETH_ALEN) == 0; }
@@ -104,16 +107,27 @@ class ESPNowComponent : public Component {
   // Handle Primary Master Key (PMK)
   void set_pmk(const std::string& pmk);
   bool has_pmk();
+  void hash_mk(const std::string& mk, const uint8_t* out);
   void set_espnow_pmk();
 
   // Add a peer to the internal list of peers
-  void add_peer(peer_address_t address) {
+  void add_peer(peer_address_t address, const std::string& lmk = EMPTY_STRING) {
     ESPNowPeer peer;
+    memset(&peer, 0, sizeof(ESPNowPeer));
     memcpy(peer.address, address.data(), ESP_NOW_ETH_ALEN);
+    if (! lmk.empty()) {
+      this->hash_mk(lmk, (const uint8_t*) peer.lmk);
+    }
     this->peers_.push_back(peer);
   }
+  // Add a peer with a string LMK that needs to be hashed first
+  esp_err_t add_peer(const uint8_t *peer, const std::string& lmk) {
+    uint8_t hash[ESP_NOW_KEY_LEN];
+    this->hash_mk(lmk, (const uint8_t*) hash);
+    return this->add_peer(peer, (const uint8_t*) hash);
+  }
   // Add a peer with the esp_now api and add to the internal list if doesnt exist already
-  esp_err_t add_peer(const uint8_t *peer);
+  esp_err_t add_peer(const uint8_t *peer, const uint8_t* lmk = nullptr);
   // Remove a peer with the esp_now api and remove from the internal list if exists
   esp_err_t del_peer(const uint8_t *peer);
 


### PR DESCRIPTION

# What does this implement/fix?

Implementation of [ESP-NOW encryption](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/network/esp_now.html#security).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5770

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Tested boards:
- ESP32-C3
- ESP32-C6
- ESP32-S3
- ESP32-PICO

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
espnow:
  channel: 1
  pmk: !secret pmk
  peers:
    - 01:02:03:04:05:06
    - address: 06:05:04:03:02:01
      lmk: !secret lmk
  on_...:
    - espnow.peer.add:
        address: 06:05:04:03:02:01
        lmk: !secret lmk
  on_start:
    - logger.log:
        format: "ESP-NOW has started"
        level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
