### PR TITLE
[mopeka] Reduce heap allocations with stack-based string formatting

### DIFF
--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -36,6 +36,7 @@ static const uint8_t MANUFACTURER_NRF52_DATA_LENGTH = 10;
  */
 
 bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   // Fetch information about BLE device.
   const auto &service_uuids = device.get_service_uuids();
   if (service_uuids.size() != 1) {
@@ -62,7 +63,6 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[3] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s", device.address_str_to(addr_buf));
     }
 
@@ -79,7 +79,6 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[2] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s", device.address_str_to(addr_buf));
     }
   }

--- a/esphome/components/mopeka_ble/mopeka_ble.cpp
+++ b/esphome/components/mopeka_ble/mopeka_ble.cpp
@@ -62,7 +62,8 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[3] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s", device.address_str().c_str());
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGI(TAG, "MOPEKA STD (CC2540) SENSOR FOUND: %s", device.address_str_to(addr_buf));
     }
 
     // Is the device maybe a Mopeka Pro (NRF52) sensor.
@@ -78,7 +79,8 @@ bool MopekaListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     const bool sync_button_pressed = (manu_data.data[2] & 0x80) != 0;
 
     if (this->show_sensors_without_sync_ || sync_button_pressed) {
-      ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s", device.address_str().c_str());
+      char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      ESP_LOGI(TAG, "MOPEKA PRO (NRF52) SENSOR FOUND: %s", device.address_str_to(addr_buf));
     }
   }
 

--- a/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
+++ b/esphome/components/mopeka_pro_check/mopeka_pro_check.cpp
@@ -31,7 +31,8 @@ bool MopekaProCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
     return false;
   }
 
-  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str_to(addr_buf));
 
   const auto &manu_datas = device.get_manufacturer_datas();
 


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `address_str().c_str()` with stack-based `address_str_to()` in Mopeka component logging.

**Changes:**
- `mopeka_ble.cpp`: Use stack buffer for MAC address logging when sensor found
- `mopeka_pro_check.cpp`: Use stack buffer for MAC address in parse_device()
- `mopeka_std_check.cpp`: Create single stack buffer at function start and reuse `addr_str` pointer throughout (eliminates 17 heap allocations per parse_device() call)

This eliminates temporary `std::string` heap allocations in logging paths, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
