### PR TITLE
[esp32] Support all IDF component version operators in shorthand syntax

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -616,19 +616,10 @@ def require_vfs_dir() -> None:
 
 
 def _parse_idf_component(value: str) -> ConfigType:
-    """Parse IDF component shorthand syntax like 'owner/component^version'
-
-    Supports version operators: ^, ~, ~=, ==, !=, >=, >, <=, <
-    Examples:
-        espressif/arduino-esp32^3.3.3   -> ref: ^3.3.3
-        espressif/mdns==1.2.0           -> ref: ==1.2.0
-        espressif/esp_tinyusb>=1.0.0    -> ref: >=1.0.0
-    """
+    """Parse IDF component shorthand syntax like 'owner/component^version'"""
     # Match operator followed by version-like string (digit or *)
-    match = re.search(r"(~=|>=|<=|==|!=|>|<|\^|~)(\d|\*)", value)
-    if match:
-        pos = match.start()
-        return {CONF_NAME: value[:pos], CONF_REF: value[pos:]}
+    if match := re.search(r"(~=|>=|<=|==|!=|>|<|\^|~)(\d|\*)", value):
+        return {CONF_NAME: value[: match.start()], CONF_REF: value[match.start() :]}
     raise cv.Invalid(
         f"Invalid IDF component shorthand '{value}'. "
         f"Expected format: 'owner/component<op>version' where <op> is one of: ^, ~, ~=, ==, !=, >=, >, <=, <"

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 import os
 from pathlib import Path
+import re
 
 from esphome import yaml_util
 import esphome.codegen as cg
@@ -615,11 +616,23 @@ def require_vfs_dir() -> None:
 
 
 def _parse_idf_component(value: str) -> ConfigType:
-    """Parse IDF component shorthand syntax like 'owner/component^version'"""
-    if "^" not in value:
-        raise cv.Invalid(f"Invalid IDF component shorthand '{value}'")
-    name, ref = value.split("^", 1)
-    return {CONF_NAME: name, CONF_REF: ref}
+    """Parse IDF component shorthand syntax like 'owner/component^version'
+
+    Supports version operators: ^, ~, ~=, ==, !=, >=, >, <=, <
+    Examples:
+        espressif/arduino-esp32^3.3.3   -> ref: ^3.3.3
+        espressif/mdns==1.2.0           -> ref: ==1.2.0
+        espressif/esp_tinyusb>=1.0.0    -> ref: >=1.0.0
+    """
+    # Match operator followed by version-like string (digit or *)
+    match = re.search(r"(~=|>=|<=|==|!=|>|<|\^|~)(\d|\*)", value)
+    if match:
+        pos = match.start()
+        return {CONF_NAME: value[:pos], CONF_REF: value[pos:]}
+    raise cv.Invalid(
+        f"Invalid IDF component shorthand '{value}'. "
+        f"Expected format: 'owner/component<op>version' where <op> is one of: ^, ~, ~=, ==, !=, >=, >, <=, <"
+    )
 
 
 def _validate_idf_component(config: ConfigType) -> ConfigType:


### PR DESCRIPTION
# What does this implement/fix?

Add support for all ESP-IDF Component Manager version operators in the shorthand syntax for `idf_components`. Previously only `^` was supported.

Now supports: `^`, `~`, `~=`, `==`, `!=`, `>=`, `>`, `<=`, `<`

Examples:
- `espressif/mdns^1.2.0` (compatible major)
- `espressif/mdns~1.2.0` (compatible minor)
- `espressif/mdns==1.2.0` (exact version)
- `espressif/mdns>=1.2.0` (minimum version)

Reference: https://docs.espressif.com/projects/idf-component-manager/en/latest/reference/versioning.html

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5786

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    components:
      - espressif/mdns^1.2.0    # Compatible major (>=1.2.0,==1.*)
      - espressif/cbor==0.6.0   # Exact version
      - owner/component>=1.0.0  # Minimum version
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).