### PR TITLE
Add host platform support to MD5 component

### DIFF
--- a/esphome/components/md5/__init__.py
+++ b/esphome/components/md5/__init__.py
@@ -1,7 +1,17 @@
 import esphome.codegen as cg
+from esphome.core import CORE
+from esphome.helpers import IS_MACOS
 
 CODEOWNERS = ["@esphome/core"]
 
 
 async def to_code(config):
     cg.add_define("USE_MD5")
+
+    # Add OpenSSL library for host platform
+    if CORE.is_host:
+        if IS_MACOS:
+            # macOS needs special handling for Homebrew OpenSSL
+            cg.add_build_flag("-I/opt/homebrew/opt/openssl/include")
+            cg.add_build_flag("-L/opt/homebrew/opt/openssl/lib")
+        cg.add_build_flag("-lcrypto")

--- a/esphome/components/md5/md5.cpp
+++ b/esphome/components/md5/md5.cpp
@@ -39,6 +39,22 @@ void MD5Digest::add(const uint8_t *data, size_t len) { br_md5_update(&this->ctx_
 void MD5Digest::calculate() { br_md5_out(&this->ctx_, this->digest_); }
 #endif  // USE_RP2040
 
+#ifdef USE_HOST
+void MD5Digest::init() {
+  memset(this->digest_, 0, 16);
+  this->ctx_ = EVP_MD_CTX_new();
+  EVP_DigestInit_ex(this->ctx_, EVP_md5(), nullptr);
+}
+
+void MD5Digest::add(const uint8_t *data, size_t len) { EVP_DigestUpdate(this->ctx_, data, len); }
+
+void MD5Digest::calculate() {
+  unsigned int len = 16;
+  EVP_DigestFinal_ex(this->ctx_, this->digest_, &len);
+  EVP_MD_CTX_free(this->ctx_);
+}
+#endif  // USE_HOST
+
 }  // namespace md5
 }  // namespace esphome
 #endif

--- a/esphome/components/md5/md5.cpp
+++ b/esphome/components/md5/md5.cpp
@@ -40,19 +40,41 @@ void MD5Digest::calculate() { br_md5_out(&this->ctx_, this->digest_); }
 #endif  // USE_RP2040
 
 #ifdef USE_HOST
+MD5Digest::~MD5Digest() {
+  if (this->ctx_) {
+    EVP_MD_CTX_free(this->ctx_);
+  }
+}
+
 void MD5Digest::init() {
-  memset(this->digest_, 0, 16);
+  if (this->ctx_) {
+    EVP_MD_CTX_free(this->ctx_);
+  }
   this->ctx_ = EVP_MD_CTX_new();
   EVP_DigestInit_ex(this->ctx_, EVP_md5(), nullptr);
+  this->calculated_ = false;
+  memset(this->digest_, 0, 16);
 }
 
-void MD5Digest::add(const uint8_t *data, size_t len) { EVP_DigestUpdate(this->ctx_, data, len); }
+void MD5Digest::add(const uint8_t *data, size_t len) {
+  if (!this->ctx_) {
+    this->init();
+  }
+  EVP_DigestUpdate(this->ctx_, data, len);
+}
 
 void MD5Digest::calculate() {
-  unsigned int len = 16;
-  EVP_DigestFinal_ex(this->ctx_, this->digest_, &len);
-  EVP_MD_CTX_free(this->ctx_);
+  if (!this->ctx_) {
+    this->init();
+  }
+  if (!this->calculated_) {
+    unsigned int len = 16;
+    EVP_DigestFinal_ex(this->ctx_, this->digest_, &len);
+    this->calculated_ = true;
+  }
 }
+#else
+MD5Digest::~MD5Digest() = default;
 #endif  // USE_HOST
 
 }  // namespace md5

--- a/esphome/components/md5/md5.h
+++ b/esphome/components/md5/md5.h
@@ -25,6 +25,11 @@
 #define MD5_CTX_TYPE LT_MD5_CTX_T
 #endif
 
+#if defined(USE_HOST)
+#include <openssl/evp.h>
+#define MD5_CTX_TYPE EVP_MD_CTX *
+#endif
+
 namespace esphome {
 namespace md5 {
 

--- a/esphome/components/md5/md5.h
+++ b/esphome/components/md5/md5.h
@@ -25,9 +25,26 @@
 #define MD5_CTX_TYPE LT_MD5_CTX_T
 #endif
 
-#if defined(USE_HOST)
+#ifdef USE_HOST
 #include <openssl/evp.h>
-#define MD5_CTX_TYPE EVP_MD_CTX *
+#endif
+
+#ifndef USE_HOST
+#ifdef USE_ESP32
+#define MD5_CTX_TYPE md5_context_t
+#endif
+
+#if defined(USE_ARDUINO) && defined(USE_ESP8266)
+#define MD5_CTX_TYPE md5_context_t
+#endif
+
+#ifdef USE_RP2040
+#define MD5_CTX_TYPE br_md5_context
+#endif
+
+#if defined(USE_LIBRETINY)
+#define MD5_CTX_TYPE LT_MD5_CTX_T
+#endif
 #endif
 
 namespace esphome {
@@ -36,7 +53,7 @@ namespace md5 {
 class MD5Digest : public HashBase {
  public:
   MD5Digest() = default;
-  ~MD5Digest() override = default;
+  ~MD5Digest() override;
 
   /// Initialize a new MD5 digest computation.
   void init() override;
@@ -52,7 +69,12 @@ class MD5Digest : public HashBase {
   size_t get_size() const override { return 16; }
 
  protected:
+#ifdef USE_HOST
+  EVP_MD_CTX *ctx_{nullptr};
+  bool calculated_{false};
+#else
   MD5_CTX_TYPE ctx_{};
+#endif
 };
 
 }  // namespace md5

--- a/esphome/components/md5/md5.h
+++ b/esphome/components/md5/md5.h
@@ -5,6 +5,10 @@
 
 #include "esphome/core/hash_base.h"
 
+#ifdef USE_HOST
+#include <openssl/evp.h>
+#endif
+
 #ifdef USE_ESP32
 #include "esp_rom_md5.h"
 #define MD5_CTX_TYPE md5_context_t
@@ -23,28 +27,6 @@
 #if defined(USE_LIBRETINY)
 #include <MD5.h>
 #define MD5_CTX_TYPE LT_MD5_CTX_T
-#endif
-
-#ifdef USE_HOST
-#include <openssl/evp.h>
-#endif
-
-#ifndef USE_HOST
-#ifdef USE_ESP32
-#define MD5_CTX_TYPE md5_context_t
-#endif
-
-#if defined(USE_ARDUINO) && defined(USE_ESP8266)
-#define MD5_CTX_TYPE md5_context_t
-#endif
-
-#ifdef USE_RP2040
-#define MD5_CTX_TYPE br_md5_context
-#endif
-
-#if defined(USE_LIBRETINY)
-#define MD5_CTX_TYPE LT_MD5_CTX_T
-#endif
 #endif
 
 namespace esphome {

--- a/tests/components/hmac_md5/test.host.yaml
+++ b/tests/components/hmac_md5/test.host.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
Use OpenSSL EVP interface for MD5 on host platform, enabling HMAC-MD5 testing. Verified with known test vector.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
