### PR TITLE
[ruuvi_ble] Reduce heap allocation with stack-based string formatting

### DIFF
--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -99,7 +99,8 @@ bool RuuviListener::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   if (!res.has_value())
     return false;
 
-  ESP_LOGD(TAG, "Got RuuviTag (%s):", device.address_str().c_str());
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  ESP_LOGD(TAG, "Got RuuviTag (%s):", device.address_str_to(addr_buf));
 
   if (res->humidity.has_value()) {
     ESP_LOGD(TAG, "  Humidity: %.2f%%", *res->humidity);


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in RuuviTag BLE component logging by using stack-based string formatting.

## Changes

- Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for device MAC address formatting

This eliminates a temporary `std::string` heap allocation in the BLE advertisement parsing path, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
