### PR TITLE
[wifi] Use wifi_ssid_to() to avoid heap allocations in automation and connection checks

### DIFF
--- a/esphome/components/wifi/automation.h
+++ b/esphome/components/wifi/automation.h
@@ -45,7 +45,8 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     if (this->connecting_)
       return;
     // If already connected to the same AP, do nothing
-    if (global_wifi_component->wifi_ssid() == ssid) {
+    char ssid_buf[SSID_BUFFER_SIZE];
+    if (strcmp(global_wifi_component->wifi_ssid_to(ssid_buf), ssid.c_str()) == 0) {
       // Callback to notify the user that the connection was successful
       this->connect_trigger_->trigger();
       return;
@@ -94,7 +95,8 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
       this->cancel_timeout("wifi-connect-timeout");
       this->cancel_timeout("wifi-fallback-timeout");
       this->connecting_ = false;
-      if (global_wifi_component->wifi_ssid() == this->new_sta_.get_ssid()) {
+      char ssid_buf[SSID_BUFFER_SIZE];
+      if (strcmp(global_wifi_component->wifi_ssid_to(ssid_buf), this->new_sta_.get_ssid().c_str()) == 0) {
         // Callback to notify the user that the connection was successful
         this->connect_trigger_->trigger();
       } else {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1167,7 +1167,8 @@ void WiFiComponent::check_connecting_finished() {
   auto status = this->wifi_sta_connect_status_();
 
   if (status == WiFiSTAConnectStatus::CONNECTED) {
-    if (wifi_ssid().empty()) {
+    char ssid_buf[SSID_BUFFER_SIZE];
+    if (wifi_ssid_to(ssid_buf)[0] == '\0') {
       ESP_LOGW(TAG, "Connection incomplete");
       this->retry_connect();
       return;


### PR DESCRIPTION
# What does this implement/fix?

Replaces `wifi_ssid()` calls with `wifi_ssid_to()` to avoid heap allocations when checking the current SSID.

**Changes:**
- `WiFiConfigureAction::play()` - Use stack buffer instead of allocating `std::string` when comparing current SSID
- `WiFiConfigureAction::loop()` - Use stack buffer instead of allocating `std::string` when checking connection success
- `WiFiComponent::check_connecting_finished()` - Use stack buffer instead of allocating `std::string` when checking for empty SSID

The `wifi_ssid_to()` method writes to a 33-byte stack buffer (IEEE 802.11 max SSID length + null), avoiding the heap allocation overhead of `std::string`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
