### PR TITLE
[neopixelbus] Fix ESP8266 compilation by enabling Serial/Serial1 for NeoPixelBus library

### DIFF
--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -194,6 +194,14 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    if CORE.is_esp8266:
+        # NeoPixelBus library unconditionally includes NeoEsp8266UartMethod.h
+        # which references Serial and Serial1, so we must enable both
+        from esphome.components.esp8266.const import enable_serial, enable_serial1
+
+        enable_serial()
+        enable_serial1()
+
     has_white = "W" in config[CONF_TYPE]
     method = config[CONF_METHOD]
 


### PR DESCRIPTION
# What does this implement/fix?

Fix ESP8266 compilation error when using the neopixelbus component after the recent serial optimization changes.

The NeoPixelBus library unconditionally includes `NeoEsp8266UartMethod.h` which references both `Serial` and `Serial1` globals, regardless of which output method is actually configured. This causes compilation failures because the recent ESP8266 serial optimization excludes these objects when no component requests them.

The fix enables both `Serial` and `Serial1` unconditionally when neopixelbus is used on ESP8266.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes CI failure from serial optimization changes

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp8266:
  board: d1_mini

light:
  - platform: neopixelbus
    type: GRB
    variant: ws2812x
    pin: 3
    num_leds: 10
    name: "Test LED"
    method:
      type: esp8266_dma
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
