### PR TITLE
[absolute_humidity] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -90,13 +90,16 @@ void AbsoluteHumidityComponent::loop() {
       this->status_set_error(LOG_STR("Invalid saturation vapor pressure equation selection!"));
       return;
   }
-  ESP_LOGD(TAG, "Saturation vapor pressure %f kPa", es);
 
   // Calculate absolute humidity
   const float absolute_humidity = vapor_density(es, hr, temperature_k);
 
+  ESP_LOGD(TAG,
+           "Saturation vapor pressure %f kPa\n"
+           "Publishing absolute humidity %f g/m³",
+           es, absolute_humidity);
+
   // Publish absolute humidity
-  ESP_LOGD(TAG, "Publishing absolute humidity %f g/m³", absolute_humidity);
   this->status_clear_warning();
   this->publish_state(absolute_humidity);
 }


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals. https://developers.esphome.io/architecture/logging/

## Benefits

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).