### PR TITLE
[core] Remove deprecated config options from before 2025

### DIFF
--- a/esphome/components/bedjet/climate/__init__.py
+++ b/esphome/components/bedjet/climate/__init__.py
@@ -1,12 +1,7 @@
 import esphome.codegen as cg
-from esphome.components import ble_client, climate
+from esphome.components import climate
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_HEAT_MODE,
-    CONF_RECEIVE_TIMEOUT,
-    CONF_TEMPERATURE_SOURCE,
-    CONF_TIME_ID,
-)
+from esphome.const import CONF_HEAT_MODE, CONF_TEMPERATURE_SOURCE
 
 from .. import BEDJET_CLIENT_SCHEMA, bedjet_ns, register_bedjet_child
 
@@ -38,22 +33,6 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.polling_component_schema("60s"))
-    .extend(
-        # TODO: remove compat layer.
-        {
-            cv.Optional(ble_client.CONF_BLE_CLIENT_ID): cv.invalid(
-                "The 'ble_client_id' option has been removed. Please migrate "
-                "to the new `bedjet_id` option in the `bedjet` component.\n"
-                "See https://esphome.io/components/climate/bedjet/"
-            ),
-            cv.Optional(CONF_TIME_ID): cv.invalid(
-                "The 'time_id' option has been moved to the `bedjet` component."
-            ),
-            cv.Optional(CONF_RECEIVE_TIMEOUT): cv.invalid(
-                "The 'receive_timeout' option has been moved to the `bedjet` component."
-            ),
-        }
-    )
     .extend(BEDJET_CLIENT_SCHEMA)
 )
 

--- a/esphome/components/bh1750/sensor.py
+++ b/esphome/components/bh1750/sensor.py
@@ -20,16 +20,6 @@ CONFIG_SCHEMA = (
         device_class=DEVICE_CLASS_ILLUMINANCE,
         state_class=STATE_CLASS_MEASUREMENT,
     )
-    .extend(
-        {
-            cv.Optional("resolution"): cv.invalid(
-                "The 'resolution' option has been removed. The optimal value is now dynamically calculated."
-            ),
-            cv.Optional("measurement_duration"): cv.invalid(
-                "The 'measurement_duration' option has been removed. The optimal value is now dynamically calculated."
-            ),
-        }
-    )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x23))
 )

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -220,10 +220,6 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_MANUAL_IP): MANUAL_IP_SCHEMA,
         cv.Optional(CONF_DOMAIN, default=".local"): cv.domain_name,
         cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
-        cv.Optional("enable_mdns"): cv.invalid(
-            "This option has been removed. Please use the [disabled] option under the "
-            "new mdns component instead."
-        ),
         cv.Optional(CONF_MAC_ADDRESS): cv.mac_address,
     }
 ).extend(cv.COMPONENT_SCHEMA)

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -237,10 +237,6 @@ def i2c_device_schema(default_address):
     """
     schema = {
         cv.GenerateID(CONF_I2C_ID): cv.use_id(I2CBus),
-        cv.Optional("multiplexer"): cv.invalid(
-            "This option has been removed, please see "
-            "the tca9584a docs for the updated way to use multiplexers"
-        ),
     }
     if default_address is None:
         schema[cv.Required(CONF_ADDRESS)] = cv.i2c_address

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -108,9 +108,6 @@ def register_trigger(name, type, data_type):
     validator = automation.validate_automation(
         {
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(type),
-            cv.Optional(CONF_RECEIVER_ID): cv.invalid(
-                "This has been removed in ESPHome 2022.3.0 and the trigger attaches directly to the parent receiver."
-            ),
         }
     )
     registerer = TRIGGER_REGISTRY.register(f"on_{name}", validator)
@@ -207,13 +204,7 @@ validate_binary_sensor = cv.validate_registry_entry(
     "remote receiver", BINARY_SENSOR_REGISTRY
 )
 TRIGGER_REGISTRY = SimpleRegistry()
-DUMPER_REGISTRY = Registry(
-    {
-        cv.Optional(CONF_RECEIVER_ID): cv.invalid(
-            "This has been removed in ESPHome 1.20.0 and the dumper attaches directly to the parent receiver."
-        ),
-    }
-)
+DUMPER_REGISTRY = Registry()
 
 
 def validate_dumpers(value):
@@ -480,10 +471,6 @@ COOLIX_BASE_SCHEMA = cv.Schema(
     {
         cv.Required(CONF_FIRST): cv.hex_int_range(0, 16777215),
         cv.Optional(CONF_SECOND, default=0): cv.hex_int_range(0, 16777215),
-        cv.Optional(CONF_DATA): cv.invalid(
-            "'data' option has been removed in ESPHome 2023.8. "
-            "Use the 'first' and 'second' options instead."
-        ),
     }
 )
 

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -304,9 +304,6 @@ _SENSOR_SCHEMA = (
             cv.Optional(CONF_DEVICE_CLASS): validate_device_class,
             cv.Optional(CONF_STATE_CLASS): validate_state_class,
             cv.Optional(CONF_ENTITY_CATEGORY): sensor_entity_category,
-            cv.Optional("last_reset_type"): cv.invalid(
-                "last_reset_type has been removed since 2021.9.0. state_class: total_increasing should be used for total values."
-            ),
             cv.Optional(CONF_FORCE_UPDATE, default=False): cv.boolean,
             cv.Optional(CONF_EXPIRE_AFTER): cv.All(
                 cv.requires_component("mqtt"),

--- a/esphome/components/tca9548a/__init__.py
+++ b/esphome/components/tca9548a/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import i2c
 import esphome.config_validation as cv
-from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID, CONF_SCAN
+from esphome.const import CONF_CHANNEL, CONF_CHANNELS, CONF_ID
 
 CODEOWNERS = ["@andreashergert1984"]
 
@@ -18,7 +18,6 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(TCA9548AComponent),
-            cv.Optional(CONF_SCAN): cv.invalid("This option has been removed"),
             cv.Optional(CONF_CHANNELS, default=[]): cv.ensure_list(
                 {
                     cv.Required(CONF_BUS_ID): cv.declare_id(TCA9548AChannel),

--- a/esphome/components/template/switch/__init__.py
+++ b/esphome/components/template/switch/__init__.py
@@ -7,7 +7,6 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_OPTIMISTIC,
-    CONF_RESTORE_STATE,
     CONF_STATE,
     CONF_TURN_OFF_ACTION,
     CONF_TURN_ON_ACTION,
@@ -43,9 +42,6 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_TURN_ON_ACTION): automation.validate_automation(
                 single=True
-            ),
-            cv.Optional(CONF_RESTORE_STATE): cv.invalid(
-                "The restore_state option has been removed in 2023.7.0. Use the restore_mode option instead"
             ),
         }
     )

--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -37,10 +37,6 @@ COLOR_TYPES = {
 
 TuyaLight = tuya_ns.class_("TuyaLight", light.LightOutput, cg.Component)
 
-COLOR_CONFIG_ERROR = (
-    "This option has been removed, use color_datapoint and color_type instead."
-)
-
 CONFIG_SCHEMA = cv.All(
     light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(
         {
@@ -49,8 +45,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DIMMER_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_MIN_VALUE_DATAPOINT): cv.uint8_t,
             cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
-            cv.Optional(CONF_RGB_DATAPOINT): cv.invalid(COLOR_CONFIG_ERROR),
-            cv.Optional(CONF_HSV_DATAPOINT): cv.invalid(COLOR_CONFIG_ERROR),
             cv.Inclusive(CONF_COLOR_DATAPOINT, "color"): cv.uint8_t,
             cv.Inclusive(CONF_COLOR_TYPE, "color"): cv.enum(COLOR_TYPES, upper=True),
             cv.Optional(CONF_COLOR_INTERLOCK, default=False): cv.boolean,

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -19,7 +19,6 @@ from esphome.const import (
     CONF_DUMMY_RECEIVER_ID,
     CONF_FLOW_CONTROL_PIN,
     CONF_ID,
-    CONF_INVERT,
     CONF_LAMBDA,
     CONF_NUMBER,
     CONF_PORT,
@@ -303,9 +302,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DATA_BITS, default=8): cv.int_range(min=5, max=8),
             cv.Optional(CONF_PARITY, default="NONE"): cv.enum(
                 UART_PARITY_OPTIONS, upper=True
-            ),
-            cv.Optional(CONF_INVERT): cv.invalid(
-                "This option has been removed. Please instead use invert in the tx/rx pin schemas."
             ),
             cv.Optional(CONF_DEBUG): maybe_empty_debug,
         }

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -348,10 +348,6 @@ CONFIG_SCHEMA = cv.All(
                 cv.boolean, cv.only_on_esp32
             ),
             cv.Optional(CONF_PASSIVE_SCAN, default=False): cv.boolean,
-            cv.Optional("enable_mdns"): cv.invalid(
-                "This option has been removed. Please use the [disabled] option under the "
-                "new mdns component instead."
-            ),
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
             cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
             cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(


### PR DESCRIPTION
# What does this implement/fix?

Removes old deprecated configuration options that have been showing error messages for years. These options were all deprecated before 2025 and users have had ample time to migrate.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - cleanup of old deprecation warnings

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - these options were already removed from docs when deprecated

## Removed Options

| Component | Removed Options | Deprecated Since |
|-----------|-----------------|------------------|
| bedjet/climate | `ble_client_id`, `time_id`, `receive_timeout` | 2022.8 |
| bh1750 | `resolution`, `measurement_duration` | 2022.2 |
| ethernet | `enable_mdns` | 2021.9 |
| wifi | `enable_mdns` | 2021.9 |
| i2c | `multiplexer` | 2021.9 |
| uart | `invert` | 2021.9 |
| tca9548a | `scan` | 2021.9 |
| tuya/light | `rgb_datapoint`, `hsv_datapoint` | 2023.2 |
| remote_base | `receiver_id` (trigger/dumper), coolix `data` | 2020-2023 |
| sensor | `last_reset_type` | 2021.9 |
| template/switch | `restore_state` | 2023.7 |

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - this removes deprecated options, no new configuration needed

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).