### PR TITLE
[ble_client] Use stack-based format_hex_pretty_to for very verbose logging

### DIFF
--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -7,9 +7,13 @@
 
 #include "esphome/core/automation.h"
 #include "esphome/components/ble_client/ble_client.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome::ble_client {
+
+// Maximum bytes to log in very verbose hex output (168 * 3 = 504, under TX buffer size of 512)
+static constexpr size_t BLE_CLIENT_MAX_LOG_BYTES = 168;
 
 // placeholder class for static TAG .
 class Automation {
@@ -151,7 +155,11 @@ template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, publ
       esph_log_w(Automation::TAG, "Cannot write to BLE characteristic - not connected");
       return false;
     }
-    esph_log_vv(Automation::TAG, "Will write %d bytes: %s", len, format_hex_pretty(data, len).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+    char hex_buf[format_hex_pretty_size(BLE_CLIENT_MAX_LOG_BYTES)];
+#endif
+    esph_log_vv(Automation::TAG, "Will write %d bytes: %s", len,
+                format_hex_pretty_to(hex_buf, data, len < BLE_CLIENT_MAX_LOG_BYTES ? len : BLE_CLIENT_MAX_LOG_BYTES));
     esp_err_t err =
         esp_ble_gattc_write_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->char_handle_, len,
                                  const_cast<uint8_t *>(data), this->write_type_, ESP_GATT_AUTH_REQ_NONE);


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the ble_client component's very verbose logging.

This eliminates `std::string` heap allocation in the LOGVV path for:
- Write bytes logging in automation.h

The buffer is wrapped in a compile guard to avoid stack allocation when very verbose logging is disabled.

Buffer size is 504 bytes (`format_hex_pretty_size(168)`). Data longer than 168 bytes is truncated (168 × 3 = 504, just under TX buffer size of 512).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard ble_client configuration - no changes needed
esp32_ble_tracker:

ble_client:
  - mac_address: AA:BB:CC:DD:EE:FF
    id: my_ble_client
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
