### PR TITLE
[pn7160] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/pn7160/pn7160.cpp
+++ b/esphome/components/pn7160/pn7160.cpp
@@ -262,9 +262,12 @@ uint8_t PN7160::reset_core_(const bool reset_config, const bool power) {
     return nfc::STATUS_FAILED;
   }
 
-  ESP_LOGD(TAG, "Configuration %s", rx.get_message()[4] ? "reset" : "retained");
-  ESP_LOGD(TAG, "NCI version: %s", rx.get_message()[5] == 0x20 ? "2.0" : "1.0");
-  ESP_LOGD(TAG, "Manufacturer ID: 0x%02X", rx.get_message()[6]);
+  ESP_LOGD(TAG,
+           "Configuration %s\n"
+           "NCI version: %s\n"
+           "Manufacturer ID: 0x%02X",
+           rx.get_message()[4] ? "reset" : "retained", rx.get_message()[5] == 0x20 ? "2.0" : "1.0",
+           rx.get_message()[6]);
   rx.get_message().erase(rx.get_message().begin(), rx.get_message().begin() + 8);
   ESP_LOGD(TAG, "Manufacturer info: %s", nfc::format_bytes(rx.get_message()).c_str());
 
@@ -291,11 +294,13 @@ uint8_t PN7160::init_core_() {
   uint8_t flash_minor_version = rx.get_message()[20 + rx.get_message()[8]];
   std::vector<uint8_t> features(rx.get_message().begin() + 4, rx.get_message().begin() + 8);
 
-  ESP_LOGD(TAG, "Hardware version: %u", hw_version);
-  ESP_LOGD(TAG, "ROM code version: %u", rom_code_version);
-  ESP_LOGD(TAG, "FLASH major version: %u", flash_major_version);
-  ESP_LOGD(TAG, "FLASH minor version: %u", flash_minor_version);
-  ESP_LOGD(TAG, "Features: %s", nfc::format_bytes(features).c_str());
+  ESP_LOGD(TAG,
+           "Hardware version: %u\n"
+           "ROM code version: %u\n"
+           "FLASH major version: %u\n"
+           "FLASH minor version: %u\n"
+           "Features: %s",
+           hw_version, rom_code_version, flash_major_version, flash_minor_version, nfc::format_bytes(features).c_str());
 
   return rx.get_simple_status_response();
 }
@@ -871,8 +876,8 @@ void PN7160::process_rf_intf_activated_oid_(nfc::NciMessage &rx) {  // an endpoi
 
       case EP_WRITE:
         if (this->next_task_message_to_write_ != nullptr) {
-          ESP_LOGD(TAG, "  Tag writing");
-          ESP_LOGD(TAG, "  Tag formatting");
+          ESP_LOGD(TAG, "  Tag writing\n"
+                        "  Tag formatting");
           if (this->format_endpoint_(working_endpoint.tag->get_uid()) != nfc::STATUS_OK) {
             ESP_LOGE(TAG, "  Tag could not be formatted for writing");
           } else {


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
