### PR TITLE
[micro_wake_word] Add ExpandDims to tflite ops

### DIFF
--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -266,7 +266,7 @@ DetectionEvent VADModel::determine_detected() {
   return detection_event;
 }
 
-bool StreamingModel::register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver) {
+bool StreamingModel::register_streaming_ops_(tflite::MicroMutableOpResolver<21> &op_resolver) {
   if (op_resolver.AddCallOnce() != kTfLiteOk)
     return false;
   if (op_resolver.AddVarHandle() != kTfLiteOk)
@@ -306,6 +306,8 @@ bool StreamingModel::register_streaming_ops_(tflite::MicroMutableOpResolver<20> 
   if (op_resolver.AddPack() != kTfLiteOk)
     return false;
   if (op_resolver.AddSplitV() != kTfLiteOk)
+    return false;
+  if (op_resolver.AddExpandDims() != kTfLiteOk)
     return false;
 
   return true;

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -64,9 +64,9 @@ class StreamingModel {
   /// @return True if successful, false otherwise
   bool load_model_();
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
-  bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);
+  bool register_streaming_ops_(tflite::MicroMutableOpResolver<21> &op_resolver);
 
-  tflite::MicroMutableOpResolver<20> streaming_op_resolver_;
+  tflite::MicroMutableOpResolver<21> streaming_op_resolver_;
 
   bool loaded_{false};
   bool enabled_{true};


### PR DESCRIPTION
# What does this implement/fix?

After training and installing a new voice model recently (using instructions and code from https://github.com/OHF-Voice/micro-wake-word), I found that the model used EXPAND_DIMS but that the tflite implementation in micro_wake_word implementation did not include the EXPAND_DIMS op.

Here is the full list of ops used by my model, for reference:
```
ASSIGN_VARIABLE
CALL_ONCE
CONCATENATION
CONV_2D
DELEGATE
DEPTHWISE_CONV_2D
EXPAND_DIMS
FULLY_CONNECTED
LOGISTIC
QUANTIZE
READ_VARIABLE
RESHAPE
SPLIT_V
STRIDED_SLICE
VAR_HANDLE
```

Note that I did have to make modifications to the micro-wake-word repo to compensate for tensorflow updates. I will at some point open a PR for that repo with those changes. In the meantime, I have not verified that the changes I made to generate the model were correct, so if anyone reviewing is more familiar with these tflite ops and believes EXPAND_DIMS should not be necessary, let me know. I did verify that with this change the model that I generated does function as expected on an esp32-s3-box-3.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None; I didn't file an issue.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

None necessary

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

None required; issue is model-dependent.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
