### PR TITLE
[esp32][libretiny] Avoid duplicate snprintf when syncing preferences

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -130,10 +130,10 @@ class ESP32Preferences : public ESPPreferences {
     // go through vector from back to front (makes erase easier/more efficient)
     for (ssize_t i = s_pending_save.size() - 1; i >= 0; i--) {
       const auto &save = s_pending_save[i];
-      ESP_LOGVV(TAG, "Checking if NVS data %" PRIu32 " has changed", save.key);
-      if (this->is_changed(this->nvs_handle, save)) {
-        char key_str[KEY_BUFFER_SIZE];
-        snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+      char key_str[KEY_BUFFER_SIZE];
+      snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+      ESP_LOGVV(TAG, "Checking if NVS data %s has changed", key_str);
+      if (this->is_changed_(this->nvs_handle, save, key_str)) {
         esp_err_t err = nvs_set_blob(this->nvs_handle, key_str, save.data.get(), save.len);
         ESP_LOGV(TAG, "sync: key: %s, len: %zu", key_str, save.len);
         if (err != 0) {
@@ -166,10 +166,9 @@ class ESP32Preferences : public ESPPreferences {
 
     return failed == 0;
   }
-  bool is_changed(const uint32_t nvs_handle, const NVSData &to_save) {
-    char key_str[KEY_BUFFER_SIZE];
-    snprintf(key_str, sizeof(key_str), "%" PRIu32, to_save.key);
 
+ protected:
+  bool is_changed_(uint32_t nvs_handle, const NVSData &to_save, const char *key_str) {
     size_t actual_len;
     esp_err_t err = nvs_get_blob(nvs_handle, key_str, nullptr, &actual_len);
     if (err != 0) {

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -120,10 +120,10 @@ class LibreTinyPreferences : public ESPPreferences {
     // go through vector from back to front (makes erase easier/more efficient)
     for (ssize_t i = s_pending_save.size() - 1; i >= 0; i--) {
       const auto &save = s_pending_save[i];
-      ESP_LOGVV(TAG, "Checking if FDB data %" PRIu32 " has changed", save.key);
-      if (this->is_changed(&this->db, save)) {
-        char key_str[KEY_BUFFER_SIZE];
-        snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+      char key_str[KEY_BUFFER_SIZE];
+      snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+      ESP_LOGVV(TAG, "Checking if FDB data %s has changed", key_str);
+      if (this->is_changed_(&this->db, save, key_str)) {
         ESP_LOGV(TAG, "sync: key: %s, len: %zu", key_str, save.len);
         fdb_blob_make(&this->blob, save.data.get(), save.len);
         fdb_err_t err = fdb_kv_set_blob(&this->db, key_str, &this->blob);
@@ -150,10 +150,8 @@ class LibreTinyPreferences : public ESPPreferences {
     return failed == 0;
   }
 
-  bool is_changed(const fdb_kvdb_t db, const NVSData &to_save) {
-    char key_str[KEY_BUFFER_SIZE];
-    snprintf(key_str, sizeof(key_str), "%" PRIu32, to_save.key);
-
+ protected:
+  bool is_changed_(fdb_kvdb_t db, const NVSData &to_save, const char *key_str) {
     struct fdb_kv kv;
     fdb_kv_t kvp = fdb_kv_get_obj(db, key_str, &kv);
     if (kvp == nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

Avoids duplicate `snprintf` calls when syncing preferences by converting the key to a string once and passing it to `is_changed_()`.

Previously, when a preference had changed, `snprintf` was called twice for the same key:
1. Inside `is_changed()` to check if the value changed
2. In `sync()` immediately after to write the value

This change moves the string conversion before the `is_changed_()` call and passes the pre-converted string, eliminating the redundant conversion.

Also moves `is_changed_()` to the `protected` section with proper naming convention.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #12494

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
