### PR TITLE
[ee895] Use stack-based format_hex_to for verbose logging

### DIFF
--- a/esphome/components/ee895/ee895.cpp
+++ b/esphome/components/ee895/ee895.cpp
@@ -7,6 +7,9 @@ namespace ee895 {
 
 static const char *const TAG = "ee895";
 
+// Serial number is 16 bytes
+static constexpr size_t EE895_SERIAL_NUMBER_SIZE = 16;
+
 static const uint16_t CRC16_ONEWIRE_START = 0xFFFF;
 static const uint8_t FUNCTION_CODE_READ = 0x03;
 static const uint16_t SERIAL_NUMBER = 0x0000;
@@ -26,7 +29,10 @@ void EE895Component::setup() {
     this->mark_failed();
     return;
   }
-  ESP_LOGV(TAG, "    Serial Number: 0x%s", format_hex(serial_number + 2, 16).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  char serial_hex[format_hex_size(EE895_SERIAL_NUMBER_SIZE)];
+#endif
+  ESP_LOGV(TAG, "    Serial Number: 0x%s", format_hex_to(serial_hex, serial_number + 2, EE895_SERIAL_NUMBER_SIZE));
 }
 
 void EE895Component::dump_config() {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -728,6 +728,9 @@ inline char *format_hex_to(char (&buffer)[N], T val) {
   return format_hex_to(buffer, reinterpret_cast<const uint8_t *>(&val), sizeof(T));
 }
 
+/// Calculate buffer size needed for format_hex_to: "XXXXXXXX...\0" = bytes * 2 + 1
+constexpr size_t format_hex_size(size_t byte_count) { return byte_count * 2 + 1; }
+
 /// Calculate buffer size needed for format_hex_pretty_to with separator: "XX:XX:...:XX\0"
 constexpr size_t format_hex_pretty_size(size_t byte_count) { return byte_count * 3; }
 


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex(...).c_str()` with stack-based `format_hex_to()` in the ee895 component's verbose logging.

This eliminates `std::string` heap allocation in the LOGV path for:
- Serial number logging during setup

Also adds a new `format_hex_size()` constexpr helper to `helpers.h` for calculating buffer sizes for plain lowercase hex formatting (complementing existing `format_hex_pretty_size()`).

The buffer is wrapped in a compile guard to avoid stack allocation when verbose logging is disabled.

Buffer size is 33 bytes (`format_hex_size(16)`) for the 16-byte serial number.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard ee895 configuration - no changes needed
i2c:

sensor:
  - platform: ee895
    co2:
      name: "CO2"
    temperature:
      name: "Temperature"
    pressure:
      name: "Pressure"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
