### PR TITLE
[bedjet] Use stack-based UUID formatting in logging

### DIFF
--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -3,7 +3,6 @@
 #include "bedjet_hub.h"
 #include "bedjet_child.h"
 #include "bedjet_const.h"
-#include "esphome/components/esp32_ble/ble_uuid.h"
 #include "esphome/core/application.h"
 #include <cinttypes>
 

--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -3,6 +3,7 @@
 #include "bedjet_hub.h"
 #include "bedjet_child.h"
 #include "bedjet_const.h"
+#include "esphome/components/esp32_ble/ble_uuid.h"
 #include "esphome/core/application.h"
 #include <cinttypes>
 
@@ -193,8 +194,9 @@ bool BedJetHub::discover_characteristics_() {
       result = false;
     } else if (descr->uuid.get_uuid().len != ESP_UUID_LEN_16 ||
                descr->uuid.get_uuid().uuid.uuid16 != ESP_GATT_UUID_CHAR_CLIENT_CONFIG) {
+      char uuid_buf[esp32_ble::UUID_STR_LEN];
       ESP_LOGW(TAG, "Config descriptor 0x%x (uuid %s) is not a client config char uuid", this->char_handle_status_,
-               descr->uuid.to_string().c_str());
+               descr->uuid.to_str(uuid_buf));
       result = false;
     } else {
       this->config_descr_status_ = descr->handle;

--- a/esphome/components/bedjet/bedjet_hub.cpp
+++ b/esphome/components/bedjet/bedjet_hub.cpp
@@ -194,7 +194,7 @@ bool BedJetHub::discover_characteristics_() {
       result = false;
     } else if (descr->uuid.get_uuid().len != ESP_UUID_LEN_16 ||
                descr->uuid.get_uuid().uuid.uuid16 != ESP_GATT_UUID_CHAR_CLIENT_CONFIG) {
-      char uuid_buf[esp32_ble::UUID_STR_LEN];
+      char uuid_buf[espbt::UUID_STR_LEN];
       ESP_LOGW(TAG, "Config descriptor 0x%x (uuid %s) is not a client config char uuid", this->char_handle_status_,
                descr->uuid.to_str(uuid_buf));
       result = false;


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `to_string().c_str()` with stack-based `to_str()` for UUID logging in BedJet component.

This eliminates a temporary `std::string` heap allocation in the warning log path, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
