### PR TITLE
[thermostat] Enhance timer behavior for immediate response to duration changes

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -267,6 +267,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool timer_active_(ThermostatClimateTimerIndex timer_index);
   uint32_t timer_duration_(ThermostatClimateTimerIndex timer_index);
   std::function<void()> timer_cbf_(ThermostatClimateTimerIndex timer_index);
+  /// Enhanced timer duration setter with running timer adjustment
+  void set_timer_duration_in_sec_(ThermostatClimateTimerIndex timer_index, uint32_t time);
 
   /// set_timeout() callbacks for various actions (see above)
   void cooling_max_run_time_timer_callback_();


### PR DESCRIPTION
# What does this implement/fix?

Enhances thermostat timer behavior to provide immediate response when timer durations are changed. Previously, calling `set_heating_minimum_off_time_in_sec(0)` while a heating off timer was running would not immediately allow heating to start - the timer would continue running until its natural expiration. This enhancement implements intelligent timer adjustment that:

- Calculates elapsed time when a running timer's duration is changed
- Completes timers immediately if the new duration is less than elapsed time (including when set to 0)
- Adjusts remaining time when new duration is greater than elapsed time
- Triggers timer callbacks immediately upon early completion
- Applies consistently across all thermostat timer functions

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- New feature - addresses user need for immediate timer response in dynamic heating control scenarios

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not required - this is an internal implementation improvement that doesn't change user-facing API or documentation

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml - no changes needed, existing configuration works with enhanced behavior
climate:
  - platform: thermostat
    name: "Enhanced Thermostat"
    sensor: temperature_sensor
    min_heating_off_time: 600s  # Now responds immediately when changed to 0s
    min_heating_run_time: 300s
    heat_action:
      - switch.turn_on: heater
    idle_action:
      - switch.turn_off: heater

# Lambda usage - now provides immediate response
on_...:
  then:
    - lambda: |-
        // Setting to 0s now immediately allows heating to start
        id(thermostat).set_heating_minimum_off_time_in_sec(0);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).