### PR TITLE
[ultrasonic] Fix timeout issues and deprecate timeout option

### DIFF
--- a/esphome/components/ultrasonic/sensor.py
+++ b/esphome/components/ultrasonic/sensor.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import sensor
@@ -10,6 +12,8 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     UNIT_METER,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_PULSE_TIME = "pulse_time"
 
@@ -30,7 +34,7 @@ CONFIG_SCHEMA = (
         {
             cv.Required(CONF_TRIGGER_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_ECHO_PIN): pins.internal_gpio_input_pin_schema,
-            cv.Optional(CONF_TIMEOUT, default="2m"): cv.distance,
+            cv.Optional(CONF_TIMEOUT): cv.distance,
             cv.Optional(
                 CONF_PULSE_TIME, default="10us"
             ): cv.positive_time_period_microseconds,
@@ -49,5 +53,11 @@ async def to_code(config):
     echo = await cg.gpio_pin_expression(config[CONF_ECHO_PIN])
     cg.add(var.set_echo_pin(echo))
 
-    cg.add(var.set_timeout_us(config[CONF_TIMEOUT] / (0.000343 / 2)))
+    # Remove before 2026.8.0
+    if CONF_TIMEOUT in config:
+        _LOGGER.warning(
+            "'timeout' option is deprecated and will be removed in 2026.8.0. "
+            "The option has no effect and can be safely removed."
+        )
+
     cg.add(var.set_pulse_time_us(config[CONF_PULSE_TIME]))

--- a/esphome/components/ultrasonic/ultrasonic_sensor.h
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.h
@@ -22,9 +22,6 @@ class UltrasonicSensorComponent : public sensor::Sensor, public PollingComponent
   void set_trigger_pin(InternalGPIOPin *trigger_pin) { this->trigger_pin_ = trigger_pin; }
   void set_echo_pin(InternalGPIOPin *echo_pin) { this->echo_pin_ = echo_pin; }
 
-  /// Set the timeout for waiting for the echo in µs.
-  void set_timeout_us(uint32_t timeout_us) { this->timeout_us_ = timeout_us; }
-
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -44,7 +41,6 @@ class UltrasonicSensorComponent : public sensor::Sensor, public PollingComponent
   ISRInternalGPIOPin trigger_pin_isr_;
   InternalGPIOPin *echo_pin_;
   UltrasonicSensorStore store_;
-  uint32_t timeout_us_{};
   uint32_t pulse_time_us_{};
 
   uint32_t measurement_start_us_{0};


### PR DESCRIPTION
## What does this implement/fix?

At least some boards have a delay of 12.3ms before sending the pulse. Now that this component is using interrupts and not busy waiting it doesn't make sense to have a configurable timeout (not saving any time). Use a fixed 80ms measurement timeout instead of the user-configurable timeout which didn't work reliably due to processing delays on the SR04.

The `timeout` option is deprecated and will be removed in 2026.8.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11177

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5856

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ultrasonic
    trigger_pin: GPIO12
    echo_pin: GPIO14
    name: "Ultrasonic Distance"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)