### PR TITLE
[wifi] Use stack buffers for IP address logging to avoid heap allocations

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -655,12 +655,15 @@ void WiFiComponent::setup_ap_config_() {
 #ifdef USE_WIFI_MANUAL_IP
   auto manual_ip = this->ap_.get_manual_ip();
   if (manual_ip.has_value()) {
+    char static_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char gateway_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char subnet_buf[network::IP_ADDRESS_BUFFER_SIZE];
     ESP_LOGCONFIG(TAG,
                   "  AP Static IP: '%s'\n"
                   "  AP Gateway: '%s'\n"
                   "  AP Subnet: '%s'",
-                  manual_ip->static_ip.str().c_str(), manual_ip->gateway.str().c_str(),
-                  manual_ip->subnet.str().c_str());
+                  manual_ip->static_ip.str_to(static_ip_buf), manual_ip->gateway.str_to(gateway_buf),
+                  manual_ip->subnet.str_to(subnet_buf));
   }
 #endif
 
@@ -816,8 +819,14 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
 #ifdef USE_WIFI_MANUAL_IP
   if (ap.get_manual_ip().has_value()) {
     ManualIP m = *ap.get_manual_ip();
-    ESP_LOGV(TAG, "  Manual IP: Static IP=%s Gateway=%s Subnet=%s DNS1=%s DNS2=%s", m.static_ip.str().c_str(),
-             m.gateway.str().c_str(), m.subnet.str().c_str(), m.dns1.str().c_str(), m.dns2.str().c_str());
+    char static_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char gateway_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char subnet_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char dns1_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    char dns2_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    ESP_LOGV(TAG, "  Manual IP: Static IP=%s Gateway=%s Subnet=%s DNS1=%s DNS2=%s", m.static_ip.str_to(static_ip_buf),
+             m.gateway.str_to(gateway_buf), m.subnet.str_to(subnet_buf), m.dns1.str_to(dns1_buf),
+             m.dns2.str_to(dns2_buf));
   } else
 #endif
   {

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -810,10 +810,13 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   network::IPAddress start_address = network::IPAddress(&info.ip);
   start_address += 99;
   lease.start_ip = start_address;
-  ESP_LOGV(TAG, "DHCP server IP lease start: %s", start_address.str().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+#endif
+  ESP_LOGV(TAG, "DHCP server IP lease start: %s", start_address.str_to(ip_buf));
   start_address += 10;
   lease.end_ip = start_address;
-  ESP_LOGV(TAG, "DHCP server IP lease end: %s", start_address.str().c_str());
+  ESP_LOGV(TAG, "DHCP server IP lease end: %s", start_address.str_to(ip_buf));
   if (!wifi_softap_set_dhcps_lease(&lease)) {
     ESP_LOGE(TAG, "Set SoftAP DHCP lease failed");
     return false;

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -981,7 +981,8 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   // Configure DHCP Option 114 (Captive Portal URI) if captive portal is enabled
   // This provides a standards-compliant way for clients to discover the captive portal
   if (captive_portal::global_captive_portal != nullptr) {
-    char captive_portal_uri[7 + network::IP_ADDRESS_BUFFER_SIZE];  // "http://" + IP
+    // Buffer must be static - dhcps_set_option_info stores pointer, doesn't copy
+    static char captive_portal_uri[7 + network::IP_ADDRESS_BUFFER_SIZE];  // "http://" + IP
     memcpy(captive_portal_uri, "http://", 7);
     network::IPAddress(&info.ip).str_to(captive_portal_uri + 7);
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -982,8 +982,8 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   // This provides a standards-compliant way for clients to discover the captive portal
   if (captive_portal::global_captive_portal != nullptr) {
     // Buffer must be static - dhcps_set_option_info stores pointer, doesn't copy
-    static char captive_portal_uri[24];  // "http://" (7) + IPv4 max (15) + null
-    memcpy(captive_portal_uri, "http://", 7);
+    static char captive_portal_uri[24];        // "http://" (7) + IPv4 max (15) + null
+    memcpy(captive_portal_uri, "http://", 7);  // NOLINT - str_to null-terminates
     network::IPAddress(&info.ip).str_to(captive_portal_uri + 7);
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,
                                  strlen(captive_portal_uri));

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -963,10 +963,13 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   network::IPAddress start_address = network::IPAddress(&info.ip);
   start_address += 99;
   lease.start_ip = start_address;
-  ESP_LOGV(TAG, "DHCP server IP lease start: %s", start_address.str().c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+#endif
+  ESP_LOGV(TAG, "DHCP server IP lease start: %s", start_address.str_to(ip_buf));
   start_address += 10;
   lease.end_ip = start_address;
-  ESP_LOGV(TAG, "DHCP server IP lease end: %s", start_address.str().c_str());
+  ESP_LOGV(TAG, "DHCP server IP lease end: %s", start_address.str_to(ip_buf));
   err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_REQUESTED_IP_ADDRESS, &lease, sizeof(lease));
 
   if (err != ESP_OK) {
@@ -979,7 +982,8 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   // This provides a standards-compliant way for clients to discover the captive portal
   if (captive_portal::global_captive_portal != nullptr) {
     static char captive_portal_uri[32];
-    snprintf(captive_portal_uri, sizeof(captive_portal_uri), "http://%s", network::IPAddress(&info.ip).str().c_str());
+    char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    snprintf(captive_portal_uri, sizeof(captive_portal_uri), "http://%s", network::IPAddress(&info.ip).str_to(ip_buf));
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,
                                  strlen(captive_portal_uri));
     if (err != ESP_OK) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -983,7 +983,7 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   if (captive_portal::global_captive_portal != nullptr) {
     // Buffer must be static - dhcps_set_option_info stores pointer, doesn't copy
     static char captive_portal_uri[24];        // "http://" (7) + IPv4 max (15) + null
-    memcpy(captive_portal_uri, "http://", 7);  // NOLINT - str_to null-terminates
+    memcpy(captive_portal_uri, "http://", 7);  // NOLINT(bugprone-not-null-terminated-result) - str_to null-terminates
     network::IPAddress(&info.ip).str_to(captive_portal_uri + 7);
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,
                                  strlen(captive_portal_uri));

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -981,9 +981,9 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   // Configure DHCP Option 114 (Captive Portal URI) if captive portal is enabled
   // This provides a standards-compliant way for clients to discover the captive portal
   if (captive_portal::global_captive_portal != nullptr) {
-    static char captive_portal_uri[32];
-    char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
-    snprintf(captive_portal_uri, sizeof(captive_portal_uri), "http://%s", network::IPAddress(&info.ip).str_to(ip_buf));
+    char captive_portal_uri[7 + network::IP_ADDRESS_BUFFER_SIZE];  // "http://" + IP
+    memcpy(captive_portal_uri, "http://", 7);
+    network::IPAddress(&info.ip).str_to(captive_portal_uri + 7);
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,
                                  strlen(captive_portal_uri));
     if (err != ESP_OK) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -982,7 +982,7 @@ bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
   // This provides a standards-compliant way for clients to discover the captive portal
   if (captive_portal::global_captive_portal != nullptr) {
     // Buffer must be static - dhcps_set_option_info stores pointer, doesn't copy
-    static char captive_portal_uri[7 + network::IP_ADDRESS_BUFFER_SIZE];  // "http://" + IP
+    static char captive_portal_uri[24];  // "http://" (7) + IPv4 max (15) + null
     memcpy(captive_portal_uri, "http://", 7);
     network::IPAddress(&info.ip).str_to(captive_portal_uri + 7);
     err = esp_netif_dhcps_option(s_ap_netif, ESP_NETIF_OP_SET, ESP_NETIF_CAPTIVEPORTAL_URI, captive_portal_uri,


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocations in WiFi component logging by using stack-based `str_to()` instead of `str().c_str()` for IP address formatting.

Changes:
- `wifi_component.cpp`: Use stack buffers for AP manual IP logging (LOGCONFIG) and STA manual IP logging (LOGV)
- `wifi_component_esp_idf.cpp`: Use stack buffers for DHCP lease logging; replace `snprintf` with direct `memcpy` + `str_to()` for captive portal URI formatting
- `wifi_component_esp8266.cpp`: Use stack buffers for DHCP lease logging

The `IPAddress::str()` method returns a `std::string` which heap allocates, while `str_to(buf)` writes directly to a provided stack buffer, avoiding allocation overhead.

For LOGV calls, only the buffer declaration is guarded with `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE` since ESP_LOGV already expands to nothing when verbose logging is disabled.

The captive portal URI buffer remains `static` because `esp_netif_dhcps_option` stores the pointer without copying the data. Buffer reduced from 32 to 24 bytes since AP is always IPv4 (7 for "http://" + 15 for max IPv4 + null + alignment).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
