### PR TITLE
[esp32_camera] Fix I2C driver conflict with other components

### DIFF
--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -352,7 +352,6 @@ async def to_code(config):
     cg.add_define("USE_CAMERA")
 
     add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
-    # Use new SCCB I2C driver to avoid conflicts with other I2C components
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
 

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -3,7 +3,7 @@ import logging
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import i2c
-from esphome.components.esp32 import add_idf_component
+from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
 from esphome.components.psram import DOMAIN as psram_domain
 import esphome.config_validation as cv
 from esphome.const import (
@@ -352,6 +352,9 @@ async def to_code(config):
     cg.add_define("USE_CAMERA")
 
     add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
+    # Use new SCCB I2C driver to avoid conflicts with other I2C components
+    add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
+    add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)


### PR DESCRIPTION
# What does this implement/fix?

Fix boot loops on ESP32-S3 devices when using `esp32_camera` with other I2C components (e.g., `pn532`).

## The conflict

Since #8483, ESPHome's I2C component uses the new `i2c_master.h` API (driver_ng) on IDF 5.4+. The esp32-camera component's SCCB (camera I2C bus) needs to use the matching new driver, otherwise you get:
```
E (257) i2c: CONFLICT! driver_ng is not allowed to be used with this old driver
```

## The fix

The esp32-camera component should default to the new SCCB I2C driver on IDF 5.4+, but for some users it doesn't. The root cause is unclear as it works fine in some environments.

This PR explicitly sets the sdkconfig options to ensure the new SCCB driver is always used, regardless of build environment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11916

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - the fix is automatic
esp32_camera:
  external_clock:
    pin: GPIO0
    frequency: 20MHz
  i2c_pins:
    sda: GPIO26
    scl: GPIO27
  data_pins: [GPIO5, GPIO18, GPIO19, GPIO21, GPIO36, GPIO39, GPIO34, GPIO35]
  vsync_pin: GPIO25
  href_pin: GPIO23
  pixel_clock_pin: GPIO22
  name: My Camera
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).