### PR TITLE
[wifi] Fix for `wifi_info` when static IP is configured

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -528,6 +528,16 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
         listener->on_wifi_connect_state(global_wifi_component->wifi_ssid(), global_wifi_component->wifi_bssid());
       }
+      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
+#ifdef USE_WIFI_MANUAL_IP
+      if (const WiFiAP *config = global_wifi_component->get_selected_sta_();
+          config && config->get_manual_ip().has_value()) {
+        for (auto *listener : global_wifi_component->ip_state_listeners_) {
+          listener->on_ip_state(global_wifi_component->wifi_sta_ip_addresses(),
+                                global_wifi_component->get_dns_address(0), global_wifi_component->get_dns_address(1));
+        }
+      }
+#endif
 #endif
       break;
     }

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -739,6 +739,14 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     for (auto *listener : this->connect_state_listeners_) {
       listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
     }
+    // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
+#ifdef USE_WIFI_MANUAL_IP
+    if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
+      for (auto *listener : this->ip_state_listeners_) {
+        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
+      }
+    }
+#endif
 #endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_DISCONNECTED) {

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -305,6 +305,14 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       for (auto *listener : this->connect_state_listeners_) {
         listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
       }
+      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
+#ifdef USE_WIFI_MANUAL_IP
+      if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
+        for (auto *listener : this->ip_state_listeners_) {
+          listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
+        }
+      }
+#endif
 #endif
       break;
     }

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -259,6 +259,15 @@ void WiFiComponent::wifi_loop_() {
     for (auto *listener : this->connect_state_listeners_) {
       listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
     }
+    // For static IP configurations, notify IP listeners immediately as the IP is already configured
+#ifdef USE_WIFI_MANUAL_IP
+    if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
+      s_sta_had_ip = true;
+      for (auto *listener : this->ip_state_listeners_) {
+        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
+      }
+    }
+#endif
 #endif
   } else if (!is_connected && s_sta_was_connected) {
     // Just disconnected


### PR DESCRIPTION
# What does this implement/fix?

Fixes an issue where the WiFi IP Address sensor in the `wifi_info` component would indicate "Unknown" when using a static IP configuration.

## Root Cause

The problem was that the IP state listeners (which update the `wifi_info` sensors) were only being triggered by the GOT_IP event, which fires when DHCP assigns an IP address. When using a static IP configuration (manual_ip), this event may not fire because the IP is configured manually rather than obtained via DHCP.

While the issue was only observed on LT platforms, this could impact ESP or Pico W platforms, as well.

## Solution

I've modified all four platform-specific WiFi implementations to notify IP state listeners immediately upon WiFi connection when a static IP is configured:

- `wifi_component_libretiny.cpp` - Added IP listener notification in WIFI_STA_CONNECTED event handler
- `wifi_component_esp_idf.cpp` - Added IP listener notification in WIFI_EVENT_STA_CONNECTED event handler
- `wifi_component_esp8266.cpp` - Added IP listener notification in EVENT_STAMODE_CONNECTED event handler
- `wifi_component_pico_w.cpp` - Added IP listener notification when connection state changes to connected

## How It Works

When WiFi connects and a manual IP is configured:
1. The connection event fires (STA_CONNECTED)
1. The code checks if the currently selected AP has a manual_ip configured
1. If yes, it immediately notifies all IP state listeners with the current IP addresses
1. The `wifi_info` IP address sensor receives this notification and updates its state

This fix ensures that `wifi_info` sensors display the correct IP address immediately upon connection, regardless of whether the IP was obtained via DHCP or configured statically.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12565

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
