### PR TITLE
[core] Make LockFreeQueue more widely available

### DIFF
--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#if defined(USE_ESP32)
-
 #include <atomic>
 #include <cstddef>
 
+#ifdef USE_ESP32
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#endif
 
 /*
  * Lock-free queue for single-producer single-consumer scenarios.
@@ -95,7 +95,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   }
 
  protected:
-  T *buffer_[SIZE];
+  T *buffer_[SIZE]{};
   // Atomic: written by producer (push/increment), read+reset by consumer (get_and_reset)
   std::atomic<uint16_t> dropped_count_;  // 65535 max - more than enough for drop tracking
   // Atomic: written by consumer (pop), read by producer (push) to check if full
@@ -106,6 +106,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   std::atomic<uint8_t> tail_;
 };
 
+#ifdef USE_ESP32
 // Extended queue with task notification support
 template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQueue<T, SIZE> {
  public:
@@ -140,7 +141,6 @@ template<class T, uint8_t SIZE> class NotifyingLockFreeQueue : public LockFreeQu
  private:
   TaskHandle_t task_to_notify_;
 };
+#endif
 
 }  // namespace esphome
-
-#endif  // defined(USE_ESP32)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `LockFreeQueue` is currently only compiled for ESP32. It will compile for other platforms, but the notify version is FreeRTOS specific so just conditionally compile that, making `LockFreeQueue` available on any platform.

Required for an upcoming PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
