### PR TITLE
[ledc,mqtt,resampler] Remove unnecessary ESP-IDF framework restrictions

### DIFF
--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
         cv.Optional(CONF_FREQUENCY, default="1kHz"): cv.frequency,
         cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=15),
         cv.Optional(CONF_PHASE_ANGLE): cv.All(
-            cv.only_with_esp_idf, cv.angle, cv.float_range(min=0.0, max=360.0)
+            cv.angle, cv.float_range(min=0.0, max=360.0)
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -233,11 +233,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_PASSWORD, default=""): cv.string,
             cv.Optional(CONF_CLEAN_SESSION, default=False): cv.boolean,
             cv.Optional(CONF_CLIENT_ID): cv.string,
-            cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
+            cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32=False): cv.All(
+                cv.boolean, cv.only_on_esp32
             ),
             cv.Optional(CONF_CERTIFICATE_AUTHORITY): cv.All(
-                cv.string, cv.only_with_esp_idf
+                cv.string, cv.only_on_esp32
             ),
             cv.Inclusive(CONF_CLIENT_CERTIFICATE, "cert-key-pair"): cv.All(
                 cv.string, cv.only_on_esp32
@@ -245,8 +245,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Inclusive(CONF_CLIENT_CERTIFICATE_KEY, "cert-key-pair"): cv.All(
                 cv.string, cv.only_on_esp32
             ),
-            cv.SplitDefault(CONF_SKIP_CERT_CN_CHECK, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
+            cv.SplitDefault(CONF_SKIP_CERT_CN_CHECK, esp32=False): cv.All(
+                cv.boolean, cv.only_on_esp32
             ),
             cv.Optional(CONF_DISCOVERY, default=True): cv.Any(
                 cv.boolean, cv.one_of("CLEAN", upper=True)

--- a/esphome/components/resampler/speaker/__init__.py
+++ b/esphome/components/resampler/speaker/__init__.py
@@ -63,9 +63,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_BUFFER_DURATION, default="100ms"
             ): cv.positive_time_period_milliseconds,
-            cv.SplitDefault(CONF_TASK_STACK_IN_PSRAM, esp32_idf=False): cv.All(
-                cv.boolean, cv.only_with_esp_idf
-            ),
+            cv.Optional(CONF_TASK_STACK_IN_PSRAM, default=False): cv.boolean,
             cv.Optional(CONF_FILTERS, default=16): cv.int_range(min=2, max=1024),
             cv.Optional(CONF_TAPS, default=16): _validate_taps,
         }


### PR DESCRIPTION
# What does this implement/fix?

Remove unnecessary `cv.only_with_esp_idf` restrictions from several components since Arduino-ESP32 is built on ESP-IDF and includes these APIs.

**Changes:**
- **LEDC `phase_angle`**: Removed framework restriction (component is already ESP32-only via `DEPENDENCIES`). Uses `ledc_set_duty_with_hpoint()` from `<driver/ledc.h>`.
- **MQTT `certificate_authority`, `skip_cert_cn_check`, `idf_send_async`**: Changed from `esp32_idf` to `esp32` since the ESP32 MQTT backend uses ESP-IDF's `mqtt_client.h` for all ESP32 builds (both Arduino and ESP-IDF).
- **Resampler `task_stack_in_psram`**: Removed framework restriction (component is already ESP32-only). Uses `heap_caps_malloc()` which is available on both frameworks.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5772

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# LEDC with phase_angle on Arduino
output:
  - platform: ledc
    id: pwm_output
    pin: GPIO4
    phase_angle: 90

# MQTT with TLS on Arduino
mqtt:
  broker: mqtt.example.com
  certificate_authority: |
    -----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
  skip_cert_cn_check: false
  idf_send_async: true

# Resampler with PSRAM on Arduino
speaker:
  - platform: resampler
    output_speaker: my_speaker
    task_stack_in_psram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)