### PR TITLE
[nextion] Fix `FILTER_SOURCE_FILES` location

### DIFF
--- a/esphome/components/nextion/__init__.py
+++ b/esphome/components/nextion/__init__.py
@@ -1,7 +1,5 @@
 import esphome.codegen as cg
 from esphome.components import uart
-from esphome.config_helpers import filter_source_files_from_platform
-from esphome.const import PlatformFramework
 
 nextion_ns = cg.esphome_ns.namespace("nextion")
 Nextion = nextion_ns.class_("Nextion", cg.PollingComponent, uart.UARTDevice)
@@ -10,19 +8,3 @@ nextion_ref = Nextion.operator("ref")
 CONF_NEXTION_ID = "nextion_id"
 CONF_PUBLISH_STATE = "publish_state"
 CONF_SEND_TO_NEXTION = "send_to_nextion"
-
-FILTER_SOURCE_FILES = filter_source_files_from_platform(
-    {
-        "nextion_upload_esp32.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
-            PlatformFramework.ESP32_IDF,
-        },
-        "nextion_upload_arduino.cpp": {
-            PlatformFramework.ESP8266_ARDUINO,
-            PlatformFramework.RP2040_ARDUINO,
-            PlatformFramework.BK72XX_ARDUINO,
-            PlatformFramework.RTL87XX_ARDUINO,
-            PlatformFramework.LN882X_ARDUINO,
-        },
-    }
-)

--- a/esphome/components/nextion/base_component.py
+++ b/esphome/components/nextion/base_component.py
@@ -3,12 +3,10 @@ from string import ascii_letters, digits
 import esphome.codegen as cg
 from esphome.components import color
 import esphome.config_validation as cv
-from esphome.config_helpers import filter_source_files_from_platform
 from esphome.const import (
     CONF_BACKGROUND_COLOR,
     CONF_FOREGROUND_COLOR,
     CONF_VISIBLE,
-    PlatformFramework,
 )
 
 from . import CONF_NEXTION_ID, Nextion
@@ -134,20 +132,3 @@ async def setup_component_core_(var, config, arg):
 
     if CONF_VISIBLE in config:
         cg.add(var.set_visible(config[CONF_VISIBLE]))
-
-
-FILTER_SOURCE_FILES = filter_source_files_from_platform(
-    {
-        "nextion_upload_arduino.cpp": {
-            PlatformFramework.ESP8266_ARDUINO,
-            PlatformFramework.RP2040_ARDUINO,
-            PlatformFramework.BK72XX_ARDUINO,
-            PlatformFramework.RTL87XX_ARDUINO,
-            PlatformFramework.LN882X_ARDUINO,
-        },
-        "nextion_upload_esp32.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
-            PlatformFramework.ESP32_IDF,
-        },
-    }
-)

--- a/esphome/components/nextion/base_component.py
+++ b/esphome/components/nextion/base_component.py
@@ -3,11 +3,7 @@ from string import ascii_letters, digits
 import esphome.codegen as cg
 from esphome.components import color
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_BACKGROUND_COLOR,
-    CONF_FOREGROUND_COLOR,
-    CONF_VISIBLE,
-)
+from esphome.const import CONF_BACKGROUND_COLOR, CONF_FOREGROUND_COLOR, CONF_VISIBLE
 
 from . import CONF_NEXTION_ID, Nextion
 

--- a/esphome/components/nextion/base_component.py
+++ b/esphome/components/nextion/base_component.py
@@ -3,7 +3,13 @@ from string import ascii_letters, digits
 import esphome.codegen as cg
 from esphome.components import color
 import esphome.config_validation as cv
-from esphome.const import CONF_BACKGROUND_COLOR, CONF_FOREGROUND_COLOR, CONF_VISIBLE
+from esphome.config_helpers import filter_source_files_from_platform
+from esphome.const import (
+    CONF_BACKGROUND_COLOR,
+    CONF_FOREGROUND_COLOR,
+    CONF_VISIBLE,
+    PlatformFramework,
+)
 
 from . import CONF_NEXTION_ID, Nextion
 
@@ -128,3 +134,20 @@ async def setup_component_core_(var, config, arg):
 
     if CONF_VISIBLE in config:
         cg.add(var.set_visible(config[CONF_VISIBLE]))
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "nextion_upload_arduino.cpp": {
+            PlatformFramework.ESP8266_ARDUINO,
+            PlatformFramework.RP2040_ARDUINO,
+            PlatformFramework.BK72XX_ARDUINO,
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.LN882X_ARDUINO,
+        },
+        "nextion_upload_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
+    }
+)

--- a/esphome/components/nextion/base_component.py
+++ b/esphome/components/nextion/base_component.py
@@ -2,8 +2,8 @@ from string import ascii_letters, digits
 
 import esphome.codegen as cg
 from esphome.components import color
-import esphome.config_validation as cv
 from esphome.config_helpers import filter_source_files_from_platform
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_BACKGROUND_COLOR,
     CONF_FOREGROUND_COLOR,

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -1,6 +1,7 @@
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
+from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BRIGHTNESS,
@@ -8,6 +9,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_ON_TOUCH,
     CONF_TRIGGER_ID,
+    PlatformFramework
 )
 from esphome.core import CORE, TimePeriod
 
@@ -219,3 +221,20 @@ async def to_code(config):
     for conf in config.get(CONF_ON_BUFFER_OVERFLOW, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "nextion_upload_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
+        "nextion_upload_arduino.cpp": {
+            PlatformFramework.ESP8266_ARDUINO,
+            PlatformFramework.RP2040_ARDUINO,
+            PlatformFramework.BK72XX_ARDUINO,
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.LN882X_ARDUINO,
+        },
+    }
+)

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -9,7 +9,7 @@ from esphome.const import (
     CONF_LAMBDA,
     CONF_ON_TOUCH,
     CONF_TRIGGER_ID,
-    PlatformFramework
+    PlatformFramework,
 )
 from esphome.core import CORE, TimePeriod
 

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -2,12 +2,14 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
 import esphome.config_validation as cv
+from esphome.config_helpers import filter_source_files_from_platform
 from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_ID,
     CONF_LAMBDA,
     CONF_ON_TOUCH,
     CONF_TRIGGER_ID,
+    PlatformFramework,
 )
 from esphome.core import CORE, TimePeriod
 
@@ -219,3 +221,20 @@ async def to_code(config):
     for conf in config.get(CONF_ON_BUFFER_OVERFLOW, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "nextion_upload_arduino.cpp": {
+            PlatformFramework.ESP8266_ARDUINO,
+            PlatformFramework.RP2040_ARDUINO,
+            PlatformFramework.BK72XX_ARDUINO,
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.LN882X_ARDUINO,
+        },
+        "nextion_upload_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
+    }
+)

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -1,8 +1,8 @@
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
-from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
+from esphome.config_helpers import filter_source_files_from_platform
 from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_ID,
@@ -225,16 +225,16 @@ async def to_code(config):
 
 FILTER_SOURCE_FILES = filter_source_files_from_platform(
     {
-        "nextion_upload_esp32.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
-            PlatformFramework.ESP32_IDF,
-        },
         "nextion_upload_arduino.cpp": {
             PlatformFramework.ESP8266_ARDUINO,
             PlatformFramework.RP2040_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,
             PlatformFramework.LN882X_ARDUINO,
+        },
+        "nextion_upload_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
         },
     }
 )

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -1,8 +1,8 @@
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
-import esphome.config_validation as cv
 from esphome.config_helpers import filter_source_files_from_platform
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_ID,

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -2,14 +2,12 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import display, esp32, uart
 import esphome.config_validation as cv
-from esphome.config_helpers import filter_source_files_from_platform
 from esphome.const import (
     CONF_BRIGHTNESS,
     CONF_ID,
     CONF_LAMBDA,
     CONF_ON_TOUCH,
     CONF_TRIGGER_ID,
-    PlatformFramework,
 )
 from esphome.core import CORE, TimePeriod
 
@@ -221,20 +219,3 @@ async def to_code(config):
     for conf in config.get(CONF_ON_BUFFER_OVERFLOW, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
-
-
-FILTER_SOURCE_FILES = filter_source_files_from_platform(
-    {
-        "nextion_upload_arduino.cpp": {
-            PlatformFramework.ESP8266_ARDUINO,
-            PlatformFramework.RP2040_ARDUINO,
-            PlatformFramework.BK72XX_ARDUINO,
-            PlatformFramework.RTL87XX_ARDUINO,
-            PlatformFramework.LN882X_ARDUINO,
-        },
-        "nextion_upload_esp32.cpp": {
-            PlatformFramework.ESP32_ARDUINO,
-            PlatformFramework.ESP32_IDF,
-        },
-    }
-)


### PR DESCRIPTION
# What does this implement/fix?

This is similar to #10673, but while that one if fixing this to `adc`, this one do the same for `nextion`.

`FILTER_SOURCE_FILES` is supposed to be located in the file of the component/platform that is actually being loaded.


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
