### PR TITLE
[wifi] Eliminate heap allocations in IP address logging

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -644,13 +644,13 @@ void WiFiComponent::setup_ap_config_() {
   }
   this->ap_setup_ = this->wifi_start_ap_(this->ap_);
 
-  auto ip_address = this->wifi_soft_ap_ip().str();
+  char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
   ESP_LOGCONFIG(TAG,
                 "Setting up AP:\n"
                 "  AP SSID: '%s'\n"
                 "  AP Password: '%s'\n"
                 "  IP Address: %s",
-                this->ap_.get_ssid().c_str(), this->ap_.get_password().c_str(), ip_address.c_str());
+                this->ap_.get_ssid().c_str(), this->ap_.get_password().c_str(), this->wifi_soft_ap_ip().str_to(ip_buf));
 
 #ifdef USE_WIFI_MANUAL_IP
   auto manual_ip = this->ap_.get_manual_ip();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -8,7 +8,6 @@
 
 #include <utility>
 #include <algorithm>
-#include <span>
 #ifdef USE_WIFI_WPA2_EAP
 #include <wpa2_enterprise.h>
 #endif
@@ -415,20 +414,6 @@ const LogString *get_auth_mode_str(uint8_t mode) {
       return LOG_STR("UNKNOWN");
   }
 }
-// Format IP address to provided buffer, returns pointer to buf for convenience
-#ifdef ipv4_addr
-char *format_ip_addr_to(struct ipv4_addr ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
-  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
-           uint8_t(ip.addr >> 24));
-  return buf.data();
-}
-#else
-char *format_ip_addr_to(struct ip_addr ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
-  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
-           uint8_t(ip.addr >> 24));
-  return buf.data();
-}
-#endif
 const LogString *get_op_mode_str(uint8_t mode) {
   switch (mode) {
     case WIFI_OFF:
@@ -585,8 +570,8 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       auto it = event->event_info.got_ip;
       char ip_buf[network::IP_ADDRESS_BUFFER_SIZE], gw_buf[network::IP_ADDRESS_BUFFER_SIZE],
           mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
-      ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", format_ip_addr_to(it.ip, ip_buf),
-               format_ip_addr_to(it.gw, gw_buf), format_ip_addr_to(it.mask, mask_buf));
+      ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", network::IPAddress(&it.ip).str_to(ip_buf),
+               network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
       s_sta_got_ip = true;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : global_wifi_component->ip_state_listeners_) {
@@ -640,7 +625,8 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
       char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
       format_mac_addr_upper(it.mac, mac_buf);
-      ESP_LOGV(TAG, "AP Distribute Station IP MAC=%s IP=%s aid=%u", mac_buf, format_ip_addr_to(it.ip, ip_buf), it.aid);
+      ESP_LOGV(TAG, "AP Distribute Station IP MAC=%s IP=%s aid=%u", mac_buf, network::IPAddress(&it.ip).str_to(ip_buf),
+               it.aid);
 #endif
       break;
     }

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -8,6 +8,7 @@
 
 #include <utility>
 #include <algorithm>
+#include <span>
 #ifdef USE_WIFI_WPA2_EAP
 #include <wpa2_enterprise.h>
 #endif
@@ -371,7 +372,8 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   while (!connected) {
     uint8_t ipv6_addr_count = 0;
     for (auto addr : addrList) {
-      ESP_LOGV(TAG, "Address %s", addr.toString().c_str());
+      char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+      ESP_LOGV(TAG, "Address %s", network::IPAddress(addr.ipFromNetifNum()).str_to(ip_buf));
       if (addr.isV6()) {
         ipv6_addr_count++;
       }
@@ -413,19 +415,18 @@ const LogString *get_auth_mode_str(uint8_t mode) {
       return LOG_STR("UNKNOWN");
   }
 }
+// Format IP address to provided buffer, returns pointer to buf for convenience
 #ifdef ipv4_addr
-std::string format_ip_addr(struct ipv4_addr ip) {
-  char buf[20];
-  sprintf(buf, "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
-          uint8_t(ip.addr >> 24));
-  return buf;
+char *format_ip_addr_to(struct ipv4_addr ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
+  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
+           uint8_t(ip.addr >> 24));
+  return buf.data();
 }
 #else
-std::string format_ip_addr(struct ip_addr ip) {
-  char buf[20];
-  sprintf(buf, "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
-          uint8_t(ip.addr >> 24));
-  return buf;
+char *format_ip_addr_to(struct ip_addr ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
+  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(ip.addr >> 0), uint8_t(ip.addr >> 8), uint8_t(ip.addr >> 16),
+           uint8_t(ip.addr >> 24));
+  return buf.data();
 }
 #endif
 const LogString *get_op_mode_str(uint8_t mode) {
@@ -582,8 +583,10 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
     }
     case EVENT_STAMODE_GOT_IP: {
       auto it = event->event_info.got_ip;
-      ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", format_ip_addr(it.ip).c_str(), format_ip_addr(it.gw).c_str(),
-               format_ip_addr(it.mask).c_str());
+      char ip_buf[network::IP_ADDRESS_BUFFER_SIZE], gw_buf[network::IP_ADDRESS_BUFFER_SIZE],
+          mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
+      ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", format_ip_addr_to(it.ip, ip_buf),
+               format_ip_addr_to(it.gw, gw_buf), format_ip_addr_to(it.mask, mask_buf));
       s_sta_got_ip = true;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : global_wifi_component->ip_state_listeners_) {
@@ -635,8 +638,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
       auto it = event->event_info.distribute_sta_ip;
       char mac_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+      char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
       format_mac_addr_upper(it.mac, mac_buf);
-      ESP_LOGV(TAG, "AP Distribute Station IP MAC=%s IP=%s aid=%u", mac_buf, format_ip_addr(it.ip).c_str(), it.aid);
+      ESP_LOGV(TAG, "AP Distribute Station IP MAC=%s IP=%s aid=%u", mac_buf, format_ip_addr_to(it.ip, ip_buf), it.aid);
 #endif
       break;
     }

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -6,7 +6,6 @@
 #include <cinttypes>
 #include <utility>
 #include <algorithm>
-#include <span>
 #include "lwip/ip_addr.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -6,6 +6,7 @@
 #include <cinttypes>
 #include <utility>
 #include <algorithm>
+#include <span>
 #include "lwip/ip_addr.h"
 #include "lwip/err.h"
 #include "lwip/dns.h"
@@ -233,11 +234,12 @@ const char *get_auth_mode_str(uint8_t mode) {
 
 using esphome_ip4_addr_t = IPAddress;
 
-std::string format_ip4_addr(const esphome_ip4_addr_t &ip) {
-  char buf[20];
+// Format IP address to provided buffer, returns pointer to buf for convenience
+char *format_ip4_addr_to(const esphome_ip4_addr_t &ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
   uint32_t addr = ip;
-  sprintf(buf, "%u.%u.%u.%u", uint8_t(addr >> 0), uint8_t(addr >> 8), uint8_t(addr >> 16), uint8_t(addr >> 24));
-  return buf;
+  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(addr >> 0), uint8_t(addr >> 8), uint8_t(addr >> 16),
+           uint8_t(addr >> 24));
+  return buf.data();
 }
 const char *get_op_mode_str(uint8_t mode) {
   switch (mode) {
@@ -530,8 +532,9 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_GOT_IP: {
-      ESP_LOGV(TAG, "static_ip=%s gateway=%s", format_ip4_addr(WiFi.localIP()).c_str(),
-               format_ip4_addr(WiFi.gatewayIP()).c_str());
+      char ip_buf[network::IP_ADDRESS_BUFFER_SIZE], gw_buf[network::IP_ADDRESS_BUFFER_SIZE];
+      ESP_LOGV(TAG, "static_ip=%s gateway=%s", format_ip4_addr_to(WiFi.localIP(), ip_buf),
+               format_ip4_addr_to(WiFi.gatewayIP(), gw_buf));
       s_sta_state = LTWiFiSTAState::CONNECTED;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : this->ip_state_listeners_) {

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -232,15 +232,6 @@ const char *get_auth_mode_str(uint8_t mode) {
   }
 }
 
-using esphome_ip4_addr_t = IPAddress;
-
-// Format IP address to provided buffer, returns pointer to buf for convenience
-char *format_ip4_addr_to(const esphome_ip4_addr_t &ip, std::span<char, network::IP_ADDRESS_BUFFER_SIZE> buf) {
-  uint32_t addr = ip;
-  snprintf(buf.data(), buf.size(), "%u.%u.%u.%u", uint8_t(addr >> 0), uint8_t(addr >> 8), uint8_t(addr >> 16),
-           uint8_t(addr >> 24));
-  return buf.data();
-}
 const char *get_op_mode_str(uint8_t mode) {
   switch (mode) {
     case WIFI_OFF:
@@ -533,8 +524,8 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
     }
     case ESPHOME_EVENT_ID_WIFI_STA_GOT_IP: {
       char ip_buf[network::IP_ADDRESS_BUFFER_SIZE], gw_buf[network::IP_ADDRESS_BUFFER_SIZE];
-      ESP_LOGV(TAG, "static_ip=%s gateway=%s", format_ip4_addr_to(WiFi.localIP(), ip_buf),
-               format_ip4_addr_to(WiFi.gatewayIP(), gw_buf));
+      ESP_LOGV(TAG, "static_ip=%s gateway=%s", network::IPAddress(WiFi.localIP()).str_to(ip_buf),
+               network::IPAddress(WiFi.gatewayIP()).str_to(gw_buf));
       s_sta_state = LTWiFiSTAState::CONNECTED;
 #ifdef USE_WIFI_LISTENERS
       for (auto *listener : this->ip_state_listeners_) {


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocations during WiFi IP address logging by using stack buffers instead of creating temporary `std::string` objects.

## Changes

### wifi_component.cpp
- Changed `wifi_soft_ap_ip().str()` (creates `std::string`) to `wifi_soft_ap_ip().str_to(ip_buf)` (uses stack buffer)

### wifi_component_esp8266.cpp
- Removed `format_ip_addr()` function that returned `std::string`
- Now uses `network::IPAddress(&ip).str_to(ip_buf)` which leverages the existing lwIP `ipaddr_ntoa_r()` function
- Changed `addr.toString().c_str()` (Arduino String allocation) to `network::IPAddress(...).str_to(ip_buf)`

### wifi_component_libretiny.cpp
- Removed `format_ip4_addr()` function that returned `std::string`
- Now uses `network::IPAddress(ip).str_to(ip_buf)` which leverages the existing lwIP `ipaddr_ntoa_r()` function

All logging now uses stack-allocated buffers with the existing `network::IPAddress::str_to()` method, which internally uses lwIP's `ipaddr_ntoa_r()` - already linked in the binary for other IP operations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  ap:
    ssid: "Fallback AP"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
