### PR TITLE
[core] Remove unused USE_ESP32_FRAMEWORK_ARDUINO ifdefs

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -12,12 +12,6 @@
 #include <string>
 #include <vector>
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
-#include <WiFi.h>
-#include <WiFiType.h>
-#include <esp_wifi.h>
-#endif
-
 #ifdef USE_LIBRETINY
 #include <WiFi.h>
 #endif
@@ -578,10 +572,6 @@ class WiFiComponent : public Component {
   static void s_wifi_scan_done_callback(void *arg, STATUS status);
 #endif
 
-#ifdef USE_ESP32_FRAMEWORK_ARDUINO
-  void wifi_event_callback_(arduino_event_id_t event, arduino_event_info_t info);
-  void wifi_scan_done_callback_();
-#endif
 #ifdef USE_ESP32
   void wifi_process_event_(IDFWiFiEvent *data);
 #endif

--- a/esphome/core/hal.h
+++ b/esphome/core/hal.h
@@ -3,16 +3,8 @@
 #include <cstdint>
 #include "gpio.h"
 
-#if defined(USE_ESP32_FRAMEWORK_ESP_IDF)
+#if defined(USE_ESP32)
 #include <esp_attr.h>
-#ifndef PROGMEM
-#define PROGMEM
-#endif
-
-#elif defined(USE_ESP32_FRAMEWORK_ARDUINO)
-
-#include <esp_attr.h>
-
 #ifndef PROGMEM
 #define PROGMEM
 #endif


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Removes dead code related to `USE_ESP32_FRAMEWORK_ARDUINO`. ESP32 Arduino framework uses the same ESP-IDF implementation as pure ESP-IDF, so these framework-specific ifdefs are unnecessary.

### wifi_component.h
- Removed Arduino WiFi includes (`WiFi.h`, `WiFiType.h`, `esp_wifi.h`) that were never used
- Removed unimplemented callback declarations (`wifi_event_callback_`, `wifi_scan_done_callback_`)

The ESP32 wifi implementation (`wifi_component_esp_idf.cpp`) is guarded by `#ifdef USE_ESP32`, not framework-specific. It uses `wifi_process_event_(IDFWiFiEvent*)` for event handling, not the Arduino-style callbacks.

### hal.h
- Consolidated identical `USE_ESP32_FRAMEWORK_ESP_IDF` and `USE_ESP32_FRAMEWORK_ARDUINO` blocks into a single `USE_ESP32` check
- Both blocks included `<esp_attr.h>` and defined `PROGMEM` identically

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal cleanup only)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)