### PR TITLE
[bme68x_bsec2] add `id:` to allow extending

### DIFF
--- a/esphome/components/bme68x_bsec2/sensor.py
+++ b/esphome/components/bme68x_bsec2/sensor.py
@@ -50,6 +50,7 @@ TYPES = [
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_BME68X_BSEC2_ID): cv.use_id(BME68xBSEC2Component),
         cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
             unit_of_measurement=UNIT_CELSIUS,

--- a/tests/components/bme68x_bsec2_i2c/common.yaml
+++ b/tests/components/bme68x_bsec2_i2c/common.yaml
@@ -9,6 +9,7 @@ bme68x_bsec2_i2c:
 
 sensor:
   - platform: bme68x_bsec2
+    id: bme_sensor
     temperature:
       name: BME68X Temperature
     pressure:


### PR DESCRIPTION
# What does this implement/fix?

The `bme68x_bsec2` sensor component doesn't take an `id:` because it just attaches the sensors to the parent.  But this means there's no target for extending.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5820

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: bme68x_bsec2
    id: bmx_sensor
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
