### PR TITLE
[esp32_camera] Throttle frame logging to reduce overhead and improve throughput

### DIFF
--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -210,6 +210,10 @@ void ESP32Camera::loop() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   ESP_LOGV(TAG, "Got Image: len=%u", fb->len);
 #else
+  // Initialize log time on first frame to ensure accurate interval measurement
+  if (this->frame_count_ == 0) {
+    this->last_log_time_ = now;
+  }
   this->frame_count_++;
   if (now - this->last_log_time_ >= FRAME_LOG_INTERVAL_MS) {
     ESP_LOGD(TAG, "Received %u images in last 60s", this->frame_count_);

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -11,6 +11,9 @@ namespace esphome {
 namespace esp32_camera {
 
 static const char *const TAG = "esp32_camera";
+#if ESPHOME_LOG_LEVEL < ESPHOME_LOG_LEVEL_VERBOSE
+static constexpr uint32_t FRAME_LOG_INTERVAL_MS = 60000;
+#endif
 
 /* ---------------- public API (derivated) ---------------- */
 void ESP32Camera::setup() {
@@ -204,7 +207,16 @@ void ESP32Camera::loop() {
   }
   this->current_image_ = std::make_shared<ESP32CameraImage>(fb, this->single_requesters_ | this->stream_requesters_);
 
-  ESP_LOGD(TAG, "Got Image: len=%u", fb->len);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  ESP_LOGV(TAG, "Got Image: len=%u", fb->len);
+#else
+  this->frame_count_++;
+  if (now - this->last_log_time_ >= FRAME_LOG_INTERVAL_MS) {
+    ESP_LOGD(TAG, "Received %u images in last 60s", this->frame_count_);
+    this->last_log_time_ = now;
+    this->frame_count_ = 0;
+  }
+#endif
   for (auto *listener : this->listeners_) {
     listener->on_camera_image(this->current_image_);
   }

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -216,7 +216,7 @@ void ESP32Camera::loop() {
   }
   this->frame_count_++;
   if (now - this->last_log_time_ >= FRAME_LOG_INTERVAL_MS) {
-    ESP_LOGD(TAG, "Received %u images in last 60s", this->frame_count_);
+    ESP_LOGD(TAG, "Received %u images in last %us", this->frame_count_, FRAME_LOG_INTERVAL_MS / 1000);
     this->last_log_time_ = now;
     this->frame_count_ = 0;
   }

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -213,6 +213,10 @@ class ESP32Camera : public camera::Camera {
 
   uint32_t last_idle_request_{0};
   uint32_t last_update_{0};
+#if ESPHOME_LOG_LEVEL < ESPHOME_LOG_LEVEL_VERBOSE
+  uint32_t last_log_time_{0};
+  uint16_t frame_count_{0};
+#endif
 #ifdef USE_I2C
   i2c::InternalI2CBus *i2c_bus_{nullptr};
 #endif  // USE_I2C


### PR DESCRIPTION
# What does this implement/fix?

Reduces logging overhead in esp32_camera by throttling frame logs to a summary every 60 seconds instead of logging every frame.

Previously, `ESP_LOGD` was called for every camera frame (~7-10 fps), causing significant overhead from:
- String formatting and UART output
- Network congestion: each small log message consumes a WiFi frame, forcing large camera image frames to queue behind them and wait for transmission

Now:
- At VERBOSE log level: logs every frame (for debugging)
- Below VERBOSE (default): logs a summary every 60s showing frame count

The member variables for throttling are conditionally compiled out when VERBOSE is enabled to save RAM.

**Before:** ~5 fps with constant log spam
**After:** ~7.5 fps with one log line per 60s

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_camera:
  name: Camera
  external_clock:
    pin: GPIO10
    frequency: 20MHz
  i2c_pins:
    sda: GPIO40
    scl: GPIO39
  data_pins: [GPIO15, GPIO17, GPIO18, GPIO16, GPIO14, GPIO12, GPIO11, GPIO48]
  vsync_pin: GPIO38
  href_pin: GPIO47
  pixel_clock_pin: GPIO13
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
