### PR TITLE
[wifi] Fix ESP-IDF reporting connected before DHCP completes on reconnect

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -483,6 +483,12 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   s_sta_connected = false;
   s_sta_connect_error = false;
   s_sta_connect_not_found = false;
+  // Reset IP address flags - ensures we don't report connected before DHCP completes
+  // (IP_EVENT_STA_LOST_IP doesn't always fire on disconnect)
+  this->got_ipv4_address_ = false;
+#if USE_NETWORK_IPV6
+  this->num_ipv6_addresses_ = 0;
+#endif
 
   err = esp_wifi_connect();
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes WiFi reconnection on ESP-IDF when `IP_EVENT_STA_LOST_IP` doesn't fire on disconnect.

When WiFi disconnects with certain reasons (e.g., "Not Associated", "Association Expired"), the `IP_EVENT_STA_LOST_IP` event may not fire. This leaves `got_ipv4_address_` set to `true` from the previous connection.

On reconnection:
1. 802.11 association completes → `s_sta_connected = true`
2. `got_ipv4_address_` is still `true` from previous connection
3. `wifi_sta_connect_status_()` returns `CONNECTED` before DHCP completes
4. Device reports "Connected" but has IP `0.0.0.0`

The fix resets `got_ipv4_address_` (and `num_ipv6_addresses_`) when starting a new connection attempt, matching the ESP8266 implementation which already does this correctly with `s_sta_got_ip = false`.

**Observed symptoms:**
```
[wifi:630]: Connected
[wifi:455]:  Subnet: 0.0.0.0
[wifi:455]:  Gateway: 0.0.0.0
[wifi:455]:  DNS1: 0.0.0.0
[wifi:455]:  DNS2: 0.0.0.0
```

After this, the device requires a reboot to restore connectivity.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes (user report - no issue link)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is a bug fix
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
