### PR TITLE
[esp32_ble] Remove requirement for configured network

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -22,7 +22,6 @@ from esphome.core import CORE, CoroPriority, TimePeriod, coroutine_with_priority
 import esphome.final_validate as fv
 
 DEPENDENCIES = ["esp32"]
-AUTO_LOAD = ["socket"]
 CODEOWNERS = ["@jesserockz", "@Rapsssito", "@bdraco"]
 DOMAIN = "esp32_ble"
 

--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -58,7 +58,7 @@ def require_wake_loop_threadsafe() -> None:
     """
 
     # Only set up once (idempotent - multiple components can call this)
-    if ("wifi" in CORE.config or "ethernet" in CORE.config) and not CORE.data.get(
+    if CORE.has_networking and not CORE.data.get(
         KEY_WAKE_LOOP_THREADSAFE_REQUIRED, False
     ):
         CORE.data[KEY_WAKE_LOOP_THREADSAFE_REQUIRED] = True

--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -47,6 +47,8 @@ def require_wake_loop_threadsafe() -> None:
     This enables the shared UDP loopback socket mechanism (~208 bytes RAM).
     The socket is shared across all components that use this feature.
 
+    This call is a no-op if networking is not enabled in the configuration.
+
     IMPORTANT: This is for background thread context only, NOT ISR context.
     Socket operations are not safe to call from ISR handlers.
 

--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -56,8 +56,11 @@ def require_wake_loop_threadsafe() -> None:
         async def to_code(config):
             socket.require_wake_loop_threadsafe()
     """
+
     # Only set up once (idempotent - multiple components can call this)
-    if not CORE.data.get(KEY_WAKE_LOOP_THREADSAFE_REQUIRED, False):
+    if ("wifi" in CORE.config or "ethernet" in CORE.config) and not CORE.data.get(
+        KEY_WAKE_LOOP_THREADSAFE_REQUIRED, False
+    ):
         CORE.data[KEY_WAKE_LOOP_THREADSAFE_REQUIRED] = True
         cg.add_define("USE_WAKE_LOOP_THREADSAFE")
         # Consume 1 socket for the shared wake notification socket

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -721,6 +721,25 @@ class EsphomeCore:
     def config_filename(self) -> str:
         return self.config_path.name
 
+    def has_at_least_one_component(self, *components: str) -> bool:
+        """
+        Are any of the given components configured?
+        :param components: component names
+        :return: true if so
+        """
+        if self.config is None:
+            raise ValueError("Config has not been loaded yet")
+
+        return any(component in self.config for component in components)
+
+    @property
+    def has_networking(self) -> bool:
+        """
+        Is a network component configured?
+        :return: true if so
+        """
+        return self.has_at_least_one_component("wifi", "ethernet", "openthread")
+
     def relative_config_path(self, *path: str | Path) -> Path:
         path_ = Path(*path).expanduser()
         return self.config_dir / path_

--- a/tests/components/socket/test_wake_loop_threadsafe.py
+++ b/tests/components/socket/test_wake_loop_threadsafe.py
@@ -43,3 +43,35 @@ def test_require_wake_loop_threadsafe__multiple_calls() -> None:
 
     # Verify the define was added (only once, but we can just check it exists)
     assert any(d.name == "USE_WAKE_LOOP_THREADSAFE" for d in CORE.defines)
+
+
+def test_require_wake_loop_threadsafe__no_networking() -> None:
+    """Test that wake loop is NOT configured when no networking is configured."""
+    # Set up config without any networking components
+    CORE.config = {"esphome": {"name": "test"}, "logger": {}}
+
+    # Call require_wake_loop_threadsafe
+    socket.require_wake_loop_threadsafe()
+
+    # Verify CORE.data flag was NOT set (since has_networking returns False)
+    assert socket.KEY_WAKE_LOOP_THREADSAFE_REQUIRED not in CORE.data
+
+    # Verify the define was NOT added
+    assert not any(d.name == "USE_WAKE_LOOP_THREADSAFE" for d in CORE.defines)
+
+
+def test_require_wake_loop_threadsafe__no_networking_does_not_consume_socket() -> None:
+    """Test that no socket is consumed when no networking is configured."""
+    # Set up config without any networking components
+    CORE.config = {"logger": {}}
+
+    # Track initial socket consumer state
+    initial_consumers = CORE.data.get(socket.KEY_SOCKET_CONSUMERS, {})
+
+    # Call require_wake_loop_threadsafe
+    socket.require_wake_loop_threadsafe()
+
+    # Verify no socket was consumed
+    consumers = CORE.data.get(socket.KEY_SOCKET_CONSUMERS, {})
+    assert "socket.wake_loop_threadsafe" not in consumers
+    assert consumers == initial_consumers

--- a/tests/components/socket/test_wake_loop_threadsafe.py
+++ b/tests/components/socket/test_wake_loop_threadsafe.py
@@ -4,6 +4,7 @@ from esphome.core import CORE
 
 def test_require_wake_loop_threadsafe__first_call() -> None:
     """Test that first call sets up define and consumes socket."""
+    CORE.config = {"wifi": True}
     socket.require_wake_loop_threadsafe()
 
     # Verify CORE.data was updated
@@ -17,6 +18,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
     """Test that subsequent calls are idempotent."""
     # Set up initial state as if already called
     CORE.data[socket.KEY_WAKE_LOOP_THREADSAFE_REQUIRED] = True
+    CORE.config = {"wifi": True}
 
     # Call again - should not raise or fail
     socket.require_wake_loop_threadsafe()
@@ -31,6 +33,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
 def test_require_wake_loop_threadsafe__multiple_calls() -> None:
     """Test that multiple calls only set up once."""
     # Call three times
+    CORE.config = {"wifi": True}
     socket.require_wake_loop_threadsafe()
     socket.require_wake_loop_threadsafe()
     socket.require_wake_loop_threadsafe()

--- a/tests/components/socket/test_wake_loop_threadsafe.py
+++ b/tests/components/socket/test_wake_loop_threadsafe.py
@@ -18,7 +18,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
     """Test that subsequent calls are idempotent."""
     # Set up initial state as if already called
     CORE.data[socket.KEY_WAKE_LOOP_THREADSAFE_REQUIRED] = True
-    CORE.config = {"wifi": True}
+    CORE.config = {"ethernet": True}
 
     # Call again - should not raise or fail
     socket.require_wake_loop_threadsafe()
@@ -33,7 +33,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
 def test_require_wake_loop_threadsafe__multiple_calls() -> None:
     """Test that multiple calls only set up once."""
     # Call three times
-    CORE.config = {"wifi": True}
+    CORE.config = {"openthread": True}
     socket.require_wake_loop_threadsafe()
     socket.require_wake_loop_threadsafe()
     socket.require_wake_loop_threadsafe()

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -718,3 +718,65 @@ class TestEsphomeCore:
         # Even though "web_server" is in loaded_integrations due to the platform,
         # web_port must return None because the full web_server component is not configured
         assert target.web_port is None
+
+    def test_has_at_least_one_component__none_configured(self, target):
+        """Test has_at_least_one_component returns False when none of the components are configured."""
+        target.config = {const.CONF_ESPHOME: {"name": "test"}, "logger": {}}
+
+        assert target.has_at_least_one_component("wifi", "ethernet") is False
+
+    def test_has_at_least_one_component__one_configured(self, target):
+        """Test has_at_least_one_component returns True when one component is configured."""
+        target.config = {const.CONF_WIFI: {}, "logger": {}}
+
+        assert target.has_at_least_one_component("wifi", "ethernet") is True
+
+    def test_has_at_least_one_component__multiple_configured(self, target):
+        """Test has_at_least_one_component returns True when multiple components are configured."""
+        target.config = {
+            const.CONF_WIFI: {},
+            const.CONF_ETHERNET: {},
+            "logger": {},
+        }
+
+        assert (
+            target.has_at_least_one_component("wifi", "ethernet", "bluetooth") is True
+        )
+
+    def test_has_at_least_one_component__single_component(self, target):
+        """Test has_at_least_one_component works with a single component."""
+        target.config = {const.CONF_MQTT: {}}
+
+        assert target.has_at_least_one_component("mqtt") is True
+        assert target.has_at_least_one_component("wifi") is False
+
+    def test_has_at_least_one_component__config_not_loaded(self, target):
+        """Test has_at_least_one_component raises ValueError when config is not loaded."""
+        target.config = None
+
+        with pytest.raises(ValueError, match="Config has not been loaded yet"):
+            target.has_at_least_one_component("wifi")
+
+    def test_has_networking__with_wifi(self, target):
+        """Test has_networking returns True when wifi is configured."""
+        target.config = {const.CONF_WIFI: {}}
+
+        assert target.has_networking is True
+
+    def test_has_networking__with_ethernet(self, target):
+        """Test has_networking returns True when ethernet is configured."""
+        target.config = {const.CONF_ETHERNET: {}}
+
+        assert target.has_networking is True
+
+    def test_has_networking__with_openthread(self, target):
+        """Test has_networking returns True when openthread is configured."""
+        target.config = {const.CONF_OPENTHREAD: {}}
+
+        assert target.has_networking is True
+
+    def test_has_networking__without_networking(self, target):
+        """Test has_networking returns False when no networking component is configured."""
+        target.config = {const.CONF_ESPHOME: {"name": "test"}, "logger": {}}
+
+        assert target.has_networking is False


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `esp32_ble` component uses the threadsafe loop wake mechanism, but this is not available if no network interface is configured. Running code using `esp32_ble` results in a boot loop.

So disable the use of the wake mechanism unless a network is available.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1456993546539368511

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esphome:
  name: beacon
  friendly_name: beacon

esp32:
  board: freenove_esp32_wrover
  framework:
    type: esp-idf

# This fixes the problem. Remove this block to demonstrate the bootloop
external_components:
  - source: github://pr#12891
    components: [socket]
    refresh: 1h

# Enable logging
logger:

esp32_ble_beacon:
  type: iBeacon
  uuid: 'c29ce823-e67a-4e71-bff2-abaa32e77a98'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
