### PR TITLE
[core] Add format_hex_to helper for zero-allocation hex formatting

### DIFF
--- a/esphome/components/one_wire/one_wire_bus.cpp
+++ b/esphome/components/one_wire/one_wire_bus.cpp
@@ -49,7 +49,8 @@ void OneWireBus::search() {
       break;
     auto *address8 = reinterpret_cast<uint8_t *>(&address);
     if (crc8(address8, 7) != address8[7]) {
-      ESP_LOGW(TAG, "Dallas device 0x%s has invalid CRC.", format_hex(address).c_str());
+      char hex_buf[17];
+      ESP_LOGW(TAG, "Dallas device 0x%s has invalid CRC.", format_hex_to(hex_buf, address));
     } else {
       this->devices_.push_back(address);
     }
@@ -82,8 +83,9 @@ void OneWireBus::dump_devices_(const char *tag) {
     ESP_LOGW(tag, "  Found no devices!");
   } else {
     ESP_LOGCONFIG(tag, "  Found devices:");
+    char hex_buf[17];  // uint64_t = 16 hex chars + null
     for (auto &address : this->devices_) {
-      ESP_LOGCONFIG(tag, "    0x%s (%s)", format_hex(address).c_str(), LOG_STR_ARG(get_model_str(address & 0xff)));
+      ESP_LOGCONFIG(tag, "    0x%s (%s)", format_hex_to(hex_buf, address), LOG_STR_ARG(get_model_str(address & 0xff)));
     }
   }
 }

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -527,7 +527,9 @@ void SX126x::dump_config() {
                   this->spreading_factor_, cr, this->preamble_size_);
   }
   if (!this->sync_value_.empty()) {
-    ESP_LOGCONFIG(TAG, "  Sync Value: 0x%s", format_hex(this->sync_value_).c_str());
+    char hex_buf[17];  // 8 bytes max = 16 hex chars + null
+    ESP_LOGCONFIG(TAG, "  Sync Value: 0x%s",
+                  format_hex_to(hex_buf, this->sync_value_.data(), this->sync_value_.size()));
   }
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Configuring SX126x failed");

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -476,7 +476,9 @@ void SX127x::dump_config() {
       ESP_LOGCONFIG(TAG, "  Payload Length: %" PRIu32, this->payload_length_);
     }
     if (!this->sync_value_.empty()) {
-      ESP_LOGCONFIG(TAG, "  Sync Value: 0x%s", format_hex(this->sync_value_).c_str());
+      char hex_buf[17];  // 8 bytes max = 16 hex chars + null
+      ESP_LOGCONFIG(TAG, "  Sync Value: 0x%s",
+                    format_hex_to(hex_buf, this->sync_value_.data(), this->sync_value_.size()));
     }
     if (this->preamble_size_ > 0 || this->preamble_detect_ > 0) {
       ESP_LOGCONFIG(TAG,

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -297,6 +297,19 @@ std::string format_hex(const uint8_t *data, size_t length) {
 }
 std::string format_hex(const std::vector<uint8_t> &data) { return format_hex(data.data(), data.size()); }
 
+char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length) {
+  size_t max_bytes = (buffer_size - 1) / 2;
+  if (length > max_bytes) {
+    length = max_bytes;
+  }
+  for (size_t i = 0; i < length; i++) {
+    buffer[2 * i] = format_hex_char(data[i] >> 4);
+    buffer[2 * i + 1] = format_hex_char(data[i] & 0x0F);
+  }
+  buffer[length * 2] = '\0';
+  return buffer;
+}
+
 // Shared implementation for uint8_t and string hex formatting
 static std::string format_hex_pretty_uint8(const uint8_t *data, size_t length, char separator, bool show_length) {
   if (data == nullptr || length == 0)

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -706,20 +706,14 @@ inline void format_mac_addr_lower_no_sep(const uint8_t *mac, char *output) {
   output[12] = '\0';
 }
 
+/// Format byte array as lowercase hex to buffer (base implementation).
+char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length);
+
 /// Format byte array as lowercase hex to buffer. Automatically deduces buffer size.
 /// Truncates output if data exceeds buffer capacity. Returns pointer to buffer.
 template<size_t N> inline char *format_hex_to(char (&buffer)[N], const uint8_t *data, size_t length) {
   static_assert(N >= 3, "Buffer must hold at least one hex byte (3 chars)");
-  size_t max_bytes = (N - 1) / 2;
-  if (length > max_bytes) {
-    length = max_bytes;
-  }
-  for (size_t i = 0; i < length; i++) {
-    buffer[2 * i] = format_hex_char(data[i] >> 4);
-    buffer[2 * i + 1] = format_hex_char(data[i] & 0x0F);
-  }
-  buffer[length * 2] = '\0';
-  return buffer;
+  return format_hex_to(buffer, N, data, length);
 }
 
 /// Format an unsigned integer in lowercased hex to buffer, starting with the most significant byte.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -706,6 +706,30 @@ inline void format_mac_addr_lower_no_sep(const uint8_t *mac, char *output) {
   output[12] = '\0';
 }
 
+/// Format byte array as lowercase hex to buffer. Automatically deduces buffer size.
+/// Truncates output if data exceeds buffer capacity. Returns pointer to buffer.
+template<size_t N> inline char *format_hex_to(char (&buffer)[N], const uint8_t *data, size_t length) {
+  static_assert(N >= 3, "Buffer must hold at least one hex byte (3 chars)");
+  size_t max_bytes = (N - 1) / 2;
+  if (length > max_bytes) {
+    length = max_bytes;
+  }
+  for (size_t i = 0; i < length; i++) {
+    buffer[2 * i] = format_hex_char(data[i] >> 4);
+    buffer[2 * i + 1] = format_hex_char(data[i] & 0x0F);
+  }
+  buffer[length * 2] = '\0';
+  return buffer;
+}
+
+/// Format an unsigned integer in lowercased hex to buffer, starting with the most significant byte.
+template<size_t N, typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
+inline char *format_hex_to(char (&buffer)[N], T val) {
+  static_assert(N >= sizeof(T) * 2 + 1, "Buffer too small for type");
+  val = convert_big_endian(val);
+  return format_hex_to(buffer, reinterpret_cast<const uint8_t *>(&val), sizeof(T));
+}
+
 /// Format the six-byte array \p mac into a MAC address.
 std::string format_mac_address_pretty(const uint8_t mac[6]);
 /// Format the byte array \p data of length \p len in lowercased hex.


### PR DESCRIPTION
# What does this implement/fix?

Add `format_hex_to()` helper to avoid heap allocations when formatting hex values for logging.

`format_hex()` returns `std::string` which allocates on the heap. For logging, this allocation is unnecessary since the string is immediately discarded. The new `format_hex_to()` writes directly to a caller-provided stack buffer, enabling zero-allocation hex formatting.

```cpp
// Before (allocates on heap)
ESP_LOGCONFIG(TAG, "Address: 0x%s", format_hex(address).c_str());

// After (stack buffer, no allocation)
char hex_buf[17];
ESP_LOGCONFIG(TAG, "Address: 0x%s", format_hex_to(hex_buf, address));
```

The API mirrors `format_hex()` with both byte array and unsigned integer overloads:
- Byte array: truncates if buffer too small
- Unsigned integer: `static_assert` if buffer too small, outputs MSB first

Updated `sx127x`, `sx126x`, and `one_wire` to use the new helper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
