### PR TITLE
[pn532_spi] Replace format_hex_pretty with stack-based format_hex_pretty_to

### DIFF
--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -1,4 +1,5 @@
 #include "pn532_spi.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 // Based on:
@@ -10,6 +11,9 @@ namespace esphome {
 namespace pn532_spi {
 
 static const char *const TAG = "pn532_spi";
+
+// Maximum bytes to log in verbose hex output
+static constexpr size_t PN532_MAX_LOG_BYTES = 64;
 
 void PN532Spi::setup() {
   this->spi_setup();
@@ -32,7 +36,10 @@ bool PN532Spi::write_data(const std::vector<uint8_t> &data) {
   delay(2);
   // First byte, communication mode: Write data
   this->write_byte(0x01);
-  ESP_LOGV(TAG, "Writing data: %s", format_hex_pretty(data).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(PN532_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGV(TAG, "Writing data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), data.data(), data.size()));
   this->write_array(data.data(), data.size());
   this->disable();
 
@@ -55,7 +62,10 @@ bool PN532Spi::read_data(std::vector<uint8_t> &data, uint8_t len) {
   this->read_array(data.data(), len);
   this->disable();
   data.insert(data.begin(), 0x01);
-  ESP_LOGV(TAG, "Read data: %s", format_hex_pretty(data).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(PN532_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGV(TAG, "Read data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), data.data(), data.size()));
   return true;
 }
 
@@ -73,7 +83,10 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
   std::vector<uint8_t> header(7);
   this->read_array(header.data(), 7);
 
-  ESP_LOGV(TAG, "Header data: %s", format_hex_pretty(header).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(PN532_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGV(TAG, "Header data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), header.data(), header.size()));
 
   if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
     // invalid packet
@@ -103,7 +116,7 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
   this->read_array(data.data(), len + 1);
   this->disable();
 
-  ESP_LOGV(TAG, "Response data: %s", format_hex_pretty(data).c_str());
+  ESP_LOGV(TAG, "Response data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), data.data(), data.size()));
 
   uint8_t checksum = header[5] + header[6];  // TFI + Command response code
   for (int i = 0; i < len - 1; i++) {


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the pn532_spi component's verbose logging.

This eliminates `std::string` heap allocations in the LOGV paths for:
- `write_data()` - Writing data logging
- `read_data()` - Read data logging
- `read_response()` - Header data and response data logging (shared buffer)

The buffers are wrapped in compile guards to avoid stack allocation when verbose logging is disabled.

Buffer size is 192 bytes (`format_hex_pretty_size(64)`) to cover typical PN532 packets while truncating unusually large ones.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard pn532_spi configuration - no changes needed
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19

pn532_spi:
  cs_pin: GPIO5
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
