### PR TITLE
[wifi_signal] Skip publishing disconnected RSSI value

### DIFF
--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -16,7 +16,12 @@ class WiFiSignalSensor : public sensor::Sensor, public PollingComponent {
 #ifdef USE_WIFI_LISTENERS
   void setup() override { wifi::global_wifi_component->add_connect_state_listener(this); }
 #endif
-  void update() override { this->publish_state(wifi::global_wifi_component->wifi_rssi()); }
+  void update() override {
+    int8_t rssi = wifi::global_wifi_component->wifi_rssi();
+    if (rssi != wifi::WIFI_RSSI_DISCONNECTED) {
+      this->publish_state(rssi);
+    }
+  }
   void dump_config() override;
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }


### PR DESCRIPTION
# What does this implement/fix?

Skip publishing WiFi signal strength when WiFi is disconnected to prevent invalid -127 dBm readings from being sent to Home Assistant.

When a device boots or wakes from deep sleep, the WiFi signal sensor's `update()` can be called before WiFi is fully connected. This causes `wifi_rssi()` to return `WIFI_RSSI_DISCONNECTED` (-127), which gets stored as the sensor state. Once WiFi and the API connection are established, this invalid value is synced to Home Assistant, corrupting signal strength history and trend analysis.

The fix simply skips publishing when the RSSI value equals the disconnected sentinel value (-127), ensuring only valid readings are sent.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12476

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard wifi_signal configuration - no changes required
sensor:
  - platform: wifi_signal
    name: "WiFi Signal"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
