### PR TITLE
[dfrobot_sen0395] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/dfrobot_sen0395/commands.cpp
+++ b/esphome/components/dfrobot_sen0395/commands.cpp
@@ -179,8 +179,10 @@ uint8_t DetRangeCfgCommand::on_message(std::string &message) {
     ESP_LOGE(TAG, "Cannot configure range config. Sensor is not stopped!");
     return 1;  // Command done
   } else if (message == "Done") {
-    ESP_LOGI(TAG, "Updated detection area config:");
-    ESP_LOGI(TAG, "Detection area 1 from %.02fm to %.02fm.", this->min1_, this->max1_);
+    ESP_LOGI(TAG,
+             "Updated detection area config:\n"
+             "Detection area 1 from %.02fm to %.02fm.",
+             this->min1_, this->max1_);
     if (this->min2_ >= 0 && this->max2_ >= 0) {
       ESP_LOGI(TAG, "Detection area 2 from %.02fm to %.02fm.", this->min2_, this->max2_);
     }
@@ -209,9 +211,11 @@ uint8_t SetLatencyCommand::on_message(std::string &message) {
     ESP_LOGE(TAG, "Cannot configure output latency. Sensor is not stopped!");
     return 1;  // Command done
   } else if (message == "Done") {
-    ESP_LOGI(TAG, "Updated output latency config:");
-    ESP_LOGI(TAG, "Signal that someone was detected is delayed by %.03f s.", this->delay_after_detection_);
-    ESP_LOGI(TAG, "Signal that nobody is detected anymore is delayed by %.03f s.", this->delay_after_disappear_);
+    ESP_LOGI(TAG,
+             "Updated output latency config:\n"
+             "Signal that someone was detected is delayed by %.03f s.\n"
+             "Signal that nobody is detected anymore is delayed by %.03f s.",
+             this->delay_after_detection_, this->delay_after_disappear_);
     ESP_LOGD(TAG, "Used command: %s", this->cmd_.c_str());
     return 1;  // Command done
   }


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
