### PR TITLE
[docker] Make ESP-IDF venvs cleanable with "Clean All"

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -15,11 +15,18 @@ if [[ ! -d "${pio_cache_base}" ]]; then
     mkdir -p "${pio_cache_base}"
 fi
 
-# we can't set core_dir, because the settings file is stored in `core_dir/appstate.json`
-# setting `core_dir` would therefore prevent pio from accessing
+# We can't set PLATFORMIO_CORE_DIR because the settings file is stored in
+# `core_dir/appstate.json` and setting it would prevent pio from reading
+# cached settings. Instead we override individual subdirectories.
 export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
+
+# Symlink penv to persistent storage so ESP-IDF venvs can be cleaned with
+# "Clean All". There's no env var for penv location.
+mkdir -p "${pio_cache_base}/penv"
+mkdir -p /root/.platformio
+ln -sfn "${pio_cache_base}/penv" /root/.platformio/penv
 
 # If /build is mounted, use that as the build path
 # otherwise use path in /config (so that builds aren't lost on container restart)

--- a/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
+++ b/docker/ha-addon-rootfs/etc/s6-overlay/s6-rc.d/esphome/run
@@ -9,11 +9,18 @@ readonly pio_cache_base=/data/cache/platformio
 export ESPHOME_IS_HA_ADDON=true
 export PLATFORMIO_GLOBALLIB_DIR=/piolibs
 
-# we can't set core_dir, because the settings file is stored in `core_dir/appstate.json`
-# setting `core_dir` would therefore prevent pio from accessing
+# We can't set PLATFORMIO_CORE_DIR because the settings file is stored in
+# `core_dir/appstate.json` and setting it would prevent pio from reading
+# cached settings. Instead we override individual subdirectories.
 export PLATFORMIO_PLATFORMS_DIR="${pio_cache_base}/platforms"
 export PLATFORMIO_PACKAGES_DIR="${pio_cache_base}/packages"
 export PLATFORMIO_CACHE_DIR="${pio_cache_base}/cache"
+
+# Symlink penv to persistent storage so ESP-IDF venvs can be cleaned with
+# "Clean All". There's no env var for penv location.
+mkdir -p "${pio_cache_base}/penv"
+mkdir -p /root/.platformio
+ln -sfn "${pio_cache_base}/penv" /root/.platformio/penv
 
 if bashio::config.true 'leave_front_door_open'; then
     export DISABLE_HA_AUTHENTICATION=true


### PR DESCRIPTION
# What does this implement/fix?

Symlinks the PlatformIO penv directory to the cache location so ESP-IDF Python virtual environments can be cleaned with "Clean All".

Previously, the ESP-IDF venvs were stored at `/root/.platformio/penv` which is outside the cache directory structure. This meant corrupted venvs (like from the ruamel.yaml 0.19.0 issue) couldn't be cleaned via the dashboard - users had to manually SSH in and delete `/root/.platformio/penv`.

Now the penv directory is symlinked to the cache location:
- HA addon: `/data/cache/platformio/penv`
- Docker: `/config/.esphome/platformio/penv`

This allows "Clean All" to also clean corrupted ESP-IDF venvs, consistent with how other PlatformIO directories are handled.

> [!WARNING]
> This change can only be fully tested on an existing container environment. It should go through a dev release before production.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - Docker infrastructure change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
