### PR TITLE
[cc1101] Fix option defaults and move them to YAML

### DIFF
--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -214,7 +214,7 @@ CONFIG_MAP = {
     cv.Optional(CONF_WAIT_TIME, default="32"): cv.enum(WAIT_TIME, upper=False),
     cv.Optional(CONF_HYST_LEVEL): cv.enum(HYST_LEVEL, upper=False),
     cv.Optional(CONF_PACKET_MODE, default=False): cv.boolean,
-    cv.Optional(CONF_PACKET_LENGTH, default=0): cv.uint8_t,
+    cv.Optional(CONF_PACKET_LENGTH): cv.uint8_t,
     cv.Optional(CONF_CRC_ENABLE, default=False): cv.boolean,
     cv.Optional(CONF_WHITENING, default=False): cv.boolean,
 }

--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -160,41 +160,63 @@ HYST_LEVEL = {
     "High": HystLevel.HYST_LEVEL_HIGH,
 }
 
-# Config key -> Validator mapping
+# Optional settings to generate setter calls for
 CONFIG_MAP = {
-    CONF_OUTPUT_POWER: cv.float_range(min=-30.0, max=11.0),
-    CONF_RX_ATTENUATION: cv.enum(RX_ATTENUATION, upper=False),
-    CONF_DC_BLOCKING_FILTER: cv.boolean,
-    CONF_FREQUENCY: cv.All(cv.frequency, cv.float_range(min=300.0e6, max=928.0e6)),
-    CONF_IF_FREQUENCY: cv.All(cv.frequency, cv.float_range(min=25000, max=788000)),
-    CONF_FILTER_BANDWIDTH: cv.All(cv.frequency, cv.float_range(min=58000, max=812000)),
-    CONF_CHANNEL: cv.uint8_t,
-    CONF_CHANNEL_SPACING: cv.All(cv.frequency, cv.float_range(min=25000, max=405000)),
-    CONF_FSK_DEVIATION: cv.All(cv.frequency, cv.float_range(min=1500, max=381000)),
-    CONF_MSK_DEVIATION: cv.int_range(min=1, max=8),
-    CONF_SYMBOL_RATE: cv.float_range(min=600, max=500000),
-    CONF_SYNC_MODE: cv.enum(SYNC_MODE, upper=False),
-    CONF_CARRIER_SENSE_ABOVE_THRESHOLD: cv.boolean,
-    CONF_MODULATION_TYPE: cv.enum(MODULATION, upper=False),
-    CONF_MANCHESTER: cv.boolean,
-    CONF_NUM_PREAMBLE: cv.int_range(min=0, max=7),
-    CONF_SYNC1: cv.hex_uint8_t,
-    CONF_SYNC0: cv.hex_uint8_t,
-    CONF_MAGN_TARGET: cv.enum(MAGN_TARGET, upper=False),
-    CONF_MAX_LNA_GAIN: cv.enum(MAX_LNA_GAIN, upper=False),
-    CONF_MAX_DVGA_GAIN: cv.enum(MAX_DVGA_GAIN, upper=False),
-    CONF_CARRIER_SENSE_ABS_THR: cv.int_range(min=-8, max=7),
-    CONF_CARRIER_SENSE_REL_THR: cv.enum(CARRIER_SENSE_REL_THR, upper=False),
-    CONF_LNA_PRIORITY: cv.boolean,
-    CONF_FILTER_LENGTH_FSK_MSK: cv.enum(FILTER_LENGTH_FSK_MSK, upper=False),
-    CONF_FILTER_LENGTH_ASK_OOK: cv.enum(FILTER_LENGTH_ASK_OOK, upper=False),
-    CONF_FREEZE: cv.enum(FREEZE, upper=False),
-    CONF_WAIT_TIME: cv.enum(WAIT_TIME, upper=False),
-    CONF_HYST_LEVEL: cv.enum(HYST_LEVEL, upper=False),
-    CONF_PACKET_MODE: cv.boolean,
-    CONF_PACKET_LENGTH: cv.uint8_t,
-    CONF_CRC_ENABLE: cv.boolean,
-    CONF_WHITENING: cv.boolean,
+    cv.Optional(CONF_OUTPUT_POWER, default=10): cv.float_range(min=-30.0, max=11.0),
+    cv.Optional(CONF_RX_ATTENUATION, default="0dB"): cv.enum(
+        RX_ATTENUATION, upper=False
+    ),
+    cv.Optional(CONF_DC_BLOCKING_FILTER, default=True): cv.boolean,
+    cv.Optional(CONF_FREQUENCY, default="433.92MHz"): cv.All(
+        cv.frequency, cv.float_range(min=300.0e6, max=928.0e6)
+    ),
+    cv.Optional(CONF_IF_FREQUENCY, default="153kHz"): cv.All(
+        cv.frequency, cv.float_range(min=25000, max=788000)
+    ),
+    cv.Optional(CONF_FILTER_BANDWIDTH, default="203kHz"): cv.All(
+        cv.frequency, cv.float_range(min=58000, max=812000)
+    ),
+    cv.Optional(CONF_CHANNEL, default=0): cv.uint8_t,
+    cv.Optional(CONF_CHANNEL_SPACING, default="200kHz"): cv.All(
+        cv.frequency, cv.float_range(min=25000, max=405000)
+    ),
+    cv.Optional(CONF_FSK_DEVIATION): cv.All(
+        cv.frequency, cv.float_range(min=1500, max=381000)
+    ),
+    cv.Optional(CONF_MSK_DEVIATION): cv.int_range(min=1, max=8),
+    cv.Optional(CONF_SYMBOL_RATE, default=5000): cv.float_range(min=600, max=500000),
+    cv.Optional(CONF_SYNC_MODE, default="16/16"): cv.enum(SYNC_MODE, upper=False),
+    cv.Optional(CONF_CARRIER_SENSE_ABOVE_THRESHOLD, default=False): cv.boolean,
+    cv.Optional(CONF_MODULATION_TYPE, default="ASK/OOK"): cv.enum(
+        MODULATION, upper=False
+    ),
+    cv.Optional(CONF_MANCHESTER, default=False): cv.boolean,
+    cv.Optional(CONF_NUM_PREAMBLE, default=2): cv.int_range(min=0, max=7),
+    cv.Optional(CONF_SYNC1, default=0xD3): cv.hex_uint8_t,
+    cv.Optional(CONF_SYNC0, default=0x91): cv.hex_uint8_t,
+    cv.Optional(CONF_MAGN_TARGET, default="42dB"): cv.enum(MAGN_TARGET, upper=False),
+    cv.Optional(CONF_MAX_LNA_GAIN, default="Default"): cv.enum(
+        MAX_LNA_GAIN, upper=False
+    ),
+    cv.Optional(CONF_MAX_DVGA_GAIN, default="-3"): cv.enum(MAX_DVGA_GAIN, upper=False),
+    cv.Optional(CONF_CARRIER_SENSE_ABS_THR): cv.int_range(min=-8, max=7),
+    cv.Optional(CONF_CARRIER_SENSE_REL_THR): cv.enum(
+        CARRIER_SENSE_REL_THR, upper=False
+    ),
+    cv.Optional(CONF_LNA_PRIORITY, default=False): cv.boolean,
+    cv.Optional(CONF_FILTER_LENGTH_FSK_MSK): cv.enum(
+        FILTER_LENGTH_FSK_MSK, upper=False
+    ),
+    cv.Optional(CONF_FILTER_LENGTH_ASK_OOK): cv.enum(
+        FILTER_LENGTH_ASK_OOK, upper=False
+    ),
+    cv.Optional(CONF_FREEZE): cv.enum(FREEZE, upper=False),
+    cv.Optional(CONF_WAIT_TIME, default="32"): cv.enum(WAIT_TIME, upper=False),
+    cv.Optional(CONF_HYST_LEVEL): cv.enum(HYST_LEVEL, upper=False),
+    cv.Optional(CONF_PACKET_MODE, default=False): cv.boolean,
+    cv.Optional(CONF_PACKET_LENGTH, default=0): cv.uint8_t,
+    cv.Optional(CONF_CRC_ENABLE, default=False): cv.boolean,
+    cv.Optional(CONF_WHITENING, default=False): cv.boolean,
 }
 
 
@@ -217,7 +239,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ON_PACKET): automation.validate_automation(single=True),
         }
     )
-    .extend({cv.Optional(key): validator for key, validator in CONFIG_MAP.items()})
+    .extend(CONFIG_MAP)
     .extend(cv.COMPONENT_SCHEMA)
     .extend(spi.spi_device_schema(cs_pin_required=True)),
     _validate_packet_mode,
@@ -229,7 +251,8 @@ async def to_code(config):
     await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
 
-    for key in CONFIG_MAP:
+    for opt in CONFIG_MAP:
+        key = opt.schema
         if key in config:
             cg.add(getattr(var, f"set_{key}")(config[key]))
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -98,25 +98,8 @@ CC1101Component::CC1101Component() {
   this->state_.LENGTH_CONFIG = 2;
   this->state_.FS_AUTOCAL = 1;
 
-  // Default Settings
-  this->set_frequency(433920000);
-  this->set_if_frequency(153000);
-  this->set_filter_bandwidth(203000);
-  this->set_channel(0);
-  this->set_channel_spacing(200000);
-  this->set_symbol_rate(5000);
-  this->set_sync_mode(SyncMode::SYNC_MODE_NONE);
-  this->set_carrier_sense_above_threshold(true);
-  this->set_modulation_type(Modulation::MODULATION_ASK_OOK);
-  this->set_magn_target(MagnTarget::MAGN_TARGET_42DB);
-  this->set_max_lna_gain(MaxLnaGain::MAX_LNA_GAIN_DEFAULT);
-  this->set_max_dvga_gain(MaxDvgaGain::MAX_DVGA_GAIN_MINUS_3);
-  this->set_lna_priority(false);
-  this->set_wait_time(WaitTime::WAIT_TIME_32_SAMPLES);
-
   // CRITICAL: Initialize PA Table to avoid transmitting 0 power (Silence)
   memset(this->pa_table_, 0, sizeof(this->pa_table_));
-  this->set_output_power(10.0f);
 }
 
 void CC1101Component::setup() {


### PR DESCRIPTION
# What does this implement/fix?

A bunch of config options for `cc1101` had different default values in the documentation and in reality.
For example, `crc_enable`, `whitening` and `carrier_sense_above_threshold` are supposed to be `false` by default, but are actually `true`. `sync_mode` is expected to be `16/16`, but is actually `None`.

This sets all the defaults right in the schema, keeping everything in one place and preventing stuff like #12539 from happening.

It did get kinda bulky though, especially with the formatting rules.
If you want, I can implement an alternative approach with tuple items like this:
```python
# Config key -> (Validator, default value) mapping
CONFIG_MAP = {
...
  CONF_IF_FREQUENCY: (cv.All(cv.frequency, cv.float_range(min=25000, max=788000)), "153kHz"),
...
}
```
Much less bulky, but also less conventional than a regular schema object, and it's not immediately clear what it does.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).