### PR TITLE
[text_sensor][text] Add const char* overloads to publish_state to eliminate heap churn

### DIFF
--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -27,6 +27,8 @@ class Text : public EntityBase {
   TextTraits traits;
 
   void publish_state(const std::string &state);
+  void publish_state(const char *state);
+  void publish_state(const char *state, size_t len);
 
   /// Instantiate a TextCall object to modify this text component's state.
   TextCall make_call() { return TextCall(this); }

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -41,10 +41,10 @@ void TextSensor::publish_state(const char *state, size_t len) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     this->raw_state.assign(state, len);
-#pragma GCC diagnostic pop
     this->raw_callback_.call(this->raw_state);
     ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->raw_state.c_str());
     this->filter_list_->input(this->raw_state);
+#pragma GCC diagnostic pop
   }
 }
 

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
+#include <cstring>
 
 namespace esphome {
 namespace text_sensor {
@@ -24,20 +25,26 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   }
 }
 
-void TextSensor::publish_state(const std::string &state) {
-// Suppress deprecation warning - we need to populate raw_state for backwards compatibility
+void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }
+
+void TextSensor::publish_state(const char *state) { this->publish_state(state, strlen(state)); }
+
+void TextSensor::publish_state(const char *state, size_t len) {
+  if (this->filter_list_ == nullptr) {
+    // No filters: raw_state == state, store once and use for both callbacks
+    this->state.assign(state, len);
+    this->raw_callback_.call(this->state);
+    ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->state.c_str());
+    this->notify_frontend_();
+  } else {
+    // Has filters: need separate raw storage
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  this->raw_state = state;
+    this->raw_state.assign(state, len);
 #pragma GCC diagnostic pop
-  this->raw_callback_.call(state);
-
-  ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), state.c_str());
-
-  if (this->filter_list_ == nullptr) {
-    this->internal_send_state_to_frontend(state);
-  } else {
-    this->filter_list_->input(state);
+    this->raw_callback_.call(this->raw_state);
+    ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->raw_state.c_str());
+    this->filter_list_->input(this->raw_state);
   }
 }
 
@@ -80,6 +87,9 @@ void TextSensor::add_on_raw_state_callback(std::function<void(const std::string 
 
 const std::string &TextSensor::get_state() const { return this->state; }
 const std::string &TextSensor::get_raw_state() const {
+  if (this->filter_list_ == nullptr) {
+    return this->state;  // No filters, raw == filtered
+  }
 // Suppress deprecation warning - get_raw_state() is the replacement API
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -87,10 +97,18 @@ const std::string &TextSensor::get_raw_state() const {
 #pragma GCC diagnostic pop
 }
 void TextSensor::internal_send_state_to_frontend(const std::string &state) {
-  this->state = state;
+  this->internal_send_state_to_frontend(state.data(), state.size());
+}
+
+void TextSensor::internal_send_state_to_frontend(const char *state, size_t len) {
+  this->state.assign(state, len);
+  this->notify_frontend_();
+}
+
+void TextSensor::notify_frontend_() {
   this->set_has_state(true);
-  ESP_LOGD(TAG, "'%s': Sending state '%s'", this->name_.c_str(), state.c_str());
-  this->callback_.call(state);
+  ESP_LOGD(TAG, "'%s': Sending state '%s'", this->name_.c_str(), this->state.c_str());
+  this->callback_.call(this->state);
 #if defined(USE_TEXT_SENSOR) && defined(USE_CONTROLLER_REGISTRY)
   ControllerRegistry::notify_text_sensor_update(this);
 #endif

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -42,6 +42,8 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   const std::string &get_raw_state() const;
 
   void publish_state(const std::string &state);
+  void publish_state(const char *state);
+  void publish_state(const char *state, size_t len);
 
   /// Add a filter to the filter chain. Will be appended to the back.
   void add_filter(Filter *filter);
@@ -63,8 +65,11 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
   // (In most use cases you won't need these)
 
   void internal_send_state_to_frontend(const std::string &state);
+  void internal_send_state_to_frontend(const char *state, size_t len);
 
  protected:
+  /// Notify frontend that state has changed (assumes this->state is already set)
+  void notify_frontend_();
   LazyCallbackManager<void(const std::string &)> raw_callback_;  ///< Storage for raw state callbacks.
   LazyCallbackManager<void(const std::string &)> callback_;      ///< Storage for filtered state callbacks.
 


### PR DESCRIPTION
# What does this implement/fix?

Add `const char*` overloads to `publish_state()` for `text_sensor` and `text` entities to eliminate heap churn from implicit `std::string` conversion.

**Problem:** When callers pass a stack buffer (e.g., `char buf[256]`) to `publish_state(const std::string &state)`, implicit conversion creates a temporary `std::string`, causing a heap allocation. On 32-bit systems (ESP8266, ESP32), SSO capacity is only ~10-11 bytes, so most real-world strings trigger allocation.

**Solution:**
- Add `publish_state(const char *state)` and `publish_state(const char *state, size_t len)` overloads
- Callers passing `const char*` now avoid the temporary `std::string` entirely
- For `text_sensor`: optimize the no-filter case to store only once (`state`) instead of twice (`raw_state` + `state`)
- `get_raw_state()` now returns `state` when no filters exist (since they're identical)

**Benefits:**
- Eliminates heap allocation for the temporary when passing `const char*`
- `assign(ptr, len)` reuses existing string capacity, so repeated publishes of similar-sized values have zero allocations
- No-filter case (common): 1 string copy instead of 2

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Existing text_sensor and text configurations work unchanged

text_sensor:
  - platform: template
    name: "My Text Sensor"
    # publish_state() now accepts const char* without heap allocation
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- covered by existing integration tests already
   

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a - no user-facing changes)
