### PR TITLE
[syslog] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/time.h"
 
-namespace esphome {
-namespace syslog {
+namespace esphome::syslog {
 
 // Map log levels to syslog severity using an array, indexed by ESPHome log level (1-7)
 constexpr int LOG_LEVEL_TO_SYSLOG_SEVERITY[] = {
@@ -54,5 +53,4 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
   this->parent_->send_packet((const uint8_t *) data.data(), data.size());
 }
 
-}  // namespace syslog
-}  // namespace esphome
+}  // namespace esphome::syslog

--- a/esphome/components/syslog/esphome_syslog.h
+++ b/esphome/components/syslog/esphome_syslog.h
@@ -7,8 +7,7 @@
 #include "esphome/components/time/real_time_clock.h"
 
 #ifdef USE_NETWORK
-namespace esphome {
-namespace syslog {
+namespace esphome::syslog {
 class Syslog : public Component, public Parented<udp::UDPComponent>, public logger::LogListener {
  public:
   Syslog(int level, time::RealTimeClock *time) : log_level_(level), time_(time) {}
@@ -24,6 +23,5 @@ class Syslog : public Component, public Parented<udp::UDPComponent>, public logg
   bool strip_{true};
   int facility_{16};
 };
-}  // namespace syslog
-}  // namespace esphome
+}  // namespace esphome::syslog
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Convert syslog component to use C++17 nested namespace syntax.

Changes `namespace esphome { namespace syslog {` to `namespace esphome::syslog {` for cleaner, more modern code style.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - code style only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
