### PR TITLE
[api] Coalesce log packets to reduce buffer pressure and prevent dropped state updates

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1820,9 +1820,16 @@ bool APIConnection::try_to_clear_buffer(bool log_out_of_space) {
   return false;
 }
 bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
-  if (!this->try_to_clear_buffer(message_type != SubscribeLogsResponse::MESSAGE_TYPE)) {  // SubscribeLogsResponse
+  const bool is_log_message = (message_type == SubscribeLogsResponse::MESSAGE_TYPE);
+
+  if (!this->try_to_clear_buffer(!is_log_message)) {
     return false;
   }
+
+  // Toggle NODELAY based on message type:
+  // - Log messages: Enable Nagle (NODELAY=false) so they coalesce into fewer packets
+  // - All other messages: Disable Nagle (NODELAY=true) for immediate delivery
+  this->helper_->set_nodelay(!is_log_message);
 
   APIError err = this->helper_->write_protobuf_packet(message_type, buffer);
   if (err == APIError::WOULD_BLOCK)

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1829,6 +1829,10 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
   // Toggle Nagle's algorithm based on message type to prevent log messages from
   // filling the TCP send buffer and crowding out important state updates.
   //
+  // This honors the `no_delay` proto option - SubscribeLogsResponse is the only
+  // message with `option (no_delay) = false;` in api.proto, indicating it should
+  // allow Nagle coalescing. This option existed since 2019 but was never implemented.
+  //
   // - Log messages: Enable Nagle (NODELAY=false) so small log packets coalesce
   //   into fewer, larger packets. They flush naturally via TCP delayed ACK timer
   //   (~200ms), buffer filling, or when a state update triggers a flush.

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1826,9 +1826,18 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
     return false;
   }
 
-  // Toggle NODELAY based on message type:
-  // - Log messages: Enable Nagle (NODELAY=false) so they coalesce into fewer packets
-  // - All other messages: Disable Nagle (NODELAY=true) for immediate delivery
+  // Toggle Nagle's algorithm based on message type to prevent log messages from
+  // filling the TCP send buffer and crowding out important state updates.
+  //
+  // - Log messages: Enable Nagle (NODELAY=false) so small log packets coalesce
+  //   into fewer, larger packets. They flush naturally via TCP delayed ACK timer
+  //   (~200ms), buffer filling, or when a state update triggers a flush.
+  //
+  // - All other messages (state updates, responses): Disable Nagle (NODELAY=true)
+  //   for immediate delivery. These are time-sensitive and should not be delayed.
+  //
+  // This must be done proactively BEFORE the buffer fills up - checking buffer
+  // state here would be too late since we'd already be in a degraded state.
   this->helper_->set_nodelay(!is_log_message);
 
   APIError err = this->helper_->write_protobuf_packet(message_type, buffer);

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -111,7 +111,15 @@ class APIFrameHelper {
     }
     return APIError::OK;
   }
-  /// Set TCP_NODELAY option. Only calls setsockopt when state changes.
+  /// Toggle TCP_NODELAY socket option to control Nagle's algorithm.
+  ///
+  /// This is used to allow log messages to coalesce (Nagle enabled) while keeping
+  /// state updates low-latency (NODELAY enabled). Without this, many small log
+  /// packets fill the TCP send buffer, crowding out important state updates.
+  ///
+  /// State is tracked to minimize setsockopt() overhead - on lwip_raw (ESP8266/RP2040)
+  /// this is just a boolean assignment; on other platforms it's a lightweight syscall.
+  ///
   /// @param enable true to enable NODELAY (disable Nagle), false to enable Nagle
   /// @return true if successful or already in desired state
   bool set_nodelay(bool enable) {
@@ -211,7 +219,10 @@ class APIFrameHelper {
   uint8_t tx_buf_head_{0};
   uint8_t tx_buf_tail_{0};
   uint8_t tx_buf_count_{0};
-  bool nodelay_enabled_{true};  // Tracks current TCP_NODELAY state
+  // Tracks TCP_NODELAY state to minimize setsockopt() calls. Initialized to true
+  // since init_common_() enables NODELAY. Used by set_nodelay() to allow log
+  // messages to coalesce while keeping state updates low-latency.
+  bool nodelay_enabled_{true};
 
   // Common initialization for both plaintext and noise protocols
   APIError init_common_();

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -111,6 +111,19 @@ class APIFrameHelper {
     }
     return APIError::OK;
   }
+  /// Set TCP_NODELAY option. Only calls setsockopt when state changes.
+  /// @param enable true to enable NODELAY (disable Nagle), false to enable Nagle
+  /// @return true if successful or already in desired state
+  bool set_nodelay(bool enable) {
+    if (this->nodelay_enabled_ == enable)
+      return true;
+    int val = enable ? 1 : 0;
+    int err = this->socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+    if (err == 0) {
+      this->nodelay_enabled_ = enable;
+    }
+    return err == 0;
+  }
   virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
   // Write multiple protobuf messages in a single operation
   // messages contains (message_type, offset, length) for each message in the buffer
@@ -198,7 +211,7 @@ class APIFrameHelper {
   uint8_t tx_buf_head_{0};
   uint8_t tx_buf_tail_{0};
   uint8_t tx_buf_count_{0};
-  // 8 bytes total, 0 bytes padding
+  bool nodelay_enabled_{true};  // Tracks current TCP_NODELAY state
 
   // Common initialization for both plaintext and noise protocols
   APIError init_common_();


### PR DESCRIPTION
# What does this implement/fix?

Reduces dropped log messages over the API by enabling Nagle's algorithm (disabling TCP_NODELAY) when sending log messages, while keeping NODELAY enabled for all other message types like state updates.

**The problem:** With TCP_NODELAY always enabled, every small log message is sent immediately as a separate TCP packet. This fills up the TCP send buffer quickly with many tiny packets, leaving no room for important state updates (sensor values, entity states, etc.) which then get dropped once we hit the limit on the secondary buffers in the API component.

**The solution:** Toggle TCP_NODELAY per message type:
- **Log messages:** Enable Nagle (NODELAY=0) so multiple small log packets coalesce into fewer, larger packets
- **All other messages:** Keep NODELAY enabled for immediate delivery of state updates

Log messages naturally flush when:
- TCP delayed ACK timer fires (~200ms)
- Buffer fills up
- A state update with NODELAY triggers a flush

The implementation tracks the current NODELAY state to minimize setsockopt() overhead - only calling it when transitioning between message types. On ESP8266/RP2040 (lwip_raw), this is essentially free (just a boolean assignment). On ESP32-IDF, it's a lightweight syscall.

**Historical context:** The `no_delay` proto option was added in 2019 (commit 369d175694) with `SubscribeLogsResponse` being the only message marked with `option (no_delay) = false;`. However, this option was never actually implemented on the server side - TCP_NODELAY was always enabled for all messages. This PR finally honors that original design intent.

## Performance Results

Runtime stats with moderate logging (60 second period, same relative time after boot):

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Count | 6365 | 6555 | +3% more operations |
| Average | 0.43ms | 0.30ms | **30% faster** |
| Max | 14ms | 8ms | **43% lower worst-case** |
| Total | 2718ms | 1961ms | **28% less CPU time** |

The setsockopt() overhead is negligible - far outweighed by savings from fewer TCP packets, less buffer contention, and fewer write syscalls.

**Trade-off:** Individual log entries may be delayed up to ~200ms (TCP delayed ACK timer) before appearing. This is acceptable since:
- Logs still appear promptly when state updates flush the buffer
- Burst logging still streams quickly (packets coalesce and flush as buffer fills)
- Far better than dropped logs and dropped state updates

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to log message reliability over the native API

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an automatic improvement
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
