### PR TITLE
[web_server_idf] Always enable LRU purge to prevent socket exhaustion

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -65,12 +65,6 @@ void CaptivePortal::start() {
   this->base_->init();
   if (!this->initialized_) {
     this->base_->add_handler(this);
-#ifdef USE_ESP32
-    // Enable LRU socket purging to handle captive portal detection probe bursts
-    // OS captive portal detection makes many simultaneous HTTP requests which can
-    // exhaust sockets. LRU purging automatically closes oldest idle connections.
-    this->base_->get_server()->set_lru_purge_enable(true);
-#endif
   }
 
   network::IPAddress ip = wifi::global_wifi_component->wifi_soft_ap_ip();

--- a/esphome/components/captive_portal/captive_portal.h
+++ b/esphome/components/captive_portal/captive_portal.h
@@ -40,10 +40,6 @@ class CaptivePortal : public AsyncWebHandler, public Component {
   void end() {
     this->active_ = false;
     this->disable_loop();  // Stop processing DNS requests
-#ifdef USE_ESP32
-    // Disable LRU socket purging now that captive portal is done
-    this->base_->get_server()->set_lru_purge_enable(false);
-#endif
     this->base_->deinit();
     if (this->dns_server_ != nullptr) {
       this->dns_server_->stop();

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -199,13 +199,11 @@ class AsyncWebServer {
     return *handler;
   }
 
-  void set_lru_purge_enable(bool enable);
   httpd_handle_t get_server() { return this->server_; }
 
  protected:
   uint16_t port_{};
   httpd_handle_t server_{};
-  bool lru_purge_enable_{false};
   static esp_err_t request_handler(httpd_req_t *r);
   static esp_err_t request_post_handler(httpd_req_t *r);
   esp_err_t request_handler_(AsyncWebServerRequest *request) const;


### PR DESCRIPTION
# What does this implement/fix?

Always enables `lru_purge_enable` for the ESP-IDF HTTP server to prevent "httpd_accept_conn: error in accept (23)" errors when socket limits are reached.

**The Problem:**

Users reported that after upgrading ESPHome, the web interface becomes unstable with repeated errors:
```
[D][esp-idf:000][httpd]: E (66626) httpd: httpd_accept_conn: error in accept (23)
```

Error 23 is `ENFILE` (too many open files), indicating socket exhaustion. This happens when all available sockets are in use (e.g., by SSE connections) and new connections arrive.

**The Solution:**

ESP-IDF's httpd server has an `lru_purge_enable` option that, when enabled, automatically closes the least-recently-used connection when the server needs to accept a new connection but is at capacity. This is the recommended setting for servers with long-lived connections like SSE.

From [ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/protocols/esp_http_server.html):
> "When LRU purge is enabled, if a client is requesting for connection but maximum number of sockets/sessions is reached, then the session having the earliest LRU counter is closed automatically."

ESP-IDF's own [async_handlers example](https://github.com/espressif/esp-idf/blob/master/examples/protocols/http_server/async_handlers/main/main.c) enables this by default for long-running connections.

**Changes:**
- Always enable `config.lru_purge_enable = true` in `AsyncWebServer::begin()`
- Remove the now-unused `set_lru_purge_enable()` method and `lru_purge_enable_` member
- Remove captive_portal calls that were toggling this setting (no longer needed since it's always enabled)

**Why this is safe:**
- SSE clients automatically reconnect if their connection is closed (browser `EventSource` has built-in retry)
- Active connections receiving data are marked "recently used" and less likely to be purged
- A brief reconnect is far better than completely failing to load the page
- The captive_portal component already enabled this for the same reason

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12464

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - fix is automatic
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
