### PR TITLE
[hub75] Bump esp-hub75 version to 0.2.2

### DIFF
--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -147,7 +147,6 @@ HUB75Display = hub75_ns.class_("HUB75Display", cg.PollingComponent, display.Disp
 Hub75Config = cg.global_ns.struct("Hub75Config")
 Hub75Pins = cg.global_ns.struct("Hub75Pins")
 SetBrightnessAction = hub75_ns.class_("SetBrightnessAction", automation.Action)
-SetRotationAction = hub75_ns.class_("SetRotationAction", automation.Action)
 
 
 def _merge_board_pins(config: ConfigType) -> ConfigType:
@@ -624,28 +623,4 @@ async def hub75_set_brightness_to_code(
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_BRIGHTNESS], args, cg.uint8)
     cg.add(var.set_brightness(template_))
-    return var
-
-
-@automation.register_action(
-    "hub75.set_rotation",
-    SetRotationAction,
-    cv.maybe_simple_value(
-        {
-            cv.GenerateID(): cv.use_id(HUB75Display),
-            cv.Required(CONF_ROTATION): cv.templatable(cv.one_of(0, 90, 180, 270)),
-        },
-        key=CONF_ROTATION,
-    ),
-)
-async def hub75_set_rotation_to_code(
-    config: ConfigType,
-    action_id: ID,
-    template_arg: cg.TemplateArguments,
-    args: TemplateArgsType,
-) -> MockObj:
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_ROTATION], args, cg.int_)
-    cg.add(var.set_hub75_rotation(template_))
     return var

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -548,7 +548,7 @@ def _build_config_struct(
 async def to_code(config: ConfigType) -> None:
     add_idf_component(
         name="esphome/esp-hub75",
-        ref="0.2.1",
+        ref="0.2.2",
     )
 
     # Set compile-time configuration via defines

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -15,6 +15,7 @@ from esphome.const import (
     CONF_ID,
     CONF_LAMBDA,
     CONF_OE_PIN,
+    CONF_ROTATION,
     CONF_UPDATE_INTERVAL,
 )
 from esphome.core import ID
@@ -132,6 +133,14 @@ CLOCK_SPEEDS = {
     "10MHZ": Hub75ClockSpeed.HZ_10M,
     "16MHZ": Hub75ClockSpeed.HZ_16M,
     "20MHZ": Hub75ClockSpeed.HZ_20M,
+}
+
+Hub75Rotation = cg.global_ns.enum("Hub75Rotation", is_class=True)
+ROTATIONS = {
+    0: Hub75Rotation.ROTATE_0,
+    90: Hub75Rotation.ROTATE_90,
+    180: Hub75Rotation.ROTATE_180,
+    270: Hub75Rotation.ROTATE_270,
 }
 
 HUB75Display = hub75_ns.class_("HUB75Display", cg.PollingComponent, display.Display)
@@ -361,6 +370,8 @@ CONFIG_SCHEMA = cv.All(
     display.FULL_DISPLAY_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(HUB75Display),
+            # Override rotation - store Hub75Rotation directly (driver handles rotation)
+            cv.Optional(CONF_ROTATION): cv.enum(ROTATIONS, int=True),
             # Board preset (optional - provides default pin mappings)
             cv.Optional(CONF_BOARD): cv.one_of(*BOARDS.keys(), lower=True),
             # Panel dimensions
@@ -490,10 +501,11 @@ def _build_config_struct(
     Fields must be added in declaration order (see hub75_types.h) to satisfy
     C++ designated initializer requirements. The order is:
       1. fields_before_pins (panel_width through layout)
-      2. pins
-      3. output_clock_speed
-      4. min_refresh_rate
-      5. fields_after_min_refresh (latch_blanking through brightness)
+      2. rotation
+      3. pins
+      4. output_clock_speed
+      5. min_refresh_rate
+      6. fields_after_min_refresh (latch_blanking through brightness)
     """
     fields_before_pins = [
         (CONF_PANEL_WIDTH, "panel_width"),
@@ -516,6 +528,10 @@ def _build_config_struct(
 
     _append_config_fields(config, fields_before_pins, config_fields)
 
+    # Rotation - config already contains Hub75Rotation enum from cv.enum
+    if CONF_ROTATION in config:
+        config_fields.append(("rotation", config[CONF_ROTATION]))
+
     config_fields.append(("pins", pins_struct))
 
     if CONF_CLOCK_SPEED in config:
@@ -531,7 +547,7 @@ def _build_config_struct(
 async def to_code(config: ConfigType) -> None:
     add_idf_component(
         name="esphome/esp-hub75",
-        ref="0.1.7",
+        ref="0.2.0",
     )
 
     # Set compile-time configuration via defines
@@ -569,6 +585,11 @@ async def to_code(config: ConfigType) -> None:
     min_refresh = _calculate_min_refresh_rate(config)
     pins_struct = _build_pins_struct(pin_expressions, e_pin_num)
     hub75_config = _build_config_struct(config, pins_struct, min_refresh)
+
+    # Rotation is handled by the hub75 driver (config_.rotation already set above).
+    # Force rotation to 0 for ESPHome's Display base class to avoid double-rotation.
+    if CONF_ROTATION in config:
+        config[CONF_ROTATION] = 0
 
     # Create display and register
     var = cg.new_Pvariable(config[CONF_ID], hub75_config)

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -147,6 +147,7 @@ HUB75Display = hub75_ns.class_("HUB75Display", cg.PollingComponent, display.Disp
 Hub75Config = cg.global_ns.struct("Hub75Config")
 Hub75Pins = cg.global_ns.struct("Hub75Pins")
 SetBrightnessAction = hub75_ns.class_("SetBrightnessAction", automation.Action)
+SetRotationAction = hub75_ns.class_("SetRotationAction", automation.Action)
 
 
 def _merge_board_pins(config: ConfigType) -> ConfigType:
@@ -623,4 +624,28 @@ async def hub75_set_brightness_to_code(
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_BRIGHTNESS], args, cg.uint8)
     cg.add(var.set_brightness(template_))
+    return var
+
+
+@automation.register_action(
+    "hub75.set_rotation",
+    SetRotationAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(HUB75Display),
+            cv.Required(CONF_ROTATION): cv.templatable(cv.enum(ROTATIONS, int=True)),
+        },
+        key=CONF_ROTATION,
+    ),
+)
+async def hub75_set_rotation_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_ROTATION], args, Hub75Rotation)
+    cg.add(var.set_hub75_rotation(template_))
     return var

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -633,7 +633,7 @@ async def hub75_set_brightness_to_code(
     cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(HUB75Display),
-            cv.Required(CONF_ROTATION): cv.templatable(cv.enum(ROTATIONS, int=True)),
+            cv.Required(CONF_ROTATION): cv.templatable(cv.one_of(0, 90, 180, 270)),
         },
         key=CONF_ROTATION,
     ),
@@ -646,6 +646,6 @@ async def hub75_set_rotation_to_code(
 ) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_ROTATION], args, Hub75Rotation)
+    template_ = await cg.templatable(config[CONF_ROTATION], args, cg.int_)
     cg.add(var.set_hub75_rotation(template_))
     return var

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -390,7 +390,7 @@ CONFIG_SCHEMA = cv.All(
             # Display configuration
             cv.Optional(CONF_DOUBLE_BUFFER): cv.boolean,
             cv.Optional(CONF_BRIGHTNESS): cv.int_range(min=0, max=255),
-            cv.Optional(CONF_BIT_DEPTH): cv.int_range(min=6, max=12),
+            cv.Optional(CONF_BIT_DEPTH): cv.int_range(min=4, max=12),
             cv.Optional(CONF_GAMMA_CORRECT): cv.enum(
                 {"LINEAR": 0, "CIE1931": 1, "GAMMA_2_2": 2}, upper=True
             ),
@@ -548,7 +548,7 @@ def _build_config_struct(
 async def to_code(config: ConfigType) -> None:
     add_idf_component(
         name="esphome/esp-hub75",
-        ref="0.2.0",
+        ref="0.2.1",
     )
 
     # Set compile-time configuration via defines

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -190,11 +190,24 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
-void HUB75Display::set_hub75_rotation(Hub75Rotation rotation) {
-  if (rotation != Hub75Rotation::ROTATE_0 && rotation != Hub75Rotation::ROTATE_90 &&
-      rotation != Hub75Rotation::ROTATE_180 && rotation != Hub75Rotation::ROTATE_270) {
-    ESP_LOGW(TAG, "Invalid rotation: %d", static_cast<int>(rotation));
-    return;
+void HUB75Display::set_hub75_rotation(int degrees) {
+  Hub75Rotation rotation;
+  switch (degrees) {
+    case 0:
+      rotation = Hub75Rotation::ROTATE_0;
+      break;
+    case 90:
+      rotation = Hub75Rotation::ROTATE_90;
+      break;
+    case 180:
+      rotation = Hub75Rotation::ROTATE_180;
+      break;
+    case 270:
+      rotation = Hub75Rotation::ROTATE_270;
+      break;
+    default:
+      ESP_LOGW(TAG, "Invalid rotation: %d degrees", degrees);
+      return;
   }
 
   if (this->driver_ != nullptr) {

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -92,14 +92,25 @@ void HUB75Display::fill(Color color) {
   if (!this->enabled_) [[unlikely]]
     return;
 
-  // Special case: black (off) - use fast hardware clear
-  if (!color.is_on()) {
+  // Start with full display rect
+  Rect fill_rect(0, 0, this->get_width_internal(), this->get_height_internal());
+
+  // Apply clipping using Rect::shrink() to intersect
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Fast path: black filling entire display
+  if (!color.is_on() && fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == this->get_width_internal() &&
+      fill_rect.h == this->get_height_internal()) {
     driver_->clear();
     return;
   }
 
-  // For non-black colors, fall back to base class (pixel-by-pixel)
-  Display::fill(color);
+  driver_->fill(fill_rect.x, fill_rect.y, fill_rect.w, fill_rect.h, color.r, color.g, color.b);
 }
 
 void HOT HUB75Display::draw_pixel_at(int x, int y, Color color) {

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -190,6 +190,18 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
+void HUB75Display::set_hub75_rotation(Hub75Rotation rotation) {
+  if (rotation != Hub75Rotation::ROTATE_0 && rotation != Hub75Rotation::ROTATE_90 &&
+      rotation != Hub75Rotation::ROTATE_180 && rotation != Hub75Rotation::ROTATE_270) {
+    ESP_LOGW(TAG, "Invalid rotation: %d", static_cast<int>(rotation));
+    return;
+  }
+
+  if (this->driver_ != nullptr) {
+    this->driver_->set_rotation(rotation);
+  }
+}
+
 int HUB75Display::get_width_internal() { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }
 
 int HUB75Display::get_height_internal() { return this->driver_ != nullptr ? this->driver_->get_height() : 0; }

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -190,6 +190,10 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
+int HUB75Display::get_width_internal() { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }
+
+int HUB75Display::get_height_internal() { return this->driver_ != nullptr ? this->driver_->get_height() : 0; }
+
 }  // namespace esphome::hub75
 
 #endif

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -201,10 +201,6 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
-int HUB75Display::get_width_internal() { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }
-
-int HUB75Display::get_height_internal() { return this->driver_ != nullptr ? this->driver_->get_height() : 0; }
-
 }  // namespace esphome::hub75
 
 #endif

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -201,31 +201,6 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
-void HUB75Display::set_hub75_rotation(int degrees) {
-  Hub75Rotation rotation;
-  switch (degrees) {
-    case 0:
-      rotation = Hub75Rotation::ROTATE_0;
-      break;
-    case 90:
-      rotation = Hub75Rotation::ROTATE_90;
-      break;
-    case 180:
-      rotation = Hub75Rotation::ROTATE_180;
-      break;
-    case 270:
-      rotation = Hub75Rotation::ROTATE_270;
-      break;
-    default:
-      ESP_LOGW(TAG, "Invalid rotation: %d degrees", degrees);
-      return;
-  }
-
-  if (this->driver_ != nullptr) {
-    this->driver_->set_rotation(rotation);
-  }
-}
-
 int HUB75Display::get_width_internal() { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }
 
 int HUB75Display::get_height_internal() { return this->driver_ != nullptr ? this->driver_->get_height() : 0; }

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -93,10 +93,10 @@ void HUB75Display::fill(Color color) {
     return;
 
   // Start with full display rect
-  Rect fill_rect(0, 0, this->get_width_internal(), this->get_height_internal());
+  display::Rect fill_rect(0, 0, this->get_width_internal(), this->get_height_internal());
 
   // Apply clipping using Rect::shrink() to intersect
-  Rect clip = this->get_clipping();
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -37,9 +37,6 @@ class HUB75Display : public display::Display {
   // Brightness control (runtime mutable)
   void set_brightness(uint8_t brightness);
 
-  // Rotation control (runtime mutable, accepts degrees: 0, 90, 180, 270)
-  void set_hub75_rotation(int degrees);
-
  protected:
   // Display internal methods
   int get_width_internal() override;
@@ -59,13 +56,6 @@ template<typename... Ts> class SetBrightnessAction : public Action<Ts...>, publi
   TEMPLATABLE_VALUE(uint8_t, brightness)
 
   void play(const Ts &...x) override { this->parent_->set_brightness(this->brightness_.value(x...)); }
-};
-
-template<typename... Ts> class SetRotationAction : public Action<Ts...>, public Parented<HUB75Display> {
- public:
-  TEMPLATABLE_VALUE(int, hub75_rotation)
-
-  void play(const Ts &...x) override { this->parent_->set_hub75_rotation(this->hub75_rotation_.value(x...)); }
 };
 
 }  // namespace esphome::hub75

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -37,6 +37,9 @@ class HUB75Display : public display::Display {
   // Brightness control (runtime mutable)
   void set_brightness(uint8_t brightness);
 
+  // Rotation control (runtime mutable)
+  void set_hub75_rotation(Hub75Rotation rotation);
+
  protected:
   // Display internal methods
   int get_width_internal() override;
@@ -56,6 +59,13 @@ template<typename... Ts> class SetBrightnessAction : public Action<Ts...>, publi
   TEMPLATABLE_VALUE(uint8_t, brightness)
 
   void play(const Ts &...x) override { this->parent_->set_brightness(this->brightness_.value(x...)); }
+};
+
+template<typename... Ts> class SetRotationAction : public Action<Ts...>, public Parented<HUB75Display> {
+ public:
+  TEMPLATABLE_VALUE(Hub75Rotation, hub75_rotation)
+
+  void play(const Ts &...x) override { this->parent_->set_hub75_rotation(this->hub75_rotation_.value(x...)); }
 };
 
 }  // namespace esphome::hub75

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -39,8 +39,8 @@ class HUB75Display : public display::Display {
 
  protected:
   // Display internal methods
-  int get_width_internal() override { return config_.panel_width * config_.layout_cols; }
-  int get_height_internal() override { return config_.panel_height * config_.layout_rows; }
+  int get_width_internal() override;
+  int get_height_internal() override;
 
   // Member variables
   Hub75Driver *driver_{nullptr};

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -37,8 +37,8 @@ class HUB75Display : public display::Display {
   // Brightness control (runtime mutable)
   void set_brightness(uint8_t brightness);
 
-  // Rotation control (runtime mutable)
-  void set_hub75_rotation(Hub75Rotation rotation);
+  // Rotation control (runtime mutable, accepts degrees: 0, 90, 180, 270)
+  void set_hub75_rotation(int degrees);
 
  protected:
   // Display internal methods
@@ -63,7 +63,7 @@ template<typename... Ts> class SetBrightnessAction : public Action<Ts...>, publi
 
 template<typename... Ts> class SetRotationAction : public Action<Ts...>, public Parented<HUB75Display> {
  public:
-  TEMPLATABLE_VALUE(Hub75Rotation, hub75_rotation)
+  TEMPLATABLE_VALUE(int, hub75_rotation)
 
   void play(const Ts &...x) override { this->parent_->set_hub75_rotation(this->hub75_rotation_.value(x...)); }
 };

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -39,8 +39,8 @@ class HUB75Display : public display::Display {
 
  protected:
   // Display internal methods
-  int get_width_internal() override;
-  int get_height_internal() override;
+  int get_width_internal() override { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }
+  int get_height_internal() override { return this->driver_ != nullptr ? this->driver_->get_height() : 0; }
 
   // Member variables
   Hub75Driver *driver_{nullptr};

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -28,6 +28,6 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.2.0
+    version: 0.2.1
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -28,6 +28,6 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.1.7
+    version: 0.2.0
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -28,6 +28,6 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.2.1
+    version: 0.2.2
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"

--- a/tests/components/hub75/common.yaml
+++ b/tests/components/hub75/common.yaml
@@ -10,3 +10,14 @@ esphome:
     - hub75.set_brightness:
         id: my_hub75
         brightness: 50
+
+    # Test set_rotation simple value
+    - hub75.set_rotation: 90
+
+    # Test set_rotation templatable value
+    - hub75.set_rotation: !lambda 'return 180;'
+
+    # Test set_rotation with explicit ID
+    - hub75.set_rotation:
+        id: my_hub75
+        rotation: 270

--- a/tests/components/hub75/common.yaml
+++ b/tests/components/hub75/common.yaml
@@ -10,14 +10,3 @@ esphome:
     - hub75.set_brightness:
         id: my_hub75
         brightness: 50
-
-    # Test set_rotation simple value
-    - hub75.set_rotation: 90
-
-    # Test set_rotation templatable value
-    - hub75.set_rotation: !lambda 'return 180;'
-
-    # Test set_rotation with explicit ID
-    - hub75.set_rotation:
-        id: my_hub75
-        rotation: 270

--- a/tests/components/hub75/test.esp32-s3-idf-rotate.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf-rotate.yaml
@@ -1,0 +1,39 @@
+display:
+  - platform: hub75
+    id: my_hub75
+    board: apollo-automation-rev6
+    panel_width: 64
+    panel_height: 64
+    layout_rows: 1
+    layout_cols: 2
+    rotation: 90
+    bit_depth: 4
+    double_buffer: true
+    auto_clear_enabled: true
+    update_interval: 16ms
+    latch_blanking: 1
+    clock_speed: 20MHz
+    lambda: |-
+      // Test clipping: 8 columns x 4 rows of 16x16 colored squares
+      Color colors[32] = {
+        Color(255, 0, 0),     Color(0, 255, 0),     Color(0, 0, 255),     Color(255, 255, 0),
+        Color(255, 0, 255),   Color(0, 255, 255),   Color(255, 128, 0),   Color(128, 0, 255),
+        Color(0, 128, 255),   Color(255, 0, 128),   Color(128, 255, 0),   Color(0, 255, 128),
+        Color(255, 128, 128), Color(128, 255, 128), Color(128, 128, 255), Color(255, 255, 128),
+        Color(255, 128, 255), Color(128, 255, 255), Color(192, 64, 0),    Color(64, 192, 0),
+        Color(0, 64, 192),    Color(192, 0, 64),    Color(64, 0, 192),    Color(0, 192, 64),
+        Color(128, 64, 64),   Color(64, 128, 64),   Color(64, 64, 128),   Color(128, 128, 64),
+        Color(128, 64, 128),  Color(64, 128, 128),  Color(255, 255, 255), Color(128, 128, 128)
+      };
+      int idx = 0;
+      for (int row = 0; row < 4; row++) {
+        for (int col = 0; col < 8; col++) {
+          // Clipping mode: clip to square bounds, then fill "entire screen"
+          it.start_clipping(col * 16, row * 16, (col + 1) * 16, (row + 1) * 16);
+          it.fill(colors[idx]);
+          it.end_clipping();
+          idx++;
+        }
+      }
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

tldr: rotation now works, fill/clear are clipped correctly, and there are expanded bit depths supported (for lower color accuracy but faster refresh)

esp-hub75 [0.2.0](https://github.com/esphome-libs/esp-hub75/releases/tag/v0.2.0) added rotation support to the driver.  This bumps the version and utilizes the rotation support in the driver directly.

esp-hub75 [0.2.1](https://github.com/esphome-libs/esp-hub75/releases/tag/v0.2.1) expanded bit depth options to 4-12 from 6-12.

esp-hub75 [0.2.2](https://github.com/esphome-libs/esp-hub75/releases/tag/v0.2.2) Adds a fill API that can be used to optimize the display component's fill implementation.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5837

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
