### PR TITLE
[improv_base] Optimize next_url to avoid STL string operations

### DIFF
--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -398,9 +398,12 @@ void ESP32ImprovComponent::check_wifi_connection_() {
 
 #ifdef USE_ESP32_IMPROV_NEXT_URL
     // Add next_url if configured (should be first per Improv BLE spec)
-    std::string next_url = this->get_formatted_next_url_();
-    if (!next_url.empty()) {
-      url_strings[url_count++] = std::move(next_url);
+    {
+      char url_buffer[384];
+      size_t len = this->get_formatted_next_url_(url_buffer, sizeof(url_buffer));
+      if (len > 0) {
+        url_strings[url_count++] = std::string(url_buffer, len);
+      }
     }
 #endif
 

--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -1,5 +1,6 @@
 #include "improv_base.h"
 
+#include <cstring>
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
@@ -13,37 +14,54 @@ static constexpr size_t DEVICE_NAME_PLACEHOLDER_LEN = sizeof(DEVICE_NAME_PLACEHO
 static constexpr const char IP_ADDRESS_PLACEHOLDER[] = "{{ip_address}}";
 static constexpr size_t IP_ADDRESS_PLACEHOLDER_LEN = sizeof(IP_ADDRESS_PLACEHOLDER) - 1;
 
-static void replace_all_in_place(std::string &str, const char *placeholder, size_t placeholder_len,
-                                 const std::string &replacement) {
-  size_t pos = 0;
-  const size_t replacement_len = replacement.length();
-  while ((pos = str.find(placeholder, pos)) != std::string::npos) {
-    str.replace(pos, placeholder_len, replacement);
-    pos += replacement_len;
+/// Copy src to dest, returning pointer past last written char. Stops at end or if src is null.
+static char *copy_to_buffer(char *dest, const char *end, const char *src) {
+  if (src == nullptr) {
+    return dest;
   }
+  while (*src != '\0' && dest < end) {
+    *dest++ = *src++;
+  }
+  return dest;
 }
 
-std::string ImprovBase::get_formatted_next_url_() {
-  if (this->next_url_.empty()) {
-    return "";
+size_t ImprovBase::get_formatted_next_url_(char *buffer, size_t buffer_size) {
+  if (this->next_url_ == nullptr || buffer_size == 0) {
+    if (buffer_size > 0) {
+      buffer[0] = '\0';
+    }
+    return 0;
   }
 
-  std::string formatted_url = this->next_url_;
-
-  // Replace all occurrences of {{device_name}}
-  replace_all_in_place(formatted_url, DEVICE_NAME_PLACEHOLDER, DEVICE_NAME_PLACEHOLDER_LEN, App.get_name());
-
-  // Replace all occurrences of {{ip_address}}
+  // Get IP address once for replacement
+  const char *ip_str = nullptr;
+  char ip_buffer[network::IP_ADDRESS_BUFFER_SIZE];
   for (auto &ip : network::get_ip_addresses()) {
     if (ip.is_ip4()) {
-      replace_all_in_place(formatted_url, IP_ADDRESS_PLACEHOLDER, IP_ADDRESS_PLACEHOLDER_LEN, ip.str());
+      ip.str_to(ip_buffer);
+      ip_str = ip_buffer;
       break;
     }
   }
 
-  // Note: {{esphome_version}} is replaced at code generation time in Python
+  const char *device_name = App.get_name().c_str();
+  char *out = buffer;
+  const char *end = buffer + buffer_size - 1;
 
-  return formatted_url;
+  // Note: {{esphome_version}} is replaced at code generation time in Python
+  for (const char *p = this->next_url_; *p != '\0' && out < end;) {
+    if (strncmp(p, DEVICE_NAME_PLACEHOLDER, DEVICE_NAME_PLACEHOLDER_LEN) == 0) {
+      out = copy_to_buffer(out, end, device_name);
+      p += DEVICE_NAME_PLACEHOLDER_LEN;
+    } else if (strncmp(p, IP_ADDRESS_PLACEHOLDER, IP_ADDRESS_PLACEHOLDER_LEN) == 0) {
+      out = copy_to_buffer(out, end, ip_str);
+      p += IP_ADDRESS_PLACEHOLDER_LEN;
+    } else {
+      *out++ = *p++;
+    }
+  }
+  *out = '\0';
+  return out - buffer;
 }
 #endif
 

--- a/esphome/components/improv_base/improv_base.cpp
+++ b/esphome/components/improv_base/improv_base.cpp
@@ -53,7 +53,7 @@ size_t ImprovBase::get_formatted_next_url_(char *buffer, size_t buffer_size) {
     if (strncmp(p, DEVICE_NAME_PLACEHOLDER, DEVICE_NAME_PLACEHOLDER_LEN) == 0) {
       out = copy_to_buffer(out, end, device_name);
       p += DEVICE_NAME_PLACEHOLDER_LEN;
-    } else if (strncmp(p, IP_ADDRESS_PLACEHOLDER, IP_ADDRESS_PLACEHOLDER_LEN) == 0) {
+    } else if (ip_str != nullptr && strncmp(p, IP_ADDRESS_PLACEHOLDER, IP_ADDRESS_PLACEHOLDER_LEN) == 0) {
       out = copy_to_buffer(out, end, ip_str);
       p += IP_ADDRESS_PLACEHOLDER_LEN;
     } else {

--- a/esphome/components/improv_base/improv_base.h
+++ b/esphome/components/improv_base/improv_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <string>
+#include <cstddef>
 #include "esphome/core/defines.h"
 
 namespace esphome {
@@ -9,13 +9,14 @@ namespace improv_base {
 class ImprovBase {
  public:
 #if defined(USE_ESP32_IMPROV_NEXT_URL) || defined(USE_IMPROV_SERIAL_NEXT_URL)
-  void set_next_url(const std::string &next_url) { this->next_url_ = next_url; }
+  void set_next_url(const char *next_url) { this->next_url_ = next_url; }
 #endif
 
  protected:
 #if defined(USE_ESP32_IMPROV_NEXT_URL) || defined(USE_IMPROV_SERIAL_NEXT_URL)
-  std::string get_formatted_next_url_();
-  std::string next_url_;
+  /// Format next_url_ into buffer, replacing placeholders. Returns length written.
+  size_t get_formatted_next_url_(char *buffer, size_t buffer_size);
+  const char *next_url_{nullptr};
 #endif
 };
 

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -182,8 +182,12 @@ void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) 
 std::vector<uint8_t> ImprovSerialComponent::build_rpc_settings_response_(improv::Command command) {
   std::vector<std::string> urls;
 #ifdef USE_IMPROV_SERIAL_NEXT_URL
-  if (!this->next_url_.empty()) {
-    urls.push_back(this->get_formatted_next_url_());
+  {
+    char url_buffer[384];
+    size_t len = this->get_formatted_next_url_(url_buffer, sizeof(url_buffer));
+    if (len > 0) {
+      urls.emplace_back(url_buffer, len);
+    }
   }
 #endif
 #ifdef USE_WEBSERVER


### PR DESCRIPTION
# What does this implement/fix?

Reduces flash usage for the `next_url` feature in improv components by eliminating STL string operations.

Changes:
- Store `next_url` template as `const char*` (flash) instead of `std::string` (RAM + heap)
- Replace `std::string` copy + `find()` + `replace()` with single-pass direct buffer formatting
- Use caller-provided stack buffer (scoped, reclaimed immediately after use)
- Add `copy_to_buffer()` helper with bounds checking

This is a follow-up cleanup promised in #10757.

bdraco noted:
> "+1600 bytes of flash from all the stl templates/allocator overhead"
> "A few tweaks and I think we can reduce the impact by at least 50%"

jesserockz replied:
> "I will improve on this work in a new PR after merging this one as the improvements can be made to improv_serial too."

The original implementation pulled in ~450 bytes of STL template code:
- `std::string::replace()` - 277 bytes
- `std::string::find()` - 88 bytes
- `std::__relocate_a_1<>` - 85 bytes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #10757

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No changes to user configuration
esp32_improv:
  authorizer: none
  next_url: "https://example.com/setup?device={{device_name}}&ip={{ip_address}}&version={{esphome_version}}"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
