### PR TITLE
[mitsubishi] Use stack buffer for hex formatting in verbose logging

### DIFF
--- a/esphome/components/mitsubishi/mitsubishi.cpp
+++ b/esphome/components/mitsubishi/mitsubishi.cpp
@@ -1,10 +1,14 @@
 #include "mitsubishi.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
 namespace mitsubishi {
 
 static const char *const TAG = "mitsubishi.climate";
+
+// IR frame size for Mitsubishi climate
+static constexpr size_t MITSUBISHI_FRAME_SIZE = 18;
 
 const uint8_t MITSUBISHI_OFF = 0x00;
 
@@ -388,7 +392,10 @@ bool MitsubishiClimate::on_receive(remote_base::RemoteReceiveData data) {
       break;
   }
 
-  ESP_LOGV(TAG, "Receiving: %s", format_hex_pretty(state_frame, 18).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(MITSUBISHI_FRAME_SIZE)];
+#endif
+  ESP_LOGV(TAG, "Receiving: %s", format_hex_pretty_to(hex_buf, state_frame, MITSUBISHI_FRAME_SIZE));
 
   this->publish_state();
   return true;


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the mitsubishi component's verbose logging.

This eliminates a `std::string` heap allocation in the LOGV path when receiving IR frames. The buffer is wrapped in a compile guard to avoid stack allocation when verbose logging is disabled.

Buffer size is 54 bytes (`format_hex_pretty_size(18)`) matching the fixed IR frame size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard mitsubishi configuration - no changes needed
climate:
  - platform: mitsubishi
    name: "Mitsubishi AC"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
