### PR TITLE
[esp32_ble] Avoid heap allocation in ESPBTUUID::from_raw for string literals

### DIFF
--- a/esphome/components/alpha3/alpha3.h
+++ b/esphome/components/alpha3/alpha3.h
@@ -15,10 +15,8 @@ namespace alpha3 {
 namespace espbt = esphome::esp32_ble_tracker;
 
 static const espbt::ESPBTUUID ALPHA3_GENI_SERVICE_UUID = espbt::ESPBTUUID::from_uint16(0xfe5d);
-static const espbt::ESPBTUUID ALPHA3_GENI_CHARACTERISTIC_UUID =
-    espbt::ESPBTUUID::from_raw({static_cast<char>(0xa9), 0x7b, static_cast<char>(0xb8), static_cast<char>(0x85), 0x0,
-                                0x1a, 0x28, static_cast<char>(0xaa), 0x2a, 0x43, 0x6e, 0x3, static_cast<char>(0xd1),
-                                static_cast<char>(0xff), static_cast<char>(0x9c), static_cast<char>(0x85)});
+static const espbt::ESPBTUUID ALPHA3_GENI_CHARACTERISTIC_UUID = espbt::ESPBTUUID::from_raw(
+    {0xa9, 0x7b, 0xb8, 0x85, 0x00, 0x1a, 0x28, 0xaa, 0x2a, 0x43, 0x6e, 0x03, 0xd1, 0xff, 0x9c, 0x85});
 static const int16_t GENI_RESPONSE_HEADER_LENGTH = 13;
 static const size_t GENI_RESPONSE_TYPE_LENGTH = 8;
 

--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -39,36 +39,36 @@ ESPBTUUID ESPBTUUID::from_raw_reversed(const uint8_t *data) {
     ret.uuid_.uuid.uuid128[ESP_UUID_LEN_128 - 1 - i] = data[i];
   return ret;
 }
-ESPBTUUID ESPBTUUID::from_raw(const std::string &data) {
+ESPBTUUID ESPBTUUID::from_raw(const char *data, size_t length) {
   ESPBTUUID ret;
-  if (data.length() == 4) {
+  if (length == 4) {
     // 16-bit UUID as 4-character hex string
-    auto parsed = parse_hex<uint16_t>(data);
+    auto parsed = parse_hex<uint16_t>(data, length);
     if (parsed.has_value()) {
       ret.uuid_.len = ESP_UUID_LEN_16;
       ret.uuid_.uuid.uuid16 = parsed.value();
     }
-  } else if (data.length() == 8) {
+  } else if (length == 8) {
     // 32-bit UUID as 8-character hex string
-    auto parsed = parse_hex<uint32_t>(data);
+    auto parsed = parse_hex<uint32_t>(data, length);
     if (parsed.has_value()) {
       ret.uuid_.len = ESP_UUID_LEN_32;
       ret.uuid_.uuid.uuid32 = parsed.value();
     }
-  } else if (data.length() == 16) {  // how we can have 16 byte length string reprezenting 128 bit uuid??? needs to be
-                                     // investigated (lack of time)
+  } else if (length == 16) {  // how we can have 16 byte length string reprezenting 128 bit uuid??? needs to be
+                              // investigated (lack of time)
     ret.uuid_.len = ESP_UUID_LEN_128;
-    memcpy(ret.uuid_.uuid.uuid128, (uint8_t *) data.data(), 16);
-  } else if (data.length() == 36) {
+    memcpy(ret.uuid_.uuid.uuid128, reinterpret_cast<const uint8_t *>(data), 16);
+  } else if (length == 36) {
     // If the length of the string is 36 bytes then we will assume it is a long hex string in
     // UUID format.
     ret.uuid_.len = ESP_UUID_LEN_128;
     int n = 0;
-    for (uint i = 0; i < data.length(); i += 2) {
-      if (data.c_str()[i] == '-')
+    for (size_t i = 0; i < length; i += 2) {
+      if (data[i] == '-')
         i++;
-      uint8_t msb = data.c_str()[i];
-      uint8_t lsb = data.c_str()[i + 1];
+      uint8_t msb = data[i];
+      uint8_t lsb = data[i + 1];
 
       if (msb > '9')
         msb -= 7;
@@ -77,7 +77,7 @@ ESPBTUUID ESPBTUUID::from_raw(const std::string &data) {
       ret.uuid_.uuid.uuid128[15 - n++] = ((msb & 0x0F) << 4) | (lsb & 0x0F);
     }
   } else {
-    ESP_LOGE(TAG, "ERROR: UUID value not 2, 4, 16 or 36 bytes - %s", data.c_str());
+    ESP_LOGE(TAG, "ERROR: UUID value not 2, 4, 16 or 36 bytes - %s", data);
   }
   return ret;
 }

--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -4,10 +4,83 @@
 #ifdef USE_ESP32_BLE_UUID
 
 #include <cstring>
+#include <cstdio>
+#include <cinttypes>
+#include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome::esp32_ble {
 
+static const char *const TAG = "esp32_ble";
+
+ESPBTUUID::ESPBTUUID() : uuid_() {}
+ESPBTUUID ESPBTUUID::from_uint16(uint16_t uuid) {
+  ESPBTUUID ret;
+  ret.uuid_.len = ESP_UUID_LEN_16;
+  ret.uuid_.uuid.uuid16 = uuid;
+  return ret;
+}
+ESPBTUUID ESPBTUUID::from_uint32(uint32_t uuid) {
+  ESPBTUUID ret;
+  ret.uuid_.len = ESP_UUID_LEN_32;
+  ret.uuid_.uuid.uuid32 = uuid;
+  return ret;
+}
+ESPBTUUID ESPBTUUID::from_raw(const uint8_t *data) {
+  ESPBTUUID ret;
+  ret.uuid_.len = ESP_UUID_LEN_128;
+  memcpy(ret.uuid_.uuid.uuid128, data, ESP_UUID_LEN_128);
+  return ret;
+}
+ESPBTUUID ESPBTUUID::from_raw_reversed(const uint8_t *data) {
+  ESPBTUUID ret;
+  ret.uuid_.len = ESP_UUID_LEN_128;
+  for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
+    ret.uuid_.uuid.uuid128[ESP_UUID_LEN_128 - 1 - i] = data[i];
+  return ret;
+}
+ESPBTUUID ESPBTUUID::from_raw(const char *data, size_t length) {
+  ESPBTUUID ret;
+  if (length == 4) {
+    // 16-bit UUID as 4-character hex string
+    auto parsed = parse_hex<uint16_t>(data, length);
+    if (parsed.has_value()) {
+      ret.uuid_.len = ESP_UUID_LEN_16;
+      ret.uuid_.uuid.uuid16 = parsed.value();
+    }
+  } else if (length == 8) {
+    // 32-bit UUID as 8-character hex string
+    auto parsed = parse_hex<uint32_t>(data, length);
+    if (parsed.has_value()) {
+      ret.uuid_.len = ESP_UUID_LEN_32;
+      ret.uuid_.uuid.uuid32 = parsed.value();
+    }
+  } else if (length == 16) {  // how we can have 16 byte length string reprezenting 128 bit uuid??? needs to be
+                              // investigated (lack of time)
+    ret.uuid_.len = ESP_UUID_LEN_128;
+    memcpy(ret.uuid_.uuid.uuid128, reinterpret_cast<const uint8_t *>(data), 16);
+  } else if (length == 36) {
+    // If the length of the string is 36 bytes then we will assume it is a long hex string in
+    // UUID format.
+    ret.uuid_.len = ESP_UUID_LEN_128;
+    int n = 0;
+    for (size_t i = 0; i < length; i += 2) {
+      if (data[i] == '-')
+        i++;
+      uint8_t msb = data[i];
+      uint8_t lsb = data[i + 1];
+
+      if (msb > '9')
+        msb -= 7;
+      if (lsb > '9')
+        lsb -= 7;
+      ret.uuid_.uuid.uuid128[15 - n++] = ((msb & 0x0F) << 4) | (lsb & 0x0F);
+    }
+  } else {
+    ESP_LOGE(TAG, "ERROR: UUID value not 2, 4, 16 or 36 bytes - %s", data);
+  }
+  return ret;
+}
 ESPBTUUID ESPBTUUID::from_uuid(esp_bt_uuid_t uuid) {
   ESPBTUUID ret;
   ret.uuid_.len = uuid.len;

--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -4,83 +4,10 @@
 #ifdef USE_ESP32_BLE_UUID
 
 #include <cstring>
-#include <cstdio>
-#include <cinttypes>
-#include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 
 namespace esphome::esp32_ble {
 
-static const char *const TAG = "esp32_ble";
-
-ESPBTUUID::ESPBTUUID() : uuid_() {}
-ESPBTUUID ESPBTUUID::from_uint16(uint16_t uuid) {
-  ESPBTUUID ret;
-  ret.uuid_.len = ESP_UUID_LEN_16;
-  ret.uuid_.uuid.uuid16 = uuid;
-  return ret;
-}
-ESPBTUUID ESPBTUUID::from_uint32(uint32_t uuid) {
-  ESPBTUUID ret;
-  ret.uuid_.len = ESP_UUID_LEN_32;
-  ret.uuid_.uuid.uuid32 = uuid;
-  return ret;
-}
-ESPBTUUID ESPBTUUID::from_raw(const uint8_t *data) {
-  ESPBTUUID ret;
-  ret.uuid_.len = ESP_UUID_LEN_128;
-  memcpy(ret.uuid_.uuid.uuid128, data, ESP_UUID_LEN_128);
-  return ret;
-}
-ESPBTUUID ESPBTUUID::from_raw_reversed(const uint8_t *data) {
-  ESPBTUUID ret;
-  ret.uuid_.len = ESP_UUID_LEN_128;
-  for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
-    ret.uuid_.uuid.uuid128[ESP_UUID_LEN_128 - 1 - i] = data[i];
-  return ret;
-}
-ESPBTUUID ESPBTUUID::from_raw(const char *data, size_t length) {
-  ESPBTUUID ret;
-  if (length == 4) {
-    // 16-bit UUID as 4-character hex string
-    auto parsed = parse_hex<uint16_t>(data, length);
-    if (parsed.has_value()) {
-      ret.uuid_.len = ESP_UUID_LEN_16;
-      ret.uuid_.uuid.uuid16 = parsed.value();
-    }
-  } else if (length == 8) {
-    // 32-bit UUID as 8-character hex string
-    auto parsed = parse_hex<uint32_t>(data, length);
-    if (parsed.has_value()) {
-      ret.uuid_.len = ESP_UUID_LEN_32;
-      ret.uuid_.uuid.uuid32 = parsed.value();
-    }
-  } else if (length == 16) {  // how we can have 16 byte length string reprezenting 128 bit uuid??? needs to be
-                              // investigated (lack of time)
-    ret.uuid_.len = ESP_UUID_LEN_128;
-    memcpy(ret.uuid_.uuid.uuid128, reinterpret_cast<const uint8_t *>(data), 16);
-  } else if (length == 36) {
-    // If the length of the string is 36 bytes then we will assume it is a long hex string in
-    // UUID format.
-    ret.uuid_.len = ESP_UUID_LEN_128;
-    int n = 0;
-    for (size_t i = 0; i < length; i += 2) {
-      if (data[i] == '-')
-        i++;
-      uint8_t msb = data[i];
-      uint8_t lsb = data[i + 1];
-
-      if (msb > '9')
-        msb -= 7;
-      if (lsb > '9')
-        lsb -= 7;
-      ret.uuid_.uuid.uuid128[15 - n++] = ((msb & 0x0F) << 4) | (lsb & 0x0F);
-    }
-  } else {
-    ESP_LOGE(TAG, "ERROR: UUID value not 2, 4, 16 or 36 bytes - %s", data);
-  }
-  return ret;
-}
 ESPBTUUID ESPBTUUID::from_uuid(esp_bt_uuid_t uuid) {
   ESPBTUUID ret;
   ret.uuid_.len = uuid.len;

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -19,70 +19,19 @@ static constexpr size_t UUID_STR_LEN = 37;
 
 class ESPBTUUID {
  public:
-  constexpr ESPBTUUID() : uuid_{} {}
+  ESPBTUUID();
 
-  static constexpr ESPBTUUID from_uint16(uint16_t uuid) {
-    ESPBTUUID ret;
-    ret.uuid_.len = ESP_UUID_LEN_16;
-    ret.uuid_.uuid.uuid16 = uuid;
-    return ret;
-  }
+  static ESPBTUUID from_uint16(uint16_t uuid);
 
-  static constexpr ESPBTUUID from_uint32(uint32_t uuid) {
-    ESPBTUUID ret;
-    ret.uuid_.len = ESP_UUID_LEN_32;
-    ret.uuid_.uuid.uuid32 = uuid;
-    return ret;
-  }
+  static ESPBTUUID from_uint32(uint32_t uuid);
 
-  static constexpr ESPBTUUID from_raw(const uint8_t *data) {
-    ESPBTUUID ret;
-    ret.uuid_.len = ESP_UUID_LEN_128;
-    for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
-      ret.uuid_.uuid.uuid128[i] = data[i];
-    return ret;
-  }
+  static ESPBTUUID from_raw(const uint8_t *data);
+  static ESPBTUUID from_raw_reversed(const uint8_t *data);
 
-  static constexpr ESPBTUUID from_raw_reversed(const uint8_t *data) {
-    ESPBTUUID ret;
-    ret.uuid_.len = ESP_UUID_LEN_128;
-    for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
-      ret.uuid_.uuid.uuid128[ESP_UUID_LEN_128 - 1 - i] = data[i];
-    return ret;
-  }
-
-  static constexpr ESPBTUUID from_raw(const char *data, size_t length) {
-    ESPBTUUID ret;
-    if (length == 4) {
-      // 16-bit UUID as 4-character hex string
-      ret.uuid_.len = ESP_UUID_LEN_16;
-      ret.uuid_.uuid.uuid16 = parse_hex_16_(data);
-    } else if (length == 8) {
-      // 32-bit UUID as 8-character hex string
-      ret.uuid_.len = ESP_UUID_LEN_32;
-      ret.uuid_.uuid.uuid32 = parse_hex_32_(data);
-    } else if (length == 16) {
-      // 16 raw bytes
-      ret.uuid_.len = ESP_UUID_LEN_128;
-      for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
-        ret.uuid_.uuid.uuid128[i] = static_cast<uint8_t>(data[i]);
-    } else if (length == 36) {
-      // UUID format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-      ret.uuid_.len = ESP_UUID_LEN_128;
-      int n = 0;
-      for (size_t i = 0; i < 36; i += 2) {
-        if (data[i] == '-')
-          i++;
-        ret.uuid_.uuid.uuid128[15 - n++] = (parse_hex_char(data[i]) << 4) | parse_hex_char(data[i + 1]);
-      }
-    }
-    // Invalid length returns empty UUID (len=0)
-    return ret;
-  }
-
-  static constexpr ESPBTUUID from_raw(const char *data) { return from_raw(data, c_strlen_(data)); }
+  static ESPBTUUID from_raw(const char *data, size_t length);
+  static ESPBTUUID from_raw(const char *data) { return from_raw(data, strlen(data)); }
   static ESPBTUUID from_raw(const std::string &data) { return from_raw(data.c_str(), data.length()); }
-  static constexpr ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
+  static ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
 
   static ESPBTUUID from_uuid(esp_bt_uuid_t uuid);
 
@@ -100,23 +49,6 @@ class ESPBTUUID {
 
  protected:
   esp_bt_uuid_t uuid_;
-
- private:
-  static constexpr uint16_t parse_hex_16_(const char *s) {
-    return (parse_hex_char(s[0]) << 12) | (parse_hex_char(s[1]) << 8) | (parse_hex_char(s[2]) << 4) |
-           parse_hex_char(s[3]);
-  }
-
-  static constexpr uint32_t parse_hex_32_(const char *s) {
-    return (static_cast<uint32_t>(parse_hex_16_(s)) << 16) | parse_hex_16_(s + 4);
-  }
-
-  static constexpr size_t c_strlen_(const char *s) {
-    size_t len = 0;
-    while (s[len] != '\0')
-      len++;
-    return len;
-  }
 };
 
 }  // namespace esphome::esp32_ble

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -7,6 +7,7 @@
 #ifdef USE_ESP32
 #ifdef USE_ESP32_BLE_UUID
 
+#include <initializer_list>
 #include <span>
 #include <string>
 #include <esp_bt_defs.h>
@@ -27,7 +28,10 @@ class ESPBTUUID {
   static ESPBTUUID from_raw(const uint8_t *data);
   static ESPBTUUID from_raw_reversed(const uint8_t *data);
 
-  static ESPBTUUID from_raw(const std::string &data);
+  static ESPBTUUID from_raw(const char *data, size_t length);
+  static ESPBTUUID from_raw(const char *data) { return from_raw(data, strlen(data)); }
+  static ESPBTUUID from_raw(const std::string &data) { return from_raw(data.c_str(), data.length()); }
+  static ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
 
   static ESPBTUUID from_uuid(esp_bt_uuid_t uuid);
 

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -19,19 +19,70 @@ static constexpr size_t UUID_STR_LEN = 37;
 
 class ESPBTUUID {
  public:
-  ESPBTUUID();
+  constexpr ESPBTUUID() : uuid_{} {}
 
-  static ESPBTUUID from_uint16(uint16_t uuid);
+  static constexpr ESPBTUUID from_uint16(uint16_t uuid) {
+    ESPBTUUID ret;
+    ret.uuid_.len = ESP_UUID_LEN_16;
+    ret.uuid_.uuid.uuid16 = uuid;
+    return ret;
+  }
 
-  static ESPBTUUID from_uint32(uint32_t uuid);
+  static constexpr ESPBTUUID from_uint32(uint32_t uuid) {
+    ESPBTUUID ret;
+    ret.uuid_.len = ESP_UUID_LEN_32;
+    ret.uuid_.uuid.uuid32 = uuid;
+    return ret;
+  }
 
-  static ESPBTUUID from_raw(const uint8_t *data);
-  static ESPBTUUID from_raw_reversed(const uint8_t *data);
+  static constexpr ESPBTUUID from_raw(const uint8_t *data) {
+    ESPBTUUID ret;
+    ret.uuid_.len = ESP_UUID_LEN_128;
+    for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
+      ret.uuid_.uuid.uuid128[i] = data[i];
+    return ret;
+  }
 
-  static ESPBTUUID from_raw(const char *data, size_t length);
-  static ESPBTUUID from_raw(const char *data) { return from_raw(data, strlen(data)); }
+  static constexpr ESPBTUUID from_raw_reversed(const uint8_t *data) {
+    ESPBTUUID ret;
+    ret.uuid_.len = ESP_UUID_LEN_128;
+    for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
+      ret.uuid_.uuid.uuid128[ESP_UUID_LEN_128 - 1 - i] = data[i];
+    return ret;
+  }
+
+  static constexpr ESPBTUUID from_raw(const char *data, size_t length) {
+    ESPBTUUID ret;
+    if (length == 4) {
+      // 16-bit UUID as 4-character hex string
+      ret.uuid_.len = ESP_UUID_LEN_16;
+      ret.uuid_.uuid.uuid16 = parse_hex_16_(data);
+    } else if (length == 8) {
+      // 32-bit UUID as 8-character hex string
+      ret.uuid_.len = ESP_UUID_LEN_32;
+      ret.uuid_.uuid.uuid32 = parse_hex_32_(data);
+    } else if (length == 16) {
+      // 16 raw bytes
+      ret.uuid_.len = ESP_UUID_LEN_128;
+      for (uint8_t i = 0; i < ESP_UUID_LEN_128; i++)
+        ret.uuid_.uuid.uuid128[i] = static_cast<uint8_t>(data[i]);
+    } else if (length == 36) {
+      // UUID format: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ret.uuid_.len = ESP_UUID_LEN_128;
+      int n = 0;
+      for (size_t i = 0; i < 36; i += 2) {
+        if (data[i] == '-')
+          i++;
+        ret.uuid_.uuid.uuid128[15 - n++] = (parse_hex_char(data[i]) << 4) | parse_hex_char(data[i + 1]);
+      }
+    }
+    // Invalid length returns empty UUID (len=0)
+    return ret;
+  }
+
+  static constexpr ESPBTUUID from_raw(const char *data) { return from_raw(data, c_strlen_(data)); }
   static ESPBTUUID from_raw(const std::string &data) { return from_raw(data.c_str(), data.length()); }
-  static ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
+  static constexpr ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
 
   static ESPBTUUID from_uuid(esp_bt_uuid_t uuid);
 
@@ -49,6 +100,23 @@ class ESPBTUUID {
 
  protected:
   esp_bt_uuid_t uuid_;
+
+ private:
+  static constexpr uint16_t parse_hex_16_(const char *s) {
+    return (parse_hex_char(s[0]) << 12) | (parse_hex_char(s[1]) << 8) | (parse_hex_char(s[2]) << 4) |
+           parse_hex_char(s[3]);
+  }
+
+  static constexpr uint32_t parse_hex_32_(const char *s) {
+    return (static_cast<uint32_t>(parse_hex_16_(s)) << 16) | parse_hex_16_(s + 4);
+  }
+
+  static constexpr size_t c_strlen_(const char *s) {
+    size_t len = 0;
+    while (s[len] != '\0')
+      len++;
+    return len;
+  }
 };
 
 }  // namespace esphome::esp32_ble

--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -31,7 +31,9 @@ class ESPBTUUID {
   static ESPBTUUID from_raw(const char *data, size_t length);
   static ESPBTUUID from_raw(const char *data) { return from_raw(data, strlen(data)); }
   static ESPBTUUID from_raw(const std::string &data) { return from_raw(data.c_str(), data.length()); }
-  static ESPBTUUID from_raw(std::initializer_list<char> data) { return from_raw(data.begin(), data.size()); }
+  static ESPBTUUID from_raw(std::initializer_list<uint8_t> data) {
+    return from_raw(reinterpret_cast<const char *>(data.begin()), data.size());
+  }
 
   static ESPBTUUID from_uuid(esp_bt_uuid_t uuid);
 


### PR DESCRIPTION
# What does this implement/fix?

Adds `const char*` and `std::initializer_list<uint8_t>` overloads to `ESPBTUUID::from_raw()` to avoid runtime heap allocations when constructing UUIDs from string literals or raw byte initializer lists.

Previously, all string-based UUID construction went through `from_raw(const std::string&)`, which required constructing a temporary `std::string` object (heap allocation + deallocation) even for compile-time constant strings like `from_raw("00001000-bed0-0080-aa55-4265644a6574")`.

**Changes:**
- Add `from_raw(const char *data, size_t length)` as the core implementation
- Add `from_raw(const char *data)` inline overload using `strlen()` for null-terminated strings
- Add `from_raw(std::initializer_list<uint8_t>)` inline overload for raw byte lists
- Refactor `from_raw(const std::string&)` to delegate to the `(const char*, size_t)` version
- Simplify alpha3 component to use the new `uint8_t` initializer list (removes `static_cast<char>` clutter)

**Overload resolution:**
| Call pattern | Runtime heap alloc? |
|--------------|---------------------|
| `from_raw("uuid-string")` | No (was: Yes) |
| `from_raw(some_const_char_ptr)` | No (was: Yes) |
| `from_raw(std::string)` | Already allocated |
| `from_raw({0xa9, 0x7b, ...})` (uint8_t) | No |
| `from_raw({'a', 'b', ...})` (char) | Yes (via std::string) |

**Note:** This is a runtime optimization (avoids malloc/free overhead), not a code size optimization.

**Not a breaking change:** `initializer_list<char>` still works (via `std::string` overload with heap allocation). The new `uint8_t` overload is additive.

This benefits all BLE components that construct UUIDs from string literals (bedjet, pvvx_mithermometer, airthings, esp32_improv, etc.) and the alpha3 component which uses raw byte initializer lists.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any existing BLE component configuration will benefit automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
