### PR TITLE
[voice_assistant] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -429,10 +429,12 @@ void VoiceAssistant::client_subscription(api::APIConnection *client, bool subscr
   }
 
   if (this->api_client_ != nullptr) {
-    ESP_LOGE(TAG, "Multiple API Clients attempting to connect to Voice Assistant");
-    ESP_LOGE(TAG, "Current client: %s (%s)", this->api_client_->get_name().c_str(),
-             this->api_client_->get_peername().c_str());
-    ESP_LOGE(TAG, "New client: %s (%s)", client->get_name().c_str(), client->get_peername().c_str());
+    ESP_LOGE(TAG,
+             "Multiple API Clients attempting to connect to Voice Assistant\n"
+             "Current client: %s (%s)\n"
+             "New client: %s (%s)",
+             this->api_client_->get_name().c_str(), this->api_client_->get_peername().c_str(),
+             client->get_name().c_str(), client->get_peername().c_str());
     return;
   }
 
@@ -864,9 +866,11 @@ void VoiceAssistant::on_timer_event(const api::VoiceAssistantTimerEventResponse 
       .is_active = msg.is_active,
   };
   this->timers_[timer.id] = timer;
-  ESP_LOGD(TAG, "Timer Event");
-  ESP_LOGD(TAG, "  Type: %" PRId32, msg.event_type);
-  ESP_LOGD(TAG, "  %s", timer.to_string().c_str());
+  ESP_LOGD(TAG,
+           "Timer Event\n"
+           "  Type: %" PRId32 "\n"
+           "  %s",
+           msg.event_type, timer.to_string().c_str());
 
   switch (msg.event_type) {
     case api::enums::VOICE_ASSISTANT_TIMER_STARTED:


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
