### PR TITLE
[dashboard] Add ESPHOME_TRUSTED_DOMAINS support to events WebSocket

### DIFF
--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1567,3 +1567,64 @@ async def test_dashboard_yaml_loading_with_packages_and_secrets(
     # If we get here, secret resolution worked!
     assert "esphome" in config
     assert config["esphome"]["name"] == "test-download-secrets"
+
+
+@pytest.mark.asyncio
+async def test_websocket_check_origin_trusted_domain(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket accepts connections from trusted domains."""
+    with patch.dict(os.environ, {"ESPHOME_TRUSTED_DOMAINS": "trusted.example.com"}):
+        from tornado.httpclient import HTTPRequest
+
+        url = f"ws://127.0.0.1:{dashboard.port}/events"
+        request = HTTPRequest(url, headers={"Origin": "https://trusted.example.com"})
+        ws = await websocket_connect(request)
+        try:
+            # Should receive initial state
+            msg = await ws.read_message()
+            assert msg is not None
+            data = json.loads(msg)
+            assert data["event"] == "initial_state"
+        finally:
+            ws.close()
+
+
+@pytest.mark.asyncio
+async def test_websocket_check_origin_untrusted_domain(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket rejects connections from untrusted domains."""
+    with patch.dict(os.environ, {"ESPHOME_TRUSTED_DOMAINS": "trusted.example.com"}):
+        from tornado.httpclient import HTTPRequest
+
+        url = f"ws://127.0.0.1:{dashboard.port}/events"
+        request = HTTPRequest(url, headers={"Origin": "https://untrusted.example.com"})
+        with pytest.raises(HTTPClientError) as exc_info:
+            await websocket_connect(request)
+        # Should get HTTP 403 Forbidden due to origin check failure
+        assert exc_info.value.code == 403
+
+
+@pytest.mark.asyncio
+async def test_websocket_check_origin_multiple_trusted_domains(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket accepts connections from multiple trusted domains."""
+    with patch.dict(
+        os.environ,
+        {"ESPHOME_TRUSTED_DOMAINS": "first.example.com, second.example.com"},
+    ):
+        from tornado.httpclient import HTTPRequest
+
+        url = f"ws://127.0.0.1:{dashboard.port}/events"
+        # Test second domain in list (with space after comma)
+        request = HTTPRequest(url, headers={"Origin": "https://second.example.com"})
+        ws = await websocket_connect(request)
+        try:
+            msg = await ws.read_message()
+            assert msg is not None
+            data = json.loads(msg)
+            assert data["event"] == "initial_state"
+        finally:
+            ws.close()

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1570,6 +1570,32 @@ async def test_dashboard_yaml_loading_with_packages_and_secrets(
 
 
 @pytest.mark.asyncio
+async def test_websocket_check_origin_default_same_origin(
+    dashboard: DashboardTestHelper,
+) -> None:
+    """Test WebSocket uses default same-origin check when ESPHOME_TRUSTED_DOMAINS not set."""
+    # Ensure ESPHOME_TRUSTED_DOMAINS is not set
+    env = os.environ.copy()
+    env.pop("ESPHOME_TRUSTED_DOMAINS", None)
+    with patch.dict(os.environ, env, clear=True):
+        from tornado.httpclient import HTTPRequest
+
+        url = f"ws://127.0.0.1:{dashboard.port}/events"
+        # Same origin should work (default Tornado behavior)
+        request = HTTPRequest(
+            url, headers={"Origin": f"http://127.0.0.1:{dashboard.port}"}
+        )
+        ws = await websocket_connect(request)
+        try:
+            msg = await ws.read_message()
+            assert msg is not None
+            data = json.loads(msg)
+            assert data["event"] == "initial_state"
+        finally:
+            ws.close()
+
+
+@pytest.mark.asyncio
 async def test_websocket_check_origin_trusted_domain(
     dashboard: DashboardTestHelper,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Adds `ESPHOME_TRUSTED_DOMAINS` environment variable support to `DashboardEventsWebSocket`, matching the existing behavior of `EsphomeCommandWebSocket` added in #6845.

Previously, only the command WebSocket (used for compile/upload/logs) supported the `ESPHOME_TRUSTED_DOMAINS` environment variable for reverse proxy configurations. The events WebSocket (used for real-time dashboard updates) was missing this support, causing it to reject connections from trusted domains when `ESPHOME_TRUSTED_DOMAINS` was set.

This PR:
- Creates a `CheckOriginMixin` class with the shared `check_origin()` logic
- Both `EsphomeCommandWebSocket` and `DashboardEventsWebSocket` now inherit from this mixin
- Adds tests for the `ESPHOME_TRUSTED_DOMAINS` functionality on the events WebSocket

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #6845 (original PR that added `ESPHOME_TRUSTED_DOMAINS` support)
- Found while investigating #11822 (but this fix likely won't solve that issue, which appears to be upstream)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (existing functionality, documentation request tracked in esphome/feature-requests#2759)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

N/A - Dashboard-only change, tested via unit tests.

## Example entry for `config.yaml`:

N/A - This is configured via environment variable, not YAML config.

```bash
# Set trusted domains for reverse proxy setups
export ESPHOME_TRUSTED_DOMAINS="homeassistant.local,my-proxy.example.com"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

N/A - No new functionality, just extending existing `ESPHOME_TRUSTED_DOMAINS` support to the events WebSocket.
