### PR TITLE
[esphome] Improve OTA field alignment to save 4 bytes on 32-bit

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -80,6 +80,7 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
 
 #ifdef USE_OTA_PASSWORD
   std::string password_;
+  std::unique_ptr<uint8_t[]> auth_buf_;
 #endif  // USE_OTA_PASSWORD
 
   std::unique_ptr<socket::Socket> server_;
@@ -93,7 +94,6 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   uint8_t handshake_buf_pos_{0};
   uint8_t ota_features_{0};
 #ifdef USE_OTA_PASSWORD
-  std::unique_ptr<uint8_t[]> auth_buf_;
   uint8_t auth_buf_pos_{0};
   uint8_t auth_type_{0};  // Store auth type to know which hasher to use
 #endif                    // USE_OTA_PASSWORD


### PR DESCRIPTION
# What does this implement/fix?

Reorder `ESPHomeOTAComponent` fields to improve struct packing on 32-bit systems.

Move `auth_buf_` (a 4-byte aligned `std::unique_ptr`) to be grouped with `password_` instead of placing it after the `uint8_t` fields. This eliminates 2 bytes of internal padding and 2 bytes of end padding, saving 4 bytes total when `USE_OTA_PASSWORD` is defined.

**Before:** `auth_buf_` followed `ota_features_` (a `uint8_t`), requiring padding to reach 4-byte alignment.

**After:** `auth_buf_` follows `password_` (already 4-byte aligned), and the trailing `uint8_t` fields pack together naturally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
ota:
  - platform: esphome
    password: "secret"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
