### PR TITLE
[codegen] Add static storage class to global variables for size optimization

### DIFF
--- a/esphome/components/lvgl/__init__.py
+++ b/esphome/components/lvgl/__init__.py
@@ -256,9 +256,11 @@ async def to_code(configs):
             True,
             type=lv_font_t.operator("ptr").operator("const"),
         )
+        # static=False because LV_FONT_CUSTOM_DECLARE creates an extern declaration
         cg.new_variable(
             globfont_id,
             MockObj(await lvalid.lv_font.process(default_font), "->").get_lv_font(),
+            static=False,
         )
         add_define("LV_FONT_DEFAULT", df.DEFAULT_ESPHOME_FONT)
     else:

--- a/esphome/components/lvgl/lvcode.py
+++ b/esphome/components/lvgl/lvcode.py
@@ -337,7 +337,7 @@ def lv_Pvariable(type, name) -> MockObj:
     """
     if isinstance(name, str):
         name = ID(name, True, type)
-    decl = VariableDeclarationExpression(type, "*", name, storage_class="static")
+    decl = VariableDeclarationExpression(type, "*", name, static=True)
     CORE.add_global(decl)
     var = MockObj(name, "->")
     CORE.register_variable(name, var)
@@ -353,7 +353,7 @@ def lv_variable(type, name) -> MockObj:
     """
     if isinstance(name, str):
         name = ID(name, True, type)
-    decl = VariableDeclarationExpression(type, "", name, storage_class="static")
+    decl = VariableDeclarationExpression(type, "", name, static=True)
     CORE.add_global(decl)
     var = MockObj(name, ".")
     CORE.register_variable(name, var)

--- a/esphome/components/lvgl/lvcode.py
+++ b/esphome/components/lvgl/lvcode.py
@@ -337,7 +337,7 @@ def lv_Pvariable(type, name) -> MockObj:
     """
     if isinstance(name, str):
         name = ID(name, True, type)
-    decl = VariableDeclarationExpression(type, "*", name)
+    decl = VariableDeclarationExpression(type, "*", name, storage_class="static")
     CORE.add_global(decl)
     var = MockObj(name, "->")
     CORE.register_variable(name, var)
@@ -353,7 +353,7 @@ def lv_variable(type, name) -> MockObj:
     """
     if isinstance(name, str):
         name = ID(name, True, type)
-    decl = VariableDeclarationExpression(type, "", name)
+    decl = VariableDeclarationExpression(type, "", name, storage_class="static")
     CORE.add_global(decl)
     var = MockObj(name, ".")
     CORE.register_variable(name, var)

--- a/esphome/components/mapping/__init__.py
+++ b/esphome/components/mapping/__init__.py
@@ -133,7 +133,7 @@ async def to_code(config):
         value_type,
     )
     var = MockObj(varid, ".")
-    decl = VariableDeclarationExpression(varid.type, "", varid, storage_class="static")
+    decl = VariableDeclarationExpression(varid.type, "", varid, static=True)
     add_global(decl)
     CORE.register_variable(varid, var)
 

--- a/esphome/components/mapping/__init__.py
+++ b/esphome/components/mapping/__init__.py
@@ -133,7 +133,7 @@ async def to_code(config):
         value_type,
     )
     var = MockObj(varid, ".")
-    decl = VariableDeclarationExpression(varid.type, "", varid)
+    decl = VariableDeclarationExpression(varid.type, "", varid, storage_class="static")
     add_global(decl)
     CORE.register_variable(varid, var)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -51,20 +51,19 @@ class AssignmentExpression(Expression):
 
 
 class VariableDeclarationExpression(Expression):
-    __slots__ = ("type", "modifier", "name", "storage_class")
+    __slots__ = ("type", "modifier", "name", "static")
 
     def __init__(
-        self, type_: "MockObj", modifier: str, name: ID, storage_class: str = ""
+        self, type_: "MockObj", modifier: str, name: ID, *, static: bool = False
     ) -> None:
         self.type = type_
         self.modifier = modifier
         self.name = name
-        self.storage_class = storage_class
+        self.static = static
 
     def __str__(self) -> str:
-        if self.storage_class:
-            return f"{self.storage_class} {self.type} {self.modifier}{self.name}"
-        return f"{self.type} {self.modifier}{self.name}"
+        prefix = "static " if self.static else ""
+        return f"{prefix}{self.type} {self.modifier}{self.name}"
 
 
 class ExpressionList(Expression):
@@ -527,7 +526,7 @@ def new_variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj
     obj = MockObj(id_, ".")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "", id_, storage_class="static")
+    decl = VariableDeclarationExpression(id_.type, "", id_, static=True)
     CORE.add_global(decl)
     assignment = AssignmentExpression(None, "", id_, rhs)
     CORE.add(assignment)
@@ -549,7 +548,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     obj = MockObj(id_, "->")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "*", id_, storage_class="static")
+    decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)
     CORE.add_global(decl)
     assignment = AssignmentExpression(None, None, id_, rhs)
     CORE.add(assignment)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -51,14 +51,19 @@ class AssignmentExpression(Expression):
 
 
 class VariableDeclarationExpression(Expression):
-    __slots__ = ("type", "modifier", "name")
+    __slots__ = ("type", "modifier", "name", "storage_class")
 
-    def __init__(self, type_, modifier, name):
+    def __init__(
+        self, type_: "MockObj", modifier: str, name: ID, storage_class: str = ""
+    ) -> None:
         self.type = type_
         self.modifier = modifier
         self.name = name
+        self.storage_class = storage_class
 
-    def __str__(self):
+    def __str__(self) -> str:
+        if self.storage_class:
+            return f"{self.storage_class} {self.type} {self.modifier}{self.name}"
         return f"{self.type} {self.modifier}{self.name}"
 
 
@@ -522,7 +527,7 @@ def new_variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj
     obj = MockObj(id_, ".")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "", id_)
+    decl = VariableDeclarationExpression(id_.type, "", id_, storage_class="static")
     CORE.add_global(decl)
     assignment = AssignmentExpression(None, "", id_, rhs)
     CORE.add(assignment)
@@ -544,7 +549,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     obj = MockObj(id_, "->")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "*", id_)
+    decl = VariableDeclarationExpression(id_.type, "*", id_, storage_class="static")
     CORE.add_global(decl)
     assignment = AssignmentExpression(None, None, id_, rhs)
     CORE.add(assignment)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -511,13 +511,17 @@ def with_local_variable(id_: ID, rhs: SafeExpType, callback: Callable, *args) ->
     CORE.add(RawStatement("}"))  # output closing curly brace
 
 
-def new_variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
+def new_variable(
+    id_: ID, rhs: SafeExpType, type_: "MockObj" = None, *, static: bool = True
+) -> "MockObj":
     """Declare and define a new variable, not pointer type, in the code generation.
 
     :param id_: The ID used to declare the variable.
     :param rhs: The expression to place on the right hand side of the assignment.
     :param type_: Manually define a type for the variable, only use this when it's not possible
       to do so during config validation phase (for example because of template arguments).
+    :param static: If True (default), declare with static storage class for optimization.
+      Set to False when the variable must have external linkage (e.g., to match library declarations).
 
     :return: The new variable as a MockObj.
     """
@@ -526,7 +530,7 @@ def new_variable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj
     obj = MockObj(id_, ".")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "", id_, static=True)
+    decl = VariableDeclarationExpression(id_.type, "", id_, static=static)
     CORE.add_global(decl)
     assignment = AssignmentExpression(None, "", id_, rhs)
     CORE.add(assignment)


### PR DESCRIPTION
# What does this implement/fix?

Add `static` storage class to global variable declarations in generated C++ code to enable better compiler optimization.

Global pointer variables declared at file scope without `static` have external linkage, which prevents the compiler from eliminating unused variables or optimizing their access patterns. By adding `static`, these variables become file-local, allowing the compiler to:

- Eliminate unused pointers entirely
- Enable better inlining opportunities
- Reduce binary size (especially with LTO)

This is implemented by adding a `static: bool` parameter to `VariableDeclarationExpression` and passing `static=True` for all global variable declarations (via `CORE.add_global()`).

Note: The `static` parameter defaults to `False` in `VariableDeclarationExpression`, which is intentional. It is also used for local variable declarations within function blocks (e.g., LVGL's `CodeContext.append()`), where `static` would have a different meaning (persistent storage across function calls).

### Edge case: External library declarations

In rare cases, a variable must have external linkage to match an `extern` declaration from a library header. The `new_variable()` function accepts `static=False` for this purpose:

```python
# LVGL font example - must match LV_FONT_CUSTOM_DECLARE's extern declaration
cg.new_variable(globfont_id, font_value, static=False)
```

This is only needed when a library macro creates an `extern` declaration that ESPHome code must define. All other globals use `static=True` by default.

### Measured Results

**Simple configuration (ESP8266):**
| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| RAM | 31,868 bytes | 31,844 bytes | **24 bytes** |
| Flash | 407,145 bytes | 407,065 bytes | **80 bytes** |

**Complex configuration (ESP8266):**
| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| RAM | 35,272 bytes | 35,160 bytes | **112 bytes** |
| Flash | 499,241 bytes | 499,001 bytes | **240 bytes** |

**Large configuration (ESP32):**
| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| RAM | 41,684 bytes | 41,468 bytes | **216 bytes** |
| Flash | 1,086,991 bytes | 1,085,919 bytes | **1,072 bytes** |

**CI Memory Impact Analysis (ESP32-IDF with lvgl + mapping):**
| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| RAM | 51,360 bytes | 51,120 bytes | **240 bytes (-0.47%)** |
| Flash | 1,478,434 bytes | 1,477,742 bytes | **692 bytes (-0.05%)** |

Savings scale with configuration complexity - more components means more global pointers and greater optimization potential.

### How the optimization works

Without `static`, global variables have external linkage - the compiler must assume they could be accessed from other translation units, so it cannot eliminate them even if unused:

```cpp
sensor::Sensor *unused_sensor;  // External linkage - compiler MUST keep it
```

With `static`, variables have internal linkage - the compiler knows nothing outside the file can reference them, enabling dead code elimination:

```cpp
static sensor::Sensor *unused_sensor;  // Internal linkage - safe to eliminate if unused
```

### Does `id()` still work in lambdas?

Yes! The `id(my_sensor)` syntax in YAML lambdas simply expands to the variable name (`my_sensor`). Since all ESPHome generated code lives in the same `main.cpp` file, file-scope `static` variables are fully accessible:

```cpp
// Generated code:
static template_::TemplateSensor *test_sensor;  // Declaration (line 10)

// In lambda - id(test_sensor).state becomes:
float val = test_sensor->state;  // Works perfectly (line 114)
```

### What gets optimized away?

Only truly unused globals are eliminated. If any code references the variable (via `id()`, automations, API, etc.), it remains. The CI symbol analysis shows this working:

1. **Unused pointers eliminated** - Variables like `esp32_esp32internalgpiopin_id` that were allocated but never referenced are now removed
2. **ABI mangling removed** - Symbols like `weather_map[abi:cxx11]` become `weather_map` since static variables don't need external linkage decoration
3. **`setup()` function shrinks** - The compiler can inline and optimize more aggressively (-36 bytes in CI)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

### Why not a developer breaking change?

The `static` keyword is added automatically to all global variable declarations. The only case where this could cause issues is when a variable must have external linkage to match an `extern` declaration from an external library header.

After extensive search of the codebase, the LVGL font case (`LV_FONT_CUSTOM_DECLARE` → `LV_FONT_DECLARE`) is the **only** instance of this pattern. This occurs because the LVGL library's macro creates an `extern const lv_font_t *` declaration that ESPHome must match.

This pattern is unlikely to appear in external components because:
1. It requires an external library macro that creates `extern` declarations
2. The variable name must be passed to that macro via `add_define()`
3. ESPHome must then define that exact variable via `new_variable()` or `Pvariable()`

No other library integration in ESPHome uses this pattern, and external components typically don't integrate with libraries at this level. If an external component does encounter this issue, the fix is simple: pass `static=False` to `new_variable()`.

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/3115

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this optimization applies automatically
# to all generated code.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
