### PR TITLE
[qspi_dbi] Replace format_hex_pretty with stack-based format_hex_pretty_to

### DIFF
--- a/esphome/components/qspi_dbi/qspi_dbi.cpp
+++ b/esphome/components/qspi_dbi/qspi_dbi.cpp
@@ -1,9 +1,13 @@
 #if defined(USE_ESP32) && defined(USE_ESP32_VARIANT_ESP32S3)
 #include "qspi_dbi.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
 namespace qspi_dbi {
+
+// Maximum bytes to log in verbose hex output
+static constexpr size_t QSPI_DBI_MAX_LOG_BYTES = 64;
 
 void QspiDbi::setup() {
   this->spi_setup();
@@ -174,7 +178,11 @@ void QspiDbi::write_to_display_(int x_start, int y_start, int w, int h, const ui
   this->disable();
 }
 void QspiDbi::write_command_(uint8_t cmd, const uint8_t *bytes, size_t len) {
-  ESP_LOGV(TAG, "Command %02X, length %d, bytes %s", cmd, len, format_hex_pretty(bytes, len).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(QSPI_DBI_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGV(TAG, "Command %02X, length %d, bytes %s", cmd, len,
+           format_hex_pretty_to(hex_buf, sizeof(hex_buf), bytes, len));
   this->enable();
   this->write_cmd_addr_data(8, 0x02, 24, cmd << 8, bytes, len);
   this->disable();


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the qspi_dbi component's verbose logging.

This eliminates a `std::string` heap allocation in the LOGV path for command byte logging in `write_command_()`.

The buffer is wrapped in a compile guard to avoid stack allocation when verbose logging is disabled.

Buffer size is 192 bytes (`format_hex_pretty_size(64)`) to cover typical display init commands while truncating unusually large ones.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard qspi_dbi configuration - no changes needed
display:
  - platform: qspi_dbi
    model: "ST7701S"
    # ... other config
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
