### PR TITLE
[voice_assistant] Reduce heap allocation with stack-based timer formatting

### DIFF
--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -866,11 +866,12 @@ void VoiceAssistant::on_timer_event(const api::VoiceAssistantTimerEventResponse 
       .is_active = msg.is_active,
   };
   this->timers_[timer.id] = timer;
+  char timer_buf[Timer::TO_STR_BUFFER_SIZE];
   ESP_LOGD(TAG,
            "Timer Event\n"
            "  Type: %" PRId32 "\n"
            "  %s",
-           msg.event_type, timer.to_string().c_str());
+           msg.event_type, timer.to_str(timer_buf));
 
   switch (msg.event_type) {
     case api::enums::VOICE_ASSISTANT_TIMER_STARTED:

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -23,6 +23,7 @@
 #endif
 #include "esphome/components/socket/socket.h"
 
+#include <span>
 #include <unordered_map>
 #include <vector>
 
@@ -75,6 +76,15 @@ struct Timer {
     return str_sprintf("Timer(id=%s, name=%s, total_seconds=%" PRIu32 ", seconds_left=%" PRIu32 ", is_active=%s)",
                        this->id.c_str(), this->name.c_str(), this->total_seconds, this->seconds_left,
                        YESNO(this->is_active));
+  }
+  /// Buffer size for to_str() - sufficient for typical timer names
+  static constexpr size_t TO_STR_BUFFER_SIZE = 128;
+  /// Format to buffer, returns pointer to buffer (may truncate long names)
+  const char *to_str(std::span<char, TO_STR_BUFFER_SIZE> buffer) const {
+    snprintf(buffer.data(), buffer.size(),
+             "Timer(id=%s, name=%s, total_seconds=%" PRIu32 ", seconds_left=%" PRIu32 ", is_active=%s)",
+             this->id.c_str(), this->name.c_str(), this->total_seconds, this->seconds_left, YESNO(this->is_active));
+    return buffer.data();
   }
 };
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -72,11 +72,6 @@ struct Timer {
   uint32_t seconds_left;
   bool is_active;
 
-  std::string to_string() const {
-    return str_sprintf("Timer(id=%s, name=%s, total_seconds=%" PRIu32 ", seconds_left=%" PRIu32 ", is_active=%s)",
-                       this->id.c_str(), this->name.c_str(), this->total_seconds, this->seconds_left,
-                       YESNO(this->is_active));
-  }
   /// Buffer size for to_str() - sufficient for typical timer names
   static constexpr size_t TO_STR_BUFFER_SIZE = 128;
   /// Format to buffer, returns pointer to buffer (may truncate long names)
@@ -85,6 +80,10 @@ struct Timer {
              "Timer(id=%s, name=%s, total_seconds=%" PRIu32 ", seconds_left=%" PRIu32 ", is_active=%s)",
              this->id.c_str(), this->name.c_str(), this->total_seconds, this->seconds_left, YESNO(this->is_active));
     return buffer.data();
+  }
+  std::string to_string() const {
+    char buffer[TO_STR_BUFFER_SIZE];
+    return this->to_str(buffer);
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in Voice Assistant timer event logging by adding a stack-based string formatting method.

## Changes

- Added `TO_STR_BUFFER_SIZE` constant and `to_str(std::span<char, TO_STR_BUFFER_SIZE>)` method to `Timer` struct
- Updated `on_timer_event()` to use stack buffer instead of `to_string().c_str()`
- Uses `std::span` for compile-time buffer size enforcement

The new `to_str()` method uses `snprintf` to write directly to a caller-provided buffer, eliminating a temporary `std::string` heap allocation in the timer event logging path. The 128-byte buffer is sufficient for typical timer names, and `snprintf` safely truncates if names are unusually long.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
