### PR TITLE
[api] Batch multiple responses into single TCP packet

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -57,6 +57,14 @@ static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 5;
 // Ensure batch size matches loop limit - send_buffer relies on this to skip count check
 static_assert(MAX_RESPONSES_PER_BATCH == MAX_MESSAGES_PER_LOOP,
               "MAX_RESPONSES_PER_BATCH must equal MAX_MESSAGES_PER_LOOP");
+
+// Out-of-line to reduce code size at call sites (saves ~30 bytes per call)
+void ResponseBatch::add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size) {
+  uint16_t payload_size = static_cast<uint16_t>(buffer_size - this->current_offset - header_padding);
+  new (&this->packets()[this->count++]) PacketInfo(message_type, this->current_offset, payload_size);
+  this->current_offset = static_cast<uint16_t>(buffer_size + footer_size);
+}
+
 static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -57,14 +57,6 @@ static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 5;
 // Ensure batch size matches loop limit - send_buffer relies on this to skip count check
 static_assert(MAX_RESPONSES_PER_BATCH == MAX_MESSAGES_PER_LOOP,
               "MAX_RESPONSES_PER_BATCH must equal MAX_MESSAGES_PER_LOOP");
-
-// Out-of-line to reduce code size at call sites (saves ~30 bytes per call)
-void ResponseBatch::add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size) {
-  uint16_t payload_size = static_cast<uint16_t>(buffer_size - this->current_offset - header_padding);
-  new (&this->packets()[this->count++]) PacketInfo(message_type, this->current_offset, payload_size);
-  this->current_offset = static_cast<uint16_t>(buffer_size + footer_size);
-}
-
 static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -192,6 +192,11 @@ void APIConnection::loop() {
   const uint32_t now = App.get_loop_component_start_time();
   // Check if socket has data ready before attempting to read
   if (this->helper_->is_socket_ready()) {
+    // Stack-allocated batch for collecting responses during request processing
+    // This allows multiple responses to be sent in a single TCP packet
+    ResponseBatch response_batch;
+    this->response_batch_ = &response_batch;
+
     // Read up to MAX_MESSAGES_PER_LOOP messages per loop to improve throughput
     for (uint8_t message_count = 0; message_count < MAX_MESSAGES_PER_LOOP; message_count++) {
       ReadPacketBuffer buffer;
@@ -200,15 +205,23 @@ void APIConnection::loop() {
         // No more data available
         break;
       } else if (err != APIError::OK) {
+        this->response_batch_ = nullptr;
         this->fatal_error_with_log_(LOG_STR("Reading failed"), err);
         return;
       } else {
         this->last_traffic_ = now;
         // read a packet
         this->read_message(buffer.data_len, buffer.type, buffer.data);
-        if (this->flags_.remove)
+        if (this->flags_.remove) {
+          this->response_batch_ = nullptr;
           return;
+        }
       }
+    }
+
+    // Flush batched responses and clear the pointer
+    if (!this->flush_response_batch_()) {
+      return;  // Fatal error occurred
     }
   }
 
@@ -337,10 +350,7 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint8_t mess
     }
   } else {
     // Batch message second or later
-    // Add padding for previous message footer + this message header
-    size_t current_size = shared_buf.size();
-    shared_buf.reserve(current_size + total_calculated_size);
-    shared_buf.resize(current_size + footer_size + header_padding);
+    conn->prepare_next_message_buffer(shared_buf, header_padding, footer_size, total_calculated_size);
   }
 
   // Encode directly into buffer
@@ -1831,6 +1841,13 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   return false;
 }
 bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
+  // If response batching is active, collect PacketInfo instead of sending
+  if (this->response_batch_ != nullptr && this->response_batch_->count < MAX_RESPONSES_PER_BATCH) {
+    this->response_batch_->add_packet(message_type, buffer.get_buffer()->size(), this->helper_->frame_header_padding(),
+                                      this->helper_->frame_footer_size());
+    return true;
+  }
+
   if (!this->try_to_clear_buffer(message_type != SubscribeLogsResponse::MESSAGE_TYPE)) {  // SubscribeLogsResponse
     return false;
   }
@@ -1894,6 +1911,38 @@ bool APIConnection::schedule_batch_() {
   if (!this->flags_.batch_scheduled) {
     this->flags_.batch_scheduled = true;
     this->deferred_batch_.batch_start_time = App.get_loop_component_start_time();
+  }
+  return true;
+}
+
+bool APIConnection::flush_response_batch_() {
+  ResponseBatch *batch = this->response_batch_;
+  this->response_batch_ = nullptr;
+
+  if (batch == nullptr || batch->count == 0) {
+    return true;  // Nothing to flush
+  }
+
+  // Try to clear buffer before sending
+  if (!this->try_to_clear_buffer(true)) {
+    return true;  // Can't send now, but not a fatal error
+  }
+
+  return this->send_batch_(std::span<const PacketInfo>(batch->packets(), batch->count));
+}
+
+bool APIConnection::send_batch_(std::span<const PacketInfo> packets) {
+  // Add footer space for the last message (for Noise protocol MAC)
+  uint8_t footer_size = this->helper_->frame_footer_size();
+  std::vector<uint8_t> &shared_buf = this->parent_->get_shared_buffer_ref();
+  if (footer_size > 0) {
+    shared_buf.resize(shared_buf.size() + footer_size);
+  }
+
+  APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&shared_buf}, packets);
+  if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
+    this->fatal_error_with_log_(LOG_STR("Batch write failed"), err);
+    return false;
   }
   return true;
 }
@@ -2014,17 +2063,8 @@ void APIConnection::process_batch_() {
     return;
   }
 
-  // Add footer space for the last message (for Noise protocol MAC)
-  if (footer_size > 0) {
-    shared_buf.resize(shared_buf.size() + footer_size);
-  }
-
   // Send all collected packets
-  APIError err = this->helper_->write_protobuf_packets(ProtoWriteBuffer{&shared_buf},
-                                                       std::span<const PacketInfo>(packet_info, packet_count));
-  if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
-    this->fatal_error_with_log_(LOG_STR("Batch write failed"), err);
-  }
+  this->send_batch_(std::span<const PacketInfo>(packet_info, packet_count));
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // Log messages after send attempt for VV debugging

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -54,6 +54,9 @@ namespace esphome::api {
 // Since each message could contain multiple protobuf messages when using packet batching,
 // this limits the number of messages processed, not the number of TCP packets.
 static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 5;
+// Ensure batch size matches loop limit - send_buffer relies on this to skip count check
+static_assert(MAX_RESPONSES_PER_BATCH == MAX_MESSAGES_PER_LOOP,
+              "MAX_RESPONSES_PER_BATCH must equal MAX_MESSAGES_PER_LOOP");
 static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;
@@ -1842,7 +1845,8 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
 }
 bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   // If response batching is active, collect PacketInfo instead of sending
-  if (this->response_batch_ != nullptr && this->response_batch_->count < MAX_RESPONSES_PER_BATCH) {
+  // Note: No count check needed - MAX_RESPONSES_PER_BATCH matches MAX_MESSAGES_PER_LOOP
+  if (this->response_batch_ != nullptr) {
     this->response_batch_->add_packet(message_type, buffer.get_buffer()->size(), this->helper_->frame_header_padding(),
                                       this->helper_->frame_footer_size());
     return true;

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -53,11 +53,8 @@ struct ResponseBatch {
   const PacketInfo *packets() const { return reinterpret_cast<const PacketInfo *>(packet_storage); }
 
   // Add a packet to the batch and update offset for next message
-  void add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size) {
-    uint16_t payload_size = static_cast<uint16_t>(buffer_size - current_offset - header_padding);
-    new (&packets()[count++]) PacketInfo(message_type, current_offset, payload_size);
-    current_offset = static_cast<uint16_t>(buffer_size + footer_size);
-  }
+  // Defined out-of-line to reduce code size at call sites
+  void add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size);
 };
 
 class APIConnection final : public APIServerConnection {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -53,8 +53,11 @@ struct ResponseBatch {
   const PacketInfo *packets() const { return reinterpret_cast<const PacketInfo *>(packet_storage); }
 
   // Add a packet to the batch and update offset for next message
-  // Defined out-of-line to reduce code size at call sites
-  void add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size);
+  void add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size) {
+    uint16_t payload_size = static_cast<uint16_t>(buffer_size - this->current_offset - header_padding);
+    new (&this->packets()[this->count++]) PacketInfo(message_type, this->current_offset, payload_size);
+    this->current_offset = static_cast<uint16_t>(buffer_size + footer_size);
+  }
 };
 
 class APIConnection final : public APIServerConnection {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -36,6 +36,30 @@ static constexpr size_t MAX_PACKETS_PER_BATCH = 64;  // ESP32 has 8KB+ stack, HO
 static constexpr size_t MAX_PACKETS_PER_BATCH = 32;  // ESP8266/RP2040/etc have smaller stacks
 #endif
 
+// Maximum responses to batch when processing incoming requests
+// Each request typically generates one response, so this matches MAX_MESSAGES_PER_LOOP (5)
+static constexpr uint8_t MAX_RESPONSES_PER_BATCH = 5;
+
+// Stack-allocated batch for collecting responses during request processing loop
+// This allows multiple responses to be sent in a single TCP packet
+struct ResponseBatch {
+  // Use aligned storage since PacketInfo has no default constructor
+  // PacketInfo is trivially destructible, so no explicit destruction needed
+  alignas(PacketInfo) char packet_storage[MAX_RESPONSES_PER_BATCH * sizeof(PacketInfo)];
+  uint8_t count{0};
+  uint16_t current_offset{0};  // Tracks where next message starts in buffer
+
+  PacketInfo *packets() { return reinterpret_cast<PacketInfo *>(packet_storage); }
+  const PacketInfo *packets() const { return reinterpret_cast<const PacketInfo *>(packet_storage); }
+
+  // Add a packet to the batch and update offset for next message
+  void add_packet(uint8_t message_type, size_t buffer_size, uint8_t header_padding, uint8_t footer_size) {
+    uint16_t payload_size = static_cast<uint16_t>(buffer_size - current_offset - header_padding);
+    new (&packets()[count++]) PacketInfo(message_type, current_offset, payload_size);
+    current_offset = static_cast<uint16_t>(buffer_size + footer_size);
+  }
+};
+
 class APIConnection final : public APIServerConnection {
  public:
   friend class APIServer;
@@ -269,10 +293,18 @@ class APIConnection final : public APIServerConnection {
 
     // Get header padding size - used for both reserve and insert
     uint8_t header_padding = this->helper_->frame_header_padding();
+    uint8_t footer_size = this->helper_->frame_footer_size();
     // Get shared buffer from parent server
     std::vector<uint8_t> &shared_buf = this->parent_->get_shared_buffer_ref();
-    this->prepare_first_message_buffer(shared_buf, header_padding,
-                                       reserve_size + header_padding + this->helper_->frame_footer_size());
+    size_t total_size = reserve_size + header_padding + footer_size;
+
+    // If response batching is active and we already have messages, append to buffer
+    if (this->response_batch_ != nullptr && this->response_batch_->count > 0) {
+      this->prepare_next_message_buffer(shared_buf, header_padding, footer_size, total_size);
+    } else {
+      // First message or not batching: clear and prepare fresh buffer
+      this->prepare_first_message_buffer(shared_buf, header_padding, total_size);
+    }
     return {&shared_buf};
   }
 
@@ -284,6 +316,14 @@ class APIConnection final : public APIServerConnection {
     shared_buf.reserve(total_size);
     // Resize to add header padding so message encoding starts at the correct position
     shared_buf.resize(header_padding);
+  }
+
+  // Append space for next message in a batch (footer for previous + header padding for this one)
+  void prepare_next_message_buffer(std::vector<uint8_t> &shared_buf, size_t header_padding, size_t footer_size,
+                                   size_t total_size) {
+    size_t current_size = shared_buf.size();
+    shared_buf.reserve(current_size + total_size);
+    shared_buf.resize(current_size + footer_size + header_padding);
   }
 
   bool try_to_clear_buffer(bool log_out_of_space);
@@ -501,6 +541,7 @@ class APIConnection final : public APIServerConnection {
   // Group 1: Pointers (4 bytes each on 32-bit)
   std::unique_ptr<APIFrameHelper> helper_;
   APIServer *parent_;
+  ResponseBatch *response_batch_{nullptr};  // Non-null during request processing loop
 
   // Group 2: Iterator union (saves ~16 bytes vs separate iterators)
   // These iterators are never active simultaneously - list_entities runs to completion
@@ -656,6 +697,14 @@ class APIConnection final : public APIServerConnection {
     this->deferred_batch_.clear();
     this->flags_.batch_scheduled = false;
   }
+
+  // Flush collected responses from response_batch_ to the network
+  // Returns true on success, false on fatal error (connection should be closed)
+  bool flush_response_batch_();
+
+  // Send a batch of packets - adds footer space and calls write_protobuf_packets
+  // Returns true on success or WOULD_BLOCK, false on fatal error
+  bool send_batch_(std::span<const PacketInfo> packets);
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // Helper to log a proto message from a MessageCreator object


### PR DESCRIPTION
# What does this implement/fix?

Batch multiple API responses into a single TCP packet when processing incoming requests.

Previously, when the API processed up to 5 incoming requests per loop iteration, each response was sent as a separate TCP packet via individual `write_protobuf_packet()` calls. This resulted in up to 5 separate TCP packets for 5 requests.

This PR batches responses during the request processing loop and sends them all at once using the existing `write_protobuf_packets()` API, reducing network overhead and improving throughput.

**Implementation:**
- Added `ResponseBatch` struct (stack-allocated) to collect up to 5 responses
- Modified `send_buffer()` to collect `PacketInfo` when batching is active
- Modified `create_buffer()` to append to the shared buffer for subsequent messages
- At end of loop, flush all responses in a single `write_protobuf_packets()` call

**Helpers added to reduce code duplication:**
- `ResponseBatch::add_packet()` - adds PacketInfo with placement new
- `prepare_next_message_buffer()` - appends space for next message in batch
- `send_batch_()` - adds footer space and sends packets (shared with `process_batch_()`)
- `flush_response_batch_()` - flushes collected responses

**No heap allocations:** All new data structures are stack-allocated.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A (performance optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
