### PR TITLE
[mcp3204] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/mcp3204/mcp3204.cpp
+++ b/esphome/components/mcp3204/mcp3204.cpp
@@ -11,9 +11,11 @@ float MCP3204::get_setup_priority() const { return setup_priority::HARDWARE; }
 void MCP3204::setup() { this->spi_setup(); }
 
 void MCP3204::dump_config() {
-  ESP_LOGCONFIG(TAG, "MCP3204:");
+  ESP_LOGCONFIG(TAG,
+                "MCP3204:\n"
+                "  Reference Voltage: %.2fV",
+                this->reference_voltage_);
   LOG_PIN("  CS Pin:", this->cs_);
-  ESP_LOGCONFIG(TAG, "  Reference Voltage: %.2fV", this->reference_voltage_);
 }
 
 float MCP3204::read_data(uint8_t pin, bool differential) {

--- a/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
+++ b/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
@@ -11,8 +11,10 @@ float MCP3204Sensor::get_setup_priority() const { return setup_priority::DATA; }
 
 void MCP3204Sensor::dump_config() {
   LOG_SENSOR("", "MCP3204 Sensor", this);
-  ESP_LOGCONFIG(TAG, "  Pin: %u", this->pin_);
-  ESP_LOGCONFIG(TAG, "  Differential Mode: %s", YESNO(this->differential_mode_));
+  ESP_LOGCONFIG(TAG,
+                "  Pin: %u\n"
+                "  Differential Mode: %s",
+                this->pin_, YESNO(this->differential_mode_));
   LOG_UPDATE_INTERVAL(this);
 }
 float MCP3204Sensor::sample() { return this->parent_->read_data(this->pin_, this->differential_mode_); }


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
