### PR TITLE
[libretiny] Fix millis() ambiguity on BK72XX

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -382,10 +382,15 @@ def include_file(path: Path, basename: Path, is_c_header: bool = False):
 
 
 ARDUINO_GLUE_CODE = """\
+#undef yield
 #define yield() esphome::yield()
+#undef millis
 #define millis() esphome::millis()
+#undef micros
 #define micros() esphome::micros()
+#undef delay
 #define delay(x) esphome::delay(x)
+#undef delayMicroseconds
 #define delayMicroseconds(x) esphome::delayMicroseconds(x)
 """
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -537,7 +537,7 @@ async def to_code(config: ConfigType) -> None:
     if config[CONF_DEBUG_SCHEDULER]:
         cg.add_define("ESPHOME_DEBUG_SCHEDULER")
 
-    if CORE.using_arduino and not CORE.is_bk72xx:
+    if CORE.using_arduino:
         CORE.add_job(add_arduino_global_workaround)
 
     if config[CONF_INCLUDES]:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Removes the BK72XX exclusion from the Arduino global workaround that adds `#define millis() esphome::millis()` (and similar macros). Without this workaround, BK72XX builds fail with ambiguous call errors when code uses `millis()` without explicit namespace qualification.

The exclusion was originally added in PR #3509 (initial LibreTiny support) but the reason for excluding BK72XX specifically was not documented. RTL87XX (also LibreTiny) was never excluded and works correctly with the workaround.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12361

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).