### PR TITLE
[bme68x_bsec2_i2c] Add MULTI_CONF to fix multiple sensors

### DIFF
--- a/esphome/components/bme68x_bsec2_i2c/__init__.py
+++ b/esphome/components/bme68x_bsec2_i2c/__init__.py
@@ -11,6 +11,7 @@ CODEOWNERS = ["@neffs", "@kbx81"]
 
 AUTO_LOAD = ["bme68x_bsec2"]
 DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
 
 bme68x_bsec2_i2c_ns = cg.esphome_ns.namespace("bme68x_bsec2_i2c")
 BME68xBSEC2I2CComponent = bme68x_bsec2_i2c_ns.class_(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Adds `MULTI_CONF = True` to the `bme68x_bsec2_i2c` component, allowing users to configure multiple BME680/BME688 sensors with the BSEC2 library.

Without this change, attempting to configure multiple sensors results in an "expected a dictionary" error because ESPHome treats the component as single-instance only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11351

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bme68x_bsec2_i2c:
  - id: sensor1
    address: 0x76
    model: bme680
  - id: sensor2
    address: 0x77
    model: bme680
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).