### PR TITLE
[ota] Use precision format specifier for auth logging

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -736,7 +736,7 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
 
   ESP_LOGV(TAG, "Auth: CNonce is %.*s", hex_size, cnonce);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-  char computed_hash[65];  // SHA256 hex (64) + null
+  char computed_hash[65];  // Buffer for hex-encoded hash (max expected length + null terminator)
   hasher->get_hex(computed_hash);
   ESP_LOGV(TAG, "Auth: Result is %.*s", hex_size, computed_hash);
 #endif

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -654,12 +654,7 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
     this->auth_buf_[0] = this->auth_type_;
     hasher->get_hex(buf);
 
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-    char log_buf[65];  // Fixed size for SHA256 hex (64) + null, works for MD5 (32) too
-    memcpy(log_buf, buf, hex_size);
-    log_buf[hex_size] = '\0';
-    ESP_LOGV(TAG, "Auth: Nonce is %s", log_buf);
-#endif
+    ESP_LOGV(TAG, "Auth: Nonce is %.*s", hex_size, buf);
   }
 
   // Try to write auth_type + nonce
@@ -739,23 +734,13 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
   hasher->add(nonce, hex_size * 2);  // Add both nonce and cnonce (contiguous in buffer)
   hasher->calculate();
 
+  ESP_LOGV(TAG, "Auth: CNonce is %.*s", hex_size, cnonce);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-  char log_buf[65];  // Fixed size for SHA256 hex (64) + null, works for MD5 (32) too
-  // Log CNonce
-  memcpy(log_buf, cnonce, hex_size);
-  log_buf[hex_size] = '\0';
-  ESP_LOGV(TAG, "Auth: CNonce is %s", log_buf);
-
-  // Log computed hash
-  hasher->get_hex(log_buf);
-  log_buf[hex_size] = '\0';
-  ESP_LOGV(TAG, "Auth: Result is %s", log_buf);
-
-  // Log received response
-  memcpy(log_buf, response, hex_size);
-  log_buf[hex_size] = '\0';
-  ESP_LOGV(TAG, "Auth: Response is %s", log_buf);
+  char computed_hash[65];  // SHA256 hex (64) + null
+  hasher->get_hex(computed_hash);
+  ESP_LOGV(TAG, "Auth: Result is %.*s", hex_size, computed_hash);
 #endif
+  ESP_LOGV(TAG, "Auth: Response is %.*s", hex_size, response);
 
   // Compare response
   bool matches = hasher->equals_hex(response);


### PR DESCRIPTION
# What does this implement/fix?

Use `%.*s` format specifier for OTA auth logging instead of copying to null-terminated buffers.

- Replace `memcpy` + null termination + `%s` with direct `%.*s` format for nonce, cnonce, and response logging
- Remove redundant `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE` guards around `ESP_LOGV` calls (they already evaluate to nothing when disabled)
- Keep the guard only around the computed hash logging since `get_hex()` has runtime cost

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
