### PR TITLE
[esp32_rmt_led_strip] Support inverted logic

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -98,7 +98,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
   channel.trans_queue_depth = 1;
   channel.flags.io_loop_back = 0;
   channel.flags.io_od_mode = 0;
-  channel.flags.invert_out = 0;
+  channel.flags.invert_out = this->invert_out_;
   channel.flags.with_dma = this->use_dma_;
   channel.intr_priority = 0;
   if (rmt_new_tx_channel(&channel, &this->channel_) != ESP_OK) {

--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -49,6 +49,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
   }
 
   void set_pin(uint8_t pin) { this->pin_ = pin; }
+  void set_inverted(bool inverted) { this->invert_out_ = inverted; }
   void set_num_leds(uint16_t num_leds) { this->num_leds_ = num_leds; }
   void set_is_rgbw(bool is_rgbw) { this->is_rgbw_ = is_rgbw; }
   void set_is_wrgb(bool is_wrgb) { this->is_wrgb_ = is_wrgb; }
@@ -93,6 +94,7 @@ class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
   bool is_wrgb_{false};
   bool use_dma_{false};
   bool use_psram_{false};
+  bool invert_out_{false};
 
   RGBOrder rgb_order_{ORDER_RGB};
 

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_IS_RGBW,
     CONF_MAX_REFRESH_RATE,
     CONF_NUM_LEDS,
+    CONF_NUMBER,
     CONF_OUTPUT_ID,
     CONF_PIN,
     CONF_RGB_ORDER,
@@ -72,7 +73,7 @@ CONFIG_SCHEMA = cv.All(
     light.ADDRESSABLE_LIGHT_SCHEMA.extend(
         {
             cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(ESP32RMTLEDStripLightOutput),
-            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_number,
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_NUM_LEDS): cv.positive_not_null_int,
             cv.Required(CONF_RGB_ORDER): cv.enum(RGB_ORDERS, upper=True),
             cv.SplitDefault(
@@ -86,7 +87,6 @@ CONFIG_SCHEMA = cv.All(
                 esp32_s2=192,
                 esp32_s3=192,
             ): cv.int_range(min=2),
-            cv.Optional(CONF_INVERTED, default=False): cv.boolean,
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
             cv.Optional(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
             cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,
@@ -134,10 +134,9 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
-    cg.add(var.set_pin(config[CONF_PIN]))
-
-    if CONF_INVERTED in config:
-        cg.add(var.set_inverted(config[CONF_INVERTED]))
+    cg.add(var.set_pin(config[CONF_PIN][CONF_NUMBER]))
+    if config[CONF_PIN][CONF_INVERTED]:
+        cg.add(var.set_inverted(True))
 
     if CONF_MAX_REFRESH_RATE in config:
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -86,7 +86,7 @@ CONFIG_SCHEMA = cv.All(
                 esp32_s2=192,
                 esp32_s3=192,
             ): cv.int_range(min=2),
-            cv.Optional(CONF_INVERTED): cv.boolean,
+            cv.Optional(CONF_INVERTED, default=False): cv.boolean,
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
             cv.Optional(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
             cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -8,6 +8,7 @@ from esphome.components.const import CONF_USE_PSRAM
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHIPSET,
+    CONF_INVERTED,
     CONF_IS_RGBW,
     CONF_MAX_REFRESH_RATE,
     CONF_NUM_LEDS,
@@ -85,6 +86,7 @@ CONFIG_SCHEMA = cv.All(
                 esp32_s2=192,
                 esp32_s3=192,
             ): cv.int_range(min=2),
+            cv.Optional(CONF_INVERTED): cv.boolean,
             cv.Optional(CONF_MAX_REFRESH_RATE): cv.positive_time_period_microseconds,
             cv.Optional(CONF_CHIPSET): cv.one_of(*CHIPSETS, upper=True),
             cv.Optional(CONF_IS_RGBW, default=False): cv.boolean,
@@ -133,6 +135,9 @@ async def to_code(config):
 
     cg.add(var.set_num_leds(config[CONF_NUM_LEDS]))
     cg.add(var.set_pin(config[CONF_PIN]))
+
+    if CONF_INVERTED in config:
+        cg.add(var.set_inverted(config[CONF_INVERTED]))
 
     if CONF_MAX_REFRESH_RATE in config:
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))


### PR DESCRIPTION
# What does this implement/fix?

This PR adds support to invert the data signal to the ESP32 RMT LED strip component. This way, a simple level shifter can be implemented using a transistor/mosfet.
<img width="646" height="324" alt="image" src="https://github.com/user-attachments/assets/51394c6c-2ec4-4e68-b06f-6d43384d7cd0" />


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- implements https://github.com/esphome/feature-requests/issues/2964

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5849

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  variant: esp32c6
  flash_size: 8MB
  framework:
    type: esp-idf

light:
  - platform: esp32_rmt_led_strip
    name: "Light"
    rgb_order: GRB
    pin: GPIO15
    inverted: true
    num_leds: 30
    chipset: ws2812
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
