### PR TITLE
[logger] Zephyr: Use k_str_out() with known length instead of printk()

### DIFF
--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -118,11 +118,11 @@ static constexpr uint16_t MAX_HEADER_SIZE = 128;
 static constexpr size_t MAX_POINTER_REPRESENTATION = 2 + sizeof(void *) * 2 + 1;
 
 // Platform-specific: does write_msg_ add its own newline?
-// false: Caller must add newline to buffer before calling write_msg_ (ESP32, ESP8266, RP2040, LibreTiny)
+// false: Caller must add newline to buffer before calling write_msg_ (ESP32, ESP8266, RP2040, LibreTiny, Zephyr)
 //        Allows single write call with newline included for efficiency
 // true:  write_msg_ adds newline itself via puts()/println() (other platforms)
 //        Newline should NOT be added to buffer
-#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR)
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = false;
 #else
 static constexpr bool WRITE_MSG_ADDS_NEWLINE = true;

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "logger";
 
 #ifdef USE_LOGGER_USB_CDC
 void Logger::loop() {
-  if (this->uart_ != UART_SELECTION_USB_CDC || nullptr == this->uart_dev_) {
+  if (this->uart_ != UART_SELECTION_USB_CDC || this->uart_dev_ == nullptr) {
     return;
   }
   static bool opened = false;

--- a/esphome/components/logger/logger_zephyr.cpp
+++ b/esphome/components/logger/logger_zephyr.cpp
@@ -6,6 +6,7 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/sys/printk.h>
 #include <zephyr/usb/usb_device.h>
 
 namespace esphome::logger {
@@ -62,18 +63,17 @@ void Logger::pre_setup() {
   ESP_LOGI(TAG, "Log initialized");
 }
 
-void HOT Logger::write_msg_(const char *msg, size_t) {
+void HOT Logger::write_msg_(const char *msg, size_t len) {
+  // Single write with newline already in buffer (added by caller)
 #ifdef CONFIG_PRINTK
-  printk("%s\n", msg);
+  k_str_out(const_cast<char *>(msg), len);
 #endif
-  if (nullptr == this->uart_dev_) {
+  if (this->uart_dev_ == nullptr) {
     return;
   }
-  while (*msg) {
-    uart_poll_out(this->uart_dev_, *msg);
-    ++msg;
+  for (size_t i = 0; i < len; ++i) {
+    uart_poll_out(this->uart_dev_, msg[i]);
   }
-  uart_poll_out(this->uart_dev_, '\n');
 }
 
 const LogString *Logger::get_uart_selection_() {


### PR DESCRIPTION
**Note:** I don't have an nRF52 board to test with, so this will need verification by someone with Zephyr hardware before merging.


# What does this implement/fix?

Optimizes Zephyr logger output by using `k_str_out()` instead of `printk()` and leveraging pre-computed message length.

This aligns Zephyr with the optimization done for RP2040 in #12615 and the existing approach used by ESP32, ESP8266, and LibreTiny.

**Changes:**
- Use `k_str_out(msg, len)` instead of `printk("%s\n", msg)` - eliminates format string parsing overhead
- Use pre-computed length for UART output loop instead of null-terminator scanning
- Newline is now included in the buffer by the caller, eliminating the separate newline write

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #12615

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840 - **Needs testing by someone with hardware**

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
logger:
  level: DEBUG
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
