### PR TITLE
[xiaomi_*] Use stack-based hex formatting for bindkey logging

### DIFF
--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -16,7 +16,7 @@ void XiaomiCGD1::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGD1\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGD1_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGD1_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_cgd1.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_cgd1 {
 
 static const char *const TAG = "xiaomi_cgd1";
 
+static constexpr size_t CGD1_BINDKEY_SIZE = 16;
+
 void XiaomiCGD1::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(CGD1_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGD1\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGD1_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_cgdk2.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_cgdk2 {
 
 static const char *const TAG = "xiaomi_cgdk2";
 
+static constexpr size_t CGDK2_BINDKEY_SIZE = 16;
+
 void XiaomiCGDK2::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(CGDK2_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGDK2\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGDK2_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -16,7 +16,7 @@ void XiaomiCGDK2::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGDK2\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGDK2_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGDK2_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_cgg1.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_cgg1 {
 
 static const char *const TAG = "xiaomi_cgg1";
 
+static constexpr size_t CGG1_BINDKEY_SIZE = 16;
+
 void XiaomiCGG1::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(CGG1_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGG1\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGG1_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -16,7 +16,7 @@ void XiaomiCGG1::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi CGG1\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGG1_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, CGG1_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_lywsd02mmc.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_lywsd02mmc {
 
 static const char *const TAG = "xiaomi_lywsd02mmc";
 
+static constexpr size_t LYWSD02MMC_BINDKEY_SIZE = 16;
+
 void XiaomiLYWSD02MMC::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(LYWSD02MMC_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi LYWSD02MMC\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD02MMC_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -16,7 +16,7 @@ void XiaomiLYWSD02MMC::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi LYWSD02MMC\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD02MMC_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD02MMC_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -16,7 +16,7 @@ void XiaomiLYWSD03MMC::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi LYWSD03MMC\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD03MMC_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD03MMC_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_lywsd03mmc.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_lywsd03mmc {
 
 static const char *const TAG = "xiaomi_lywsd03mmc";
 
+static constexpr size_t LYWSD03MMC_BINDKEY_SIZE = 16;
+
 void XiaomiLYWSD03MMC::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(LYWSD03MMC_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi LYWSD03MMC\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, LYWSD03MMC_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_mhoc401.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,11 +9,14 @@ namespace xiaomi_mhoc401 {
 
 static const char *const TAG = "xiaomi_mhoc401";
 
+static constexpr size_t MHOC401_BINDKEY_SIZE = 16;
+
 void XiaomiMHOC401::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(MHOC401_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG,
                 "Xiaomi MHOC401\n"
                 "  Bindkey: %s",
-                format_hex_pretty(this->bindkey_, 16).c_str());
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, MHOC401_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -16,7 +16,7 @@ void XiaomiMHOC401::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Xiaomi MHOC401\n"
                 "  Bindkey: %s",
-                format_hex_pretty_to(bindkey_hex, this->bindkey_, MHOC401_BINDKEY_SIZE));
+                format_hex_pretty_to(bindkey_hex, this->bindkey_, MHOC401_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_rtcgq02lm.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,9 +9,12 @@ namespace xiaomi_rtcgq02lm {
 
 static const char *const TAG = "xiaomi_rtcgq02lm";
 
+static constexpr size_t RTCGQ02LM_BINDKEY_SIZE = 16;
+
 void XiaomiRTCGQ02LM::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(RTCGQ02LM_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG, "Xiaomi RTCGQ02LM");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, RTCGQ02LM_BINDKEY_SIZE));
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Motion", this->motion_);
   LOG_BINARY_SENSOR("  ", "Light", this->light_);

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
@@ -14,7 +14,7 @@ static constexpr size_t RTCGQ02LM_BINDKEY_SIZE = 16;
 void XiaomiRTCGQ02LM::dump_config() {
   char bindkey_hex[format_hex_pretty_size(RTCGQ02LM_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG, "Xiaomi RTCGQ02LM");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, RTCGQ02LM_BINDKEY_SIZE));
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, RTCGQ02LM_BINDKEY_SIZE, '.'));
 #ifdef USE_BINARY_SENSOR
   LOG_BINARY_SENSOR("  ", "Motion", this->motion_);
   LOG_BINARY_SENSOR("  ", "Light", this->light_);

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
@@ -14,7 +14,7 @@ static constexpr size_t XMWSDJ04MMC_BINDKEY_SIZE = 16;
 void XiaomiXMWSDJ04MMC::dump_config() {
   char bindkey_hex[format_hex_pretty_size(XMWSDJ04MMC_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG, "Xiaomi XMWSDJ04MMC");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, XMWSDJ04MMC_BINDKEY_SIZE));
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, XMWSDJ04MMC_BINDKEY_SIZE, '.'));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_xmwsdj04mmc.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,9 +9,12 @@ namespace xiaomi_xmwsdj04mmc {
 
 static const char *const TAG = "xiaomi_xmwsdj04mmc";
 
+static constexpr size_t XMWSDJ04MMC_BINDKEY_SIZE = 16;
+
 void XiaomiXMWSDJ04MMC::dump_config() {
+  char bindkey_hex[format_hex_pretty_size(XMWSDJ04MMC_BINDKEY_SIZE)];
   ESP_LOGCONFIG(TAG, "Xiaomi XMWSDJ04MMC");
-  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
+  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty_to(bindkey_hex, this->bindkey_, XMWSDJ04MMC_BINDKEY_SIZE));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);


### PR DESCRIPTION
# What does this implement/fix?

Use stack-based `format_hex_pretty_to()` instead of heap-allocating `format_hex_pretty(...).c_str()` for bindkey logging in 8 Xiaomi BLE sensor components.

**Before (each component):**
```cpp
void XiaomiComponent::dump_config() {
  ESP_LOGCONFIG(TAG, "Xiaomi ComponentName");
  ESP_LOGCONFIG(TAG, "  Bindkey: %s", format_hex_pretty(this->bindkey_, 16).c_str());
  // ...
}
```

**After (each component):**
```cpp
static constexpr size_t COMPONENT_BINDKEY_SIZE = 16;

void XiaomiComponent::dump_config() {
  char bindkey_hex[format_hex_pretty_size(COMPONENT_BINDKEY_SIZE)];
  ESP_LOGCONFIG(TAG,
                "Xiaomi ComponentName\n"
                "  Bindkey: %s",
                format_hex_pretty_to(bindkey_hex, this->bindkey_, COMPONENT_BINDKEY_SIZE));
  // ...
}
```

**Components updated:**
- xiaomi_cgd1
- xiaomi_cgdk2
- xiaomi_cgg1
- xiaomi_lywsd02mmc
- xiaomi_lywsd03mmc
- xiaomi_mhoc401
- xiaomi_rtcgq02lm
- xiaomi_xmwsdj04mmc

This eliminates a temporary `std::string` heap allocation during startup config dump for each of these components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard Xiaomi BLE sensor configuration (unchanged)
sensor:
  - platform: xiaomi_lywsd03mmc
    mac_address: "A4:C1:38:XX:XX:XX"
    bindkey: "00112233445566778899AABBCCDDEEFF"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    battery_level:
      name: "Battery Level"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
