### PR TITLE
Update dallas_temp.cpp

### DIFF
--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -51,7 +51,7 @@ void DallasTemperatureSensor::update() {
     }
 
     float tempc = this->get_temp_c_();
-    ESP_LOGD(TAG, "'%s': Got Temperature=%.4f°C", this->get_name().c_str(), tempc);
+    ESP_LOGD(TAG, "'%s': Got Temperature=%f°C", this->get_name().c_str(), tempc);
     this->publish_state(tempc);
   });
 }

--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -51,7 +51,7 @@ void DallasTemperatureSensor::update() {
     }
 
     float tempc = this->get_temp_c_();
-    ESP_LOGD(TAG, "'%s': Got Temperature=%.1f°C", this->get_name().c_str(), tempc);
+    ESP_LOGD(TAG, "'%s': Got Temperature=%.4f°C", this->get_name().c_str(), tempc);
     this->publish_state(tempc);
   });
 }


### PR DESCRIPTION
Log 4 decimals to match default 12bit == 0.0625°C resolution.

# What does this implement/fix?

Log 4 decimals instead of 1 to match default 12bit == 0.0625°C resolution.
Following example message is confusing as it is not in sync with the resolution.

> [dallas.temp.sensor:054]    'Forward Temperature': Got Temperature=30.8°


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
one_wire:
  - platform: gpio
    pin: GPIO4
    id: bus1

sensor:
  - platform: dallas_temp
    address: 0x0d0000005342e028
    one_wire_id: bus1
    id: forward_temp
    name: "Forward Temperature"
    resolution: 12
    accuracy_decimals: 4
    filters:
      - offset: -0.2
      - exponential_moving_average:
          alpha: 0.1
          send_every: 5
    update_interval: 2s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
