### PR TITLE
[mhz19] Refactor Actions to Parented

### DIFF
--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -52,45 +52,26 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   MHZ19DetectionRange detection_range_{MHZ19_DETECTION_RANGE_DEFAULT};
 };
 
-template<typename... Ts> class MHZ19CalibrateZeroAction : public Action<Ts...> {
+template<typename... Ts> class MHZ19CalibrateZeroAction : public Action<Ts...>, public Parented<MHZ19Component> {
  public:
-  MHZ19CalibrateZeroAction(MHZ19Component *mhz19) : mhz19_(mhz19) {}
-
-  void play(const Ts &...x) override { this->mhz19_->calibrate_zero(); }
-
- protected:
-  MHZ19Component *mhz19_;
+  void play(const Ts &...x) override { this->parent_->calibrate_zero(); }
 };
 
-template<typename... Ts> class MHZ19ABCEnableAction : public Action<Ts...> {
+template<typename... Ts> class MHZ19ABCEnableAction : public Action<Ts...>, public Parented<MHZ19Component> {
  public:
-  MHZ19ABCEnableAction(MHZ19Component *mhz19) : mhz19_(mhz19) {}
-
-  void play(const Ts &...x) override { this->mhz19_->abc_enable(); }
-
- protected:
-  MHZ19Component *mhz19_;
+  void play(const Ts &...x) override { this->parent_->abc_enable(); }
 };
 
-template<typename... Ts> class MHZ19ABCDisableAction : public Action<Ts...> {
+template<typename... Ts> class MHZ19ABCDisableAction : public Action<Ts...>, public Parented<MHZ19Component> {
  public:
-  MHZ19ABCDisableAction(MHZ19Component *mhz19) : mhz19_(mhz19) {}
-
-  void play(const Ts &...x) override { this->mhz19_->abc_disable(); }
-
- protected:
-  MHZ19Component *mhz19_;
+  void play(const Ts &...x) override { this->parent_->abc_disable(); }
 };
 
-template<typename... Ts> class MHZ19DetectionRangeSetAction : public Action<Ts...> {
+template<typename... Ts> class MHZ19DetectionRangeSetAction : public Action<Ts...>, public Parented<MHZ19Component> {
  public:
-  MHZ19DetectionRangeSetAction(MHZ19Component *mhz19) : mhz19_(mhz19) {}
   TEMPLATABLE_VALUE(MHZ19DetectionRange, detection_range)
 
-  void play(const Ts &...x) override { this->mhz19_->range_set(this->detection_range_.value(x...)); }
-
- protected:
-  MHZ19Component *mhz19_;
+  void play(const Ts &...x) override { this->parent_->range_set(this->detection_range_.value(x...)); }
 };
 
 }  // namespace mhz19


### PR DESCRIPTION
# What does this implement/fix?

Use Parented for Action as requested in review of #12677

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes review item in #12677

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  name: testco2
  friendly_name: testco2

esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: esp-idf

# Enable logging
logger: 
  level: VERY_VERBOSE

uart:
  - id: uart_co2
    rx_pin: 20
    tx_pin: 21
    baud_rate: 9600

sensor:
  - platform: mhz19
    id: mhz19_1
    uart_id: uart_co2
    co2:
      name: "CO2 Level"
    temperature:
      name: "CO2 Sensor Temperature"
    update_interval: 25s
    warmup_time: 90s
    detection_range: 5000ppm

interval:
  - interval: 15s
    then:
      - mhz19.detection_range_set:
         id: mhz19_1
         detection_range: 2000ppm
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
