### PR TITLE
[as3935] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -305,12 +305,14 @@ bool AS3935Component::calibrate_oscillator() {
 }
 
 void AS3935Component::tune_antenna() {
-  ESP_LOGI(TAG, "Starting antenna tuning");
   uint8_t div_ratio = this->read_div_ratio();
   uint8_t tune_val = this->read_capacitance();
-  ESP_LOGI(TAG, "Division Ratio is set to: %d", div_ratio);
-  ESP_LOGI(TAG, "Internal Capacitor is set to: %d", tune_val);
-  ESP_LOGI(TAG, "Displaying oscillator on INT pin. Measure its frequency - multiply value by Division Ratio");
+  ESP_LOGI(TAG,
+           "Starting antenna tuning\n"
+           "Division Ratio is set to: %d\n"
+           "Internal Capacitor is set to: %d\n"
+           "Displaying oscillator on INT pin. Measure its frequency - multiply value by Division Ratio",
+           div_ratio, tune_val);
   this->display_oscillator(true, ANTFREQ);
 }
 


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
