### PR TITLE
[core] Deprecate custom_components folder

### DIFF
--- a/esphome/loader.py
+++ b/esphome/loader.py
@@ -187,7 +187,14 @@ def install_meta_finder(
 
 
 def install_custom_components_meta_finder():
+    # Remove before 2026.6.0
     custom_components_dir = (Path(CORE.config_dir) / "custom_components").resolve()
+    if custom_components_dir.is_dir() and any(custom_components_dir.iterdir()):
+        _LOGGER.warning(
+            "The 'custom_components' folder is deprecated and will be removed in 2026.6.0. "
+            "Please use 'external_components' instead. "
+            "See https://esphome.io/components/external_components.html for more information."
+        )
     install_meta_finder(custom_components_dir)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Add a deprecation warning when the `custom_components` folder is used. Users should migrate to `external_components` instead.

The warning only appears if the `custom_components` folder exists and contains files.

Scheduled for removal in 2026.6.0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12546

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - deprecation warning only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).