### PR TITLE
[web_server] Replace str_sprintf with stack buffers

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1044,7 +1044,11 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
 
   // Format: YYYY-MM-DD (max 10 chars + null)
   char value[12];
+#ifdef USE_ESP8266
+  snprintf_P(value, sizeof(value), PSTR("%d-%02d-%02d"), obj->year, obj->month, obj->day);
+#else
   snprintf(value, sizeof(value), "%d-%02d-%02d", obj->year, obj->month, obj->day);
+#endif
   set_json_icon_state_value(root, obj, "date", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
@@ -1102,7 +1106,11 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
 
   // Format: HH:MM:SS (8 chars + null)
   char value[12];
+#ifdef USE_ESP8266
+  snprintf_P(value, sizeof(value), PSTR("%02d:%02d:%02d"), obj->hour, obj->minute, obj->second);
+#else
   snprintf(value, sizeof(value), "%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
+#endif
   set_json_icon_state_value(root, obj, "time", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
@@ -1160,8 +1168,13 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
 
   // Format: YYYY-MM-DD HH:MM:SS (max 19 chars + null)
   char value[24];
+#ifdef USE_ESP8266
+  snprintf_P(value, sizeof(value), PSTR("%d-%02d-%02d %02d:%02d:%02d"), obj->year, obj->month, obj->day, obj->hour,
+             obj->minute, obj->second);
+#else
   snprintf(value, sizeof(value), "%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour, obj->minute,
            obj->second);
+#endif
   set_json_icon_state_value(root, obj, "datetime", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1042,7 +1042,9 @@ std::string WebServer::date_json(datetime::DateEntity *obj, JsonDetail start_con
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  std::string value = str_sprintf("%d-%02d-%02d", obj->year, obj->month, obj->day);
+  // Format: YYYY-MM-DD (max 10 chars + null)
+  char value[12];
+  snprintf(value, sizeof(value), "%d-%02d-%02d", obj->year, obj->month, obj->day);
   set_json_icon_state_value(root, obj, "date", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
@@ -1098,7 +1100,9 @@ std::string WebServer::time_json(datetime::TimeEntity *obj, JsonDetail start_con
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  std::string value = str_sprintf("%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
+  // Format: HH:MM:SS (8 chars + null)
+  char value[12];
+  snprintf(value, sizeof(value), "%02d:%02d:%02d", obj->hour, obj->minute, obj->second);
   set_json_icon_state_value(root, obj, "time", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);
@@ -1154,8 +1158,10 @@ std::string WebServer::datetime_json(datetime::DateTimeEntity *obj, JsonDetail s
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
-  std::string value =
-      str_sprintf("%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour, obj->minute, obj->second);
+  // Format: YYYY-MM-DD HH:MM:SS (max 19 chars + null)
+  char value[24];
+  snprintf(value, sizeof(value), "%d-%02d-%02d %02d:%02d:%02d", obj->year, obj->month, obj->day, obj->hour, obj->minute,
+           obj->second);
   set_json_icon_state_value(root, obj, "datetime", value, value, start_config);
   if (start_config == DETAIL_ALL) {
     this->add_sorting_info_(root, obj);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -343,8 +343,9 @@ bool AsyncWebServerRequest::authenticate(const char *username, const char *passw
 
 void AsyncWebServerRequest::requestAuthentication(const char *realm) const {
   httpd_resp_set_hdr(*this, "Connection", "keep-alive");
-  auto auth_val = str_sprintf("Basic realm=\"%s\"", realm ? realm : "Login Required");
-  httpd_resp_set_hdr(*this, "WWW-Authenticate", auth_val.c_str());
+  // Note: realm is never configured in ESPHome, always nullptr -> "Login Required"
+  (void) realm;  // Unused - always use default
+  httpd_resp_set_hdr(*this, "WWW-Authenticate", "Basic realm=\"Login Required\"");
   httpd_resp_send_err(*this, HTTPD_401_UNAUTHORIZED, nullptr);
 }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Eliminates unnecessary heap allocations in web_server date/time formatting by using stack-allocated buffers instead of `str_sprintf()`.

## Changes

### `web_server.cpp`
- `date_json()`: Use 12-byte stack buffer for `YYYY-MM-DD` format
- `time_json()`: Use 12-byte stack buffer for `HH:MM:SS` format
- `datetime_json()`: Use 24-byte stack buffer for `YYYY-MM-DD HH:MM:SS` format
- On ESP8266: Use `snprintf_P` with `PSTR()` to keep format strings in flash (~53 bytes RAM saved)

### `web_server_idf.cpp`
- `requestAuthentication()`: Use inline string literal instead of `str_sprintf()` since realm is never configured in ESPHome (always uses default "Login Required")

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
