### PR TITLE
[hub75] Add set_brightness action

### DIFF
--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -179,7 +179,7 @@ void HOT HUB75Display::draw_pixels_at(int x_start, int y_start, int w, int h, co
   }
 }
 
-void HUB75Display::set_brightness(int brightness) {
+void HUB75Display::set_brightness(uint8_t brightness) {
   this->brightness_ = brightness;
   this->enabled_ = (brightness > 0);
   if (this->driver_ != nullptr) {

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "esphome/components/display/display_buffer.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
@@ -34,7 +35,7 @@ class HUB75Display : public display::Display {
                       display::ColorBitness bitness, bool big_endian, int x_offset, int y_offset, int x_pad) override;
 
   // Brightness control (runtime mutable)
-  void set_brightness(int brightness);
+  void set_brightness(uint8_t brightness);
 
  protected:
   // Display internal methods
@@ -46,8 +47,15 @@ class HUB75Display : public display::Display {
   Hub75Config config_;  // Immutable configuration
 
   // Runtime state (mutable)
-  int brightness_{128};
+  uint8_t brightness_{128};
   bool enabled_{false};
+};
+
+template<typename... Ts> class SetBrightnessAction : public Action<Ts...>, public Parented<HUB75Display> {
+ public:
+  TEMPLATABLE_VALUE(uint8_t, brightness)
+
+  void play(const Ts &...x) override { this->parent_->set_brightness(this->brightness_.value(x...)); }
 };
 
 }  // namespace esphome::hub75

--- a/tests/components/hub75/common.yaml
+++ b/tests/components/hub75/common.yaml
@@ -1,0 +1,12 @@
+esphome:
+  on_boot:
+    # Test simple value
+    - hub75.set_brightness: 200
+
+    # Test templatable value
+    - hub75.set_brightness: !lambda 'return 100;'
+
+    # Test with explicit ID
+    - hub75.set_brightness:
+        id: my_hub75
+        brightness: 50

--- a/tests/components/hub75/test.esp32-idf.yaml
+++ b/tests/components/hub75/test.esp32-idf.yaml
@@ -3,6 +3,19 @@ esp32:
   framework:
     type: esp-idf
 
+esphome:
+  on_boot:
+    # Test simple value
+    - hub75.set_brightness: 200
+
+    # Test templatable value
+    - hub75.set_brightness: !lambda 'return 100;'
+
+    # Test with explicit ID
+    - hub75.set_brightness:
+        id: my_hub75
+        brightness: 50
+
 display:
   - platform: hub75
     id: my_hub75

--- a/tests/components/hub75/test.esp32-idf.yaml
+++ b/tests/components/hub75/test.esp32-idf.yaml
@@ -1,21 +1,3 @@
-esp32:
-  board: esp32dev
-  framework:
-    type: esp-idf
-
-esphome:
-  on_boot:
-    # Test simple value
-    - hub75.set_brightness: 200
-
-    # Test templatable value
-    - hub75.set_brightness: !lambda 'return 100;'
-
-    # Test with explicit ID
-    - hub75.set_brightness:
-        id: my_hub75
-        brightness: 50
-
 display:
   - platform: hub75
     id: my_hub75
@@ -50,3 +32,5 @@ display:
       then:
         lambda: |-
           ESP_LOGD("display", "1 -> 2");
+
+<<: !include common.yaml

--- a/tests/components/hub75/test.esp32-s3-idf-board.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf-board.yaml
@@ -1,8 +1,3 @@
-esp32:
-  board: esp32-s3-devkitc-1
-  framework:
-    type: esp-idf
-
 display:
   - platform: hub75
     id: hub75_display_board
@@ -24,3 +19,5 @@ display:
       then:
         lambda: |-
           ESP_LOGD("display", "1 -> 2");
+
+<<: !include common.yaml

--- a/tests/components/hub75/test.esp32-s3-idf.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf.yaml
@@ -3,6 +3,19 @@ esp32:
   framework:
     type: esp-idf
 
+esphome:
+  on_boot:
+    # Test simple value
+    - hub75.set_brightness: 200
+
+    # Test templatable value
+    - hub75.set_brightness: !lambda 'return 100;'
+
+    # Test with explicit ID
+    - hub75.set_brightness:
+        id: my_hub75
+        brightness: 50
+
 display:
   - platform: hub75
     id: my_hub75

--- a/tests/components/hub75/test.esp32-s3-idf.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf.yaml
@@ -1,21 +1,3 @@
-esp32:
-  board: esp32-s3-devkitc-1
-  framework:
-    type: esp-idf
-
-esphome:
-  on_boot:
-    # Test simple value
-    - hub75.set_brightness: 200
-
-    # Test templatable value
-    - hub75.set_brightness: !lambda 'return 100;'
-
-    # Test with explicit ID
-    - hub75.set_brightness:
-        id: my_hub75
-        brightness: 50
-
 display:
   - platform: hub75
     id: my_hub75
@@ -50,3 +32,5 @@ display:
       then:
         lambda: |-
           ESP_LOGD("display", "1 -> 2");
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5792

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```
# Matrix display controls
switch:
  - platform: template
    name: "Power"
    id: power
    icon: "mdi:power"
    restore_mode: RESTORE_DEFAULT_ON
    optimistic: true
    turn_on_action:
      - hub75.set_brightness:
          id: matrix
          brightness: !lambda return id(brightness).state;
    turn_off_action:
      - hub75.set_brightness:
          id: matrix
          brightness: 0

number:
  - platform: template
    name: "Brightness"
    id: brightness
    icon: "mdi:brightness-6"
    min_value: 1
    max_value: 255
    step: 1
    optimistic: true
    restore_value: true
    initial_value: 128
    on_value:
      then:
        - if:
            condition:
              switch.is_on: power
            then:
              - hub75.set_brightness:
                  id: matrix
                  brightness: !lambda return x;

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
