### PR TITLE
[midea] Reduce heap allocations with stack-based string formatting

### DIFF
--- a/esphome/components/midea_ir/midea_ir.cpp
+++ b/esphome/components/midea_ir/midea_ir.cpp
@@ -165,7 +165,8 @@ bool MideaIR::on_receive(remote_base::RemoteReceiveData data) {
 }
 
 bool MideaIR::on_midea_(const MideaData &data) {
-  ESP_LOGV(TAG, "Decoded Midea IR data: %s", data.to_string().c_str());
+  char buf[MideaData::TO_STR_BUFFER_SIZE];
+  ESP_LOGV(TAG, "Decoded Midea IR data: %s", data.to_str(buf));
   if (data.type() == MideaData::MIDEA_TYPE_CONTROL) {
     const ControlData status = data;
     if (status.get_mode() != climate::CLIMATE_MODE_FAN_ONLY)

--- a/esphome/components/remote_base/midea_protocol.cpp
+++ b/esphome/components/remote_base/midea_protocol.cpp
@@ -70,7 +70,10 @@ optional<MideaData> MideaProtocol::decode(RemoteReceiveData src) {
   return {};
 }
 
-void MideaProtocol::dump(const MideaData &data) { ESP_LOGI(TAG, "Received Midea: %s", data.to_string().c_str()); }
+void MideaProtocol::dump(const MideaData &data) {
+  char buf[MideaData::TO_STR_BUFFER_SIZE];
+  ESP_LOGI(TAG, "Received Midea: %s", data.to_str(buf));
+}
 
 }  // namespace remote_base
 }  // namespace esphome

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -30,6 +30,13 @@ class MideaData {
   void finalize() { this->data_[OFFSET_CS] = this->calc_cs_(); }
   bool is_compliment(const MideaData &rhs) const;
   std::string to_string() const { return format_hex_pretty(this->data_.data(), this->data_.size()); }
+  /// Buffer size for to_str(): 6 bytes = "AA.BB.CC.DD.EE.FF\0"
+  static constexpr size_t TO_STR_BUFFER_SIZE = format_hex_pretty_size(6);
+  /// Format to buffer, returns pointer to buffer
+  const char *to_str(char *buffer) const {
+    format_hex_pretty_to(buffer, TO_STR_BUFFER_SIZE, this->data_.data(), this->data_.size(), '.');
+    return buffer;
+  }
   // compare only 40-bits
   bool operator==(const MideaData &rhs) const {
     return std::equal(this->data_.begin(), this->data_.begin() + OFFSET_CS, rhs.data_.begin());


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in Midea IR protocol logging by adding a stack-based string formatting method.

## Changes

- Added `TO_STR_BUFFER_SIZE` constant and `to_str(char *buffer)` method to `MideaData` class
- Updated `MideaProtocol::dump()` to use stack buffer instead of `to_string().c_str()`
- Updated `MideaIR::on_midea_()` to use stack buffer instead of `to_string().c_str()`

The new `to_str()` method uses `format_hex_pretty_to()` which writes directly to a caller-provided buffer, eliminating temporary `std::string` heap allocations in IR data logging paths.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
