### PR TITLE
2025.12.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2025.12.0
+PROJECT_NUMBER         = 2025.12.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/bme68x_bsec2_i2c/__init__.py
+++ b/esphome/components/bme68x_bsec2_i2c/__init__.py
@@ -11,6 +11,7 @@ CODEOWNERS = ["@neffs", "@kbx81"]
 
 AUTO_LOAD = ["bme68x_bsec2"]
 DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
 
 bme68x_bsec2_i2c_ns = cg.esphome_ns.namespace("bme68x_bsec2_i2c")
 BME68xBSEC2I2CComponent = bme68x_bsec2_i2c_ns.class_(

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -99,11 +99,11 @@ CC1101Component::CC1101Component() {
   this->state_.FS_AUTOCAL = 1;
 
   // Default Settings
-  this->set_frequency(433920);
-  this->set_if_frequency(153);
-  this->set_filter_bandwidth(203);
+  this->set_frequency(433920000);
+  this->set_if_frequency(153000);
+  this->set_filter_bandwidth(203000);
   this->set_channel(0);
-  this->set_channel_spacing(200);
+  this->set_channel_spacing(200000);
   this->set_symbol_rate(5000);
   this->set_sync_mode(SyncMode::SYNC_MODE_NONE);
   this->set_carrier_sense_above_threshold(true);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -308,13 +308,21 @@ bool ESP32BLE::ble_setup_() {
 bool ESP32BLE::ble_dismantle_() {
   esp_err_t err = esp_bluedroid_disable();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_disable failed: %d", err);
-    return false;
+    // ESP_ERR_INVALID_STATE means Bluedroid is already disabled, which is fine
+    if (err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE(TAG, "esp_bluedroid_disable failed: %d", err);
+      return false;
+    }
+    ESP_LOGD(TAG, "Already disabled");
   }
   err = esp_bluedroid_deinit();
   if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_deinit failed: %d", err);
-    return false;
+    // ESP_ERR_INVALID_STATE means Bluedroid is already deinitialized, which is fine
+    if (err != ESP_ERR_INVALID_STATE) {
+      ESP_LOGE(TAG, "esp_bluedroid_deinit failed: %d", err);
+      return false;
+    }
+    ESP_LOGD(TAG, "Already deinitialized");
   }
 
 #ifndef CONFIG_ESP_HOSTED_ENABLE_BT_BLUEDROID

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -212,17 +212,23 @@ extern ESP32BLE *global_ble;
 
 template<typename... Ts> class BLEEnabledCondition : public Condition<Ts...> {
  public:
-  bool check(const Ts &...x) override { return global_ble->is_active(); }
+  bool check(const Ts &...x) override { return global_ble != nullptr && global_ble->is_active(); }
 };
 
 template<typename... Ts> class BLEEnableAction : public Action<Ts...> {
  public:
-  void play(const Ts &...x) override { global_ble->enable(); }
+  void play(const Ts &...x) override {
+    if (global_ble != nullptr)
+      global_ble->enable();
+  }
 };
 
 template<typename... Ts> class BLEDisableAction : public Action<Ts...> {
  public:
-  void play(const Ts &...x) override { global_ble->disable(); }
+  void play(const Ts &...x) override {
+    if (global_ble != nullptr)
+      global_ble->disable();
+  }
 };
 
 }  // namespace esphome::esp32_ble

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -185,7 +185,10 @@ void ESP32BLETracker::ble_before_disabled_event_handler() { this->stop_scan_(); 
 
 void ESP32BLETracker::stop_scan_() {
   if (this->scanner_state_ != ScannerState::RUNNING && this->scanner_state_ != ScannerState::FAILED) {
-    ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
+    // If scanner is already idle, there's nothing to stop - this is not an error
+    if (this->scanner_state_ != ScannerState::IDLE) {
+      ESP_LOGE(TAG, "Cannot stop scan: %s", this->scanner_state_to_string_(this->scanner_state_));
+    }
     return;
   }
   // Reset timeout state machine when stopping scan

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -3,7 +3,7 @@ import logging
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import i2c
-from esphome.components.esp32 import add_idf_component
+from esphome.components.esp32 import add_idf_component, add_idf_sdkconfig_option
 from esphome.components.psram import DOMAIN as psram_domain
 import esphome.config_validation as cv
 from esphome.const import (
@@ -352,6 +352,8 @@ async def to_code(config):
     cg.add_define("USE_CAMERA")
 
     add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
+    add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
+    add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
 
     for conf in config.get(CONF_ON_STREAM_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)

--- a/esphome/components/pm1006/sensor.py
+++ b/esphome/components/pm1006/sensor.py
@@ -7,10 +7,10 @@ from esphome.const import (
     CONF_UPDATE_INTERVAL,
     DEVICE_CLASS_PM25,
     ICON_BLUR,
+    SCHEDULER_DONT_RUN,
     STATE_CLASS_MEASUREMENT,
     UNIT_MICROGRAMS_PER_CUBIC_METER,
 )
-from esphome.core import TimePeriodMilliseconds
 
 CODEOWNERS = ["@habbie"]
 DEPENDENCIES = ["uart"]
@@ -41,16 +41,12 @@ CONFIG_SCHEMA = cv.All(
 
 
 def validate_interval_uart(config):
-    require_tx = False
-
     interval = config.get(CONF_UPDATE_INTERVAL)
-
-    if isinstance(interval, TimePeriodMilliseconds):
-        # 'never' is encoded as a very large int, not as a TimePeriodMilliseconds objects
-        require_tx = True
-
     uart.final_validate_device_schema(
-        "pm1006", baud_rate=9600, require_rx=True, require_tx=require_tx
+        "pm1006",
+        baud_rate=9600,
+        require_rx=True,
+        require_tx=interval.total_milliseconds != SCHEDULER_DONT_RUN,
     )(config)
 
 

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -39,6 +39,7 @@ enum TemplateAlarmControlPanelRestoreMode {
   ALARM_CONTROL_PANEL_RESTORE_DEFAULT_DISARMED,
 };
 
+#ifdef USE_BINARY_SENSOR
 struct SensorDataStore {
   bool last_chime_state;
 };
@@ -49,7 +50,6 @@ struct SensorInfo {
   uint8_t store_index;
 };
 
-#ifdef USE_BINARY_SENSOR
 struct AlarmSensor {
   binary_sensor::BinarySensor *sensor;
   SensorInfo info;
@@ -139,6 +139,9 @@ class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControl
   FixedVector<AlarmSensor> sensors_;
   // a list of automatically bypassed sensors
   std::vector<uint8_t> bypassed_sensor_indicies_;
+  // Per sensor data store
+  std::vector<SensorDataStore> sensor_data_;
+  uint8_t next_store_index_ = 0;
 #endif
   TemplateAlarmControlPanelRestoreMode restore_mode_{};
 
@@ -154,14 +157,11 @@ class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControl
   uint32_t trigger_time_;
   // a list of codes
   std::vector<std::string> codes_;
-  // Per sensor data store
-  std::vector<SensorDataStore> sensor_data_;
   // requires a code to arm
   bool requires_code_to_arm_ = false;
   bool supports_arm_home_ = false;
   bool supports_arm_night_ = false;
   bool sensors_ready_ = false;
-  uint8_t next_store_index_ = 0;
   // check if the code is valid
   bool is_code_valid_(optional<std::string> code);
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2025.12.0"
+__version__ = "2025.12.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [cc1101] Fix default frequencies [esphome#12539](https://github.com/esphome/esphome/pull/12539)
- [pm1006] Fix "never" update interval detection [esphome#12529](https://github.com/esphome/esphome/pull/12529)
- [bme68x_bsec2_i2c] Add MULTI_CONF to fix multiple sensors [esphome#12535](https://github.com/esphome/esphome/pull/12535)
- [esp32_camera] Fix I2C driver conflict with other components [esphome#12533](https://github.com/esphome/esphome/pull/12533)
- [template.alarm_control_panel] Fix compile without binary_sensor [esphome#12548](https://github.com/esphome/esphome/pull/12548)
- [esp32_ble, esp32_ble_tracker] Fix crash, error messages when `ble.disable` called during boot [esphome#12560](https://github.com/esphome/esphome/pull/12560)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
