### PR TITLE
[water_heater] (2/5) Implement  new water_heater component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -536,6 +536,7 @@ esphome/components/version/* @esphome/core
 esphome/components/voice_assistant/* @jesserockz @kahrendt
 esphome/components/wake_on_lan/* @clydebarrow @willwill2will54
 esphome/components/watchdog/* @oarcher
+esphome/components/water_heater/* @dhoeben
 esphome/components/waveshare_epaper/* @clydebarrow
 esphome/components/web_server/ota/* @esphome/core
 esphome/components/web_server_base/* @esphome/core

--- a/esphome/components/water_heater/__init__.py
+++ b/esphome/components/water_heater/__init__.py
@@ -1,0 +1,75 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MAX_TEMPERATURE,
+    CONF_MIN_TEMPERATURE,
+    CONF_VISUAL,
+)
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
+
+CODEOWNERS = ["@dhoeben"]
+
+IS_PLATFORM_COMPONENT = True
+
+water_heater_ns = cg.esphome_ns.namespace("water_heater")
+WaterHeater = water_heater_ns.class_("WaterHeater", cg.EntityBase, cg.Component)
+WaterHeaterCall = water_heater_ns.class_("WaterHeaterCall")
+WaterHeaterTraits = water_heater_ns.class_("WaterHeaterTraits")
+
+CONF_TARGET_TEMPERATURE_STEP = "target_temperature_step"
+CONF_CURRENT_TEMPERATURE_STEP = "current_temperature_step"
+
+WaterHeaterMode = water_heater_ns.enum("WaterHeaterMode")
+WATER_HEATER_MODES = {
+    "OFF": WaterHeaterMode.WATER_HEATER_MODE_OFF,
+    "ECO": WaterHeaterMode.WATER_HEATER_MODE_ECO,
+    "ELECTRIC": WaterHeaterMode.WATER_HEATER_MODE_ELECTRIC,
+    "PERFORMANCE": WaterHeaterMode.WATER_HEATER_MODE_PERFORMANCE,
+    "HIGH_DEMAND": WaterHeaterMode.WATER_HEATER_MODE_HIGH_DEMAND,
+    "HEAT_PUMP": WaterHeaterMode.WATER_HEATER_MODE_HEAT_PUMP,
+    "GAS": WaterHeaterMode.WATER_HEATER_MODE_GAS,
+}
+validate_water_heater_mode = cv.enum(WATER_HEATER_MODES, upper=True)
+
+WATER_HEATER_SCHEMA = cv.ENTITY_BASE_SCHEMA.extend(
+    {
+        cv.GenerateID(): cv.declare_id(WaterHeater),
+        cv.Optional(CONF_VISUAL, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_MIN_TEMPERATURE): cv.temperature,
+                cv.Optional(CONF_MAX_TEMPERATURE): cv.temperature,
+                cv.Optional(CONF_TARGET_TEMPERATURE_STEP): cv.float_,
+                cv.Optional(CONF_CURRENT_TEMPERATURE_STEP): cv.float_,
+            }
+        ),
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def setup_water_heater_core_(var, config):
+    """Setup the core water heater properties in C++."""
+    visual = config[CONF_VISUAL]
+    if (min_temp := visual.get(CONF_MIN_TEMPERATURE)) is not None:
+        cg.add(var.set_visual_min_temperature_override(min_temp))
+    if (max_temp := visual.get(CONF_MAX_TEMPERATURE)) is not None:
+        cg.add(var.set_visual_max_temperature_override(max_temp))
+
+
+async def register_water_heater(var, config):
+    if not CORE.has_id(config[CONF_ID]):
+        var = cg.Pvariable(config[CONF_ID], var)
+
+    cg.add_define("USE_WATER_HEATER")
+
+    await cg.register_component(var, config)
+
+    cg.add(cg.App.register_water_heater(var))
+
+    CORE.register_platform_component("water_heater", var)
+    await setup_water_heater_core_(var, config)
+
+
+@coroutine_with_priority(CoroPriority.CORE)
+async def to_code(config):
+    cg.add_global(water_heater_ns.using)

--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -1,0 +1,143 @@
+#include "water_heater.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "esphome/core/controller_registry.h"
+
+#include <set>
+#include <utility>
+
+namespace esphome {
+namespace water_heater {
+
+static const char *const TAG = "water_heater";
+
+WaterHeaterCall::WaterHeaterCall(WaterHeater *parent) : parent_(parent) {}
+
+WaterHeaterCall &WaterHeaterCall::set_mode(WaterHeaterMode mode) {
+  this->mode_ = mode;
+  return *this;
+}
+
+WaterHeaterCall &WaterHeaterCall::set_mode(const std::string &mode) {
+  if (str_equals_case_insensitive(mode, "OFF")) {
+    this->set_mode(WATER_HEATER_MODE_OFF);
+  } else if (str_equals_case_insensitive(mode, "ECO")) {
+    this->set_mode(WATER_HEATER_MODE_ECO);
+  } else if (str_equals_case_insensitive(mode, "ELECTRIC")) {
+    this->set_mode(WATER_HEATER_MODE_ELECTRIC);
+  } else if (str_equals_case_insensitive(mode, "PERFORMANCE")) {
+    this->set_mode(WATER_HEATER_MODE_PERFORMANCE);
+  } else if (str_equals_case_insensitive(mode, "HIGH_DEMAND")) {
+    this->set_mode(WATER_HEATER_MODE_HIGH_DEMAND);
+  } else if (str_equals_case_insensitive(mode, "HEAT_PUMP")) {
+    this->set_mode(WATER_HEATER_MODE_HEAT_PUMP);
+  } else if (str_equals_case_insensitive(mode, "GAS")) {
+    this->set_mode(WATER_HEATER_MODE_GAS);
+  } else {
+    ESP_LOGW(TAG, "'%s' - Unrecognized mode %s", this->parent_->get_name().c_str(), mode.c_str());
+  }
+  return *this;
+}
+
+WaterHeaterCall &WaterHeaterCall::set_target_temperature(float temperature) {
+  this->target_temperature_ = temperature;
+  return *this;
+}
+
+void WaterHeaterCall::apply(WaterHeater *water_heater) { *this = water_heater->make_call(); }
+
+WaterHeaterCall &WaterHeaterCall::to_call(WaterHeater *water_heater) {
+  water_heater->make_call().set_from_restore(*this).perform();
+  return *this;
+}
+
+void WaterHeaterCall::perform() {
+  this->validate_();
+  this->parent_->control(*this);
+}
+
+void WaterHeaterCall::validate_() {
+  auto traits = this->parent_->get_traits();
+  if (this->mode_.has_value()) {
+    if (!traits.supports_mode(*this->mode_)) {
+      ESP_LOGW(TAG, "'%s' - Mode %d not supported", this->parent_->get_name().c_str(), *this->mode_);
+      this->mode_.reset();
+    }
+  }
+  if (this->target_temperature_.has_value()) {
+    if (*this->target_temperature_ < traits.get_min_temperature() ||
+        *this->target_temperature_ > traits.get_max_temperature()) {
+      ESP_LOGW(TAG, "'%s' - Target temperature %.1f is out of range [%.1f - %.1f]", this->parent_->get_name().c_str(),
+               *this->target_temperature_, traits.get_min_temperature(), traits.get_max_temperature());
+
+      if (*this->target_temperature_ < traits.get_min_temperature())
+        *this->target_temperature_ = traits.get_min_temperature();
+      if (*this->target_temperature_ > traits.get_max_temperature())
+        *this->target_temperature_ = traits.get_max_temperature();
+    }
+  }
+}
+
+void WaterHeaterTraits::set_supports_current_temperature(bool supports_current_temperature) {
+  this->supports_current_temperature_ = supports_current_temperature;
+}
+bool WaterHeaterTraits::get_supports_current_temperature() const { return this->supports_current_temperature_; }
+
+void WaterHeaterTraits::set_min_temperature(float min_temperature) { this->min_temperature_ = min_temperature; }
+float WaterHeaterTraits::get_min_temperature() const { return this->min_temperature_; }
+
+void WaterHeaterTraits::set_max_temperature(float max_temperature) { this->max_temperature_ = max_temperature; }
+float WaterHeaterTraits::get_max_temperature() const { return this->max_temperature_; }
+
+void WaterHeaterTraits::set_supported_modes(std::set<WaterHeaterMode> modes) {
+  this->supported_modes_ = std::move(modes);
+}
+const std::set<WaterHeaterMode> &WaterHeaterTraits::get_supported_modes() const { return this->supported_modes_; }
+bool WaterHeaterTraits::supports_mode(WaterHeaterMode mode) const { return this->supported_modes_.count(mode); }
+
+void WaterHeater::setup() {
+  this->pref_ = global_preferences->make_preference<SavedWaterHeaterState>(this->get_object_id_hash());
+}
+
+void WaterHeater::publish_state() {
+#if defined(USE_WATER_HEATER) && defined(USE_CONTROLLER_REGISTRY)
+  ControllerRegistry::notify_water_heater_update(this);
+#endif
+
+  SavedWaterHeaterState saved{};
+  saved.mode = this->mode;
+  saved.target_temperature = this->target_temperature;
+  this->pref_.save(&saved);
+}
+
+optional<WaterHeaterCall> WaterHeater::restore_state() {
+  SavedWaterHeaterState recovered{};
+  if (!this->pref_.load(&recovered))
+    return {};
+
+  auto call = this->make_call();
+  call.set_mode(recovered.mode);
+  call.set_target_temperature(recovered.target_temperature);
+  return call;
+}
+
+WaterHeaterTraits WaterHeater::get_traits() {
+  auto traits = this->traits();
+  if (this->visual_min_temperature_override_.has_value()) {
+    traits.set_min_temperature(*this->visual_min_temperature_override_);
+  }
+  if (this->visual_max_temperature_override_.has_value()) {
+    traits.set_max_temperature(*this->visual_max_temperature_override_);
+  }
+  return traits;
+}
+
+void WaterHeater::set_visual_min_temperature_override(float min_temperature_override) {
+  this->visual_min_temperature_override_ = min_temperature_override;
+}
+void WaterHeater::set_visual_max_temperature_override(float max_temperature_override) {
+  this->visual_max_temperature_override_ = max_temperature_override;
+}
+
+}  // namespace water_heater
+}  // namespace esphome

--- a/esphome/components/water_heater/water_heater.h
+++ b/esphome/components/water_heater/water_heater.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <set>
+#include "esphome/core/component.h"
+#include "esphome/core/entity_base.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+#include "esphome/core/preferences.h"
+
+namespace esphome {
+
+namespace water_heater {
+
+struct WaterHeaterCallInternal;
+
+class WaterHeater;
+void call_water_heater_update(WaterHeater *a);
+void register_water_heater(WaterHeater *a);
+
+enum WaterHeaterMode : uint32_t {
+  WATER_HEATER_MODE_OFF = 0,
+  WATER_HEATER_MODE_ECO = 1,
+  WATER_HEATER_MODE_ELECTRIC = 2,
+  WATER_HEATER_MODE_PERFORMANCE = 3,
+  WATER_HEATER_MODE_HIGH_DEMAND = 4,
+  WATER_HEATER_MODE_HEAT_PUMP = 5,
+  WATER_HEATER_MODE_GAS = 6,
+};
+
+struct SavedWaterHeaterState {
+  WaterHeaterMode mode;
+  float target_temperature;
+} __attribute__((packed));
+
+class WaterHeaterCall {
+ public:
+  WaterHeaterCall() : parent_(nullptr) {}
+
+  WaterHeaterCall(WaterHeater *parent);
+
+  WaterHeaterCall &set_mode(WaterHeaterMode mode);
+  WaterHeaterCall &set_mode(const std::string &mode);
+  WaterHeaterCall &set_target_temperature(float temperature);
+
+  void perform();
+
+  void apply(WaterHeater *water_heater);
+  WaterHeaterCall &to_call(WaterHeater *water_heater);
+
+  optional<WaterHeaterMode> mode_;
+  optional<float> target_temperature_;
+
+  const optional<WaterHeaterMode> &get_mode() const { return this->mode_; }
+  const optional<float> &get_target_temperature() const { return this->target_temperature_; }
+
+ protected:
+  void validate_();
+  WaterHeater *parent_;
+};
+
+struct WaterHeaterCallInternal : public WaterHeaterCall {
+  WaterHeaterCallInternal(WaterHeater *parent) : WaterHeaterCall(parent) {}
+
+  WaterHeaterCallInternal &set_from_restore(const WaterHeaterCall &restore) {
+    this->mode_ = restore.mode_;
+    this->target_temperature_ = restore.target_temperature_;
+    return *this;
+  }
+};
+
+class WaterHeaterTraits {
+ public:
+  void set_supports_current_temperature(bool supports_current_temperature);
+  bool get_supports_current_temperature() const;
+
+  void set_min_temperature(float min_temperature);
+  float get_min_temperature() const;
+
+  void set_max_temperature(float max_temperature);
+  float get_max_temperature() const;
+
+  void set_supported_modes(std::set<WaterHeaterMode> modes);
+  const std::set<WaterHeaterMode> &get_supported_modes() const;
+  bool supports_mode(WaterHeaterMode mode) const;
+
+ protected:
+  bool supports_current_temperature_{false};
+  float min_temperature_{0.0f};
+  float max_temperature_{0.0f};
+  std::set<WaterHeaterMode> supported_modes_;
+};
+
+class WaterHeater : public EntityBase, public Component {
+ public:
+  WaterHeaterMode mode{WATER_HEATER_MODE_OFF};
+  float current_temperature{NAN};
+  float target_temperature{0.0f};
+
+  virtual void publish_state();
+  virtual WaterHeaterTraits get_traits();
+  virtual WaterHeaterCallInternal make_call() = 0;
+
+  virtual void set_visual_min_temperature_override(float min_temperature_override);
+  virtual void set_visual_max_temperature_override(float max_temperature_override);
+  virtual void control(const WaterHeaterCall &call) = 0;
+
+  void setup() override;
+
+  optional<WaterHeaterCall> restore_state();
+
+ protected:
+  virtual WaterHeaterTraits traits() = 0;
+
+  optional<float> visual_min_temperature_override_{};
+  optional<float> visual_max_temperature_override_{};
+
+  uint32_t restore_storage_key_;
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace water_heater
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?
Now split-up config for a new `water_heater` component. 

**This requires more pull requests!**

Order of PR:
1: [water_heater api/core](https://github.com/esphome/esphome/pull/12498)
2: This one
3: [water_heater template](https://github.com/esphome/esphome/pull/12516)
4: [water_heater web_server](https://github.com/esphome/esphome/pull/12511)
5: [water_heater tests](https://github.com/esphome/esphome/pull/12517)

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes: https://github.com/esphome/feature-requests/issues/2047)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- docs: https://github.com/esphome/esphome-docs/pull/5785
- HA: https://github.com/home-assistant/home-assistant.io/pull/42599
- HA-core: https://github.com/home-assistant/core/pull/159201
- 
## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
water_heater:
  - platform: template
    id: my_boiler
    name: "Boiler"
    min_temperature: 10 °C
    max_temperature: 85 °C
    current_temperature: !lambda "return 45.0;"
    mode: !lambda "return water_heater::WATER_HEATER_MODE_ECO;"
    optimistic: true
    visual:
      min_temperature: 10 °C
      max_temperature: 85 °C
      target_temperature_step: 0.5 °C
      current_temperature_step: 0.1 °C
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
