### PR TITLE
Fix progmem.h includes for host

### DIFF
--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -1,10 +1,10 @@
 #pragma once
 
 // Platform-agnostic macros for PROGMEM string handling
-// On ESP32 (both Arduino and IDF): Use plain strings (no PROGMEM)
+// On ESP32 (both Arduino and IDF) or HOST: Use plain strings (no PROGMEM)
 // On ESP8266/Arduino: Use Arduino's F() macro for PROGMEM strings
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32) or defined(USE_HOST)
 #define ESPHOME_F(string_literal) (string_literal)
 #define ESPHOME_PGM_P const char *
 #define ESPHOME_strncpy_P strncpy

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -1,16 +1,16 @@
 #pragma once
 
 // Platform-agnostic macros for PROGMEM string handling
-// On ESP32 (both Arduino and IDF) or HOST: Use plain strings (no PROGMEM)
 // On ESP8266/Arduino: Use Arduino's F() macro for PROGMEM strings
+// On other platforms: Use plain strings (no PROGMEM)
 
-#if defined(USE_ESP32) or defined(USE_HOST)
-#define ESPHOME_F(string_literal) (string_literal)
-#define ESPHOME_PGM_P const char *
-#define ESPHOME_strncpy_P strncpy
-#else
-// ESP8266 and other Arduino platforms use Arduino macros
+#ifdef USE_ESP8266
+// ESP8266 uses Arduino macros
 #define ESPHOME_F(string_literal) F(string_literal)
 #define ESPHOME_PGM_P PGM_P
 #define ESPHOME_strncpy_P strncpy_P
+#else
+#define ESPHOME_F(string_literal) (string_literal)
+#define ESPHOME_PGM_P const char *
+#define ESPHOME_strncpy_P strncpy
 #endif


### PR DESCRIPTION
host doesn't have the "F", "PGM_P" or "strncpy_P" calls introduced in #12214. Force host to use the defaults (like ESP32 does)

# What does this implement/fix?
#12214 introduced some macros for string handling, to reduce memory usage for ESP8266 or other Arduino platforms.
This broke compilation on Host for some components (e.g. light), because host does not have Arduino's `F()` macro.


<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
