### PR TITLE
[airthings_wave_base, airthings_ble] Use stack-based string formatting in logging

### DIFF
--- a/esphome/components/airthings_ble/airthings_listener.cpp
+++ b/esphome/components/airthings_ble/airthings_listener.cpp
@@ -20,7 +20,8 @@ bool AirthingsListener::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
       sn |= ((uint32_t) it.data[2] << 16);
       sn |= ((uint32_t) it.data[3] << 24);
 
-      ESP_LOGD(TAG, "Found AirThings device Serial:%" PRIu32 " (MAC: %s)", sn, device.address_str().c_str());
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGD(TAG, "Found AirThings device Serial:%" PRIu32 " (MAC: %s)", sn, device.address_str_to(addr_buf));
       return true;
     }
   }

--- a/esphome/components/airthings_wave_base/airthings_wave_base.cpp
+++ b/esphome/components/airthings_wave_base/airthings_wave_base.cpp
@@ -1,4 +1,5 @@
 #include "airthings_wave_base.h"
+#include "esphome/components/esp32_ble/ble_uuid.h"
 
 // All information related to reading battery information came from the sensors.airthings_wave
 // project by Sverre Hamre (https://github.com/sverrham/sensor.airthings_wave)
@@ -93,8 +94,10 @@ void AirthingsWaveBase::update() {
 bool AirthingsWaveBase::request_read_values_() {
   auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->sensors_data_characteristic_uuid_);
   if (chr == nullptr) {
-    ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", this->service_uuid_.to_string().c_str(),
-             this->sensors_data_characteristic_uuid_.to_string().c_str());
+    char service_buf[esp32_ble::UUID_STR_LEN];
+    char char_buf[esp32_ble::UUID_STR_LEN];
+    ESP_LOGW(TAG, "No sensor characteristic found at service %s char %s", this->service_uuid_.to_str(service_buf),
+             this->sensors_data_characteristic_uuid_.to_str(char_buf));
     return false;
   }
 
@@ -117,17 +120,20 @@ bool AirthingsWaveBase::request_battery_() {
 
   auto *chr = this->parent()->get_characteristic(this->service_uuid_, this->access_control_point_characteristic_uuid_);
   if (chr == nullptr) {
+    char service_buf[esp32_ble::UUID_STR_LEN];
+    char char_buf[esp32_ble::UUID_STR_LEN];
     ESP_LOGW(TAG, "No access control point characteristic found at service %s char %s",
-             this->service_uuid_.to_string().c_str(),
-             this->access_control_point_characteristic_uuid_.to_string().c_str());
+             this->service_uuid_.to_str(service_buf), this->access_control_point_characteristic_uuid_.to_str(char_buf));
     return false;
   }
 
   auto *descr = this->parent()->get_descriptor(this->service_uuid_, this->access_control_point_characteristic_uuid_,
                                                CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR_UUID);
   if (descr == nullptr) {
-    ESP_LOGW(TAG, "No CCC descriptor found at service %s char %s", this->service_uuid_.to_string().c_str(),
-             this->access_control_point_characteristic_uuid_.to_string().c_str());
+    char service_buf[esp32_ble::UUID_STR_LEN];
+    char char_buf[esp32_ble::UUID_STR_LEN];
+    ESP_LOGW(TAG, "No CCC descriptor found at service %s char %s", this->service_uuid_.to_str(service_buf),
+             this->access_control_point_characteristic_uuid_.to_str(char_buf));
     return false;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating string formatting with stack-based buffers in AirThings component logging.

**Changes:**
- `airthings_wave_base.cpp`: Use `ESPBTUUID::to_str()` with stack buffers instead of `to_string().c_str()` for UUID logging
- `airthings_listener.cpp`: Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for MAC address logging

This eliminates temporary `std::string` heap allocations in warning/debug log paths, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
