### PR TITLE
Add AQI calculation support to remaining PM sensors

### DIFF
--- a/esphome/components/gcja5/gcja5.cpp
+++ b/esphome/components/gcja5/gcja5.cpp
@@ -43,6 +43,11 @@ void GCJA5Component::loop() {
           this->pm_2_5_sensor_->publish_state(get_32_bit_uint_(5));
         if (this->pm_10_0_sensor_ != nullptr)
           this->pm_10_0_sensor_->publish_state(get_32_bit_uint_(9));
+        if (this->aqi_sensor_ != nullptr) {
+          aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+          int aqi_value = calculator->get_aqi(get_32_bit_uint_(5), get_32_bit_uint_(9));
+          this->aqi_sensor_->publish_state(aqi_value);
+        }
         if (this->pmc_0_3_sensor_ != nullptr)
           this->pmc_0_3_sensor_->publish_state(get_16_bit_uint_(13));
         if (this->pmc_0_5_sensor_ != nullptr)

--- a/esphome/components/gcja5/gcja5.h
+++ b/esphome/components/gcja5/gcja5.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
@@ -23,6 +24,9 @@ class GCJA5Component : public Component, public uart::UARTDevice {
   void set_pmc_2_5_sensor(sensor::Sensor *pmc_2_5) { pmc_2_5_sensor_ = pmc_2_5; }
   void set_pmc_5_0_sensor(sensor::Sensor *pmc_5_0) { pmc_5_0_sensor_ = pmc_5_0; }
   void set_pmc_10_0_sensor(sensor::Sensor *pmc_10_0) { pmc_10_0_sensor_ = pmc_10_0; }
+
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { aqi_calc_type_ = aqi_calc_type; }
 
  protected:
   void parse_data_();
@@ -50,6 +54,10 @@ class GCJA5Component : public Component, public uart::UARTDevice {
   sensor::Sensor *pmc_2_5_sensor_{nullptr};
   sensor::Sensor *pmc_5_0_sensor_{nullptr};
   sensor::Sensor *pmc_10_0_sensor_{nullptr};
+
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 };
 
 }  // namespace gcja5

--- a/esphome/components/gcja5/sensor.py
+++ b/esphome/components/gcja5/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
-from esphome.components import aqi, sensor, uart
+from esphome.components import sensor, uart
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -10,6 +11,7 @@ from esphome.const import (
     CONF_PMC_1_0,
     CONF_PMC_2_5,
     CONF_PMC_10_0,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_PM1,
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
@@ -23,9 +25,7 @@ CODEOWNERS = ["@gcormier"]
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["aqi"]
 
-CONF_AQI = aqi.CONF_AQI
-CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
-AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
+UNIT_INDEX = "index"
 
 gcja5_ns = cg.esphome_ns.namespace("gcja5")
 
@@ -95,8 +95,10 @@ CONFIG_SCHEMA = cv.Schema(
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_AQI): sensor.sensor_schema(
+            unit_of_measurement=UNIT_INDEX,
             icon=ICON_CHEMICAL_WEAPON,
             accuracy_decimals=0,
+            device_class=DEVICE_CLASS_AQI,
             state_class=STATE_CLASS_MEASUREMENT,
         ).extend(
             {

--- a/esphome/components/gcja5/sensor.py
+++ b/esphome/components/gcja5/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import sensor, uart
+from esphome.components import aqi, sensor, uart
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -21,6 +21,11 @@ from esphome.const import (
 
 CODEOWNERS = ["@gcormier"]
 DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["aqi"]
+
+CONF_AQI = aqi.CONF_AQI
+CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
+AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
 
 gcja5_ns = cg.esphome_ns.namespace("gcja5")
 
@@ -89,10 +94,34 @@ CONFIG_SCHEMA = cv.Schema(
             accuracy_decimals=0,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_AQI): sensor.sensor_schema(
+            icon=ICON_CHEMICAL_WEAPON,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(
+            {
+                cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                    AQI_CALCULATION_TYPE, upper=True
+                ),
+            }
+        ),
     }
 ).extend(uart.UART_DEVICE_SCHEMA)
-FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "gcja5", baud_rate=9600, require_rx=True, parity="EVEN"
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = cv.All(
+    uart.final_validate_device_schema(
+        "gcja5", baud_rate=9600, require_rx=True, parity="EVEN"
+    ),
+    validate_aqi_requires_pm,
 )
 TYPES = {
     CONF_PM_1_0: "set_pm_1_0_sensor",
@@ -104,6 +133,7 @@ TYPES = {
     CONF_PMC_2_5: "set_pmc_2_5_sensor",
     CONF_PMC_5_0: "set_pmc_5_0_sensor",
     CONF_PMC_10_0: "set_pmc_10_0_sensor",
+    CONF_AQI: "set_aqi_sensor",
 }
 
 
@@ -116,3 +146,6 @@ async def to_code(config):
         if key in config:
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(var, funcName)(sens))
+
+    if CONF_AQI in config:
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))

--- a/esphome/components/pm2005/pm2005.cpp
+++ b/esphome/components/pm2005/pm2005.cpp
@@ -98,6 +98,12 @@ void PM2005Component::update() {
     this->pm_10_0_sensor_->publish_state(pm10);
   }
 
+  if (this->aqi_sensor_ != nullptr) {
+    aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+    int aqi_value = calculator->get_aqi(pm25, pm10);
+    this->aqi_sensor_->publish_state(aqi_value);
+  }
+
   this->status_clear_warning();
 }
 

--- a/esphome/components/pm2005/pm2005.h
+++ b/esphome/components/pm2005/pm2005.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
@@ -21,6 +22,8 @@ class PM2005Component : public PollingComponent, public i2c::I2CDevice {
   void set_pm_1_0_sensor(sensor::Sensor *pm_1_0_sensor) { this->pm_1_0_sensor_ = pm_1_0_sensor; }
   void set_pm_2_5_sensor(sensor::Sensor *pm_2_5_sensor) { this->pm_2_5_sensor_ = pm_2_5_sensor; }
   void set_pm_10_0_sensor(sensor::Sensor *pm_10_0_sensor) { this->pm_10_0_sensor_ = pm_10_0_sensor; }
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { this->aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { this->aqi_calc_type_ = aqi_calc_type; }
 
   void setup() override;
   void dump_config() override;
@@ -34,6 +37,9 @@ class PM2005Component : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *pm_1_0_sensor_{nullptr};
   sensor::Sensor *pm_2_5_sensor_{nullptr};
   sensor::Sensor *pm_10_0_sensor_{nullptr};
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 
   uint8_t situation_value_index_{3};
   uint8_t pm_1_0_value_index_{4};

--- a/esphome/components/pm2005/sensor.py
+++ b/esphome/components/pm2005/sensor.py
@@ -1,7 +1,8 @@
 """PM2005/2105 Sensor component for ESPHome."""
 
 import esphome.codegen as cg
-from esphome.components import aqi, i2c, sensor
+from esphome.components import i2c, sensor
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -9,6 +10,7 @@ from esphome.const import (
     CONF_PM_2_5,
     CONF_PM_10_0,
     CONF_TYPE,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_PM1,
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
@@ -21,9 +23,7 @@ DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["aqi"]
 CODEOWNERS = ["@andrewjswan"]
 
-CONF_AQI = aqi.CONF_AQI
-CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
-AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
+UNIT_INDEX = "index"
 
 pm2005_ns = cg.esphome_ns.namespace("pm2005")
 PM2005Component = pm2005_ns.class_(
@@ -64,8 +64,10 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
                 icon=ICON_CHEMICAL_WEAPON,
                 accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(
                 {

--- a/esphome/components/pm2005/sensor.py
+++ b/esphome/components/pm2005/sensor.py
@@ -1,7 +1,7 @@
 """PM2005/2105 Sensor component for ESPHome."""
 
 import esphome.codegen as cg
-from esphome.components import i2c, sensor
+from esphome.components import aqi, i2c, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -18,7 +18,12 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["aqi"]
 CODEOWNERS = ["@andrewjswan"]
+
+CONF_AQI = aqi.CONF_AQI
+CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
+AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
 
 pm2005_ns = cg.esphome_ns.namespace("pm2005")
 PM2005Component = pm2005_ns.class_(
@@ -58,11 +63,33 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_PM10,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
         },
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x28)),
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 
 async def to_code(config) -> None:
@@ -84,3 +111,8 @@ async def to_code(config) -> None:
     if pm_10_0_config := config.get(CONF_PM_10_0):
         sens = await sensor.new_sensor(pm_10_0_config)
         cg.add(var.set_pm_10_0_sensor(sens))
+
+    if CONF_AQI in config:
+        sens = await sensor.new_sensor(config[CONF_AQI])
+        cg.add(var.set_aqi_sensor(sens))
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))

--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -80,6 +80,14 @@ void PMSA003IComponent::update() {
       this->pmc_5_0_sensor_->publish_state(data.particles_50um);
     if (this->pmc_10_0_sensor_ != nullptr)
       this->pmc_10_0_sensor_->publish_state(data.particles_100um);
+
+    if (this->aqi_sensor_ != nullptr) {
+      uint16_t pm25 = this->standard_units_ ? data.pm25_standard : data.pm25_env;
+      uint16_t pm100 = this->standard_units_ ? data.pm100_standard : data.pm100_env;
+      aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+      int aqi_value = calculator->get_aqi(pm25, pm100);
+      this->aqi_sensor_->publish_state(aqi_value);
+    }
   } else {
     this->status_set_warning();
     ESP_LOGV(TAG, "Read failure. Skipping update.");

--- a/esphome/components/pmsa003i/pmsa003i.h
+++ b/esphome/components/pmsa003i/pmsa003i.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/i2c/i2c.h"
 
@@ -46,6 +47,9 @@ class PMSA003IComponent : public PollingComponent, public i2c::I2CDevice {
   void set_pmc_5_0_sensor(sensor::Sensor *pmc_5_0) { this->pmc_5_0_sensor_ = pmc_5_0; }
   void set_pmc_10_0_sensor(sensor::Sensor *pmc_10_0) { this->pmc_10_0_sensor_ = pmc_10_0; }
 
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { this->aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { this->aqi_calc_type_ = aqi_calc_type; }
+
  protected:
   bool read_data_(PM25AQIData *data);
 
@@ -61,6 +65,10 @@ class PMSA003IComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *pmc_2_5_sensor_{nullptr};
   sensor::Sensor *pmc_5_0_sensor_{nullptr};
   sensor::Sensor *pmc_10_0_sensor_{nullptr};
+
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 };
 
 }  // namespace pmsa003i

--- a/esphome/components/pmsa003i/sensor.py
+++ b/esphome/components/pmsa003i/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import i2c, sensor
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -10,6 +11,7 @@ from esphome.const import (
     CONF_PMC_1_0,
     CONF_PMC_2_5,
     CONF_PMC_10_0,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_PM1,
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
@@ -21,6 +23,9 @@ from esphome.const import (
 
 CODEOWNERS = ["@sjtrny"]
 DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["aqi"]
+
+UNIT_INDEX = "index"
 
 pmsa003i_ns = cg.esphome_ns.namespace("pmsa003i")
 
@@ -95,11 +100,35 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x12))
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 TYPES = {
     CONF_PM_1_0: "set_pm_1_0_sensor",
@@ -125,3 +154,8 @@ async def to_code(config):
         if key in config:
             sens = await sensor.new_sensor(config[key])
             cg.add(getattr(var, funcName)(sens))
+
+    if CONF_AQI in config:
+        sens = await sensor.new_sensor(config[CONF_AQI])
+        cg.add(var.set_aqi_sensor(sens))
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -180,6 +180,12 @@ void SDS011Component::parse_data_() {
   if (this->pm_10_0_sensor_ != nullptr) {
     this->pm_10_0_sensor_->publish_state(pm_10_0_concentration);
   }
+
+  if (this->aqi_sensor_ != nullptr) {
+    aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+    int aqi_value = calculator->get_aqi(pm_2_5_concentration, pm_10_0_concentration);
+    this->aqi_sensor_->publish_state(aqi_value);
+  }
 }
 
 void SDS011Component::set_update_interval_min(uint8_t update_interval_min) {

--- a/esphome/components/sds011/sds011.h
+++ b/esphome/components/sds011/sds011.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
@@ -17,6 +18,8 @@ class SDS011Component : public Component, public uart::UARTDevice {
 
   void set_pm_2_5_sensor(sensor::Sensor *pm_2_5_sensor) { pm_2_5_sensor_ = pm_2_5_sensor; }
   void set_pm_10_0_sensor(sensor::Sensor *pm_10_0_sensor) { pm_10_0_sensor_ = pm_10_0_sensor; }
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { aqi_calc_type_ = aqi_calc_type; }
   void setup() override;
   void dump_config() override;
   void loop() override;
@@ -39,6 +42,9 @@ class SDS011Component : public Component, public uart::UARTDevice {
 
   sensor::Sensor *pm_2_5_sensor_{nullptr};
   sensor::Sensor *pm_10_0_sensor_{nullptr};
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 
   uint8_t data_[10];
   uint8_t data_index_{0};

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import sensor, uart
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -7,6 +8,7 @@ from esphome.const import (
     CONF_PM_10_0,
     CONF_RX_ONLY,
     CONF_UPDATE_INTERVAL,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
     ICON_CHEMICAL_WEAPON,
@@ -15,6 +17,9 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["aqi"]
+
+UNIT_INDEX = "index"
 
 sds011_ns = cg.esphome_ns.namespace("sds011")
 SDS011Component = sds011_ns.class_("SDS011Component", uart.UARTDevice, cg.Component)
@@ -53,6 +58,19 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_PM10,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
             cv.Optional(CONF_RX_ONLY, default=False): cv.boolean,
             cv.Optional(CONF_UPDATE_INTERVAL): cv.positive_time_period_minutes,
         }
@@ -61,6 +79,17 @@ CONFIG_SCHEMA = cv.All(
     .extend(uart.UART_DEVICE_SCHEMA),
     validate_sds011_rx_mode,
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 
 async def to_code(config):
@@ -79,3 +108,8 @@ async def to_code(config):
     if CONF_PM_10_0 in config:
         sens = await sensor.new_sensor(config[CONF_PM_10_0])
         cg.add(var.set_pm_10_0_sensor(sens))
+
+    if CONF_AQI in config:
+        sens = await sensor.new_sensor(config[CONF_AQI])
+        cg.add(var.set_aqi_sensor(sens))
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -390,6 +390,13 @@ void SEN5XComponent::update() {
     if (this->pm_10_0_sensor_ != nullptr) {
       this->pm_10_0_sensor_->publish_state(pm_10_0);
     }
+
+    if (this->aqi_sensor_ != nullptr) {
+      aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+      int aqi_value = calculator->get_aqi(pm_2_5, pm_10_0);
+      this->aqi_sensor_->publish_state(aqi_value);
+    }
+
     if (this->temperature_sensor_ != nullptr) {
       this->temperature_sensor_->publish_state(temperature);
     }

--- a/esphome/components/sen5x/sen5x.h
+++ b/esphome/components/sen5x/sen5x.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 #include "esphome/core/application.h"
@@ -67,6 +68,8 @@ class SEN5XComponent : public PollingComponent, public sensirion_common::Sensiri
   void set_nox_sensor(sensor::Sensor *nox_sensor) { nox_sensor_ = nox_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { aqi_calc_type_ = aqi_calc_type; }
   void set_store_baseline(bool store_baseline) { store_baseline_ = store_baseline; }
   void set_acceleration_mode(RhtAccelerationMode mode) { acceleration_mode_ = mode; }
   void set_auto_cleaning_interval(uint32_t auto_cleaning_interval) { auto_cleaning_interval_ = auto_cleaning_interval; }
@@ -124,6 +127,9 @@ class SEN5XComponent : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *voc_sensor_{nullptr};
   // SEN55 only
   sensor::Sensor *nox_sensor_{nullptr};
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 
   optional<RhtAccelerationMode> acceleration_mode_;
   optional<uint32_t> auto_cleaning_interval_;

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -1,7 +1,8 @@
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
-from esphome.components import aqi, i2c, sensirion_common, sensor
+from esphome.components import i2c, sensirion_common, sensor
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ALGORITHM_TUNING,
@@ -46,9 +47,7 @@ CODEOWNERS = ["@martgras"]
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["aqi", "sensirion_common"]
 
-CONF_AQI = aqi.CONF_AQI
-CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
-AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
+UNIT_INDEX = "index"
 
 sen5x_ns = cg.esphome_ns.namespace("sen5x")
 SEN5XComponent = sen5x_ns.class_(
@@ -195,8 +194,10 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_ACCELERATION_MODE): cv.enum(ACCELERATION_MODES),
             cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
                 icon=ICON_CHEMICAL_WEAPON,
                 accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(
                 {

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -1,7 +1,7 @@
 from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
-from esphome.components import i2c, sensirion_common, sensor
+from esphome.components import aqi, i2c, sensirion_common, sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ALGORITHM_TUNING,
@@ -44,7 +44,11 @@ from esphome.const import (
 
 CODEOWNERS = ["@martgras"]
 DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["sensirion_common"]
+AUTO_LOAD = ["aqi", "sensirion_common"]
+
+CONF_AQI = aqi.CONF_AQI
+CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
+AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
 
 sen5x_ns = cg.esphome_ns.namespace("sen5x")
 SEN5XComponent = sen5x_ns.class_(
@@ -190,11 +194,33 @@ CONFIG_SCHEMA = (
                 }
             ),
             cv.Optional(CONF_ACCELERATION_MODE): cv.enum(ACCELERATION_MODES),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x69))
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 SENSOR_MAP = {
     CONF_PM_1_0: "set_pm_1_0_sensor",
@@ -205,6 +231,7 @@ SENSOR_MAP = {
     CONF_NOX: "set_nox_sensor",
     CONF_TEMPERATURE: "set_temperature_sensor",
     CONF_HUMIDITY: "set_humidity_sensor",
+    CONF_AQI: "set_aqi_sensor",
 }
 
 SETTING_MAP = {
@@ -226,6 +253,9 @@ async def to_code(config):
         if cfg := config.get(key):
             sens = await sensor.new_sensor(cfg)
             cg.add(getattr(var, funcName)(sens))
+
+    if CONF_AQI in config:
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))
 
     if cfg := config.get(CONF_VOC, {}).get(CONF_ALGORITHM_TUNING):
         cg.add(

--- a/esphome/components/sm300d2/sensor.py
+++ b/esphome/components/sm300d2/sensor.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import sensor, uart
+from esphome.components import aqi, sensor, uart
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CO2,
@@ -28,6 +28,11 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["aqi"]
+
+CONF_AQI = aqi.CONF_AQI
+CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
+AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
 
 sm300d2_ns = cg.esphome_ns.namespace("sm300d2")
 SM300D2Sensor = sm300d2_ns.class_("SM300D2Sensor", cg.PollingComponent, uart.UARTDevice)
@@ -82,11 +87,33 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_HUMIDITY,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 
 async def to_code(config):
@@ -115,3 +142,7 @@ async def to_code(config):
     if CONF_HUMIDITY in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY])
         cg.add(var.set_humidity_sensor(sens))
+    if CONF_AQI in config:
+        sens = await sensor.new_sensor(config[CONF_AQI])
+        cg.add(var.set_aqi_sensor(sens))
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))

--- a/esphome/components/sm300d2/sensor.py
+++ b/esphome/components/sm300d2/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
-from esphome.components import aqi, sensor, uart
+from esphome.components import sensor, uart
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CO2,
@@ -10,6 +11,7 @@ from esphome.const import (
     CONF_PM_10_0,
     CONF_TEMPERATURE,
     CONF_TVOC,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_CARBON_DIOXIDE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PM10,
@@ -30,9 +32,7 @@ from esphome.const import (
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["aqi"]
 
-CONF_AQI = aqi.CONF_AQI
-CONF_CALCULATION_TYPE = aqi.CONF_CALCULATION_TYPE
-AQI_CALCULATION_TYPE = aqi.AQI_CALCULATION_TYPE
+UNIT_INDEX = "index"
 
 sm300d2_ns = cg.esphome_ns.namespace("sm300d2")
 SM300D2Sensor = sm300d2_ns.class_("SM300D2Sensor", cg.PollingComponent, uart.UARTDevice)
@@ -88,8 +88,10 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
                 icon=ICON_CHEMICAL_WEAPON,
                 accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(
                 {

--- a/esphome/components/sm300d2/sm300d2.cpp
+++ b/esphome/components/sm300d2/sm300d2.cpp
@@ -75,6 +75,12 @@ void SM300D2Sensor::update() {
   if (this->pm_10_0_sensor_ != nullptr)
     this->pm_10_0_sensor_->publish_state(pm_10_0);
 
+  if (this->aqi_sensor_ != nullptr) {
+    aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+    int aqi_value = calculator->get_aqi(pm_2_5, pm_10_0);
+    this->aqi_sensor_->publish_state(aqi_value);
+  }
+
   ESP_LOGD(TAG, "Received Temperature: %.2f °C", temperature);
   if (this->temperature_sensor_ != nullptr)
     this->temperature_sensor_->publish_state(temperature);

--- a/esphome/components/sm300d2/sm300d2.h
+++ b/esphome/components/sm300d2/sm300d2.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
@@ -16,6 +17,8 @@ class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
   void set_pm_10_0_sensor(sensor::Sensor *pm_10_0_sensor) { pm_10_0_sensor_ = pm_10_0_sensor; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { aqi_calc_type_ = aqi_calc_type; }
 
   void update() override;
   void dump_config() override;
@@ -30,6 +33,9 @@ class SM300D2Sensor : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *pm_10_0_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
 };
 
 }  // namespace sm300d2

--- a/esphome/components/sps30/sensor.py
+++ b/esphome/components/sps30/sensor.py
@@ -2,6 +2,7 @@ from esphome import automation
 from esphome.automation import maybe_simple_id
 import esphome.codegen as cg
 from esphome.components import i2c, sensirion_common, sensor
+from esphome.components.aqi import AQI_CALCULATION_TYPE, CONF_AQI, CONF_CALCULATION_TYPE
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
@@ -15,6 +16,7 @@ from esphome.const import (
     CONF_PMC_2_5,
     CONF_PMC_4_0,
     CONF_PMC_10_0,
+    DEVICE_CLASS_AQI,
     DEVICE_CLASS_PM1,
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
@@ -29,7 +31,9 @@ from esphome.const import (
 
 CODEOWNERS = ["@martgras"]
 DEPENDENCIES = ["i2c"]
-AUTO_LOAD = ["sensirion_common"]
+AUTO_LOAD = ["aqi", "sensirion_common"]
+
+UNIT_INDEX = "index"
 
 sps30_ns = cg.esphome_ns.namespace("sps30")
 SPS30Component = sps30_ns.class_(
@@ -111,6 +115,19 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_AQI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_CALCULATION_TYPE): cv.enum(
+                        AQI_CALCULATION_TYPE, upper=True
+                    ),
+                }
+            ),
             cv.Optional(CONF_AUTO_CLEANING_INTERVAL): cv.update_interval,
             cv.Optional(CONF_IDLE_INTERVAL): cv.update_interval,
         }
@@ -118,6 +135,17 @@ CONFIG_SCHEMA = (
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x69))
 )
+
+
+def validate_aqi_requires_pm(config):
+    if CONF_AQI in config and (CONF_PM_2_5 not in config or CONF_PM_10_0 not in config):
+        raise cv.Invalid(
+            f"AQI sensor requires both '{CONF_PM_2_5}' and '{CONF_PM_10_0}' sensors to be configured"
+        )
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = validate_aqi_requires_pm
 
 
 async def to_code(config):
@@ -170,6 +198,11 @@ async def to_code(config):
 
     if CONF_IDLE_INTERVAL in config:
         cg.add(var.set_idle_interval(config[CONF_IDLE_INTERVAL]))
+
+    if CONF_AQI in config:
+        sens = await sensor.new_sensor(config[CONF_AQI])
+        cg.add(var.set_aqi_sensor(sens))
+        cg.add(var.set_aqi_calculation_type(config[CONF_AQI][CONF_CALCULATION_TYPE]))
 
 
 SPS30_ACTION_SCHEMA = maybe_simple_id(

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -235,6 +235,12 @@ void SPS30Component::update() {
     if (this->pm_size_sensor_ != nullptr)
       this->pm_size_sensor_->publish_state(pm_size.value);
 
+    if (this->aqi_sensor_ != nullptr) {
+      aqi::AbstractAQICalculator *calculator = this->aqi_calculator_factory_.get_calculator(this->aqi_calc_type_);
+      int aqi_value = calculator->get_aqi(pm_2_5.value, pm_10_0.value);
+      this->aqi_sensor_->publish_state(aqi_value);
+    }
+
     this->status_clear_warning();
     this->skipped_data_read_cycles_ = 0;
 

--- a/esphome/components/sps30/sps30.h
+++ b/esphome/components/sps30/sps30.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/components/aqi/aqi_calculator_factory.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
@@ -22,6 +23,8 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   void set_pmc_10_0_sensor(sensor::Sensor *pmc_10_0) { pmc_10_0_sensor_ = pmc_10_0; }
 
   void set_pm_size_sensor(sensor::Sensor *pm_size) { pm_size_sensor_ = pm_size; }
+  void set_aqi_sensor(sensor::Sensor *aqi_sensor) { aqi_sensor_ = aqi_sensor; }
+  void set_aqi_calculation_type(aqi::AQICalculatorType aqi_calc_type) { aqi_calc_type_ = aqi_calc_type; }
   void set_auto_cleaning_interval(uint32_t auto_cleaning_interval) { fan_interval_ = auto_cleaning_interval; }
   void set_idle_interval(uint32_t idle_interval) { idle_interval_ = idle_interval; }
   void setup() override;
@@ -63,6 +66,9 @@ class SPS30Component : public PollingComponent, public sensirion_common::Sensiri
   sensor::Sensor *pmc_4_0_sensor_{nullptr};
   sensor::Sensor *pmc_10_0_sensor_{nullptr};
   sensor::Sensor *pm_size_sensor_{nullptr};
+  sensor::Sensor *aqi_sensor_{nullptr};
+  aqi::AQICalculatorType aqi_calc_type_;
+  aqi::AQICalculatorFactory aqi_calculator_factory_;
   optional<uint32_t> fan_interval_;
   optional<uint32_t> idle_interval_;
 };

--- a/tests/components/gcja5/common.yaml
+++ b/tests/components/gcja5/common.yaml
@@ -17,3 +17,6 @@ sensor:
       name: "PMC 5.0"
     pmc_10_0:
       name: "PMC 10.0"
+    aqi:
+      name: "AQI"
+      calculation_type: AQI

--- a/tests/components/pm2005/common.yaml
+++ b/tests/components/pm2005/common.yaml
@@ -7,3 +7,6 @@ sensor:
       name: PM2.5
     pm_10_0:
       name: PM10.0
+    aqi:
+      name: AQI
+      calculation_type: AQI

--- a/tests/components/pmsa003i/common.yaml
+++ b/tests/components/pmsa003i/common.yaml
@@ -21,3 +21,6 @@ sensor:
       name: PMSA003i PMC <10µm
     address: 0x12
     standard_units: true
+    aqi:
+      name: PMSA003i AQI
+      calculation_type: CAQI

--- a/tests/components/sds011/common.yaml
+++ b/tests/components/sds011/common.yaml
@@ -4,5 +4,8 @@ sensor:
       name: SDS011 PM2.5
     pm_10_0:
       name: SDS011 PM10.0
+    aqi:
+      name: SDS011 AQI
+      calculation_type: AQI
     rx_only: false
     update_interval: 5min

--- a/tests/components/sen5x/common.yaml
+++ b/tests/components/sen5x/common.yaml
@@ -43,3 +43,6 @@ sensor:
     acceleration_mode: low
     store_baseline: true
     address: 0x69
+    aqi:
+      name: AQI
+      calculation_type: CAQI

--- a/tests/components/sm300d2/common.yaml
+++ b/tests/components/sm300d2/common.yaml
@@ -14,4 +14,7 @@ sensor:
       name: SM300D2 Temperature Value
     humidity:
       name: SM300D2 Humidity Value
+    aqi:
+      name: SM300D2 AQI
+      calculation_type: CAQI
     update_interval: 60s

--- a/tests/components/sps30/common.yaml
+++ b/tests/components/sps30/common.yaml
@@ -31,3 +31,6 @@ sensor:
     address: 0x69
     update_interval: 10s
     idle_interval: 5min
+    aqi:
+      name: Workshop AQI
+      calculation_type: AQI


### PR DESCRIPTION
# What does this implement/fix?
Adds AQI (Air Quality Index) calculation support to 7 additional particulate matter sensors, following the same pattern established in #12203 for pmsx003 and hm3301.

  This PR extends the shared aqi component to calculate EPA AQI (US) or CAQI (European) indices from PM2.5 and PM10.0 readings for the following sensors:
  - pm2005
  - sen5x
  - sm300d2
  - sds011
  - sps30
  - pmsa003i
  - gcja5

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5805

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
  sensor:
    - platform: sps30
      pm_2_5:
        name: "PM 2.5"
      pm_10_0:
        name: "PM 10.0"
      aqi:
        name: "Air Quality Index"
        calculation_type: AQI  # or CAQI for European index
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
