### PR TITLE
[ci] Check changed headers in clang-tidy when using --changed

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -253,18 +253,30 @@ def main():
         print(f"Split {args.split_at}/{args.split_num}: checking {len(files)} files")
 
     # Print file count before adding header file
-    print(f"\nTotal files to check: {len(files)}")
+    print(f"\nTotal cpp files to check: {len(files)}")
+
+    # Add header file for checking (before early exit check)
+    if args.all_headers and args.split_at in (None, 1):
+        # When --changed is used, only include changed headers instead of all headers
+        if args.changed:
+            all_headers = [
+                os.path.relpath(p, cwd) for p in git_ls_files(["esphome/**/*.h"])
+            ]
+            changed_headers = filter_changed(all_headers)
+            if changed_headers:
+                build_all_include(changed_headers)
+                files.insert(0, temp_header_file)
+            else:
+                print("No changed headers to check")
+        else:
+            build_all_include()
+            files.insert(0, temp_header_file)
+            print(f"Added all-include header file, new total: {len(files)}")
 
     # Early exit if no files to check
     if not files:
         print("No files to check - exiting early")
         return 0
-
-    # Only build header file if we have actual files to check
-    if args.all_headers and args.split_at in (None, 1):
-        build_all_include()
-        files.insert(0, temp_header_file)
-        print(f"Added all-include header file, new total: {len(files)}")
 
     # Print final file list before loading idedata
     print_file_list(files, "Final files to process:")


### PR DESCRIPTION
# What does this implement/fix?

When running clang-tidy with `--changed --all-headers`, previously all headers were included in the all-include.cpp file. This meant that header-only changes that didn't match the `--grep` filter would not be checked.

This PR modifies the behavior so that when `--changed` is combined with `--all-headers`, only the headers that have actually changed are included. This ensures header-only changes are checked by clang-tidy on all platforms, even when the `--grep` filter would normally exclude them.

**Background**: This was discovered when PR #9429 introduced a Zephyr clang-tidy error in `nextion.h`. The CI didn't catch it because the Zephyr clang-tidy job uses `--grep USE_ZEPHYR --grep USE_NRF52` to filter files, and none of the files modified contain those strings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI tooling)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a CI script change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).