### PR TITLE
[bthome_mithermometer] Reduce heap allocations with stack-based string formatting

### DIFF
--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -12,13 +12,12 @@ namespace bthome_mithermometer {
 
 static const char *const TAG = "bthome_mithermometer";
 
-static std::string format_mac_address(uint64_t address) {
+static const char *format_mac_address(char *buffer, uint64_t address) {
   std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
   for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
     mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  char buffer[MAC_ADDRESS_SIZE * 3];
   format_mac_addr_upper(mac.data(), buffer);
   return buffer;
 }
@@ -127,8 +126,9 @@ static bool get_bthome_value_length(uint8_t obj_type, size_t &value_length) {
 }
 
 void BTHomeMiThermometer::dump_config() {
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   ESP_LOGCONFIG(TAG, "BTHome MiThermometer");
-  ESP_LOGCONFIG(TAG, "  MAC Address: %s", format_mac_address(this->address_).c_str());
+  ESP_LOGCONFIG(TAG, "  MAC Address: %s", format_mac_address(addr_buf, this->address_));
   LOG_SENSOR("  ", "Temperature", this->temperature_);
   LOG_SENSOR("  ", "Humidity", this->humidity_);
   LOG_SENSOR("  ", "Battery Level", this->battery_level_);
@@ -172,8 +172,9 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
     return false;
   }
 
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   if (is_encrypted) {
-    ESP_LOGV(TAG, "Ignoring encrypted BTHome frame from %s", device.address_str().c_str());
+    ESP_LOGV(TAG, "Ignoring encrypted BTHome frame from %s", device.address_str_to(addr_buf));
     return false;
   }
 
@@ -193,7 +194,7 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
   }
 
   if (source_address != this->address_) {
-    ESP_LOGVV(TAG, "BTHome frame from unexpected device %s", format_mac_address(source_address).c_str());
+    ESP_LOGVV(TAG, "BTHome frame from unexpected device %s", format_mac_address(addr_buf, source_address));
     return false;
   }
 
@@ -286,7 +287,7 @@ bool BTHomeMiThermometer::handle_service_data_(const esp32_ble_tracker::ServiceD
   }
 
   if (reported) {
-    ESP_LOGD(TAG, "BTHome data%sfrom %s", is_trigger_based ? " (triggered) " : " ", device.address_str().c_str());
+    ESP_LOGD(TAG, "BTHome data%sfrom %s", is_trigger_based ? " (triggered) " : " ", device.address_str_to(addr_buf));
   }
 
   return reported;

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/log.h"
 
 #include <array>
+#include <span>
 
 #ifdef USE_ESP32
 
@@ -12,14 +13,14 @@ namespace bthome_mithermometer {
 
 static const char *const TAG = "bthome_mithermometer";
 
-static const char *format_mac_address(char *buffer, uint64_t address) {
+static const char *format_mac_address(std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE> buffer, uint64_t address) {
   std::array<uint8_t, MAC_ADDRESS_SIZE> mac{};
   for (size_t i = 0; i < MAC_ADDRESS_SIZE; i++) {
     mac[i] = (address >> ((MAC_ADDRESS_SIZE - 1 - i) * 8)) & 0xFF;
   }
 
-  format_mac_addr_upper(mac.data(), buffer);
-  return buffer;
+  format_mac_addr_upper(mac.data(), buffer.data());
+  return buffer.data();
 }
 
 static bool get_bthome_value_length(uint8_t obj_type, size_t &value_length) {


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in BTHome MiThermometer component logging by using stack-based string formatting.

## Changes

- Changed `format_mac_address()` helper from returning `std::string` to taking a `std::span<char, MAC_ADDRESS_PRETTY_BUFFER_SIZE>` buffer parameter for compile-time size enforcement
- Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for device MAC address formatting
- Declare buffer once at function scope and reuse for multiple log statements

This eliminates temporary `std::string` heap allocations in BLE advertisement parsing and logging paths, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
