### PR TITLE
[cc1101] Fix default frequencies

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -99,7 +99,7 @@ CC1101Component::CC1101Component() {
   this->state_.FS_AUTOCAL = 1;
 
   // Default Settings
-  this->set_frequency(433920);
+  this->set_frequency(433920000);
   this->set_if_frequency(153);
   this->set_filter_bandwidth(203);
   this->set_channel(0);

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -100,10 +100,10 @@ CC1101Component::CC1101Component() {
 
   // Default Settings
   this->set_frequency(433920000);
-  this->set_if_frequency(153);
-  this->set_filter_bandwidth(203);
+  this->set_if_frequency(153000);
+  this->set_filter_bandwidth(203000);
   this->set_channel(0);
-  this->set_channel_spacing(200);
+  this->set_channel_spacing(200000);
   this->set_symbol_rate(5000);
   this->set_sync_mode(SyncMode::SYNC_MODE_NONE);
   this->set_carrier_sense_above_threshold(true);


### PR DESCRIPTION
# What does this implement/fix?

When a (very nice) configuration type change was introduced by #12313, the call to set default frequency to 433.92 MHz was not adjusted to use Hz instead of kHz.

That results in the component trying to set the frequency to 433.92 **k**Hz, if none is specified in the configuration.

My small change fixes this so the component behaves as documented.

UPD: The IF frequency, filter bandwidth and channel spacing values were affected as well. Fixed that too.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
