### PR TITLE
[wifi] Use precision format specifier for SSID logging to avoid stack copy

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -728,16 +728,13 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_CONNECTED) {
     const auto &it = data->data.sta_connected;
-    char buf[33];
-    assert(it.ssid_len <= 32);
-    memcpy(buf, it.ssid, it.ssid_len);
-    buf[it.ssid_len] = '\0';
-    ESP_LOGV(TAG, "Connected ssid='%s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", buf,
-             format_mac_address_pretty(it.bssid).c_str(), it.channel, get_auth_mode_str(it.authmode));
+    ESP_LOGV(TAG, "Connected ssid='%.*s' bssid=" LOG_SECRET("%s") " channel=%u, authmode=%s", it.ssid_len,
+             (const char *) it.ssid, format_mac_address_pretty(it.bssid).c_str(), it.channel,
+             get_auth_mode_str(it.authmode));
     s_sta_connected = true;
 #ifdef USE_WIFI_LISTENERS
     for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(buf, it.ssid_len), it.bssid);
+      listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
     }
     // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #ifdef USE_WIFI_MANUAL_IP
@@ -751,21 +748,18 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_DISCONNECTED) {
     const auto &it = data->data.sta_disconnected;
-    char buf[33];
-    assert(it.ssid_len <= 32);
-    memcpy(buf, it.ssid, it.ssid_len);
-    buf[it.ssid_len] = '\0';
     if (it.reason == WIFI_REASON_NO_AP_FOUND) {
-      ESP_LOGW(TAG, "Disconnected ssid='%s' reason='Probe Request Unsuccessful'", buf);
+      ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
+               (const char *) it.ssid);
       s_sta_connect_not_found = true;
     } else if (it.reason == WIFI_REASON_ROAMING) {
-      ESP_LOGI(TAG, "Disconnected ssid='%s' reason='Station Roaming'", buf);
+      ESP_LOGI(TAG, "Disconnected ssid='%.*s' reason='Station Roaming'", it.ssid_len, (const char *) it.ssid);
       return;
     } else {
       char bssid_s[18];
       format_mac_addr_upper(it.bssid, bssid_s);
-      ESP_LOGW(TAG, "Disconnected ssid='%s' bssid=" LOG_SECRET("%s") " reason='%s'", buf, bssid_s,
-               get_disconnect_reason_str(it.reason));
+      ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
+               (const char *) it.ssid, bssid_s, get_disconnect_reason_str(it.reason));
       s_sta_connect_error = true;
     }
     s_sta_connected = false;


### PR DESCRIPTION
# What does this implement/fix?

Use `%.*s` format specifier for SSID logging instead of copying to a null-terminated stack buffer.

The SSID in Wi-Fi event structures is a `uint8_t[32]` array with a separate `ssid_len` field - it is not null-terminated. The previous code copied the SSID to a 33-byte stack buffer and added null termination to use with `%s`:

```cpp
char buf[33];
memcpy(buf, it.ssid, it.ssid_len);
buf[it.ssid_len] = '\0';
ESP_LOGV(TAG, "... ssid='%s' ...", buf);
```

The `%.*s` format specifier accepts a precision argument that limits how many characters to print, eliminating the need for the copy:

```cpp
ESP_LOGV(TAG, "... ssid='%.*s' ...", it.ssid_len, (const char *) it.ssid);
```

`StringRef` already has a templated constructor that accepts `uint8_t*` with length, so it can receive the SSID directly without copying.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
