### PR TITLE
[wts01] Fix negative values for WTS01 sensor

### DIFF
--- a/esphome/components/wts01/wts01.cpp
+++ b/esphome/components/wts01/wts01.cpp
@@ -71,16 +71,19 @@ void WTS01Sensor::process_packet_() {
   }
 
   // Extract temperature value
-  int8_t temp = this->buffer_[6];
-  int32_t sign = 1;
+  const uint8_t raw = this->buffer_[6];
 
-  // Handle negative temperatures
-  if (temp < 0) {
-    sign = -1;
+  // WTS01 encodes sign in bit 7, magnitude in bits 0-6
+  const bool negative = (raw & 0x80) != 0;
+  const uint8_t magnitude = raw & 0x7F;
+
+  const float decimal = static_cast<float>(this->buffer_[7]) / 100.0f;
+
+  float temperature = static_cast<float>(magnitude) + decimal;
+
+  if (negative) {
+    temperature = -temperature;
   }
-
-  // Calculate temperature (temp + decimal/100)
-  float temperature = static_cast<float>(temp) + (sign * static_cast<float>(this->buffer_[7]) / 100.0f);
 
   ESP_LOGV(TAG, "Received new temperature: %.2f°C", temperature);
 


### PR DESCRIPTION
# What does this implement/fix?
When using WTS01 sensor below 0C, the sensor goes to -128C and then increases from there.
The 7th bit of the integer part should be interpreted as the sign.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
