### PR TITLE
[alarm_control_panel] Use C++17 nested namespace and remove unused include

### DIFF
--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -8,8 +8,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 static const char *const TAG = "alarm_control_panel";
 
@@ -115,5 +114,4 @@ void AlarmControlPanel::disarm(optional<std::string> code) {
   call.perform();
 }
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <map>
-
 #include "alarm_control_panel_call.h"
 #include "alarm_control_panel_state.h"
 
@@ -9,8 +7,7 @@
 #include "esphome/core/entity_base.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 enum AlarmControlPanelFeature : uint8_t {
   // Matches Home Assistant values
@@ -141,5 +138,4 @@ class AlarmControlPanel : public EntityBase {
   LazyCallbackManager<void()> ready_callback_{};
 };
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel_call.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_call.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 static const char *const TAG = "alarm_control_panel";
 
@@ -99,5 +98,4 @@ void AlarmControlPanelCall::perform() {
   }
 }
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel_call.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_call.h
@@ -6,8 +6,7 @@
 
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 class AlarmControlPanel;
 
@@ -36,5 +35,4 @@ class AlarmControlPanelCall {
   void validate_();
 };
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel_state.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_state.cpp
@@ -1,7 +1,6 @@
 #include "alarm_control_panel_state.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 const LogString *alarm_control_panel_state_to_string(AlarmControlPanelState state) {
   switch (state) {
@@ -30,5 +29,4 @@ const LogString *alarm_control_panel_state_to_string(AlarmControlPanelState stat
   }
 }
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel_state.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_state.h
@@ -3,8 +3,7 @@
 #include <cstdint>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 enum AlarmControlPanelState : uint8_t {
   ACP_STATE_DISARMED = 0,
@@ -25,5 +24,4 @@ enum AlarmControlPanelState : uint8_t {
  */
 const LogString *alarm_control_panel_state_to_string(AlarmControlPanelState state);
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -3,8 +3,7 @@
 #include "esphome/core/automation.h"
 #include "alarm_control_panel.h"
 
-namespace esphome {
-namespace alarm_control_panel {
+namespace esphome::alarm_control_panel {
 
 /// Trigger on any state change
 class StateTrigger : public Trigger<> {
@@ -165,5 +164,4 @@ template<typename... Ts> class AlarmControlPanelCondition : public Condition<Ts.
   AlarmControlPanel *parent_;
 };
 
-}  // namespace alarm_control_panel
-}  // namespace esphome
+}  // namespace esphome::alarm_control_panel


### PR DESCRIPTION
# What does this implement/fix?

Code cleanup for the alarm_control_panel component:
- Remove unused `#include <map>` header
- Convert to C++17 nested namespace syntax (`namespace esphome::alarm_control_panel`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). N/A - no user-facing changes
