### PR TITLE
[logger] RP2040: Use write() with known length instead of println()

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -118,11 +118,11 @@ static constexpr uint16_t MAX_HEADER_SIZE = 128;
 static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
 
 // Platform-specific: does write_msg_ add its own newline?
-// false: Caller must add newline to buffer before calling write_msg_ (ESP32, ESP8266, LibreTiny)
+// false: Caller must add newline to buffer before calling write_msg_ (ESP32, ESP8266, RP2040, LibreTiny)
 //        Allows single write call with newline included for efficiency
 // true:  write_msg_ adds newline itself via puts()/println() (other platforms)
 //        Newline should NOT be added to buffer
-#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY)
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;
 #else
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = true;

--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -27,7 +27,10 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg, size_t) { this->hw_serial_->println(msg); }
+void HOT Logger::write_msg_(const char *msg, size_t len) {
+  // Single write with newline already in buffer (added by caller)
+  this->hw_serial_->write(msg, len);
+}
 
 const LogString *Logger::get_uart_selection_() {
   switch (this->uart_) {


### PR DESCRIPTION
# What does this implement/fix?

Align RP2040 logger serial output with ESP8266 and LibreTiny by using `write(msg, len)` instead of `println(msg)`.

Previously, RP2040 used `println()` which:
1. Calls `strlen()` internally to determine message length (we already know it)
2. Adds its own newline (the caller now provides it in the buffer)
3. May result in multiple write calls

Now RP2040 uses `write(msg, len)` like ESP8266 and LibreTiny, which:
1. Uses the pre-computed length directly (avoids redundant `strlen()`)
2. Writes the message with newline in a single call
3. Is consistent across all Arduino-based platforms

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - internal optimization
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
