### PR TITLE
[api] Add zero-copy support for Home Assistant state response messages

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -824,9 +824,9 @@ message HomeAssistantStateResponse {
   option (no_delay) = true;
   option (ifdef) = "USE_API_HOMEASSISTANT_STATES";
 
-  string entity_id = 1;
-  string state = 2;
-  string attribute = 3;
+  string entity_id = 1 [(pointer_to_buffer) = true];
+  string state = 2 [(pointer_to_buffer) = true];
+  string attribute = 3 [(pointer_to_buffer) = true];
 }
 
 // ==================== IMPORT TIME ====================

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -963,15 +963,24 @@ void SubscribeHomeAssistantStateResponse::calculate_size(ProtoSize &size) const 
 }
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->entity_id = value.as_string();
+    case 1: {
+      // Use raw data directly to avoid allocation
+      this->entity_id = value.data();
+      this->entity_id_len = value.size();
       break;
-    case 2:
-      this->state = value.as_string();
+    }
+    case 2: {
+      // Use raw data directly to avoid allocation
+      this->state = value.data();
+      this->state_len = value.size();
       break;
-    case 3:
-      this->attribute = value.as_string();
+    }
+    case 3: {
+      // Use raw data directly to avoid allocation
+      this->attribute = value.data();
+      this->attribute_len = value.size();
       break;
+    }
     default:
       return false;
   }

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1202,13 +1202,16 @@ class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
 class HomeAssistantStateResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 40;
-  static constexpr uint8_t ESTIMATED_SIZE = 27;
+  static constexpr uint8_t ESTIMATED_SIZE = 57;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "home_assistant_state_response"; }
 #endif
-  std::string entity_id{};
-  std::string state{};
-  std::string attribute{};
+  const uint8_t *entity_id{nullptr};
+  uint16_t entity_id_len{0};
+  const uint8_t *state{nullptr};
+  uint16_t state_len{0};
+  const uint8_t *attribute{nullptr};
+  uint16_t attribute_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -1184,9 +1184,15 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
 }
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "HomeAssistantStateResponse");
-  dump_field(out, "entity_id", this->entity_id);
-  dump_field(out, "state", this->state);
-  dump_field(out, "attribute", this->attribute);
+  out.append("  entity_id: ");
+  out.append(format_hex_pretty(this->entity_id, this->entity_id_len));
+  out.append("\n");
+  out.append("  state: ");
+  out.append(format_hex_pretty(this->state, this->state_len));
+  out.append("\n");
+  out.append("  attribute: ");
+  out.append(format_hex_pretty(this->attribute, this->attribute_len));
+  out.append("\n");
 }
 #endif
 void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }

--- a/tests/integration/test_api_homeassistant.py
+++ b/tests/integration/test_api_homeassistant.py
@@ -182,8 +182,8 @@ async def test_api_homeassistant(
         # Test edge cases for zero-copy implementation safety
         # Empty entity_id should be silently ignored (no crash)
         client.send_home_assistant_state("", "", "should_be_ignored")
-        # Empty state with valid entity should work
-        client.send_home_assistant_state("sensor.external_temperature", "", "")
+        # Empty state with valid entity should work (use different entity to not interfere with test)
+        client.send_home_assistant_state("sensor.edge_case_empty_state", "", "")
 
         # List entities and services
         _, services = await client.list_entities_services()

--- a/tests/integration/test_api_homeassistant.py
+++ b/tests/integration/test_api_homeassistant.py
@@ -179,6 +179,12 @@ async def test_api_homeassistant(
         client.send_home_assistant_state("binary_sensor.external_motion", "", "ON")
         client.send_home_assistant_state("weather.home", "condition", "sunny")
 
+        # Test edge cases for zero-copy implementation safety
+        # Empty entity_id should be silently ignored (no crash)
+        client.send_home_assistant_state("", "", "should_be_ignored")
+        # Empty state with valid entity should work
+        client.send_home_assistant_state("sensor.external_temperature", "", "")
+
         # List entities and services
         _, services = await client.list_entities_services()
 


### PR DESCRIPTION
needs
- [x] https://github.com/esphome/esphome/pull/12597

# What does this implement/fix?

Reduces memory allocations when processing Home Assistant state updates by using zero-copy protobuf decoding for `HomeAssistantStateResponse` messages.

Previously, the protobuf decoder allocated three `std::string` objects for every state update:
- `entity_id` - only used for strcmp comparison
- `attribute` - only used for strcmp comparison
- `state` - passed to callback

With this change, `entity_id` and `attribute` are compared directly from the protobuf buffer using `memcmp`, avoiding two allocations per message. The `state` field still requires a temporary `std::string` because callbacks expect `const std::string &`.

**Before:** 3 heap allocations per state update
**After:** 1 heap allocation per state update (for callback)

This follows the pattern established in #12329, #12384, #12402, and #12404.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
api:

sensor:
  - platform: homeassistant
    name: "Temperature"
    entity_id: sensor.temperature
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
