### PR TITLE
Add nix files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ venv-*/
 # mypy
 .mypy_cache/
 
+# nix
+/default.nix
+/shell.nix
+
 .pioenvs
 .piolibdeps
 .pio


### PR DESCRIPTION
# What does this implement/fix?

This adds shell.nix and default.nix to the gitignore file. User of the Nix package manager, like myself, can use these files to install any required development tooling.

<!-- Quick description and explanation of changes -->

<s>
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

</s>