### PR TITLE
[opentherm][nau7802] Use direct format specifiers instead of to_string().c_str()

### DIFF
--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -131,9 +131,9 @@ void NAU7802Sensor::dump_config() {
   }
   // Note these may differ from the values on the device if calbration has been run
   ESP_LOGCONFIG(TAG,
-                "  Offset Calibration: %s\n"
+                "  Offset Calibration: %" PRId32 "\n"
                 "  Gain Calibration: %f",
-                to_string(this->offset_calibration_).c_str(), this->gain_calibration_);
+                this->offset_calibration_, this->gain_calibration_);
 
   std::string voltage = "unknown";
   switch (this->ldo_) {
@@ -289,7 +289,7 @@ void NAU7802Sensor::loop() {
       this->status_clear_error();
 
     int32_t ocal = this->read_value_(OCAL1_B2_REG, 3);
-    ESP_LOGI(TAG, "New Offset: %s", to_string(ocal).c_str());
+    ESP_LOGI(TAG, "New Offset: %" PRId32, ocal);
     uint32_t gcal = this->read_value_(GCAL1_B3_REG, 4);
     float gcal_f = ((float) gcal / (float) (1 << GCAL1_FRACTIONAL));
     ESP_LOGI(TAG, "New Gain: %f", gcal_f);

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -564,10 +564,9 @@ const char *OpenTherm::message_id_to_str(MessageId id) {
 void OpenTherm::debug_data(OpenthermData &data) {
   ESP_LOGD(TAG, "%s %s %s %s", format_bin(data.type).c_str(), format_bin(data.id).c_str(),
            format_bin(data.valueHB).c_str(), format_bin(data.valueLB).c_str());
-  ESP_LOGD(TAG, "type: %s; id: %s; HB: %s; LB: %s; uint_16: %s; float: %s",
-           this->message_type_to_str((MessageType) data.type), to_string(data.id).c_str(),
-           to_string(data.valueHB).c_str(), to_string(data.valueLB).c_str(), to_string(data.u16()).c_str(),
-           to_string(data.f88()).c_str());
+  ESP_LOGD(TAG, "type: %s; id: %u; HB: %u; LB: %u; uint_16: %u; float: %f",
+           this->message_type_to_str((MessageType) data.type), data.id, data.valueHB, data.valueLB, data.u16(),
+           data.f88());
 }
 void OpenTherm::debug_error(OpenThermError &error) const {
   ESP_LOGD(TAG, "data: 0x%08" PRIx32 "; clock: %u; capture: 0x%08" PRIx32 "; bit_pos: %u", error.data, this->clock_,

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -21,7 +21,6 @@ namespace esphome {
 namespace opentherm {
 
 using std::string;
-using std::to_string;
 
 static const char *const TAG = "opentherm";
 


### PR DESCRIPTION
# What does this implement/fix?

Replace `to_string(...).c_str()` patterns in logging with direct format specifiers to avoid unnecessary temporary `std::string` heap allocations.

**Changes:**
- `opentherm.cpp`: Use `%u` and `%f` directly for uint8_t, uint16_t, and float values in `debug_data()`
- `nau7802.cpp`: Use `PRId32` for int32_t values in config dump and calibration logging

Each `to_string().c_str()` call creates a temporary `std::string` on the heap just to extract its pointer for printf-style logging. Using direct format specifiers eliminates these allocations entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
