### PR TITLE
[ads1115] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/ads1115/sensor/ads1115_sensor.cpp
+++ b/esphome/components/ads1115/sensor/ads1115_sensor.cpp
@@ -21,10 +21,12 @@ void ADS1115Sensor::update() {
 
 void ADS1115Sensor::dump_config() {
   LOG_SENSOR("  ", "ADS1115 Sensor", this);
-  ESP_LOGCONFIG(TAG, "    Multiplexer: %u", this->multiplexer_);
-  ESP_LOGCONFIG(TAG, "    Gain: %u", this->gain_);
-  ESP_LOGCONFIG(TAG, "    Resolution: %u", this->resolution_);
-  ESP_LOGCONFIG(TAG, "    Sample rate: %u", this->samplerate_);
+  ESP_LOGCONFIG(TAG,
+                "    Multiplexer: %u\n"
+                "    Gain: %u\n"
+                "    Resolution: %u\n"
+                "    Sample rate: %u",
+                this->multiplexer_, this->gain_, this->resolution_, this->samplerate_);
 }
 
 }  // namespace ads1115


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
