### PR TITLE
[syslog] send NIL ("-") as timestamp if time source is not valid

### DIFF
--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -36,12 +36,13 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
   int pri = this->facility_ * 8 + severity;
   auto now = this->time_->now();
   std::string timestamp;
-  if (now.is_valid())
+  if (now.is_valid()) {
     timestamp = now.strftime("%b %e %H:%M:%S");
-  else
+  } else {
     // RFC 5424: A syslog application MUST use the NILVALUE as TIMESTAMP if the syslog application is incapable of
     //           obtaining system time.
     timestamp = "-";
+  }
   size_t len = message_len;
   // remove color formatting
   if (this->strip_ && message[0] == 0x1B && len > 11) {

--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -34,7 +34,14 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
     severity = LOG_LEVEL_TO_SYSLOG_SEVERITY[level];
   }
   int pri = this->facility_ * 8 + severity;
-  auto timestamp = this->time_->now().strftime("%b %e %H:%M:%S");
+  auto now = this->time_->now();
+  std::string timestamp;
+  if (now.is_valid())
+    timestamp = now.strftime("%b %e %H:%M:%S");
+  else
+    // RFC 5424: A syslog application MUST use the NILVALUE as TIMESTAMP if the syslog application is incapable of
+    //           obtaining system time.
+    timestamp = "-";
   size_t len = message_len;
   // remove color formatting
   if (this->strip_ && message[0] == 0x1B && len > 11) {


### PR DESCRIPTION
# What does this implement/fix?

Currently the syslog component always sends a timestamp even if the real time clock is not synchronized yet.

RFC5424 requires the client to send "-" if the time is not valid:

https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.3

>    A syslog application MUST use the NILVALUE as TIMESTAMP if the syslog application is incapable of obtaining system time.

This PR checks if the real time clock is valid and uses _NILVALUE_ (`-`) otherwise.


- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12587

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
