### PR TITLE
[text] Avoid string copies in callbacks by passing const ref

### DIFF
--- a/esphome/components/text/text.cpp
+++ b/esphome/components/text/text.cpp
@@ -23,7 +23,7 @@ void Text::publish_state(const std::string &state) {
 #endif
 }
 
-void Text::add_on_state_callback(std::function<void(std::string)> &&callback) {
+void Text::add_on_state_callback(std::function<void(const std::string &)> &&callback) {
   this->state_callback_.add(std::move(callback));
 }
 

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -31,7 +31,7 @@ class Text : public EntityBase {
   /// Instantiate a TextCall object to modify this text component's state.
   TextCall make_call() { return TextCall(this); }
 
-  void add_on_state_callback(std::function<void(std::string)> &&callback);
+  void add_on_state_callback(std::function<void(const std::string &)> &&callback);
 
  protected:
   friend class TextCall;
@@ -44,7 +44,7 @@ class Text : public EntityBase {
    */
   virtual void control(const std::string &value) = 0;
 
-  CallbackManager<void(std::string)> state_callback_;
+  CallbackManager<void(const std::string &)> state_callback_;
 };
 
 }  // namespace text


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap churn in text entity by changing callback signatures from `std::function<void(std::string)>` to `std::function<void(const std::string &)>`.

Previously, every callback invocation caused a string copy because the callback signature passed by value. With this change, strings are passed by const reference, eliminating unnecessary heap allocations.

**Before:** Each `publish_state()` call copied the string once per registered callback.
**After:** Strings are passed by reference - no copies for callbacks.

**No lifetime issues:** The string is always valid during callback execution because:
1. Callbacks are invoked synchronously (not deferred)
2. The string is already copied into `this->state` before callbacks run
3. The original caller's string remains alive until `publish_state()` returns

This is a minor API change. Lambdas (the common pattern) continue to work unchanged:
```cpp
// These all still work:
text->add_on_state_callback([](const std::string &value) { ... });
text->add_on_state_callback([](std::string value) { ... });
```

The only breaking case is explicitly-typed `std::function` variables:
```cpp
// This would need to be updated:
std::function<void(std::string)> cb = ...;  // Change to std::function<void(const std::string &)>
text->add_on_state_callback(std::move(cb));
```

This pattern is extremely rare in practice.

Follow-up to #12503 which applied the same optimization to text_sensor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal API change only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
text:
  - platform: template
    name: "Test"
    optimistic: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). Existing integration tests in `tests/integration/` cover text callbacks.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
