### PR TITLE
[api] Auto-generate StringRef for incoming API string fields

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -102,7 +102,7 @@ message HelloRequest {
   // For example "Home Assistant"
   // Not strictly necessary to send but nice for debugging
   // purposes.
-  string client_info = 1 [(pointer_to_buffer) = true];
+  string client_info = 1;
   uint32 api_version_major = 2;
   uint32 api_version_minor = 3;
 }
@@ -139,7 +139,7 @@ message AuthenticationRequest {
   option (ifdef) = "USE_API_PASSWORD";
 
   // The password to log in with
-  string password = 1 [(pointer_to_buffer) = true];
+  string password = 1;
 }
 
 // Confirmation of successful connection. After this the connection is available for all traffic.
@@ -477,7 +477,7 @@ message FanCommandRequest {
   bool has_speed_level = 10;
   int32 speed_level = 11;
   bool has_preset_mode = 12;
-  string preset_mode = 13 [(pointer_to_buffer) = true];
+  string preset_mode = 13;
   uint32 device_id = 14 [(field_ifdef) = "USE_DEVICES"];
 }
 
@@ -579,7 +579,7 @@ message LightCommandRequest {
   bool has_flash_length = 16;
   uint32 flash_length = 17;
   bool has_effect = 18;
-  string effect = 19 [(pointer_to_buffer) = true];
+  string effect = 19;
   uint32 device_id = 28 [(field_ifdef) = "USE_DEVICES"];
 }
 
@@ -824,9 +824,9 @@ message HomeAssistantStateResponse {
   option (no_delay) = true;
   option (ifdef) = "USE_API_HOMEASSISTANT_STATES";
 
-  string entity_id = 1 [(pointer_to_buffer) = true];
-  string state = 2 [(pointer_to_buffer) = true];
-  string attribute = 3 [(pointer_to_buffer) = true];
+  string entity_id = 1;
+  string state = 2;
+  string attribute = 3;
 }
 
 // ==================== IMPORT TIME ====================
@@ -841,7 +841,7 @@ message GetTimeResponse {
   option (no_delay) = true;
 
   fixed32 epoch_seconds = 1;
-  string timezone = 2 [(pointer_to_buffer) = true];
+  string timezone = 2;
 }
 
 // ==================== USER-DEFINES SERVICES ====================
@@ -1091,11 +1091,11 @@ message ClimateCommandRequest {
   bool has_swing_mode = 14;
   ClimateSwingMode swing_mode = 15;
   bool has_custom_fan_mode = 16;
-  string custom_fan_mode = 17 [(pointer_to_buffer) = true];
+  string custom_fan_mode = 17;
   bool has_preset = 18;
   ClimatePreset preset = 19;
   bool has_custom_preset = 20;
-  string custom_preset = 21 [(pointer_to_buffer) = true];
+  string custom_preset = 21;
   bool has_target_humidity = 22;
   float target_humidity = 23;
   uint32 device_id = 24 [(field_ifdef) = "USE_DEVICES"];
@@ -1274,7 +1274,7 @@ message SelectCommandRequest {
   option (base_class) = "CommandProtoMessage";
 
   fixed32 key = 1;
-  string state = 2 [(pointer_to_buffer) = true];
+  string state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -23,7 +23,6 @@ bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -48,7 +47,6 @@ void HelloResponse::calculate_size(ProtoSize &size) const {
 bool AuthenticationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->password = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -446,7 +444,6 @@ bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool FanCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 13: {
-      // Use raw data directly via StringRef to avoid allocation
       this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -612,7 +609,6 @@ bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool LightCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 19: {
-      // Use raw data directly via StringRef to avoid allocation
       this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -855,7 +851,6 @@ void SubscribeLogsResponse::calculate_size(ProtoSize &size) const {
 bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly to avoid allocation
       this->key = value.data();
       this->key_len = value.size();
       break;
@@ -933,13 +928,11 @@ bool HomeassistantActionResponse::decode_varint(uint32_t field_id, ProtoVarInt v
 bool HomeassistantActionResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      // Use raw data directly via StringRef to avoid allocation
       this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
     case 4: {
-      // Use raw data directly to avoid allocation
       this->response_data = value.data();
       this->response_data_len = value.size();
       break;
@@ -965,17 +958,14 @@ void SubscribeHomeAssistantStateResponse::calculate_size(ProtoSize &size) const 
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 3: {
-      // Use raw data directly via StringRef to avoid allocation
       this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -988,7 +978,6 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
 bool GetTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -1055,7 +1044,6 @@ bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value)
 bool ExecuteServiceArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      // Use raw data directly via StringRef to avoid allocation
       this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -1404,12 +1392,10 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
 bool ClimateCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 17: {
-      // Use raw data directly via StringRef to avoid allocation
       this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 21: {
-      // Use raw data directly via StringRef to avoid allocation
       this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -1696,7 +1682,6 @@ bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -1802,7 +1787,6 @@ bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool SirenCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 5: {
-      // Use raw data directly via StringRef to avoid allocation
       this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -1895,7 +1879,6 @@ bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool LockCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      // Use raw data directly via StringRef to avoid allocation
       this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2067,7 +2050,6 @@ bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt val
 bool MediaPlayerCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 7: {
-      // Use raw data directly via StringRef to avoid allocation
       this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2278,7 +2260,6 @@ bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt val
 bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      // Use raw data directly to avoid allocation
       this->data = value.data();
       this->data_len = value.size();
       break;
@@ -2317,7 +2298,6 @@ bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, Proto
 bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      // Use raw data directly to avoid allocation
       this->data = value.data();
       this->data_len = value.size();
       break;
@@ -2502,12 +2482,10 @@ bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value)
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2587,12 +2565,10 @@ bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVar
 bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 3: {
-      // Use raw data directly via StringRef to avoid allocation
       this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2614,17 +2590,14 @@ bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt
 bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 3: {
-      // Use raw data directly via StringRef to avoid allocation
       this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2664,12 +2637,10 @@ bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarIn
 bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly via StringRef to avoid allocation
       this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2677,17 +2648,14 @@ bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengt
       this->trained_languages.push_back(value.as_string());
       break;
     case 4: {
-      // Use raw data directly via StringRef to avoid allocation
       this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 6: {
-      // Use raw data directly via StringRef to avoid allocation
       this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 7: {
-      // Use raw data directly via StringRef to avoid allocation
       this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2801,7 +2769,6 @@ bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarI
 bool AlarmControlPanelCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      // Use raw data directly via StringRef to avoid allocation
       this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -2887,7 +2854,6 @@ bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly via StringRef to avoid allocation
       this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
@@ -3358,7 +3324,6 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 bool ZWaveProxyFrame::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly to avoid allocation
       this->data = value.data();
       this->data_len = value.size();
       break;
@@ -3383,7 +3348,6 @@ bool ZWaveProxyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool ZWaveProxyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly to avoid allocation
       this->data = value.data();
       this->data_len = value.size();
       break;

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -23,9 +23,8 @@ bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly to avoid allocation
-      this->client_info = value.data();
-      this->client_info_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -49,9 +48,8 @@ void HelloResponse::calculate_size(ProtoSize &size) const {
 bool AuthenticationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly to avoid allocation
-      this->password = value.data();
-      this->password_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->password = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -448,9 +446,8 @@ bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool FanCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 13: {
-      // Use raw data directly to avoid allocation
-      this->preset_mode = value.data();
-      this->preset_mode_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -615,9 +612,8 @@ bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool LightCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 19: {
-      // Use raw data directly to avoid allocation
-      this->effect = value.data();
-      this->effect_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -936,9 +932,11 @@ bool HomeassistantActionResponse::decode_varint(uint32_t field_id, ProtoVarInt v
 }
 bool HomeassistantActionResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 3:
-      this->error_message = value.as_string();
+    case 3: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
     case 4: {
       // Use raw data directly to avoid allocation
@@ -967,21 +965,18 @@ void SubscribeHomeAssistantStateResponse::calculate_size(ProtoSize &size) const 
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      // Use raw data directly to avoid allocation
-      this->entity_id = value.data();
-      this->entity_id_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 2: {
-      // Use raw data directly to avoid allocation
-      this->state = value.data();
-      this->state_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 3: {
-      // Use raw data directly to avoid allocation
-      this->attribute = value.data();
-      this->attribute_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -993,9 +988,8 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
 bool GetTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly to avoid allocation
-      this->timezone = value.data();
-      this->timezone_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -1060,9 +1054,11 @@ bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value)
 }
 bool ExecuteServiceArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 4:
-      this->string_ = value.as_string();
+    case 4: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     case 9:
       this->string_array.push_back(value.as_string());
       break;
@@ -1408,15 +1404,13 @@ bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) 
 bool ClimateCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 17: {
-      // Use raw data directly to avoid allocation
-      this->custom_fan_mode = value.data();
-      this->custom_fan_mode_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     case 21: {
-      // Use raw data directly to avoid allocation
-      this->custom_preset = value.data();
-      this->custom_preset_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -1702,9 +1696,8 @@ bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      // Use raw data directly to avoid allocation
-      this->state = value.data();
-      this->state_len = value.size();
+      // Use raw data directly via StringRef to avoid allocation
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }
     default:
@@ -1808,9 +1801,11 @@ bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 }
 bool SirenCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 5:
-      this->tone = value.as_string();
+    case 5: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -1899,9 +1894,11 @@ bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 }
 bool LockCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 4:
-      this->code = value.as_string();
+    case 4: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2069,9 +2066,11 @@ bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt val
 }
 bool MediaPlayerCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 7:
-      this->media_url = value.as_string();
+    case 7: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2502,12 +2501,16 @@ bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value)
 }
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->name = value.as_string();
+    case 1: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 2:
-      this->value = value.as_string();
+    }
+    case 2: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2583,12 +2586,16 @@ bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVar
 }
 bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2:
-      this->timer_id = value.as_string();
+    case 2: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 3:
-      this->name = value.as_string();
+    }
+    case 3: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2606,15 +2613,21 @@ bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt
 }
 bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->media_id = value.as_string();
+    case 1: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 2:
-      this->text = value.as_string();
+    }
+    case 2: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 3:
-      this->preannounce_media_id = value.as_string();
+    }
+    case 3: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2650,24 +2663,34 @@ bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarIn
 }
 bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->id = value.as_string();
+    case 1: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 2:
-      this->wake_word = value.as_string();
+    }
+    case 2: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     case 3:
       this->trained_languages.push_back(value.as_string());
       break;
-    case 4:
-      this->model_type = value.as_string();
+    case 4: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 6:
-      this->model_hash = value.as_string();
+    }
+    case 6: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
-    case 7:
-      this->url = value.as_string();
+    }
+    case 7: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2777,9 +2800,11 @@ bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarI
 }
 bool AlarmControlPanelCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 3:
-      this->code = value.as_string();
+    case 3: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }
@@ -2861,9 +2886,11 @@ bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
 }
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2:
-      this->state = value.as_string();
+    case 2: {
+      // Use raw data directly via StringRef to avoid allocation
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
+    }
     default:
       return false;
   }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1149,7 +1149,7 @@ void ExecuteServiceResponse::calculate_size(ProtoSize &size) const {
   size.add_bool(1, this->success);
   size.add_length(1, this->error_message_ref_.size());
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
-  size.add_length(4, this->response_data_len);
+  size.add_length(1, this->response_data_len);
 #endif
 }
 #endif
@@ -3399,7 +3399,7 @@ void ZWaveProxyRequest::encode(ProtoWriteBuffer buffer) const {
 }
 void ZWaveProxyRequest::calculate_size(ProtoSize &size) const {
   size.add_uint32(1, static_cast<uint32_t>(this->type));
-  size.add_length(2, this->data_len);
+  size.add_length(1, this->data_len);
 }
 #endif
 

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -357,12 +357,11 @@ class CommandProtoMessage : public ProtoDecodableMessage {
 class HelloRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 1;
-  static constexpr uint8_t ESTIMATED_SIZE = 27;
+  static constexpr uint8_t ESTIMATED_SIZE = 17;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "hello_request"; }
 #endif
-  const uint8_t *client_info{nullptr};
-  uint16_t client_info_len{0};
+  StringRef client_info{};
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -398,12 +397,11 @@ class HelloResponse final : public ProtoMessage {
 class AuthenticationRequest final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 3;
-  static constexpr uint8_t ESTIMATED_SIZE = 19;
+  static constexpr uint8_t ESTIMATED_SIZE = 9;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "authentication_request"; }
 #endif
-  const uint8_t *password{nullptr};
-  uint16_t password_len{0};
+  StringRef password{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -784,7 +782,7 @@ class FanStateResponse final : public StateResponseProtoMessage {
 class FanCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 31;
-  static constexpr uint8_t ESTIMATED_SIZE = 48;
+  static constexpr uint8_t ESTIMATED_SIZE = 38;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "fan_command_request"; }
 #endif
@@ -797,8 +795,7 @@ class FanCommandRequest final : public CommandProtoMessage {
   bool has_speed_level{false};
   int32_t speed_level{0};
   bool has_preset_mode{false};
-  const uint8_t *preset_mode{nullptr};
-  uint16_t preset_mode_len{0};
+  StringRef preset_mode{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -860,7 +857,7 @@ class LightStateResponse final : public StateResponseProtoMessage {
 class LightCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 32;
-  static constexpr uint8_t ESTIMATED_SIZE = 122;
+  static constexpr uint8_t ESTIMATED_SIZE = 112;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "light_command_request"; }
 #endif
@@ -889,8 +886,7 @@ class LightCommandRequest final : public CommandProtoMessage {
   bool has_flash_length{false};
   uint32_t flash_length{0};
   bool has_effect{false};
-  const uint8_t *effect{nullptr};
-  uint16_t effect_len{0};
+  StringRef effect{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1171,7 +1167,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
 #endif
   uint32_t call_id{0};
   bool success{false};
-  std::string error_message{};
+  StringRef error_message{};
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   const uint8_t *response_data{nullptr};
   uint16_t response_data_len{0};
@@ -1222,16 +1218,13 @@ class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
 class HomeAssistantStateResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 40;
-  static constexpr uint8_t ESTIMATED_SIZE = 57;
+  static constexpr uint8_t ESTIMATED_SIZE = 27;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "home_assistant_state_response"; }
 #endif
-  const uint8_t *entity_id{nullptr};
-  uint16_t entity_id_len{0};
-  const uint8_t *state{nullptr};
-  uint16_t state_len{0};
-  const uint8_t *attribute{nullptr};
-  uint16_t attribute_len{0};
+  StringRef entity_id{};
+  StringRef state{};
+  StringRef attribute{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1256,13 +1249,12 @@ class GetTimeRequest final : public ProtoMessage {
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 37;
-  static constexpr uint8_t ESTIMATED_SIZE = 24;
+  static constexpr uint8_t ESTIMATED_SIZE = 14;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "get_time_response"; }
 #endif
   uint32_t epoch_seconds{0};
-  const uint8_t *timezone{nullptr};
-  uint16_t timezone_len{0};
+  StringRef timezone{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1310,7 +1302,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
   bool bool_{false};
   int32_t legacy_int{0};
   float float_{0.0f};
-  std::string string_{};
+  StringRef string_{};
   int32_t int_{0};
   FixedVector<bool> bool_array{};
   FixedVector<int32_t> int_array{};
@@ -1499,7 +1491,7 @@ class ClimateStateResponse final : public StateResponseProtoMessage {
 class ClimateCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 48;
-  static constexpr uint8_t ESTIMATED_SIZE = 104;
+  static constexpr uint8_t ESTIMATED_SIZE = 84;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "climate_command_request"; }
 #endif
@@ -1516,13 +1508,11 @@ class ClimateCommandRequest final : public CommandProtoMessage {
   bool has_swing_mode{false};
   enums::ClimateSwingMode swing_mode{};
   bool has_custom_fan_mode{false};
-  const uint8_t *custom_fan_mode{nullptr};
-  uint16_t custom_fan_mode_len{0};
+  StringRef custom_fan_mode{};
   bool has_preset{false};
   enums::ClimatePreset preset{};
   bool has_custom_preset{false};
-  const uint8_t *custom_preset{nullptr};
-  uint16_t custom_preset_len{0};
+  StringRef custom_preset{};
   bool has_target_humidity{false};
   float target_humidity{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1695,12 +1685,11 @@ class SelectStateResponse final : public StateResponseProtoMessage {
 class SelectCommandRequest final : public CommandProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 54;
-  static constexpr uint8_t ESTIMATED_SIZE = 28;
+  static constexpr uint8_t ESTIMATED_SIZE = 18;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "select_command_request"; }
 #endif
-  const uint8_t *state{nullptr};
-  uint16_t state_len{0};
+  StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1756,7 +1745,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
   bool has_state{false};
   bool state{false};
   bool has_tone{false};
-  std::string tone{};
+  StringRef tone{};
   bool has_duration{false};
   uint32_t duration{0};
   bool has_volume{false};
@@ -1817,7 +1806,7 @@ class LockCommandRequest final : public CommandProtoMessage {
 #endif
   enums::LockCommand command{};
   bool has_code{false};
-  std::string code{};
+  StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -1927,7 +1916,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
   bool has_volume{false};
   float volume{0.0f};
   bool has_media_url{false};
-  std::string media_url{};
+  StringRef media_url{};
   bool has_announcement{false};
   bool announcement{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2503,8 +2492,8 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
 };
 class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
-  std::string name{};
-  std::string value{};
+  StringRef name{};
+  StringRef value{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2562,8 +2551,8 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
   const char *message_name() const override { return "voice_assistant_timer_event_response"; }
 #endif
   enums::VoiceAssistantTimerEvent event_type{};
-  std::string timer_id{};
-  std::string name{};
+  StringRef timer_id{};
+  StringRef name{};
   uint32_t total_seconds{0};
   uint32_t seconds_left{0};
   bool is_active{false};
@@ -2582,9 +2571,9 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "voice_assistant_announce_request"; }
 #endif
-  std::string media_id{};
-  std::string text{};
-  std::string preannounce_media_id{};
+  StringRef media_id{};
+  StringRef text{};
+  StringRef preannounce_media_id{};
   bool start_conversation{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
@@ -2627,13 +2616,13 @@ class VoiceAssistantWakeWord final : public ProtoMessage {
 };
 class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
  public:
-  std::string id{};
-  std::string wake_word{};
+  StringRef id{};
+  StringRef wake_word{};
   std::vector<std::string> trained_languages{};
-  std::string model_type{};
+  StringRef model_type{};
   uint32_t model_size{0};
-  std::string model_hash{};
-  std::string url{};
+  StringRef model_hash{};
+  StringRef url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2734,7 +2723,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
   const char *message_name() const override { return "alarm_control_panel_command_request"; }
 #endif
   enums::AlarmControlPanelStateCommand command{};
-  std::string code{};
+  StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif
@@ -2791,7 +2780,7 @@ class TextCommandRequest final : public CommandProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "text_command_request"; }
 #endif
-  std::string state{};
+  StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
   void dump_to(std::string &out) const override;
 #endif

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -736,7 +736,7 @@ template<> const char *proto_enum_to_string<enums::ZWaveProxyRequestType>(enums:
 void HelloRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "HelloRequest");
   out.append("  client_info: ");
-  out.append(format_hex_pretty(this->client_info, this->client_info_len));
+  out.append("'").append(this->client_info.c_str(), this->client_info.size()).append("'");
   out.append("\n");
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
@@ -752,7 +752,7 @@ void HelloResponse::dump_to(std::string &out) const {
 void AuthenticationRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "AuthenticationRequest");
   out.append("  password: ");
-  out.append(format_hex_pretty(this->password, this->password_len));
+  out.append("'").append(this->password.c_str(), this->password.size()).append("'");
   out.append("\n");
 }
 void AuthenticationResponse::dump_to(std::string &out) const {
@@ -965,7 +965,7 @@ void FanCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "speed_level", this->speed_level);
   dump_field(out, "has_preset_mode", this->has_preset_mode);
   out.append("  preset_mode: ");
-  out.append(format_hex_pretty(this->preset_mode, this->preset_mode_len));
+  out.append("'").append(this->preset_mode.c_str(), this->preset_mode.size()).append("'");
   out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -1043,7 +1043,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "flash_length", this->flash_length);
   dump_field(out, "has_effect", this->has_effect);
   out.append("  effect: ");
-  out.append(format_hex_pretty(this->effect, this->effect_len));
+  out.append("'").append(this->effect.c_str(), this->effect.size()).append("'");
   out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -1205,7 +1205,9 @@ void HomeassistantActionResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "HomeassistantActionResponse");
   dump_field(out, "call_id", this->call_id);
   dump_field(out, "success", this->success);
-  dump_field(out, "error_message", this->error_message);
+  out.append("  error_message: ");
+  out.append("'").append(this->error_message.c_str(), this->error_message.size()).append("'");
+  out.append("\n");
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   out.append("  response_data: ");
   out.append(format_hex_pretty(this->response_data, this->response_data_len));
@@ -1226,13 +1228,13 @@ void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
 void HomeAssistantStateResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "HomeAssistantStateResponse");
   out.append("  entity_id: ");
-  out.append(format_hex_pretty(this->entity_id, this->entity_id_len));
+  out.append("'").append(this->entity_id.c_str(), this->entity_id.size()).append("'");
   out.append("\n");
   out.append("  state: ");
-  out.append(format_hex_pretty(this->state, this->state_len));
+  out.append("'").append(this->state.c_str(), this->state.size()).append("'");
   out.append("\n");
   out.append("  attribute: ");
-  out.append(format_hex_pretty(this->attribute, this->attribute_len));
+  out.append("'").append(this->attribute.c_str(), this->attribute.size()).append("'");
   out.append("\n");
 }
 #endif
@@ -1241,7 +1243,7 @@ void GetTimeResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "GetTimeResponse");
   dump_field(out, "epoch_seconds", this->epoch_seconds);
   out.append("  timezone: ");
-  out.append(format_hex_pretty(this->timezone, this->timezone_len));
+  out.append("'").append(this->timezone.c_str(), this->timezone.size()).append("'");
   out.append("\n");
 }
 #ifdef USE_API_USER_DEFINED_ACTIONS
@@ -1266,7 +1268,9 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
   dump_field(out, "bool_", this->bool_);
   dump_field(out, "legacy_int", this->legacy_int);
   dump_field(out, "float_", this->float_);
-  dump_field(out, "string_", this->string_);
+  out.append("  string_: ");
+  out.append("'").append(this->string_.c_str(), this->string_.size()).append("'");
+  out.append("\n");
   dump_field(out, "int_", this->int_);
   for (const auto it : this->bool_array) {
     dump_field(out, "bool_array", static_cast<bool>(it), 4);
@@ -1424,13 +1428,13 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "swing_mode", static_cast<enums::ClimateSwingMode>(this->swing_mode));
   dump_field(out, "has_custom_fan_mode", this->has_custom_fan_mode);
   out.append("  custom_fan_mode: ");
-  out.append(format_hex_pretty(this->custom_fan_mode, this->custom_fan_mode_len));
+  out.append("'").append(this->custom_fan_mode.c_str(), this->custom_fan_mode.size()).append("'");
   out.append("\n");
   dump_field(out, "has_preset", this->has_preset);
   dump_field(out, "preset", static_cast<enums::ClimatePreset>(this->preset));
   dump_field(out, "has_custom_preset", this->has_custom_preset);
   out.append("  custom_preset: ");
-  out.append(format_hex_pretty(this->custom_preset, this->custom_preset_len));
+  out.append("'").append(this->custom_preset.c_str(), this->custom_preset.size()).append("'");
   out.append("\n");
   dump_field(out, "has_target_humidity", this->has_target_humidity);
   dump_field(out, "target_humidity", this->target_humidity);
@@ -1558,7 +1562,7 @@ void SelectCommandRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "SelectCommandRequest");
   dump_field(out, "key", this->key);
   out.append("  state: ");
-  out.append(format_hex_pretty(this->state, this->state_len));
+  out.append("'").append(this->state.c_str(), this->state.size()).append("'");
   out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -1599,7 +1603,9 @@ void SirenCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "has_state", this->has_state);
   dump_field(out, "state", this->state);
   dump_field(out, "has_tone", this->has_tone);
-  dump_field(out, "tone", this->tone);
+  out.append("  tone: ");
+  out.append("'").append(this->tone.c_str(), this->tone.size()).append("'");
+  out.append("\n");
   dump_field(out, "has_duration", this->has_duration);
   dump_field(out, "duration", this->duration);
   dump_field(out, "has_volume", this->has_volume);
@@ -1641,7 +1647,9 @@ void LockCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
   dump_field(out, "has_code", this->has_code);
-  dump_field(out, "code", this->code);
+  out.append("  code: ");
+  out.append("'").append(this->code.c_str(), this->code.size()).append("'");
+  out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
@@ -1719,7 +1727,9 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
   dump_field(out, "has_volume", this->has_volume);
   dump_field(out, "volume", this->volume);
   dump_field(out, "has_media_url", this->has_media_url);
-  dump_field(out, "media_url", this->media_url);
+  out.append("  media_url: ");
+  out.append("'").append(this->media_url.c_str(), this->media_url.size()).append("'");
+  out.append("\n");
   dump_field(out, "has_announcement", this->has_announcement);
   dump_field(out, "announcement", this->announcement);
 #ifdef USE_DEVICES
@@ -1949,8 +1959,12 @@ void VoiceAssistantResponse::dump_to(std::string &out) const {
 }
 void VoiceAssistantEventData::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventData");
-  dump_field(out, "name", this->name);
-  dump_field(out, "value", this->value);
+  out.append("  name: ");
+  out.append("'").append(this->name.c_str(), this->name.size()).append("'");
+  out.append("\n");
+  out.append("  value: ");
+  out.append("'").append(this->value.c_str(), this->value.size()).append("'");
+  out.append("\n");
 }
 void VoiceAssistantEventResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventResponse");
@@ -1975,17 +1989,27 @@ void VoiceAssistantAudio::dump_to(std::string &out) const {
 void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantTimerEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
-  dump_field(out, "timer_id", this->timer_id);
-  dump_field(out, "name", this->name);
+  out.append("  timer_id: ");
+  out.append("'").append(this->timer_id.c_str(), this->timer_id.size()).append("'");
+  out.append("\n");
+  out.append("  name: ");
+  out.append("'").append(this->name.c_str(), this->name.size()).append("'");
+  out.append("\n");
   dump_field(out, "total_seconds", this->total_seconds);
   dump_field(out, "seconds_left", this->seconds_left);
   dump_field(out, "is_active", this->is_active);
 }
 void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAnnounceRequest");
-  dump_field(out, "media_id", this->media_id);
-  dump_field(out, "text", this->text);
-  dump_field(out, "preannounce_media_id", this->preannounce_media_id);
+  out.append("  media_id: ");
+  out.append("'").append(this->media_id.c_str(), this->media_id.size()).append("'");
+  out.append("\n");
+  out.append("  text: ");
+  out.append("'").append(this->text.c_str(), this->text.size()).append("'");
+  out.append("\n");
+  out.append("  preannounce_media_id: ");
+  out.append("'").append(this->preannounce_media_id.c_str(), this->preannounce_media_id.size()).append("'");
+  out.append("\n");
   dump_field(out, "start_conversation", this->start_conversation);
 }
 void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const { dump_field(out, "success", this->success); }
@@ -1999,15 +2023,25 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
 }
 void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantExternalWakeWord");
-  dump_field(out, "id", this->id);
-  dump_field(out, "wake_word", this->wake_word);
+  out.append("  id: ");
+  out.append("'").append(this->id.c_str(), this->id.size()).append("'");
+  out.append("\n");
+  out.append("  wake_word: ");
+  out.append("'").append(this->wake_word.c_str(), this->wake_word.size()).append("'");
+  out.append("\n");
   for (const auto &it : this->trained_languages) {
     dump_field(out, "trained_languages", it, 4);
   }
-  dump_field(out, "model_type", this->model_type);
+  out.append("  model_type: ");
+  out.append("'").append(this->model_type.c_str(), this->model_type.size()).append("'");
+  out.append("\n");
   dump_field(out, "model_size", this->model_size);
-  dump_field(out, "model_hash", this->model_hash);
-  dump_field(out, "url", this->url);
+  out.append("  model_hash: ");
+  out.append("'").append(this->model_hash.c_str(), this->model_hash.size()).append("'");
+  out.append("\n");
+  out.append("  url: ");
+  out.append("'").append(this->url.c_str(), this->url.size()).append("'");
+  out.append("\n");
 }
 void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationRequest");
@@ -2066,7 +2100,9 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "AlarmControlPanelCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
-  dump_field(out, "code", this->code);
+  out.append("  code: ");
+  out.append("'").append(this->code.c_str(), this->code.size()).append("'");
+  out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
@@ -2103,7 +2139,9 @@ void TextStateResponse::dump_to(std::string &out) const {
 void TextCommandRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "TextCommandRequest");
   dump_field(out, "key", this->key);
-  dump_field(out, "state", this->state);
+  out.append("  state: ");
+  out.append("'").append(this->state.c_str(), this->state.size()).append("'");
+  out.append("\n");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -627,9 +627,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       ESP_LOGD(TAG, "Assist Pipeline running");
 #ifdef USE_MEDIA_PLAYER
       this->started_streaming_tts_ = false;
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "url") {
-          this->tts_response_url_ = std::move(arg.value);
+          this->tts_response_url_ = arg.value;
         }
       }
 #endif
@@ -648,9 +648,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       break;
     case api::enums::VOICE_ASSISTANT_STT_END: {
       std::string text;
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "text") {
-          text = std::move(arg.value);
+          text = arg.value;
         }
       }
       if (text.empty()) {
@@ -693,9 +693,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
       break;
     }
     case api::enums::VOICE_ASSISTANT_INTENT_END: {
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "conversation_id") {
-          this->conversation_id_ = std::move(arg.value);
+          this->conversation_id_ = arg.value;
         } else if (arg.name == "continue_conversation") {
           this->continue_conversation_ = (arg.value == "1");
         }
@@ -705,9 +705,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_TTS_START: {
       std::string text;
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "text") {
-          text = std::move(arg.value);
+          text = arg.value;
         }
       }
       if (text.empty()) {
@@ -731,9 +731,9 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     }
     case api::enums::VOICE_ASSISTANT_TTS_END: {
       std::string url;
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "url") {
-          url = std::move(arg.value);
+          url = arg.value;
         }
       }
       if (url.empty()) {
@@ -778,11 +778,11 @@ void VoiceAssistant::on_event(const api::VoiceAssistantEventResponse &msg) {
     case api::enums::VOICE_ASSISTANT_ERROR: {
       std::string code = "";
       std::string message = "";
-      for (auto arg : msg.data) {
+      for (const auto &arg : msg.data) {
         if (arg.name == "code") {
-          code = std::move(arg.value);
+          code = arg.value;
         } else if (arg.name == "message") {
-          message = std::move(arg.value);
+          message = arg.value;
         }
       }
       if (code == "wake-word-timeout" || code == "wake_word_detection_aborted" || code == "no_wake_word") {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -907,7 +907,7 @@ class PointerToBytesBufferType(PointerToBufferTypeBase):
         )
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
-        return f"size.add_length({self.number}, this->{self.field_name}_len);"
+        return f"size.add_length({self.calculate_field_id_size()}, this->{self.field_name}_len);"
 
 
 class PointerToStringBufferType(PointerToBufferTypeBase):
@@ -932,7 +932,6 @@ class PointerToStringBufferType(PointerToBufferTypeBase):
     @property
     def decode_length_content(self) -> str | None:
         return f"""case {self.number}: {{
-      // Use raw data directly via StringRef to avoid allocation
       this->{self.field_name} = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
       break;
     }}"""

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -374,20 +374,16 @@ def create_field_type_info(
             # Traditional fixed array approach with copy
             return FixedArrayBytesType(field, fixed_size)
 
-    # Check for pointer_to_buffer option on string fields
-    if field.type == 9:
-        has_pointer_to_buffer = get_field_opt(field, pb.pointer_to_buffer, False)
-
-        if has_pointer_to_buffer:
-            # Zero-copy pointer approach for strings
-            return PointerToBytesBufferType(field, None)
-
     # Special handling for bytes fields
     if field.type == 12:
         return BytesType(field, needs_decode, needs_encode)
 
     # Special handling for string fields
     if field.type == 9:
+        # For SOURCE_CLIENT only messages (decode but no encode), use StringRef
+        # for zero-copy access to the receive buffer
+        if needs_decode and not needs_encode:
+            return PointerToStringBufferType(field, None)
         return StringType(field, needs_decode, needs_encode)
 
     validate_field_type(field.type, field.name)
@@ -840,8 +836,8 @@ class BytesType(TypeInfo):
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical bytes
 
 
-class PointerToBytesBufferType(TypeInfo):
-    """Type for bytes fields that use pointer_to_buffer option for zero-copy."""
+class PointerToBufferTypeBase(TypeInfo):
+    """Base class for pointer_to_buffer types (bytes and strings) for zero-copy decoding."""
 
     @classmethod
     def can_use_dump_field(cls) -> bool:
@@ -851,29 +847,34 @@ class PointerToBytesBufferType(TypeInfo):
         self, field: descriptor.FieldDescriptorProto, size: int | None = None
     ) -> None:
         super().__init__(field)
-        # Size is not used for pointer_to_buffer - we always use size_t for length
         self.array_size = 0
 
     @property
-    def cpp_type(self) -> str:
-        return "const uint8_t*"
+    def decode_length(self) -> str | None:
+        # This is handled in decode_length_content
+        return None
 
     @property
-    def default_value(self) -> str:
-        return "nullptr"
+    def wire_type(self) -> WireType:
+        """Get the wire type for this field."""
+        return WireType.LENGTH_DELIMITED  # Uses wire type 2
 
-    @property
-    def reference_type(self) -> str:
-        return "const uint8_t*"
+    def get_estimated_size(self) -> int:
+        # field ID + length varint + typical data (assume small for pointer fields)
+        return self.calculate_field_id_size() + 2 + 16
 
-    @property
-    def const_reference_type(self) -> str:
-        return "const uint8_t*"
+
+class PointerToBytesBufferType(PointerToBufferTypeBase):
+    """Type for bytes fields that use pointer_to_buffer option for zero-copy."""
+
+    cpp_type = "const uint8_t*"
+    default_value = "nullptr"
+    reference_type = "const uint8_t*"
+    const_reference_type = "const uint8_t*"
 
     @property
     def public_content(self) -> list[str]:
         # Use uint16_t for length - max packet size is well below 65535
-        # Add pointer and length fields
         return [
             f"const uint8_t* {self.field_name}{{nullptr}};",
             f"uint16_t {self.field_name}_len{{0}};",
@@ -885,23 +886,12 @@ class PointerToBytesBufferType(TypeInfo):
 
     @property
     def decode_length_content(self) -> str | None:
-        # Decode directly stores the pointer to avoid allocation
         return f"""case {self.number}: {{
       // Use raw data directly to avoid allocation
       this->{self.field_name} = value.data();
       this->{self.field_name}_len = value.size();
       break;
     }}"""
-
-    @property
-    def decode_length(self) -> str | None:
-        # This is handled in decode_length_content
-        return None
-
-    @property
-    def wire_type(self) -> WireType:
-        """Get the wire type for this bytes field."""
-        return WireType.LENGTH_DELIMITED  # Uses wire type 2
 
     def dump(self, name: str) -> str:
         return (
@@ -910,7 +900,6 @@ class PointerToBytesBufferType(TypeInfo):
 
     @property
     def dump_content(self) -> str:
-        # Custom dump that doesn't use dump_field template
         return (
             f'out.append("  {self.name}: ");\n'
             + f"out.append({self.dump(self.field_name)});\n"
@@ -920,9 +909,47 @@ class PointerToBytesBufferType(TypeInfo):
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         return f"size.add_length({self.number}, this->{self.field_name}_len);"
 
-    def get_estimated_size(self) -> int:
-        # field ID + length varint + typical data (assume small for pointer fields)
-        return self.calculate_field_id_size() + 2 + 16
+
+class PointerToStringBufferType(PointerToBufferTypeBase):
+    """Type for string fields that use pointer_to_buffer option for zero-copy.
+
+    Uses StringRef instead of separate pointer and length fields.
+    """
+
+    cpp_type = "StringRef"
+    default_value = ""
+    reference_type = "StringRef &"
+    const_reference_type = "const StringRef &"
+
+    @property
+    def public_content(self) -> list[str]:
+        return [f"StringRef {self.field_name}{{}};"]
+
+    @property
+    def encode_content(self) -> str:
+        return f"buffer.encode_string({self.number}, this->{self.field_name});"
+
+    @property
+    def decode_length_content(self) -> str | None:
+        return f"""case {self.number}: {{
+      // Use raw data directly via StringRef to avoid allocation
+      this->{self.field_name} = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }}"""
+
+    def dump(self, name: str) -> str:
+        return f'out.append("\'").append(this->{self.field_name}.c_str(), this->{self.field_name}.size()).append("\'");'
+
+    @property
+    def dump_content(self) -> str:
+        return (
+            f'out.append("  {self.name}: ");\n'
+            + f"{self.dump(self.field_name)}\n"
+            + 'out.append("\\n");'
+        )
+
+    def get_size_calculation(self, name: str, force: bool = False) -> str:
+        return f"size.add_length({self.calculate_field_id_size()}, this->{self.field_name}.size());"
 
 
 class FixedArrayBytesType(TypeInfo):

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -887,7 +887,6 @@ class PointerToBytesBufferType(PointerToBufferTypeBase):
     @property
     def decode_length_content(self) -> str | None:
         return f"""case {self.number}: {{
-      // Use raw data directly to avoid allocation
       this->{self.field_name} = value.data();
       this->{self.field_name}_len = value.size();
       break;


### PR DESCRIPTION
# What does this implement/fix?

Use `StringRef` for all string fields in `SOURCE_CLIENT` API messages instead of `std::string`.

Over the past few months, we've been converting individual string APIs one by one to use zero-copy buffer access via `[(pointer_to_buffer) = true]` annotations. Now that the groundwork is complete, this PR makes zero-copy the default for all SOURCE_CLIENT string fields - ensuring new development does the right thing going forward without friction.

Previously, string fields in incoming (client → device) messages were decoded into `std::string`, which requires heap allocation. This change automatically uses `StringRef` for all string fields in `SOURCE_CLIENT` messages, which points directly into the receive buffer without allocation.

## Changes

1. **`api_protobuf.py`**: For `SOURCE_CLIENT` messages (decode-only), all string fields now automatically use `PointerToStringBufferType` which generates `StringRef` fields
2. **`api.proto`**: Removed `[(pointer_to_buffer) = true]` annotations from string fields - no longer needed since it's automatic for SOURCE_CLIENT
3. **`api_connection.cpp`**: Updated field accesses to use StringRef API (`.c_str()`, `.size()`, `.empty()`, `.byte()`)
4. **Refactored**: `PointerToBytesBufferType` and `PointerToStringBufferType` now share a common base class `PointerToBufferTypeBase`
5. **Bugfix**: Fixed `PointerToBytesBufferType.get_size_calculation()` to use `calculate_field_id_size()` instead of field number (bug existed since Sept 2025, caused minor over-estimation of buffer sizes for bytes fields with `pointer_to_buffer` - field 4 would add 4 bytes instead of 1 byte to size calc; no functional issues, just slightly wasted memory in size calculations for ZWave proxy, Bluetooth GATT writes, and action response fields)

## Benefits

- **Zero-copy by default for new APIs**: All new SOURCE_CLIENT message handlers automatically get zero-copy string access without developers needing to remember special annotations. This prevents accidentally creating non-zero-copy APIs.
- **Safe and flexible**: Handlers that need to keep the string data simply assign to `std::string` and the implicit conversion copies the data. Handlers that can work with the temporary data use `StringRef` directly.
- **Cleaner generated code**: Single `StringRef` field instead of separate `pointer` + `length` fields
- **~200 bytes flash savings**: From not generating `std::string` storage in message structs
- **Easy optimization path**: Existing consumers can be updated incrementally to accept `StringRef` directly and avoid allocations entirely

## Future optimization opportunities

**Automatic zero-copy for bytes fields**: This PR only covers string fields. Bytes fields in SOURCE_CLIENT messages still require explicit `[(pointer_to_buffer) = true]` annotations. A follow-up PR could apply the same automatic treatment to bytes fields for consistency.

**VoiceAssistantAudio zero-copy**: `VoiceAssistantAudio.data` (bytes) currently copies audio data into `std::string` on decode. Adding `[(pointer_to_buffer) = true]` would make it zero-copy like `ZWaveProxyFrame`, which is particularly valuable given audio data volume.

**StringRef parameter optimization**: The following functions currently accept `const std::string &` but could be updated to accept `StringRef` to avoid temporary `std::string` construction:

- `APIServer::handle_action_response(uint32_t, bool, const std::string &)` - would save ~67 bytes

## Affected messages

All `SOURCE_CLIENT` messages with string fields now use `StringRef`:
- `HelloRequest` (client_info)
- `AuthenticationRequest` (password)
- `FanCommandRequest` (preset_mode)
- `LightCommandRequest` (effect)
- `ClimateCommandRequest` (custom_fan_mode, custom_preset)
- `SelectCommandRequest` (state)
- `GetTimeResponse` (timezone)
- `HomeAssistantStateResponse` (entity_id, state, attribute)
- `SirenCommandRequest` (tone)
- `LockCommandRequest` (code)
- `MediaPlayerCommandRequest` (media_url)
- `AlarmControlPanelCommandRequest` (code)
- `TextCommandRequest` (state)
- `VoiceAssistantTimerEventResponse` (timer_id, name)
- `VoiceAssistantAnnounceRequest` (media_id, text, preannounce_media_id)
- `HomeassistantActionResponse` (error_message)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
api:
  password: "test"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes

## Memory Impact

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| RAM | 42,180 bytes | 42,180 bytes | 0 |
| Flash | 1,084,511 bytes | 1,084,315 bytes | **-196 bytes** |
