### PR TITLE
[api] Fix KeyError when running logs after password removal

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -16,7 +16,7 @@ with warnings.catch_warnings():
 
 import contextlib
 
-from esphome.const import CONF_KEY, CONF_PASSWORD, CONF_PORT, __version__
+from esphome.const import CONF_KEY, CONF_PORT, __version__
 from esphome.core import CORE
 
 from . import CONF_ENCRYPTION
@@ -35,7 +35,6 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
     conf = config["api"]
     name = config["esphome"]["name"]
     port: int = int(conf[CONF_PORT])
-    password: str = conf[CONF_PASSWORD]
     noise_psk: str | None = None
     if (encryption := conf.get(CONF_ENCRYPTION)) and (key := encryption.get(CONF_KEY)):
         noise_psk = key
@@ -50,7 +49,7 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
     cli = APIClient(
         addresses[0],  # Primary address for compatibility
         port,
-        password,
+        "",  # Password auth removed in 2026.1.0
         client_info=f"ESPHome Logs {__version__}",
         noise_psk=noise_psk,
         addresses=addresses,  # Pass all addresses for automatic retry


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression from #12819 where the `client.py` file was not updated to remove the password reference. This caused `esphome run` and `esphome logs` to crash with:

```
KeyError: 'password'
```

The fix removes the `CONF_PASSWORD` usage from `client.py` since password authentication was removed in 2026.1.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #12819

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config with api: that uses esphome run/logs
esphome:
  name: test-device

api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
