### PR TITLE
Add HMAC-MD5 component tests

### DIFF
--- a/esphome/components/hmac_md5/__init__.py
+++ b/esphome/components/hmac_md5/__init__.py
@@ -1,2 +1,6 @@
+import esphome.config_validation as cv
+
 AUTO_LOAD = ["md5"]
 CODEOWNERS = ["@dwmw2"]
+
+CONFIG_SCHEMA = cv.Schema({})

--- a/tests/components/hmac_md5/common.yaml
+++ b/tests/components/hmac_md5/common.yaml
@@ -1,0 +1,34 @@
+esphome:
+  on_boot:
+    - lambda: |-
+        // Test HMAC-MD5 functionality
+        #ifdef USE_MD5
+        using esphome::hmac_md5::HmacMD5;
+        HmacMD5 hmac;
+
+        // Test with key "key" and message "The quick brown fox jumps over the lazy dog"
+        const char* key = "key";
+        const char* message = "The quick brown fox jumps over the lazy dog";
+
+        hmac.init(key, strlen(key));
+        hmac.add(message, strlen(message));
+        hmac.calculate();
+
+        char hex_output[33];
+        hmac.get_hex(hex_output);
+        hex_output[32] = '\0';
+
+        ESP_LOGD("HMAC_MD5", "HMAC-MD5('%s', '%s') = %s", key, message, hex_output);
+
+        // Expected: 80070713463e7749b90c2dc24911e275
+        const char* expected = "80070713463e7749b90c2dc24911e275";
+        if (strcmp(hex_output, expected) == 0) {
+          ESP_LOGI("HMAC_MD5", "Test PASSED");
+        } else {
+          ESP_LOGE("HMAC_MD5", "Test FAILED. Expected %s", expected);
+        }
+        #else
+        ESP_LOGW("HMAC_MD5", "HMAC-MD5 not available on this platform");
+        #endif
+
+hmac_md5:

--- a/tests/components/hmac_md5/test.bk72xx-ard.yaml
+++ b/tests/components/hmac_md5/test.bk72xx-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/hmac_md5/test.esp32-idf.yaml
+++ b/tests/components/hmac_md5/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/hmac_md5/test.esp8266-ard.yaml
+++ b/tests/components/hmac_md5/test.esp8266-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/hmac_md5/test.rp2040-ard.yaml
+++ b/tests/components/hmac_md5/test.rp2040-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
Test HMAC-MD5 with known test vector using key 'key' and message 'The quick brown fox jumps over the lazy dog'. Note: MD5 component doesn't support host platform.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
