### PR TITLE
[ota] Match client timeout to device timeout to prevent premature failures

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -322,8 +322,8 @@ def perform_ota(
         hash_func, nonce_size, hash_name = _AUTH_METHODS[auth]
         perform_auth(sock, password, hash_func, nonce_size, hash_name)
 
-    # Set higher timeout during upload
-    sock.settimeout(30.0)
+    # Timeout must match device-side OTA_SOCKET_TIMEOUT_DATA to prevent premature failures
+    sock.settimeout(90.0)
 
     upload_size = len(upload_contents)
     upload_size_encoded = [


### PR DESCRIPTION
# What does this implement/fix?

Increases the OTA client-side socket timeout from 30 seconds to 90 seconds to match the device-side `OTA_SOCKET_TIMEOUT_DATA`.

When the timeouts don't match, the client can give up waiting for chunk acknowledgments before the device has actually failed. This is particularly problematic on slower platforms like LibreTiny/Beken where flash writes can take longer. The premature timeout causes:

1. Client disconnects mid-transfer
2. Device OTA state is left in a bad state
3. Subsequent OTA attempts fail with "Begin error: 0" until device reboots

By matching the timeouts, actual failures are detected via proper error responses rather than timeouts.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes OTA reliability
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
