### PR TITLE
[seeed_mr60fda2] Use stack-based format_hex_pretty_to for verbose logging

### DIFF
--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -210,9 +210,7 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
         char byte_buf[format_hex_pretty_size(1)];
 #endif
         ESP_LOGV(TAG, "CURRENT_FRAME: %s %s",
-                 format_hex_pretty_to(frame_buf, this->current_frame_buf_,
-                                      this->current_frame_len_ < MR60FDA2_MAX_LOG_BYTES ? this->current_frame_len_
-                                                                                        : MR60FDA2_MAX_LOG_BYTES),
+                 format_hex_pretty_to(frame_buf, this->current_frame_buf_, this->current_frame_len_),
                  format_hex_pretty_to(byte_buf, &buffer, 1));
         this->current_frame_locate_ = LOCATE_FRAME_HEADER;
       }
@@ -242,9 +240,7 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
         char byte_buf[format_hex_pretty_size(1)];
 #endif
         ESP_LOGV(TAG, "GET CURRENT_FRAME: %s %s",
-                 format_hex_pretty_to(frame_buf, this->current_frame_buf_,
-                                      this->current_frame_len_ < MR60FDA2_MAX_LOG_BYTES ? this->current_frame_len_
-                                                                                        : MR60FDA2_MAX_LOG_BYTES),
+                 format_hex_pretty_to(frame_buf, this->current_frame_buf_, this->current_frame_len_),
                  format_hex_pretty_to(byte_buf, &buffer, 1));
 
         this->current_frame_locate_ = LOCATE_FRAME_HEADER;

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -10,6 +10,9 @@ namespace seeed_mr60fda2 {
 
 static const char *const TAG = "seeed_mr60fda2";
 
+// Maximum bytes to log in verbose hex output
+static constexpr size_t MR60FDA2_MAX_LOG_BYTES = 64;
+
 // Prints the component's configuration data. dump_config() prints all of the component's configuration
 // items in an easy-to-read format, including the configuration key-value pairs.
 void MR60FDA2Component::dump_config() {
@@ -202,9 +205,15 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
         this->current_frame_locate_++;
       } else {
         ESP_LOGD(TAG, "HEAD_CKSUM_FRAME ERROR: 0x%02x", buffer);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+        char frame_buf[format_hex_pretty_size(MR60FDA2_MAX_LOG_BYTES)];
+        char byte_buf[format_hex_pretty_size(1)];
+#endif
         ESP_LOGV(TAG, "CURRENT_FRAME: %s %s",
-                 format_hex_pretty(this->current_frame_buf_, this->current_frame_len_).c_str(),
-                 format_hex_pretty(&buffer, 1).c_str());
+                 format_hex_pretty_to(frame_buf, this->current_frame_buf_,
+                                      this->current_frame_len_ < MR60FDA2_MAX_LOG_BYTES ? this->current_frame_len_
+                                                                                        : MR60FDA2_MAX_LOG_BYTES),
+                 format_hex_pretty_to(byte_buf, &buffer, 1));
         this->current_frame_locate_ = LOCATE_FRAME_HEADER;
       }
       break;
@@ -228,9 +237,15 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
         this->process_frame_();
       } else {
         ESP_LOGD(TAG, "DATA_CKSUM_FRAME ERROR: 0x%02x", buffer);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+        char frame_buf[format_hex_pretty_size(MR60FDA2_MAX_LOG_BYTES)];
+        char byte_buf[format_hex_pretty_size(1)];
+#endif
         ESP_LOGV(TAG, "GET CURRENT_FRAME: %s %s",
-                 format_hex_pretty(this->current_frame_buf_, this->current_frame_len_).c_str(),
-                 format_hex_pretty(&buffer, 1).c_str());
+                 format_hex_pretty_to(frame_buf, this->current_frame_buf_,
+                                      this->current_frame_len_ < MR60FDA2_MAX_LOG_BYTES ? this->current_frame_len_
+                                                                                        : MR60FDA2_MAX_LOG_BYTES),
+                 format_hex_pretty_to(byte_buf, &buffer, 1));
 
         this->current_frame_locate_ = LOCATE_FRAME_HEADER;
       }
@@ -328,7 +343,10 @@ void MR60FDA2Component::set_install_height(uint8_t index) {
   float_to_bytes(INSTALL_HEIGHT[index], &send_data[8]);
   send_data[12] = calculate_checksum(send_data + 8, 4);
   this->write_array(send_data, 13);
-  ESP_LOGV(TAG, "SEND INSTALL HEIGHT FRAME: %s", format_hex_pretty(send_data, 13).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(13)];
+#endif
+  ESP_LOGV(TAG, "SEND INSTALL HEIGHT FRAME: %s", format_hex_pretty_to(hex_buf, send_data, 13));
 }
 
 void MR60FDA2Component::set_height_threshold(uint8_t index) {
@@ -336,7 +354,10 @@ void MR60FDA2Component::set_height_threshold(uint8_t index) {
   float_to_bytes(HEIGHT_THRESHOLD[index], &send_data[8]);
   send_data[12] = calculate_checksum(send_data + 8, 4);
   this->write_array(send_data, 13);
-  ESP_LOGV(TAG, "SEND HEIGHT THRESHOLD: %s", format_hex_pretty(send_data, 13).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(13)];
+#endif
+  ESP_LOGV(TAG, "SEND HEIGHT THRESHOLD: %s", format_hex_pretty_to(hex_buf, send_data, 13));
 }
 
 void MR60FDA2Component::set_sensitivity(uint8_t index) {
@@ -346,19 +367,28 @@ void MR60FDA2Component::set_sensitivity(uint8_t index) {
 
   send_data[12] = calculate_checksum(send_data + 8, 4);
   this->write_array(send_data, 13);
-  ESP_LOGV(TAG, "SEND SET SENSITIVITY: %s", format_hex_pretty(send_data, 13).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(13)];
+#endif
+  ESP_LOGV(TAG, "SEND SET SENSITIVITY: %s", format_hex_pretty_to(hex_buf, send_data, 13));
 }
 
 void MR60FDA2Component::get_radar_parameters() {
   uint8_t send_data[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x0E, 0x06, 0xF6};
   this->write_array(send_data, 8);
-  ESP_LOGV(TAG, "SEND GET PARAMETERS: %s", format_hex_pretty(send_data, 8).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(8)];
+#endif
+  ESP_LOGV(TAG, "SEND GET PARAMETERS: %s", format_hex_pretty_to(hex_buf, send_data, 8));
 }
 
 void MR60FDA2Component::factory_reset() {
   uint8_t send_data[8] = {0x01, 0x00, 0x00, 0x00, 0x00, 0x21, 0x10, 0xCF};
   this->write_array(send_data, 8);
-  ESP_LOGV(TAG, "SEND RESET: %s", format_hex_pretty(send_data, 8).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char hex_buf[format_hex_pretty_size(8)];
+#endif
+  ESP_LOGV(TAG, "SEND RESET: %s", format_hex_pretty_to(hex_buf, send_data, 8));
   this->get_radar_parameters();
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the seeed_mr60fda2 component's verbose logging.

This eliminates `std::string` heap allocations in the LOGV paths for:
- Header checksum error logging (CURRENT_FRAME - 2 buffers)
- Data checksum error logging (GET CURRENT_FRAME - 2 buffers)
- Send install height frame logging
- Send height threshold logging
- Send sensitivity logging
- Send get parameters logging
- Send reset logging

The buffers are wrapped in compile guards to avoid stack allocation when verbose logging is disabled.

Buffer sizes:
- 192 bytes (`format_hex_pretty_size(64)`) for frame buffers to cover typical radar frames while truncating unusually large ones
- 39 bytes (`format_hex_pretty_size(13)`) for send command buffers (13 bytes max)
- 24 bytes (`format_hex_pretty_size(8)`) for shorter send command buffers (8 bytes)
- 3 bytes (`format_hex_pretty_size(1)`) for single byte buffers

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard seeed_mr60fda2 configuration - no changes needed
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

seeed_mr60fda2:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
