### PR TITLE
[ledc] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -130,8 +130,10 @@ void LEDCOutput::setup() {
   }
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
 
-  ESP_LOGV(TAG, "Configured frequency %f with a bit depth of %u bits", this->frequency_, this->bit_depth_);
-  ESP_LOGV(TAG, "Angle of %.1f° results in hpoint %u", this->phase_angle_, hpoint);
+  ESP_LOGV(TAG,
+           "Configured frequency %f with a bit depth of %u bits\n"
+           "Angle of %.1f° results in hpoint %u",
+           this->frequency_, this->bit_depth_, this->phase_angle_, hpoint);
 
   ledc_channel_config_t chan_conf{};
   chan_conf.gpio_num = this->pin_->get_pin();
@@ -147,25 +149,30 @@ void LEDCOutput::setup() {
 }
 
 void LEDCOutput::dump_config() {
-  ESP_LOGCONFIG(TAG, "Output:");
-  LOG_PIN("  Pin ", this->pin_);
   ESP_LOGCONFIG(TAG,
+                "Output:\n"
                 "  Channel: %u\n"
                 "  PWM Frequency: %.1f Hz\n"
                 "  Phase angle: %.1f°\n"
                 "  Bit depth: %u",
                 this->channel_, this->frequency_, this->phase_angle_, this->bit_depth_);
-  ESP_LOGV(TAG, "  Max frequency for bit depth: %f", ledc_max_frequency_for_bit_depth(this->bit_depth_));
-  ESP_LOGV(TAG, "  Min frequency for bit depth: %f",
-           ledc_min_frequency_for_bit_depth(this->bit_depth_, (this->frequency_ < 100)));
-  ESP_LOGV(TAG, "  Max frequency for bit depth-1: %f", ledc_max_frequency_for_bit_depth(this->bit_depth_ - 1));
-  ESP_LOGV(TAG, "  Min frequency for bit depth-1: %f",
-           ledc_min_frequency_for_bit_depth(this->bit_depth_ - 1, (this->frequency_ < 100)));
-  ESP_LOGV(TAG, "  Max frequency for bit depth+1: %f", ledc_max_frequency_for_bit_depth(this->bit_depth_ + 1));
-  ESP_LOGV(TAG, "  Min frequency for bit depth+1: %f",
-           ledc_min_frequency_for_bit_depth(this->bit_depth_ + 1, (this->frequency_ < 100)));
-  ESP_LOGV(TAG, "  Max res bits: %d", MAX_RES_BITS);
-  ESP_LOGV(TAG, "  Clock frequency: %f", CLOCK_FREQUENCY);
+  LOG_PIN("  Pin ", this->pin_);
+  ESP_LOGV(TAG,
+           "  Max frequency for bit depth: %f\n"
+           "  Min frequency for bit depth: %f\n"
+           "  Max frequency for bit depth-1: %f\n"
+           "  Min frequency for bit depth-1: %f\n"
+           "  Max frequency for bit depth+1: %f\n"
+           "  Min frequency for bit depth+1: %f\n"
+           "  Max res bits: %d\n"
+           "  Clock frequency: %f",
+           ledc_max_frequency_for_bit_depth(this->bit_depth_),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_, (this->frequency_ < 100)),
+           ledc_max_frequency_for_bit_depth(this->bit_depth_ - 1),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_ - 1, (this->frequency_ < 100)),
+           ledc_max_frequency_for_bit_depth(this->bit_depth_ + 1),
+           ledc_min_frequency_for_bit_depth(this->bit_depth_ + 1, (this->frequency_ < 100)), MAX_RES_BITS,
+           CLOCK_FREQUENCY);
 }
 
 void LEDCOutput::update_frequency(float frequency) {


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
