### PR TITLE
[sprinkler] Remove internal latching valve support

### DIFF
--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -19,6 +19,7 @@ from esphome.const import (
     UNIT_MINUTE,
     UNIT_SECOND,
 )
+from esphome.helpers import docs_url
 
 AUTO_LOAD = ["number", "switch"]
 CODEOWNERS = ["@kbx81"]
@@ -100,7 +101,50 @@ def validate_min_max(config):
 
 
 def validate_sprinkler(config):
+    # Configuration keys that have been removed
+    REMOVED_PUMP_KEYS = [
+        CONF_PUMP_OFF_SWITCH_ID,
+        CONF_PUMP_ON_SWITCH_ID,
+        CONF_PUMP_PULSE_DURATION,
+    ]
+    REMOVED_VALVE_KEYS = [
+        CONF_VALVE_PULSE_DURATION,
+        CONF_VALVE_OFF_SWITCH_ID,
+        CONF_VALVE_ON_SWITCH_ID,
+    ]
+
     for sprinkler_controller_index, sprinkler_controller in enumerate(config):
+        # Check for removed latching pump configuration keys
+        for key in REMOVED_PUMP_KEYS:
+            if key in sprinkler_controller:
+                raise cv.Invalid(
+                    f"'{key}' has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch."
+                    f"See {docs_url('components/switch/h_bridge')} for more information"
+                )
+
+        # Check for removed latching valve configuration keys
+        for key in REMOVED_VALVE_KEYS:
+            if key in sprinkler_controller:
+                raise cv.Invalid(
+                    f"'{key}' has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch."
+                    f"See {docs_url('components/switch/h_bridge')} for more information"
+                )
+
+        # Check valves for removed latching configuration keys
+        for valve in sprinkler_controller[CONF_VALVES]:
+            for key in REMOVED_PUMP_KEYS:
+                if key in valve:
+                    raise cv.Invalid(
+                        f"'{key}' has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch."
+                        f"See {docs_url('components/switch/h_bridge')} for more information"
+                    )
+            for key in REMOVED_VALVE_KEYS:
+                if key in valve:
+                    raise cv.Invalid(
+                        f"'{key}' has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch."
+                        f"See {docs_url('components/switch/h_bridge')} for more information"
+                    )
+
         if len(sprinkler_controller[CONF_VALVES]) <= 1:
             exclusions = [
                 CONF_VALVE_OPEN_DELAY,
@@ -162,55 +206,9 @@ def validate_sprinkler(config):
                 raise cv.Invalid(
                     f"{CONF_RUN_DURATION} must be greater than {CONF_VALVE_OPEN_DELAY}"
                 )
-            if (
-                CONF_PUMP_OFF_SWITCH_ID in valve and CONF_PUMP_ON_SWITCH_ID not in valve
-            ) or (
-                CONF_PUMP_ON_SWITCH_ID in valve and CONF_PUMP_OFF_SWITCH_ID not in valve
-            ):
+            if CONF_VALVE_SWITCH_ID not in valve:
                 raise cv.Invalid(
-                    f"Both {CONF_PUMP_OFF_SWITCH_ID} and {CONF_PUMP_ON_SWITCH_ID} must be specified for latching pump configuration"
-                )
-            if CONF_PUMP_SWITCH_ID in valve and (
-                CONF_PUMP_OFF_SWITCH_ID in valve or CONF_PUMP_ON_SWITCH_ID in valve
-            ):
-                raise cv.Invalid(
-                    f"Do not specify {CONF_PUMP_OFF_SWITCH_ID} or {CONF_PUMP_ON_SWITCH_ID} when using {CONF_PUMP_SWITCH_ID}"
-                )
-            if CONF_PUMP_PULSE_DURATION not in sprinkler_controller and (
-                CONF_PUMP_OFF_SWITCH_ID in valve or CONF_PUMP_ON_SWITCH_ID in valve
-            ):
-                raise cv.Invalid(
-                    f"{CONF_PUMP_PULSE_DURATION} must be specified when using {CONF_PUMP_OFF_SWITCH_ID} and {CONF_PUMP_ON_SWITCH_ID}"
-                )
-            if (
-                CONF_VALVE_OFF_SWITCH_ID in valve
-                and CONF_VALVE_ON_SWITCH_ID not in valve
-            ) or (
-                CONF_VALVE_ON_SWITCH_ID in valve
-                and CONF_VALVE_OFF_SWITCH_ID not in valve
-            ):
-                raise cv.Invalid(
-                    f"Both {CONF_VALVE_OFF_SWITCH_ID} and {CONF_VALVE_ON_SWITCH_ID} must be specified for latching valve configuration"
-                )
-            if CONF_VALVE_SWITCH_ID in valve and (
-                CONF_VALVE_OFF_SWITCH_ID in valve or CONF_VALVE_ON_SWITCH_ID in valve
-            ):
-                raise cv.Invalid(
-                    f"Do not specify {CONF_VALVE_OFF_SWITCH_ID} or {CONF_VALVE_ON_SWITCH_ID} when using {CONF_VALVE_SWITCH_ID}"
-                )
-            if CONF_VALVE_PULSE_DURATION not in sprinkler_controller and (
-                CONF_VALVE_OFF_SWITCH_ID in valve or CONF_VALVE_ON_SWITCH_ID in valve
-            ):
-                raise cv.Invalid(
-                    f"{CONF_VALVE_PULSE_DURATION} must be specified when using {CONF_VALVE_OFF_SWITCH_ID} and {CONF_VALVE_ON_SWITCH_ID}"
-                )
-            if (
-                CONF_VALVE_SWITCH_ID not in valve
-                and CONF_VALVE_OFF_SWITCH_ID not in valve
-                and CONF_VALVE_ON_SWITCH_ID not in valve
-            ):
-                raise cv.Invalid(
-                    f"Either {CONF_VALVE_SWITCH_ID} or {CONF_VALVE_OFF_SWITCH_ID} and {CONF_VALVE_ON_SWITCH_ID} must be specified in valve configuration"
+                    f"{CONF_VALVE_SWITCH_ID} must be specified in valve configuration"
                 )
             if CONF_RUN_DURATION not in valve and CONF_RUN_DURATION_NUMBER not in valve:
                 raise cv.Invalid(
@@ -290,8 +288,6 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
             ),
             key=CONF_NAME,
         ),
-        cv.Optional(CONF_PUMP_OFF_SWITCH_ID): cv.use_id(switch.Switch),
-        cv.Optional(CONF_PUMP_ON_SWITCH_ID): cv.use_id(switch.Switch),
         cv.Optional(CONF_PUMP_SWITCH_ID): cv.use_id(switch.Switch),
         cv.Optional(CONF_RUN_DURATION): cv.positive_time_period_seconds,
         cv.Optional(CONF_RUN_DURATION_NUMBER): cv.maybe_simple_value(
@@ -321,8 +317,6 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
             switch.switch_schema(SprinklerControllerSwitch),
             key=CONF_NAME,
         ),
-        cv.Optional(CONF_VALVE_OFF_SWITCH_ID): cv.use_id(switch.Switch),
-        cv.Optional(CONF_VALVE_ON_SWITCH_ID): cv.use_id(switch.Switch),
         cv.Optional(CONF_VALVE_SWITCH_ID): cv.use_id(switch.Switch),
     }
 )
@@ -410,8 +404,6 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             validate_min_max,
             key=CONF_NAME,
         ),
-        cv.Optional(CONF_PUMP_PULSE_DURATION): cv.positive_time_period_milliseconds,
-        cv.Optional(CONF_VALVE_PULSE_DURATION): cv.positive_time_period_milliseconds,
         cv.Exclusive(
             CONF_PUMP_START_PUMP_DELAY, "pump_start_xxxx_delay"
         ): cv.positive_time_period_seconds,
@@ -765,35 +757,10 @@ async def to_code(config):
                         valve_index, valve_switch, valve[CONF_RUN_DURATION]
                     )
                 )
-            elif CONF_VALVE_OFF_SWITCH_ID in valve and CONF_VALVE_ON_SWITCH_ID in valve:
-                valve_switch_off = await cg.get_variable(
-                    valve[CONF_VALVE_OFF_SWITCH_ID]
-                )
-                valve_switch_on = await cg.get_variable(valve[CONF_VALVE_ON_SWITCH_ID])
-                cg.add(
-                    var.configure_valve_switch_pulsed(
-                        valve_index,
-                        valve_switch_off,
-                        valve_switch_on,
-                        sprinkler_controller[CONF_VALVE_PULSE_DURATION],
-                        valve[CONF_RUN_DURATION],
-                    )
-                )
 
             if CONF_PUMP_SWITCH_ID in valve:
                 pump = await cg.get_variable(valve[CONF_PUMP_SWITCH_ID])
                 cg.add(var.configure_valve_pump_switch(valve_index, pump))
-            elif CONF_PUMP_OFF_SWITCH_ID in valve and CONF_PUMP_ON_SWITCH_ID in valve:
-                pump_off = await cg.get_variable(valve[CONF_PUMP_OFF_SWITCH_ID])
-                pump_on = await cg.get_variable(valve[CONF_PUMP_ON_SWITCH_ID])
-                cg.add(
-                    var.configure_valve_pump_switch_pulsed(
-                        valve_index,
-                        pump_off,
-                        pump_on,
-                        sprinkler_controller[CONF_PUMP_PULSE_DURATION],
-                    )
-                )
 
             if CONF_RUN_DURATION_NUMBER in valve:
                 num_rd_var = await number.new_number(

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -247,11 +247,11 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
         ),
         # Removed latching pump keys - accepted for validation error reporting
         cv.Optional(CONF_PUMP_OFF_SWITCH_ID): cv.invalid(
-            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_PUMP_ON_SWITCH_ID): cv.invalid(
-            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_PUMP_SWITCH_ID): cv.use_id(switch.Switch),
@@ -285,11 +285,11 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
         ),
         # Removed latching valve keys - accepted for validation error reporting
         cv.Optional(CONF_VALVE_OFF_SWITCH_ID): cv.invalid(
-            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_VALVE_ON_SWITCH_ID): cv.invalid(
-            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_VALVE_SWITCH_ID): cv.use_id(switch.Switch),
@@ -381,11 +381,11 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
         ),
         # Removed latching valve keys - accepted for validation error reporting
         cv.Optional(CONF_PUMP_PULSE_DURATION): cv.invalid(
-            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_VALVE_PULSE_DURATION): cv.invalid(
-            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"This option was removed in 2026.1.0; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
             f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Exclusive(

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -101,50 +101,7 @@ def validate_min_max(config):
 
 
 def validate_sprinkler(config):
-    # Configuration keys that have been removed
-    REMOVED_PUMP_KEYS = [
-        CONF_PUMP_OFF_SWITCH_ID,
-        CONF_PUMP_ON_SWITCH_ID,
-        CONF_PUMP_PULSE_DURATION,
-    ]
-    REMOVED_VALVE_KEYS = [
-        CONF_VALVE_PULSE_DURATION,
-        CONF_VALVE_OFF_SWITCH_ID,
-        CONF_VALVE_ON_SWITCH_ID,
-    ]
-
     for sprinkler_controller_index, sprinkler_controller in enumerate(config):
-        # Check for removed latching pump configuration keys
-        for key in REMOVED_PUMP_KEYS:
-            if key in sprinkler_controller:
-                raise cv.Invalid(
-                    f"'{key}' has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch."
-                    f"See {docs_url('components/switch/h_bridge')} for more information"
-                )
-
-        # Check for removed latching valve configuration keys
-        for key in REMOVED_VALVE_KEYS:
-            if key in sprinkler_controller:
-                raise cv.Invalid(
-                    f"'{key}' has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch."
-                    f"See {docs_url('components/switch/h_bridge')} for more information"
-                )
-
-        # Check valves for removed latching configuration keys
-        for valve in sprinkler_controller[CONF_VALVES]:
-            for key in REMOVED_PUMP_KEYS:
-                if key in valve:
-                    raise cv.Invalid(
-                        f"'{key}' has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch."
-                        f"See {docs_url('components/switch/h_bridge')} for more information"
-                    )
-            for key in REMOVED_VALVE_KEYS:
-                if key in valve:
-                    raise cv.Invalid(
-                        f"'{key}' has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch."
-                        f"See {docs_url('components/switch/h_bridge')} for more information"
-                    )
-
         if len(sprinkler_controller[CONF_VALVES]) <= 1:
             exclusions = [
                 CONF_VALVE_OPEN_DELAY,
@@ -288,6 +245,15 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
             ),
             key=CONF_NAME,
         ),
+        # Removed latching pump keys - accepted for validation error reporting
+        cv.Optional(CONF_PUMP_OFF_SWITCH_ID): cv.invalid(
+            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
+        ),
+        cv.Optional(CONF_PUMP_ON_SWITCH_ID): cv.invalid(
+            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
+        ),
         cv.Optional(CONF_PUMP_SWITCH_ID): cv.use_id(switch.Switch),
         cv.Optional(CONF_RUN_DURATION): cv.positive_time_period_seconds,
         cv.Optional(CONF_RUN_DURATION_NUMBER): cv.maybe_simple_value(
@@ -316,6 +282,15 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
         cv.Required(CONF_VALVE_SWITCH): cv.maybe_simple_value(
             switch.switch_schema(SprinklerControllerSwitch),
             key=CONF_NAME,
+        ),
+        # Removed latching valve keys - accepted for validation error reporting
+        cv.Optional(CONF_VALVE_OFF_SWITCH_ID): cv.invalid(
+            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
+        ),
+        cv.Optional(CONF_VALVE_ON_SWITCH_ID): cv.invalid(
+            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Optional(CONF_VALVE_SWITCH_ID): cv.use_id(switch.Switch),
     }
@@ -403,6 +378,15 @@ SPRINKLER_CONTROLLER_SCHEMA = cv.Schema(
             .extend(cv.COMPONENT_SCHEMA),
             validate_min_max,
             key=CONF_NAME,
+        ),
+        # Removed latching valve keys - accepted for validation error reporting
+        cv.Optional(CONF_PUMP_PULSE_DURATION): cv.invalid(
+            f"This option has been removed; for latching pumps, use {CONF_PUMP_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
+        ),
+        cv.Optional(CONF_VALVE_PULSE_DURATION): cv.invalid(
+            f"This option has been removed; for latching valves, use {CONF_VALVE_SWITCH_ID} with an H-Bridge switch. "
+            f"See {docs_url('components/switch/h_bridge')} for more information"
         ),
         cv.Exclusive(
             CONF_PUMP_START_PUMP_DELAY, "pump_start_xxxx_delay"

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -35,41 +35,12 @@ enum SprinklerValveRunRequestOrigin : uint8_t {
 class Sprinkler;                  // this component
 class SprinklerControllerNumber;  // number components that appear in the front end; based on number core
 class SprinklerControllerSwitch;  // switches that appear in the front end; based on switch core
-class SprinklerSwitch;            // switches representing any valve or pump; provides abstraction for latching valves
 class SprinklerValveOperator;     // manages all switching on/off of valves and associated pumps
 class SprinklerValveRunRequest;   // tells the sprinkler controller what valve to run and for how long as well as what
                                   //  SprinklerValveOperator is handling it
 template<typename... Ts> class StartSingleValveAction;
 template<typename... Ts> class ShutdownAction;
 template<typename... Ts> class ResumeOrStartAction;
-
-class SprinklerSwitch {
- public:
-  SprinklerSwitch();
-  SprinklerSwitch(switch_::Switch *sprinkler_switch);
-  SprinklerSwitch(switch_::Switch *off_switch, switch_::Switch *on_switch, uint32_t pulse_duration);
-
-  bool is_latching_valve();  // returns true if configured as a latching valve
-  void loop();               // called as a part of loop(), used for latching valve pulses
-  uint32_t pulse_duration() { return this->pulse_duration_; }
-  bool state();  // returns the switch's current state
-  void set_off_switch(switch_::Switch *off_switch) { this->off_switch_ = off_switch; }
-  void set_on_switch(switch_::Switch *on_switch) { this->on_switch_ = on_switch; }
-  void set_pulse_duration(uint32_t pulse_duration) { this->pulse_duration_ = pulse_duration; }
-  void sync_valve_state(
-      bool latch_state);  // syncs internal state to switch; if latching valve, sets state to latch_state
-  void turn_off();        // sets internal flag and actuates the switch
-  void turn_on();         // sets internal flag and actuates the switch
-  switch_::Switch *off_switch() { return this->off_switch_; }
-  switch_::Switch *on_switch() { return this->on_switch_; }
-
- protected:
-  bool state_{false};
-  uint32_t pulse_duration_{0};
-  uint64_t pinned_millis_{0};
-  switch_::Switch *off_switch_{nullptr};  // only used for latching valves
-  switch_::Switch *on_switch_{nullptr};   // used for both latching and non-latching valves
-};
 
 struct SprinklerQueueItem {
   size_t valve_number;
@@ -88,7 +59,7 @@ struct SprinklerValve {
   SprinklerControllerNumber *run_duration_number;
   SprinklerControllerSwitch *controller_switch;
   SprinklerControllerSwitch *enable_switch;
-  SprinklerSwitch valve_switch;
+  switch_::Switch *valve_switch;
   uint32_t run_duration;
   optional<size_t> pump_switch_index;
   bool valve_cycle_complete;
@@ -155,7 +126,7 @@ class SprinklerValveOperator {
   uint32_t run_duration();         // returns the desired run duration in seconds
   uint32_t time_remaining();       // returns seconds remaining (does not include stop_delay_)
   SprinklerState state();          // returns the valve's state/status
-  SprinklerSwitch *pump_switch();  // returns this SprinklerValveOperator's pump's SprinklerSwitch
+  switch_::Switch *pump_switch();  // returns this SprinklerValveOperator's pump switch
 
  protected:
   void pump_off_();
@@ -228,13 +199,9 @@ class Sprinkler : public Component {
 
   /// configure a valve's switch object and run duration. run_duration is time in seconds.
   void configure_valve_switch(size_t valve_number, switch_::Switch *valve_switch, uint32_t run_duration);
-  void configure_valve_switch_pulsed(size_t valve_number, switch_::Switch *valve_switch_off,
-                                     switch_::Switch *valve_switch_on, uint32_t pulse_duration, uint32_t run_duration);
 
   /// configure a valve's associated pump switch object
   void configure_valve_pump_switch(size_t valve_number, switch_::Switch *pump_switch);
-  void configure_valve_pump_switch_pulsed(size_t valve_number, switch_::Switch *pump_switch_off,
-                                          switch_::Switch *pump_switch_on, uint32_t pulse_duration);
 
   /// configure a valve's run duration number component
   void configure_valve_run_duration_number(size_t valve_number, SprinklerControllerNumber *run_duration_number);
@@ -383,10 +350,10 @@ class Sprinkler : public Component {
   bool is_a_valid_valve(size_t valve_number);
 
   /// returns true if the pump the pointer points to is in use
-  bool pump_in_use(SprinklerSwitch *pump_switch);
+  bool pump_in_use(switch_::Switch *pump_switch);
 
   /// switches on/off a pump "safely" by checking that the new state will not conflict with another controller
-  void set_pump_state(SprinklerSwitch *pump_switch, bool state);
+  void set_pump_state(switch_::Switch *pump_switch, bool state);
 
   /// returns the amount of time in seconds required for all valves
   uint32_t total_cycle_time_all_valves();
@@ -419,13 +386,13 @@ class Sprinkler : public Component {
   SprinklerControllerSwitch *enable_switch(size_t valve_number);
 
   /// returns a pointer to a valve's switch object
-  SprinklerSwitch *valve_switch(size_t valve_number);
+  switch_::Switch *valve_switch(size_t valve_number);
 
   /// returns a pointer to a valve's pump switch object
-  SprinklerSwitch *valve_pump_switch(size_t valve_number);
+  switch_::Switch *valve_pump_switch(size_t valve_number);
 
   /// returns a pointer to a valve's pump switch object
-  SprinklerSwitch *valve_pump_switch_by_pump_index(size_t pump_index);
+  switch_::Switch *valve_pump_switch_by_pump_index(size_t pump_index);
 
  protected:
   /// returns true if valve number is enabled
@@ -577,8 +544,8 @@ class Sprinkler : public Component {
   /// Queue of valves to activate next, regardless of auto-advance
   std::vector<SprinklerQueueItem> queued_valves_;
 
-  /// Sprinkler valve pump objects
-  std::vector<SprinklerSwitch> pump_;
+  /// Sprinkler valve pump switches
+  std::vector<switch_::Switch *> pump_;
 
   /// Sprinkler valve objects
   std::vector<SprinklerValve> valve_;


### PR DESCRIPTION
# What does this implement/fix?

This PR removes the sprinkler component's built-in/internal latching valve support, simplifying the implementation by delegating latching valve control to [H-Bridge switches](https://esphome.io/components/switch/hbridge/).

## Breaking Changes

The following configuration variables have been **removed**:
- `pump_pulse_duration`
- `pump_off_switch_id` 
- `pump_on_switch_id`
- `valve_pulse_duration`
- `valve_off_switch_id`
- `valve_on_switch_id`

Users with latching valves must now use an [H-Bridge switch](https://esphome.io/components/switch/hbridge) with the standard `valve_switch_id` and/or `pump_switch_id` configuration.

## Migration Example

**Before (latching valve with pulse configuration):**
```yaml
sprinkler:
  - id: sprinkler_ctrl
    main_switch: "Sprinkler Controller"
    valve_pulse_duration: 50ms
    pump_pulse_duration: 50ms
    valves:
      - valve_off_switch_id: zone1_valve_off
        valve_on_switch_id: zone1_valve_on
        pump_off_switch_id: zone1_pump_off
        pump_on_switch_id: zone1_pump_on
        run_duration: 600s
```

After (using [H-Bridge switches](https://esphome.io/components/switch/hbridge/)):

```yaml
switch:
  # H-Bridge switch for latching valve
  - platform: hbridge
    id: zone1_valve
    on_pin: GPIOXX      # Previously zone1_valve_on
    off_pin: GPIOXX     # Previously zone1_valve_off
    pulse_length: 50ms  # Previously valve_pulse_duration

  # H-Bridge switch for latching pump
  - platform: hbridge
    id: zone1_pump
    on_pin: GPIOXX      # Previously zone1_pump_on
    off_pin: GPIOXX     # Previously zone1_pump_off
    pulse_length: 50ms  # Previously pump_pulse_duration

sprinkler:
  - id: sprinkler_ctrl
    main_switch: "Sprinkler Controller"
    valves:
      - valve_switch_id: zone1_valve
        pump_switch_id: zone1_pump
        run_duration: 600s
```

One should also consult the [updated documentation](https://next.esphome.io/components/sprinkler/#single-controller-three-latching-valves-single-latching-pump).

## Benefits
- Separation of concerns: Latching valve logic is now handled by the dedicated [H-Bridge switch component](https://esphome.io/components/switch/hbridge/)
- Code reduction: Removes ~270 lines of complex latching valve logic from the sprinkler component
- Maintainability: Simplifies the sprinkler component by removing the `SprinklerSwitch` abstraction layer
- Reusability: [H-Bridge switches](https://esphome.io/components/switch/hbridge/) can be used for other purposes beyond sprinkler control
- Consistency: Uses standard ESPHome switch infrastructure instead of custom implementation

## Implementation Details
- Removed the `SprinklerSwitch` class entirely
- Simplified valve/pump management to use `switch_::Switch*` directly
- Updated validation to detect removed configuration keys and provide helpful error messages with migration guidance
- Removed pulse duration tracking and loop-based pulse management
- Reduced vector storage overhead by using direct switch pointers instead of wrapper objects

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5806

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# See above
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
