### PR TITLE
[wifi] Clean up duplicate and empty logging output

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -896,7 +896,7 @@ const LogString *get_signal_bars(int8_t rssi) {
 
 void WiFiComponent::print_connect_params_() {
   bssid_t bssid = wifi_bssid();
-  char bssid_s[18];
+  char bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   format_mac_addr_upper(bssid.data(), bssid_s);
   // Use stack buffers for IP address formatting to avoid heap allocations
   char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
@@ -1169,7 +1169,7 @@ void WiFiComponent::check_scanning_finished() {
 }
 
 void WiFiComponent::dump_config() {
-  char mac_s[18];
+  char mac_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   ESP_LOGCONFIG(TAG,
                 "WiFi:\n"
                 "  Local MAC: %s\n"

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -895,9 +895,6 @@ const LogString *get_signal_bars(int8_t rssi) {
 }
 
 void WiFiComponent::print_connect_params_() {
-  if (this->is_disabled() || !this->is_connected()) {
-    return;
-  }
   bssid_t bssid = wifi_bssid();
   char bssid_s[18];
   format_mac_addr_upper(bssid.data(), bssid_s);
@@ -1180,8 +1177,11 @@ void WiFiComponent::dump_config() {
                 get_mac_address_pretty_into_buffer(mac_s), YESNO(this->is_connected()));
   if (this->is_disabled()) {
     ESP_LOGCONFIG(TAG, "  Disabled");
+    return;
   }
-  this->print_connect_params_();
+  if (this->is_connected()) {
+    this->print_connect_params_();
+  }
 }
 
 void WiFiComponent::check_connecting_finished() {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -317,7 +317,6 @@ void WiFiComponent::start_initial_connection_() {
     WiFiAP params = this->build_params_for_current_phase_();
     this->start_connecting(params);
   } else {
-    ESP_LOGI(TAG, "Starting scan");
     this->start_scanning();
   }
 }
@@ -369,11 +368,7 @@ void WiFiComponent::setup() {
 }
 
 void WiFiComponent::start() {
-  char mac_s[18];
-  ESP_LOGCONFIG(TAG,
-                "Starting\n"
-                "  Local MAC: %s",
-                get_mac_address_pretty_into_buffer(mac_s));
+  ESP_LOGCONFIG(TAG, "Starting");
   this->last_connected_ = millis();
 
   uint32_t hash = this->has_sta() ? App.get_config_version_hash() : 88491487UL;
@@ -857,14 +852,6 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
 }
 
 const LogString *get_signal_bars(int8_t rssi) {
-  // Check for disconnected sentinel value first
-  if (rssi == WIFI_RSSI_DISCONNECTED) {
-    // MULTIPLICATION SIGN
-    // Unicode: U+00D7, UTF-8: C3 97
-    return LOG_STR("\033[0;31m"  // red
-                   "\xc3\x97\xc3\x97\xc3\x97\xc3\x97"
-                   "\033[0m");
-  }
   // LOWER ONE QUARTER BLOCK
   // Unicode: U+2582, UTF-8: E2 96 82
   // LOWER HALF BLOCK
@@ -908,16 +895,12 @@ const LogString *get_signal_bars(int8_t rssi) {
 }
 
 void WiFiComponent::print_connect_params_() {
+  if (this->is_disabled() || !this->is_connected()) {
+    return;
+  }
   bssid_t bssid = wifi_bssid();
   char bssid_s[18];
   format_mac_addr_upper(bssid.data(), bssid_s);
-
-  char mac_s[18];
-  ESP_LOGCONFIG(TAG, "  Local MAC: %s", get_mac_address_pretty_into_buffer(mac_s));
-  if (this->is_disabled()) {
-    ESP_LOGCONFIG(TAG, "  Disabled");
-    return;
-  }
   // Use stack buffers for IP address formatting to avoid heap allocations
   char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
   for (auto &ip : wifi_sta_ip_addresses()) {
@@ -1189,10 +1172,15 @@ void WiFiComponent::check_scanning_finished() {
 }
 
 void WiFiComponent::dump_config() {
+  char mac_s[18];
   ESP_LOGCONFIG(TAG,
                 "WiFi:\n"
+                "  Local MAC: %s\n"
                 "  Connected: %s",
-                YESNO(this->is_connected()));
+                get_mac_address_pretty_into_buffer(mac_s), YESNO(this->is_connected()));
+  if (this->is_disabled()) {
+    ESP_LOGCONFIG(TAG, "  Disabled");
+  }
   this->print_connect_params_();
 }
 
@@ -1223,8 +1211,6 @@ void WiFiComponent::check_connecting_finished() {
     // the first connection as a failure.
     this->error_from_callback_ = false;
 
-    this->print_connect_params_();
-
     if (this->has_ap()) {
 #ifdef USE_CAPTIVE_PORTAL
       if (this->is_captive_portal_active_()) {
@@ -1242,6 +1228,7 @@ void WiFiComponent::check_connecting_finished() {
 
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
     this->num_retried_ = 0;
+    this->print_connect_params_();
 
     // Clear priority tracking if all priorities are at minimum
     this->clear_priorities_if_all_min_();


### PR DESCRIPTION
# What does this implement/fix?

Cleans up WiFi logging to reduce duplicate and useless output:

1. **Remove duplicate "Starting scan" log** - Was logged twice (once at INFO in `start_initial_connection_()`, once at DEBUG in `start_scanning()`). Now only logged once in `start_scanning()` at DEBUG level.

2. **Remove duplicate MAC address logging** - Was logged in both `start()` and `dump_config()`. Now only logged once in `dump_config()`.

3. **Skip empty connection params when not connected** - Previously logged useless values like empty SSID, `00:00:00:00:00:00` BSSID, `-127 dB` signal strength during startup before WiFi connects. Now only logs MAC and "Connected: NO" when not connected.

4. **Remove disconnected signal bars indicator** - The red "××××" indicator for `-127 dB` (disconnected sentinel) is no longer needed since we don't log signal strength when not connected.

**Before (startup, not connected):**
```
[C][wifi:423]: Starting
[C][wifi:423]:   Local MAC: CC:DB:A7:1E:CD:30
[I][wifi:371]: Starting scan
[D][wifi:1057]: Starting scan
[C][wifi:1263]: WiFi:
[C][wifi:1263]:   Connected: NO
[C][wifi:981]:   Local MAC: CC:DB:A7:1E:CD:30
[C][wifi:1005]:   SSID: ''
[C][wifi:1005]:   BSSID: 00:00:00:00:00:00
[C][wifi:1005]:   Hostname: 'test'
[C][wifi:1005]:   Signal strength: -127 dB ××××
[C][wifi:1005]:   Channel: 1
[C][wifi:1005]:   Subnet: 0.0.0.0
[C][wifi:1005]:   Gateway: 0.0.0.0
[C][wifi:1005]:   DNS1: 0.0.0.0
[C][wifi:1005]:   DNS2: 0.0.0.0
```

**After (startup, not connected):**
```
[C][wifi:422]: Starting
[D][wifi:1048]: Starting scan
[C][wifi:1254]: WiFi:
[C][wifi:1254]:   Local MAC: CC:DB:A7:1E:CD:30
[C][wifi:1254]:   Connected: NO
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing documentation changes needed

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard WiFi config - no changes needed
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
