### PR TITLE
[tests] improve mipi_spi variable naming

### DIFF
--- a/tests/component_tests/mipi_spi/conftest.py
+++ b/tests/component_tests/mipi_spi/conftest.py
@@ -20,9 +20,9 @@ def choose_variant_with_pins() -> Generator[Callable[[list], None]]:
     """
 
     def chooser(pins: list) -> None:
-        for v in VARIANTS:
+        for variant in VARIANTS:
             try:
-                CORE.data[KEY_ESP32][KEY_VARIANT] = v
+                CORE.data[KEY_ESP32][KEY_VARIANT] = variant
                 for pin in pins:
                     if pin is not None:
                         pin = gpio_pin_schema(


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
