### PR TITLE
[captive_portal] Avoid defer overhead on ESP8266 when saving WiFi credentials

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -54,8 +54,13 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
            "  SSID='%s'\n"
            "  Password=" LOG_SECRET("'%s'"),
            ssid.c_str(), psk.c_str());
+#ifdef USE_ESP8266
+  // ESP8266 is single-threaded, call directly
+  wifi::global_wifi_component->save_wifi_sta(ssid, psk);
+#else
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
   this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
+#endif
   request->redirect(ESPHOME_F("/?save"));
 }
 


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266, avoid unnecessary defer and string copies when saving WiFi credentials in the captive portal.

The defer was added in #11965 to fix thread safety issues on ESP32-IDF where `httpd` runs on a separate task and NVS operations need to happen on the main loop thread.

However, on ESP8266 with Arduino's AsyncWebServer, the HTTP handler already runs on the main loop - there's no thread safety issue and no need to defer.

By calling `save_wifi_sta()` directly on ESP8266, we avoid:
- Lambda creation overhead
- Two `std::string` copies into the lambda capture (SSID and password)
- Defer queue allocation and processing

This is particularly important on ESP8266 because unlike ESP32, the ESP8266 platform doesn't have the optimized `App.scheduler.defer()` implementation - it uses a more expensive fallback path.

**Flash savings:** 256 bytes (401,325 → 401,069)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up optimization to #11965

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - No configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
