### PR TITLE
[b_parasite] Reduce heap allocation with stack-based string formatting

### DIFF
--- a/esphome/components/b_parasite/b_parasite.cpp
+++ b/esphome/components/b_parasite/b_parasite.cpp
@@ -22,7 +22,8 @@ bool BParasite::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
     ESP_LOGVV(TAG, "parse_device(): unknown MAC address.");
     return false;
   }
-  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str().c_str());
+  char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  ESP_LOGVV(TAG, "parse_device(): MAC address %s found.", device.address_str_to(addr_buf));
   const auto &service_datas = device.get_service_datas();
   if (service_datas.size() != 1) {
     ESP_LOGE(TAG, "Unexpected service_datas size (%d)", service_datas.size());


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in b-parasite BLE component logging by using stack-based string formatting.

## Changes

- Use `address_str_to()` with stack buffer instead of `address_str().c_str()` for device MAC address formatting

This eliminates a temporary `std::string` heap allocation in the BLE advertisement parsing path, following the same pattern established in #12982.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
