### PR TITLE
[wl_134] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/wl_134/wl_134.cpp
+++ b/esphome/components/wl_134/wl_134.cpp
@@ -68,12 +68,15 @@ Wl134Component::Rfid134Error Wl134Component::read_packet_() {
   reading.reserved1 = this->hex_lsb_ascii_to_uint64_(&(packet[RFID134_PACKET_RESERVED1]),
                                                      RFID134_PACKET_CHECKSUM - RFID134_PACKET_RESERVED1);
 
-  ESP_LOGV(TAG, "Tag id:    %012lld", reading.id);
-  ESP_LOGV(TAG, "Country:   %03d", reading.country);
-  ESP_LOGV(TAG, "isData:    %s", reading.isData ? "true" : "false");
-  ESP_LOGV(TAG, "isAnimal:  %s", reading.isAnimal ? "true" : "false");
-  ESP_LOGV(TAG, "Reserved0: %d", reading.reserved0);
-  ESP_LOGV(TAG, "Reserved1: %" PRId32, reading.reserved1);
+  ESP_LOGV(TAG,
+           "Tag id:    %012lld\n"
+           "Country:   %03d\n"
+           "isData:    %s\n"
+           "isAnimal:  %s\n"
+           "Reserved0: %d\n"
+           "Reserved1: %" PRId32,
+           reading.id, reading.country, reading.isData ? "true" : "false", reading.isAnimal ? "true" : "false",
+           reading.reserved0, reading.reserved1);
 
   char buf[20];
   sprintf(buf, "%03d%012lld", reading.country, reading.id);


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
