### PR TITLE
[pvvx_mithermometer] Reduce heap allocations with stack-based string formatting

### DIFF
--- a/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
+++ b/esphome/components/pvvx_mithermometer/display/pvvx_display.cpp
@@ -1,4 +1,5 @@
 #include "pvvx_display.h"
+#include "esphome/components/esp32_ble/ble_uuid.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -8,14 +9,16 @@ namespace pvvx_mithermometer {
 static const char *const TAG = "display.pvvx_mithermometer";
 
 void PVVXDisplay::dump_config() {
+  char service_buf[esp32_ble::UUID_STR_LEN];
+  char char_buf[esp32_ble::UUID_STR_LEN];
   ESP_LOGCONFIG(TAG,
                 "PVVX MiThermometer display:\n"
                 "  MAC address           : %s\n"
                 "  Service UUID          : %s\n"
                 "  Characteristic UUID   : %s\n"
                 "  Auto clear            : %s",
-                this->parent_->address_str(), this->service_uuid_.to_string().c_str(),
-                this->char_uuid_.to_string().c_str(), YESNO(this->auto_clear_enabled_));
+                this->parent_->address_str(), this->service_uuid_.to_str(service_buf),
+                this->char_uuid_.to_str(char_buf), YESNO(this->auto_clear_enabled_));
 #ifdef USE_TIME
   ESP_LOGCONFIG(TAG, "  Set time on connection: %s", YESNO(this->time_ != nullptr));
 #endif

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
@@ -21,7 +21,9 @@ bool PVVXMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
   }
-  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  const char *addr_str = device.address_str_to(addr_buf);
+  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", addr_str);
 
   bool success = false;
   for (auto &service_data : device.get_service_datas()) {
@@ -32,7 +34,7 @@ bool PVVXMiThermometer::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     if (!(parse_message_(service_data.data, *res))) {
       continue;
     }
-    if (!(report_results_(res, device.address_str()))) {
+    if (!(report_results_(res, addr_str))) {
       continue;
     }
     if (res->temperature.has_value() && this->temperature_ != nullptr)
@@ -111,13 +113,13 @@ bool PVVXMiThermometer::parse_message_(const std::vector<uint8_t> &message, Pars
   return true;
 }
 
-bool PVVXMiThermometer::report_results_(const optional<ParseResult> &result, const std::string &address) {
+bool PVVXMiThermometer::report_results_(const optional<ParseResult> &result, const char *address) {
   if (!result.has_value()) {
     ESP_LOGVV(TAG, "report_results(): no results available.");
     return false;
   }
 
-  ESP_LOGD(TAG, "Got PVVX MiThermometer (%s):", address.c_str());
+  ESP_LOGD(TAG, "Got PVVX MiThermometer (%s):", address);
 
   if (result->temperature.has_value()) {
     ESP_LOGD(TAG, "  Temperature: %.2f °C", *result->temperature);

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -41,7 +41,7 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
 
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
-  bool report_results_(const optional<ParseResult> &result, const std::string &address);
+  bool report_results_(const optional<ParseResult> &result, const char *address);
 };
 
 }  // namespace pvvx_mithermometer


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in PVVX MiThermometer component logging by using stack-based string formatting.

## Changes

- `pvvx_display.cpp`: Use `ESPBTUUID::to_str()` with stack buffers instead of `to_string().c_str()` for UUID logging in `dump_config()`
- `pvvx_mithermometer.h`: Change `report_results_()` signature from `const std::string &address` to `const char *address`
- `pvvx_mithermometer.cpp`: Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for MAC address formatting

This eliminates temporary `std::string` heap allocations in logging and BLE advertisement parsing paths, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
