### PR TITLE
[http_request] Fix infinite loop when server doesn't send Content-Length header

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -255,6 +255,9 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
         size_t read_index = 0;
         while (container->get_bytes_read() < max_length) {
           int read = container->read(buf + read_index, std::min<size_t>(max_length - read_index, 512));
+          if (read <= 0) {
+            break;
+          }
           App.feed_wdt();
           yield();
           read_index += read;

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -132,11 +132,18 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
     App.feed_wdt();
     yield();
 
-    if (bufsize < 0) {
-      ESP_LOGE(TAG, "Stream closed");
-      this->cleanup_(std::move(backend), container);
-      return OTA_CONNECTION_ERROR;
-    } else if (bufsize > 0 && bufsize <= OtaHttpRequestComponent::HTTP_RECV_BUFFER) {
+    // Exit loop if no data available (stream closed or end of data)
+    if (bufsize <= 0) {
+      if (bufsize < 0) {
+        ESP_LOGE(TAG, "Stream closed with error");
+        this->cleanup_(std::move(backend), container);
+        return OTA_CONNECTION_ERROR;
+      }
+      // bufsize == 0: no more data available, exit loop
+      break;
+    }
+
+    if (bufsize > 0 && bufsize <= OtaHttpRequestComponent::HTTP_RECV_BUFFER) {
       // add read bytes to MD5
       md5_receive.add(buf, bufsize);
 
@@ -247,6 +254,9 @@ bool OtaHttpRequestComponent::http_get_md5_() {
   int read_len = 0;
   while (container->get_bytes_read() < MD5_SIZE) {
     read_len = container->read((uint8_t *) this->md5_expected_.data(), MD5_SIZE);
+    if (read_len <= 0) {
+      break;
+    }
     App.feed_wdt();
     yield();
   }

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -143,7 +143,7 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
       break;
     }
 
-    if (bufsize > 0 && bufsize <= OtaHttpRequestComponent::HTTP_RECV_BUFFER) {
+    if (bufsize <= OtaHttpRequestComponent::HTTP_RECV_BUFFER) {
       // add read bytes to MD5
       md5_receive.add(buf, bufsize);
 

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -76,6 +76,11 @@ void HttpRequestUpdate::update_task(void *params) {
 
     yield();
 
+    if (read_bytes <= 0) {
+      // Network error or connection closed - break to avoid infinite loop
+      break;
+    }
+
     read_index += read_bytes;
   }
 


### PR DESCRIPTION
…gth header

This commit fixes an issue where the http_request component would enter an infinite loop when an HTTP server doesn't send a Content-Length header or closes the connection prematurely.

The read loop was assuming read operations would always return data, but:
1. When the stream pointer becomes invalid (connection closed), read() returns -1
2. When no more data is available, read() returns 0

Without these checks, the loop would continue indefinitely, causing:
- "Stream pointer vanished!" errors (Arduino platform)
- CPU spinning on zero-byte reads
- Watchdog timeouts

The fix adds validation checks to break out of the read loop when:
- read() returns negative (error condition)
- read() returns 0 (no more data available)

This allows graceful handling of non-compliant HTTP servers while maintaining compatibility with properly formatted responses.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Fixes esphome/issues#6682

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
