### PR TITLE
[wifi] Use StringRef and std::span in WiFiConnectStateListener to avoid allocations

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -8,6 +8,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/string_ref.h"
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -275,7 +276,7 @@ class WiFiScanResultsListener {
  */
 class WiFiConnectStateListener {
  public:
-  virtual void on_wifi_connect_state(StringRef ssid, const bssid_t &bssid) = 0;
+  virtual void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) = 0;
 };
 
 /** Listener interface for WiFi power save mode changes.

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -6,6 +6,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
 
 #include <string>
 #include <vector>
@@ -274,7 +275,7 @@ class WiFiScanResultsListener {
  */
 class WiFiConnectStateListener {
  public:
-  virtual void on_wifi_connect_state(const std::string &ssid, const bssid_t &bssid) = 0;
+  virtual void on_wifi_connect_state(StringRef ssid, const bssid_t &bssid) = 0;
 };
 
 /** Listener interface for WiFi power save mode changes.

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -525,8 +525,10 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
                it.channel);
       s_sta_connected = true;
 #ifdef USE_WIFI_LISTENERS
+      bssid_t bssid;
+      std::copy_n(it.bssid, 6, bssid.begin());
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state(global_wifi_component->wifi_ssid(), global_wifi_component->wifi_bssid());
+        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
       }
       // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -560,7 +562,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       s_sta_connecting = false;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state("", bssid_t({0, 0, 0, 0, 0, 0}));
+        listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
       }
 #endif
       break;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -525,10 +525,8 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
                it.channel);
       s_sta_connected = true;
 #ifdef USE_WIFI_LISTENERS
-      bssid_t bssid;
-      std::copy_n(it.bssid, 6, bssid.begin());
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
+        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), it.bssid);
       }
       // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -561,8 +559,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       s_sta_connected = false;
       s_sta_connecting = false;
 #ifdef USE_WIFI_LISTENERS
+      static constexpr uint8_t EMPTY_BSSID[6] = {};
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
+        listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
       }
 #endif
       break;

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -736,10 +736,8 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
              format_mac_address_pretty(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
     s_sta_connected = true;
 #ifdef USE_WIFI_LISTENERS
-    bssid_t bssid;
-    std::copy_n(it.bssid, 6, bssid.begin());
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
+      listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), it.bssid);
     }
     // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -774,8 +772,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connecting = false;
     error_from_callback_ = true;
 #ifdef USE_WIFI_LISTENERS
+    static constexpr uint8_t EMPTY_BSSID[6] = {};
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
+      listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
     }
 #endif
 

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -736,8 +736,10 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
              format_mac_address_pretty(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
     s_sta_connected = true;
 #ifdef USE_WIFI_LISTENERS
+    bssid_t bssid;
+    std::copy_n(it.bssid, 6, bssid.begin());
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
+      listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
     }
     // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -773,7 +775,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     error_from_callback_ = true;
 #ifdef USE_WIFI_LISTENERS
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state("", bssid_t({0, 0, 0, 0, 0, 0}));
+      listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
     }
 #endif
 

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -302,8 +302,10 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       ESP_LOGV(TAG, "Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_address_pretty(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
 #ifdef USE_WIFI_LISTENERS
+      bssid_t bssid;
+      std::copy_n(it.bssid, 6, bssid.begin());
       for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
+        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
       }
       // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -358,7 +360,7 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       s_sta_connecting = false;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state("", bssid_t({0, 0, 0, 0, 0, 0}));
+        listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
       }
 #endif
       break;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -302,10 +302,8 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
       ESP_LOGV(TAG, "Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
                format_mac_address_pretty(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
 #ifdef USE_WIFI_LISTENERS
-      bssid_t bssid;
-      std::copy_n(it.bssid, 6, bssid.begin());
       for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), bssid);
+        listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), it.bssid);
       }
       // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -359,8 +357,9 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
 
       s_sta_connecting = false;
 #ifdef USE_WIFI_LISTENERS
+      static constexpr uint8_t EMPTY_BSSID[6] = {};
       for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
+        listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
       }
 #endif
       break;

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -256,8 +256,10 @@ void WiFiComponent::wifi_loop_() {
     s_sta_was_connected = true;
     ESP_LOGV(TAG, "Connected");
 #ifdef USE_WIFI_LISTENERS
+    String ssid = WiFi.SSID();
+    bssid_t bssid = this->wifi_bssid();
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(this->wifi_ssid(), this->wifi_bssid());
+      listener->on_wifi_connect_state(StringRef(ssid.c_str(), ssid.length()), bssid);
     }
     // For static IP configurations, notify IP listeners immediately as the IP is already configured
 #ifdef USE_WIFI_MANUAL_IP
@@ -276,7 +278,7 @@ void WiFiComponent::wifi_loop_() {
     ESP_LOGV(TAG, "Disconnected");
 #ifdef USE_WIFI_LISTENERS
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state("", bssid_t({0, 0, 0, 0, 0, 0}));
+      listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
     }
 #endif
   }

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -277,8 +277,9 @@ void WiFiComponent::wifi_loop_() {
     s_sta_had_ip = false;
     ESP_LOGV(TAG, "Disconnected");
 #ifdef USE_WIFI_LISTENERS
+    static constexpr uint8_t EMPTY_BSSID[6] = {};
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(), bssid_t({0, 0, 0, 0, 0, 0}));
+      listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
     }
 #endif
   }

--- a/esphome/components/wifi_info/wifi_info_text_sensor.cpp
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.cpp
@@ -103,8 +103,8 @@ void SSIDWiFiInfo::setup() { wifi::global_wifi_component->add_connect_state_list
 
 void SSIDWiFiInfo::dump_config() { LOG_TEXT_SENSOR("", "SSID", this); }
 
-void SSIDWiFiInfo::on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) {
-  this->publish_state(ssid);
+void SSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) {
+  this->publish_state(ssid.str());
 }
 
 /****************
@@ -115,7 +115,7 @@ void BSSIDWiFiInfo::setup() { wifi::global_wifi_component->add_connect_state_lis
 
 void BSSIDWiFiInfo::dump_config() { LOG_TEXT_SENSOR("", "BSSID", this); }
 
-void BSSIDWiFiInfo::on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) {
+void BSSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) {
   char buf[18] = "unknown";
   if (mac_address_is_valid(bssid.data())) {
     format_mac_addr_upper(bssid.data(), buf);

--- a/esphome/components/wifi_info/wifi_info_text_sensor.cpp
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.cpp
@@ -103,7 +103,7 @@ void SSIDWiFiInfo::setup() { wifi::global_wifi_component->add_connect_state_list
 
 void SSIDWiFiInfo::dump_config() { LOG_TEXT_SENSOR("", "SSID", this); }
 
-void SSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) {
+void SSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) {
   this->publish_state(ssid.str());
 }
 
@@ -115,7 +115,7 @@ void BSSIDWiFiInfo::setup() { wifi::global_wifi_component->add_connect_state_lis
 
 void BSSIDWiFiInfo::dump_config() { LOG_TEXT_SENSOR("", "BSSID", this); }
 
-void BSSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) {
+void BSSIDWiFiInfo::on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) {
   char buf[18] = "unknown";
   if (mac_address_is_valid(bssid.data())) {
     format_mac_addr_upper(bssid.data(), buf);

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -52,7 +52,7 @@ class SSIDWiFiInfo final : public Component, public text_sensor::TextSensor, pub
   void dump_config() override;
 
   // WiFiConnectStateListener interface
-  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override;
+  void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) override;
 };
 
 class BSSIDWiFiInfo final : public Component, public text_sensor::TextSensor, public wifi::WiFiConnectStateListener {
@@ -61,7 +61,7 @@ class BSSIDWiFiInfo final : public Component, public text_sensor::TextSensor, pu
   void dump_config() override;
 
   // WiFiConnectStateListener interface
-  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override;
+  void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) override;
 };
 
 class PowerSaveModeWiFiInfo final : public Component,

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -2,10 +2,12 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/wifi/wifi_component.h"
 #ifdef USE_WIFI
 #include <array>
+#include <span>
 
 namespace esphome::wifi_info {
 

--- a/esphome/components/wifi_info/wifi_info_text_sensor.h
+++ b/esphome/components/wifi_info/wifi_info_text_sensor.h
@@ -52,7 +52,7 @@ class SSIDWiFiInfo final : public Component, public text_sensor::TextSensor, pub
   void dump_config() override;
 
   // WiFiConnectStateListener interface
-  void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override;
+  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override;
 };
 
 class BSSIDWiFiInfo final : public Component, public text_sensor::TextSensor, public wifi::WiFiConnectStateListener {
@@ -61,7 +61,7 @@ class BSSIDWiFiInfo final : public Component, public text_sensor::TextSensor, pu
   void dump_config() override;
 
   // WiFiConnectStateListener interface
-  void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override;
+  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override;
 };
 
 class PowerSaveModeWiFiInfo final : public Component,

--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -2,9 +2,11 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/string_ref.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/wifi/wifi_component.h"
 #ifdef USE_WIFI
+#include <span>
 namespace esphome::wifi_signal {
 
 #ifdef USE_WIFI_LISTENERS

--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -28,7 +28,7 @@ class WiFiSignalSensor : public sensor::Sensor, public PollingComponent {
 
 #ifdef USE_WIFI_LISTENERS
   // WiFiConnectStateListener interface - update RSSI immediately on connect
-  void on_wifi_connect_state(const std::string &ssid, const wifi::bssid_t &bssid) override { this->update(); }
+  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override { this->update(); }
 #endif
 };
 

--- a/esphome/components/wifi_signal/wifi_signal_sensor.h
+++ b/esphome/components/wifi_signal/wifi_signal_sensor.h
@@ -28,7 +28,7 @@ class WiFiSignalSensor : public sensor::Sensor, public PollingComponent {
 
 #ifdef USE_WIFI_LISTENERS
   // WiFiConnectStateListener interface - update RSSI immediately on connect
-  void on_wifi_connect_state(StringRef ssid, const wifi::bssid_t &bssid) override { this->update(); }
+  void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) override { this->update(); }
 #endif
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocations and copies in WiFi connect/disconnect event notifications by changing the `WiFiConnectStateListener::on_wifi_connect_state()` interface:
- `const std::string &ssid` → `StringRef ssid`
- `const bssid_t &bssid` → `std::span<const uint8_t, 6> bssid`

**Before:** Each WiFi connect event caused heap allocation and extra SDK calls:
- `this->wifi_ssid()` creates a `std::string` from SDK data
- `this->wifi_bssid()` makes an extra SDK call to retrieve BSSID, copies to `bssid_t`

**After:** Zero heap allocations, zero copies on connect events:
- ESP-IDF/ESP8266/LibreTiny: Pass `StringRef` and `it.bssid` directly from event struct
- Pico W: Wrap Arduino `String` in `StringRef`, pass `bssid_t` (already fetched)

**Benefits:**
- Avoids heap allocation for SSID on every WiFi connect/disconnect event
- Avoids redundant SDK calls (SSID/BSSID already in event data)
- `StringRef` provides same API as `std::string` for read operations
- Listeners that need `std::string` can call `.str()` (only `SSIDWiFiInfo` needs this)

**Migration for external components:**
```cpp
// Before
void on_wifi_connect_state(const std::string &ssid, const bssid_t &bssid) override {
  do_something(ssid);           // ssid is std::string
  use_bssid(bssid.data());      // bssid is std::array<uint8_t, 6>
}

// After
void on_wifi_connect_state(StringRef ssid, std::span<const uint8_t, 6> bssid) override {
  do_something(ssid.str());     // Call .str() if std::string needed
  use_bssid(bssid.data());      // bssid.data() still works
  // Or use ssid.c_str(), ssid.size(), bssid.size(), etc.
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a - optimization discovered during heap allocation analysis

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a - `WiFiConnectStateListener` is not yet documented (added 2025-11-28 in #12155)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal API optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

text_sensor:
  - platform: wifi_info
    ssid:
      name: "Connected SSID"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Breaking Change Notes

This is a **minimal-impact developer breaking change**:

1. **Very recent API**: `WiFiConnectStateListener` was added only 28 days ago (#12155, 2025-11-28)
2. **Limited adoption**: Few if any external components have implemented this interface yet
3. **Easy migration**: `StringRef` provides `c_str()`, `size()`, `empty()`, and comparison operators identical to `std::string`
4. **Single method change**: Only `on_wifi_connect_state()` signature changes
5. **Implicit conversion available**: `StringRef` has `operator std::string()` for automatic conversion in many contexts

## Lifetime Safety

`StringRef` and `std::span` are non-owning views. Verified that the underlying data outlives all usage:

**Callers (data sources):**

| Platform | SSID Source | BSSID Source | Scope |
|----------|-------------|--------------|-------|
| ESP-IDF | `char buf[33]` stack | `it.bssid` from event struct | Valid for entire case block |
| ESP8266 | `char buf[33]` stack | `it.bssid` from event struct | Valid for entire case block |
| LibreTiny | `char buf[33]` stack | `it.bssid` from event struct | Valid for entire case block |
| Pico W | `String ssid` local | `bssid_t` from `wifi_bssid()` | Valid for entire if block |

**Listeners (consumers):**

| Listener | SSID Usage | BSSID Usage | Safe? |
|----------|------------|-------------|-------|
| `SSIDWiFiInfo` | `publish_state(ssid.str())` - copies | Unused | Yes |
| `BSSIDWiFiInfo` | Unused | `bssid.data()` - immediate use | Yes |
| `WiFiSignalSensor` | Unused | Unused | Yes |

All usage is synchronous within the same call stack. No listener stores the views.
