### PR TITLE
[improv_serial] Use stack buffer for RSSI formatting

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -263,8 +263,10 @@ bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command
         if (std::find(networks.begin(), networks.end(), ssid) != networks.end())
           continue;
         // Send each ssid separately to avoid overflowing the buffer
-        std::vector<uint8_t> data = improv::build_rpc_response(
-            improv::GET_WIFI_NETWORKS, {ssid, str_sprintf("%d", scan.get_rssi()), YESNO(scan.get_with_auth())}, false);
+        char rssi_buf[8];  // RSSI range: -127 to 0
+        snprintf(rssi_buf, sizeof(rssi_buf), "%d", scan.get_rssi());
+        std::vector<uint8_t> data =
+            improv::build_rpc_response(improv::GET_WIFI_NETWORKS, {ssid, rssi_buf, YESNO(scan.get_with_auth())}, false);
         this->send_response_(data);
         networks.push_back(ssid);
       }


### PR DESCRIPTION
# What does this implement/fix?

Replaces `str_sprintf` with stack-allocated buffer for RSSI formatting in wifi network scan responses.

## Changes

- Use 8-byte stack buffer with `snprintf` instead of `str_sprintf("%d", rssi)`
- Avoids `str_sprintf`'s double `vsnprintf` overhead (one to measure length, one to write)
- Cleaner code that's ready if `improv::build_rpc_response` ever gets a `const char*` overload

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
