### PR TITLE
[core] Migrate entities to use lazy callbacks

### DIFF
--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -132,13 +132,13 @@ class AlarmControlPanel : public EntityBase {
   // the call control function
   virtual void control(const AlarmControlPanelCall &call) = 0;
   // state callback - triggers check get_state() for specific state
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
   // clear callback - fires when leaving TRIGGERED state
-  CallbackManager<void()> cleared_callback_{};
+  LazyCallbackManager<void()> cleared_callback_{};
   // chime callback
-  CallbackManager<void()> chime_callback_{};
+  LazyCallbackManager<void()> chime_callback_{};
   // ready callback
-  CallbackManager<void()> ready_callback_{};
+  LazyCallbackManager<void()> ready_callback_{};
 };
 
 }  // namespace alarm_control_panel

--- a/esphome/components/button/button.h
+++ b/esphome/components/button/button.h
@@ -41,7 +41,7 @@ class Button : public EntityBase, public EntityBase_DeviceClass {
    */
   virtual void press_action() = 0;
 
-  CallbackManager<void()> press_callback_{};
+  LazyCallbackManager<void()> press_callback_{};
 };
 
 }  // namespace esphome::button

--- a/esphome/components/climate/climate.h
+++ b/esphome/components/climate/climate.h
@@ -326,8 +326,8 @@ class Climate : public EntityBase {
 
   void dump_traits_(const char *tag);
 
-  CallbackManager<void(Climate &)> state_callback_{};
-  CallbackManager<void(ClimateCall &)> control_callback_{};
+  LazyCallbackManager<void(Climate &)> state_callback_{};
+  LazyCallbackManager<void(ClimateCall &)> control_callback_{};
   ESPPreferenceObject rtc_;
 #ifdef USE_CLIMATE_VISUAL_OVERRIDES
   float visual_min_temperature_override_{NAN};

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -152,7 +152,7 @@ class Cover : public EntityBase, public EntityBase_DeviceClass {
 
   optional<CoverRestoreState> restore_state_();
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
 
   ESPPreferenceObject rtc_;
 };

--- a/esphome/components/datetime/datetime_base.h
+++ b/esphome/components/datetime/datetime_base.h
@@ -22,7 +22,7 @@ class DateTimeBase : public EntityBase {
 #endif
 
  protected:
-  CallbackManager<void()> state_callback_;
+  LazyCallbackManager<void()> state_callback_;
 
 #ifdef USE_TIME
   time::RealTimeClock *rtc_;

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -50,7 +50,7 @@ class Event : public EntityBase, public EntityBase_DeviceClass {
   void add_on_event_callback(std::function<void(const std::string &event_type)> &&callback);
 
  protected:
-  CallbackManager<void(const std::string &event_type)> event_callback_;
+  LazyCallbackManager<void(const std::string &event_type)> event_callback_;
   FixedVector<const char *> types_;
 
  private:

--- a/esphome/components/fan/fan.h
+++ b/esphome/components/fan/fan.h
@@ -155,7 +155,7 @@ class Fan : public EntityBase {
   const char *find_preset_mode_(const char *preset_mode);
   const char *find_preset_mode_(const char *preset_mode, size_t len);
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
   ESPPreferenceObject rtc_;
   FanRestoreMode restore_mode_;
 

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -174,7 +174,7 @@ class Lock : public EntityBase {
    */
   virtual void control(const LockCall &call) = 0;
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
   Deduplicator<LockState> publish_dedup_;
   ESPPreferenceObject rtc_;
 };

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -157,7 +157,7 @@ class MediaPlayer : public EntityBase {
 
   virtual void control(const MediaPlayerCall &call) = 0;
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
 };
 
 }  // namespace media_player

--- a/esphome/components/number/number.h
+++ b/esphome/components/number/number.h
@@ -49,7 +49,7 @@ class Number : public EntityBase {
    */
   virtual void control(float value) = 0;
 
-  CallbackManager<void(float)> state_callback_;
+  LazyCallbackManager<void(float)> state_callback_;
 };
 
 }  // namespace esphome::number

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -111,7 +111,7 @@ class Select : public EntityBase {
     }
   }
 
-  CallbackManager<void(size_t)> state_callback_;
+  LazyCallbackManager<void(size_t)> state_callback_;
 };
 
 }  // namespace esphome::select

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -76,9 +76,7 @@ StateClass Sensor::get_state_class() {
 
 void Sensor::publish_state(float state) {
   this->raw_state = state;
-  if (this->raw_callback_) {
-    this->raw_callback_->call(state);
-  }
+  this->raw_callback_.call(state);
 
   ESP_LOGV(TAG, "'%s': Received new state %f", this->name_.c_str(), state);
 
@@ -91,10 +89,7 @@ void Sensor::publish_state(float state) {
 
 void Sensor::add_on_state_callback(std::function<void(float)> &&callback) { this->callback_.add(std::move(callback)); }
 void Sensor::add_on_raw_state_callback(std::function<void(float)> &&callback) {
-  if (!this->raw_callback_) {
-    this->raw_callback_ = make_unique<CallbackManager<void(float)>>();
-  }
-  this->raw_callback_->add(std::move(callback));
+  this->raw_callback_.add(std::move(callback));
 }
 
 void Sensor::add_filter(Filter *filter) {

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -125,8 +125,8 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
   void internal_send_state_to_frontend(float state);
 
  protected:
-  std::unique_ptr<CallbackManager<void(float)>> raw_callback_;  ///< Storage for raw state callbacks (lazy allocated).
-  CallbackManager<void(float)> callback_;                       ///< Storage for filtered state callbacks.
+  LazyCallbackManager<void(float)> raw_callback_;  ///< Storage for raw state callbacks.
+  LazyCallbackManager<void(float)> callback_;      ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -134,8 +134,8 @@ class Switch : public EntityBase, public EntityBase_DeviceClass {
   // Pointer first (4 bytes)
   ESPPreferenceObject rtc_;
 
-  // CallbackManager (12 bytes on 32-bit - contains vector)
-  CallbackManager<void(bool)> state_callback_{};
+  // LazyCallbackManager (4 bytes on 32-bit - nullptr when empty)
+  LazyCallbackManager<void(bool)> state_callback_{};
 
   // Small types grouped together
   Deduplicator<bool> publish_dedup_;  // 2 bytes (bool has_value_ + bool last_value_)

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -44,7 +44,7 @@ class Text : public EntityBase {
    */
   virtual void control(const std::string &value) = 0;
 
-  CallbackManager<void(const std::string &)> state_callback_;
+  LazyCallbackManager<void(const std::string &)> state_callback_;
 };
 
 }  // namespace text

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -30,9 +30,7 @@ void TextSensor::publish_state(const std::string &state) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   this->raw_state = state;
 #pragma GCC diagnostic pop
-  if (this->raw_callback_) {
-    this->raw_callback_->call(state);
-  }
+  this->raw_callback_.call(state);
 
   ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), state.c_str());
 
@@ -77,10 +75,7 @@ void TextSensor::add_on_state_callback(std::function<void(std::string)> callback
   this->callback_.add(std::move(callback));
 }
 void TextSensor::add_on_raw_state_callback(std::function<void(std::string)> callback) {
-  if (!this->raw_callback_) {
-    this->raw_callback_ = make_unique<CallbackManager<void(std::string)>>();
-  }
-  this->raw_callback_->add(std::move(callback));
+  this->raw_callback_.add(std::move(callback));
 }
 
 std::string TextSensor::get_state() const { return this->state; }

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -65,9 +65,8 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   void internal_send_state_to_frontend(const std::string &state);
 
  protected:
-  std::unique_ptr<CallbackManager<void(std::string)>>
-      raw_callback_;                             ///< Storage for raw state callbacks (lazy allocated).
-  CallbackManager<void(std::string)> callback_;  ///< Storage for filtered state callbacks.
+  LazyCallbackManager<void(std::string)> raw_callback_;  ///< Storage for raw state callbacks.
+  LazyCallbackManager<void(std::string)> callback_;      ///< Storage for filtered state callbacks.
 
   Filter *filter_list_{nullptr};  ///< Store all active filters.
 };

--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -50,7 +50,7 @@ class UpdateEntity : public EntityBase, public EntityBase_DeviceClass {
   UpdateState state_{UPDATE_STATE_UNKNOWN};
   UpdateInfo update_info_;
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
   std::unique_ptr<Trigger<const UpdateInfo &>> update_available_trigger_{nullptr};
 };
 

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -144,7 +144,7 @@ class Valve : public EntityBase, public EntityBase_DeviceClass {
 
   optional<ValveRestoreState> restore_state_();
 
-  CallbackManager<void()> state_callback_{};
+  LazyCallbackManager<void()> state_callback_{};
 
   ESPPreferenceObject rtc_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Replaces and closes #11774

This PR introduces `LazyCallbackManager` as a simpler alternative to the `PartitionedCallbackManager` approach in #11774. Instead of complex partitioning logic, this uses a straightforward lazy allocation pattern that wraps `CallbackManager` in a `unique_ptr`, only allocating when callbacks are actually registered.

After the Controller Registry (#11772) eliminated most callback registrations from the API and web_server components, the vast majority of entity callback vectors are now empty. This PR reduces the memory overhead of those empty callbacks from 12 bytes (empty `std::vector`) to 4 bytes (nullptr `unique_ptr`) per callback manager on 32-bit systems.

## Memory Savings

**Per CallbackManager overhead reduction (ESP32/32-bit):**

| Before | After | Saved |
|--------|-------|-------|
| 12 bytes (empty std::vector) | 4 bytes (nullptr unique_ptr) | **8 bytes** |

**Applied to all entity types:**

| Entity Type | CallbackManagers | Bytes Saved |
|-------------|------------------|-------------|
| Sensor | 2 (raw + filtered) | 16 bytes |
| Text Sensor | 2 (raw + filtered) | 16 bytes |
| Switch | 1 | 8 bytes |
| Fan | 1 | 8 bytes |
| Climate | 2 (state + control) | 16 bytes |
| Cover | 1 | 8 bytes |
| Lock | 1 | 8 bytes |
| Number | 1 | 8 bytes |
| Select | 1 | 8 bytes |
| Text | 1 | 8 bytes |
| Button | 1 | 8 bytes |
| Event | 1 | 8 bytes |
| Alarm Control Panel | 4 | 32 bytes |
| Media Player | 1 | 8 bytes |
| Valve | 1 | 8 bytes |
| Update | 1 | 8 bytes |
| DateTime | 1 | 8 bytes |

**Example savings for typical configuration (20 sensors, 5 text sensors, 5 switches, 1 climate, 3 numbers, 2 selects):**
- Sensors: 20 x 16 = 320 bytes
- Text Sensors: 5 x 16 = 80 bytes
- Switches: 5 x 8 = 40 bytes
- Climate: 16 bytes
- Numbers: 3 x 8 = 24 bytes
- Selects: 2 x 8 = 16 bytes
- **Total: ~496 bytes of RAM saved**

## Technical Implementation

Introduces `LazyCallbackManager<void(Ts...)>` in `esphome/core/helpers.h`:

```cpp
template<typename... Ts> class LazyCallbackManager<void(Ts...)> {
 public:
  void add(std::function<void(Ts...)> &&callback);  // Allocates on first use
  void call(Ts... args);  // No-op if no callbacks registered
  size_t size() const;
  bool empty() const;

 protected:
  std::unique_ptr<CallbackManager<void(Ts...)>> callbacks_;
};
```

**Key benefits over #11774's PartitionedCallbackManager:**
- Simpler implementation - no partition tracking needed
- Drop-in replacement for `CallbackManager` with identical API
- Applied to ALL entity types, not just sensor/text_sensor
- Easier to maintain and extend

**Note:** Light component already uses an optimized listener interface pattern with lazy allocation, so it doesn't need this change.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Replaces and closes #11774
- Builds on #11772 (Global Controller Registry)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal optimization

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# Works transparently with existing entity configurations

sensor:
  - platform: template
    name: "Example Sensor"
    lambda: return 42.0;

switch:
  - platform: template
    name: "Example Switch"
    lambda: return true;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal optimization)
