### PR TITLE
[lvgl] Fix lambdas in canvas actions called from outside LVGL context

### DIFF
--- a/esphome/components/lvgl/defines.py
+++ b/esphome/components/lvgl/defines.py
@@ -5,7 +5,7 @@ Constants already defined in esphome.const are not duplicated here and must be i
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from esphome import codegen as cg, config_validation as cv
 from esphome.const import CONF_ITEMS
@@ -96,13 +96,9 @@ class LValidator:
             return None
         if isinstance(value, Lambda):
             # Local import to avoid circular import
-            from .lvcode import CodeContext, LambdaContext
+            from .lvcode import get_lambda_context_args
 
-            if TYPE_CHECKING:
-                # CodeContext does not have get_automation_parameters
-                # so we need to assert the type here
-                assert isinstance(CodeContext.code_context, LambdaContext)
-            args = args or CodeContext.code_context.get_automation_parameters()
+            args = args or get_lambda_context_args()
             return cg.RawExpression(
                 call_lambda(
                     await cg.process_lambda(value, args, return_type=self.rtype)

--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import esphome.codegen as cg
 from esphome.components import image
@@ -404,14 +404,9 @@ class TextValidator(LValidator):
         self, value: Any, args: list[tuple[SafeExpType, str]] | None = None
     ) -> Expression:
         # Local import to avoid circular import at module level
+        from .lvcode import get_lambda_context_args
 
-        from .lvcode import CodeContext, LambdaContext
-
-        if TYPE_CHECKING:
-            # CodeContext does not have get_automation_parameters
-            # so we need to assert the type here
-            assert isinstance(CodeContext.code_context, LambdaContext)
-        args = args or CodeContext.code_context.get_automation_parameters()
+        args = args or get_lambda_context_args()
 
         if isinstance(value, dict):
             if format_str := value.get(CONF_FORMAT):

--- a/esphome/components/lvgl/lvcode.py
+++ b/esphome/components/lvgl/lvcode.py
@@ -1,4 +1,5 @@
 import abc
+from typing import TYPE_CHECKING
 
 from esphome import codegen as cg
 from esphome.config import Config
@@ -198,6 +199,21 @@ class LvContext(LambdaContext):
 
     def __call__(self, *args):
         return self.add(*args)
+
+
+def get_lambda_context_args() -> list[tuple[SafeExpType, str]]:
+    """Get automation parameters from the current lambda context if available.
+
+    When called from outside LVGL's context (e.g., from interval),
+    CodeContext.code_context will be None, so return empty args.
+    """
+    if CodeContext.code_context is None:
+        return []
+    if TYPE_CHECKING:
+        # CodeContext base class doesn't define get_automation_parameters(),
+        # but LambdaContext and LvContext (the concrete implementations) do.
+        assert isinstance(CodeContext.code_context, LambdaContext)
+    return CodeContext.code_context.get_automation_parameters()
 
 
 class LocalVariable(MockObj):


### PR DESCRIPTION
# What does this implement/fix?

Fixes LVGL canvas actions with lambdas crashing when called from outside LVGL's context (e.g., from `interval`).

The issue was that `CodeContext.code_context` is `None` when actions are triggered outside LVGL's lambda context, causing an `AttributeError` when trying to call `get_automation_parameters()`.

Added `get_lambda_context_args()` helper that safely returns empty args when no context is available.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12669

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
