### PR TITLE
[time] Convert to C++17 nested namespace syntax

### DIFF
--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -4,8 +4,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace time {
+namespace esphome::time {
 
 static const char *const TAG = "automation";
 static const int MAX_TIMESTAMP_DRIFT = 900;  // how far can the clock drift before we consider
@@ -92,5 +91,4 @@ SyncTrigger::SyncTrigger(RealTimeClock *rtc) : rtc_(rtc) {
   rtc->add_on_time_sync_callback([this]() { this->trigger(); });
 }
 
-}  // namespace time
-}  // namespace esphome
+}  // namespace esphome::time

--- a/esphome/components/time/automation.h
+++ b/esphome/components/time/automation.h
@@ -8,8 +8,7 @@
 
 #include <vector>
 
-namespace esphome {
-namespace time {
+namespace esphome::time {
 
 class CronTrigger : public Trigger<>, public Component {
  public:
@@ -48,5 +47,4 @@ class SyncTrigger : public Trigger<>, public Component {
  protected:
   RealTimeClock *rtc_;
 };
-}  // namespace time
-}  // namespace esphome
+}  // namespace esphome::time

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -17,8 +17,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace time {
+namespace esphome::time {
 
 static const char *const TAG = "time";
 
@@ -78,5 +77,4 @@ void RealTimeClock::apply_timezone_() {
 }
 #endif
 
-}  // namespace time
-}  // namespace esphome
+}  // namespace esphome::time

--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/time.h"
 
-namespace esphome {
-namespace time {
+namespace esphome::time {
 
 /// The RealTimeClock class exposes common timekeeping functions via the device's local real-time clock.
 ///
@@ -75,5 +74,4 @@ template<typename... Ts> class TimeHasTimeCondition : public Condition<Ts...> {
   RealTimeClock *parent_;
 };
 
-}  // namespace time
-}  // namespace esphome
+}  // namespace esphome::time


### PR DESCRIPTION
# What does this implement/fix?

Convert the time component to use C++17 nested namespace syntax.

Changes:
- `namespace esphome {` + `namespace time {` → `namespace esphome::time {`
- Updated closing comments to match

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code style update
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
