### PR TITLE
[esp32] Remove remaining using_esp_idf checks

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 
 def AUTO_LOAD() -> list[str]:
     auto_load = ["web_server_base", "ota.web_server"]
-    if CORE.using_esp_idf:
+    if CORE.is_esp32:
         auto_load.append("socket")
     return auto_load
 

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -146,7 +146,7 @@ def _final_validate(config):
     full_config = fv.full_config.get()[CONF_I2C]
     if CORE.using_zephyr and len(full_config) > 1:
         raise cv.Invalid("Second i2c is not implemented on Zephyr yet")
-    if CORE.using_esp_idf and get_esp32_variant() in ESP32_I2C_CAPABILITIES:
+    if CORE.is_esp32 and get_esp32_variant() in ESP32_I2C_CAPABILITIES:
         variant = get_esp32_variant()
         max_num = ESP32_I2C_CAPABILITIES[variant]["NUM"]
         if len(full_config) > max_num:

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -262,7 +262,7 @@ def _final_validate(_):
 
 def use_legacy():
     legacy_driver = _get_use_legacy_driver()
-    return not (CORE.using_esp_idf and not legacy_driver)
+    return not (CORE.is_esp32 and not legacy_driver)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -232,6 +232,8 @@ def validate_use_legacy(value):
         if (not value[CONF_USE_LEGACY]) and (CORE.using_arduino):
             raise cv.Invalid("Arduino supports only the legacy i2s driver")
         _set_use_legacy_driver(value[CONF_USE_LEGACY])
+    elif CORE.using_arduino:
+        _set_use_legacy_driver(True)
     return value
 
 
@@ -261,8 +263,7 @@ def _final_validate(_):
 
 
 def use_legacy():
-    legacy_driver = _get_use_legacy_driver()
-    return not (CORE.is_esp32 and not legacy_driver)
+    return _get_use_legacy_driver()
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/improv_serial/__init__.py
+++ b/esphome/components/improv_serial/__init__.py
@@ -26,7 +26,7 @@ def validate_logger(config):
     logger_conf = fv.full_config.get()[CONF_LOGGER]
     if logger_conf[CONF_BAUD_RATE] == 0:
         raise cv.Invalid("improv_serial requires the logger baud_rate to be not 0")
-    if CORE.using_esp_idf and (
+    if CORE.is_esp32 and (
         logger_conf[CONF_HARDWARE_UART] == USB_CDC
         and get_esp32_variant() == VARIANT_ESP32S3
     ):

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -157,9 +157,7 @@ async def to_code(config):
         return
 
     if CORE.using_arduino:
-        if CORE.is_esp32:
-            cg.add_library("ESPmDNS", None)
-        elif CORE.is_esp8266:
+        if CORE.is_esp8266:
             cg.add_library("ESP8266mDNS", None)
         elif CORE.is_rp2040:
             cg.add_library("LEAmDNS", None)

--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -164,7 +164,7 @@ async def to_code(config):
         elif CORE.is_rp2040:
             cg.add_library("LEAmDNS", None)
 
-    if CORE.using_esp_idf:
+    if CORE.is_esp32:
         add_idf_component(name="espressif/mdns", ref="1.9.1")
 
     cg.add_define("USE_MDNS")

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -156,7 +156,7 @@ async def to_code(config):
             "High performance networking disabled by user configuration (overriding component request)"
         )
 
-    if CORE.is_esp32 and CORE.using_esp_idf and should_enable:
+    if CORE.is_esp32 and should_enable:
         # Check if PSRAM is guaranteed (set by psram component during final validation)
         psram_guaranteed = psram_is_guaranteed()
 
@@ -210,12 +210,8 @@ async def to_code(config):
                 "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
             )
         if CORE.is_esp32:
-            if CORE.using_esp_idf:
-                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
-                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
-            else:
-                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", True)
-                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", True)
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
         elif enable_ipv6:
             cg.add_build_flag("-DCONFIG_LWIP_IPV6")
             cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -210,8 +210,12 @@ async def to_code(config):
                 "USE_NETWORK_MIN_IPV6_ADDR_COUNT", config[CONF_MIN_IPV6_ADDR_COUNT]
             )
         if CORE.is_esp32:
-            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
-            add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
+            if CORE.using_arduino:
+                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", True)
+                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", True)
+            else:
+                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6", enable_ipv6)
+                add_idf_sdkconfig_option("CONFIG_LWIP_IPV6_AUTOCONFIG", enable_ipv6)
         elif enable_ipv6:
             cg.add_build_flag("-DCONFIG_LWIP_IPV6")
             cg.add_build_flag("-DCONFIG_LWIP_IPV6_AUTOCONFIG")

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -468,7 +468,7 @@ async def to_code(config):
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
         cg.add_define("USE_WIFI_AP")
-    elif CORE.is_esp32 and CORE.using_esp_idf:
+    elif CORE.is_esp32:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 
@@ -513,7 +513,7 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
 
     # Apply high performance WiFi settings if high performance networking is enabled
-    if CORE.is_esp32 and CORE.using_esp_idf and has_high_performance_networking():
+    if CORE.is_esp32 and has_high_performance_networking():
         # Check if PSRAM is guaranteed (set by psram component during final validation)
         psram_guaranteed = psram_is_guaranteed()
 

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -468,7 +468,7 @@ async def to_code(config):
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
         cg.add_define("USE_WIFI_AP")
-    elif CORE.is_esp32:
+    elif CORE.is_esp32 and not CORE.using_arduino:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -799,7 +799,8 @@ class EsphomeCore:
     @property
     def using_esp_idf(self):
         logging.getLogger(__name__).warning(
-            "CORE.using_esp_idf was deprecated in 2026.1, use CORE.is_esp32 and/or CORE.using_arduino instead."
+            "CORE.using_esp_idf was deprecated in 2026.1, use CORE.is_esp32 and/or CORE.using_arduino instead. "
+            "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks."
         )
         return self.target_framework == "esp-idf"
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -798,10 +798,8 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        # Deprecated: use is_esp32 instead, as Arduino also builds ESP-IDF
         logging.getLogger(__name__).warning(
-            "CORE.using_esp_idf is deprecated, use CORE.is_esp32 instead. "
-            "Arduino on ESP32 also uses ESP-IDF."
+            "CORE.using_esp_idf was deprecated in 2026.1, use CORE.is_esp32 and/or CORE.using_arduino instead."
         )
         return self.target_framework == "esp-idf"
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -798,10 +798,6 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        logging.getLogger(__name__).warning(
-            "CORE.using_esp_idf was deprecated in 2026.1, use CORE.is_esp32 and/or CORE.using_arduino instead. "
-            "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks."
-        )
         return self.target_framework == "esp-idf"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -798,7 +798,7 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        return self.target_framework == "esp-idf"
+        return self.target_platform == PLATFORM_ESP32
 
     @property
     def using_zephyr(self):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -798,7 +798,12 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
-        return self.target_platform == PLATFORM_ESP32
+        _LOGGER.warning(
+            "CORE.using_esp_idf was deprecated in 2026.1, will be change behavior in 2026.6. "
+            "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. "
+            "Use CORE.is_esp32 and/or CORE.using_arduino instead."
+        )
+        return self.target_framework == "esp-idf"
 
     @property
     def using_zephyr(self):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -799,7 +799,7 @@ class EsphomeCore:
     @property
     def using_esp_idf(self):
         _LOGGER.warning(
-            "CORE.using_esp_idf was deprecated in 2026.1, will be change behavior in 2026.6. "
+            "CORE.using_esp_idf was deprecated in 2026.1, will change behavior in 2026.6. "
             "ESP32 Arduino builds on top of ESP-IDF, so ESP-IDF features are available in both frameworks. "
             "Use CORE.is_esp32 and/or CORE.using_arduino instead."
         )

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -798,6 +798,11 @@ class EsphomeCore:
 
     @property
     def using_esp_idf(self):
+        # Deprecated: use is_esp32 instead, as Arduino also builds ESP-IDF
+        logging.getLogger(__name__).warning(
+            "CORE.using_esp_idf is deprecated, use CORE.is_esp32 instead. "
+            "Arduino on ESP32 also uses ESP-IDF."
+        )
         return self.target_framework == "esp-idf"
 
     @property


### PR DESCRIPTION
# What does this implement/fix?

All esp32 builds use IDF replace using_esp_idf with is_esp32 and using_arduino 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
