### PR TITLE
[mopeka_std_check] Use stack-based format_hex_pretty_to for very verbose logging

### DIFF
--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -13,6 +13,9 @@ static const uint16_t SERVICE_UUID = 0xADA0;
 static const uint8_t MANUFACTURER_DATA_LENGTH = 23;
 static const uint16_t MANUFACTURER_ID = 0x000D;
 
+// Maximum bytes to log in very verbose hex output
+static constexpr size_t MOPEKA_MAX_LOG_BYTES = 32;
+
 void MopekaStdCheck::dump_config() {
   ESP_LOGCONFIG(TAG, "Mopeka Std Check");
   ESP_LOGCONFIG(TAG, "  Propane Butane mix: %.0f%%", this->propane_butane_mix_ * 100);
@@ -60,7 +63,11 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
 
   const auto &manu_data = manu_datas[0];
 
-  ESP_LOGVV(TAG, "[%s] Manufacturer data: %s", device.address_str().c_str(), format_hex_pretty(manu_data.data).c_str());
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  char hex_buf[format_hex_pretty_size(MOPEKA_MAX_LOG_BYTES)];
+#endif
+  ESP_LOGVV(TAG, "[%s] Manufacturer data: %s", device.address_str().c_str(),
+            format_hex_pretty_to(hex_buf, manu_data.data.data(), manu_data.data.size()));
 
   if (manu_data.data.size() != MANUFACTURER_DATA_LENGTH) {
     ESP_LOGE(TAG, "[%s] Unexpected manu_data size (%d)", device.address_str().c_str(), manu_data.data.size());


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `format_hex_pretty(...).c_str()` with stack-based `format_hex_pretty_to()` in the mopeka_std_check component's very verbose logging.

This eliminates `std::string` heap allocation in the LOGVV path for:
- Manufacturer data logging during BLE advertisement parsing

The buffer is wrapped in a compile guard to avoid stack allocation when very verbose logging is disabled.

Buffer size is 96 bytes (`format_hex_pretty_size(32)`). The template version of `format_hex_pretty_to` automatically deduces buffer size and truncates if data exceeds capacity.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard mopeka_std_check configuration - no changes needed
esp32_ble_tracker:

sensor:
  - platform: mopeka_std_check
    mac_address: AA:BB:CC:DD:EE:FF
    tank_type: custom
    custom_distance_full: 400mm
    custom_distance_empty: 30mm
    level:
      name: "Tank Level"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
