### PR TITLE
[thermostat] Optimizations to reduce binary size

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -10,8 +10,7 @@
 #include <array>
 #include <cinttypes>
 
-namespace esphome {
-namespace thermostat {
+namespace esphome::thermostat {
 
 enum HumidificationAction : uint8_t {
   THERMOSTAT_HUMIDITY_CONTROL_ACTION_OFF = 0,
@@ -41,13 +40,11 @@ enum OnBootRestoreFrom : uint8_t {
 
 struct ThermostatClimateTimer {
   ThermostatClimateTimer() = default;
-  ThermostatClimateTimer(bool active, uint32_t time, uint32_t started, std::function<void()> func)
-      : active(active), time(time), started(started), func(std::move(func)) {}
+  ThermostatClimateTimer(bool active, uint32_t time, uint32_t started) : active(active), time(time), started(started) {}
 
   bool active;
   uint32_t time;
   uint32_t started;
-  std::function<void()> func;
 };
 
 struct ThermostatClimateTargetTempConfig {
@@ -266,7 +263,8 @@ class ThermostatClimate : public climate::Climate, public Component {
   bool cancel_timer_(ThermostatClimateTimerIndex timer_index);
   bool timer_active_(ThermostatClimateTimerIndex timer_index);
   uint32_t timer_duration_(ThermostatClimateTimerIndex timer_index);
-  std::function<void()> timer_cbf_(ThermostatClimateTimerIndex timer_index);
+  /// Call the appropriate timer callback based on timer index
+  void call_timer_callback_(ThermostatClimateTimerIndex timer_index);
   /// Enhanced timer duration setter with running timer adjustment
   void set_timer_duration_in_sec_(ThermostatClimateTimerIndex timer_index, uint32_t time);
 
@@ -534,27 +532,16 @@ class ThermostatClimate : public climate::Climate, public Component {
   Trigger<> *prev_humidity_control_trigger_{nullptr};
 
   /// Climate action timers
-  std::array<ThermostatClimateTimer, THERMOSTAT_TIMER_COUNT> timer_{
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_max_run_time_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_off_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::cooling_on_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::fan_mode_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::fanning_off_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::fanning_on_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::heating_max_run_time_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::heating_off_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::heating_on_timer_callback_, this)),
-      ThermostatClimateTimer(false, 0, 0, std::bind(&ThermostatClimate::idle_on_timer_callback_, this)),
-  };
+  std::array<ThermostatClimateTimer, THERMOSTAT_TIMER_COUNT> timer_{};
 
   /// The set of standard preset configurations this thermostat supports (Eg. AWAY, ECO, etc)
   FixedVector<PresetEntry> preset_config_{};
   /// The set of custom preset configurations this thermostat supports (eg. "My Custom Preset")
   FixedVector<CustomPresetEntry> custom_preset_config_{};
-  /// Default custom preset to use on start up (pointer to entry in custom_preset_config_)
+
  private:
+  /// Default custom preset to use on start up (pointer to entry in custom_preset_config_)
   const char *default_custom_preset_{nullptr};
 };
 
-}  // namespace thermostat
-}  // namespace esphome
+}  // namespace esphome::thermostat


### PR DESCRIPTION
# What does this implement/fix?

Refactors the thermostat component's timer system to reduce code size and improve efficiency:

## Changes

- Namespace modernization: Updated to C++17 nested namespace syntax (`namespace esphome::thermostat`)
- Timer callback refactoring:
  - Removed `std::function<void()>` callbacks from `ThermostatClimateTimer` struct
  - Replaced function pointer storage with direct switch-based dispatch in new `call_timer_callback_()` method
  - Eliminated std::bind overhead in timer initialization (simplified from 10 bind expressions to empty initialization)
  - Removed `timer_cbf_()` accessor method
- Loop optimization:
  - Cache `App.get_loop_component_start_time()` result to avoid repeated calls
  - Convert range-based for loop to index-based loop for timer iteration

## Benefits

- Reduces flash usage by eliminating std::function template instantiations and vtables
- Improves runtime performance with direct function calls instead of indirect function pointers
- Maintains identical functionality with cleaner, more maintainable code

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
