### PR TITLE
[pn7150] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/pn7150/pn7150.cpp
+++ b/esphome/components/pn7150/pn7150.cpp
@@ -240,8 +240,11 @@ uint8_t PN7150::reset_core_(const bool reset_config, const bool power) {
     return nfc::STATUS_FAILED;
   }
 
-  ESP_LOGD(TAG, "Configuration %s", rx.get_message()[nfc::NCI_PKT_PAYLOAD_OFFSET + 2] ? "reset" : "retained");
-  ESP_LOGD(TAG, "NCI version: %s", rx.get_message()[nfc::NCI_PKT_PAYLOAD_OFFSET + 1] == 0x20 ? "2.0" : "1.0");
+  ESP_LOGD(TAG,
+           "Configuration %s\n"
+           "NCI version: %s",
+           rx.get_message()[nfc::NCI_PKT_PAYLOAD_OFFSET + 2] ? "reset" : "retained",
+           rx.get_message()[nfc::NCI_PKT_PAYLOAD_OFFSET + 1] == 0x20 ? "2.0" : "1.0");
 
   return nfc::STATUS_OK;
 }
@@ -266,11 +269,13 @@ uint8_t PN7150::init_core_() {
   uint8_t flash_major_version = rx.get_message()[18 + rx.get_message()[8]];
   uint8_t flash_minor_version = rx.get_message()[19 + rx.get_message()[8]];
 
-  ESP_LOGD(TAG, "Manufacturer ID: 0x%02X", manf_id);
-  ESP_LOGD(TAG, "Hardware version: 0x%02X", hw_version);
-  ESP_LOGD(TAG, "ROM code version: 0x%02X", rom_code_version);
-  ESP_LOGD(TAG, "FLASH major version: 0x%02X", flash_major_version);
-  ESP_LOGD(TAG, "FLASH minor version: 0x%02X", flash_minor_version);
+  ESP_LOGD(TAG,
+           "Manufacturer ID: 0x%02X\n"
+           "Hardware version: 0x%02X\n"
+           "ROM code version: 0x%02X\n"
+           "FLASH major version: 0x%02X\n"
+           "FLASH minor version: 0x%02X",
+           manf_id, hw_version, rom_code_version, flash_major_version, flash_minor_version);
 
   return rx.get_simple_status_response();
 }
@@ -847,8 +852,8 @@ void PN7150::process_rf_intf_activated_oid_(nfc::NciMessage &rx) {  // an endpoi
 
       case EP_WRITE:
         if (this->next_task_message_to_write_ != nullptr) {
-          ESP_LOGD(TAG, "  Tag writing");
-          ESP_LOGD(TAG, "  Tag formatting");
+          ESP_LOGD(TAG, "  Tag writing\n"
+                        "  Tag formatting");
           if (this->format_endpoint_(working_endpoint.tag->get_uid()) != nfc::STATUS_OK) {
             ESP_LOGE(TAG, "  Tag could not be formatted for writing");
           } else {


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
