### PR TITLE
[api] Remove unused force parameter from encode_message

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -124,12 +124,12 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer buffer) const {
 #endif
 #ifdef USE_DEVICES
   for (const auto &it : this->devices) {
-    buffer.encode_message(20, it, true);
+    buffer.encode_message(20, it);
   }
 #endif
 #ifdef USE_AREAS
   for (const auto &it : this->areas) {
-    buffer.encode_message(21, it, true);
+    buffer.encode_message(21, it);
   }
 #endif
 #ifdef USE_AREAS
@@ -878,13 +878,13 @@ void HomeassistantServiceMap::calculate_size(ProtoSize &size) const {
 void HomeassistantActionRequest::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->service_ref_);
   for (auto &it : this->data) {
-    buffer.encode_message(2, it, true);
+    buffer.encode_message(2, it);
   }
   for (auto &it : this->data_template) {
-    buffer.encode_message(3, it, true);
+    buffer.encode_message(3, it);
   }
   for (auto &it : this->variables) {
-    buffer.encode_message(4, it, true);
+    buffer.encode_message(4, it);
   }
   buffer.encode_bool(5, this->is_event);
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
@@ -1011,7 +1011,7 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_string(1, this->name_ref_);
   buffer.encode_fixed32(2, this->key);
   for (auto &it : this->args) {
-    buffer.encode_message(3, it, true);
+    buffer.encode_message(3, it);
   }
   buffer.encode_uint32(4, static_cast<uint32_t>(this->supports_response));
 }
@@ -1867,7 +1867,7 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(7, static_cast<uint32_t>(this->entity_category));
   buffer.encode_bool(8, this->supports_pause);
   for (auto &it : this->supported_formats) {
-    buffer.encode_message(9, it, true);
+    buffer.encode_message(9, it);
   }
 #ifdef USE_DEVICES
   buffer.encode_uint32(10, this->device_id);
@@ -1987,7 +1987,7 @@ void BluetoothLERawAdvertisement::calculate_size(ProtoSize &size) const {
 }
 void BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer buffer) const {
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
-    buffer.encode_message(1, this->advertisements[i], true);
+    buffer.encode_message(1, this->advertisements[i]);
   }
 }
 void BluetoothLERawAdvertisementsResponse::calculate_size(ProtoSize &size) const {
@@ -2060,7 +2060,7 @@ void BluetoothGATTCharacteristic::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint32(2, this->handle);
   buffer.encode_uint32(3, this->properties);
   for (auto &it : this->descriptors) {
-    buffer.encode_message(4, it, true);
+    buffer.encode_message(4, it);
   }
   buffer.encode_uint32(5, this->short_uuid);
 }
@@ -2081,7 +2081,7 @@ void BluetoothGATTService::encode(ProtoWriteBuffer buffer) const {
   }
   buffer.encode_uint32(2, this->handle);
   for (auto &it : this->characteristics) {
-    buffer.encode_message(3, it, true);
+    buffer.encode_message(3, it);
   }
   buffer.encode_uint32(4, this->short_uuid);
 }
@@ -2097,7 +2097,7 @@ void BluetoothGATTService::calculate_size(ProtoSize &size) const {
 void BluetoothGATTGetServicesResponse::encode(ProtoWriteBuffer buffer) const {
   buffer.encode_uint64(1, this->address);
   for (auto &it : this->services) {
-    buffer.encode_message(2, it, true);
+    buffer.encode_message(2, it);
   }
 }
 void BluetoothGATTGetServicesResponse::calculate_size(ProtoSize &size) const {
@@ -2557,7 +2557,7 @@ bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoL
 }
 void VoiceAssistantConfigurationResponse::encode(ProtoWriteBuffer buffer) const {
   for (auto &it : this->available_wake_words) {
-    buffer.encode_message(1, it, true);
+    buffer.encode_message(1, it);
   }
   for (const auto &it : *this->active_wake_words) {
     buffer.encode_string(2, it, true);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -334,7 +334,7 @@ class ProtoWriteBuffer {
   void encode_sint64(uint32_t field_id, int64_t value, bool force = false) {
     this->encode_uint64(field_id, encode_zigzag64(value), force);
   }
-  void encode_message(uint32_t field_id, const ProtoMessage &value, bool force = false);
+  void encode_message(uint32_t field_id, const ProtoMessage &value);
   std::vector<uint8_t> *get_buffer() const { return buffer_; }
 
  protected:
@@ -795,7 +795,7 @@ class ProtoSize {
 };
 
 // Implementation of encode_message - must be after ProtoMessage is defined
-inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessage &value, bool force) {
+inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessage &value) {
   this->encode_field_raw(field_id, 2);  // type 2: Length-delimited message
 
   // Calculate the message size first


### PR DESCRIPTION
# What does this implement/fix?

Removes dead code: the unused `force` parameter from `ProtoWriteBuffer::encode_message()`.

All callers were passing `true` for this parameter, but the value was completely ignored - embedded messages are always encoded unconditionally. This was confusing because the code appeared to control behavior that didn't exist.

The parameter was added in 2019 for API consistency with primitive encode functions (where `force` controls whether default values are skipped), but it was never implemented for messages.

## Changes

- Remove unused `force` parameter from `encode_message()` in `proto.h`
- Update code generator to not emit the unused argument
- Regenerate `api_pb2.cpp`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Dead code removal

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
