### PR TITLE
[core] Fix startup delay from setup timing logs when console connected

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -205,7 +205,13 @@ void Component::call() {
       this->call_setup();
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
       uint32_t setup_time = millis() - start_time;
-      ESP_LOGCONFIG(TAG, "Setup %s took %ums", LOG_STR_ARG(this->get_component_log_str()), (unsigned) setup_time);
+      // Only log at CONFIG level if setup took longer than the blocking threshold
+      // to avoid spamming the log and blocking the event loop
+      if (setup_time >= WARN_IF_BLOCKING_OVER_MS) {
+        ESP_LOGCONFIG(TAG, "Setup %s took %ums", LOG_STR_ARG(this->get_component_log_str()), (unsigned) setup_time);
+      } else {
+        ESP_LOGV(TAG, "Setup %s took %ums", LOG_STR_ARG(this->get_component_log_str()), (unsigned) setup_time);
+      }
 #endif
       break;
     }


### PR DESCRIPTION
# What does this implement/fix?

Reduces startup delay for configurations with many entities by changing the component setup timing log to use VERBOSE level instead of CONFIG level when setup completes quickly.

Note if its not using JTAG console and standard UART we always have to output as there is no way to tell if its connected so it blocks startup on ESP32 classic always.

Previously, every component logged its setup time at CONFIG level:
```
[C][component:208]: Setup template.sensor took 0ms
```

With 400+ entities, each log message takes ~3ms to output, causing ~1.2 seconds of unnecessary blocking during startup just for logging.

Now:
- Components that take **>= 50ms** to setup (the blocking threshold) still log at CONFIG level as a warning
- Components that take **< 50ms** log at VERBOSE level, which is filtered out unless verbose logging is enabled

This preserves the useful diagnostic information about slow components while eliminating the startup delay from logging fast components.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/pull/12544 - same underlying problem (logging blocking the event loop during startup with many entities), but this instance was hidden because it only occurs when a console is connected at startup

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config with many entities benefits from this change
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a - no user-facing changes)
