### PR TITLE
[core] Fix polling_component_schema and type consistency

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -71,6 +71,7 @@ from esphome.const import (
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
     PLATFORM_RP2040,
+    SCHEDULER_DONT_RUN,
     TYPE_GIT,
     TYPE_LOCAL,
     VALID_SUBSTITUTIONS_CHARACTERS,
@@ -894,7 +895,7 @@ def time_period_in_minutes_(value):
 
 def update_interval(value):
     if value == "never":
-        return 4294967295  # uint32_t max
+        return TimePeriodMilliseconds(milliseconds=SCHEDULER_DONT_RUN)
     return positive_time_period_milliseconds(value)
 
 
@@ -2009,7 +2010,7 @@ def polling_component_schema(default_update_interval):
     if default_update_interval is None:
         return COMPONENT_SCHEMA.extend(
             {
-                Required(CONF_UPDATE_INTERVAL): default_update_interval,
+                Required(CONF_UPDATE_INTERVAL): update_interval,
             }
         )
     assert isinstance(default_update_interval, str)


### PR DESCRIPTION
# What does this implement/fix?

Fixes two issues in `esphome/config_validation.py`:

1. **Bug fix in `polling_component_schema()`**: When `default_update_interval` is `None`, the code was incorrectly using `None` as the validator instead of the `update_interval` function. This would cause validation to fail for components using `polling_component_schema(None)`.

2. **Use named constant**: Replace hardcoded magic number `4294967295` with `TimePeriodMilliseconds(milliseconds=SCHEDULER_DONT_RUN)` in the `update_interval()` function for better maintainability and type consistency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - Python-only change affecting config validation

## Example entry for `config.yaml`:

```yaml
# Existing configs using update_interval: never continue to work
sensor:
  - platform: template
    name: "Test Sensor"
    update_interval: never
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).