### PR TITLE
[mipi_dsi] Use stack buffer for hex formatting in very verbose logging

### DIFF
--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -1,9 +1,13 @@
 #ifdef USE_ESP32_VARIANT_ESP32P4
 #include <utility>
 #include "mipi_dsi.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace mipi_dsi {
+
+// Maximum bytes to log for init commands (truncated if larger)
+static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 
 static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata, void *user_ctx) {
   auto *sem = static_cast<SemaphoreHandle_t *>(user_ctx);
@@ -121,8 +125,11 @@ void MIPI_DSI::setup() {
         }
       }
       const auto *ptr = vec.data() + index;
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+      char hex_buf[format_hex_pretty_size(MIPI_DSI_MAX_CMD_LOG_BYTES)];
+#endif
       ESP_LOGVV(TAG, "Command %02X, length %d, byte(s) %s", cmd, num_args,
-                format_hex_pretty(ptr, num_args, '.', false).c_str());
+                format_hex_pretty_to(hex_buf, ptr, num_args, '.'));
       err = esp_lcd_panel_io_tx_param(this->io_handle_, cmd, ptr, num_args);
       if (err != ESP_OK) {
         this->smark_failed(LOG_STR("lcd_panel_io_tx_param failed"), err);


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the mipi_dsi component's very verbose logging.

This eliminates a `std::string` heap allocation in the LOGVV path during display init sequence processing. The buffer is wrapped in a compile guard to avoid stack allocation when very verbose logging is disabled.

Buffer size is 192 bytes (`format_hex_pretty_size(64)`) to cover most init command sizes while truncating unusually large ones.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard mipi_dsi configuration - no changes needed
display:
  - platform: mipi_dsi
    model: "Custom"
    # ... other config
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
