### PR TITLE
[docker] Add build-essential to fix ruamel.yaml 0.19.0 compilation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,9 +13,13 @@ RUN git config --system --add safe.directory "*"
 
 # Install build tools for Python packages that require compilation
 # (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager)
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
+RUN if command -v apk > /dev/null; then \
+        apk add --no-cache build-base; \
+    else \
+        apt-get update \
+        && apt-get install -y --no-install-recommends build-essential \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,6 +11,12 @@ FROM base-source-${BUILD_TYPE} AS base
 
 RUN git config --system --add safe.directory "*"
 
+# Install build tools for Python packages that require compilation
+# (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN pip install --no-cache-dir -U pip uv==0.6.14


### PR DESCRIPTION
# What does this implement/fix?

Adds build tools to the Docker image to fix ESP-IDF compilation failures caused by `ruamel.yaml` 0.19.0.

On December 31, 2025, `ruamel.yaml` 0.19.0 was released which no longer provides pre-built wheels. Instead, it requires compilation via `setuptools-zig`. ESP-IDF's `idf-component-manager` depends on `ruamel.yaml` without version pinning, so when platformio creates the ESP-IDF Python virtual environment, it pulls in the new version which fails to build due to missing build tools.

This adds `build-base` (Alpine) or `build-essential` (Debian) to the container so Python packages requiring compilation can be built successfully.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (upstream dependency change)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - Docker fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
