### PR TITLE
[display] Optimize clipping

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -729,12 +729,14 @@ void Display::strftime(int x, int y, BaseFont *font, const char *format, ESPTime
   this->strftime(x, y, font, COLOR_ON, COLOR_OFF, TextAlign::TOP_LEFT, format, time);
 }
 
-void Display::start_clipping(Rect rect) {
-  if (!this->clipping_rectangle_.empty()) {
-    Rect r = this->clipping_rectangle_.back();
-    rect.shrink(r);
+void Display::start_clipping(const Rect &rect) {
+  if (this->clipping_rectangle_.empty()) {
+    this->clipping_rectangle_.push_back(rect);
+  } else {
+    Rect r = rect;
+    r.shrink(this->clipping_rectangle_.back());
+    this->clipping_rectangle_.push_back(r);
   }
-  this->clipping_rectangle_.push_back(rect);
 }
 
 void Display::end_clipping() {
@@ -745,7 +747,7 @@ void Display::end_clipping() {
   }
 }
 
-void Display::extend_clipping(Rect add_rect) {
+void Display::extend_clipping(const Rect &add_rect) {
   if (this->clipping_rectangle_.empty()) {
     ESP_LOGE(TAG, "add: Clipping is not set.");
   } else {
@@ -753,7 +755,7 @@ void Display::extend_clipping(Rect add_rect) {
   }
 }
 
-void Display::shrink_clipping(Rect add_rect) {
+void Display::shrink_clipping(const Rect &add_rect) {
   if (this->clipping_rectangle_.empty()) {
     ESP_LOGE(TAG, "add: Clipping is not set.");
   } else {

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -761,12 +761,12 @@ void Display::shrink_clipping(Rect add_rect) {
   }
 }
 
-Rect Display::get_clipping() const {
+const Rect &Display::get_clipping() const {
+  static const Rect NO_CLIPPING;
   if (this->clipping_rectangle_.empty()) {
-    return Rect();
-  } else {
-    return this->clipping_rectangle_.back();
+    return NO_CLIPPING;
   }
+  return this->clipping_rectangle_.back();
 }
 
 void Display::clear_clipping_() { this->clipping_rectangle_.clear(); }

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -722,7 +722,7 @@ class Display : public PollingComponent {
    *
    * return true if success, false if error
    */
-  void start_clipping(Rect rect);
+  void start_clipping(const Rect &rect);
   void start_clipping(int16_t left, int16_t top, int16_t right, int16_t bottom) {
     start_clipping(Rect(left, top, right - left, bottom - top));
   };
@@ -732,7 +732,7 @@ class Display : public PollingComponent {
    *
    * @param[in]  rect: Rectangle to add to the invalidation region
    */
-  void extend_clipping(Rect rect);
+  void extend_clipping(const Rect &rect);
   void extend_clipping(int16_t left, int16_t top, int16_t right, int16_t bottom) {
     this->extend_clipping(Rect(left, top, right - left, bottom - top));
   };
@@ -742,7 +742,7 @@ class Display : public PollingComponent {
    *
    * @param[in]  rect: Rectangle to add to the invalidation region
    */
-  void shrink_clipping(Rect rect);
+  void shrink_clipping(const Rect &rect);
   void shrink_clipping(uint16_t left, uint16_t top, uint16_t right, uint16_t bottom) {
     this->shrink_clipping(Rect(left, top, right - left, bottom - top));
   };

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -755,7 +755,7 @@ class Display : public PollingComponent {
    *
    * return rect for active clipping region
    */
-  Rect get_clipping() const;
+  const Rect &get_clipping() const;
 
   bool is_clipping() const { return !this->clipping_rectangle_.empty(); }
 

--- a/esphome/components/display/rect.cpp
+++ b/esphome/components/display/rect.cpp
@@ -16,7 +16,7 @@ void Rect::expand(int16_t horizontal, int16_t vertical) {
   }
 }
 
-void Rect::extend(Rect rect) {
+void Rect::extend(const Rect &rect) {
   if (!this->is_set()) {
     this->x = rect.x;
     this->y = rect.y;
@@ -39,7 +39,7 @@ void Rect::extend(Rect rect) {
     }
   }
 }
-void Rect::shrink(Rect rect) {
+void Rect::shrink(const Rect &rect) {
   if (!this->inside(rect)) {
     (*this) = Rect();
   } else {
@@ -60,25 +60,8 @@ void Rect::shrink(Rect rect) {
   }
 }
 
-bool Rect::equal(Rect rect) const {
+bool Rect::equal(const Rect &rect) const {
   return (rect.x == this->x) && (rect.w == this->w) && (rect.y == this->y) && (rect.h == this->h);
-}
-
-bool Rect::inside(int16_t test_x, int16_t test_y, bool absolute) const {  // NOLINT
-  if (!this->is_set()) {
-    return true;
-  }
-  if (absolute) {
-    return test_x >= this->x && test_x < this->x2() && test_y >= this->y && test_y < this->y2();
-  }
-  return test_x >= 0 && test_x < this->w && test_y >= 0 && test_y < this->h;
-}
-
-bool Rect::inside(Rect rect) const {
-  if (!this->is_set() || !rect.is_set()) {
-    return true;
-  }
-  return this->x2() >= rect.x && this->x <= rect.x2() && this->y2() >= rect.y && this->y <= rect.y2();
 }
 
 void Rect::info(const std::string &prefix) {

--- a/esphome/components/display/rect.h
+++ b/esphome/components/display/rect.h
@@ -23,12 +23,24 @@ class Rect {
 
   void expand(int16_t horizontal, int16_t vertical);
 
-  void extend(Rect rect);
-  void shrink(Rect rect);
+  void extend(const Rect &rect);
+  void shrink(const Rect &rect);
 
-  bool inside(Rect rect) const;
-  bool inside(int16_t test_x, int16_t test_y, bool absolute = true) const;
-  bool equal(Rect rect) const;
+  inline bool inside(int16_t test_x, int16_t test_y, bool absolute = true) const ESPHOME_ALWAYS_INLINE {
+    if (!this->is_set())
+      return true;
+    if (absolute) {
+      return test_x >= this->x && test_x < this->x2() && test_y >= this->y && test_y < this->y2();
+    }
+    return test_x >= 0 && test_x < this->w && test_y >= 0 && test_y < this->h;
+  }
+
+  inline bool inside(const Rect &rect) const ESPHOME_ALWAYS_INLINE {
+    if (!this->is_set() || !rect.is_set())
+      return true;
+    return this->x2() >= rect.x && this->x <= rect.x2() && this->y2() >= rect.y && this->y <= rect.y2();
+  }
+  bool equal(const Rect &rect) const;
   void info(const std::string &prefix = "rect info:");
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Display::get_clipping and Rect::inside are called in every display driver's draw_pixel_at function, which is generally called from tight loops from higher level drawing functions.  I expect the most common rendering path is w/o clipping, so lets make sure that is optimized and at least partially inline-able.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
