### PR TITLE
[pid] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -138,20 +138,21 @@ PIDAutotuner::PIDAutotuneResult PIDAutotuner::update(float setpoint, float proce
 }
 void PIDAutotuner::dump_config() {
   if (this->state_ == AUTOTUNE_SUCCEEDED) {
-    ESP_LOGI(TAG, "%s: PID Autotune:", this->id_.c_str());
-    ESP_LOGI(TAG, "  State: Succeeded!");
+    ESP_LOGI(TAG,
+             "%s: PID Autotune:\n"
+             "  State: Succeeded!",
+             this->id_.c_str());
     bool has_issue = false;
     if (!this->amplitude_detector_.is_amplitude_convergent()) {
-      ESP_LOGW(TAG, "  Could not reliably determine oscillation amplitude, PID parameters may be inaccurate!");
-      ESP_LOGW(TAG, "    Please make sure you eliminate all outside influences on the measured temperature.");
+      ESP_LOGW(TAG, "  Could not reliably determine oscillation amplitude, PID parameters may be inaccurate!\n"
+                    "    Please make sure you eliminate all outside influences on the measured temperature.");
       has_issue = true;
     }
     if (!this->frequency_detector_.is_increase_decrease_symmetrical()) {
-      ESP_LOGW(TAG, "  Oscillation Frequency is not symmetrical. PID parameters may be inaccurate!");
-      ESP_LOGW(
-          TAG,
-          "    This is usually because the heat and cool processes do not change the temperature at the same rate.");
       ESP_LOGW(TAG,
+               "  Oscillation Frequency is not symmetrical. PID parameters may be inaccurate!\n"
+               "    This is usually because the heat and cool processes do not change the temperature at the same "
+               "rate.\n"
                "    Please try reducing the positive_output value (or increase negative_output in case of a cooler)");
       has_issue = true;
     }
@@ -160,18 +161,23 @@ void PIDAutotuner::dump_config() {
     }
 
     auto fac = get_ziegler_nichols_pid_();
-    ESP_LOGI(TAG, "  Calculated PID parameters (\"Ziegler-Nichols PID\" rule):");
-    ESP_LOGI(TAG, " ");
-    ESP_LOGI(TAG, "  control_parameters:");
-    ESP_LOGI(TAG, "    kp: %.5f", fac.kp);
-    ESP_LOGI(TAG, "    ki: %.5f", fac.ki);
-    ESP_LOGI(TAG, "    kd: %.5f", fac.kd);
-    ESP_LOGI(TAG, " ");
-    ESP_LOGI(TAG, "  Please copy these values into your YAML configuration! They will reset on the next reboot.");
+    ESP_LOGI(TAG,
+             "  Calculated PID parameters (\"Ziegler-Nichols PID\" rule):\n"
+             "\n"
+             "  control_parameters:\n"
+             "    kp: %.5f\n"
+             "    ki: %.5f\n"
+             "    kd: %.5f\n"
+             "\n"
+             "  Please copy these values into your YAML configuration! They will reset on the next reboot.",
+             fac.kp, fac.ki, fac.kd);
 
-    ESP_LOGV(TAG, "  Oscillation Period: %f", this->frequency_detector_.get_mean_oscillation_period());
-    ESP_LOGV(TAG, "  Oscillation Amplitude: %f", this->amplitude_detector_.get_mean_oscillation_amplitude());
-    ESP_LOGV(TAG, "  Ku: %f, Pu: %f", this->ku_, this->pu_);
+    ESP_LOGV(TAG,
+             "  Oscillation Period: %f\n"
+             "  Oscillation Amplitude: %f\n"
+             "  Ku: %f, Pu: %f",
+             this->frequency_detector_.get_mean_oscillation_period(),
+             this->amplitude_detector_.get_mean_oscillation_amplitude(), this->ku_, this->pu_);
 
     ESP_LOGD(TAG, "  Alternative Rules:");
     // http://www.mstarlabs.com/control/znrule.html
@@ -183,13 +189,16 @@ void PIDAutotuner::dump_config() {
   }
 
   if (this->state_ == AUTOTUNE_RUNNING) {
-    ESP_LOGD(TAG, "%s: PID Autotune:", this->id_.c_str());
-    ESP_LOGD(TAG, "  Autotune is still running!");
-    ESP_LOGD(TAG, "  Status: Trying to reach %.2f °C", setpoint_ - relay_function_.current_target_error());
-    ESP_LOGD(TAG, "  Stats so far:");
-    ESP_LOGD(TAG, "    Phases: %" PRIu32, relay_function_.phase_count);
-    ESP_LOGD(TAG, "    Detected %zu zero-crossings", frequency_detector_.zerocrossing_intervals.size());
-    ESP_LOGD(TAG, "    Current Phase Min: %.2f, Max: %.2f", amplitude_detector_.phase_min,
+    ESP_LOGD(TAG,
+             "%s: PID Autotune:\n"
+             "  Autotune is still running!\n"
+             "  Status: Trying to reach %.2f °C\n"
+             "  Stats so far:\n"
+             "    Phases: %" PRIu32 "\n"
+             "    Detected %zu zero-crossings\n"
+             "    Current Phase Min: %.2f, Max: %.2f",
+             this->id_.c_str(), setpoint_ - relay_function_.current_target_error(), relay_function_.phase_count,
+             frequency_detector_.zerocrossing_intervals.size(), amplitude_detector_.phase_min,
              amplitude_detector_.phase_max);
   }
 }
@@ -205,8 +214,10 @@ PIDAutotuner::PIDResult PIDAutotuner::calculate_pid_(float kp_factor, float ki_f
 }
 void PIDAutotuner::print_rule_(const char *name, float kp_factor, float ki_factor, float kd_factor) {
   auto fac = calculate_pid_(kp_factor, ki_factor, kd_factor);
-  ESP_LOGD(TAG, "    Rule '%s':", name);
-  ESP_LOGD(TAG, "      kp: %.5f, ki: %.5f, kd: %.5f", fac.kp, fac.ki, fac.kd);
+  ESP_LOGD(TAG,
+           "    Rule '%s':\n"
+           "      kp: %.5f, ki: %.5f, kd: %.5f",
+           name, fac.kp, fac.ki, fac.kd);
 }
 
 // ================== RelayFunction ==================


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
