### PR TITLE
[lvgl] Fix arc background angles

### DIFF
--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -85,11 +85,11 @@ class ArcType(NumberType):
             lv.arc_set_range(w.obj, min_value, max_value)
 
         await w.set_property(
-            CONF_START_ANGLE,
+            "bg_start_angle",
             await lv_angle_degrees.process(config.get(CONF_START_ANGLE)),
         )
         await w.set_property(
-            CONF_END_ANGLE, await lv_angle_degrees.process(config.get(CONF_END_ANGLE))
+            "bg_end_angle", await lv_angle_degrees.process(config.get(CONF_END_ANGLE))
         )
         await w.set_property(
             CONF_ROTATION, await lv_angle_degrees.process(config.get(CONF_ROTATION))


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent change to lvgl arc handling broke setting start and end angles - the functions being called set the indicator angles, not the background angles.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #12642 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
