### PR TITLE
[esp32_ble_tracker] Make start_scan action idempotent

### DIFF
--- a/esphome/components/esp32_ble_tracker/automation.h
+++ b/esphome/components/esp32_ble_tracker/automation.h
@@ -99,8 +99,9 @@ template<typename... Ts> class ESP32BLEStartScanAction : public Action<Ts...> {
   void play(const Ts &...x) override {
     this->parent_->set_scan_continuous(this->continuous_.value(x...));
     // Only call start_scan() if scanner is IDLE
-    // For other states (STARTING, RUNNING, STOPPING, FAILED), the state machine
-    // will handle restarting when appropriate based on the continuous flag
+    // For other states (STARTING, RUNNING, STOPPING, FAILED), the normal state
+    // machine flow will eventually transition back to IDLE, at which point
+    // loop() will see scan_continuous_ and restart scanning if it is true.
     if (this->parent_->get_scanner_state() == ScannerState::IDLE) {
       this->parent_->start_scan();
     }

--- a/esphome/components/esp32_ble_tracker/automation.h
+++ b/esphome/components/esp32_ble_tracker/automation.h
@@ -98,7 +98,12 @@ template<typename... Ts> class ESP32BLEStartScanAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(bool, continuous)
   void play(const Ts &...x) override {
     this->parent_->set_scan_continuous(this->continuous_.value(x...));
-    this->parent_->start_scan();
+    // Only call start_scan() if scanner is IDLE
+    // For other states (STARTING, RUNNING, STOPPING, FAILED), the state machine
+    // will handle restarting when appropriate based on the continuous flag
+    if (this->parent_->get_scanner_state() == ScannerState::IDLE) {
+      this->parent_->start_scan();
+    }
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `esp32_ble_tracker.start_scan` action to be idempotent by checking the scanner state before calling `start_scan()`.

Previously, when multiple API clients connected (e.g., Home Assistant and ESPHome CLI), the `on_client_connected` automation would fire for each client, causing multiple calls to `start_scan()`. The second call would fail with:

```
[E][esp32_ble_tracker:864]: Unexpected state: RUNNING on start scan, expected: IDLE
```

The fix updates the action to only call `start_scan()` when the scanner is in IDLE state. For other states (STARTING, RUNNING, STOPPING, FAILED), the continuous flag is still updated, and the state machine will handle restarting when appropriate.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None (discovered during testing)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration would trigger the bug when multiple API clients connect
api:
  on_client_connected:
    then:
      - esp32_ble_tracker.start_scan:
          continuous: true
  on_client_disconnected:
    then:
      - if:
          condition:
            not:
              api.connected:
          then:
            - esp32_ble_tracker.stop_scan: {}

esp32_ble_tracker:
  scan_parameters:
    continuous: false  # Initially disabled, enabled when API client connects

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
