### PR TITLE
[pylontech] Eliminate heap allocations in text sensors

### DIFF
--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.cpp
@@ -25,16 +25,16 @@ void PylontechTextSensor::on_line_read(PylontechListener::LineContents *line) {
     return;
   }
   if (this->base_state_text_sensor_ != nullptr) {
-    this->base_state_text_sensor_->publish_state(std::string(line->base_st));
+    this->base_state_text_sensor_->publish_state(line->base_st);
   }
   if (this->voltage_state_text_sensor_ != nullptr) {
-    this->voltage_state_text_sensor_->publish_state(std::string(line->volt_st));
+    this->voltage_state_text_sensor_->publish_state(line->volt_st);
   }
   if (this->current_state_text_sensor_ != nullptr) {
-    this->current_state_text_sensor_->publish_state(std::string(line->curr_st));
+    this->current_state_text_sensor_->publish_state(line->curr_st);
   }
   if (this->temperature_state_text_sensor_ != nullptr) {
-    this->temperature_state_text_sensor_->publish_state(std::string(line->temp_st));
+    this->temperature_state_text_sensor_->publish_state(line->temp_st);
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Eliminate 4 heap allocations per battery status update in Pylontech text sensors.

**Before:** Each `publish_state(std::string(line->xxx_st))` creates a temporary `std::string` from a char array.

**After:** Pass the char arrays directly to `publish_state()`, using the new `const char*` overload.

This eliminates 4 heap allocations per battery per status update, reducing heap fragmentation on long-running devices.

Note: These state values might be better suited as regular sensors or selects rather than text sensors, but that's a design change for another day - this PR just fixes the heap churn.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Existing pylontech configurations work unchanged

uart:
  - id: uart_pylontech
    tx_pin: GPIO1
    rx_pin: GPIO3
    baud_rate: 115200

pylontech:
  uart_id: uart_pylontech

text_sensor:
  - platform: pylontech
    battery: 1
    base_state:
      name: "Battery 1 Base State"
    voltage_state:
      name: "Battery 1 Voltage State"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a - no user-facing changes)
