### PR TITLE
[core] Fix CORE.raw_config not updated after package merge

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1010,13 +1010,13 @@ def validate_config(
             result.add_error(err)
             return result
 
-    CORE.raw_config = config
-
     # 1.1. Merge packages
     if CONF_PACKAGES in config:
         from esphome.components.packages import merge_packages
 
         config = merge_packages(config)
+
+    CORE.raw_config = config
 
     # 1.2. Resolve !extend and !remove and check for REPLACEME
     # After this step, there will not be any Extend or Remove values in the config anymore


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced in #11605 where `CORE.raw_config` was set before packages were merged, causing `KeyError: 'esphome'` when components accessed `CORE.raw_config[CONF_ESPHOME]` and the `esphome` section came from a package.

Before #11605, the order was:
```python
config = do_packages_pass(config)  # Packages merged here
CORE.raw_config = config           # Set AFTER merge
```

After #11605, `merge_packages` was moved to after substitutions but `CORE.raw_config` was left in its original position:
```python
CORE.raw_config = config           # Set BEFORE merge
config = merge_packages(config)    # Packages merged here, but raw_config not updated
```

This fix moves `CORE.raw_config = config` to after `merge_packages()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #11605

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config fails without the fix when esphome section comes from a package
packages:
  base:
    esphome:
      name: my-device

esp32:
  board: esp32dev

esp32_ble_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
