### PR TITLE
[wifi] Fix WiFi recovery after failed connection attempts

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -196,11 +196,6 @@ static constexpr uint8_t WIFI_RETRY_COUNT_PER_SSID = 1;
 // Rationale: Fast connect prioritizes speed - try each AP once to find a working one quickly
 static constexpr uint8_t WIFI_RETRY_COUNT_PER_AP = 1;
 
-// 2 forced scan cycles after credentials change via captive portal/improv
-// Rationale: After new credentials are submitted, we need fresh scan results to find the
-// best AP (strongest signal). Two cycles in case the first scan catches the network mid-transition.
-static constexpr uint8_t WIFI_FORCE_SCAN_AFTER_CREDENTIAL_CHANGE = 2;
-
 /// Cooldown duration in milliseconds after adapter restart or repeated failures
 /// Allows WiFi hardware to stabilize before next connection attempt
 static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
@@ -690,8 +685,6 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->init_sta(1);
   this->add_sta(ap);
   this->selected_sta_index_ = 0;
-  // Force scan cycles to find best AP even when captive portal/improv is active
-  this->force_scan_count_ = WIFI_FORCE_SCAN_AFTER_CREDENTIAL_CHANGE;
   // When new credentials are set (e.g., from improv), skip cooldown to retry immediately
   this->skip_cooldown_next_cycle_ = true;
 }
@@ -1338,14 +1331,8 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // Skip scanning when captive portal/improv is active to avoid disrupting AP
       // Even passive scans can cause brief AP disconnections on ESP32
-      // Exception: force scans after credential change to find best AP
       if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
-        if (this->force_scan_count_ > 0) {
-          this->force_scan_count_--;
-          ESP_LOGD(TAG, "Forcing scan despite active portal (remaining: %u)", this->force_scan_count_);
-        } else {
-          return WiFiRetryPhase::RETRY_HIDDEN;
-        }
+        return WiFiRetryPhase::RETRY_HIDDEN;
       }
       return WiFiRetryPhase::SCAN_CONNECTING;
   }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -218,7 +218,7 @@ static constexpr uint32_t WIFI_SCAN_TIMEOUT_MS = 31000;
 /// If this timeout fires prematurely while a connection is still in progress, it causes
 /// cascading failures: the subsequent scan will also fail because the WiFi driver is
 /// still busy with the previous connection attempt.
-static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 42000;
+static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 46000;
 
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1200,7 +1200,8 @@ void WiFiComponent::check_connecting_finished() {
 
   uint32_t now = millis();
   if (now - this->action_started_ > WIFI_CONNECT_TIMEOUT_MS) {
-    ESP_LOGW(TAG, "Connection timeout");
+    ESP_LOGW(TAG, "Connection timeout, aborting connection attempt");
+    this->wifi_disconnect_();
     this->retry_connect();
     return;
   }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -218,7 +218,7 @@ static constexpr uint32_t WIFI_SCAN_TIMEOUT_MS = 31000;
 /// If this timeout fires prematurely while a connection is still in progress, it causes
 /// cascading failures: the subsequent scan will also fail because the WiFi driver is
 /// still busy with the previous connection attempt.
-static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 61000;
+static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 42000;
 
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1421,6 +1421,10 @@ bool WiFiComponent::transition_to_phase_(WiFiRetryPhase new_phase) {
       // without disrupting the captive portal/improv connection
       if (!this->is_captive_portal_active_() && !this->is_esp32_improv_active_()) {
         this->restart_adapter();
+      } else {
+        // Even when skipping full restart, disconnect to clear driver state
+        // Without this, platforms like LibreTiny may think we're still connecting
+        this->wifi_disconnect_();
       }
       // Clear scan flag - we're starting a new retry cycle
       this->did_scan_this_cycle_ = false;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -205,6 +205,21 @@ static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
 /// While connecting, WiFi can't beacon the AP properly, so needs longer cooldown
 static constexpr uint32_t WIFI_COOLDOWN_WITH_AP_ACTIVE_MS = 30000;
 
+/// Timeout for WiFi scan operations
+/// This is a fallback in case we don't receive a scan done callback from the WiFi driver.
+/// Normal scans complete via callback; this only triggers if something goes wrong.
+static constexpr uint32_t WIFI_SCAN_TIMEOUT_MS = 31000;
+
+/// Timeout for WiFi connection attempts
+/// This is a fallback in case we don't receive connection success/failure callbacks.
+/// Some platforms (especially LibreTiny/Beken) can take 30-60 seconds to connect,
+/// particularly with fast_connect enabled where no prior scan provides channel info.
+/// Do not lower this value - connection failures are detected via callbacks, not timeout.
+/// If this timeout fires prematurely while a connection is still in progress, it causes
+/// cascading failures: the subsequent scan will also fail because the WiFi driver is
+/// still busy with the previous connection attempt.
+static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 61000;
+
 static constexpr uint8_t get_max_retries_for_phase(WiFiRetryPhase phase) {
   switch (phase) {
     case WiFiRetryPhase::INITIAL_CONNECT:
@@ -1035,7 +1050,7 @@ __attribute__((noinline)) static void log_scan_result(const WiFiScanResult &res)
 
 void WiFiComponent::check_scanning_finished() {
   if (!this->scan_done_) {
-    if (millis() - this->action_started_ > 30000) {
+    if (millis() - this->action_started_ > WIFI_SCAN_TIMEOUT_MS) {
       ESP_LOGE(TAG, "Scan timeout");
       this->retry_connect();
     }
@@ -1184,7 +1199,7 @@ void WiFiComponent::check_connecting_finished() {
   }
 
   uint32_t now = millis();
-  if (now - this->action_started_ > 30000) {
+  if (now - this->action_started_ > WIFI_CONNECT_TIMEOUT_MS) {
     ESP_LOGW(TAG, "Connection timeout");
     this->retry_connect();
     return;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -196,6 +196,11 @@ static constexpr uint8_t WIFI_RETRY_COUNT_PER_SSID = 1;
 // Rationale: Fast connect prioritizes speed - try each AP once to find a working one quickly
 static constexpr uint8_t WIFI_RETRY_COUNT_PER_AP = 1;
 
+// 2 forced scan cycles after credentials change via captive portal/improv
+// Rationale: After new credentials are submitted, we need fresh scan results to find the
+// best AP (strongest signal). Two cycles in case the first scan catches the network mid-transition.
+static constexpr uint8_t WIFI_FORCE_SCAN_AFTER_CREDENTIAL_CHANGE = 2;
+
 /// Cooldown duration in milliseconds after adapter restart or repeated failures
 /// Allows WiFi hardware to stabilize before next connection attempt
 static constexpr uint32_t WIFI_COOLDOWN_DURATION_MS = 500;
@@ -685,6 +690,8 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
   this->init_sta(1);
   this->add_sta(ap);
   this->selected_sta_index_ = 0;
+  // Force scan cycles to find best AP even when captive portal/improv is active
+  this->force_scan_count_ = WIFI_FORCE_SCAN_AFTER_CREDENTIAL_CHANGE;
   // When new credentials are set (e.g., from improv), skip cooldown to retry immediately
   this->skip_cooldown_next_cycle_ = true;
 }
@@ -1331,8 +1338,14 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       }
       // Skip scanning when captive portal/improv is active to avoid disrupting AP
       // Even passive scans can cause brief AP disconnections on ESP32
+      // Exception: force scans after credential change to find best AP
       if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
-        return WiFiRetryPhase::RETRY_HIDDEN;
+        if (this->force_scan_count_ > 0) {
+          this->force_scan_count_--;
+          ESP_LOGD(TAG, "Forcing scan despite active portal (remaining: %u)", this->force_scan_count_);
+        } else {
+          return WiFiRetryPhase::RETRY_HIDDEN;
+        }
       }
       return WiFiRetryPhase::SCAN_CONNECTING;
   }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -643,10 +643,6 @@ class WiFiComponent : public Component {
   bool keep_scan_results_{false};
   bool did_scan_this_cycle_{false};
   bool skip_cooldown_next_cycle_{false};
-  /// Force scan cycles after credentials change (even when AP is active)
-  /// Set to 2 after captive portal/improv submits new credentials to ensure
-  /// we find the best AP rather than connecting to a potentially weak one
-  uint8_t force_scan_count_{0};
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   WiFiPowerSaveMode configured_power_save_{WIFI_POWER_SAVE_NONE};
   bool is_high_performance_mode_{false};

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -643,6 +643,10 @@ class WiFiComponent : public Component {
   bool keep_scan_results_{false};
   bool did_scan_this_cycle_{false};
   bool skip_cooldown_next_cycle_{false};
+  /// Force scan cycles after credentials change (even when AP is active)
+  /// Set to 2 after captive portal/improv submits new credentials to ensure
+  /// we find the best AP rather than connecting to a potentially weak one
+  uint8_t force_scan_count_{0};
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   WiFiPowerSaveMode configured_power_save_{WIFI_POWER_SAVE_NONE};
   bool is_high_performance_mode_{false};

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -720,6 +720,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_STOP) {
     ESP_LOGV(TAG, "STA stop");
     s_sta_started = false;
+    s_sta_connecting = false;
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_AUTHMODE_CHANGE) {
     const auto &it = data->data.sta_authmode_change;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -291,6 +291,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
     }
     case ESPHOME_EVENT_ID_WIFI_STA_STOP: {
       ESP_LOGV(TAG, "STA stop");
+      s_sta_connecting = false;
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -322,7 +322,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       // wifi_sta_connect_status_() to return IDLE. The main loop then sees
       // "Unknown connection status 0" (wifi_component.cpp check_connecting_finished)
       // and calls retry_connect(), aborting a connection that may succeed moments later.
-      // Real connection failures will have ssid/bssid populated, or we'll hit the 30s timeout.
+      // Real connection failures will have ssid/bssid populated, or we'll hit the connection timeout.
       if (it.ssid_len == 0 && s_sta_connecting) {
         ESP_LOGV(TAG, "Ignoring disconnect event with empty ssid while connecting (reason=%s)",
                  get_disconnect_reason_str(it.reason));

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -528,7 +528,12 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {WiFi.softAPIP()}; }
 #endif  // USE_WIFI_AP
 
-bool WiFiComponent::wifi_disconnect_() { return WiFi.disconnect(); }
+bool WiFiComponent::wifi_disconnect_() {
+  // Clear connecting flag first so disconnect events aren't ignored
+  // and wifi_sta_connect_status_() returns IDLE instead of CONNECTING
+  s_sta_connecting = false;
+  return WiFi.disconnect();
+}
 
 bssid_t WiFiComponent::wifi_bssid() {
   bssid_t bssid{};


### PR DESCRIPTION
# What does this implement/fix?

Fixes WiFi connection timeout handling to properly abort in-progress connections and allow the device to recover and eventually connect.

## Problem

When a WiFi connection times out (e.g., wrong password, AP out of range), the WiFi driver may still be busy with the connection attempt. Without explicitly disconnecting, subsequent scan operations fail because the driver is occupied. This causes a cascading failure where the device never recovers to try other networks or start the fallback AP.

This was particularly visible on LibreTiny/Beken platforms with `fast_connect: true`, where connections can take 30-60 seconds when no prior scan has provided channel information.

## Solution

1. **Call `wifi_disconnect_()` on connection timeout** - This frees the WiFi driver so subsequent scans can proceed. On all platforms this calls the native disconnect API:
   - ESP32 IDF: `esp_wifi_disconnect()`
   - ESP8266: `wifi_station_disconnect()` + clears station config
   - LibreTiny: `WiFi.disconnect()`
   - Pico W: `cyw43_wifi_leave()`

2. **Clear `s_sta_connecting` on STA stop (LibreTiny, ESP32 IDF)** - When the WiFi adapter is restarted, the STA_STOP event now clears the connecting flag. Without this, `wifi_sta_connect_status_()` would return CONNECTING even after restart, causing the state machine to wait 61 seconds for a timeout instead of immediately proceeding to scan. ESP8266 doesn't have this event, and Pico W queries hardware directly so neither are affected.

3. **Call `wifi_disconnect_()` when skipping adapter restart** - When captive portal or improv is active, we skip the full adapter restart to avoid disrupting the AP. However, this meant the driver state wasn't cleared, causing a 61-second delay. Now we call `wifi_disconnect_()` to clear the connection state even when skipping the full restart.

4. **Clear `s_sta_connecting` in `wifi_disconnect_()` (LibreTiny only)** - On LibreTiny, `WiFi.disconnect()` triggers events with empty SSID which get filtered out by the spurious event protection. Clearing the flag before calling disconnect ensures the state machine sees IDLE status immediately.

5. **Increase connection timeout from 30s to 46s** - On LibreTiny without `fast_connect`, the first connection attempt can take 40-46 seconds due to internal scanning when no channel/BSSID is provided. Once the driver has located the AP, subsequent connection attempts to the same BSSID are fast (<1s). The timeout is a fallback; actual failures are detected via callbacks. 46s ensures we don't abort connections that are about to succeed.

6. **Extract timeouts as named constants with documentation** - Explains why these values should not be lowered to prevent future regressions.

Changes:
- Add `wifi_disconnect_()` call when connection times out before calling `retry_connect()`
- Add `wifi_disconnect_()` call when skipping adapter restart (captive portal/improv active)
- Clear `s_sta_connecting` flag in STA_STOP event handler (LibreTiny, ESP32 IDF)
- Clear `s_sta_connecting` flag in `wifi_disconnect_()` (LibreTiny only)
- Increase `WIFI_CONNECT_TIMEOUT_MS` from 30000 to 46000
- Extract `WIFI_SCAN_TIMEOUT_MS` (31000) as a named constant
- Add documentation explaining the timeout purpose and cascading failure risk

## Known Limitation

After credentials are submitted via captive portal, the device cannot scan for the best AP because scanning fails when the fallback AP is active. The device will connect to whatever AP the driver finds first, which may have weaker signal than optimal. The device will eventually find a good AP through retry cycles. Users who want faster optimal AP selection can reboot after submitting credentials. This is a pre-existing platform limitation, not introduced by this PR.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12152

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Tested on CB3S (BK7231N)
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap:
    ssid: "device-fallback"

captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
