### PR TITLE
[display] Make additional drawing primitives virtual

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -87,14 +87,20 @@ void Display::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8
 }
 
 void HOT Display::horizontal_line(int x, int y, int width, Color color) {
-  // Future: Could be made more efficient by manipulating buffer directly in certain rotations.
-  for (int i = x; i < x + width; i++)
-    this->draw_pixel_at(i, y, color);
+  this->horizontal_line_internal(x, y, width, color);
 }
 
 void HOT Display::vertical_line(int x, int y, int height, Color color) {
-  // Future: Could be made more efficient by manipulating buffer directly in certain rotations.
-  for (int i = y; i < y + height; i++)
+  this->vertical_line_internal(x, y, height, color);
+}
+
+void HOT Display::horizontal_line_internal(int x, int y, int w, Color color) {
+  for (int i = x; i < x + w; i++)
+    this->draw_pixel_at(i, y, color);
+}
+
+void HOT Display::vertical_line_internal(int x, int y, int h, Color color) {
+  for (int i = y; i < y + h; i++)
     this->draw_pixel_at(x, i, color);
 }
 
@@ -106,9 +112,12 @@ void Display::rectangle(int x1, int y1, int width, int height, Color color) {
 }
 
 void Display::filled_rectangle(int x1, int y1, int width, int height, Color color) {
-  // Future: Use vertical_line and horizontal_line methods depending on rotation to reduce memory accesses.
-  for (int i = y1; i < y1 + height; i++) {
-    this->horizontal_line(x1, i, width, color);
+  this->filled_rectangle_internal(x1, y1, width, height, color);
+}
+
+void Display::filled_rectangle_internal(int x, int y, int w, int h, Color color) {
+  for (int i = y; i < y + h; i++) {
+    this->horizontal_line_internal(x, i, w, color);
   }
 }
 

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -377,17 +377,17 @@ class Display : public PollingComponent {
   void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  void vertical_line(int x, int y, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
   void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
-  virtual void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);
@@ -777,6 +777,13 @@ class Display : public PollingComponent {
 
   virtual int get_height_internal() = 0;
   virtual int get_width_internal() = 0;
+
+  /// Draw a horizontal line. Override in subclass for optimized implementation.
+  virtual void horizontal_line_internal(int x, int y, int w, Color color);
+  /// Draw a vertical line. Override in subclass for optimized implementation.
+  virtual void vertical_line_internal(int x, int y, int h, Color color);
+  /// Fill a rectangle. Override in subclass for optimized implementation.
+  virtual void filled_rectangle_internal(int x, int y, int w, int h, Color color);
 
   /**
    * This method fills a triangle using only integer variables by using a

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -377,17 +377,17 @@ class Display : public PollingComponent {
   void line_at_angle(int x, int y, int angle, int start_radius, int stop_radius, Color color = COLOR_ON);
 
   /// Draw a horizontal line from the point [x,y] to [x+width,y] with the given color.
-  void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
+  virtual void horizontal_line(int x, int y, int width, Color color = COLOR_ON);
 
   /// Draw a vertical line from the point [x,y] to [x,y+width] with the given color.
-  void vertical_line(int x, int y, int height, Color color = COLOR_ON);
+  virtual void vertical_line(int x, int y, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a rectangle with the top left point at [x1,y1] and the bottom right point at
   /// [x1+width,y1+height].
   void rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Fill a rectangle with the top left point at [x1,y1] and the bottom right point at [x1+width,y1+height].
-  void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
+  virtual void filled_rectangle(int x1, int y1, int width, int height, Color color = COLOR_ON);
 
   /// Draw the outline of a circle centered around [center_x,center_y] with the radius radius with the given color.
   void circle(int center_x, int center_xy, int radius, Color color = COLOR_ON);


### PR DESCRIPTION
# What does this implement/fix?

Right now it can be faster to `start_clipping(), fill()` than to call `filled_rectangle()` because the display component can actually optimize the former but not the latter.  I suggest we make the most basic primatives be virtual so they can be overwritten when appropriate.

I will implement these in one component (hub75) as an example.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
