### PR TITLE
Fixed bug displaying negative numbers in PVVX MiThermometer Display

### DIFF
--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.h
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.h
@@ -60,13 +60,13 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
    * Valid values are from -99.5 to 1999.5. Smaller values are displayed as Lo, higher as Hi.
    * It will printed as it fits in the screen.
    */
-  void print_bignum(float bignum) { this->bignum_ = bignum * 10; }
+  void print_bignum(float bignum) { this->bignum_ = static_cast<int16_t>(bignum * 10); }
   /**
    * Print the small number
    *
    * Valid values are from -9 to 99. Smaller values are displayed as Lo, higher as Hi.
    */
-  void print_smallnum(float smallnum) { this->smallnum_ = smallnum; }
+  void print_smallnum(float smallnum) { this->smallnum_ = static_cast<int16_t>(smallnum); }
   /**
    * Print a happy face
    *
@@ -107,8 +107,8 @@ class PVVXDisplay : public ble_client::BLEClientNode, public PollingComponent {
   bool auto_clear_enabled_{true};
   uint32_t disconnect_delay_ms_ = 5000;
   uint16_t validity_period_ = 300;
-  uint16_t bignum_ = 0;
-  uint16_t smallnum_ = 0;
+  int16_t bignum_ = 0;
+  int16_t smallnum_ = 0;
   uint8_t cfg_ = 0;
 
   void setcfgbit_(uint8_t bit, bool value);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/issues/issues/6765

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:

ble_client:
- mac_address: XX:XX:XX:XX:XX:XX
  id: pvvx_ble_display

display:
- platform: pvvx_mithermometer
  ble_client_id: pvvx_ble_display
  lambda: |-
    it.print_bignum(-23.1);
    it.print_unit(pvvx_mithermometer::UNIT_DEG_C);
    it.print_smallnum(33);
    it.print_percent(true);
    it.print_happy(true);
    it.print_bracket(true);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
