### PR TITLE
[esp32_ble] Add stack-based UUID formatting to avoid heap allocations

### DIFF
--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -143,9 +143,8 @@ bool ESPBTUUID::operator==(const ESPBTUUID &uuid) const {
   return this->as_128bit() == uuid.as_128bit();
 }
 esp_bt_uuid_t ESPBTUUID::get_uuid() const { return this->uuid_; }
-std::string ESPBTUUID::to_string() const {
-  char buf[40];  // Enough for 128-bit UUID with dashes
-  char *pos = buf;
+void ESPBTUUID::to_str(std::span<char, UUID_STR_LEN> output) const {
+  char *pos = output.data();
 
   switch (this->uuid_.len) {
     case ESP_UUID_LEN_16:
@@ -156,7 +155,7 @@ std::string ESPBTUUID::to_string() const {
       *pos++ = format_hex_pretty_char((this->uuid_.uuid.uuid16 >> 4) & 0x0F);
       *pos++ = format_hex_pretty_char(this->uuid_.uuid.uuid16 & 0x0F);
       *pos = '\0';
-      return std::string(buf);
+      return;
 
     case ESP_UUID_LEN_32:
       *pos++ = '0';
@@ -165,7 +164,7 @@ std::string ESPBTUUID::to_string() const {
         *pos++ = format_hex_pretty_char((this->uuid_.uuid.uuid32 >> shift) & 0x0F);
       }
       *pos = '\0';
-      return std::string(buf);
+      return;
 
     default:
     case ESP_UUID_LEN_128:
@@ -179,9 +178,13 @@ std::string ESPBTUUID::to_string() const {
         }
       }
       *pos = '\0';
-      return std::string(buf);
+      return;
   }
-  return "";
+}
+std::string ESPBTUUID::to_string() const {
+  char buf[UUID_STR_LEN];
+  this->to_str(buf);
+  return std::string(buf);
 }
 
 }  // namespace esphome::esp32_ble

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -7,10 +7,14 @@
 #ifdef USE_ESP32
 #ifdef USE_ESP32_BLE_UUID
 
+#include <span>
 #include <string>
 #include <esp_bt_defs.h>
 
 namespace esphome::esp32_ble {
+
+/// Buffer size for UUID string: "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX\0"
+static constexpr size_t UUID_STR_LEN = 37;
 
 class ESPBTUUID {
  public:
@@ -37,6 +41,7 @@ class ESPBTUUID {
   esp_bt_uuid_t get_uuid() const;
 
   std::string to_string() const;
+  void to_str(std::span<char, UUID_STR_LEN> output) const;
 
  protected:
   esp_bt_uuid_t uuid_;

--- a/esphome/components/esp32_ble_client/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_client/ble_characteristic.cpp
@@ -50,8 +50,12 @@ void BLECharacteristic::parse_descriptors() {
     desc->handle = result.handle;
     desc->characteristic = this;
     this->descriptors.push_back(desc);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    char uuid_buf[espbt::UUID_STR_LEN];
+    desc->uuid.to_str(uuid_buf);
     ESP_LOGV(TAG, "[%d] [%s]    descriptor %s, handle 0x%x", this->service->client->get_connection_index(),
-             this->service->client->address_str(), desc->uuid.to_string().c_str(), desc->handle);
+             this->service->client->address_str(), uuid_buf, desc->handle);
+#endif
     offset++;
   }
 }

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -411,12 +411,15 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
         this->update_conn_params_(MEDIUM_MIN_CONN_INTERVAL, MEDIUM_MAX_CONN_INTERVAL, 0, MEDIUM_CONN_TIMEOUT, "medium");
       } else if (this->connection_type_ != espbt::ConnectionType::V3_WITH_CACHE) {
 #ifdef USE_ESP32_BLE_DEVICE
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
         for (auto &svc : this->services_) {
-          ESP_LOGV(TAG, "[%d] [%s] Service UUID: %s", this->connection_index_, this->address_str_,
-                   svc->uuid.to_string().c_str());
+          char uuid_buf[espbt::UUID_STR_LEN];
+          svc->uuid.to_str(uuid_buf);
+          ESP_LOGV(TAG, "[%d] [%s] Service UUID: %s", this->connection_index_, this->address_str_, uuid_buf);
           ESP_LOGV(TAG, "[%d] [%s]  start_handle: 0x%x  end_handle: 0x%x", this->connection_index_, this->address_str_,
                    svc->start_handle, svc->end_handle);
         }
+#endif
 #endif
       }
       ESP_LOGI(TAG, "[%d] [%s] Service discovery complete", this->connection_index_, this->address_str_);

--- a/esphome/components/esp32_ble_client/ble_service.cpp
+++ b/esphome/components/esp32_ble_client/ble_service.cpp
@@ -64,9 +64,12 @@ void BLEService::parse_characteristics() {
     characteristic->handle = result.char_handle;
     characteristic->service = this;
     this->characteristics.push_back(characteristic);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    char uuid_buf[espbt::UUID_STR_LEN];
+    characteristic->uuid.to_str(uuid_buf);
     ESP_LOGV(TAG, "[%d] [%s]  characteristic %s, handle 0x%x, properties 0x%x", this->client->get_connection_index(),
-             this->client->address_str(), characteristic->uuid.to_string().c_str(), characteristic->handle,
-             characteristic->properties);
+             this->client->address_str(), uuid_buf, characteristic->handle, characteristic->properties);
+#endif
     offset++;
   }
 }

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -109,7 +109,11 @@ void BLECharacteristic::do_create(BLEService *service) {
   esp_attr_control_t control;
   control.auto_rsp = ESP_GATT_RSP_BY_APP;
 
-  ESP_LOGV(TAG, "Creating characteristic - %s", this->uuid_.to_string().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char uuid_buf[esp32_ble::UUID_STR_LEN];
+  this->uuid_.to_str(uuid_buf);
+  ESP_LOGV(TAG, "Creating characteristic - %s", uuid_buf);
+#endif
 
   esp_bt_uuid_t uuid = this->uuid_.get_uuid();
   esp_err_t err = esp_ble_gatts_add_char(service->get_handle(), &uuid, static_cast<esp_gatt_perm_t>(this->permissions_),

--- a/esphome/components/esp32_ble_server/ble_descriptor.cpp
+++ b/esphome/components/esp32_ble_server/ble_descriptor.cpp
@@ -34,7 +34,11 @@ void BLEDescriptor::do_create(BLECharacteristic *characteristic) {
   esp_attr_control_t control;
   control.auto_rsp = ESP_GATT_AUTO_RSP;
 
-  ESP_LOGV(TAG, "Creating descriptor - %s", this->uuid_.to_string().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char uuid_buf[esp32_ble::UUID_STR_LEN];
+  this->uuid_.to_str(uuid_buf);
+  ESP_LOGV(TAG, "Creating descriptor - %s", uuid_buf);
+#endif
   esp_bt_uuid_t uuid = this->uuid_.get_uuid();
   esp_err_t err = esp_ble_gatts_add_char_descr(this->characteristic_->get_service()->get_handle(), &uuid,
                                                this->permissions_, &this->value_, &control);

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -106,7 +106,11 @@ void BLEServer::restart_advertising_() {
 }
 
 BLEService *BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t num_handles) {
-  ESP_LOGV(TAG, "Creating BLE service - %s", uuid.to_string().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char uuid_buf[esp32_ble::UUID_STR_LEN];
+  uuid.to_str(uuid_buf);
+  ESP_LOGV(TAG, "Creating BLE service - %s", uuid_buf);
+#endif
   // Calculate the inst_id for the service
   uint8_t inst_id = 0;
   for (; inst_id < 0xFF; inst_id++) {
@@ -115,7 +119,9 @@ BLEService *BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t n
     }
   }
   if (inst_id == 0xFF) {
-    ESP_LOGW(TAG, "Could not create BLE service %s, too many instances", uuid.to_string().c_str());
+    char warn_uuid_buf[esp32_ble::UUID_STR_LEN];
+    uuid.to_str(warn_uuid_buf);
+    ESP_LOGW(TAG, "Could not create BLE service %s, too many instances", warn_uuid_buf);
     return nullptr;
   }
   BLEService *service =  // NOLINT(cppcoreguidelines-owning-memory)
@@ -128,7 +134,11 @@ BLEService *BLEServer::create_service(ESPBTUUID uuid, bool advertise, uint16_t n
 }
 
 void BLEServer::remove_service(ESPBTUUID uuid, uint8_t inst_id) {
-  ESP_LOGV(TAG, "Removing BLE service - %s %d", uuid.to_string().c_str(), inst_id);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char uuid_buf[esp32_ble::UUID_STR_LEN];
+  uuid.to_str(uuid_buf);
+  ESP_LOGV(TAG, "Removing BLE service - %s %d", uuid_buf, inst_id);
+#endif
   for (auto it = this->services_.begin(); it != this->services_.end(); ++it) {
     if (it->uuid == uuid && it->inst_id == inst_id) {
       it->service->do_delete();
@@ -137,7 +147,9 @@ void BLEServer::remove_service(ESPBTUUID uuid, uint8_t inst_id) {
       return;
     }
   }
-  ESP_LOGW(TAG, "BLE service %s %d does not exist", uuid.to_string().c_str(), inst_id);
+  char warn_uuid_buf[esp32_ble::UUID_STR_LEN];
+  uuid.to_str(warn_uuid_buf);
+  ESP_LOGW(TAG, "BLE service %s %d does not exist", warn_uuid_buf, inst_id);
 }
 
 BLEService *BLEServer::get_service(ESPBTUUID uuid, uint8_t inst_id) {

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -435,24 +435,31 @@ void ESPBTDevice::parse_scan_rst(const BLEScanResult &scan_result) {
     ESP_LOGVV(TAG, "  Ad Flag: %u", *this->ad_flag_);
   }
   for (auto &uuid : this->service_uuids_) {
-    ESP_LOGVV(TAG, "  Service UUID: %s", uuid.to_string().c_str());
+    char uuid_buf[esp32_ble::UUID_STR_LEN];
+    uuid.to_str(uuid_buf);
+    ESP_LOGVV(TAG, "  Service UUID: %s", uuid_buf);
   }
   for (auto &data : this->manufacturer_datas_) {
     auto ibeacon = ESPBLEiBeacon::from_manufacturer_data(data);
     if (ibeacon.has_value()) {
       ESP_LOGVV(TAG, "  Manufacturer iBeacon:");
-      ESP_LOGVV(TAG, "    UUID: %s", ibeacon.value().get_uuid().to_string().c_str());
+      char uuid_buf[esp32_ble::UUID_STR_LEN];
+      ibeacon.value().get_uuid().to_str(uuid_buf);
+      ESP_LOGVV(TAG, "    UUID: %s", uuid_buf);
       ESP_LOGVV(TAG, "    Major: %u", ibeacon.value().get_major());
       ESP_LOGVV(TAG, "    Minor: %u", ibeacon.value().get_minor());
       ESP_LOGVV(TAG, "    TXPower: %d", ibeacon.value().get_signal_power());
     } else {
-      ESP_LOGVV(TAG, "  Manufacturer ID: %s, data: %s", data.uuid.to_string().c_str(),
-                format_hex_pretty(data.data).c_str());
+      char uuid_buf[esp32_ble::UUID_STR_LEN];
+      data.uuid.to_str(uuid_buf);
+      ESP_LOGVV(TAG, "  Manufacturer ID: %s, data: %s", uuid_buf, format_hex_pretty(data.data).c_str());
     }
   }
   for (auto &data : this->service_datas_) {
     ESP_LOGVV(TAG, "  Service data:");
-    ESP_LOGVV(TAG, "    UUID: %s", data.uuid.to_string().c_str());
+    char uuid_buf[esp32_ble::UUID_STR_LEN];
+    data.uuid.to_str(uuid_buf);
+    ESP_LOGVV(TAG, "    UUID: %s", uuid_buf);
     ESP_LOGVV(TAG, "    Data: %s", format_hex_pretty(data.data).c_str());
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Add stack-based UUID formatting to eliminate heap allocations when logging BLE UUIDs.

Previously, `ESPBTUUID::to_string()` returned `std::string`, causing heap allocation/deallocation for every UUID logged. This adds a new `to_str(std::span<char, UUID_STR_LEN>)` method that formats directly into a caller-provided stack buffer.

Updated call sites in core BLE components to use the new method, eliminating temporary heap allocations during UUID logging.

**Changes:**
- Add `UUID_STR_LEN` constant (37 bytes for full 128-bit UUID with dashes + null)
- Add `to_str()` method using `std::span` for compile-time buffer size safety
- Update `to_string()` to internally use `to_str()` (backward compatible)
- Convert logging call sites in esp32_ble_tracker, esp32_ble_server, and esp32_ble_client
- Guard verbose/debug log formatting with `#if ESPHOME_LOG_LEVEL` to avoid stack allocation when logging is disabled

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a - performance optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a - internal API addition

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
