### PR TITLE
[light] Use zero-copy set_effect overload in JSON schema parsing

### DIFF
--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -160,7 +160,7 @@ void LightJSONSchema::parse_json(LightState &state, LightCall &call, JsonObject 
 
   if (root[ESPHOME_F("effect")].is<const char *>()) {
     const char *effect = root[ESPHOME_F("effect")];
-    call.set_effect(effect);
+    call.set_effect(effect, strlen(effect));
   }
 
   if (root[ESPHOME_F("effect_index")].is<uint32_t>()) {


### PR DESCRIPTION
# What does this implement/fix?

Avoid unnecessary heap allocation when setting light effect from JSON by using the zero-copy `set_effect(const char*, size_t)` overload directly instead of relying on implicit `const char*` to `std::string` conversion.

Before this change, `call.set_effect(effect)` where `effect` is `const char*` would:
1. Create a temporary `std::string` (heap allocation for strings > 15 chars)
2. Call `set_effect(const std::string&)`
3. Which then extracts `.data()` and `.size()` to call the zero-copy version

After this change, we call `set_effect(effect, strlen(effect))` directly, bypassing the temporary string allocation entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Runtime optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
