### PR TITLE
[esp32_improv] Use stack buffer for URL formatting to avoid heap allocation

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -405,7 +405,7 @@ void ESP32ImprovComponent::check_wifi_connection_() {
       if (ip.is_ip4()) {
         // "http://" (7) + IPv4 max (15) + ":" (1) + port max (5) + null = 29
         char url_buffer[32];
-        memcpy(url_buffer, "http://", 7);  // NOLINT - str_to null-terminates
+        memcpy(url_buffer, "http://", 7);  // NOLINT(bugprone-not-null-terminated-result) - str_to null-terminates
         ip.str_to(url_buffer + 7);
         size_t len = strlen(url_buffer);
         snprintf(url_buffer + len, sizeof(url_buffer) - len, ":%d", USE_WEBSERVER_PORT);

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -403,8 +403,12 @@ void ESP32ImprovComponent::check_wifi_connection_() {
 #ifdef USE_WEBSERVER
     for (auto &ip : wifi::global_wifi_component->wifi_sta_ip_addresses()) {
       if (ip.is_ip4()) {
-        char url_buffer[64];
-        snprintf(url_buffer, sizeof(url_buffer), "http://%s:%d", ip.str().c_str(), USE_WEBSERVER_PORT);
+        // "http://" (7) + IPv4 max (15) + ":" (1) + port max (5) + null = 29
+        char url_buffer[32];
+        memcpy(url_buffer, "http://", 7);  // NOLINT - str_to null-terminates
+        ip.str_to(url_buffer + 7);
+        size_t len = strlen(url_buffer);
+        snprintf(url_buffer + len, sizeof(url_buffer) - len, ":%d", USE_WEBSERVER_PORT);
         url_strings[url_count++] = url_buffer;
         break;
       }


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocation in esp32_improv URL formatting by using stack-based `str_to()` instead of `str().c_str()`.

Changes:
- Replace `snprintf` with `str().c_str()` with direct buffer construction using `memcpy` + `str_to()` + `snprintf` for port
- Reduce buffer size from 64 to 32 bytes (sized exactly for IPv4: "http://" + IP + ":" + port)
- Use single buffer instead of separate IP buffer

The `IPAddress::str()` method returns a `std::string` which heap allocates, while `str_to(buf)` writes directly to a provided stack buffer, avoiding allocation overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
