### PR TITLE
[tests] Remove reserved / character from entity names in component tests

### DIFF
--- a/tests/components/micronova/common.yaml
+++ b/tests/components/micronova/common.yaml
@@ -41,7 +41,7 @@ sensor:
 switch:
   - platform: micronova
     stove:
-      name: Stove on/off
+      name: Stove
 
 text_sensor:
   - platform: micronova

--- a/tests/components/opentherm/common.yaml
+++ b/tests/components/opentherm/common.yaml
@@ -92,7 +92,7 @@ sensor:
     ch_pump_starts:
       name: "Boiler Number of starts CH pump"
     dhw_pump_valve_starts:
-      name: "Boiler Number of starts DHW pump/valve"
+      name: "Boiler Number of starts DHW pump valve"
     dhw_burner_starts:
       name: "Boiler Number of starts burner during DHW mode"
     burner_operation_hours:
@@ -139,7 +139,7 @@ binary_sensor:
     dhw_present:
       name: "Boiler DHW present"
     control_type_on_off:
-      name: "Boiler Control type is on/off"
+      name: "Boiler Control type is on-off"
     cooling_supported:
       name: "Boiler Cooling supported"
     dhw_storage_tank:
@@ -153,9 +153,9 @@ binary_sensor:
     max_ch_setpoint_transfer_enabled:
       name: "Boiler CH maximum setpoint transfer enabled"
     dhw_setpoint_rw:
-      name: "Boiler DHW setpoint read/write"
+      name: "Boiler DHW setpoint read-write"
     max_ch_setpoint_rw:
-      name: "Boiler CH maximum setpoint read/write"
+      name: "Boiler CH maximum setpoint read-write"
 
 switch:
   - platform: opentherm

--- a/tests/components/zhlt01/common.yaml
+++ b/tests/components/zhlt01/common.yaml
@@ -1,4 +1,4 @@
 climate:
   - platform: zhlt01
-    name: ZH/LT-01 Climate
+    name: ZH-LT-01 Climate
     transmitter_id: xmitr


### PR DESCRIPTION
# What does this implement/fix?

Fixes component tests that use `/` in entity names, which is now a reserved character after #12627.

The `/` character is used as a URL path separator, so it can no longer appear in entity names. This PR updates test configurations to use `-` or remove the `/` entirely.

**Changes:**
- `micronova`: "Stove on/off" → "Stove"
- `opentherm`: 4 names with `/` → `-` (e.g., "on/off" → "on-off", "read/write" → "read-write")
- `zhlt01`: "ZH/LT-01 Climate" → "ZH-LT-01 Climate"

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follows up #12627

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test-only changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test file fixes only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
