### PR TITLE
[emmeti] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/emmeti/emmeti.cpp
+++ b/esphome/components/emmeti/emmeti.cpp
@@ -153,8 +153,10 @@ void EmmetiClimate::reverse_add_(T val, size_t len, esphome::remote_base::Remote
 
 bool EmmetiClimate::check_checksum_(uint8_t checksum) {
   uint8_t expected = this->gen_checksum_();
-  ESP_LOGV(TAG, "Expected checksum: %X", expected);
-  ESP_LOGV(TAG, "Checksum received: %X", checksum);
+  ESP_LOGV(TAG,
+           "Expected checksum: %X\n"
+           "Checksum received: %X",
+           expected, checksum);
 
   return checksum == expected;
 }
@@ -264,8 +266,10 @@ bool EmmetiClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
   }
 
-  ESP_LOGD(TAG, "Swing: %d", (curr_state.bitmap >> 1) & 0x01);
-  ESP_LOGD(TAG, "Sleep: %d", (curr_state.bitmap >> 2) & 0x01);
+  ESP_LOGD(TAG,
+           "Swing: %d\n"
+           "Sleep: %d",
+           (curr_state.bitmap >> 1) & 0x01, (curr_state.bitmap >> 2) & 0x01);
 
   for (size_t pos = 0; pos < 4; pos++) {
     if (data.expect_item(EMMETI_BIT_MARK, EMMETI_ONE_SPACE)) {
@@ -291,10 +295,13 @@ bool EmmetiClimate::on_receive(remote_base::RemoteReceiveData data) {
     }
   }
 
-  ESP_LOGD(TAG, "Turbo: %d", (curr_state.bitmap >> 3) & 0x01);
-  ESP_LOGD(TAG, "Light: %d", (curr_state.bitmap >> 4) & 0x01);
-  ESP_LOGD(TAG, "Tree: %d", (curr_state.bitmap >> 5) & 0x01);
-  ESP_LOGD(TAG, "Blow: %d", (curr_state.bitmap >> 6) & 0x01);
+  ESP_LOGD(TAG,
+           "Turbo: %d\n"
+           "Light: %d\n"
+           "Tree: %d\n"
+           "Blow: %d",
+           (curr_state.bitmap >> 3) & 0x01, (curr_state.bitmap >> 4) & 0x01, (curr_state.bitmap >> 5) & 0x01,
+           (curr_state.bitmap >> 6) & 0x01);
 
   uint16_t control_data = 0;
   for (size_t pos = 0; pos < 11; pos++) {


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
