### PR TITLE
Add USE_SHA256 define to sha256 component to enable tests

### DIFF
--- a/esphome/components/sha256/__init__.py
+++ b/esphome/components/sha256/__init__.py
@@ -12,6 +12,8 @@ CONFIG_SCHEMA = cv.Schema({})
 
 
 async def to_code(config: ConfigType) -> None:
+    cg.add_define("USE_SHA256")
+
     # Add OpenSSL library for host platform
     if not CORE.is_host:
         return


### PR DESCRIPTION
This makes the tests actually run, and also allows other components to conditionally compile SHA256-dependent code.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
