### PR TITLE
[atc_mithermometer] Reduce heap allocations with stack-based string formatting

### DIFF
--- a/esphome/components/atc_mithermometer/atc_mithermometer.h
+++ b/esphome/components/atc_mithermometer/atc_mithermometer.h
@@ -41,7 +41,7 @@ class ATCMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevice
 
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
-  bool report_results_(const optional<ParseResult> &result, const std::string &address);
+  bool report_results_(const optional<ParseResult> &result, const char *address);
 };
 
 }  // namespace atc_mithermometer


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in ATC MiThermometer component logging by using stack-based string formatting.

## Changes

- Changed `report_results_()` signature from `const std::string &address` to `const char *address`
- Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for device MAC address formatting
- Declare buffer once at function scope and reuse for multiple log statements

This eliminates temporary `std::string` heap allocations in BLE advertisement parsing and logging paths, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
