### PR TITLE
[esp32][libretiny] Reuse preference buffer to avoid heap churn

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -23,7 +23,7 @@ struct NVSData {
   size_t len;
 
   void set_data(const uint8_t *src, size_t size) {
-    if (this->len != size) {
+    if (!this->data || this->len != size) {
       this->data = std::make_unique<uint8_t[]>(size);
       this->len = size;
     }

--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -23,9 +23,11 @@ struct NVSData {
   size_t len;
 
   void set_data(const uint8_t *src, size_t size) {
-    this->data = std::make_unique<uint8_t[]>(size);
+    if (this->len != size) {
+      this->data = std::make_unique<uint8_t[]>(size);
+      this->len = size;
+    }
     memcpy(this->data.get(), src, size);
-    this->len = size;
   }
 };
 

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -22,7 +22,7 @@ struct NVSData {
   size_t len;
 
   void set_data(const uint8_t *src, size_t size) {
-    if (this->len != size) {
+    if (!this->data || this->len != size) {
       this->data = std::make_unique<uint8_t[]>(size);
       this->len = size;
     }

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -22,9 +22,11 @@ struct NVSData {
   size_t len;
 
   void set_data(const uint8_t *src, size_t size) {
-    this->data = std::make_unique<uint8_t[]>(size);
+    if (this->len != size) {
+      this->data = std::make_unique<uint8_t[]>(size);
+      this->len = size;
+    }
     memcpy(this->data.get(), src, size);
-    this->len = size;
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Reuse preference data buffer when the same key is saved multiple times between sync cycles, eliminating unnecessary heap allocations.

## Problem

When a preference is saved multiple times before `sync()` is called (e.g., `total_daily_energy` saving on every sensor update, or lights saving state during animations), `set_data()` was allocating a new buffer every time, even though the size never changes for a given preference key.

## Solution

Check if the existing buffer is the correct size before allocating. Since preference sizes are fixed per key, this eliminates all intermediate allocations:

```cpp
void set_data(const uint8_t *src, size_t size) {
  if (this->len != size) {
    this->data = std::make_unique<uint8_t[]>(size);
    this->len = size;
  }
  memcpy(this->data.get(), src, size);
}
```

## Impact

Tested with a config where a light preference saves ~1/second during startup animation:
- **Before**: 60 alloc + 59 free cycles per sync window (60 sec default)
- **After**: 1 allocation per sync window

This reduces heap fragmentation on memory-constrained devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [x] BK72xx
- [ ] RTL87xx
- [ ] RP2040
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
