### PR TITLE
[factory_reset] Optimize memory by storing interval as uint16_t seconds

### DIFF
--- a/esphome/components/factory_reset/__init__.py
+++ b/esphome/components/factory_reset/__init__.py
@@ -50,7 +50,9 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(FactoryResetComponent),
             cv.Optional(CONF_MAX_DELAY, default="10s"): cv.All(
                 cv.positive_time_period_seconds,
-                cv.Range(min=cv.TimePeriod(milliseconds=1000)),
+                cv.Range(
+                    min=cv.TimePeriod(seconds=1), max=cv.TimePeriod(seconds=65535)
+                ),
             ),
             cv.Optional(CONF_RESETS_REQUIRED): cv.positive_not_null_int,
             cv.Optional(CONF_ON_INCREMENT): validate_automation(
@@ -82,7 +84,7 @@ async def to_code(config):
         var = cg.new_Pvariable(
             config[CONF_ID],
             reset_count,
-            config[CONF_MAX_DELAY].total_milliseconds,
+            config[CONF_MAX_DELAY].total_seconds,
         )
         await cg.register_component(var, config)
         for conf in config.get(CONF_ON_INCREMENT, []):

--- a/esphome/components/factory_reset/factory_reset.cpp
+++ b/esphome/components/factory_reset/factory_reset.cpp
@@ -8,8 +8,7 @@
 
 #if !defined(USE_RP2040) && !defined(USE_HOST)
 
-namespace esphome {
-namespace factory_reset {
+namespace esphome::factory_reset {
 
 static const char *const TAG = "factory_reset";
 static const uint32_t POWER_CYCLES_KEY = 0xFA5C0DE;
@@ -33,10 +32,10 @@ void FactoryResetComponent::dump_config() {
   this->flash_.load(&count);
   ESP_LOGCONFIG(TAG, "Factory Reset by Reset:");
   ESP_LOGCONFIG(TAG,
-                "  Max interval between resets %" PRIu32 " seconds\n"
+                "  Max interval between resets: %u seconds\n"
                 "  Current count: %u\n"
                 "  Factory reset after %u resets",
-                this->max_interval_ / 1000, count, this->required_count_);
+                this->max_interval_, count, this->required_count_);
 }
 
 void FactoryResetComponent::save_(uint8_t count) {
@@ -61,8 +60,8 @@ void FactoryResetComponent::setup() {
     }
     this->save_(count);
     ESP_LOGD(TAG, "Power on reset detected, incremented count to %u", count);
-    this->set_timeout(this->max_interval_, [this]() {
-      ESP_LOGD(TAG, "No reset in the last %" PRIu32 " seconds, resetting count", this->max_interval_ / 1000);
+    this->set_timeout(static_cast<uint32_t>(this->max_interval_) * 1000, [this]() {
+      ESP_LOGD(TAG, "No reset in the last %u seconds, resetting count", this->max_interval_);
       this->save_(0);  // reset count
     });
   } else {
@@ -70,7 +69,6 @@ void FactoryResetComponent::setup() {
   }
 }
 
-}  // namespace factory_reset
-}  // namespace esphome
+}  // namespace esphome::factory_reset
 
 #endif  // !defined(USE_RP2040) && !defined(USE_HOST)

--- a/esphome/components/factory_reset/factory_reset.h
+++ b/esphome/components/factory_reset/factory_reset.h
@@ -9,11 +9,10 @@
 #include <esp_system.h>
 #endif
 
-namespace esphome {
-namespace factory_reset {
+namespace esphome::factory_reset {
 class FactoryResetComponent : public Component {
  public:
-  FactoryResetComponent(uint8_t required_count, uint32_t max_interval)
+  FactoryResetComponent(uint8_t required_count, uint16_t max_interval)
       : required_count_(required_count), max_interval_(max_interval) {}
 
   void dump_config() override;
@@ -26,9 +25,9 @@ class FactoryResetComponent : public Component {
   ~FactoryResetComponent() = default;
   void save_(uint8_t count);
   ESPPreferenceObject flash_{};  // saves the number of fast power cycles
-  uint8_t required_count_;       // The number of boot attempts before fast boot is enabled
-  uint32_t max_interval_;        // max interval between power cycles
   CallbackManager<void(uint8_t, uint8_t)> increment_callback_{};
+  uint16_t max_interval_;   // max interval between power cycles in seconds
+  uint8_t required_count_;  // The number of boot attempts before fast boot is enabled
 };
 
 class FastBootTrigger : public Trigger<uint8_t, uint8_t> {
@@ -37,7 +36,6 @@ class FastBootTrigger : public Trigger<uint8_t, uint8_t> {
     parent->add_increment_callback([this](uint8_t current, uint8_t target) { this->trigger(current, target); });
   }
 };
-}  // namespace factory_reset
-}  // namespace esphome
+}  // namespace esphome::factory_reset
 
 #endif  // !defined(USE_RP2040) && !defined(USE_HOST)

--- a/esphome/components/factory_reset/factory_reset.h
+++ b/esphome/components/factory_reset/factory_reset.h
@@ -13,7 +13,7 @@ namespace esphome::factory_reset {
 class FactoryResetComponent : public Component {
  public:
   FactoryResetComponent(uint8_t required_count, uint16_t max_interval)
-      : required_count_(required_count), max_interval_(max_interval) {}
+      : max_interval_(max_interval), required_count_(required_count) {}
 
   void dump_config() override;
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the `factory_reset` component by changing `max_interval_` from `uint32_t` milliseconds to `uint16_t` seconds.

The config validation already enforced whole-second precision via `positive_time_period_seconds`, meaning sub-second values like `4750ms` were always rejected with "Maximum precision is seconds". The millisecond storage was wasted precision that could never be used.

Changes:
- `max_interval_` type: `uint32_t` → `uint16_t` (saves 2 bytes)
- Storage unit: milliseconds → seconds
- Added max validation of 65535 seconds (~18 hours) to match `uint16_t` range
- Realigned struct members for better packing (larger types first)
- Converted to C++17 nested namespace syntax

The `set_timeout()` call now multiplies by 1000 with a cast to `uint32_t` to convert back to milliseconds for the scheduler.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - optimization discovered during code review

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

Note: RP2040 and HOST platforms are excluded via `#if !defined(USE_RP2040) && !defined(USE_HOST)`

## Example entry for `config.yaml`:

```yaml
# No changes to user config - existing configs work identically
factory_reset:
  resets_required: 5
  max_delay: 10s  # Still accepts 1s to 65535s (was already whole seconds only)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
