### PR TITLE
[sun] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/sun/sun.cpp
+++ b/esphome/components/sun/sun.cpp
@@ -172,21 +172,25 @@ struct SunAtTime {
 
   void debug() const {
     // debug output like in example 25.a, p. 165
-    ESP_LOGV(TAG, "jde: %f", jde);
-    ESP_LOGV(TAG, "T: %f", t);
-    ESP_LOGV(TAG, "L_0: %f", mean_longitude());
-    ESP_LOGV(TAG, "M: %f", mean_anomaly());
-    ESP_LOGV(TAG, "e: %f", eccentricity());
-    ESP_LOGV(TAG, "C: %f", equation_of_center());
-    ESP_LOGV(TAG, "Odot: %f", true_longitude());
-    ESP_LOGV(TAG, "Omega: %f", omega());
-    ESP_LOGV(TAG, "lambda: %f", apparent_longitude());
-    ESP_LOGV(TAG, "epsilon_0: %f", mean_obliquity());
-    ESP_LOGV(TAG, "epsilon: %f", true_obliquity());
-    ESP_LOGV(TAG, "v: %f", true_anomaly());
     auto eq = equatorial_coordinate();
-    ESP_LOGV(TAG, "right_ascension: %f", eq.right_ascension);
-    ESP_LOGV(TAG, "declination: %f", eq.declination);
+    ESP_LOGV(TAG,
+             "jde: %f\n"
+             "T: %f\n"
+             "L_0: %f\n"
+             "M: %f\n"
+             "e: %f\n"
+             "C: %f\n"
+             "Odot: %f\n"
+             "Omega: %f\n"
+             "lambda: %f\n"
+             "epsilon_0: %f\n"
+             "epsilon: %f\n"
+             "v: %f\n"
+             "right_ascension: %f\n"
+             "declination: %f",
+             jde, t, mean_longitude(), mean_anomaly(), eccentricity(), equation_of_center(), true_longitude(), omega(),
+             apparent_longitude(), mean_obliquity(), true_obliquity(), true_anomaly(), eq.right_ascension,
+             eq.declination);
   }
 };
 


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
