### PR TITLE
[lc709203f] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -146,19 +146,14 @@ void Lc709203f::update() {
 }
 
 void Lc709203f::dump_config() {
-  ESP_LOGCONFIG(TAG, "LC709203F:");
-  LOG_I2C_DEVICE(this);
-
-  LOG_UPDATE_INTERVAL(this);
   ESP_LOGCONFIG(TAG,
+                "LC709203F:\n"
                 "  Pack Size: %d mAH\n"
-                "  Pack APA: 0x%02X",
-                this->pack_size_, this->apa_);
-
-  // This is only true if the pack_voltage_ is either 0x0000 or 0x0001. The config validator
-  //  should have already verified this.
-  ESP_LOGCONFIG(TAG, "  Pack Rated Voltage: 3.%sV", this->pack_voltage_ == 0x0000 ? "8" : "7");
-
+                "  Pack APA: 0x%02X\n"
+                "  Pack Rated Voltage: 3.%sV",
+                this->pack_size_, this->apa_, this->pack_voltage_ == 0x0000 ? "8" : "7");
+  LOG_I2C_DEVICE(this);
+  LOG_UPDATE_INTERVAL(this);
   LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("  ", "Battery Remaining", this->battery_remaining_sensor_);
 


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
