### PR TITLE
[debug] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/debug/debug_esp8266.cpp
+++ b/esphome/components/debug/debug_esp8266.cpp
@@ -47,14 +47,17 @@ void DebugComponent::get_device_info_(std::string &device_info) {
 
 #if !defined(CLANG_TIDY)
   auto reset_reason = get_reset_reason_();
-  ESP_LOGD(TAG, "Chip ID: 0x%08X", ESP.getChipId());
-  ESP_LOGD(TAG, "SDK Version: %s", ESP.getSdkVersion());
-  ESP_LOGD(TAG, "Core Version: %s", ESP.getCoreVersion().c_str());
-  ESP_LOGD(TAG, "Boot Version=%u Mode=%u", ESP.getBootVersion(), ESP.getBootMode());
-  ESP_LOGD(TAG, "CPU Frequency: %u", ESP.getCpuFreqMHz());
-  ESP_LOGD(TAG, "Flash Chip ID=0x%08X", ESP.getFlashChipId());
-  ESP_LOGD(TAG, "Reset Reason: %s", reset_reason.c_str());
-  ESP_LOGD(TAG, "Reset Info: %s", ESP.getResetInfo().c_str());
+  ESP_LOGD(TAG,
+           "Chip ID: 0x%08X\n"
+           "SDK Version: %s\n"
+           "Core Version: %s\n"
+           "Boot Version=%u Mode=%u\n"
+           "CPU Frequency: %u\n"
+           "Flash Chip ID=0x%08X\n"
+           "Reset Reason: %s\n"
+           "Reset Info: %s",
+           ESP.getChipId(), ESP.getSdkVersion(), ESP.getCoreVersion().c_str(), ESP.getBootVersion(), ESP.getBootMode(),
+           ESP.getCpuFreqMHz(), ESP.getFlashChipId(), reset_reason.c_str(), ESP.getResetInfo().c_str());
 
   device_info += "|Chip: 0x" + format_hex(ESP.getChipId());
   device_info += "|SDK: ";

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -13,12 +13,15 @@ uint32_t DebugComponent::get_free_heap_() { return lt_heap_get_free(); }
 
 void DebugComponent::get_device_info_(std::string &device_info) {
   std::string reset_reason = get_reset_reason_();
-  ESP_LOGD(TAG, "LibreTiny Version: %s", lt_get_version());
-  ESP_LOGD(TAG, "Chip: %s (%04x) @ %u MHz", lt_cpu_get_model_name(), lt_cpu_get_model(), lt_cpu_get_freq_mhz());
-  ESP_LOGD(TAG, "Chip ID: 0x%06X", lt_cpu_get_mac_id());
-  ESP_LOGD(TAG, "Board: %s", lt_get_board_code());
-  ESP_LOGD(TAG, "Flash: %u KiB / RAM: %u KiB", lt_flash_get_size() / 1024, lt_ram_get_size() / 1024);
-  ESP_LOGD(TAG, "Reset Reason: %s", reset_reason.c_str());
+  ESP_LOGD(TAG,
+           "LibreTiny Version: %s\n"
+           "Chip: %s (%04x) @ %u MHz\n"
+           "Chip ID: 0x%06X\n"
+           "Board: %s\n"
+           "Flash: %u KiB / RAM: %u KiB\n"
+           "Reset Reason: %s",
+           lt_get_version(), lt_cpu_get_model_name(), lt_cpu_get_model(), lt_cpu_get_freq_mhz(), lt_cpu_get_mac_id(),
+           lt_get_board_code(), lt_flash_get_size() / 1024, lt_ram_get_size() / 1024, reset_reason.c_str());
 
   device_info += "|Version: ";
   device_info += LT_BANNER_STR + 10;

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -106,13 +106,13 @@ static void fa_cb(const struct flash_area *fa, void *user_data) {
 void DebugComponent::log_partition_info_() {
 #if CONFIG_FLASH_MAP_LABELS
   ESP_LOGCONFIG(TAG, "ID | Device     | Device Name               "
-                     "| Label                   | Offset     | Size");
-  ESP_LOGCONFIG(TAG, "--------------------------------------------"
+                     "| Label                   | Offset     | Size\n"
+                     "--------------------------------------------"
                      "-----------------------------------------------");
 #else
   ESP_LOGCONFIG(TAG, "ID | Device     | Device Name               "
-                     "| Offset     | Size");
-  ESP_LOGCONFIG(TAG, "-----------------------------------------"
+                     "| Offset     | Size\n"
+                     "-----------------------------------------"
                      "------------------------------");
 #endif
   flash_area_foreach(fa_cb, nullptr);
@@ -300,18 +300,18 @@ void DebugComponent::get_device_info_(std::string &device_info) {
     return "Unspecified";
   };
 
-  ESP_LOGD(TAG, "Code page size: %u, code size: %u, device id: 0x%08x%08x", NRF_FICR->CODEPAGESIZE, NRF_FICR->CODESIZE,
-           NRF_FICR->DEVICEID[1], NRF_FICR->DEVICEID[0]);
-  ESP_LOGD(TAG, "Encryption root: 0x%08x%08x%08x%08x, Identity Root: 0x%08x%08x%08x%08x", NRF_FICR->ER[0],
+  ESP_LOGD(TAG,
+           "Code page size: %u, code size: %u, device id: 0x%08x%08x\n"
+           "Encryption root: 0x%08x%08x%08x%08x, Identity Root: 0x%08x%08x%08x%08x\n"
+           "Device address type: %s, address: %s\n"
+           "Part code: nRF%x, version: %c%c%c%c, package: %s\n"
+           "RAM: %ukB, Flash: %ukB, production test: %sdone",
+           NRF_FICR->CODEPAGESIZE, NRF_FICR->CODESIZE, NRF_FICR->DEVICEID[1], NRF_FICR->DEVICEID[0], NRF_FICR->ER[0],
            NRF_FICR->ER[1], NRF_FICR->ER[2], NRF_FICR->ER[3], NRF_FICR->IR[0], NRF_FICR->IR[1], NRF_FICR->IR[2],
-           NRF_FICR->IR[3]);
-  ESP_LOGD(TAG, "Device address type: %s, address: %s", (NRF_FICR->DEVICEADDRTYPE & 0x1 ? "Random" : "Public"),
-           get_mac_address_pretty().c_str());
-  ESP_LOGD(TAG, "Part code: nRF%x, version: %c%c%c%c, package: %s", NRF_FICR->INFO.PART,
-           NRF_FICR->INFO.VARIANT >> 24 & 0xFF, NRF_FICR->INFO.VARIANT >> 16 & 0xFF, NRF_FICR->INFO.VARIANT >> 8 & 0xFF,
-           NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE));
-  ESP_LOGD(TAG, "RAM: %ukB, Flash: %ukB, production test: %sdone", NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH,
-           (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
+           NRF_FICR->IR[3], (NRF_FICR->DEVICEADDRTYPE & 0x1 ? "Random" : "Public"), get_mac_address_pretty().c_str(),
+           NRF_FICR->INFO.PART, NRF_FICR->INFO.VARIANT >> 24 & 0xFF, NRF_FICR->INFO.VARIANT >> 16 & 0xFF,
+           NRF_FICR->INFO.VARIANT >> 8 & 0xFF, NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE),
+           NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH, (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
   bool n_reset_enabled = NRF_UICR->PSELRESET[0] == NRF_UICR->PSELRESET[1] &&
                          (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) == UICR_PSELRESET_CONNECT_Connected
                                                                                       << UICR_PSELRESET_CONNECT_Pos;
@@ -329,9 +329,10 @@ void DebugComponent::get_device_info_(std::string &device_info) {
 #else
   ESP_LOGD(TAG, "bootloader: Adafruit, version %u.%u.%u", (BOOTLOADER_VERSION_REGISTER >> 16) & 0xFF,
            (BOOTLOADER_VERSION_REGISTER >> 8) & 0xFF, BOOTLOADER_VERSION_REGISTER & 0xFF);
-  ESP_LOGD(TAG, "MBR bootloader addr 0x%08x, UICR bootloader addr 0x%08x", read_mem_u32(MBR_BOOTLOADER_ADDR),
-           NRF_UICR->NRFFW[0]);
-  ESP_LOGD(TAG, "MBR param page addr 0x%08x, UICR param page addr 0x%08x", read_mem_u32(MBR_PARAM_PAGE_ADDR),
+  ESP_LOGD(TAG,
+           "MBR bootloader addr 0x%08x, UICR bootloader addr 0x%08x\n"
+           "MBR param page addr 0x%08x, UICR param page addr 0x%08x",
+           read_mem_u32(MBR_BOOTLOADER_ADDR), NRF_UICR->NRFFW[0], read_mem_u32(MBR_PARAM_PAGE_ADDR),
            NRF_UICR->NRFFW[1]);
   if (is_sd_present()) {
     uint32_t const sd_id = sd_id_get();
@@ -368,8 +369,10 @@ void DebugComponent::get_device_info_(std::string &device_info) {
     }
     return res;
   };
-  ESP_LOGD(TAG, "NRFFW %s", uicr(NRF_UICR->NRFFW, 13).c_str());
-  ESP_LOGD(TAG, "NRFHW %s", uicr(NRF_UICR->NRFHW, 12).c_str());
+  ESP_LOGD(TAG,
+           "NRFFW %s\n"
+           "NRFHW %s",
+           uicr(NRF_UICR->NRFFW, 13).c_str(), uicr(NRF_UICR->NRFHW, 12).c_str());
 }
 
 void DebugComponent::update_platform_() {}


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
