### PR TITLE
[mmc5603] enable AUTO_SR_en to compensate for temperature drift

### DIFF
--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -83,7 +83,7 @@ void MMC5603Component::dump_config() {
     ESP_LOGE(TAG, "The ID registers don't match - Is this really an MMC5603?");
   }
   LOG_UPDATE_INTERVAL(this);
-  ESP_LOGCONFIG(TAG, "  Auto set/reset: %s", this->auto_set_reset_ ? "ENABLED" : "DISABLED");
+  ESP_LOGCONFIG(TAG, "  Auto set/reset: %s", ONOFF(this->auto_set_reset_));
 
   LOG_SENSOR("  ", "X Axis", this->x_sensor_);
   LOG_SENSOR("  ", "Y Axis", this->y_sensor_);

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -83,6 +83,7 @@ void MMC5603Component::dump_config() {
     ESP_LOGE(TAG, "The ID registers don't match - Is this really an MMC5603?");
   }
   LOG_UPDATE_INTERVAL(this);
+  ESP_LOGCONFIG(TAG, "  Auto set/reset: %s", this->auto_set_reset_ ? "ENABLED" : "DISABLED");
 
   LOG_SENSOR("  ", "X Axis", this->x_sensor_);
   LOG_SENSOR("  ", "Y Axis", this->y_sensor_);
@@ -93,7 +94,8 @@ void MMC5603Component::dump_config() {
 float MMC5603Component::get_setup_priority() const { return setup_priority::DATA; }
 
 void MMC5603Component::update() {
-  if (!this->write_byte(MMC56X3_CTRL0_REG, 0x01)) {
+  uint8_t ctrl0 = (this->auto_set_reset_) ? 0x21 : 0x01;
+  if (!this->write_byte(MMC56X3_CTRL0_REG, ctrl0)) {
     this->status_set_warning();
     return;
   }

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -25,6 +25,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   void set_y_sensor(sensor::Sensor *y_sensor) { y_sensor_ = y_sensor; }
   void set_z_sensor(sensor::Sensor *z_sensor) { z_sensor_ = z_sensor; }
   void set_heading_sensor(sensor::Sensor *heading_sensor) { heading_sensor_ = heading_sensor; }
+  void set_auto_set_reset(bool auto_set_reset) { auto_set_reset_ = auto_set_reset; }
 
  protected:
   MMC5603Datarate datarate_;
@@ -32,6 +33,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *y_sensor_{nullptr};
   sensor::Sensor *z_sensor_{nullptr};
   sensor::Sensor *heading_sensor_{nullptr};
+  bool auto_set_reset_{true};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -33,7 +33,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *y_sensor_{nullptr};
   sensor::Sensor *z_sensor_{nullptr};
   sensor::Sensor *heading_sensor_{nullptr};
-  bool auto_set_reset_;
+  bool auto_set_reset_{true};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -33,7 +33,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *y_sensor_{nullptr};
   sensor::Sensor *z_sensor_{nullptr};
   sensor::Sensor *heading_sensor_{nullptr};
-  bool auto_set_reset_{true};
+  bool auto_set_reset_;
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,

--- a/esphome/components/mmc5603/sensor.py
+++ b/esphome/components/mmc5603/sensor.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_FIELD_STRENGTH_Y): field_strength_schema,
             cv.Optional(CONF_FIELD_STRENGTH_Z): field_strength_schema,
             cv.Optional(CONF_HEADING): heading_schema,
-            cv.Optional(CONF_AUTO_SET_RESET): cv.boolean,
+            cv.Optional(CONF_AUTO_SET_RESET, default=True): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("60s"))

--- a/esphome/components/mmc5603/sensor.py
+++ b/esphome/components/mmc5603/sensor.py
@@ -16,6 +16,8 @@ from esphome.const import (
     UNIT_MICROTESLA,
 )
 
+CONF_AUTO_SET_RESET = "auto_set_reset"
+
 DEPENDENCIES = ["i2c"]
 
 mmc5603_ns = cg.esphome_ns.namespace("mmc5603")
@@ -54,6 +56,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_FIELD_STRENGTH_Y): field_strength_schema,
             cv.Optional(CONF_FIELD_STRENGTH_Z): field_strength_schema,
             cv.Optional(CONF_HEADING): heading_schema,
+            cv.Optional(CONF_AUTO_SET_RESET): cv.boolean,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -88,3 +91,5 @@ async def to_code(config):
     if CONF_HEADING in config:
         sens = await sensor.new_sensor(config[CONF_HEADING])
         cg.add(var.set_heading_sensor(sens))
+    if CONF_AUTO_SET_RESET in config:
+        cg.add(var.set_auto_set_reset(config[CONF_AUTO_SET_RESET]))

--- a/tests/components/mmc5603/common.yaml
+++ b/tests/components/mmc5603/common.yaml
@@ -2,6 +2,7 @@ sensor:
   - platform: mmc5603
     i2c_id: i2c_bus
     address: 0x30
+    auto_set_reset: true
     field_strength_x:
       name: HMC5883L Field Strength X
     field_strength_y:


### PR DESCRIPTION
# What does this implement/fix?

Readings from the MMC5603 drift significantly with temperature change.  This PR corrects that by adding an option for the MMC5603 automatic SET/RESET feature (AUTO_SR_en), and **enabled by default**.

## Context
The MMC5603 is a triple access magnetometer.  It has a feature called 'set/reset' which can be done manually through a series of 5 steps, or automatically just by enabling the `AUTO_SR_en` feature when taking a measurement.  According to the [datasheet](https://www.memsic.com/Public/Uploads/uploadfile/files/20220119/MMC5603NJDatasheetRev.B.pdf), that feature:

> - Eliminates thermal variation induced offset error (Null field output)
> - Clears the residual magnetization resulting from strong external fields

The current MMC5603 driver in ESPHome **does not use the set/reset feature when taking a measurement**, which is needed for accurate readings.  It only does set/reset on setup.

## Results

I am using an MMC5603 to measure a residential gas meter.  It reads a moving magnet inside the meter.  When gas flows, the graph should oscillate like a sine wave (no movement when gas is not flowing). 

### Before
As the temperature of the sensor changes, readings drift significantly.  This is a graph of readings from morning (cold) to afternoon (hot).  At noon the sun hits the meter when it is hottest:

![Screenshot 2025-12-18 at 9 35 46 AM copy](https://github.com/user-attachments/assets/06b13f6f-0f0f-4c75-bd73-a8d036e592ca)

### After

The datasheet does not lie when it says "Eliminates thermal variation".  Readings no longer drift (throughout night up to noon when it is hottest):

![After](https://github.com/user-attachments/assets/3da2361e-3da6-46c8-a298-f287a6375e2c)

## Should this be the default option?

I think so.

**Upsides:** This does eliminate significant temperature related drift.  The datasheet also recommends this feature be used:

> Auto_SR_en - Writing a 1 into this location will enable the function of automatic set/reset. This function applies
> to both on-demand and continuous-time measurements. This bit must be set to 1 in order to
> activate the feature of periodic set. **This bit is recommended to set to “1” in the application.**

**Downsides:** the current driver sets BW=00, which is the slowest and most accurate measurement time of 6.6ms (150Hz).  With Auto_SR_en = 1, two measurements are taken so max read frequency is reduced from 150Hz to 75Hz.  This could impact exising users unless they disable this option.

Note: if high frequency reading is needed, inhibiting unused axes and reducing measurement time (via Control Register 1) could be added as features to this component.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:**

- esphome/esphome-docs#5803

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: mmc5603
    id: mmc5603_sensor
    auto_set_reset: true
    field_strength_x:
      name: "Magnetic Field X"
    field_strength_y:
      name: "Magnetic Field Y"
    field_strength_z:
      name: "Magnetic Field Z"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs]
 
