### PR TITLE
[zwave_proxy] Add missing USE_API guards for clang-tidy

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -1,4 +1,7 @@
 #include "zwave_proxy.h"
+
+#ifdef USE_API
+
 #include "esphome/components/api/api_server.h"
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
@@ -344,3 +347,5 @@ bool ZWaveProxy::response_handler_() {
 ZWaveProxy *global_zwave_proxy = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace esphome::zwave_proxy
+
+#endif  // USE_API

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+#ifdef USE_API
+
 #include "esphome/components/api/api_connection.h"
 #include "esphome/components/api/api_pb2.h"
 #include "esphome/core/component.h"
@@ -89,3 +92,5 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
 extern ZWaveProxy *global_zwave_proxy;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 }  // namespace esphome::zwave_proxy
+
+#endif  // USE_API


### PR DESCRIPTION
# What does this implement/fix?

Add missing `USE_API` guards to the zwave_proxy component header and source files.

The zwave_proxy component depends on the API component, but the C++ files were missing the `#ifdef USE_API` guards. This caused clang-tidy to fail on Zephyr builds because Zephyr doesn't support the socket component (and therefore doesn't have API support), resulting in errors like:

```
error: no type named 'APIConnection' in namespace 'esphome::api'
```

This follows the same pattern used by other API-dependent components like `voice_assistant`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes CI clang-tidy failure for Zephyr platform

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
