### PR TITLE
[web_server] Move HTTP header strings to flash on ESP8266

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -46,10 +46,19 @@ static constexpr size_t PSTR_LOCAL_SIZE = 18;
 #define PSTR_LOCAL(mode_s) ESPHOME_strncpy_P(buf, (ESPHOME_PGM_P) ((mode_s)), PSTR_LOCAL_SIZE - 1)
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
+#ifdef USE_ESP8266
+static const char HEADER_PNA_NAME[] PROGMEM = "Private-Network-Access-Name";
+static const char HEADER_PNA_ID[] PROGMEM = "Private-Network-Access-ID";
+static const char HEADER_CORS_REQ_PNA[] PROGMEM = "Access-Control-Request-Private-Network";
+static const char HEADER_CORS_ALLOW_PNA[] PROGMEM = "Access-Control-Allow-Private-Network";
+#define PNA_HEADER(x) FPSTR(x)
+#else
 static const char *const HEADER_PNA_NAME = "Private-Network-Access-Name";
 static const char *const HEADER_PNA_ID = "Private-Network-Access-ID";
 static const char *const HEADER_CORS_REQ_PNA = "Access-Control-Request-Private-Network";
 static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-Network";
+#define PNA_HEADER(x) (x)
+#endif
 #endif
 
 // Parse URL and return match info
@@ -368,10 +377,10 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response = request->beginResponse(200, "");
-  response->addHeader(HEADER_CORS_ALLOW_PNA, "true");
-  response->addHeader(HEADER_PNA_NAME, App.get_name().c_str());
+  response->addHeader(PNA_HEADER(HEADER_CORS_ALLOW_PNA), ESPHOME_F("true"));
+  response->addHeader(PNA_HEADER(HEADER_PNA_NAME), App.get_name().c_str());
   char mac_s[18];
-  response->addHeader(HEADER_PNA_ID, get_mac_address_pretty_into_buffer(mac_s));
+  response->addHeader(PNA_HEADER(HEADER_PNA_ID), get_mac_address_pretty_into_buffer(mac_s));
   request->send(response);
 }
 #endif
@@ -1841,7 +1850,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
   }
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
-  if (method == HTTP_OPTIONS && request->hasHeader(HEADER_CORS_REQ_PNA))
+  if (method == HTTP_OPTIONS && request->hasHeader(PNA_HEADER(HEADER_CORS_REQ_PNA)))
     return true;
 #endif
 
@@ -1974,7 +1983,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
-  if (request->method() == HTTP_OPTIONS && request->hasHeader(HEADER_CORS_REQ_PNA)) {
+  if (request->method() == HTTP_OPTIONS && request->hasHeader(PNA_HEADER(HEADER_CORS_REQ_PNA))) {
     this->handle_pna_cors_request(request);
     return;
   }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -348,7 +348,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #else
   AsyncWebServerResponse *response = request->beginResponse_P(200, "text/html", INDEX_GZ, sizeof(INDEX_GZ));
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(ESPHOME_F("Content-Encoding"), ESPHOME_F("gzip"));
   request->send(response);
 }
 #elif USE_WEBSERVER_VERSION >= 2
@@ -385,7 +385,7 @@ void WebServer::handle_css_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/css", ESPHOME_WEBSERVER_CSS_INCLUDE, ESPHOME_WEBSERVER_CSS_INCLUDE_SIZE);
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(ESPHOME_F("Content-Encoding"), ESPHOME_F("gzip"));
   request->send(response);
 }
 #endif
@@ -399,7 +399,7 @@ void WebServer::handle_js_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response =
       request->beginResponse_P(200, "text/javascript", ESPHOME_WEBSERVER_JS_INCLUDE, ESPHOME_WEBSERVER_JS_INCLUDE_SIZE);
 #endif
-  response->addHeader("Content-Encoding", "gzip");
+  response->addHeader(ESPHOME_F("Content-Encoding"), ESPHOME_F("gzip"));
   request->send(response);
 }
 #endif

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -45,22 +45,6 @@ static const char *const TAG = "web_server";
 static constexpr size_t PSTR_LOCAL_SIZE = 18;
 #define PSTR_LOCAL(mode_s) ESPHOME_strncpy_P(buf, (ESPHOME_PGM_P) ((mode_s)), PSTR_LOCAL_SIZE - 1)
 
-#ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
-#ifdef USE_ESP8266
-static const char HEADER_PNA_NAME[] PROGMEM = "Private-Network-Access-Name";
-static const char HEADER_PNA_ID[] PROGMEM = "Private-Network-Access-ID";
-static const char HEADER_CORS_REQ_PNA[] PROGMEM = "Access-Control-Request-Private-Network";
-static const char HEADER_CORS_ALLOW_PNA[] PROGMEM = "Access-Control-Allow-Private-Network";
-#define PNA_HEADER(x) FPSTR(x)
-#else
-static const char *const HEADER_PNA_NAME = "Private-Network-Access-Name";
-static const char *const HEADER_PNA_ID = "Private-Network-Access-ID";
-static const char *const HEADER_CORS_REQ_PNA = "Access-Control-Request-Private-Network";
-static const char *const HEADER_CORS_ALLOW_PNA = "Access-Control-Allow-Private-Network";
-#define PNA_HEADER(x) (x)
-#endif
-#endif
-
 // Parse URL and return match info
 static UrlMatch match_url(const char *url_ptr, size_t url_len, bool only_domain) {
   UrlMatch match{};
@@ -377,10 +361,10 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
   AsyncWebServerResponse *response = request->beginResponse(200, "");
-  response->addHeader(PNA_HEADER(HEADER_CORS_ALLOW_PNA), ESPHOME_F("true"));
-  response->addHeader(PNA_HEADER(HEADER_PNA_NAME), App.get_name().c_str());
+  response->addHeader(ESPHOME_F("Access-Control-Allow-Private-Network"), ESPHOME_F("true"));
+  response->addHeader(ESPHOME_F("Private-Network-Access-Name"), App.get_name().c_str());
   char mac_s[18];
-  response->addHeader(PNA_HEADER(HEADER_PNA_ID), get_mac_address_pretty_into_buffer(mac_s));
+  response->addHeader(ESPHOME_F("Private-Network-Access-ID"), get_mac_address_pretty_into_buffer(mac_s));
   request->send(response);
 }
 #endif
@@ -1850,7 +1834,7 @@ bool WebServer::canHandle(AsyncWebServerRequest *request) const {
   }
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
-  if (method == HTTP_OPTIONS && request->hasHeader(PNA_HEADER(HEADER_CORS_REQ_PNA)))
+  if (method == HTTP_OPTIONS && request->hasHeader(ESPHOME_F("Access-Control-Request-Private-Network")))
     return true;
 #endif
 
@@ -1983,7 +1967,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
 #endif
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
-  if (request->method() == HTTP_OPTIONS && request->hasHeader(PNA_HEADER(HEADER_CORS_REQ_PNA))) {
+  if (request->method() == HTTP_OPTIONS && request->hasHeader(ESPHOME_F("Access-Control-Request-Private-Network"))) {
     this->handle_pna_cors_request(request);
     return;
   }

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -100,7 +100,7 @@ class WebServerBase : public Component {
     }
     this->server_ = std::make_unique<AsyncWebServer>(this->port_);
     // All content is controlled and created by user - so allowing all origins is fine here.
-    DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
+    DefaultHeaders::Instance().addHeader(ESPHOME_F("Access-Control-Allow-Origin"), ESPHOME_F("*"));
     this->server_->begin();
 
     for (auto *handler : this->handlers_)


### PR DESCRIPTION
# What does this implement/fix?

Move HTTP header string literals to flash on ESP8266 using `ESPHOME_F()`.

On ESP8266, string literals are stored in RAM by default. This PR wraps header strings with `ESPHOME_F()` to store them in flash instead, saving approximately 200 bytes of DRAM.

**Strings moved to flash:**
- CORS headers: `"Access-Control-Allow-Origin"`, `"*"`
- Compression headers: `"Content-Encoding"`, `"gzip"`
- Private Network Access headers: `"Access-Control-Allow-Private-Network"`, `"Access-Control-Request-Private-Network"`, `"Private-Network-Access-Name"`, `"Private-Network-Access-ID"`, `"true"`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
