### PR TITLE
[esp32_ble, esp32_ble_tracker] Fix crash, error messages when `ble.disable` called during boot

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -308,13 +308,21 @@ bool ESP32BLE::ble_setup_() {
 bool ESP32BLE::ble_dismantle_() {
   esp_err_t err = esp_bluedroid_disable();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_disable failed: %d", err);
-    return false;
+    // ESP_ERR_INVALID_STATE means Bluedroid is already disabled, which is fine
+    if (err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE(TAG, "esp_bluedroid_disable failed: %d", err);
+      return false;
+    }
+    ESP_LOGD(TAG, "Already disabled");
   }
   err = esp_bluedroid_deinit();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_deinit failed: %d", err);
-    return false;
+    // ESP_ERR_INVALID_STATE means Bluedroid is already deinitialized, which is fine
+    if (err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE(TAG, "esp_bluedroid_deinit failed: %d", err);
+      return false;
+    }
+    ESP_LOGD(TAG, "Already deinitialized");
   }
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -212,17 +212,23 @@ extern ESP32BLE *global_ble;
 
 template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {
  public:
-  bool check(const Ts &...x) override { return global_ble->is_active(); }
+  bool check(const Ts &...x) override { return global_ble != nullptr && global_ble->is_active(); }
 };
 
 template<typename... Ts> class BLEEnableAction : public Action<Ts...> {
  public:
-  void play(const Ts &...x) override { global_ble->enable(); }
+  void play(const Ts &...x) override {
+    if (global_ble != nullptr)
+      global_ble->enable();
+  }
 };
 
 template<typename... Ts> class BLEDisableAction : public Action<Ts...> {
  public:
-  void play(const Ts &...x) override { global_ble->disable(); }
+  void play(const Ts &...x) override {
+    if (global_ble != nullptr)
+      global_ble->disable();
+  }
 };
 
 }  // namespace esphome::esp32_ble

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -185,7 +185,10 @@ void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); 
 
 void ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {
-    ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
+    // If scanner is already idle, there's nothing to stop - this is not an error
+    if (this->scanner_state_ != ScannerState::IDLE) {
+      ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
+    }
     return;
   }
   // Reset timeout state machine when stopping scan


### PR DESCRIPTION
# What does this implement/fix?

This PR addresses two issues:

- A crash would occur if either `ble.disable` or `ble.enable` actions were called before the `global_ble` global variable was set. The following YAML is sufficient to reproduce this crash:
	```yaml
	switch:
	  - platform: template
	    id: bluetooth_enabled_switch
	    name: Bluetooth Enabled
	    optimistic: true
	    restore_mode: RESTORE_DEFAULT_OFF
	    turn_on_action:
	      - ble.enable:
	    turn_off_action:
	      - ble.disable:
	```
- After fixing the issue above, I realized that the `esp32_ble` component was being marked as failed if the `ble.disable` action was called while the Bluetooth stack was still initializing.
  - When Bluetooth is disabled at boot:
      - The component never initializes Bluedroid (it stays in DISABLED state)
      - But when disable() is called, it tries to dismantle BLE anyway
      - This causes `esp_bluedroid_disable()` to fail with `ESP_ERR_INVALID_STATE` (259) since Bluedroid was never enabled
      - The BLE tracker also tried to stop scanning when it was already idle, logging an unnecessary error
  - I made two minimal, targeted fixes:
	  1. `ble.cpp:308-326` - Made `ble_dismantle_()` resilient to being called when Bluedroid is already disabled:
		 - Now treats `ESP_ERR_INVALID_STATE` as a success case (logs debug message instead of error)
		 - Allows graceful shutdown whether BLE was enabled or not
      2. `esp32_ble_tracker.cpp:186-193` - Made `stop_scan_()` not log an error when scanner is already idle:
		 - Silently returns when scanner is in IDLE state (nothing to stop)
		 - Still logs errors for other unexpected states

## Impact

✅ Crash will not occur regardless of when `ble.disable` or `ble.enable` actions are called
✅ Component no longer marked as failed when disabled at boot
✅ No unnecessary error messages in logs
✅ Still properly detects and reports actual failures
✅ Minimal changes that don't affect normal operation

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
