### PR TITLE
[xiaomi_ble] Simplify set_bindkey using parse_hex and const char*

### DIFF
--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.cpp
@@ -63,17 +63,7 @@ bool XiaomiCGD1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-void XiaomiCGD1::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiCGD1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_cgd1
 }  // namespace esphome

--- a/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
+++ b/esphome/components/xiaomi_cgd1/xiaomi_cgd1.h
@@ -13,7 +13,7 @@ namespace xiaomi_cgd1 {
 class XiaomiCGD1 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.cpp
@@ -63,17 +63,7 @@ bool XiaomiCGDK2::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-void XiaomiCGDK2::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiCGDK2::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_cgdk2
 }  // namespace esphome

--- a/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
+++ b/esphome/components/xiaomi_cgdk2/xiaomi_cgdk2.h
@@ -13,7 +13,7 @@ namespace xiaomi_cgdk2 {
 class XiaomiCGDK2 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.cpp
@@ -63,17 +63,7 @@ bool XiaomiCGG1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-void XiaomiCGG1::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiCGG1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_cgg1
 }  // namespace esphome

--- a/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
+++ b/esphome/components/xiaomi_cgg1/xiaomi_cgg1.h
@@ -13,7 +13,7 @@ namespace xiaomi_cgg1 {
 class XiaomiCGG1 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 

--- a/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.cpp
+++ b/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_cgpr1.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -59,17 +60,7 @@ bool XiaomiCGPR1::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-void XiaomiCGPR1::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiCGPR1::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_cgpr1
 }  // namespace esphome

--- a/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
+++ b/esphome/components/xiaomi_cgpr1/xiaomi_cgpr1.h
@@ -16,7 +16,7 @@ class XiaomiCGPR1 : public Component,
                     public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.cpp
@@ -63,17 +63,7 @@ bool XiaomiLYWSD02MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   return success;
 }
 
-void XiaomiLYWSD02MMC::set_bindkey(const std::string &bindkey) {
-  memset(this->bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    this->bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiLYWSD02MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_lywsd02mmc
 }  // namespace esphome

--- a/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
+++ b/esphome/components/xiaomi_lywsd02mmc/xiaomi_lywsd02mmc.h
@@ -13,7 +13,7 @@ namespace xiaomi_lywsd02mmc {
 class XiaomiLYWSD02MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { this->address_ = address; }
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.cpp
@@ -67,17 +67,7 @@ bool XiaomiLYWSD03MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &device
   return success;
 }
 
-void XiaomiLYWSD03MMC::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiLYWSD03MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_lywsd03mmc
 }  // namespace esphome

--- a/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
+++ b/esphome/components/xiaomi_lywsd03mmc/xiaomi_lywsd03mmc.h
@@ -13,7 +13,7 @@ namespace xiaomi_lywsd03mmc {
 class XiaomiLYWSD03MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.cpp
@@ -67,17 +67,7 @@ bool XiaomiMHOC401::parse_device(const esp32_ble_tracker::ESPBTDevice &device) {
   return success;
 }
 
-void XiaomiMHOC401::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiMHOC401::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_mhoc401
 }  // namespace esphome

--- a/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
+++ b/esphome/components/xiaomi_mhoc401/xiaomi_mhoc401.h
@@ -13,7 +13,7 @@ namespace xiaomi_mhoc401 {
 class XiaomiMHOC401 : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.cpp
@@ -1,4 +1,5 @@
 #include "xiaomi_mjyd02yla.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
@@ -62,17 +63,7 @@ bool XiaomiMJYD02YLA::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-void XiaomiMJYD02YLA::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiMJYD02YLA::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_mjyd02yla
 }  // namespace esphome

--- a/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
+++ b/esphome/components/xiaomi_mjyd02yla/xiaomi_mjyd02yla.h
@@ -16,7 +16,7 @@ class XiaomiMJYD02YLA : public Component,
                         public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; }
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
@@ -79,17 +79,7 @@ bool XiaomiRTCGQ02LM::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
   return success;
 }
 
-void XiaomiRTCGQ02LM::set_bindkey(const std::string &bindkey) {
-  memset(bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiRTCGQ02LM::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_rtcgq02lm
 }  // namespace esphome

--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.h
@@ -19,7 +19,7 @@ namespace xiaomi_rtcgq02lm {
 class XiaomiRTCGQ02LM : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { address_ = address; };
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
   void dump_config() override;

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.cpp
@@ -67,17 +67,7 @@ bool XiaomiXMWSDJ04MMC::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
   return success;
 }
 
-void XiaomiXMWSDJ04MMC::set_bindkey(const std::string &bindkey) {
-  memset(this->bindkey_, 0, 16);
-  if (bindkey.size() != 32) {
-    return;
-  }
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
-    this->bindkey_[i] = std::strtoul(temp, nullptr, 16);
-  }
-}
+void XiaomiXMWSDJ04MMC::set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
 
 }  // namespace xiaomi_xmwsdj04mmc
 }  // namespace esphome

--- a/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
+++ b/esphome/components/xiaomi_xmwsdj04mmc/xiaomi_xmwsdj04mmc.h
@@ -13,7 +13,7 @@ namespace xiaomi_xmwsdj04mmc {
 class XiaomiXMWSDJ04MMC : public Component, public esp32_ble_tracker::ESPBTDeviceListener {
  public:
   void set_address(uint64_t address) { this->address_ = address; }
-  void set_bindkey(const std::string &bindkey);
+  void set_bindkey(const char *bindkey);
 
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override;
 


### PR DESCRIPTION
# What does this implement/fix?

Simplifies and optimizes `set_bindkey()` in all 10 Xiaomi BLE components.

**Changes:**

1. **Changed signature from `const std::string&` to `const char*`** - Avoids constructing a temporary `std::string` from the string literal that codegen produces.

2. **Replaced manual hex parsing with `parse_hex()`** - Uses the existing helper function from `esphome/core/helpers.h` instead of a 10-line manual loop with `strncpy`/`strtoul`.

3. **Added missing include** - Added `#include "esphome/core/helpers.h"` to `xiaomi_cgpr1` and `xiaomi_mjyd02yla` which were missing it.

**Before (per component):**
```cpp
void set_bindkey(const std::string &bindkey) {
  memset(bindkey_, 0, 16);
  if (bindkey.size() != 32) {
    return;
  }
  char temp[3] = {0};
  for (int i = 0; i < 16; i++) {
    strncpy(temp, &(bindkey.c_str()[i * 2]), 2);
    bindkey_[i] = std::strtoul(temp, nullptr, 16);
  }
}
```

**After:**
```cpp
void set_bindkey(const char *bindkey) { parse_hex(bindkey, this->bindkey_, sizeof(this->bindkey_)); }
```

**Components updated:**
- xiaomi_cgd1
- xiaomi_cgdk2
- xiaomi_cgg1
- xiaomi_cgpr1
- xiaomi_lywsd02mmc
- xiaomi_lywsd03mmc
- xiaomi_mhoc401
- xiaomi_mjyd02yla
- xiaomi_rtcgq02lm
- xiaomi_xmwsdj04mmc

**Behavioral equivalence verified** - See attached `xiaomi_bindkey_tests.zip` for a standalone C++ test that verifies the old and new implementations produce identical results for all valid inputs (uppercase, lowercase, mixed case, zeros, FFs, realistic keys). Python's `cv.bind_key` validator ensures only valid 32-character hex strings are ever passed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (code simplification and optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
# Any existing Xiaomi BLE sensor configuration works the same
sensor:
  - platform: xiaomi_lywsd03mmc
    mac_address: "A4:C1:38:XX:XX:XX"
    bindkey: "0123456789ABCDEF0123456789ABCDEF"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
