### PR TITLE
[packet_transport] Ensure retransmission at update intervals

### DIFF
--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -26,16 +26,10 @@ void ESPNowTransport::setup() {
            this->peer_address_[2], this->peer_address_[3], this->peer_address_[4], this->peer_address_[5]);
 
   // Register received handler
-  this->parent_->register_received_handler(static_cast<ESPNowReceivedPacketHandler *>(this));
+  this->parent_->register_received_handler(this);
 
   // Register broadcasted handler
-  this->parent_->register_broadcasted_handler(static_cast<ESPNowBroadcastedHandler *>(this));
-#ifdef USE_SENSOR
-  this->resend_data_ |= !this->sensors_.empty();
-#endif
-#ifdef USE_BINARY_SENSOR
-  this->resend_data_ |= !this->binary_sensors_.empty();
-#endif
+  this->parent_->register_broadcasted_handler(this);
 }
 
 void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {

--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -40,7 +40,7 @@ void ESPNowTransport::setup() {
 
 void ESPNowTransport::update() {
   PacketTransport::update();
-  this->updated_ = this->resend_data_;
+  this->updated_ |= this->resend_data_;
 }
 
 void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {

--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -13,7 +13,7 @@ static const char *const TAG = "espnow.transport";
 bool ESPNowTransport::should_send() { return this->parent_ != nullptr && !this->parent_->is_failed(); }
 
 void ESPNowTransport::setup() {
-  packet_transport::PacketTransport::setup();
+  PacketTransport::setup();
 
   if (this->parent_ == nullptr) {
     ESP_LOGE(TAG, "ESPNow component not set");
@@ -30,11 +30,17 @@ void ESPNowTransport::setup() {
 
   // Register broadcasted handler
   this->parent_->register_broadcasted_handler(static_cast<ESPNowBroadcastedHandler *>(this));
+#ifdef USE_SENSOR
+  this->resend_data_ |= !this->sensors_.empty();
+#endif
+#ifdef USE_BINARY_SENSOR
+  this->resend_data_ |= !this->binary_sensors_.empty();
+#endif
 }
 
 void ESPNowTransport::update() {
-  packet_transport::PacketTransport::update();
-  this->updated_ = true;
+  PacketTransport::update();
+  this->updated_ = this->resend_data_;
 }
 
 void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {

--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -38,11 +38,6 @@ void ESPNowTransport::setup() {
 #endif
 }
 
-void ESPNowTransport::update() {
-  PacketTransport::update();
-  this->updated_ |= this->resend_data_;
-}
-
 void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {
   if (this->parent_ == nullptr) {
     ESP_LOGE(TAG, "ESPNow component not set");

--- a/esphome/components/espnow/packet_transport/espnow_transport.h
+++ b/esphome/components/espnow/packet_transport/espnow_transport.h
@@ -18,7 +18,6 @@ class ESPNowTransport : public packet_transport::PacketTransport,
                         public ESPNowBroadcastedHandler {
  public:
   void setup() override;
-  void update() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
   void set_peer_address(peer_address_t address) {

--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -190,7 +190,8 @@ async def register_packet_transport(var, config):
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_binary_sensor(bcst_id, sensor))
 
-    cg.add(var.set_is_provider(is_provider))
+    if is_provider:
+        cg.add(var.set_is_provider(True))
     if encryption := config.get(CONF_ENCRYPTION):
         cg.add(var.set_encryption_key(hash_encryption_key(encryption)))
     return providers

--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -176,17 +176,21 @@ async def register_packet_transport(var, config):
         if encryption := provider.get(CONF_ENCRYPTION):
             cg.add(var.set_provider_encryption(name, hash_encryption_key(encryption)))
 
+    resend_data = False
     for sens_conf in config.get(CONF_SENSORS, ()):
+        resend_data = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_sensor(bcst_id, sensor))
     for sens_conf in config.get(CONF_BINARY_SENSORS, ()):
+        resend_data = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_binary_sensor(bcst_id, sensor))
 
+    cg.add(var.set_resend_data(resend_data))
     if encryption := config.get(CONF_ENCRYPTION):
         cg.add(var.set_encryption_key(hash_encryption_key(encryption)))
     return providers

--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -176,21 +176,21 @@ async def register_packet_transport(var, config):
         if encryption := provider.get(CONF_ENCRYPTION):
             cg.add(var.set_provider_encryption(name, hash_encryption_key(encryption)))
 
-    resend_data = False
+    is_provider = False
     for sens_conf in config.get(CONF_SENSORS, ()):
-        resend_data = True
+        is_provider = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_sensor(bcst_id, sensor))
     for sens_conf in config.get(CONF_BINARY_SENSORS, ()):
-        resend_data = True
+        is_provider = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_binary_sensor(bcst_id, sensor))
 
-    cg.add(var.set_resend_data(resend_data))
+    cg.add(var.set_is_provider(is_provider))
     if encryption := config.get(CONF_ENCRYPTION):
         cg.add(var.set_encryption_key(hash_encryption_key(encryption)))
     return providers

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -263,6 +263,7 @@ void PacketTransport::flush_() {
     xxtea::encrypt((uint32_t *) (encode_buffer.data() + header_len), len / 4,
                    (uint32_t *) this->encryption_key_.data());
   }
+  ESP_LOGVV(TAG, "Sending packet %s", format_hex_pretty(encode_buffer.data(), encode_buffer.size()).c_str());
   this->send_packet(encode_buffer);
 }
 
@@ -316,6 +317,9 @@ void PacketTransport::send_data_(bool all) {
 }
 
 void PacketTransport::update() {
+  // resend all sensors if required
+  if (this->resend_data_)
+    this->send_data_(true);
   if (!this->ping_pong_enable_) {
     return;
   }
@@ -551,7 +555,7 @@ void PacketTransport::loop() {
   if (this->resend_ping_key_)
     this->send_ping_pong_request_();
   if (this->updated_) {
-    this->send_data_(this->resend_data_);
+    this->send_data_(false);
   }
 }
 

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -318,7 +318,7 @@ void PacketTransport::send_data_(bool all) {
 
 void PacketTransport::update() {
   // resend all sensors if required
-  if (this->resend_data_)
+  if (this->is_provider_)
     this->send_data_(true);
   if (!this->ping_pong_enable_) {
     return;

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -52,7 +52,6 @@ class PacketTransport : public PollingComponent {
  public:
   void setup() override;
   void loop() override;
-  void update() override;
   void dump_config() override;
 
 #ifdef USE_SENSOR
@@ -91,7 +90,7 @@ class PacketTransport : public PollingComponent {
     }
   }
 
-  void set_resend_data(bool resend_data) { this->resend_data_ = resend_data; }
+  void set_is_provider(bool is_provider) { this->is_provider_ = is_provider; }
   void set_encryption_key(std::vector<uint8_t> key) { this->encryption_key_ = std::move(key); }
   void set_rolling_code_enable(bool enable) { this->rolling_code_enable_ = enable; }
   void set_ping_pong_enable(bool enable) { this->ping_pong_enable_ = enable; }
@@ -130,7 +129,7 @@ class PacketTransport : public PollingComponent {
   uint32_t ping_pong_recyle_time_{};
   uint32_t last_key_time_{};
   bool resend_ping_key_{};
-  bool resend_data_{};
+  bool is_provider_{};
   const char *name_{};
   ESPPreferenceObject pref_{};
 

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -91,6 +91,7 @@ class PacketTransport : public PollingComponent {
     }
   }
 
+  void set_resend_data(bool resend_data) { this->resend_data_ = resend_data; }
   void set_encryption_key(std::vector<uint8_t> key) { this->encryption_key_ = std::move(key); }
   void set_rolling_code_enable(bool enable) { this->rolling_code_enable_ = enable; }
   void set_ping_pong_enable(bool enable) { this->ping_pong_enable_ = enable; }

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -52,6 +52,7 @@ class PacketTransport : public PollingComponent {
  public:
   void setup() override;
   void loop() override;
+  void update() override;
   void dump_config() override;
 
 #ifdef USE_SENSOR

--- a/esphome/components/sx126x/packet_transport/sx126x_transport.cpp
+++ b/esphome/components/sx126x/packet_transport/sx126x_transport.cpp
@@ -12,12 +12,6 @@ void SX126xTransport::setup() {
   this->parent_->register_listener(this);
 }
 
-void SX126xTransport::update() {
-  PacketTransport::update();
-  this->updated_ = true;
-  this->resend_data_ = true;
-}
-
 void SX126xTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->transmit_packet(buf); }
 
 void SX126xTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) { this->process_(packet); }

--- a/esphome/components/sx126x/packet_transport/sx126x_transport.h
+++ b/esphome/components/sx126x/packet_transport/sx126x_transport.h
@@ -11,7 +11,6 @@ namespace sx126x {
 class SX126xTransport : public packet_transport::PacketTransport, public Parented<SX126x>, public SX126xListener {
  public:
   void setup() override;
-  void update() override;
   void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 

--- a/esphome/components/sx127x/packet_transport/sx127x_transport.cpp
+++ b/esphome/components/sx127x/packet_transport/sx127x_transport.cpp
@@ -12,12 +12,6 @@ void SX127xTransport::setup() {
   this->parent_->register_listener(this);
 }
 
-void SX127xTransport::update() {
-  PacketTransport::update();
-  this->updated_ = true;
-  this->resend_data_ = true;
-}
-
 void SX127xTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->transmit_packet(buf); }
 
 void SX127xTransport::on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) { this->process_(packet); }

--- a/esphome/components/sx127x/packet_transport/sx127x_transport.h
+++ b/esphome/components/sx127x/packet_transport/sx127x_transport.h
@@ -11,7 +11,6 @@ namespace sx127x {
 class SX127xTransport : public packet_transport::PacketTransport, public Parented<SX127x>, public SX127xListener {
  public:
   void setup() override;
-  void update() override;
   void on_packet(const std::vector<uint8_t> &packet, float rssi, float snr) override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 

--- a/esphome/components/uart/packet_transport/uart_transport.cpp
+++ b/esphome/components/uart/packet_transport/uart_transport.cpp
@@ -55,12 +55,6 @@ void UARTTransport::loop() {
   }
 }
 
-void UARTTransport::update() {
-  this->updated_ = true;
-  this->resend_data_ = true;
-  PacketTransport::update();
-}
-
 /**
  * Write a byte to the UART bus. If the byte is a flag or control byte, it will be escaped.
  * @param byte The byte to write.

--- a/esphome/components/uart/packet_transport/uart_transport.h
+++ b/esphome/components/uart/packet_transport/uart_transport.h
@@ -23,7 +23,6 @@ static const uint8_t CONTROL_BYTE = 0x7D;
 class UARTTransport : public packet_transport::PacketTransport, public UARTDevice {
  public:
   void loop() override;
-  void update() override;
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
 
  protected:

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -8,7 +8,7 @@ namespace udp {
 
 static const char *const TAG = "udp_transport";
 
-bool UDPTransport::should_send() { return this->is_provider_ && network::is_connected(); }
+bool UDPTransport::should_send() { return network::is_connected(); }
 void UDPTransport::setup() {
   PacketTransport::setup();
   if (!this->providers_.empty() || this->is_encrypted_()) {

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -8,19 +8,9 @@ namespace udp {
 
 static const char *const TAG = "udp_transport";
 
-bool UDPTransport::should_send() { return this->should_broadcast_ && network::is_connected(); }
+bool UDPTransport::should_send() { return this->resend_data_ && network::is_connected(); }
 void UDPTransport::setup() {
   PacketTransport::setup();
-  this->should_broadcast_ = this->ping_pong_enable_;
-#ifdef USE_SENSOR
-  this->should_broadcast_ |= !this->sensors_.empty();
-#endif
-#ifdef USE_BINARY_SENSOR
-  this->should_broadcast_ |= !this->binary_sensors_.empty();
-#endif
-  if (this->should_broadcast_)
-    this->parent_->set_should_broadcast();
-  this->resend_data_ = this->should_broadcast_;
   if (!this->providers_.empty() || this->is_encrypted_()) {
     this->parent_->add_listener([this](std::vector<uint8_t> &buf) { this->process_(buf); });
   }

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -20,15 +20,10 @@ void UDPTransport::setup() {
 #endif
   if (this->should_broadcast_)
     this->parent_->set_should_broadcast();
+  this->resend_data_ = this->should_broadcast_;
   if (!this->providers_.empty() || this->is_encrypted_()) {
     this->parent_->add_listener([this](std::vector<uint8_t> &buf) { this->process_(buf); });
   }
-}
-
-void UDPTransport::update() {
-  PacketTransport::update();
-  this->updated_ = true;
-  this->resend_data_ = this->should_broadcast_;
 }
 
 void UDPTransport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->send_packet(buf); }

--- a/esphome/components/udp/packet_transport/udp_transport.cpp
+++ b/esphome/components/udp/packet_transport/udp_transport.cpp
@@ -8,7 +8,7 @@ namespace udp {
 
 static const char *const TAG = "udp_transport";
 
-bool UDPTransport::should_send() { return this->resend_data_ && network::is_connected(); }
+bool UDPTransport::should_send() { return this->is_provider_ && network::is_connected(); }
 void UDPTransport::setup() {
   PacketTransport::setup();
   if (!this->providers_.empty() || this->is_encrypted_()) {

--- a/esphome/components/udp/packet_transport/udp_transport.h
+++ b/esphome/components/udp/packet_transport/udp_transport.h
@@ -12,7 +12,6 @@ namespace udp {
 class UDPTransport : public packet_transport::PacketTransport, public Parented<UDPComponent> {
  public:
   void setup() override;
-  void update() override;
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 

--- a/esphome/components/udp/packet_transport/udp_transport.h
+++ b/esphome/components/udp/packet_transport/udp_transport.h
@@ -18,7 +18,6 @@ class UDPTransport : public packet_transport::PacketTransport, public Parented<U
  protected:
   void send_packet(const std::vector<uint8_t> &buf) const override;
   bool should_send() override;
-  bool should_broadcast_{false};
   size_t get_max_packet_size() override { return MAX_PACKET_SIZE; }
 };
 

--- a/tests/components/espnow/common.yaml
+++ b/tests/components/espnow/common.yaml
@@ -62,7 +62,7 @@ packet_transport:
     sensors:
       - temp_sensor
     providers:
-      - name: test_provider
+      - name: test-provider
         encryption:
           key: "0123456789abcdef0123456789abcdef"
 
@@ -71,6 +71,6 @@ sensor:
     id: temp_sensor
 
   - platform: packet_transport
-    provider: test_provider
+    provider: test-provider
     remote_id: temp_sensor
     id: remote_temp


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The espnow packet_transport implementation was not resending sensors and binary sensors in full on each update. Since espnow is not a reliable transport it's necessary to use a time-based fallback in the same manner as UDP.

This PR refactors the logic for resending data to move most of the responsibility of periodic retransmission into the `packet_transport` component, ensuring the behaviour is consistent across different transport implementations.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12366 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
