### PR TITLE
[esp32] Move heap functions to flash, saving ~6KB

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -644,6 +644,7 @@ CONF_DISABLE_VFS_SUPPORT_SELECT = "disable_vfs_support_select"
 CONF_DISABLE_VFS_SUPPORT_DIR = "disable_vfs_support_dir"
 CONF_FREERTOS_IN_IRAM = "freertos_in_iram"
 CONF_RINGBUF_IN_IRAM = "ringbuf_in_iram"
+CONF_HEAP_IN_IRAM = "heap_in_iram"
 CONF_LOOP_TASK_STACK_SIZE = "loop_task_stack_size"
 
 # VFS requirement tracking
@@ -745,6 +746,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_VFS_SUPPORT_DIR, default=True): cv.boolean,
                 cv.Optional(CONF_FREERTOS_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_RINGBUF_IN_IRAM, default=False): cv.boolean,
+                cv.Optional(CONF_HEAP_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_EXECUTE_FROM_PSRAM, default=False): cv.boolean,
                 cv.Optional(CONF_LOOP_TASK_STACK_SIZE, default=8192): cv.int_range(
                     min=8192, max=32768
@@ -1089,6 +1091,12 @@ async def to_code(config):
     else:
         # Place in flash to save IRAM (default)
         add_idf_sdkconfig_option("CONFIG_RINGBUF_PLACE_FUNCTIONS_INTO_FLASH", True)
+
+    # Place heap functions into flash to save IRAM (~4-6KB savings)
+    # Safe as long as heap functions are not called from ISRs (which they shouldn't be)
+    # Users can set heap_in_iram: true as an escape hatch if needed
+    if not conf[CONF_ADVANCED][CONF_HEAP_IN_IRAM]:
+        add_idf_sdkconfig_option("CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH", True)
 
     # Setup watchdog
     add_idf_sdkconfig_option("CONFIG_ESP_TASK_WDT", True)


### PR DESCRIPTION
# What does this implement/fix?

This is the culmination of months of work to reduce heap churn throughout the ESPHome codebase. By systematically eliminating unnecessary dynamic allocations, we've reached a point where heap functions are called so infrequently that they can safely be moved from IRAM to flash - unlocking ~6 KB of additional heap memory essentially for free.

## Background

Over the past several months, we've made extensive optimizations to reduce heap churn:

- Introduced `StaticVector` and `FixedVector` to replace `std::vector` where sizes are known
- Replaced `std::string` with `const char*` for static strings
- Pre-allocated buffers instead of dynamic allocation in hot paths
- Moved to stack allocation where possible
- Eliminated temporary allocations in loops
- Audio/video components use pre-allocated ring buffers, not dynamic allocation during streaming

The result: heap functions (malloc, free, realloc) are now primarily called during setup, not during normal operation. This makes the performance difference between IRAM and flash access negligible.

Even without the heap churn reduction work, the impact would be minimal - the overhead only occurs on cache misses, and with heavy heap usage the functions would likely stay cached anyway.

## The Optimization

Enable `CONFIG_HEAP_PLACE_FUNCTION_INTO_FLASH` by default, moving heap functions from IRAM to flash.

This is safe because:
1. Heap functions should never be called from ISRs (and ESPHome doesn't do this)
2. `CONFIG_SPI_MASTER_ISR_IN_IRAM` is not enabled
3. The heap churn reduction work means allocations are infrequent

**Measured results:**
- Heap free before: 315,596 bytes
- Heap free after: 321,720 bytes
- **Savings: +6,124 bytes (~6 KB)**

An `advanced: heap_in_iram` escape hatch is provided for users who need heap functions in IRAM for specific use cases.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5851

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default behavior - heap functions in flash (recommended)
esp32:
  board: esp32dev
  framework:
    type: esp-idf

# Escape hatch - keep heap functions in IRAM if needed
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      heap_in_iram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
