### PR TITLE
[sn74hc595]: fix 'Attempted read from write-only channel' when using esp-idf framework

### DIFF
--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -70,7 +70,7 @@ void SN74HC595GPIOComponent::write_gpio() {
 void SN74HC595SPIComponent::write_gpio() {
   for (uint8_t &output_byte : std::ranges::reverse_view(this->output_bytes_)) {
     this->enable();
-    this->transfer_byte(output_byte);
+    this->write_byte(output_byte);
     this->disable();
   }
   SN74HC595Component::write_gpio();


### PR DESCRIPTION
# What does this implement/fix?

It seems write_byte should be used instead of transfer_byte when using over SPI mode (esp-idf framework) since SN74HC595 is write-only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes [11315](https://github.com/esphome/esphome/issues/11315)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
