### PR TITLE
[ci] Add LibreTiny (BK72XX) to memory impact analysis

### DIFF
--- a/esphome/analyze_memory/const.py
+++ b/esphome/analyze_memory/const.py
@@ -88,6 +88,77 @@ SYMBOL_PATTERNS = {
         "sys_mbox_new",
         "sys_arch_mbox_tryfetch",
     ],
+    # LibreTiny/Beken BK7231 radio calibration
+    "bk_radio_cal": [
+        "bk7011_",
+        "calibration_main",
+        "gcali_",
+        "rwnx_cal",
+    ],
+    # LibreTiny/Beken WiFi MAC layer
+    "bk_wifi_mac": [
+        "rxu_",  # RX upper layer
+        "txu_",  # TX upper layer
+        "txl_",  # TX lower layer
+        "rxl_",  # RX lower layer
+        "scanu_",  # Scan unit
+        "mm_hw_",  # MAC management hardware
+        "mm_bcn",  # MAC management beacon
+        "mm_tim",  # MAC management TIM
+        "mm_check",  # MAC management checks
+        "sm_connect",  # Station management
+        "me_beacon",  # Management entity beacon
+        "me_build",  # Management entity build
+        "hapd_",  # Host AP daemon
+        "chan_pre_",  # Channel management
+        "handle_probe_",  # Probe handling
+    ],
+    # LibreTiny/Beken system control
+    "bk_system": [
+        "sctrl_",  # System control
+        "icu_ctrl",  # Interrupt control unit
+        "gdma_ctrl",  # DMA control
+        "mpb_ctrl",  # MPB control
+        "uf2_",  # UF2 OTA
+        "bkreg_",  # Beken registers
+    ],
+    # LibreTiny/Beken BLE stack
+    "bk_ble": [
+        "gapc_",  # GAP client
+        "gattc_",  # GATT client
+        "attc_",  # ATT client
+        "attmdb_",  # ATT database
+        "atts_",  # ATT server
+        "l2cc_",  # L2CAP
+        "prf_env",  # Profile environment
+    ],
+    # LibreTiny/Beken scheduler
+    "bk_scheduler": [
+        "sch_plan_",  # Scheduler plan
+        "sch_prog_",  # Scheduler program
+        "sch_arb_",  # Scheduler arbiter
+    ],
+    # LibreTiny/Beken DMA descriptors
+    "bk_dma": [
+        "rx_payload_desc",
+        "rx_dma_hdrdesc",
+        "tx_hw_desc",
+        "host_event_data",
+        "host_cmd_data",
+    ],
+    # ARM EABI compiler runtime (LibreTiny uses ARM Cortex-M)
+    "arm_runtime": [
+        "__aeabi_",
+        "__adddf3",
+        "__subdf3",
+        "__muldf3",
+        "__divdf3",
+        "__addsf3",
+        "__subsf3",
+        "__mulsf3",
+        "__divsf3",
+        "__gnu_unwind",
+    ],
     "xtensa": ["xt_", "_xt_", "xPortEnterCriticalTimeout"],
     "heap": ["heap_", "multi_heap"],
     "spi_flash": ["spi_flash"],
@@ -782,7 +853,22 @@ SYMBOL_PATTERNS = {
     "math_internal": ["__mdiff", "__lshift", "__mprec_tens", "quorem"],
     "character_class": ["__chclass"],
     "camellia": ["camellia_", "camellia_feistel"],
-    "crypto_tables": ["FSb", "FSb2", "FSb3", "FSb4"],
+    "crypto_tables": [
+        "FSb",
+        "FSb2",
+        "FSb3",
+        "FSb4",
+        "Te0",  # AES encryption table
+        "Td0",  # AES decryption table
+        "crc32_table",  # CRC32 lookup table
+        "crc_tab",  # CRC lookup table
+    ],
+    "crypto_hash": [
+        "SHA1Transform",  # SHA1 hash function
+        "MD5Transform",  # MD5 hash function
+        "SHA256",
+        "SHA512",
+    ],
     "event_buffer": ["g_eb_list_desc", "eb_space"],
     "base_node": ["base_node_", "base_node_add_handler"],
     "file_descriptor": ["s_fd_table"],

--- a/script/ci_memory_impact_extract.py
+++ b/script/ci_memory_impact_extract.py
@@ -92,18 +92,23 @@ def run_detailed_analysis(build_dir: str) -> dict | None:
         print(f"Build directory not found: {build_dir}", file=sys.stderr)
         return None
 
-    # Find firmware.elf
+    # Find firmware.elf (or raw_firmware.elf for LibreTiny)
     elf_path = None
     for elf_candidate in [
         build_path / "firmware.elf",
         build_path / ".pioenvs" / build_path.name / "firmware.elf",
+        # LibreTiny uses raw_firmware.elf
+        build_path / "raw_firmware.elf",
+        build_path / ".pioenvs" / build_path.name / "raw_firmware.elf",
     ]:
         if elf_candidate.exists():
             elf_path = str(elf_candidate)
             break
 
     if not elf_path:
-        print(f"firmware.elf not found in {build_dir}", file=sys.stderr)
+        print(
+            f"firmware.elf/raw_firmware.elf not found in {build_dir}", file=sys.stderr
+        )
         return None
 
     # Find idedata.json - check multiple locations

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -441,7 +441,7 @@ def _detect_platform_hint_from_filename(filename: str) -> Platform | None:
     if "esp32" in filename_lower:
         return Platform.ESP32_IDF
 
-    # LibreTiny (BK72xx, RTL87xx)
+    # LibreTiny (via 'libretiny' pattern or BK72xx-specific files)
     if "libretiny" in filename_lower or "bk72" in filename_lower:
         return Platform.BK72XX_ARD
 

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -89,6 +89,7 @@ class Platform(StrEnum):
     ESP32_C6_IDF = "esp32-c6-idf"
     ESP32_S2_IDF = "esp32-s2-idf"
     ESP32_S3_IDF = "esp32-s3-idf"
+    BK72XX_ARD = "bk72xx-ard"  # LibreTiny BK7231N
 
 
 # Memory impact analysis constants
@@ -120,6 +121,7 @@ PLATFORM_SPECIFIC_COMPONENTS = frozenset(
 #                      fastest build times, most sensitive to code size changes
 # 3. ESP32 IDF - Primary ESP32 platform, most representative of modern ESPHome
 # 4-6. Other ESP32 variants - Less commonly used but still supported
+# 7. BK72XX - LibreTiny platform (good for detecting LibreTiny-specific changes)
 MEMORY_IMPACT_PLATFORM_PREFERENCE = [
     Platform.ESP32_C6_IDF,  # ESP32-C6 IDF (newest, supports Thread/Zigbee)
     Platform.ESP8266_ARD,  # ESP8266 Arduino (most memory constrained, fastest builds)
@@ -127,6 +129,7 @@ MEMORY_IMPACT_PLATFORM_PREFERENCE = [
     Platform.ESP32_C3_IDF,  # ESP32-C3 IDF
     Platform.ESP32_S2_IDF,  # ESP32-S2 IDF
     Platform.ESP32_S3_IDF,  # ESP32-S3 IDF
+    Platform.BK72XX_ARD,  # LibreTiny BK7231N
 ]
 
 
@@ -404,7 +407,7 @@ def _detect_platform_hint_from_filename(filename: str) -> Platform | None:
     - wifi_component_esp_idf.cpp, *_idf.h -> ESP32 IDF variants
     - wifi_component_esp8266.cpp, *_esp8266.h -> ESP8266_ARD
     - *_esp32*.cpp -> ESP32 IDF (generic)
-    - *_libretiny.cpp, *_retiny.* -> LibreTiny (not in preference list)
+    - *_libretiny.cpp, *_bk72*.* -> BK72XX (LibreTiny)
     - *_pico.cpp, *_rp2040.* -> RP2040 (not in preference list)
 
     Args:
@@ -438,10 +441,11 @@ def _detect_platform_hint_from_filename(filename: str) -> Platform | None:
     if "esp32" in filename_lower:
         return Platform.ESP32_IDF
 
-    # LibreTiny and RP2040 are not in MEMORY_IMPACT_PLATFORM_PREFERENCE
-    # so we don't return them as hints
-    # if "retiny" in filename_lower or "libretiny" in filename_lower:
-    #     return None  # No specific LibreTiny platform preference
+    # LibreTiny (BK72xx, RTL87xx)
+    if "libretiny" in filename_lower or "bk72" in filename_lower:
+        return Platform.BK72XX_ARD
+
+    # RP2040 is not in MEMORY_IMPACT_PLATFORM_PREFERENCE
     # if "pico" in filename_lower or "rp2040" in filename_lower:
     #     return None  # No RP2040 platform preference
 


### PR DESCRIPTION
# What does this implement/fix?

Add LibreTiny (BK72XX) platform support to CI memory impact analysis.

Previously, memory impact analysis only ran for ESP32 and ESP8266 platforms. When LibreTiny-specific files were modified (e.g., `wifi_component_libretiny.cpp`), no memory impact analysis was performed, making it difficult to catch memory regressions on this platform.

This PR adds:

1. **CI Memory Impact for BK72XX** (`script/determine-jobs.py`):
   - Added `BK72XX_ARD` to the `Platform` enum
   - Added to `MEMORY_IMPACT_PLATFORM_PREFERENCE` list
   - Updated filename detection to recognize `libretiny` and `bk72` patterns

2. **LibreTiny symbol patterns** (`esphome/analyze_memory/const.py`):
   - Added patterns to properly categorize BK7231N-specific symbols
   - Reduces the "other" category from ~178KB to ~83KB for more actionable analysis

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal CI tooling)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - This is CI infrastructure, not user-facing configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal tooling)
