### PR TITLE
[zwave_proxy] Use stack-based format_hex_pretty_to for very verbose logging

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -185,8 +185,7 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
 #endif
-  ESP_LOGVV(TAG, "Sending: %s",
-            format_hex_pretty_to(hex_buf, data, length < ZWAVE_MAX_LOG_BYTES ? length : ZWAVE_MAX_LOG_BYTES));
+  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, length));
   this->write_array(data, length);
 }
 
@@ -262,10 +261,7 @@ bool ZWaveProxy::parse_byte_(uint8_t byte) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
         char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
 #endif
-        ESP_LOGVV(TAG, "Received frame: %s",
-                  format_hex_pretty_to(
-                      hex_buf, this->buffer_.data(),
-                      this->buffer_index_ < ZWAVE_MAX_LOG_BYTES ? this->buffer_index_ : ZWAVE_MAX_LOG_BYTES));
+        ESP_LOGVV(TAG, "Received frame: %s", format_hex_pretty_to(hex_buf, this->buffer_.data(), this->buffer_index_));
         frame_completed = true;
       }
       this->response_handler_();

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -12,6 +12,9 @@ namespace esphome::zwave_proxy {
 
 static const char *const TAG = "zwave_proxy";
 
+// Maximum bytes to log in very verbose hex output (168 * 3 = 504, under TX buffer size of 512)
+static constexpr size_t ZWAVE_MAX_LOG_BYTES = 168;
+
 static constexpr uint8_t ZWAVE_COMMAND_GET_NETWORK_IDS = 0x20;
 // GET_NETWORK_IDS response: [SOF][LENGTH][TYPE][CMD][HOME_ID(4)][NODE_ID][...]
 static constexpr uint8_t ZWAVE_COMMAND_TYPE_RESPONSE = 0x01;    // Response type field value
@@ -179,7 +182,11 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
     ESP_LOGV(TAG, "Skipping sending duplicate response: 0x%02X", data[0]);
     return;
   }
-  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty(data, length).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGVV(TAG, "Sending: %s",
+            format_hex_pretty_to(hex_buf, data, length < ZWAVE_MAX_LOG_BYTES ? length : ZWAVE_MAX_LOG_BYTES));
   this->write_array(data, length);
 }
 
@@ -252,7 +259,13 @@ bool ZWaveProxy::parse_byte_(uint8_t byte) {
         this->parsing_state_ = ZWAVE_PARSING_STATE_SEND_NAK;
       } else {
         this->parsing_state_ = ZWAVE_PARSING_STATE_SEND_ACK;
-        ESP_LOGVV(TAG, "Received frame: %s", format_hex_pretty(this->buffer_.data(), this->buffer_index_).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+        char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
+#endif
+        ESP_LOGVV(TAG, "Received frame: %s",
+                  format_hex_pretty_to(
+                      hex_buf, this->buffer_.data(),
+                      this->buffer_index_ < ZWAVE_MAX_LOG_BYTES ? this->buffer_index_ : ZWAVE_MAX_LOG_BYTES));
         frame_completed = true;
       }
       this->response_handler_();


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the zwave_proxy component's very verbose logging.

This eliminates `std::string` heap allocations in the LOGVV paths for:
- Sending frame logging
- Received frame logging

The buffers are wrapped in compile guards to avoid stack allocation when very verbose logging is disabled.

Buffer size is 504 bytes (`format_hex_pretty_size(168)`) per buffer. Frames longer than 168 bytes are truncated (168 × 3 = 504, just under TX buffer size of 512).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard zwave_proxy configuration - no changes needed
uart:
  tx_pin: GPIO4
  rx_pin: GPIO5
  baud_rate: 115200

api:

zwave_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
