### PR TITLE
[ethernet_info] Eliminate heap allocations in DNS text sensor

### DIFF
--- a/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
+++ b/esphome/components/ethernet_info/ethernet_info_text_sensor.cpp
@@ -3,8 +3,7 @@
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ethernet_info {
+namespace esphome::ethernet_info {
 
 static const char *const TAG = "ethernet_info";
 
@@ -12,7 +11,6 @@ void IPAddressEthernetInfo::dump_config() { LOG_TEXT_SENSOR("", "EthernetInfo IP
 void DNSAddressEthernetInfo::dump_config() { LOG_TEXT_SENSOR("", "EthernetInfo DNS Address", this); }
 void MACAddressEthernetInfo::dump_config() { LOG_TEXT_SENSOR("", "EthernetInfo MAC Address", this); }
 
-}  // namespace ethernet_info
-}  // namespace esphome
+}  // namespace esphome::ethernet_info
 
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Eliminate heap allocations in ethernet_info DNS address text sensor.

Changes:
- Replace `std::string last_results_` with direct `network::IPAddress` comparison for dns1/dns2
- Use stack buffer with `str_to()` instead of string concatenation (`dns_one.str() + " " + dns_two.str()`)
- Convert to C++17 nested namespace style

This mirrors the optimization already done in wifi_info.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
text_sensor:
  - platform: ethernet_info
    ip_address:
      name: IP Address
    dns_address:
      name: DNS Address
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
