### PR TITLE
[sonoff_d1] Combine log statements to reduce loop blocking

### DIFF
--- a/esphome/components/sonoff_d1/sonoff_d1.cpp
+++ b/esphome/components/sonoff_d1/sonoff_d1.cpp
@@ -93,8 +93,10 @@ bool SonoffD1Output::read_command_(uint8_t *cmd, size_t &len) {
   if (this->read_array(cmd, 6)) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
     char hex_buf[format_hex_pretty_size(6)];
-    ESP_LOGV(TAG, "[%04d] Reading from dimmer:", this->write_count_);
-    ESP_LOGV(TAG, "[%04d] %s", this->write_count_, format_hex_pretty_to(hex_buf, cmd, 6));
+    ESP_LOGV(TAG,
+             "[%04d] Reading from dimmer:\n"
+             "[%04d] %s",
+             this->write_count_, this->write_count_, format_hex_pretty_to(hex_buf, cmd, 6));
 #endif
 
     if (cmd[0] != 0xAA || cmd[1] != 0x55) {
@@ -188,8 +190,10 @@ bool SonoffD1Output::write_command_(uint8_t *cmd, const size_t len, bool needs_a
   do {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
     char hex_buf[format_hex_pretty_size(SONOFF_D1_MAX_CMD_SIZE)];
-    ESP_LOGV(TAG, "[%04d] Writing to the dimmer:", this->write_count_);
-    ESP_LOGV(TAG, "[%04d] %s", this->write_count_, format_hex_pretty_to(hex_buf, cmd, len));
+    ESP_LOGV(TAG,
+             "[%04d] Writing to the dimmer:\n"
+             "[%04d] %s",
+             this->write_count_, this->write_count_, format_hex_pretty_to(hex_buf, cmd, len));
 #endif
     this->write_array(cmd, len);
     this->write_count_++;


### PR DESCRIPTION
## What does this implement/fix?

Combine consecutive log statements into single calls using multi-line string literals.

Logging is one of the most intensive operations in ESPHome and blocks the event loop longer than most other operations. Each `ESP_LOG*` call involves formatting, memory allocation, serial output, and network packet transmission. Combining consecutive log statements reduces event loop blocking and the number of network packets sent to connected clients.

Note: The log processor reformats multi-line output so each line gets its own timestamp and log level prefix - the final output format is unchanged. Minor reordering of dump_config output may occur when LOG_PIN or other logging macros cannot be combined with ESP_LOG* calls - this is acceptable as it does not affect functionality.

See https://developers.esphome.io/architecture/logging/ for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
