### PR TITLE
[socket] Fix getpeername() returning local address instead of remote in LWIP raw TCP

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -188,7 +188,7 @@ class LWIPRawImpl : public Socket {
       errno = EINVAL;
       return -1;
     }
-    return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, name, addrlen);
+    return this->ip2sockaddr_(&pcb_->remote_ip, pcb_->remote_port, name, addrlen);
   }
   std::string getpeername() override {
     if (pcb_ == nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

Fix `getpeername()` in LWIP raw TCP socket implementation to return the remote peer's address instead of the local address.

The sockaddr overload of `getpeername()` was incorrectly using `pcb_->local_ip` and `pcb_->local_port` instead of `pcb_->remote_ip` and `pcb_->remote_port`. This made it return the same result as `getsockname()`, which is incorrect:

- `getsockname()` should return the local address (our side)
- `getpeername()` should return the remote address (peer's side)

This was a copy-paste bug - the string overloads were already correct:
```cpp
std::string getpeername() { return this->format_ip_address_(pcb_->remote_ip); }  // Correct
std::string getsockname() { return this->format_ip_address_(pcb_->local_ip); }   // Correct
```

But the sockaddr overloads were identical:
```cpp
// Before (wrong):
int getpeername(...) { return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, ...); }
int getsockname(...) { return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, ...); }

// After (fixed):
int getpeername(...) { return this->ip2sockaddr_(&pcb_->remote_ip, pcb_->remote_port, ...); }
int getsockname(...) { return this->ip2sockaddr_(&pcb_->local_ip, pcb_->local_port, ...); }
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal socket API fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
