### PR TITLE
[esp_ldo] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/esp_ldo/esp_ldo.cpp
+++ b/esphome/components/esp_ldo/esp_ldo.cpp
@@ -21,9 +21,11 @@ void EspLdo::setup() {
   }
 }
 void EspLdo::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP LDO Channel %d:", this->channel_);
-  ESP_LOGCONFIG(TAG, "  Voltage: %fV", this->voltage_);
-  ESP_LOGCONFIG(TAG, "  Adjustable: %s", YESNO(this->adjustable_));
+  ESP_LOGCONFIG(TAG,
+                "ESP LDO Channel %d:\n"
+                "  Voltage: %fV\n"
+                "  Adjustable: %s",
+                this->channel_, this->voltage_, YESNO(this->adjustable_));
 }
 
 void EspLdo::adjust_voltage(float voltage) {


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
