### PR TITLE
[ota] Fix ESP32-S3 OTA crash with hardware SHA acceleration on IDF 5.5.x

### DIFF
--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -28,7 +28,7 @@ CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["network"]
 
 
-AUTO_LOAD = ["md5", "sha256", "socket"]
+AUTO_LOAD = ["sha256", "socket"]
 
 
 esphome = cg.esphome_ns.namespace("esphome")

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -28,7 +28,7 @@ CODEOWNERS = ["@esphome/core"]
 DEPENDENCIES = ["network"]
 
 
-AUTO_LOAD = ["sha256", "socket"]
+AUTO_LOAD = ["md5", "sha256", "socket"]
 
 
 esphome = cg.esphome_ns.namespace("esphome")

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -559,11 +559,17 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
     //   [1+hex_size...1+2*hex_size-1]: cnonce (hex_size bytes) - client's nonce
     //   [1+2*hex_size...1+3*hex_size-1]: response (hex_size bytes) - client's hash
 
-    // Allocate auth buffer before creating SHA256 hasher to avoid potential
-    // heap/DMA interactions on ESP32-S3 with hardware SHA acceleration
-    constexpr size_t hex_size = SHA256_HEX_SIZE;
-    constexpr size_t nonce_len = 8;  // SHA256 digest size (32) / 4
-    constexpr size_t auth_buf_size = 1 + 3 * hex_size;
+    // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
+    // (no passing to other functions). All hash operations must happen in this function.
+    // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
+    // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
+    sha256::SHA256 hasher;
+    md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
+    (void) md5_dummy;          // Suppress unused variable warning
+
+    const size_t hex_size = hasher.get_size() * 2;
+    const size_t nonce_len = hasher.get_size() / 4;
+    const size_t auth_buf_size = 1 + 3 * hex_size;
     this->auth_buf_ = std::make_unique<uint8_t[]>(auth_buf_size);
     this->auth_buf_pos_ = 0;
 
@@ -574,13 +580,6 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
       return false;
     }
 
-    // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
-    // (no passing to other functions). All hash operations must happen in this function.
-    // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
-    // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
-    sha256::SHA256 hasher;
-    md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
-    (void) md5_dummy;          // Suppress unused variable warning
     hasher.init();
     hasher.add(buf, nonce_len);
     hasher.calculate();

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -1,7 +1,6 @@
 #include "ota_esphome.h"
 #ifdef USE_OTA
 #ifdef USE_OTA_PASSWORD
-#include "esphome/components/md5/md5.h"
 #include "esphome/components/sha256/sha256.h"
 #endif
 #include "esphome/components/network/util.h"
@@ -561,11 +560,9 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
 
     // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
     // (no passing to other functions). All hash operations must happen in this function.
-    // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
-    // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
-    sha256::SHA256 hasher;
-    md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
-    (void) md5_dummy;          // Suppress unused variable warning
+    // NOTE: On ESP32-S3 with IDF 5.5.x, the SHA256 context must be properly aligned for
+    // hardware SHA acceleration DMA operations.
+    alignas(32) sha256::SHA256 hasher;
 
     const size_t hex_size = hasher.get_size() * 2;
     const size_t nonce_len = hasher.get_size() / 4;
@@ -639,11 +636,9 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
 
   // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
   // (no passing to other functions). All hash operations must happen in this function.
-  // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
-  // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
-  sha256::SHA256 hasher;
-  md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
-  (void) md5_dummy;          // Suppress unused variable warning
+  // NOTE: On ESP32-S3 with IDF 5.5.x, the SHA256 context must be properly aligned for
+  // hardware SHA acceleration DMA operations.
+  alignas(32) sha256::SHA256 hasher;
 
   hasher.init();
   hasher.add(this->password_.c_str(), this->password_.length());

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -1,6 +1,7 @@
 #include "ota_esphome.h"
 #ifdef USE_OTA
 #ifdef USE_OTA_PASSWORD
+#include "esphome/components/md5/md5.h"
 #include "esphome/components/sha256/sha256.h"
 #endif
 #include "esphome/components/network/util.h"
@@ -575,8 +576,11 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
 
     // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
     // (no passing to other functions). All hash operations must happen in this function.
-    // Create hasher AFTER heap allocations to avoid potential cache/DMA interference.
+    // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
+    // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
     sha256::SHA256 hasher;
+    md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
+    (void) md5_dummy;          // Suppress unused variable warning
     hasher.init();
     hasher.add(buf, nonce_len);
     hasher.calculate();
@@ -636,7 +640,11 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
 
   // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
   // (no passing to other functions). All hash operations must happen in this function.
+  // NOTE: On ESP32-S3 with IDF 5.5.x, having only SHA256 on the stack causes crashes with
+  // hardware SHA acceleration. Adding an MD5 object provides the necessary stack alignment.
   sha256::SHA256 hasher;
+  md5::MD5Digest md5_dummy;  // Required for ESP32-S3 IDF 5.5.x stack alignment
+  (void) md5_dummy;          // Suppress unused variable warning
 
   hasher.init();
   hasher.add(this->password_.c_str(), this->password_.length());

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -558,13 +558,11 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
     //   [1+hex_size...1+2*hex_size-1]: cnonce (hex_size bytes) - client's nonce
     //   [1+2*hex_size...1+3*hex_size-1]: response (hex_size bytes) - client's hash
 
-    // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
-    // (no passing to other functions). All hash operations must happen in this function.
-    sha256::SHA256 hasher;
-
-    const size_t hex_size = hasher.get_size() * 2;
-    const size_t nonce_len = hasher.get_size() / 4;
-    const size_t auth_buf_size = 1 + 3 * hex_size;
+    // Allocate auth buffer before creating SHA256 hasher to avoid potential
+    // heap/DMA interactions on ESP32-S3 with hardware SHA acceleration
+    constexpr size_t hex_size = SHA256_HEX_SIZE;
+    constexpr size_t nonce_len = 8;  // SHA256 digest size (32) / 4
+    constexpr size_t auth_buf_size = 1 + 3 * hex_size;
     this->auth_buf_ = std::make_unique<uint8_t[]>(auth_buf_size);
     this->auth_buf_pos_ = 0;
 
@@ -575,6 +573,10 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
       return false;
     }
 
+    // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
+    // (no passing to other functions). All hash operations must happen in this function.
+    // Create hasher AFTER heap allocations to avoid potential cache/DMA interference.
+    sha256::SHA256 hasher;
     hasher.init();
     hasher.add(buf, nonce_len);
     hasher.calculate();

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -10,23 +10,26 @@ namespace esphome::sha256 {
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
 
-// CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION REQUIREMENTS:
+// CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
 //
 // The ESP32-S3 uses hardware DMA for SHA acceleration. The mbedtls_sha256_context structure contains
-// internal state that the DMA engine references. This imposes two critical constraints:
+// internal state that the DMA engine references. This imposes three critical constraints:
 //
-// 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
+// 1. ALIGNMENT: The SHA256 object MUST be declared with `alignas(32)` for proper DMA alignment.
+//    Without this, the DMA engine may crash with an abort in sha_hal_read_digest().
+//
+// 2. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
 //    write to incorrect memory locations. This results in null pointer dereferences and crashes.
 //    ALWAYS use fixed-size arrays (e.g., char buf[65], not char buf[size+1]).
 //
-// 2. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
+// 3. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
 //    function. NEVER pass the SHA256 object or HashBase pointer to another function. When the stack
 //    frame changes (function call/return), the DMA references become invalid and will produce
 //    truncated hash output (20 bytes instead of 32) or corrupt memory.
 //
 // CORRECT USAGE:
 //   void my_function() {
-//     sha256::SHA256 hasher;  // Created locally
+//     alignas(32) sha256::SHA256 hasher;  // Created locally with proper alignment
 //     hasher.init();
 //     hasher.add(data, len);  // Any size, no chunking needed
 //     hasher.calculate();
@@ -36,7 +39,7 @@ namespace esphome::sha256 {
 //
 // INCORRECT USAGE (WILL FAIL ON ESP32-S3):
 //   void my_function() {
-//     sha256::SHA256 hasher;
+//     sha256::SHA256 hasher;  // WRONG: Missing alignas(32)
 //     helper(&hasher);  // WRONG: Passed to different stack frame
 //   }
 //   void helper(HashBase *h) {

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -22,6 +22,18 @@
 
 namespace esphome::sha256 {
 
+/// SHA256 hash implementation.
+///
+/// CRITICAL for ESP32-S3 with IDF 5.5.x hardware SHA acceleration:
+/// 1. SHA256 objects MUST be declared with `alignas(32)` for proper DMA alignment
+/// 2. The object MUST stay in the same stack frame (no passing to other functions)
+/// 3. NO Variable Length Arrays (VLAs) in the same function
+///
+/// Example usage:
+///   alignas(32) sha256::SHA256 hasher;
+///   hasher.init();
+///   hasher.add(data, len);
+///   hasher.calculate();
 class SHA256 : public esphome::HashBase {
  public:
   SHA256() = default;
@@ -39,10 +51,8 @@ class SHA256 : public esphome::HashBase {
 
  protected:
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
-  // CRITICAL: The mbedtls context MUST be stack-allocated (not a pointer) for ESP32-S3 hardware SHA acceleration.
-  // The ESP32-S3 DMA engine references this structure's memory addresses. If the context is passed to another
-  // function (crossing stack frames) or if VLAs are present, the DMA operations will corrupt memory and produce
-  // truncated/incorrect hash results.
+  // The mbedtls context for ESP32-S3 hardware SHA requires proper alignment and stack frame constraints.
+  // See class documentation above for critical requirements.
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};


### PR DESCRIPTION
## What does this implement/fix?

Fixes OTA authentication crashes on ESP32-S3 with ESP-IDF 5.5.x by using explicit 32-byte alignment for the SHA256 hasher object to satisfy hardware SHA DMA requirements.

## Background

After upgrading to ESP-IDF 5.5.x, ESP32-S3 devices crash during OTA authentication with:

```
abort() was called at PC 0x420807ce on core 1

sha_hal_read_digest at sha_hal.c:129
esp_sha_read_digest_state at sha.c:62
mbedtls_sha256_update at esp_sha256.c:217
mbedtls_sha256_finish at esp_sha256.c:260
esphome::sha256::SHA256::calculate() at sha256.cpp:55
esphome::ESPHomeOTAComponent::handle_auth_send_() at ota_esphome.cpp
```

## Root Cause Analysis

The crash was introduced by #12707 which changed the stack layout in the OTA authentication functions. Previously, both `sha256::SHA256` and `md5::MD5Digest` objects were declared on the stack. After MD5 removal, only the SHA256 object remained, and it was no longer properly aligned for ESP32-S3 hardware SHA DMA operations.

Testing confirmed:
- Pre-MD5 removal code (both objects on stack): **Works**
- Post-MD5 removal code (SHA256 only): **Crashes**
- Adding dummy MD5 object back to stack: **Works**
- Adding dummy SHA256 object (same type): **Still crashes**
- Using `HashBase*` pointer without MD5 object: **Still crashes**
- Reordering heap allocations before SHA256: **Still crashes**
- Using `alignas(32)` on SHA256 object: **Works**

The MD5 object happened to provide the necessary stack alignment. The proper fix is explicit alignment using `alignas(32)`.

## The Fix

1. Use `alignas(32)` to explicitly align the SHA256 hasher object in both `handle_auth_send_()` and `handle_auth_read_()`:

```cpp
alignas(32) sha256::SHA256 hasher;
```

2. Document the alignment requirement in `sha256.h` class documentation so future users are aware of this ESP32-S3 IDF 5.5.x requirement.

This ensures the SHA256 context is properly aligned for ESP32-S3 hardware SHA acceleration DMA operations without relying on fragile stack layout side effects.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13009

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (tested on ESP32-S3 with IDF 5.5.x)
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test-device

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

ota:
  - platform: esphome
    password: "my_ota_password"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
