### PR TITLE
[captive_portal] Use stack buffer for IP address logging in DNS server

### DIFF
--- a/esphome/components/captive_portal/dns_server_esp32_idf.cpp
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.cpp
@@ -47,7 +47,10 @@ struct DNSAnswer {
 
 void DNSServer::start(const network::IPAddress &ip) {
   this->server_ip_ = ip;
-  ESP_LOGV(TAG, "Starting DNS server on %s", ip.str().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  ESP_LOGV(TAG, "Starting DNS server on %s", ip.str_to(ip_buf));
+#endif
 
   // Create loop-monitored UDP socket
   this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocation during DNS server startup logging by using a stack buffer with `str_to()` instead of `ip.str().c_str()` which creates a temporary `std::string`.

The buffer and log statement are guarded with `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE` to avoid unused variable warnings when verbose logging is disabled.

This one doesn't matter so much but its in a place where someone might copy this pattern so good to fix since I noticed it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
captive_portal:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
