### PR TITLE
[nextion] Fix clang-tidy error on Zephyr for HTTPClient

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1426,7 +1426,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &range_start);
-#else
+#elif defined(USE_ARDUINO)
   /**
    * will request chunk_size chunks from the web server
    * and send each to the nextion
@@ -1435,7 +1435,7 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
    * @return position of last byte transferred, -1 for failure.
    */
   int upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start);
-#endif  // USE_ESP32 vs others
+#endif  // USE_ESP32 vs USE_ARDUINO
 
   /**
    * Ends the upload process, restart Nextion and, if successful,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fixes clang-tidy error on Zephyr caused by #9429. The PR changed the preprocessor guard from `#ifdef USE_ARDUINO ... #elif defined(USE_ESP_IDF)` to `#ifdef USE_ESP32 ... #else`, but the `#else` branch catches Zephyr where `HTTPClient` doesn't exist.

This changes `#else` to `#elif defined(USE_ARDUINO)` to match the include guards at the top of the file which correctly use `#elif defined(USE_ESP8266)`.

Error:
```
esphome/components/nextion/nextion.h:1437:25: error: unknown type name 'HTTPClient' [clang-diagnostic-error]
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Caused by #9429

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - clang-tidy fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).