### PR TITLE
[light] Use StringRef to avoid allocation in JSON effect name serialization

### DIFF
--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -36,7 +36,7 @@ static const char *get_color_mode_json_str(ColorMode mode) {
 void LightJSONSchema::dump_json(LightState &state, JsonObject root) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   if (state.supports_effects()) {
-    root[ESPHOME_F("effect")] = state.get_effect_name();
+    root[ESPHOME_F("effect")] = state.get_effect_name_ref();
     root[ESPHOME_F("effect_index")] = state.get_current_effect_index();
     root[ESPHOME_F("effect_count")] = state.get_effect_count();
   }


### PR DESCRIPTION
# What does this implement/fix?

Use `get_effect_name_ref()` instead of `get_effect_name()` in `LightJSONSchema::dump_json()` to avoid an unnecessary `std::string` allocation.

The `get_effect_name()` method returns `std::string` by value, which requires a heap allocation. The `get_effect_name_ref()` method returns `StringRef`, a non-owning reference that avoids the allocation. ArduinoJson can serialize `StringRef` directly via the existing `convertToJson` overload in `string_ref.h`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any light with effects configured
light:
  - platform: rgb
    name: "RGB Light"
    red: output_red
    green: output_green
    blue: output_blue
    effects:
      - strobe:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
