### PR TITLE
[spi] Add SPIInterface stub for clang-tidy on unsupported platforms

### DIFF
--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -1,5 +1,4 @@
 #pragma once
-#ifndef USE_ZEPHYR
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
@@ -23,6 +22,10 @@ using SPIInterface = SPIClassRP2040 *;
 #else
 using SPIInterface = SPIClass *;
 #endif
+
+#elif defined(CLANG_TIDY)
+
+using SPIInterface = void *;  // Stub for platforms without SPI (e.g., Zephyr)
 
 #endif  // USE_ESP32 / USE_ARDUINO
 
@@ -503,4 +506,3 @@ class SPIDevice : public SPIClient {
 };
 
 }  // namespace esphome::spi
-#endif  // USE_ZEPHYR


### PR DESCRIPTION
# What does this implement/fix?

Adds a stub `SPIInterface` type alias for clang-tidy static analysis on platforms that don't support SPI (e.g., Zephyr/nRF52).

Previously, `spi.h` was wrapped in `#ifndef USE_ZEPHYR` which excluded the entire file on Zephyr. However, when clang-tidy runs with `--all-headers`, it includes all header files including SPI-dependent components like `adc128s102.h`. These components inherit from `spi::SPIDevice` which requires the SPI namespace to be defined.

This change:
- Removes the `#ifndef USE_ZEPHYR` wrapper
- Adds an `#elif defined(CLANG_TIDY)` branch that provides a `void*` stub for `SPIInterface`
- Allows clang-tidy to analyze SPI-dependent headers on all platforms
- Real builds on unsupported platforms will still fail if they try to use SPI (since `SPIInterface` won't be defined without `CLANG_TIDY`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes clang-tidy CI failure on nRF52/Zephyr platform

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a build infrastructure fix, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)