### PR TITLE
[sht3xd] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -60,8 +60,10 @@ void SHT3XDComponent::dump_config() {
     ESP_LOGE(TAG, "  Communication with SHT3xD failed!");
     return;
   }
-  ESP_LOGD(TAG, "  Serial Number: 0x%08" PRIX32, this->serial_number_);
-  ESP_LOGD(TAG, "  Heater Enabled: %s", this->heater_enabled_ ? "true" : "false");
+  ESP_LOGD(TAG,
+           "  Serial Number: 0x%08" PRIX32 "\n"
+           "  Heater Enabled: %s",
+           this->serial_number_, this->heater_enabled_ ? "true" : "false");
 
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);

--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -63,7 +63,7 @@ void SHT3XDComponent::dump_config() {
   ESP_LOGD(TAG,
            "  Serial Number: 0x%08" PRIX32 "\n"
            "  Heater Enabled: %s",
-           this->serial_number_, this->heater_enabled_ ? "true" : "false");
+           this->serial_number_, TRUEFALSE(this->heater_enabled_));
 
   LOG_I2C_DEVICE(this);
   LOG_UPDATE_INTERVAL(this);


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
