### PR TITLE
[display_menu_base] Call on_value_ after updating the select

### DIFF
--- a/esphome/components/display_menu_base/menu_item.cpp
+++ b/esphome/components/display_menu_base/menu_item.cpp
@@ -54,6 +54,7 @@ bool MenuItemSelect::select_next() {
 
   if (this->select_var_ != nullptr) {
     this->select_var_->make_call().select_next(true).perform();
+    this->on_value_();
     changed = true;
   }
 
@@ -65,6 +66,7 @@ bool MenuItemSelect::select_prev() {
 
   if (this->select_var_ != nullptr) {
     this->select_var_->make_call().select_previous(true).perform();
+    this->on_value_();
     changed = true;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

This change ensures that the on_value automation is called when the value of a MenuItemSelect is changed, as [documented](https://next.esphome.io/components/display_menu/#select).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12583 

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
select:
  - platform: template
    id: my_select
    optimistic: true
    restore_value: true
    initial_option: "Option 1"
    options:
      - "Option 1"
      - "Option 2"

lcd_menu:
  id: my_menu
  display_id: my_display
  active: false
  mode: rotary
  mark_back: 0x08
  items:
    - type: select
      text: Units
      select: my_select
      on_value:
        then:
          - logger.log: "This should be called"
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
