### PR TITLE
[text_sensor] Return state by const reference to avoid copies

### DIFF
--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -78,8 +78,8 @@ void TextSensor::add_on_raw_state_callback(std::function<void(const std::string 
   this->raw_callback_.add(std::move(callback));
 }
 
-std::string TextSensor::get_state() const { return this->state; }
-std::string TextSensor::get_raw_state() const {
+const std::string &TextSensor::get_state() const { return this->state; }
+const std::string &TextSensor::get_raw_state() const {
 // Suppress deprecation warning - get_raw_state() is the replacement API
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -37,9 +37,9 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
 #pragma GCC diagnostic pop
 
   /// Getter-syntax for .state.
-  std::string get_state() const;
+  const std::string &get_state() const;
   /// Getter-syntax for .raw_state
-  std::string get_raw_state() const;
+  const std::string &get_raw_state() const;
 
   void publish_state(const std::string &state);
 


### PR DESCRIPTION
# What does this implement/fix?

Return `state` and `raw_state` by const reference instead of by value from `get_state()` and `get_raw_state()` methods. This avoids unnecessary string copies when callers only need to read the state values.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). N/A - no user-facing changes
