### PR TITLE
[mipi_rgb] Use stack buffer for hex formatting in init sequence logging

### DIFF
--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_ESP32_VARIANT_ESP32S3
 #include "mipi_rgb.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include "esp_lcd_panel_rgb.h"
@@ -8,6 +9,9 @@ namespace esphome {
 namespace mipi_rgb {
 
 static const uint8_t DELAY_FLAG = 0xFF;
+
+// Maximum bytes to log for init commands (truncated if larger)
+static constexpr size_t MIPI_RGB_MAX_CMD_LOG_BYTES = 64;
 static constexpr uint8_t MADCTL_MY = 0x80;     // Bit 7 Bottom to top
 static constexpr uint8_t MADCTL_MX = 0x40;     // Bit 6 Right to left
 static constexpr uint8_t MADCTL_MV = 0x20;     // Bit 5 Swap axes
@@ -91,8 +95,9 @@ void MipiRgbSpi::write_init_sequence_() {
         delay(120);  // NOLINT
       }
       const auto *ptr = vec.data() + index;
+      char hex_buf[format_hex_pretty_size(MIPI_RGB_MAX_CMD_LOG_BYTES)];
       ESP_LOGD(TAG, "Write command %02X, length %d, byte(s) %s", cmd, num_args,
-               format_hex_pretty(ptr, num_args, '.', false).c_str());
+               format_hex_pretty_to(hex_buf, ptr, num_args, '.'));
       index += num_args;
       this->write_command_(cmd);
       while (num_args-- != 0)


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the mipi_rgb component's init sequence logging.

This eliminates a `std::string` heap allocation in the LOGD path during display init sequence processing at startup.

Buffer size is 192 bytes (`format_hex_pretty_size(64)`) to cover most init command sizes while truncating unusually large ones.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard mipi_rgb configuration - no changes needed
display:
  - platform: mipi_rgb
    model: "Custom"
    # ... other config
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
