### PR TITLE
[remote_base] Fix crash when ABBWelcome action has no data field

### DIFF
--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -232,10 +232,10 @@ template<typename... Ts> class ABBWelcomeAction : public RemoteTransmitterAction
     data.set_message_id(this->message_id_.value(x...));
     data.auto_message_id = this->auto_message_id_.value(x...);
     std::vector<uint8_t> data_vec;
-    if (this->len_ >= 0) {
+    if (this->len_ > 0) {
       // Static mode: copy from flash to vector
       data_vec.assign(this->data_.data, this->data_.data + this->len_);
-    } else {
+    } else if (this->len_ < 0) {
       // Template mode: call function
       data_vec = this->data_.func(x...);
     }
@@ -245,7 +245,7 @@ template<typename... Ts> class ABBWelcomeAction : public RemoteTransmitterAction
   }
 
  protected:
-  ssize_t len_{-1};  // -1 = template mode, >=0 = static mode with length
+  ssize_t len_{0};  // <0 = template mode, >=0 = static mode with length
   union Data {
     std::vector<uint8_t> (*func)(Ts...);  // Function pointer (stateless lambdas)
     const uint8_t *data;                  // Pointer to static data in flash


### PR DESCRIPTION
# What does this implement/fix?

Fixes a crash when using `transmit_abbwelcome` action without a `data:` field. The crash was caused by an uninitialized union in `ABBWelcomeAction`.

## Root Cause

In commit 0d735dc259, the ABBWelcome action was optimized to use a union for storing either a function pointer (template mode) or a data pointer (static mode):

```cpp
ssize_t len_{-1};  // -1 = template mode
union Data {
  std::vector<uint8_t> (*func)(Ts...);
  const uint8_t *data;
} data_;  // NOT INITIALIZED!
```

When no `data:` field is specified in YAML:
- `len_` defaults to `-1` (template mode)
- `data_.func` is **uninitialized** (garbage/null)
- `encode()` calls `data_.func(x...)` → crash at address 0x00000000

## The Fix

- Change default `len_` from `-1` to `0` (empty static data mode)
- Adjust condition to only call function pointer when `len_ < 0`
- When `len_ == 0`, an empty `data_vec` is used (correct behavior)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes #12492

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config was crashing before the fix
remote_transmitter:
  pin: GPIO26
  carrier_duty_percent: 100%

lock:
  - platform: template
    name: "Front Door"
    unlock_action:
      - remote_transmitter.transmit_abbwelcome:
          source_address: 0x000147
          destination_address: 0x000401
          three_byte_address: true
          message_type: 0x0e
          # No data: field - this was causing the crash
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).