### PR TITLE
[remote_receiver] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/remote_receiver/remote_receiver.cpp
+++ b/esphome/components/remote_receiver/remote_receiver.cpp
@@ -76,9 +76,8 @@ void RemoteReceiverComponent::setup() {
 }
 
 void RemoteReceiverComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Receiver:");
-  LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG,
+                "Remote Receiver:\n"
                 "  Buffer Size: %u\n"
                 "  Tolerance: %u%s\n"
                 "  Filter out pulses shorter than: %u us\n"
@@ -86,6 +85,7 @@ void RemoteReceiverComponent::dump_config() {
                 this->buffer_size_, this->tolerance_,
                 (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%", this->filter_us_,
                 this->idle_us_);
+  LOG_PIN("  Pin: ", this->pin_);
 }
 
 void RemoteReceiverComponent::loop() {

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -117,9 +117,8 @@ void RemoteReceiverComponent::setup() {
 }
 
 void RemoteReceiverComponent::dump_config() {
-  ESP_LOGCONFIG(TAG, "Remote Receiver:");
-  LOG_PIN("  Pin: ", this->pin_);
   ESP_LOGCONFIG(TAG,
+                "Remote Receiver:\n"
                 "  Clock resolution: %" PRIu32 " hz\n"
                 "  RMT symbols: %" PRIu32 "\n"
                 "  Filter symbols: %" PRIu32 "\n"
@@ -132,6 +131,7 @@ void RemoteReceiverComponent::dump_config() {
                 this->clock_resolution_, this->rmt_symbols_, this->filter_symbols_, this->receive_symbols_,
                 this->tolerance_, (this->tolerance_mode_ == remote_base::TOLERANCE_MODE_TIME) ? " us" : "%",
                 this->carrier_frequency_, this->carrier_duty_percent_, this->filter_us_, this->idle_us_);
+  LOG_PIN("  Pin: ", this->pin_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Configuring RMT driver failed: %s (%s)", esp_err_to_name(this->error_code_),
              this->error_string_.c_str());


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
