### PR TITLE
[ethernet] fix used pins validation in configuration of RMII pins

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -434,9 +434,12 @@ def _final_validate_rmii_pins(config: ConfigType) -> None:
 
     # Check all used pins against RMII reserved pins
     for pin_list in pins.PIN_SCHEMA_REGISTRY.pins_used.values():
-        for pin_path, _, pin_config in pin_list:
+        for pin_path, pin_device, pin_config in pin_list:
             pin_num = pin_config.get(CONF_NUMBER)
             if pin_num not in rmii_pins:
+                continue
+            # Skip if pin is not directly on ESP, but at some expander (device set to something else than 'None')
+            if pin_device is not None:
                 continue
             # Found a conflict - show helpful error message
             pin_function = rmii_pins[pin_num]

--- a/tests/components/ethernet/test-lan8720-with-expander.esp32-idf.yaml
+++ b/tests/components/ethernet/test-lan8720-with-expander.esp32-idf.yaml
@@ -1,0 +1,15 @@
+<<: !include common-lan8720.yaml
+
+sn74hc165:
+  - id: sn74hc165_hub
+    clock_pin: GPIO13
+    data_pin: GPIO14
+    load_pin: GPIO15
+    sr_count: 3
+
+binary_sensor:
+  - platform: gpio
+    pin:
+      sn74hc165: sn74hc165_hub
+      number: 19
+    id: relay_2


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a defect in validation of used pins when configuring ethernet component with RMII interface. The pin validation was to restrictive and was triggering a failure if the pin number was matching even on a i2c or serial expander. The example yaml below shows the pin GPIO19 being used on a sn74hc165 expander, this would fail to validate and project cannot be build. It was properly working before on 2025.10.5 but fails on 2025.11.5.
Fix is to check if the device is set to something else than `None`. `None` is set in case of the esp device itself holding the pin. For the example below this is set to `sn74hc165_hub`, so the id of the device this pin belongs to.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- issue introduced with too rigorous validation: https://github.com/esphome/esphome/pull/11488

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: "example"
  libraries: []
esp32:
  board: esp32dev
  framework:
    version: recommended
    type: arduino
  variant: ESP32

ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk:
    pin: GPIO17
    mode: CLK_OUT
  phy_addr: 0
  power_pin: GPIO12

sn74hc165:
  - id: sn74hc165_hub
    clock_pin: GPIO14
    data_pin: GPIO15
    load_pin: GPIO13
    sr_count: 3

binary_sensor:
  - platform: gpio
    pin: 
      sn74hc165: sn74hc165_hub
      number: 19
    id: relay_1
```
Before changes the validation fails with this error:
```
GPIO19 is reserved for Ethernet RMII (EMAC_TXD0) and cannot be used. This pin is hardcoded by ESP-IDF and cannot be changed when using RMII Ethernet PHYs. Please choose a different GPIO pin for 'binary_sensor.0'.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
