### PR TITLE
[wifi] Avoid unnecessary string copy in failed connection logging

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1523,12 +1523,12 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
     return;  // No BSSID to penalize
   }
 
-  // Get SSID for logging
-  std::string ssid;
+  // Get SSID for logging (use pointer to avoid copy)
+  const std::string *ssid = nullptr;
   if (this->retry_phase_ == WiFiRetryPhase::SCAN_CONNECTING && !this->scan_result_.empty()) {
-    ssid = this->scan_result_[0].get_ssid();
+    ssid = &this->scan_result_[0].get_ssid();
   } else if (const WiFiAP *config = this->get_selected_sta_()) {
-    ssid = config->get_ssid();
+    ssid = &config->get_ssid();
   }
 
   // Only decrease priority on the last attempt for this phase
@@ -1548,8 +1548,8 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
   }
   char bssid_s[18];
   format_mac_addr_upper(failed_bssid.value().data(), bssid_s);
-  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d", ssid.c_str(), bssid_s,
-           old_priority, new_priority);
+  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d",
+           ssid != nullptr ? ssid->c_str() : "", bssid_s, old_priority, new_priority);
 
   // After adjusting priority, check if all priorities are now at minimum
   // If so, clear the vector to save memory and reset for fresh start


### PR DESCRIPTION
# What does this implement/fix?

Avoids an unnecessary `std::string` copy in `log_and_adjust_priority_for_failed_connect_()`.

The SSID was being copied into a local `std::string` variable just for logging, but since `get_ssid()` returns `const std::string&`, we can simply store a pointer to the existing string instead.

**Before:**
```cpp
std::string ssid;
if (...) {
  ssid = this->scan_result_[0].get_ssid();  // Copy from const ref
} else if (...) {
  ssid = config->get_ssid();  // Copy from const ref
}
ESP_LOGD(TAG, "...", ssid.c_str(), ...);
```

**After:**
```cpp
const std::string *ssid = nullptr;
if (...) {
  ssid = &this->scan_result_[0].get_ssid();  // Just store address
} else if (...) {
  ssid = &config->get_ssid();  // Just store address
}
ESP_LOGD(TAG, "...", ssid != nullptr ? ssid->c_str() : "", ...);
```

This eliminates one heap allocation per failed connection attempt.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (micro-optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
