### PR TITLE
[safe_mode] Defer preference sync in clean_rtc to avoid blocking event loop

### DIFF
--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -69,7 +69,6 @@ void SafeModeComponent::set_safe_mode_pending(const bool &pending) {
   if (pending && current_rtc != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
     ESP_LOGI(TAG, "Device will enter on next boot");
     this->write_rtc_(SafeModeComponent::ENTER_SAFE_MODE_MAGIC);
-    global_preferences->sync();  // Must persist before potential reboot
   }
 
   if (!pending && current_rtc == SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
@@ -104,7 +103,6 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   if (rtc_val < num_attempts && !is_manual) {
     // increment counter
     this->write_rtc_(rtc_val + 1);
-    global_preferences->sync();  // Must persist before potential crash
     return false;
   }
 
@@ -131,7 +129,10 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   return true;
 }
 
-void SafeModeComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }
+void SafeModeComponent::write_rtc_(uint32_t val) {
+  this->rtc_.save(&val);
+  global_preferences->sync();
+}
 
 uint32_t SafeModeComponent::read_rtc_() {
   uint32_t val;
@@ -140,7 +141,12 @@ uint32_t SafeModeComponent::read_rtc_() {
   return val;
 }
 
-void SafeModeComponent::clean_rtc() { this->write_rtc_(0); }
+void SafeModeComponent::clean_rtc() {
+  // Save without sync - preferences will be written at shutdown or by IntervalSyncer
+  // This avoids blocking the loop for 50+ ms on flash write
+  uint32_t val = 0;
+  this->rtc_.save(&val);
+}
 
 void SafeModeComponent::on_safe_shutdown() {
   if (this->read_rtc_() != SafeModeComponent::ENTER_SAFE_MODE_MAGIC)

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -142,8 +142,10 @@ uint32_t SafeModeComponent::read_rtc_() {
 }
 
 void SafeModeComponent::clean_rtc() {
-  // Save without sync - preferences will be written at shutdown or by IntervalSyncer
-  // This avoids blocking the loop for 50+ ms on flash write
+  // Save without sync - preferences will be written at shutdown or by IntervalSyncer.
+  // This avoids blocking the loop for 50+ ms on flash write. If the device crashes
+  // before sync, the boot wasn't really successful anyway and the counter should
+  // remain incremented.
   uint32_t val = 0;
   this->rtc_.save(&val);
 }

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -69,6 +69,7 @@ void SafeModeComponent::set_safe_mode_pending(const bool &pending) {
   if (pending && current_rtc != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
     ESP_LOGI(TAG, "Device will enter on next boot");
     this->write_rtc_(SafeModeComponent::ENTER_SAFE_MODE_MAGIC);
+    global_preferences->sync();  // Must persist before potential reboot
   }
 
   if (!pending && current_rtc == SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
@@ -103,6 +104,7 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   if (rtc_val < num_attempts && !is_manual) {
     // increment counter
     this->write_rtc_(rtc_val + 1);
+    global_preferences->sync();  // Must persist before potential crash
     return false;
   }
 
@@ -129,10 +131,7 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   return true;
 }
 
-void SafeModeComponent::write_rtc_(uint32_t val) {
-  this->rtc_.save(&val);
-  global_preferences->sync();
-}
+void SafeModeComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }
 
 uint32_t SafeModeComponent::read_rtc_() {
   uint32_t val;


### PR DESCRIPTION
# What does this implement/fix?

Remove unnecessary 50+ ms blocking flash write from `safe_mode` component's event loop.

When the boot is considered successful (after `boot_is_good_after` seconds), safe_mode resets the boot loop counter by calling `clean_rtc()`, which immediately calls `global_preferences->sync()`. This forces an immediate flash write, blocking the event loop for 50+ ms and triggering warnings like:

```
[W][component:490]: safe_mode took a long time for an operation (54 ms)
[W][component:493]: Components should block for at most 30 ms
```

The immediate sync is unnecessary because:

1. **IntervalSyncer handles periodic writes** - The `preferences` component already syncs pending preferences every 60 seconds (configurable)
2. **Shutdown hooks ensure persistence** - `IntervalSyncer::on_shutdown()` calls `sync()` before any reboot
3. **safe_mode has its own shutdown hook** - `SafeModeComponent::on_safe_shutdown()` queues the counter reset before reboot

This change modifies `clean_rtc()` to save directly without calling `write_rtc_()`, avoiding the immediate sync. The preference will be written at shutdown or by the `IntervalSyncer`.

If the device crashes before the preference is synced, the boot wasn't really successful anyway - the counter should remain incremented so safe mode can still be triggered after repeated failures.

### Historical context

The original implementation (commit 6682c43df) did **not** call `sync()`:
```cpp
void OTAComponent::write_rtc_(uint32_t val) { this->rtc_.save(&val); }
```

The `sync()` was added in commit 491f8cc61 (Sept 2021) as part of "Configurable Flash Write Interval" (#2119), which introduced the deferred `preferences` syncer component with a 60s default interval. The `sync()` was added to ensure the boot counter was immediately persisted since it's critical for boot loop detection.

When safe_mode was split from OTA in commit 76abf2200 (May 2024), the code was copied verbatim including the `sync()` call in `write_rtc_()`, which caused every RTC write to block - including the unnecessary "successful boot" reset in `loop()`.

### Before
```
loop() → clean_rtc() → write_rtc_(0) → sync() → 54ms flash write block
```

### After
```
loop() → clean_rtc() → rtc_.save(0) → adds to pending queue (instant)
                                     ↓
           IntervalSyncer or on_shutdown() syncs later
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard safe_mode config - no changes needed
safe_mode:
  boot_is_good_after: 10s
  num_attempts: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
