### PR TITLE
[pm1006] Fix "never" update interval detection

### DIFF
--- a/esphome/components/pm1006/sensor.py
+++ b/esphome/components/pm1006/sensor.py
@@ -7,10 +7,10 @@ from esphome.const import (
     CONF_UPDATE_INTERVAL,
     DEVICE_CLASS_PM25,
     ICON_BLUR,
+    SCHEDULER_DONT_RUN,
     STATE_CLASS_MEASUREMENT,
     UNIT_MICROGRAMS_PER_CUBIC_METER,
 )
-from esphome.core import TimePeriodMilliseconds
 
 CODEOWNERS = ["@habbie"]
 DEPENDENCIES = ["uart"]
@@ -41,16 +41,12 @@ CONFIG_SCHEMA = cv.All(
 
 
 def validate_interval_uart(config):
-    require_tx = False
-
     interval = config.get(CONF_UPDATE_INTERVAL)
-
-    if isinstance(interval, TimePeriodMilliseconds):
-        # 'never' is encoded as a very large int, not as a TimePeriodMilliseconds objects
-        require_tx = True
-
     uart.final_validate_device_schema(
-        "pm1006", baud_rate=9600, require_rx=True, require_tx=require_tx
+        "pm1006",
+        baud_rate=9600,
+        require_rx=True,
+        require_tx=interval.total_milliseconds != SCHEDULER_DONT_RUN,
     )(config)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes detection of `never` update interval failing, causing `pm1006` to incorrectly require a TX pin.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- introduced by #12478
- fixes #12526

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pm1006
    pm_2_5:
      name: "Particulate Matter 2.5µm concentration"

uart:
  rx_pin: D2
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
