### PR TITLE
[addressable_light] Use StringRef to avoid allocation when saving effect name

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/color.h"
+#include "esphome/core/string_ref.h"
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/light/addressable_light.h"
 
@@ -25,11 +26,14 @@ class AddressableLightDisplay : public display::DisplayBuffer {
       if (enabled_ && !enabled) {  // enabled -> disabled
         // - Tell the parent light to refresh, effectively wiping the display. Also
         //   restores the previous effect (if any).
-        light_state_->make_call().set_effect(this->last_effect_).perform();
+        if (this->last_effect_.has_value()) {
+          auto &ref = *this->last_effect_;
+          light_state_->make_call().set_effect(ref.c_str(), ref.size()).perform();
+        }
 
       } else if (!enabled_ && enabled) {  // disabled -> enabled
-        // - Save the current effect.
-        this->last_effect_ = light_state_->get_effect_name();
+        // - Save the current effect (pointer to rodata, valid for program lifetime).
+        this->last_effect_ = light_state_->get_effect_name_ref();
         // - Disable any current effect.
         light_state_->make_call().set_effect(0).perform();
       }
@@ -56,7 +60,7 @@ class AddressableLightDisplay : public display::DisplayBuffer {
   int32_t width_;
   int32_t height_;
   std::vector<Color> addressable_light_buffer_;
-  optional<std::string> last_effect_;
+  optional<StringRef> last_effect_;
   optional<std::function<int(int, int)>> pixel_mapper_f_;
 };
 }  // namespace addressable_light

--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -2,7 +2,6 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/color.h"
-#include "esphome/core/string_ref.h"
 #include "esphome/components/display/display_buffer.h"
 #include "esphome/components/light/addressable_light.h"
 
@@ -26,14 +25,13 @@ class AddressableLightDisplay : public display::DisplayBuffer {
       if (enabled_ && !enabled) {  // enabled -> disabled
         // - Tell the parent light to refresh, effectively wiping the display. Also
         //   restores the previous effect (if any).
-        if (this->last_effect_.has_value()) {
-          auto &ref = *this->last_effect_;
-          light_state_->make_call().set_effect(ref.c_str(), ref.size()).perform();
+        if (this->last_effect_index_.has_value()) {
+          light_state_->make_call().set_effect(*this->last_effect_index_).perform();
         }
 
       } else if (!enabled_ && enabled) {  // disabled -> enabled
-        // - Save the current effect (pointer to rodata, valid for program lifetime).
-        this->last_effect_ = light_state_->get_effect_name_ref();
+        // - Save the current effect index.
+        this->last_effect_index_ = light_state_->get_current_effect_index();
         // - Disable any current effect.
         light_state_->make_call().set_effect(0).perform();
       }
@@ -60,7 +58,7 @@ class AddressableLightDisplay : public display::DisplayBuffer {
   int32_t width_;
   int32_t height_;
   std::vector<Color> addressable_light_buffer_;
-  optional<StringRef> last_effect_;
+  optional<uint32_t> last_effect_index_;
   optional<std::function<int(int, int)>> pixel_mapper_f_;
 };
 }  // namespace addressable_light


### PR DESCRIPTION
# What does this implement/fix?

Store effect index instead of effect name string in `AddressableLightDisplay`, avoiding a heap allocation.

The previous code stored the effect name as `optional<std::string>` to restore it when re-enabling the display. Since effect indices are stable for the program lifetime, we can simply store `optional<uint32_t>` instead.

Changes:
- Change `optional<std::string> last_effect_` to `optional<uint32_t> last_effect_index_`
- Use `get_current_effect_index()` instead of `get_effect_name()` when saving
- Use `set_effect(uint32_t)` directly when restoring

This is simpler, safer (no pointer lifetime concerns), and avoids heap allocation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Addressable light display with effects
light:
  - platform: fastled_clockless
    id: light_strip
    chipset: WS2812B
    pin: GPIO5
    num_leds: 64
    effects:
      - rainbow:

display:
  - platform: addressable_light
    id: led_display
    addressable_light_id: light_strip
    width: 8
    height: 8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
