### PR TITLE
[core] Deprecate get_object_id() and migrate remaining usages to get_object_id_to()

### DIFF
--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -1,5 +1,4 @@
 #include "pid_climate.h"
-#include "esphome/core/entity_base.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -163,16 +162,14 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   float min_value = this->supports_cool_() ? -1.0f : 0.0f;
   float max_value = this->supports_heat_() ? 1.0f : 0.0f;
   this->autotuner_->config(min_value, max_value);
-  char object_id_buf[OBJECT_ID_MAX_LEN];
-  StringRef object_id = this->get_object_id_to(object_id_buf);
-  this->autotuner_->set_autotuner_id(object_id.str());
+  this->autotuner_->set_autotuner_id(this->get_name().str());
 
   ESP_LOGI(TAG,
            "%s: Autotune has started. This can take a long time depending on the "
            "responsiveness of your system. Your system "
            "output will be altered to deliberately oscillate above and below the setpoint multiple times. "
            "Until your sensor provides a reading, the autotuner may display \'nan\'",
-           object_id.c_str());
+           this->get_name().c_str());
 
   this->set_interval("autotune-progress", 10000, [this]() {
     if (this->autotuner_ != nullptr && !this->autotuner_->is_finished())
@@ -180,7 +177,8 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   });
 
   if (mode != climate::CLIMATE_MODE_HEAT_COOL) {
-    ESP_LOGW(TAG, "%s: !!! For PID autotuner you need to set AUTO (also called heat/cool) mode!", object_id.c_str());
+    ESP_LOGW(TAG, "%s: !!! For PID autotuner you need to set AUTO (also called heat/cool) mode!",
+             this->get_name().c_str());
   }
 }
 

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -1,4 +1,5 @@
 #include "pid_climate.h"
+#include "esphome/core/entity_base.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -162,14 +163,16 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   float min_value = this->supports_cool_() ? -1.0f : 0.0f;
   float max_value = this->supports_heat_() ? 1.0f : 0.0f;
   this->autotuner_->config(min_value, max_value);
-  this->autotuner_->set_autotuner_id(this->get_object_id());
+  char object_id_buf[OBJECT_ID_MAX_LEN];
+  StringRef object_id = this->get_object_id_to(object_id_buf);
+  this->autotuner_->set_autotuner_id(std::string(object_id.c_str()));
 
   ESP_LOGI(TAG,
            "%s: Autotune has started. This can take a long time depending on the "
            "responsiveness of your system. Your system "
            "output will be altered to deliberately oscillate above and below the setpoint multiple times. "
            "Until your sensor provides a reading, the autotuner may display \'nan\'",
-           this->get_object_id().c_str());
+           object_id.c_str());
 
   this->set_interval("autotune-progress", 10000, [this]() {
     if (this->autotuner_ != nullptr && !this->autotuner_->is_finished())
@@ -177,8 +180,7 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   });
 
   if (mode != climate::CLIMATE_MODE_HEAT_COOL) {
-    ESP_LOGW(TAG, "%s: !!! For PID autotuner you need to set AUTO (also called heat/cool) mode!",
-             this->get_object_id().c_str());
+    ESP_LOGW(TAG, "%s: !!! For PID autotuner you need to set AUTO (also called heat/cool) mode!", object_id.c_str());
   }
 }
 

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -165,7 +165,7 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   this->autotuner_->config(min_value, max_value);
   char object_id_buf[OBJECT_ID_MAX_LEN];
   StringRef object_id = this->get_object_id_to(object_id_buf);
-  this->autotuner_->set_autotuner_id(std::string(object_id.c_str()));
+  this->autotuner_->set_autotuner_id(object_id.str());
 
   ESP_LOGI(TAG,
            "%s: Autotune has started. This can take a long time depending on the "

--- a/esphome/components/pid/pid_climate.cpp
+++ b/esphome/components/pid/pid_climate.cpp
@@ -162,7 +162,7 @@ void PIDClimate::start_autotune(std::unique_ptr<PIDAutotuner> &&autotune) {
   float min_value = this->supports_cool_() ? -1.0f : 0.0f;
   float max_value = this->supports_heat_() ? 1.0f : 0.0f;
   this->autotuner_->config(min_value, max_value);
-  this->autotuner_->set_autotuner_id(this->get_name().str());
+  this->autotuner_->set_autotuner_id(this->get_name());
 
   ESP_LOGI(TAG,
            "%s: Autotune has started. This can take a long time depending on the "

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -112,7 +112,12 @@ void PrometheusHandler::handleRequest(AsyncWebServerRequest *req) {
 
 std::string PrometheusHandler::relabel_id_(EntityBase *obj) {
   auto item = relabel_map_id_.find(obj);
-  return item == relabel_map_id_.end() ? obj->get_object_id() : item->second;
+  if (item != relabel_map_id_.end()) {
+    return item->second;
+  }
+  char object_id_buf[OBJECT_ID_MAX_LEN];
+  StringRef object_id = obj->get_object_id_to(object_id_buf);
+  return std::string(object_id.c_str());
 }
 
 std::string PrometheusHandler::relabel_name_(EntityBase *obj) {

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -117,7 +117,7 @@ std::string PrometheusHandler::relabel_id_(EntityBase *obj) {
   }
   char object_id_buf[OBJECT_ID_MAX_LEN];
   StringRef object_id = obj->get_object_id_to(object_id_buf);
-  return std::string(object_id.c_str());
+  return object_id.str();
 }
 
 std::string PrometheusHandler::relabel_name_(EntityBase *obj) {

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -116,8 +116,7 @@ std::string PrometheusHandler::relabel_id_(EntityBase *obj) {
     return item->second;
   }
   char object_id_buf[OBJECT_ID_MAX_LEN];
-  StringRef object_id = obj->get_object_id_to(object_id_buf);
-  return object_id.str();
+  return obj->get_object_id_to(object_id_buf).str();
 }
 
 std::string PrometheusHandler::relabel_name_(EntityBase *obj) {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -33,6 +33,15 @@ class EntityBase {
   bool has_own_name() const { return this->flags_.has_own_name; }
 
   // Get the sanitized name of this Entity as an ID.
+  // Deprecated: object_id mangles names and all object_id methods are planned for removal.
+  // See https://github.com/esphome/backlog/issues/76
+  // Now is the time to stop using object_id entirely. If you still need it temporarily,
+  // use get_object_id_to() which will remain available longer but will also eventually be removed.
+  ESPDEPRECATED("object_id mangles names and all object_id methods are planned for removal "
+                "(see https://github.com/esphome/backlog/issues/76). "
+                "Now is the time to stop using object_id. If still needed, use get_object_id_to() "
+                "which will remain available longer. get_object_id() will be removed in 2026.7.0",
+                "2025.12.0")
   std::string get_object_id() const;
   void set_object_id(const char *object_id);
 


### PR DESCRIPTION
# What does this implement/fix?

Migrates remaining usages of `get_object_id()` and deprecates it.

The `object_id` concept mangles entity names and is planned for removal (see [backlog#76](https://github.com/esphome/backlog/issues/76)). The main problems are:
- UTF-8 names get sanitized to underscores, causing collisions (e.g., `"温度传感器"` and `"湿度传感器"` both become `"___"`)
- Sub-devices with same-named entities collide (e.g., two "Battery" sensors on different sub-devices get the same object_id) - see [esphome-webserver#160](https://github.com/esphome/esphome-webserver/issues/160) and [esphome-webserver#153](https://github.com/esphome/esphome-webserver/issues/153)

This PR:
- Migrates `pid_climate.cpp` to use `get_name()` instead - it was only using object_id for logging, and log messages are more readable with the human-friendly entity name (e.g., "Living Room Thermostat" vs "living_room_thermostat")
- Migrates `prometheus_handler.cpp` to use `get_object_id_to()` - Prometheus metrics require snake_case identifiers for compatibility
- Deprecates `get_object_id()` with removal planned for 2026.7.0

`get_object_id_to()` will remain available longer to give external components time to migrate, but it will also eventually be removed as part of the object_id elimination effort.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/backlog/issues/76

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal API change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
