### PR TITLE
Fix display driver fill implementations to honor clipping correctly

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -81,8 +81,8 @@ class EPaperBase : public Display,
     const int16_t h = this->get_height_internal();
 
     // Calculate fill region, respecting clipping
-    Rect fill_rect(0, 0, w, h);
-    Rect clip = this->get_clipping();
+    display::Rect fill_rect(0, 0, w, h);
+    display::Rect clip = this->get_clipping();
     if (clip.is_set()) {
       fill_rect.shrink(clip);
       if (!fill_rect.is_set())

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -82,8 +82,9 @@ class EPaperBase : public Display,
       return;
     }
 
-    // Fast path: fill entire buffer
-    const uint8_t pixel_color = color_to_bit(color) ? 0xFF : 0x00;
+    auto pixel_color = color_to_bit(color) ? 0xFF : 0x00;
+
+    // We store 8 pixels per byte
     this->buffer_.fill(pixel_color);
     this->x_high_ = this->width_;
     this->y_high_ = this->height_;

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -76,14 +76,55 @@ class EPaperBase : public Display,
     return 0;
   }
   void fill(Color color) override {
-    auto pixel_color = color_to_bit(color) ? 0xFF : 0x00;
+    const uint8_t pixel_color = color_to_bit(color) ? 0xFF : 0x00;
+    const int16_t w = this->get_width_internal();
+    const int16_t h = this->get_height_internal();
 
-    // We store 8 pixels per byte
-    this->buffer_.fill(pixel_color);
-    this->x_high_ = this->width_;
-    this->y_high_ = this->height_;
-    this->x_low_ = 0;
-    this->y_low_ = 0;
+    // Calculate fill region, respecting clipping
+    Rect fill_rect(0, 0, w, h);
+    Rect clip = this->get_clipping();
+    if (clip.is_set()) {
+      fill_rect.shrink(clip);
+      if (!fill_rect.is_set())
+        return;  // Completely clipped
+    }
+
+    // Check if filling entire display
+    if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+      this->buffer_.fill(pixel_color);
+      this->x_high_ = this->width_;
+      this->y_high_ = this->height_;
+      this->x_low_ = 0;
+      this->y_low_ = 0;
+      return;
+    }
+
+    // Partial fill - 1-bit, 8 pixels per byte, MSB first, row-major
+    const int16_t x_start = fill_rect.x;
+    const int16_t x_end = fill_rect.x + fill_rect.w;
+    const int16_t y_start = fill_rect.y;
+    const int16_t y_end = fill_rect.y + fill_rect.h;
+
+    for (int16_t y = y_start; y < y_end; y++) {
+      for (int16_t x = x_start; x < x_end; x++) {
+        const size_t pixel_position = y * w + x;
+        const size_t byte_position = pixel_position / 8;
+        const uint8_t bit_position = pixel_position % 8;
+        const uint8_t pixel_bit = 0x80 >> bit_position;
+
+        if (pixel_color) {
+          this->buffer_[byte_position] = this->buffer_[byte_position] | pixel_bit;
+        } else {
+          this->buffer_[byte_position] = this->buffer_[byte_position] & ~pixel_bit;
+        }
+      }
+    }
+
+    // Update dirty region
+    this->x_low_ = std::min(this->x_low_, static_cast<uint16_t>(x_start));
+    this->y_low_ = std::min(this->y_low_, static_cast<uint16_t>(y_start));
+    this->x_high_ = std::max(this->x_high_, static_cast<uint16_t>(x_end));
+    this->y_high_ = std::max(this->y_high_, static_cast<uint16_t>(y_end));
   }
 
   void clear() override {

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -76,55 +76,19 @@ class EPaperBase : public Display,
     return 0;
   }
   void fill(Color color) override {
-    const uint8_t pixel_color = color_to_bit(color) ? 0xFF : 0x00;
-    const int16_t w = this->get_width_internal();
-    const int16_t h = this->get_height_internal();
-
-    // Calculate fill region, respecting clipping
-    display::Rect fill_rect(0, 0, w, h);
-    display::Rect clip = this->get_clipping();
-    if (clip.is_set()) {
-      fill_rect.shrink(clip);
-      if (!fill_rect.is_set())
-        return;  // Completely clipped
-    }
-
-    // Check if filling entire display
-    if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-      this->buffer_.fill(pixel_color);
-      this->x_high_ = this->width_;
-      this->y_high_ = this->height_;
-      this->x_low_ = 0;
-      this->y_low_ = 0;
+    // If clipping is active, fall back to base implementation
+    if (this->get_clipping().is_set()) {
+      Display::fill(color);
       return;
     }
 
-    // Partial fill - 1-bit, 8 pixels per byte, MSB first, row-major
-    const int16_t x_start = fill_rect.x;
-    const int16_t x_end = fill_rect.x + fill_rect.w;
-    const int16_t y_start = fill_rect.y;
-    const int16_t y_end = fill_rect.y + fill_rect.h;
-
-    for (int16_t y = y_start; y < y_end; y++) {
-      for (int16_t x = x_start; x < x_end; x++) {
-        const size_t pixel_position = y * w + x;
-        const size_t byte_position = pixel_position / 8;
-        const uint8_t bit_position = pixel_position % 8;
-        const uint8_t pixel_bit = 0x80 >> bit_position;
-
-        if (pixel_color) {
-          this->buffer_[byte_position] = this->buffer_[byte_position] | pixel_bit;
-        } else {
-          this->buffer_[byte_position] = this->buffer_[byte_position] & ~pixel_bit;
-        }
-      }
-    }
-
-    // Update dirty region
-    this->x_low_ = std::min(this->x_low_, static_cast<uint16_t>(x_start));
-    this->y_low_ = std::min(this->y_low_, static_cast<uint16_t>(y_start));
-    this->x_high_ = std::max(this->x_high_, static_cast<uint16_t>(x_end));
-    this->y_high_ = std::max(this->y_high_, static_cast<uint16_t>(y_end));
+    // Fast path: fill entire buffer
+    const uint8_t pixel_color = color_to_bit(color) ? 0xFF : 0x00;
+    this->buffer_.fill(pixel_color);
+    this->x_high_ = this->width_;
+    this->y_high_ = this->height_;
+    this->x_low_ = 0;
+    this->y_low_ = 0;
   }
 
   void clear() override {

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -103,9 +103,10 @@ void EPaperSpectraE6::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer (2 pixels per byte)
-  const uint8_t pixel_color = color_to_hex(color);
-  this->buffer_.fill(pixel_color | (pixel_color << 4));
+  auto pixel_color = color_to_hex(color);
+
+  // We store 2 pixels per byte
+  this->buffer_.fill(pixel_color + (pixel_color << 4));
 }
 
 void EPaperSpectraE6::clear() {

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -99,7 +99,7 @@ void EPaperSpectraE6::deep_sleep() {
 void EPaperSpectraE6::fill(Color color) {
   // If clipping is active, fall back to base implementation
   if (this->get_clipping().is_set()) {
-    Display::fill(color);
+    display::Display::fill(color);
     return;
   }
 

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -97,10 +97,56 @@ void EPaperSpectraE6::deep_sleep() {
 }
 
 void EPaperSpectraE6::fill(Color color) {
-  auto pixel_color = color_to_hex(color);
+  const uint8_t pixel_color = color_to_hex(color);
+  const uint8_t fill_byte = pixel_color | (pixel_color << 4);
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
 
-  // We store 2 pixels per byte
-  this->buffer_.fill(pixel_color + (pixel_color << 4));
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    // We store 2 pixels per byte
+    this->buffer_.fill(fill_byte);
+    return;
+  }
+
+  // Partial fill - 4-bit, 2 pixels per byte, high nibble first
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    int16_t x = x_start;
+
+    // Handle partial byte at start (odd position - low nibble)
+    if ((y * w + x) % 2 != 0) {
+      const uint32_t byte_position = (y * w + x) / 2;
+      this->buffer_[byte_position] = (this->buffer_[byte_position] & 0xF0) | pixel_color;
+      x++;
+    }
+
+    // Handle full bytes in the middle
+    while (x + 1 < x_end) {
+      const uint32_t byte_position = (y * w + x) / 2;
+      this->buffer_[byte_position] = fill_byte;
+      x += 2;
+    }
+
+    // Handle partial byte at end (if remaining - high nibble)
+    if (x < x_end) {
+      const uint32_t byte_position = (y * w + x) / 2;
+      this->buffer_[byte_position] = (this->buffer_[byte_position] & 0x0F) | (pixel_color << 4);
+    }
+  }
 }
 
 void EPaperSpectraE6::clear() {

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -99,7 +99,7 @@ void EPaperSpectraE6::deep_sleep() {
 void EPaperSpectraE6::fill(Color color) {
   // If clipping is active, fall back to base implementation
   if (this->get_clipping().is_set()) {
-    display::Display::fill(color);
+    EPaperBase::fill(color);
     return;
   }
 

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -103,8 +103,8 @@ void EPaperSpectraE6::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_spectra_e6.cpp
@@ -97,56 +97,15 @@ void EPaperSpectraE6::deep_sleep() {
 }
 
 void EPaperSpectraE6::fill(Color color) {
-  const uint8_t pixel_color = color_to_hex(color);
-  const uint8_t fill_byte = pixel_color | (pixel_color << 4);
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    // We store 2 pixels per byte
-    this->buffer_.fill(fill_byte);
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - 4-bit, 2 pixels per byte, high nibble first
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    int16_t x = x_start;
-
-    // Handle partial byte at start (odd position - low nibble)
-    if ((y * w + x) % 2 != 0) {
-      const uint32_t byte_position = (y * w + x) / 2;
-      this->buffer_[byte_position] = (this->buffer_[byte_position] & 0xF0) | pixel_color;
-      x++;
-    }
-
-    // Handle full bytes in the middle
-    while (x + 1 < x_end) {
-      const uint32_t byte_position = (y * w + x) / 2;
-      this->buffer_[byte_position] = fill_byte;
-      x += 2;
-    }
-
-    // Handle partial byte at end (if remaining - high nibble)
-    if (x < x_end) {
-      const uint32_t byte_position = (y * w + x) / 2;
-      this->buffer_[byte_position] = (this->buffer_[byte_position] & 0x0F) | (pixel_color << 4);
-    }
-  }
+  // Fast path: fill entire buffer (2 pixels per byte)
+  const uint8_t pixel_color = color_to_hex(color);
+  this->buffer_.fill(pixel_color | (pixel_color << 4));
 }
 
 void EPaperSpectraE6::clear() {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -132,29 +132,17 @@ void ILI9XXXDisplay::fill(Color color) {
   if (!this->check_buffer_())
     return;
 
-  // Calculate fill region, respecting clipping
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
+    return;
   }
 
-  // Update dirty region tracking
-  if (fill_rect.x < this->x_low_)
-    this->x_low_ = fill_rect.x;
-  if (fill_rect.y < this->y_low_)
-    this->y_low_ = fill_rect.y;
-  if (fill_rect.x + fill_rect.w - 1 > this->x_high_)
-    this->x_high_ = fill_rect.x + fill_rect.w - 1;
-  if (fill_rect.y + fill_rect.h - 1 > this->y_high_)
-    this->y_high_ = fill_rect.y + fill_rect.h - 1;
-
-  // Check if filling entire display (no clipping active)
-  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
+  // Fast path: fill entire buffer
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+  this->x_high_ = this->get_width_internal() - 1;
+  this->y_high_ = this->get_height_internal() - 1;
 
   uint16_t new_color = 0;
   switch (this->buffer_color_mode_) {
@@ -163,31 +151,13 @@ void ILI9XXXDisplay::fill(Color color) {
       break;
     case BITS_16: {
       new_color = display::ColorUtil::color_to_565(color);
-      const uint8_t hi = (uint8_t) (new_color >> 8);
-      const uint8_t lo = (uint8_t) new_color;
-      if (full_fill) {
-        // Fast path: fill entire buffer
-        const uint32_t buffer_length_16_bits = this->get_buffer_length_() * 2;
-        if (hi == lo) {
-          memset(this->buffer_, hi, buffer_length_16_bits);
-        } else {
-          for (uint32_t i = 0; i < buffer_length_16_bits; i += 2) {
-            this->buffer_[i] = hi;
-            this->buffer_[i + 1] = lo;
-          }
-        }
+      const uint32_t buffer_length_16_bits = this->get_buffer_length_() * 2;
+      if (((uint8_t) (new_color >> 8)) == ((uint8_t) new_color)) {
+        memset(this->buffer_, (uint8_t) new_color, buffer_length_16_bits);
       } else {
-        // Partial fill: fill only the clipped region row by row
-        for (int16_t y = fill_rect.y; y < fill_rect.y + fill_rect.h; y++) {
-          uint32_t row_start = (y * w + fill_rect.x) * 2;
-          if (hi == lo) {
-            memset(&this->buffer_[row_start], hi, fill_rect.w * 2);
-          } else {
-            for (int16_t x = 0; x < fill_rect.w; x++) {
-              this->buffer_[row_start + x * 2] = hi;
-              this->buffer_[row_start + x * 2 + 1] = lo;
-            }
-          }
+        for (uint32_t i = 0; i < buffer_length_16_bits; i += 2) {
+          this->buffer_[i] = (uint8_t) (new_color >> 8);
+          this->buffer_[i + 1] = (uint8_t) new_color;
         }
       }
       return;
@@ -197,16 +167,7 @@ void ILI9XXXDisplay::fill(Color color) {
       break;
   }
 
-  // 8-bit modes (indexed or RGB332)
-  if (full_fill) {
-    memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
-  } else {
-    // Partial fill: fill only the clipped region row by row
-    for (int16_t y = fill_rect.y; y < fill_rect.y + fill_rect.h; y++) {
-      uint32_t row_start = y * w + fill_rect.x;
-      memset(&this->buffer_[row_start], (uint8_t) new_color, fill_rect.w);
-    }
-  }
+  memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
 }
 
 void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color) {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -138,13 +138,11 @@ void ILI9XXXDisplay::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
+  uint16_t new_color = 0;
   this->x_low_ = 0;
   this->y_low_ = 0;
   this->x_high_ = this->get_width_internal() - 1;
   this->y_high_ = this->get_height_internal() - 1;
-
-  uint16_t new_color = 0;
   switch (this->buffer_color_mode_) {
     case BITS_8_INDEXED:
       new_color = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
@@ -168,7 +166,6 @@ void ILI9XXXDisplay::fill(Color color) {
       new_color = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
       break;
   }
-
   memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
 }
 

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -135,8 +135,8 @@ void ILI9XXXDisplay::fill(Color color) {
   // Calculate fill region, respecting clipping
   const int16_t w = this->get_width_internal();
   const int16_t h = this->get_height_internal();
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -131,35 +131,82 @@ float ILI9XXXDisplay::get_setup_priority() const { return setup_priority::HARDWA
 void ILI9XXXDisplay::fill(Color color) {
   if (!this->check_buffer_())
     return;
+
+  // Calculate fill region, respecting clipping
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Update dirty region tracking
+  if (fill_rect.x < this->x_low_)
+    this->x_low_ = fill_rect.x;
+  if (fill_rect.y < this->y_low_)
+    this->y_low_ = fill_rect.y;
+  if (fill_rect.x + fill_rect.w - 1 > this->x_high_)
+    this->x_high_ = fill_rect.x + fill_rect.w - 1;
+  if (fill_rect.y + fill_rect.h - 1 > this->y_high_)
+    this->y_high_ = fill_rect.y + fill_rect.h - 1;
+
+  // Check if filling entire display (no clipping active)
+  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
+
   uint16_t new_color = 0;
-  this->x_low_ = 0;
-  this->y_low_ = 0;
-  this->x_high_ = this->get_width_internal() - 1;
-  this->y_high_ = this->get_height_internal() - 1;
   switch (this->buffer_color_mode_) {
     case BITS_8_INDEXED:
       new_color = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
       break;
-    case BITS_16:
+    case BITS_16: {
       new_color = display::ColorUtil::color_to_565(color);
-      {
+      const uint8_t hi = (uint8_t) (new_color >> 8);
+      const uint8_t lo = (uint8_t) new_color;
+      if (full_fill) {
+        // Fast path: fill entire buffer
         const uint32_t buffer_length_16_bits = this->get_buffer_length_() * 2;
-        if (((uint8_t) (new_color >> 8)) == ((uint8_t) new_color)) {
-          // Upper and lower is equal can use quicker memset operation. Takes ~20ms.
-          memset(this->buffer_, (uint8_t) new_color, buffer_length_16_bits);
+        if (hi == lo) {
+          memset(this->buffer_, hi, buffer_length_16_bits);
         } else {
-          for (uint32_t i = 0; i < buffer_length_16_bits; i = i + 2) {
-            this->buffer_[i] = (uint8_t) (new_color >> 8);
-            this->buffer_[i + 1] = (uint8_t) new_color;
+          for (uint32_t i = 0; i < buffer_length_16_bits; i += 2) {
+            this->buffer_[i] = hi;
+            this->buffer_[i + 1] = lo;
+          }
+        }
+      } else {
+        // Partial fill: fill only the clipped region row by row
+        for (int16_t y = fill_rect.y; y < fill_rect.y + fill_rect.h; y++) {
+          uint32_t row_start = (y * w + fill_rect.x) * 2;
+          if (hi == lo) {
+            memset(&this->buffer_[row_start], hi, fill_rect.w * 2);
+          } else {
+            for (int16_t x = 0; x < fill_rect.w; x++) {
+              this->buffer_[row_start + x * 2] = hi;
+              this->buffer_[row_start + x * 2 + 1] = lo;
+            }
           }
         }
       }
       return;
+    }
     default:
       new_color = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
       break;
   }
-  memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
+
+  // 8-bit modes (indexed or RGB332)
+  if (full_fill) {
+    memset(this->buffer_, (uint8_t) new_color, this->get_buffer_length_());
+  } else {
+    // Partial fill: fill only the clipped region row by row
+    for (int16_t y = fill_rect.y; y < fill_rect.y + fill_rect.h; y++) {
+      uint32_t row_start = y * w + fill_rect.x;
+      memset(&this->buffer_[row_start], (uint8_t) new_color, fill_rect.w);
+    }
+  }
 }
 
 void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color) {

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -149,19 +149,21 @@ void ILI9XXXDisplay::fill(Color color) {
     case BITS_8_INDEXED:
       new_color = display::ColorUtil::color_to_index8_palette888(color, this->palette_);
       break;
-    case BITS_16: {
+    case BITS_16:
       new_color = display::ColorUtil::color_to_565(color);
-      const uint32_t buffer_length_16_bits = this->get_buffer_length_() * 2;
-      if (((uint8_t) (new_color >> 8)) == ((uint8_t) new_color)) {
-        memset(this->buffer_, (uint8_t) new_color, buffer_length_16_bits);
-      } else {
-        for (uint32_t i = 0; i < buffer_length_16_bits; i += 2) {
-          this->buffer_[i] = (uint8_t) (new_color >> 8);
-          this->buffer_[i + 1] = (uint8_t) new_color;
+      {
+        const uint32_t buffer_length_16_bits = this->get_buffer_length_() * 2;
+        if (((uint8_t) (new_color >> 8)) == ((uint8_t) new_color)) {
+          // Upper and lower is equal can use quicker memset operation. Takes ~20ms.
+          memset(this->buffer_, (uint8_t) new_color, buffer_length_16_bits);
+        } else {
+          for (uint32_t i = 0; i < buffer_length_16_bits; i = i + 2) {
+            this->buffer_[i] = (uint8_t) (new_color >> 8);
+            this->buffer_[i + 1] = (uint8_t) new_color;
+          }
         }
       }
       return;
-    }
     default:
       new_color = display::ColorUtil::color_to_332(color, display::ColorOrder::COLOR_ORDER_RGB);
       break;

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -293,12 +293,108 @@ void Inkplate::fill(Color color) {
   ESP_LOGV(TAG, "Fill called");
   uint32_t start_time = millis();
 
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set()) {
+      ESP_LOGV(TAG, "Fill completely clipped");
+      return;
+    }
+  }
+
+  // Check if filling entire display
+  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
+
   if (this->greyscale_) {
-    uint8_t fill = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
-    memset(this->buffer_, (fill << 4) | fill, this->get_buffer_length_());
+    uint8_t gs = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
+    const uint8_t fill = (gs << 4) | gs;
+    const int16_t w_bytes = w / 2;
+
+    if (full_fill) {
+      memset(this->buffer_, fill, this->get_buffer_length_());
+    } else {
+      // Partial fill - 4-bit grayscale, 2 pixels per byte, high nibble first
+      const int16_t x_start = fill_rect.x;
+      const int16_t x_end = fill_rect.x + fill_rect.w;
+      const int16_t y_start = fill_rect.y;
+      const int16_t y_end = fill_rect.y + fill_rect.h;
+
+      for (int16_t y = y_start; y < y_end; y++) {
+        const uint32_t row_offset = y * w_bytes;
+        int16_t x = x_start;
+
+        // Handle partial byte at start (odd x - low nibble)
+        if (x % 2 != 0) {
+          uint32_t pos = row_offset + x / 2;
+          this->buffer_[pos] = (this->buffer_[pos] & 0xF0) | gs;
+          x++;
+        }
+
+        // Handle full bytes in the middle
+        while (x + 1 < x_end) {
+          this->buffer_[row_offset + x / 2] = fill;
+          x += 2;
+        }
+
+        // Handle partial byte at end (if remaining - high nibble)
+        if (x < x_end) {
+          uint32_t pos = row_offset + x / 2;
+          this->buffer_[pos] = (this->buffer_[pos] & 0x0F) | (gs << 4);
+        }
+      }
+    }
   } else {
-    uint8_t fill = color.is_on() ? 0x00 : 0xFF;
-    memset(this->partial_buffer_, fill, this->get_buffer_length_());
+    // Binary mode - inverted logic (on = 0x00, off = 0xFF)
+    const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+    const int16_t w_bytes = w / 8;
+
+    if (full_fill) {
+      memset(this->partial_buffer_, fill, this->get_buffer_length_());
+    } else {
+      // Partial fill - 1-bit, 8 pixels per byte, LSB first
+      const int16_t x_start = fill_rect.x;
+      const int16_t x_end = fill_rect.x + fill_rect.w;
+      const int16_t y_start = fill_rect.y;
+      const int16_t y_end = fill_rect.y + fill_rect.h;
+
+      for (int16_t y = y_start; y < y_end; y++) {
+        const uint32_t row_offset = y * w_bytes;
+
+        // Calculate byte boundaries
+        const int16_t byte_start = x_start / 8;
+        const int16_t byte_end = (x_end - 1) / 8;
+
+        for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
+          const int16_t byte_x_start = byte_idx * 8;
+          const int16_t byte_x_end = byte_x_start + 8;
+
+          // Calculate which bits in this byte are affected
+          const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
+          const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
+
+          // Create mask for affected bits (LSB first)
+          uint8_t mask = 0;
+          for (int16_t bit = bit_start; bit < bit_end; bit++) {
+            mask |= (1 << bit);
+          }
+
+          if (mask == 0xFF) {
+            this->partial_buffer_[row_offset + byte_idx] = fill;
+          } else {
+            if (fill) {
+              this->partial_buffer_[row_offset + byte_idx] |= mask;
+            } else {
+              this->partial_buffer_[row_offset + byte_idx] &= ~mask;
+            }
+          }
+        }
+      }
+    }
   }
 
   ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -293,108 +293,20 @@ void Inkplate::fill(Color color) {
   ESP_LOGV(TAG, "Fill called");
   uint32_t start_time = millis();
 
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set()) {
-      ESP_LOGV(TAG, "Fill completely clipped");
-      return;
-    }
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
+    ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);
+    return;
   }
 
-  // Check if filling entire display
-  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
-
+  // Fast path: fill entire buffer
   if (this->greyscale_) {
     uint8_t gs = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
-    const uint8_t fill = (gs << 4) | gs;
-    const int16_t w_bytes = w / 2;
-
-    if (full_fill) {
-      memset(this->buffer_, fill, this->get_buffer_length_());
-    } else {
-      // Partial fill - 4-bit grayscale, 2 pixels per byte, high nibble first
-      const int16_t x_start = fill_rect.x;
-      const int16_t x_end = fill_rect.x + fill_rect.w;
-      const int16_t y_start = fill_rect.y;
-      const int16_t y_end = fill_rect.y + fill_rect.h;
-
-      for (int16_t y = y_start; y < y_end; y++) {
-        const uint32_t row_offset = y * w_bytes;
-        int16_t x = x_start;
-
-        // Handle partial byte at start (odd x - low nibble)
-        if (x % 2 != 0) {
-          uint32_t pos = row_offset + x / 2;
-          this->buffer_[pos] = (this->buffer_[pos] & 0xF0) | gs;
-          x++;
-        }
-
-        // Handle full bytes in the middle
-        while (x + 1 < x_end) {
-          this->buffer_[row_offset + x / 2] = fill;
-          x += 2;
-        }
-
-        // Handle partial byte at end (if remaining - high nibble)
-        if (x < x_end) {
-          uint32_t pos = row_offset + x / 2;
-          this->buffer_[pos] = (this->buffer_[pos] & 0x0F) | (gs << 4);
-        }
-      }
-    }
+    memset(this->buffer_, (gs << 4) | gs, this->get_buffer_length_());
   } else {
-    // Binary mode - inverted logic (on = 0x00, off = 0xFF)
-    const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
-    const int16_t w_bytes = w / 8;
-
-    if (full_fill) {
-      memset(this->partial_buffer_, fill, this->get_buffer_length_());
-    } else {
-      // Partial fill - 1-bit, 8 pixels per byte, LSB first
-      const int16_t x_start = fill_rect.x;
-      const int16_t x_end = fill_rect.x + fill_rect.w;
-      const int16_t y_start = fill_rect.y;
-      const int16_t y_end = fill_rect.y + fill_rect.h;
-
-      for (int16_t y = y_start; y < y_end; y++) {
-        const uint32_t row_offset = y * w_bytes;
-
-        // Calculate byte boundaries
-        const int16_t byte_start = x_start / 8;
-        const int16_t byte_end = (x_end - 1) / 8;
-
-        for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
-          const int16_t byte_x_start = byte_idx * 8;
-          const int16_t byte_x_end = byte_x_start + 8;
-
-          // Calculate which bits in this byte are affected
-          const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
-          const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
-
-          // Create mask for affected bits (LSB first)
-          uint8_t mask = 0;
-          for (int16_t bit = bit_start; bit < bit_end; bit++) {
-            mask |= (1 << bit);
-          }
-
-          if (mask == 0xFF) {
-            this->partial_buffer_[row_offset + byte_idx] = fill;
-          } else {
-            if (fill) {
-              this->partial_buffer_[row_offset + byte_idx] |= mask;
-            } else {
-              this->partial_buffer_[row_offset + byte_idx] &= ~mask;
-            }
-          }
-        }
-      }
-    }
+    uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+    memset(this->partial_buffer_, fill, this->get_buffer_length_());
   }
 
   ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -300,10 +300,9 @@ void Inkplate::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   if (this->greyscale_) {
-    uint8_t gs = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
-    memset(this->buffer_, (gs << 4) | gs, this->get_buffer_length_());
+    uint8_t fill = ((color.red * 2126 / 10000) + (color.green * 7152 / 10000) + (color.blue * 722 / 10000)) >> 5;
+    memset(this->buffer_, (fill << 4) | fill, this->get_buffer_length_());
   } else {
     uint8_t fill = color.is_on() ? 0x00 : 0xFF;
     memset(this->partial_buffer_, fill, this->get_buffer_length_());

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -297,8 +297,8 @@ void Inkplate::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set()) {

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -293,30 +293,74 @@ void MIPI_DSI::draw_pixel_at(int x, int y, Color color) {
 void MIPI_DSI::fill(Color color) {
   if (!this->check_buffer_())
     return;
+
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
+
   switch (this->color_depth_) {
     case display::COLOR_BITNESS_565: {
       auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
       uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
       uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
       uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
-      std::fill_n(ptr_16, this->width_ * this->height_, new_color);
+
+      if (full_fill) {
+        std::fill_n(ptr_16, w * h, new_color);
+      } else {
+        const int16_t x_start = fill_rect.x;
+        const int16_t x_end = fill_rect.x + fill_rect.w;
+        const int16_t y_start = fill_rect.y;
+        const int16_t y_end = fill_rect.y + fill_rect.h;
+
+        for (int16_t y = y_start; y < y_end; y++) {
+          uint16_t *row = ptr_16 + y * w;
+          for (int16_t x = x_start; x < x_end; x++) {
+            row[x] = new_color;
+          }
+        }
+      }
       break;
     }
 
-    case display::COLOR_BITNESS_888:
-      if (this->color_mode_ == display::COLOR_ORDER_BGR) {
-        for (size_t i = 0; i != this->width_ * this->height_; i++) {
-          this->buffer_[i * 3 + 0] = color.b;
-          this->buffer_[i * 3 + 1] = color.g;
-          this->buffer_[i * 3 + 2] = color.r;
+    case display::COLOR_BITNESS_888: {
+      const uint8_t c0 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.b : color.r;
+      const uint8_t c1 = color.g;
+      const uint8_t c2 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.r : color.b;
+
+      if (full_fill) {
+        for (size_t i = 0; i != static_cast<size_t>(w * h); i++) {
+          this->buffer_[i * 3 + 0] = c0;
+          this->buffer_[i * 3 + 1] = c1;
+          this->buffer_[i * 3 + 2] = c2;
         }
       } else {
-        for (size_t i = 0; i != this->width_ * this->height_; i++) {
-          this->buffer_[i * 3 + 0] = color.r;
-          this->buffer_[i * 3 + 1] = color.g;
-          this->buffer_[i * 3 + 2] = color.b;
+        const int16_t x_start = fill_rect.x;
+        const int16_t x_end = fill_rect.x + fill_rect.w;
+        const int16_t y_start = fill_rect.y;
+        const int16_t y_end = fill_rect.y + fill_rect.h;
+
+        for (int16_t y = y_start; y < y_end; y++) {
+          for (int16_t x = x_start; x < x_end; x++) {
+            size_t pos = (y * w + x) * 3;
+            this->buffer_[pos + 0] = c0;
+            this->buffer_[pos + 1] = c1;
+            this->buffer_[pos + 2] = c2;
+          }
         }
       }
+      break;
+    }
 
     default:
       break;

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -298,8 +298,8 @@ void MIPI_DSI::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -294,19 +294,15 @@ void MIPI_DSI::fill(Color color) {
   if (!this->check_buffer_())
     return;
 
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
+    return;
   }
 
-  const bool full_fill = (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h);
+  // Fast path: fill entire buffer
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
 
   switch (this->color_depth_) {
     case display::COLOR_BITNESS_565: {
@@ -314,22 +310,7 @@ void MIPI_DSI::fill(Color color) {
       uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
       uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
       uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
-
-      if (full_fill) {
-        std::fill_n(ptr_16, w * h, new_color);
-      } else {
-        const int16_t x_start = fill_rect.x;
-        const int16_t x_end = fill_rect.x + fill_rect.w;
-        const int16_t y_start = fill_rect.y;
-        const int16_t y_end = fill_rect.y + fill_rect.h;
-
-        for (int16_t y = y_start; y < y_end; y++) {
-          uint16_t *row = ptr_16 + y * w;
-          for (int16_t x = x_start; x < x_end; x++) {
-            row[x] = new_color;
-          }
-        }
-      }
+      std::fill_n(ptr_16, w * h, new_color);
       break;
     }
 
@@ -337,27 +318,10 @@ void MIPI_DSI::fill(Color color) {
       const uint8_t c0 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.b : color.r;
       const uint8_t c1 = color.g;
       const uint8_t c2 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.r : color.b;
-
-      if (full_fill) {
-        for (size_t i = 0; i != static_cast<size_t>(w * h); i++) {
-          this->buffer_[i * 3 + 0] = c0;
-          this->buffer_[i * 3 + 1] = c1;
-          this->buffer_[i * 3 + 2] = c2;
-        }
-      } else {
-        const int16_t x_start = fill_rect.x;
-        const int16_t x_end = fill_rect.x + fill_rect.w;
-        const int16_t y_start = fill_rect.y;
-        const int16_t y_end = fill_rect.y + fill_rect.h;
-
-        for (int16_t y = y_start; y < y_end; y++) {
-          for (int16_t x = x_start; x < x_end; x++) {
-            size_t pos = (y * w + x) * 3;
-            this->buffer_[pos + 0] = c0;
-            this->buffer_[pos + 1] = c1;
-            this->buffer_[pos + 2] = c2;
-          }
-        }
+      for (size_t i = 0; i != static_cast<size_t>(w * h); i++) {
+        this->buffer_[i * 3 + 0] = c0;
+        this->buffer_[i * 3 + 1] = c1;
+        this->buffer_[i * 3 + 2] = c2;
       }
       break;
     }

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -300,31 +300,30 @@ void MIPI_DSI::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
   switch (this->color_depth_) {
     case display::COLOR_BITNESS_565: {
       auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
       uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
       uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
       uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
-      std::fill_n(ptr_16, w * h, new_color);
+      std::fill_n(ptr_16, this->width_ * this->height_, new_color);
       break;
     }
 
-    case display::COLOR_BITNESS_888: {
-      const uint8_t c0 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.b : color.r;
-      const uint8_t c1 = color.g;
-      const uint8_t c2 = (this->color_mode_ == display::COLOR_ORDER_BGR) ? color.r : color.b;
-      for (size_t i = 0; i != static_cast<size_t>(w * h); i++) {
-        this->buffer_[i * 3 + 0] = c0;
-        this->buffer_[i * 3 + 1] = c1;
-        this->buffer_[i * 3 + 2] = c2;
+    case display::COLOR_BITNESS_888:
+      if (this->color_mode_ == display::COLOR_ORDER_BGR) {
+        for (size_t i = 0; i != this->width_ * this->height_; i++) {
+          this->buffer_[i * 3 + 0] = color.b;
+          this->buffer_[i * 3 + 1] = color.g;
+          this->buffer_[i * 3 + 2] = color.r;
+        }
+      } else {
+        for (size_t i = 0; i != this->width_ * this->height_; i++) {
+          this->buffer_[i * 3 + 0] = color.r;
+          this->buffer_[i * 3 + 1] = color.g;
+          this->buffer_[i * 3 + 2] = color.b;
+        }
       }
-      break;
-    }
 
     default:
       break;

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -307,7 +307,6 @@ void MipiRgb::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
   uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
   uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -301,41 +301,18 @@ void MipiRgb::fill(Color color) {
   if (!this->check_buffer_())
     return;
 
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
+    return;
   }
 
+  // Fast path: fill entire buffer
   auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
   uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
   uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
   uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    std::fill_n(ptr_16, w * h, new_color);
-    return;
-  }
-
-  // Partial fill - 16-bit RGB565, row-major
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    uint16_t *row = ptr_16 + y * w;
-    for (int16_t x = x_start; x < x_end; x++) {
-      row[x] = new_color;
-    }
-  }
+  std::fill_n(ptr_16, this->width_ * this->height_, new_color);
 }
 
 int MipiRgb::get_width() {

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -305,8 +305,8 @@ void MipiRgb::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -300,11 +300,42 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
 void MipiRgb::fill(Color color) {
   if (!this->check_buffer_())
     return;
+
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
   auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
   uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
   uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
   uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
-  std::fill_n(ptr_16, this->width_ * this->height_, new_color);
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    std::fill_n(ptr_16, w * h, new_color);
+    return;
+  }
+
+  // Partial fill - 16-bit RGB565, row-major
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    uint16_t *row = ptr_16 + y * w;
+    for (int16_t x = x_start; x < x_end; x++) {
+      row[x] = new_color;
+    }
+  }
 }
 
 int MipiRgb::get_width() {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -569,11 +569,51 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
 
   // Fills the display with a color.
   void fill(Color color) override {
-    this->x_low_ = 0;
-    this->y_low_ = this->start_line_;
-    this->x_high_ = WIDTH - 1;
-    this->y_high_ = this->end_line_ - 1;
-    std::fill_n(this->buffer_, HEIGHT * BUFFER_WIDTH / FRACTION, convert_color(color));
+    const auto fill_color = convert_color(color);
+    const int16_t buffer_h = HEIGHT / FRACTION;
+
+    // Calculate fill region, respecting clipping
+    Rect fill_rect(0, this->start_line_, WIDTH, buffer_h);
+    Rect clip = this->get_clipping();
+    if (clip.is_set()) {
+      fill_rect.shrink(clip);
+      if (!fill_rect.is_set())
+        return;  // Completely clipped
+    }
+
+    // Check if filling entire buffer
+    if (fill_rect.x == 0 && fill_rect.y == this->start_line_ && fill_rect.w == WIDTH &&
+        fill_rect.h == static_cast<int16_t>(buffer_h)) {
+      std::fill_n(this->buffer_, buffer_h * BUFFER_WIDTH, fill_color);
+      this->x_low_ = 0;
+      this->y_low_ = this->start_line_;
+      this->x_high_ = WIDTH - 1;
+      this->y_high_ = this->end_line_ - 1;
+      return;
+    }
+
+    // Partial fill - row-major, 8 or 16-bit pixels
+    const int16_t x_start = fill_rect.x;
+    const int16_t x_end = fill_rect.x + fill_rect.w;
+    const int16_t y_start = fill_rect.y;
+    const int16_t y_end = fill_rect.y + fill_rect.h;
+
+    for (int16_t y = y_start; y < y_end; y++) {
+      const size_t row_offset = (y - this->start_line_) * BUFFER_WIDTH;
+      for (int16_t x = x_start; x < x_end; x++) {
+        this->buffer_[row_offset + x] = fill_color;
+      }
+    }
+
+    // Update dirty region
+    if (x_start < this->x_low_)
+      this->x_low_ = x_start;
+    if (y_start < this->y_low_)
+      this->y_low_ = y_start;
+    if (x_end - 1 > this->x_high_)
+      this->x_high_ = x_end - 1;
+    if (y_end - 1 > this->y_high_)
+      this->y_high_ = y_end - 1;
   }
 
   int get_width() override {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -575,13 +575,11 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
       return;
     }
 
-    // Fast path: fill entire buffer
-    const int16_t buffer_h = HEIGHT / FRACTION;
-    std::fill_n(this->buffer_, buffer_h * BUFFER_WIDTH, convert_color(color));
     this->x_low_ = 0;
     this->y_low_ = this->start_line_;
     this->x_high_ = WIDTH - 1;
     this->y_high_ = this->end_line_ - 1;
+    std::fill_n(this->buffer_, HEIGHT * BUFFER_WIDTH / FRACTION, convert_color(color));
   }
 
   int get_width() override {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -569,51 +569,19 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
 
   // Fills the display with a color.
   void fill(Color color) override {
-    const auto fill_color = convert_color(color);
-    const int16_t buffer_h = HEIGHT / FRACTION;
-
-    // Calculate fill region, respecting clipping
-    display::Rect fill_rect(0, this->start_line_, WIDTH, buffer_h);
-    display::Rect clip = this->get_clipping();
-    if (clip.is_set()) {
-      fill_rect.shrink(clip);
-      if (!fill_rect.is_set())
-        return;  // Completely clipped
-    }
-
-    // Check if filling entire buffer
-    if (fill_rect.x == 0 && fill_rect.y == this->start_line_ && fill_rect.w == WIDTH &&
-        fill_rect.h == static_cast<int16_t>(buffer_h)) {
-      std::fill_n(this->buffer_, buffer_h * BUFFER_WIDTH, fill_color);
-      this->x_low_ = 0;
-      this->y_low_ = this->start_line_;
-      this->x_high_ = WIDTH - 1;
-      this->y_high_ = this->end_line_ - 1;
+    // If clipping is active, fall back to base implementation
+    if (this->get_clipping().is_set()) {
+      Display::fill(color);
       return;
     }
 
-    // Partial fill - row-major, 8 or 16-bit pixels
-    const int16_t x_start = fill_rect.x;
-    const int16_t x_end = fill_rect.x + fill_rect.w;
-    const int16_t y_start = fill_rect.y;
-    const int16_t y_end = fill_rect.y + fill_rect.h;
-
-    for (int16_t y = y_start; y < y_end; y++) {
-      const size_t row_offset = (y - this->start_line_) * BUFFER_WIDTH;
-      for (int16_t x = x_start; x < x_end; x++) {
-        this->buffer_[row_offset + x] = fill_color;
-      }
-    }
-
-    // Update dirty region
-    if (x_start < this->x_low_)
-      this->x_low_ = x_start;
-    if (y_start < this->y_low_)
-      this->y_low_ = y_start;
-    if (x_end - 1 > this->x_high_)
-      this->x_high_ = x_end - 1;
-    if (y_end - 1 > this->y_high_)
-      this->y_high_ = y_end - 1;
+    // Fast path: fill entire buffer
+    const int16_t buffer_h = HEIGHT / FRACTION;
+    std::fill_n(this->buffer_, buffer_h * BUFFER_WIDTH, convert_color(color));
+    this->x_low_ = 0;
+    this->y_low_ = this->start_line_;
+    this->x_high_ = WIDTH - 1;
+    this->y_high_ = this->end_line_ - 1;
   }
 
   int get_width() override {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -571,7 +571,7 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
   void fill(Color color) override {
     // If clipping is active, fall back to base implementation
     if (this->get_clipping().is_set()) {
-      Display::fill(color);
+      display::Display::fill(color);
       return;
     }
 

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -573,8 +573,8 @@ class MipiSpiBuffer : public MipiSpi<BUFFERTYPE, BUFFERPIXEL, IS_BIG_ENDIAN, DIS
     const int16_t buffer_h = HEIGHT / FRACTION;
 
     // Calculate fill region, respecting clipping
-    Rect fill_rect(0, this->start_line_, WIDTH, buffer_h);
-    Rect clip = this->get_clipping();
+    display::Rect fill_rect(0, this->start_line_, WIDTH, buffer_h);
+    display::Rect clip = this->get_clipping();
     if (clip.is_set()) {
       fill_rect.shrink(clip);
       if (!fill_rect.is_set())

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -122,8 +122,8 @@ void PCD8544::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -117,9 +117,67 @@ void PCD8544::update() {
 }
 
 void PCD8544::fill(Color color) {
-  uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-    this->buffer_[i] = fill;
+  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+      this->buffer_[i] = fill;
+    return;
+  }
+
+  // Partial fill - handle page-based layout (8 vertical pixels per byte)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  const int16_t page_start = y_start / 8;
+  const int16_t page_end = (y_end - 1) / 8;
+
+  for (int16_t page = page_start; page <= page_end; page++) {
+    const int16_t page_y_start = page * 8;
+    const int16_t page_y_end = page_y_start + 8;
+
+    // Calculate which bits in this page are affected
+    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
+    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
+
+    // Create mask for affected bits
+    uint8_t mask = 0;
+    for (int16_t bit = bit_start; bit < bit_end; bit++) {
+      mask |= (1 << bit);
+    }
+
+    // Fill this page's row segment
+    const uint32_t row_offset = page * w;
+    if (mask == 0xFF) {
+      // Full page - can use direct assignment
+      for (int16_t x = x_start; x < x_end; x++) {
+        this->buffer_[row_offset + x] = fill;
+      }
+    } else {
+      // Partial page - need bit manipulation
+      for (int16_t x = x_start; x < x_end; x++) {
+        if (fill) {
+          this->buffer_[row_offset + x] |= mask;
+        } else {
+          this->buffer_[row_offset + x] &= ~mask;
+        }
+      }
+    }
+  }
 }
 
 }  // namespace pcd8544

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -117,67 +117,16 @@ void PCD8544::update() {
 }
 
 void PCD8544::fill(Color color) {
-  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-      this->buffer_[i] = fill;
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - handle page-based layout (8 vertical pixels per byte)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  const int16_t page_start = y_start / 8;
-  const int16_t page_end = (y_end - 1) / 8;
-
-  for (int16_t page = page_start; page <= page_end; page++) {
-    const int16_t page_y_start = page * 8;
-    const int16_t page_y_end = page_y_start + 8;
-
-    // Calculate which bits in this page are affected
-    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
-    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
-
-    // Create mask for affected bits
-    uint8_t mask = 0;
-    for (int16_t bit = bit_start; bit < bit_end; bit++) {
-      mask |= (1 << bit);
-    }
-
-    // Fill this page's row segment
-    const uint32_t row_offset = page * w;
-    if (mask == 0xFF) {
-      // Full page - can use direct assignment
-      for (int16_t x = x_start; x < x_end; x++) {
-        this->buffer_[row_offset + x] = fill;
-      }
-    } else {
-      // Partial page - need bit manipulation
-      for (int16_t x = x_start; x < x_end; x++) {
-        if (fill) {
-          this->buffer_[row_offset + x] |= mask;
-        } else {
-          this->buffer_[row_offset + x] &= ~mask;
-        }
-      }
-    }
-  }
+  // Fast path: fill entire buffer
+  uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
 }
 
 }  // namespace pcd8544

--- a/esphome/components/pcd8544/pcd_8544.cpp
+++ b/esphome/components/pcd8544/pcd_8544.cpp
@@ -123,7 +123,6 @@ void PCD8544::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -329,67 +329,16 @@ void HOT SSD1306::draw_absolute_pixel_internal(int x, int y, Color color) {
   }
 }
 void SSD1306::fill(Color color) {
-  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-      this->buffer_[i] = fill;
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - handle page-based layout (8 vertical pixels per byte)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  const int16_t page_start = y_start / 8;
-  const int16_t page_end = (y_end - 1) / 8;
-
-  for (int16_t page = page_start; page <= page_end; page++) {
-    const int16_t page_y_start = page * 8;
-    const int16_t page_y_end = page_y_start + 8;
-
-    // Calculate which bits in this page are affected
-    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
-    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
-
-    // Create mask for affected bits
-    uint8_t mask = 0;
-    for (int16_t bit = bit_start; bit < bit_end; bit++) {
-      mask |= (1 << bit);
-    }
-
-    // Fill this page's row segment
-    const uint32_t row_offset = page * w;
-    if (mask == 0xFF) {
-      // Full page - can use direct assignment
-      for (int16_t x = x_start; x < x_end; x++) {
-        this->buffer_[row_offset + x] = fill;
-      }
-    } else {
-      // Partial page - need bit manipulation
-      for (int16_t x = x_start; x < x_end; x++) {
-        if (fill) {
-          this->buffer_[row_offset + x] |= mask;
-        } else {
-          this->buffer_[row_offset + x] &= ~mask;
-        }
-      }
-    }
-  }
+  // Fast path: fill entire buffer
+  uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
 }
 void SSD1306::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -329,9 +329,67 @@ void HOT SSD1306::draw_absolute_pixel_internal(int x, int y, Color color) {
   }
 }
 void SSD1306::fill(Color color) {
-  uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-    this->buffer_[i] = fill;
+  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+      this->buffer_[i] = fill;
+    return;
+  }
+
+  // Partial fill - handle page-based layout (8 vertical pixels per byte)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  const int16_t page_start = y_start / 8;
+  const int16_t page_end = (y_end - 1) / 8;
+
+  for (int16_t page = page_start; page <= page_end; page++) {
+    const int16_t page_y_start = page * 8;
+    const int16_t page_y_end = page_y_start + 8;
+
+    // Calculate which bits in this page are affected
+    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
+    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
+
+    // Create mask for affected bits
+    uint8_t mask = 0;
+    for (int16_t bit = bit_start; bit < bit_end; bit++) {
+      mask |= (1 << bit);
+    }
+
+    // Fill this page's row segment
+    const uint32_t row_offset = page * w;
+    if (mask == 0xFF) {
+      // Full page - can use direct assignment
+      for (int16_t x = x_start; x < x_end; x++) {
+        this->buffer_[row_offset + x] = fill;
+      }
+    } else {
+      // Partial page - need bit manipulation
+      for (int16_t x = x_start; x < x_end; x++) {
+        if (fill) {
+          this->buffer_[row_offset + x] |= mask;
+        } else {
+          this->buffer_[row_offset + x] &= ~mask;
+        }
+      }
+    }
+  }
 }
 void SSD1306::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -335,7 +335,6 @@ void SSD1306::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;

--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -334,8 +334,8 @@ void SSD1306::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -174,57 +174,17 @@ void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] |= color4;
 }
 void SSD1322::fill(Color color) {
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1322_COLORMASK;
-  const uint8_t fill = color4 | (color4 << SSD1322_COLORSHIFT);
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-  const int16_t w_bytes = w / SSD1322_PIXELSPERBYTE;
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-      this->buffer_[i] = fill;
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - 4-bit grayscale, 2 pixels per byte, upper nibble first (reversed from SSD1325/1327)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    const uint32_t row_offset = y * w_bytes;
-    int16_t x = x_start;
-
-    // Handle partial byte at start (odd x - lower nibble)
-    if (x % 2 != 0) {
-      uint32_t pos = row_offset + x / 2;
-      this->buffer_[pos] = (this->buffer_[pos] & (SSD1322_COLORMASK << SSD1322_COLORSHIFT)) | color4;
-      x++;
-    }
-
-    // Handle full bytes in the middle
-    while (x + 1 < x_end) {
-      this->buffer_[row_offset + x / 2] = fill;
-      x += 2;
-    }
-
-    // Handle partial byte at end (if remaining - upper nibble)
-    if (x < x_end) {
-      uint32_t pos = row_offset + x / 2;
-      this->buffer_[pos] = (this->buffer_[pos] & SSD1322_COLORMASK) | (color4 << SSD1322_COLORSHIFT);
-    }
-  }
+  // Fast path: fill entire buffer
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1322_COLORMASK;
+  uint8_t fill = color4 | (color4 << SSD1322_COLORSHIFT);
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
 }
 void SSD1322::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -180,9 +180,8 @@ void SSD1322::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1322_COLORMASK;
-  uint8_t fill = color4 | (color4 << SSD1322_COLORSHIFT);
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
+  uint8_t fill = (color4 & SSD1322_COLORMASK) | ((color4 & SSD1322_COLORMASK) << SSD1322_COLORSHIFT);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -181,8 +181,8 @@ void SSD1322::fill(Color color) {
   const int16_t w_bytes = w / SSD1322_PIXELSPERBYTE;
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -174,10 +174,57 @@ void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] |= color4;
 }
 void SSD1322::fill(Color color) {
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
-  uint8_t fill = (color4 & SSD1322_COLORMASK) | ((color4 & SSD1322_COLORMASK) << SSD1322_COLORSHIFT);
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-    this->buffer_[i] = fill;
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1322_COLORMASK;
+  const uint8_t fill = color4 | (color4 << SSD1322_COLORSHIFT);
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+  const int16_t w_bytes = w / SSD1322_PIXELSPERBYTE;
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+      this->buffer_[i] = fill;
+    return;
+  }
+
+  // Partial fill - 4-bit grayscale, 2 pixels per byte, upper nibble first (reversed from SSD1325/1327)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    const uint32_t row_offset = y * w_bytes;
+    int16_t x = x_start;
+
+    // Handle partial byte at start (odd x - lower nibble)
+    if (x % 2 != 0) {
+      uint32_t pos = row_offset + x / 2;
+      this->buffer_[pos] = (this->buffer_[pos] & (SSD1322_COLORMASK << SSD1322_COLORSHIFT)) | color4;
+      x++;
+    }
+
+    // Handle full bytes in the middle
+    while (x + 1 < x_end) {
+      this->buffer_[row_offset + x / 2] = fill;
+      x += 2;
+    }
+
+    // Handle partial byte at end (if remaining - upper nibble)
+    if (x < x_end) {
+      uint32_t pos = row_offset + x / 2;
+      this->buffer_[pos] = (this->buffer_[pos] & SSD1322_COLORMASK) | (color4 << SSD1322_COLORSHIFT);
+    }
+  }
 }
 void SSD1322::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -156,9 +156,8 @@ void SSD1327::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1327_COLORMASK;
-  uint8_t fill = color4 | (color4 << SSD1327_COLORSHIFT);
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
+  uint8_t fill = (color4 & SSD1327_COLORMASK) | ((color4 & SSD1327_COLORMASK) << SSD1327_COLORSHIFT);
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -157,8 +157,8 @@ void SSD1327::fill(Color color) {
   const int16_t w_bytes = w / SSD1327_PIXELSPERBYTE;
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -150,57 +150,17 @@ void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] |= color4;
 }
 void SSD1327::fill(Color color) {
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1327_COLORMASK;
-  const uint8_t fill = color4 | (color4 << SSD1327_COLORSHIFT);
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-  const int16_t w_bytes = w / SSD1327_PIXELSPERBYTE;
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-      this->buffer_[i] = fill;
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - 4-bit grayscale, 2 pixels per byte, lower nibble first
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    const uint32_t row_offset = y * w_bytes;
-    int16_t x = x_start;
-
-    // Handle partial byte at start (odd x)
-    if (x % 2 != 0) {
-      uint32_t pos = row_offset + x / 2;
-      this->buffer_[pos] = (this->buffer_[pos] & SSD1327_COLORMASK) | (color4 << SSD1327_COLORSHIFT);
-      x++;
-    }
-
-    // Handle full bytes in the middle
-    while (x + 1 < x_end) {
-      this->buffer_[row_offset + x / 2] = fill;
-      x += 2;
-    }
-
-    // Handle partial byte at end (if remaining)
-    if (x < x_end) {
-      uint32_t pos = row_offset + x / 2;
-      this->buffer_[pos] = (this->buffer_[pos] & (SSD1327_COLORMASK << SSD1327_COLORSHIFT)) | color4;
-    }
-  }
+  // Fast path: fill entire buffer
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1327_COLORMASK;
+  uint8_t fill = color4 | (color4 << SSD1327_COLORSHIFT);
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
 }
 void SSD1327::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -150,10 +150,57 @@ void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] |= color4;
 }
 void SSD1327::fill(Color color) {
-  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color);
-  uint8_t fill = (color4 & SSD1327_COLORMASK) | ((color4 & SSD1327_COLORMASK) << SSD1327_COLORSHIFT);
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-    this->buffer_[i] = fill;
+  const uint32_t color4 = display::ColorUtil::color_to_grayscale4(color) & SSD1327_COLORMASK;
+  const uint8_t fill = color4 | (color4 << SSD1327_COLORSHIFT);
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+  const int16_t w_bytes = w / SSD1327_PIXELSPERBYTE;
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+      this->buffer_[i] = fill;
+    return;
+  }
+
+  // Partial fill - 4-bit grayscale, 2 pixels per byte, lower nibble first
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    const uint32_t row_offset = y * w_bytes;
+    int16_t x = x_start;
+
+    // Handle partial byte at start (odd x)
+    if (x % 2 != 0) {
+      uint32_t pos = row_offset + x / 2;
+      this->buffer_[pos] = (this->buffer_[pos] & SSD1327_COLORMASK) | (color4 << SSD1327_COLORSHIFT);
+      x++;
+    }
+
+    // Handle full bytes in the middle
+    while (x + 1 < x_end) {
+      this->buffer_[row_offset + x / 2] = fill;
+      x += 2;
+    }
+
+    // Handle partial byte at end (if remaining)
+    if (x < x_end) {
+      uint32_t pos = row_offset + x / 2;
+      this->buffer_[pos] = (this->buffer_[pos] & (SSD1327_COLORMASK << SSD1327_COLORSHIFT)) | color4;
+    }
+  }
 }
 void SSD1327::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -135,8 +135,8 @@ void SSD1331::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -129,11 +129,40 @@ void HOT SSD1331::draw_absolute_pixel_internal(int x, int y, Color color) {
 }
 void SSD1331::fill(Color color) {
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
-    if (i & 1) {
-      this->buffer_[i] = color565 & 0xff;
-    } else {
-      this->buffer_[i] = (color565 >> 8) & 0xff;
+  const uint8_t color_hi = (color565 >> 8) & 0xff;
+  const uint8_t color_lo = color565 & 0xff;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
+      this->buffer_[i] = color_hi;
+      this->buffer_[i + 1] = color_lo;
+    }
+    return;
+  }
+
+  // Partial fill - 16-bit RGB565 (2 bytes per pixel, row-major)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    uint32_t row_pos = (y * w + x_start) * SSD1331_BYTESPERPIXEL;
+    for (int16_t x = x_start; x < x_end; x++) {
+      this->buffer_[row_pos++] = color_hi;
+      this->buffer_[row_pos++] = color_lo;
     }
   }
 }

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -128,42 +128,19 @@ void HOT SSD1331::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] = color565 & 0xff;
 }
 void SSD1331::fill(Color color) {
-  const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  const uint8_t color_hi = (color565 >> 8) & 0xff;
-  const uint8_t color_lo = color565 & 0xff;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
-      this->buffer_[i] = color_hi;
-      this->buffer_[i + 1] = color_lo;
-    }
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - 16-bit RGB565 (2 bytes per pixel, row-major)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    uint32_t row_pos = (y * w + x_start) * SSD1331_BYTESPERPIXEL;
-    for (int16_t x = x_start; x < x_end; x++) {
-      this->buffer_[row_pos++] = color_hi;
-      this->buffer_[row_pos++] = color_lo;
-    }
+  // Fast path: fill entire buffer
+  const uint32_t color565 = display::ColorUtil::color_to_565(color);
+  const uint8_t color_hi = (color565 >> 8) & 0xff;
+  const uint8_t color_lo = color565 & 0xff;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
+    this->buffer_[i] = color_hi;
+    this->buffer_[i + 1] = color_lo;
   }
 }
 void SSD1331::init_reset_() {

--- a/esphome/components/ssd1331_base/ssd1331_base.cpp
+++ b/esphome/components/ssd1331_base/ssd1331_base.cpp
@@ -134,13 +134,13 @@ void SSD1331::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  const uint8_t color_hi = (color565 >> 8) & 0xff;
-  const uint8_t color_lo = color565 & 0xff;
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
-    this->buffer_[i] = color_hi;
-    this->buffer_[i + 1] = color_lo;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
+    if (i & 1) {
+      this->buffer_[i] = color565 & 0xff;
+    } else {
+      this->buffer_[i] = (color565 >> 8) & 0xff;
+    }
   }
 }
 void SSD1331::init_reset_() {

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -161,11 +161,40 @@ void HOT SSD1351::draw_absolute_pixel_internal(int x, int y, Color color) {
 }
 void SSD1351::fill(Color color) {
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
-    if (i & 1) {
-      this->buffer_[i] = color565 & 0xff;
-    } else {
-      this->buffer_[i] = (color565 >> 8) & 0xff;
+  const uint8_t color_hi = (color565 >> 8) & 0xff;
+  const uint8_t color_lo = color565 & 0xff;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
+      this->buffer_[i] = color_hi;
+      this->buffer_[i + 1] = color_lo;
+    }
+    return;
+  }
+
+  // Partial fill - 16-bit RGB565 (2 bytes per pixel, row-major)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    uint32_t row_pos = (y * w + x_start) * SSD1351_BYTESPERPIXEL;
+    for (int16_t x = x_start; x < x_end; x++) {
+      this->buffer_[row_pos++] = color_hi;
+      this->buffer_[row_pos++] = color_lo;
     }
   }
 }

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -166,13 +166,13 @@ void SSD1351::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  const uint8_t color_hi = (color565 >> 8) & 0xff;
-  const uint8_t color_lo = color565 & 0xff;
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
-    this->buffer_[i] = color_hi;
-    this->buffer_[i + 1] = color_lo;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++) {
+    if (i & 1) {
+      this->buffer_[i] = color565 & 0xff;
+    } else {
+      this->buffer_[i] = (color565 >> 8) & 0xff;
+    }
   }
 }
 void SSD1351::init_reset_() {

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -167,8 +167,8 @@ void SSD1351::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/ssd1351_base/ssd1351_base.cpp
+++ b/esphome/components/ssd1351_base/ssd1351_base.cpp
@@ -160,42 +160,19 @@ void HOT SSD1351::draw_absolute_pixel_internal(int x, int y, Color color) {
   this->buffer_[pos] = color565 & 0xff;
 }
 void SSD1351::fill(Color color) {
-  const uint32_t color565 = display::ColorUtil::color_to_565(color);
-  const uint8_t color_hi = (color565 >> 8) & 0xff;
-  const uint8_t color_lo = color565 & 0xff;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
-      this->buffer_[i] = color_hi;
-      this->buffer_[i + 1] = color_lo;
-    }
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - 16-bit RGB565 (2 bytes per pixel, row-major)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    uint32_t row_pos = (y * w + x_start) * SSD1351_BYTESPERPIXEL;
-    for (int16_t x = x_start; x < x_end; x++) {
-      this->buffer_[row_pos++] = color_hi;
-      this->buffer_[row_pos++] = color_lo;
-    }
+  // Fast path: fill entire buffer
+  const uint32_t color565 = display::ColorUtil::color_to_565(color);
+  const uint8_t color_hi = (color565 >> 8) & 0xff;
+  const uint8_t color_lo = color565 & 0xff;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i += 2) {
+    this->buffer_[i] = color_hi;
+    this->buffer_[i + 1] = color_lo;
   }
 }
 void SSD1351::init_reset_() {

--- a/esphome/components/st7567_base/st7567_base.cpp
+++ b/esphome/components/st7567_base/st7567_base.cpp
@@ -137,8 +137,8 @@ void ST7567::fill(Color color) {
   const int16_t h = this->get_height_internal();
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/st7567_base/st7567_base.cpp
+++ b/esphome/components/st7567_base/st7567_base.cpp
@@ -138,7 +138,6 @@ void ST7567::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   memset(buffer_, fill, this->get_buffer_length_());
 }

--- a/esphome/components/st7567_base/st7567_base.cpp
+++ b/esphome/components/st7567_base/st7567_base.cpp
@@ -132,66 +132,15 @@ void HOT ST7567::draw_absolute_pixel_internal(int x, int y, Color color) {
 }
 
 void ST7567::fill(Color color) {
-  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    memset(buffer_, fill, this->get_buffer_length_());
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - handle page-based layout (8 vertical pixels per byte)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  const int16_t page_start = y_start / 8;
-  const int16_t page_end = (y_end - 1) / 8;
-
-  for (int16_t page = page_start; page <= page_end; page++) {
-    const int16_t page_y_start = page * 8;
-    const int16_t page_y_end = page_y_start + 8;
-
-    // Calculate which bits in this page are affected
-    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
-    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
-
-    // Create mask for affected bits
-    uint8_t mask = 0;
-    for (int16_t bit = bit_start; bit < bit_end; bit++) {
-      mask |= (1 << bit);
-    }
-
-    // Fill this page's row segment
-    const uint32_t row_offset = page * w;
-    if (mask == 0xFF) {
-      // Full page - can use direct assignment
-      for (int16_t x = x_start; x < x_end; x++) {
-        this->buffer_[row_offset + x] = fill;
-      }
-    } else {
-      // Partial page - need bit manipulation
-      for (int16_t x = x_start; x < x_end; x++) {
-        if (fill) {
-          this->buffer_[row_offset + x] |= mask;
-        } else {
-          this->buffer_[row_offset + x] &= ~mask;
-        }
-      }
-    }
-  }
+  // Fast path: fill entire buffer
+  uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  memset(buffer_, fill, this->get_buffer_length_());
 }
 
 void ST7567::init_reset_() {

--- a/esphome/components/st7567_base/st7567_base.cpp
+++ b/esphome/components/st7567_base/st7567_base.cpp
@@ -131,7 +131,68 @@ void HOT ST7567::draw_absolute_pixel_internal(int x, int y, Color color) {
   }
 }
 
-void ST7567::fill(Color color) { memset(buffer_, color.is_on() ? 0xFF : 0x00, this->get_buffer_length_()); }
+void ST7567::fill(Color color) {
+  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    memset(buffer_, fill, this->get_buffer_length_());
+    return;
+  }
+
+  // Partial fill - handle page-based layout (8 vertical pixels per byte)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  const int16_t page_start = y_start / 8;
+  const int16_t page_end = (y_end - 1) / 8;
+
+  for (int16_t page = page_start; page <= page_end; page++) {
+    const int16_t page_y_start = page * 8;
+    const int16_t page_y_end = page_y_start + 8;
+
+    // Calculate which bits in this page are affected
+    const int16_t bit_start = (y_start > page_y_start) ? (y_start - page_y_start) : 0;
+    const int16_t bit_end = (y_end < page_y_end) ? (y_end - page_y_start) : 8;
+
+    // Create mask for affected bits
+    uint8_t mask = 0;
+    for (int16_t bit = bit_start; bit < bit_end; bit++) {
+      mask |= (1 << bit);
+    }
+
+    // Fill this page's row segment
+    const uint32_t row_offset = page * w;
+    if (mask == 0xFF) {
+      // Full page - can use direct assignment
+      for (int16_t x = x_start; x < x_end; x++) {
+        this->buffer_[row_offset + x] = fill;
+      }
+    } else {
+      // Partial page - need bit manipulation
+      for (int16_t x = x_start; x < x_end; x++) {
+        if (fill) {
+          this->buffer_[row_offset + x] |= mask;
+        } else {
+          this->buffer_[row_offset + x] &= ~mask;
+        }
+      }
+    }
+  }
+}
 
 void ST7567::init_reset_() {
   if (this->reset_pin_ != nullptr) {

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -90,64 +90,15 @@ void HOT ST7920::write_display_data() {
 }
 
 void ST7920::fill(Color color) {
-  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-  const int16_t w_bytes = w / 8;  // 8 horizontal pixels per byte
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    memset(this->buffer_, fill, this->get_buffer_length_());
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - horizontal layout (8 horizontal pixels per byte, MSB first)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    const uint32_t row_offset = y * w_bytes;
-
-    // Calculate byte boundaries
-    const int16_t byte_start = x_start / 8;
-    const int16_t byte_end = (x_end - 1) / 8;
-
-    for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
-      const int16_t byte_x_start = byte_idx * 8;
-      const int16_t byte_x_end = byte_x_start + 8;
-
-      // Calculate which bits in this byte are affected
-      const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
-      const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
-
-      // Create mask for affected bits (MSB first: bit 0 is 0x80)
-      uint8_t mask = 0;
-      for (int16_t bit = bit_start; bit < bit_end; bit++) {
-        mask |= (0x80 >> bit);
-      }
-
-      if (mask == 0xFF) {
-        this->buffer_[row_offset + byte_idx] = fill;
-      } else {
-        if (fill) {
-          this->buffer_[row_offset + byte_idx] |= mask;
-        } else {
-          this->buffer_[row_offset + byte_idx] &= ~mask;
-        }
-      }
-    }
-  }
+  // Fast path: fill entire buffer
+  uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  memset(this->buffer_, fill, this->get_buffer_length_());
 }
 
 void ST7920::dump_config() {

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -96,7 +96,6 @@ void ST7920::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer
   uint8_t fill = color.is_on() ? 0xFF : 0x00;
   memset(this->buffer_, fill, this->get_buffer_length_());
 }

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -89,7 +89,66 @@ void HOT ST7920::write_display_data() {
   }
 }
 
-void ST7920::fill(Color color) { memset(this->buffer_, color.is_on() ? 0xFF : 0x00, this->get_buffer_length_()); }
+void ST7920::fill(Color color) {
+  const uint8_t fill = color.is_on() ? 0xFF : 0x00;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+  const int16_t w_bytes = w / 8;  // 8 horizontal pixels per byte
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    memset(this->buffer_, fill, this->get_buffer_length_());
+    return;
+  }
+
+  // Partial fill - horizontal layout (8 horizontal pixels per byte, MSB first)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    const uint32_t row_offset = y * w_bytes;
+
+    // Calculate byte boundaries
+    const int16_t byte_start = x_start / 8;
+    const int16_t byte_end = (x_end - 1) / 8;
+
+    for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
+      const int16_t byte_x_start = byte_idx * 8;
+      const int16_t byte_x_end = byte_x_start + 8;
+
+      // Calculate which bits in this byte are affected
+      const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
+      const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
+
+      // Create mask for affected bits (MSB first: bit 0 is 0x80)
+      uint8_t mask = 0;
+      for (int16_t bit = bit_start; bit < bit_end; bit++) {
+        mask |= (0x80 >> bit);
+      }
+
+      if (mask == 0xFF) {
+        this->buffer_[row_offset + byte_idx] = fill;
+      } else {
+        if (fill) {
+          this->buffer_[row_offset + byte_idx] |= mask;
+        } else {
+          this->buffer_[row_offset + byte_idx] &= ~mask;
+        }
+      }
+    }
+  }
+}
 
 void ST7920::dump_config() {
   LOG_DISPLAY("", "ST7920", this);

--- a/esphome/components/st7920/st7920.cpp
+++ b/esphome/components/st7920/st7920.cpp
@@ -96,8 +96,8 @@ void ST7920::fill(Color color) {
   const int16_t w_bytes = w / 8;  // 8 horizontal pixels per byte
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -172,67 +172,16 @@ void WaveshareEPaperBase::update() {
   this->display();
 }
 void WaveshareEPaper::fill(Color color) {
-  // flip logic
-  const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
-  const int16_t w = this->get_width_internal();
-  const int16_t h = this->get_height_internal();
-  const int16_t w_ctrl = this->get_width_controller();  // row stride may differ from visible width
-  const int16_t w_bytes = w_ctrl / 8;
-
-  // Calculate fill region, respecting clipping
-  display::Rect fill_rect(0, 0, w, h);
-  display::Rect clip = this->get_clipping();
-  if (clip.is_set()) {
-    fill_rect.shrink(clip);
-    if (!fill_rect.is_set())
-      return;  // Completely clipped
-  }
-
-  // Check if filling entire display
-  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
-    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-      this->buffer_[i] = fill;
+  // If clipping is active, fall back to base implementation
+  if (this->get_clipping().is_set()) {
+    Display::fill(color);
     return;
   }
 
-  // Partial fill - horizontal layout (8 horizontal pixels per byte, MSB first)
-  const int16_t x_start = fill_rect.x;
-  const int16_t x_end = fill_rect.x + fill_rect.w;
-  const int16_t y_start = fill_rect.y;
-  const int16_t y_end = fill_rect.y + fill_rect.h;
-
-  for (int16_t y = y_start; y < y_end; y++) {
-    const uint32_t row_offset = y * w_bytes;
-
-    // Calculate byte boundaries
-    const int16_t byte_start = x_start / 8;
-    const int16_t byte_end = (x_end - 1) / 8;
-
-    for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
-      const int16_t byte_x_start = byte_idx * 8;
-      const int16_t byte_x_end = byte_x_start + 8;
-
-      // Calculate which bits in this byte are affected
-      const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
-      const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
-
-      // Create mask for affected bits (MSB first: bit 0 is 0x80)
-      uint8_t mask = 0;
-      for (int16_t bit = bit_start; bit < bit_end; bit++) {
-        mask |= (0x80 >> bit);
-      }
-
-      if (mask == 0xFF) {
-        this->buffer_[row_offset + byte_idx] = fill;
-      } else {
-        if (fill) {
-          this->buffer_[row_offset + byte_idx] |= mask;
-        } else {
-          this->buffer_[row_offset + byte_idx] &= ~mask;
-        }
-      }
-    }
-  }
+  // Fast path: fill entire buffer (flip logic: on = 0x00, off = 0xFF)
+  uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+    this->buffer_[i] = fill;
 }
 void WaveshareEPaper7C::setup() {
   this->init_internal_7c_(this->get_buffer_length_());

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -180,8 +180,8 @@ void WaveshareEPaper::fill(Color color) {
   const int16_t w_bytes = w_ctrl / 8;
 
   // Calculate fill region, respecting clipping
-  Rect fill_rect(0, 0, w, h);
-  Rect clip = this->get_clipping();
+  display::Rect fill_rect(0, 0, w, h);
+  display::Rect clip = this->get_clipping();
   if (clip.is_set()) {
     fill_rect.shrink(clip);
     if (!fill_rect.is_set())

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -174,8 +174,65 @@ void WaveshareEPaperBase::update() {
 void WaveshareEPaper::fill(Color color) {
   // flip logic
   const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
-  for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
-    this->buffer_[i] = fill;
+  const int16_t w = this->get_width_internal();
+  const int16_t h = this->get_height_internal();
+  const int16_t w_ctrl = this->get_width_controller();  // row stride may differ from visible width
+  const int16_t w_bytes = w_ctrl / 8;
+
+  // Calculate fill region, respecting clipping
+  Rect fill_rect(0, 0, w, h);
+  Rect clip = this->get_clipping();
+  if (clip.is_set()) {
+    fill_rect.shrink(clip);
+    if (!fill_rect.is_set())
+      return;  // Completely clipped
+  }
+
+  // Check if filling entire display
+  if (fill_rect.x == 0 && fill_rect.y == 0 && fill_rect.w == w && fill_rect.h == h) {
+    for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
+      this->buffer_[i] = fill;
+    return;
+  }
+
+  // Partial fill - horizontal layout (8 horizontal pixels per byte, MSB first)
+  const int16_t x_start = fill_rect.x;
+  const int16_t x_end = fill_rect.x + fill_rect.w;
+  const int16_t y_start = fill_rect.y;
+  const int16_t y_end = fill_rect.y + fill_rect.h;
+
+  for (int16_t y = y_start; y < y_end; y++) {
+    const uint32_t row_offset = y * w_bytes;
+
+    // Calculate byte boundaries
+    const int16_t byte_start = x_start / 8;
+    const int16_t byte_end = (x_end - 1) / 8;
+
+    for (int16_t byte_idx = byte_start; byte_idx <= byte_end; byte_idx++) {
+      const int16_t byte_x_start = byte_idx * 8;
+      const int16_t byte_x_end = byte_x_start + 8;
+
+      // Calculate which bits in this byte are affected
+      const int16_t bit_start = (x_start > byte_x_start) ? (x_start - byte_x_start) : 0;
+      const int16_t bit_end = (x_end < byte_x_end) ? (x_end - byte_x_start) : 8;
+
+      // Create mask for affected bits (MSB first: bit 0 is 0x80)
+      uint8_t mask = 0;
+      for (int16_t bit = bit_start; bit < bit_end; bit++) {
+        mask |= (0x80 >> bit);
+      }
+
+      if (mask == 0xFF) {
+        this->buffer_[row_offset + byte_idx] = fill;
+      } else {
+        if (fill) {
+          this->buffer_[row_offset + byte_idx] |= mask;
+        } else {
+          this->buffer_[row_offset + byte_idx] &= ~mask;
+        }
+      }
+    }
+  }
 }
 void WaveshareEPaper7C::setup() {
   this->init_internal_7c_(this->get_buffer_length_());
@@ -234,6 +291,12 @@ uint8_t WaveshareEPaper7C::color_to_hex(Color color) {
   return hex_code;
 }
 void WaveshareEPaper7C::fill(Color color) {
+  // If clipping is active, use base class (3-bit packing is complex for partial fills)
+  if (this->get_clipping().is_set()) {
+    display::Display::fill(color);
+    return;
+  }
+
   uint8_t pixel_color;
   if (color.is_on()) {
     pixel_color = this->color_to_hex(color);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -178,8 +178,8 @@ void WaveshareEPaper::fill(Color color) {
     return;
   }
 
-  // Fast path: fill entire buffer (flip logic: on = 0x00, off = 0xFF)
-  uint8_t fill = color.is_on() ? 0x00 : 0xFF;
+  // flip logic
+  const uint8_t fill = color.is_on() ? 0x00 : 0xFF;
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }


### PR DESCRIPTION
# What does this implement/fix?

A lot of the display drivers that override fill() do not honor clipping.

I don't have most of these displays to fully test this, so implementing the simpliest solution that falls back to known pixel by pixel path that does check.

Note: hub75 implementation has a similar bug with a fix in PR#12674, left out of here to avoid duplication.

While this is technically a bug fix, if anyone has code written using fill or clear and clipping, this will change that behavior, so marking it as a breaking change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml

globals:
  - id: use_clipping_mode
    type: bool
    initial_value: "true"

switch:
  - platform: template
    name: "Use Clipping Mode"
    id: clipping_mode_switch
    optimistic: true
    restore_mode: RESTORE_DEFAULT_ON
    lambda: return id(use_clipping_mode);
    turn_on_action:
      - globals.set:
          id: use_clipping_mode
          value: "true"
    turn_off_action:
      - globals.set:
          id: use_clipping_mode
          value: "false"

display:
  - platform: [...]
    lambda: |-
      // Test clipping: 8 columns x 4 rows of 16x16 colored squares
      // Toggle "Use Clipping Mode" switch to compare methods
      // If clipping works: both modes produce identical output
      // If clipping fails: clipping mode shows solid gray screen
      Color colors[32] = {
        Color(255, 0, 0),     Color(0, 255, 0),     Color(0, 0, 255),     Color(255, 255, 0),
        Color(255, 0, 255),   Color(0, 255, 255),   Color(255, 128, 0),   Color(128, 0, 255),
        Color(0, 128, 255),   Color(255, 0, 128),   Color(128, 255, 0),   Color(0, 255, 128),
        Color(255, 128, 128), Color(128, 255, 128), Color(128, 128, 255), Color(255, 255, 128),
        Color(255, 128, 255), Color(128, 255, 255), Color(192, 64, 0),    Color(64, 192, 0),
        Color(0, 64, 192),    Color(192, 0, 64),    Color(64, 0, 192),    Color(0, 192, 64),
        Color(128, 64, 64),   Color(64, 128, 64),   Color(64, 64, 128),   Color(128, 128, 64),
        Color(128, 64, 128),  Color(64, 128, 128),  Color(255, 255, 255), Color(128, 128, 128)
      };
      int idx = 0;
      for (int row = 0; row < 4; row++) {
        for (int col = 0; col < 8; col++) {
          if (id(use_clipping_mode)) {
            // Clipping mode: clip to square bounds, then fill "entire screen"
            it.start_clipping(col * 16, row * 16, (col + 1) * 16, (row + 1) * 16);
            it.fill(colors[idx]);
            it.end_clipping();
          } else {
            // Direct mode: use filled_rectangle
            it.filled_rectangle(col * 16, row * 16, 16, 16, colors[idx]);
          }
          idx++;
        }
      }
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
