### PR TITLE
Add Mitsubishi fahrenheit_compatibility mode

### DIFF
--- a/esphome/components/mitsubishi/climate.py
+++ b/esphome/components/mitsubishi/climate.py
@@ -19,6 +19,7 @@ SETFANMODE = {
 
 CONF_SUPPORTS_DRY = "supports_dry"
 CONF_SUPPORTS_FAN_ONLY = "supports_fan_only"
+CONF_FAHRENHEIT_COMPATIBILITY = "fahrenheit_compatibility"
 
 CONF_HORIZONTAL_DEFAULT = "horizontal_default"
 HorizontalDirections = mitsubishi_ns.enum("HorizontalDirections")
@@ -48,6 +49,7 @@ CONFIG_SCHEMA = climate_ir.climate_ir_with_receiver_schema(MitsubishiClimate).ex
         cv.Optional(CONF_SET_FAN_MODE, default="3levels"): cv.enum(SETFANMODE),
         cv.Optional(CONF_SUPPORTS_DRY, default=False): cv.boolean,
         cv.Optional(CONF_SUPPORTS_FAN_ONLY, default=False): cv.boolean,
+        cv.Optional(CONF_FAHRENHEIT_COMPATIBILITY, default=False): cv.boolean,
         cv.Optional(CONF_HORIZONTAL_DEFAULT, default="middle"): cv.enum(
             HORIZONTAL_DIRECTIONS
         ),
@@ -64,5 +66,6 @@ async def to_code(config):
     cg.add(var.set_fan_mode(config[CONF_SET_FAN_MODE]))
     cg.add(var.set_supports_dry(config[CONF_SUPPORTS_DRY]))
     cg.add(var.set_supports_fan_only(config[CONF_SUPPORTS_FAN_ONLY]))
+    cg.add(var.set_fahrenheit_compatibility(config[CONF_FAHRENHEIT_COMPATIBILITY]))
     cg.add(var.set_horizontal_default(config[CONF_HORIZONTAL_DEFAULT]))
     cg.add(var.set_vertical_default(config[CONF_VERTICAL_DEFAULT]))

--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -151,8 +151,12 @@ void MitsubishiClimate::transmit_state() {
   if (this->mode == climate::CLIMATE_MODE_DRY) {
     remote_state[7] = 24 - MITSUBISHI_TEMP_MIN;  // Remote sends always 24°C if "Dry" mode is selected
   } else {
-    remote_state[7] = (uint8_t) roundf(
-        clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) - MITSUBISHI_TEMP_MIN);
+    if (!this->fahrenheit_compatibility_) {
+      remote_state[7] = (uint8_t) roundf(
+          clamp<float>(this->target_temperature, MITSUBISHI_TEMP_MIN, MITSUBISHI_TEMP_MAX) - MITSUBISHI_TEMP_MIN);
+    } else {
+      remote_state[7] = reconvert_from_fahrenheit_(this->target_temperature);
+    }
   }
 
   // Wide Vane
@@ -282,6 +286,32 @@ void MitsubishiClimate::transmit_state() {
 
 bool MitsubishiClimate::parse_state_frame_(const uint8_t frame[]) { return false; }
 
+static const uint8_t FAHRENHEIT_CODES[] = {0x00, 0x10, 0x01, 0x11, 0x02, 0x12, 0x03, 0x04, 0x05, 0x15,
+                                           0x06, 0x16, 0x07, 0x17, 0x08, 0x18, 0x09, 0x19, 0x0a, 0x1a,
+                                           0x0b, 0x1b, 0x0c, 0x1c, 0x0d, 0x1d, 0x0e, 0x0f};
+
+uint8_t MitsubishiClimate::reconvert_from_fahrenheit_(float c_temp) {
+  if (c_temp < 16.0f) {
+    return 0x00;
+  }
+  if (c_temp > 31.2f) {
+    return 0x0f;
+  }
+
+  // Every temperature from 61F..88F sends a unique code to the unit.
+  uint8_t f_index = (uint8_t) roundf(c_temp * 1.8f + 32) - 61;
+  return FAHRENHEIT_CODES[f_index];
+}
+
+float MitsubishiClimate::temp_code_to_celsius_(uint8_t code) {
+  for (size_t i = 0; i < sizeof(FAHRENHEIT_CODES) / sizeof(FAHRENHEIT_CODES[0]); i++) {
+    if (code == FAHRENHEIT_CODES[i]) {
+      return (61.0f + i - 32) / 1.8;
+    }
+  }
+  return -1.0f;
+}
+
 bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   uint8_t state_frame[18] = {};
 
@@ -336,7 +366,18 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Temp
-  this->target_temperature = state_frame[7] + MITSUBISHI_TEMP_MIN;
+  if (!this->fahrenheit_compatibility_) {
+    this->target_temperature = state_frame[7] + MITSUBISHI_TEMP_MIN;
+    if (state_frame[7] & 0x10) {
+      ESP_LOGV(TAG, "Transmitter is in Fahrenheit mode; enable `fahrenheit_compatibility` for proper decoding");
+    }
+  } else {
+    this->target_temperature = temp_code_to_celsius_(state_frame[7]);
+    if (this->target_temperature < 0) {
+      ESP_LOGV(TAG, "Invalid temperature code %02x", state_frame[7]);
+      return false;
+    }
+  }
 
   // Fan
   uint8_t fan = state_frame[9] & 0x07;  //(Bit 0,1,2 = Speed)

--- a/esphome/components/mitsubishi/mitsubishi.h
+++ b/esphome/components/mitsubishi/mitsubishi.h
@@ -9,7 +9,7 @@ namespace mitsubishi {
 
 // Temperature
 const uint8_t MITSUBISHI_TEMP_MIN = 16;  // Celsius
-const uint8_t MITSUBISHI_TEMP_MAX = 31;  // Celsius
+const uint8_t MITSUBISHI_TEMP_MAX = 32;  // 88F gets sent to us as 31.11C
 
 // Fan mode
 enum SetFanMode {
@@ -54,6 +54,9 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
   void set_supports_dry(bool supports_dry) { this->supports_dry_ = supports_dry; }
   void set_supports_fan_only(bool supports_fan_only) { this->supports_fan_only_ = supports_fan_only; }
   void set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }
+  void set_fahrenheit_compatibility(bool fahrenheit_compatibility) {
+    this->fahrenheit_compatibility_ = fahrenheit_compatibility;
+  }
 
   void set_fan_mode(SetFanMode fan_mode) { this->fan_mode_ = fan_mode; }
 
@@ -70,8 +73,11 @@ class MitsubishiClimate : public climate_ir::ClimateIR {
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);
+  uint8_t reconvert_from_fahrenheit_(float c_temp);
+  float temp_code_to_celsius_(uint8_t code);
 
   SetFanMode fan_mode_;
+  bool fahrenheit_compatibility_;
 
   HorizontalDirection default_horizontal_direction_;
   VerticalDirection default_vertical_direction_;

--- a/tests/components/mitsubishi/common.yaml
+++ b/tests/components/mitsubishi/common.yaml
@@ -2,3 +2,4 @@ climate:
   - platform: mitsubishi
     name: Mitsubishi
     transmitter_id: xmitr
+    fahrenheit_compatibility: "false"


### PR DESCRIPTION
# What does this implement/fix?

Per https://github.com/echavet/MitsubishiCN105ESPHome/pull/298

> Because Celsius and Fahrenheit do not evenly correspond (Δ1°F = Δ0.56°C), Mitsubishi has implemented a custom translation between the two based on a lookup table for the ease of controlling their heat pumps (which use Celsius internally) from thermostats set to Fahrenheit.

My HA setup uses American units, so temperatures are all in Fahrenheit.  I found two bugs when sniffing the IR codes produced by the esphome Mitsubishi climate IR module:

1. I could set the dial widget in HA to 88F, however after it is internally converted to 31.11C, it exceeds esphome's `MITSUBISHI_TEMP_MAX` of 31C.  So, the OEM remote goes up to 88F but HA only goes up to 87F.

2. The OEM remote allows setting temperatures from 61F to 88F, inclusive.  Every distinct temperature setting sends a distinct code in IR byte 7.  Mitsubishi accomplishes this by designating bit 4 as a "half degree C" bit.  This bit is never set in esphome's present logic.

The observed byte 7 values sent by esphome for each Fahrenheit temperature are in parentheses below:

```
88F: forbidden! should be 0x0f
87F: 30.555555C (0x0f), should be 0x0e
86F: 30.000000C (0x0e), should be 0x1d
85F: 29.444445C (0x0d)
84F: 28.888889C (0x0d), should be 0x1c
83F: 28.333334C (0x0c)
82F: 27.777779C (0x0c), should be 0x1b
81F: 27.222221C (0x0b)
80F: 26.666666C (0x0b), should be 0x1a
79F: 26.111111C (0x0a)
78F: 25.555555C (0x0a), should be 0x19
77F: 25.000000C (0x09)
76F: 24.444445C (0x08), should be 0x18
75F: 23.888889C (0x08)
74F: 23.333334C (0x07), should be 0x17
73F: 22.777779C (0x07)
72F: 22.222221C (0x06), should be 0x16
71F: 21.666666C (0x06)
70F: 21.111111C (0x05), should be 0x15
69F: 20.555555C (0x05)
68F: 20.000000C (0x04)
67F: 19.444445C (0x03)
66F: 18.888889C (0x03), should be 0x12
65F: 18.333334C (0x02)
64F: 17.777779C (0x02), should be 0x11
63F: 17.222221C (0x01)
62F: 16.666666C (0x01), should be 0x10
61F: 16.111111C (0x00)
```

This PR bumps up the Celsius limit to 32 degrees, and implements a simple lookup table to translate HA's Celsius setting into a Mitsubishi's temperature byte.  As with the CN105 project mentioned above, the new behavior is disabled by default and gated by the `fahrenheit_compatibility` boolean.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/echavet/MitsubishiCN105ESPHome/issues/272 (same issue seen in another project)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/5809

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: mitsubishi
    name: "office-minisplit"
    set_fan_mode: "quiet_4levels"
    supports_dry: "true"
    supports_fan_only: "true"
    horizontal_default: "left"
    vertical_default: "up"
    fahrenheit_compatibility: "true"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
