### PR TITLE
[hlk_fm22x] Fix Action play() signature to match base class

### DIFF
--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -189,7 +189,7 @@ template<typename... Ts> class EnrollmentAction : public Action<Ts...>, public P
   TEMPLATABLE_VALUE(std::string, name)
   TEMPLATABLE_VALUE(uint8_t, direction)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     auto name = this->name_.value(x...);
     auto direction = (HlkFm22xFaceDirection) this->direction_.value(x...);
     this->parent_->enroll_face(name, direction);
@@ -200,7 +200,7 @@ template<typename... Ts> class DeleteAction : public Action<Ts...>, public Paren
  public:
   TEMPLATABLE_VALUE(int16_t, face_id)
 
-  void play(Ts... x) override {
+  void play(const Ts &...x) override {
     auto face_id = this->face_id_.value(x...);
     this->parent_->delete_face(face_id);
   }
@@ -208,17 +208,17 @@ template<typename... Ts> class DeleteAction : public Action<Ts...>, public Paren
 
 template<typename... Ts> class DeleteAllAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->delete_all_faces(); }
+  void play(const Ts &...x) override { this->parent_->delete_all_faces(); }
 };
 
 template<typename... Ts> class ScanAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->scan_face(); }
+  void play(const Ts &...x) override { this->parent_->scan_face(); }
 };
 
 template<typename... Ts> class ResetAction : public Action<Ts...>, public Parented<HlkFm22xComponent> {
  public:
-  void play(Ts... x) override { this->parent_->reset(); }
+  void play(const Ts &...x) override { this->parent_->reset(); }
 };
 
 }  // namespace esphome::hlk_fm22x


### PR DESCRIPTION
# What does this implement/fix?

Fix `play()` method signatures in hlk_fm22x action classes to match the base `Action` class signature. This component was missed in PR #11704 which changed the Action framework to use const references.

Without this fix, the hlk_fm22x actions fail to compile when used with API service variables (where `Ts` is non-empty).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #11704

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - existing component, signature fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).