### PR TITLE
[preferences] Fix preferences not syncing in safe mode due to component registration order

### DIFF
--- a/esphome/components/preferences/__init__.py
+++ b/esphome/components/preferences/__init__.py
@@ -1,6 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.core import coroutine_with_priority
+from esphome.coroutine import CoroPriority
 
 CODEOWNERS = ["@esphome/core"]
 
@@ -16,6 +18,7 @@ CONFIG_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
+@coroutine_with_priority(CoroPriority.PREFERENCES)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_write_interval(config[CONF_FLASH_WRITE_INTERVAL]))

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -150,6 +150,16 @@ void SafeModeComponent::clean_rtc() {
   // remain incremented.
   uint32_t val = 0;
   this->rtc_.save(&val);
+#ifdef USE_LIBRETINY
+  // On LibreTiny (BK72xx, RTL87xx), preferences queued during shutdown are not
+  // reliably persisted to flash. This was observed on TuyaMCU devices where:
+  // 1. Safe mode button pressed or boot loop detected -> clean_rtc() queues counter=0
+  // 2. OTA completes -> safe_reboot() triggers IntervalSyncer::on_shutdown() -> sync()
+  // 3. After reboot, counter is NOT cleared -> device stuck in safe mode loop
+  // The FlashDB layer appears to fail silently when writing during shutdown.
+  // Sync immediately to ensure the boot counter is actually persisted.
+  global_preferences->sync();
+#endif
 }
 
 void SafeModeComponent::on_safe_shutdown() {

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -150,16 +150,6 @@ void SafeModeComponent::clean_rtc() {
   // remain incremented.
   uint32_t val = 0;
   this->rtc_.save(&val);
-#ifdef USE_LIBRETINY
-  // On LibreTiny (BK72xx, RTL87xx), preferences queued during shutdown are not
-  // reliably persisted to flash. This was observed on TuyaMCU devices where:
-  // 1. Safe mode button pressed or boot loop detected -> clean_rtc() queues counter=0
-  // 2. OTA completes -> safe_reboot() triggers IntervalSyncer::on_shutdown() -> sync()
-  // 3. After reboot, counter is NOT cleared -> device stuck in safe mode loop
-  // The FlashDB layer appears to fail silently when writing during shutdown.
-  // Sync immediately to ensure the boot counter is actually persisted.
-  global_preferences->sync();
-#endif
 }
 
 void SafeModeComponent::on_safe_shutdown() {

--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -114,6 +114,14 @@ class CoroPriority(enum.IntEnum):
     # Examples: web_server_ota (52)
     WEB_SERVER_OTA = 52
 
+    # Preferences - must run before APPLICATION (safe_mode) because safe_mode
+    # uses an early return when entering safe mode, skipping all lower priority
+    # component registration. Without IntervalSyncer registered, preferences
+    # cannot be synced during shutdown in safe mode, causing issues like the
+    # boot counter never being cleared and devices getting stuck in safe mode.
+    # Examples: preferences (51)
+    PREFERENCES = 51
+
     # Application-level services
     # Examples: safe_mode (50)
     APPLICATION = 50


### PR DESCRIPTION
# What does this implement/fix?

Fixes devices getting stuck in safe mode because preferences were not being synced during shutdown when in safe mode.

## Background

When a device enters safe mode, `should_enter_safe_mode()` uses an early `return` statement that skips all lower-priority component registration. The `preferences` component (which registers `IntervalSyncer`) had no explicit priority, defaulting to 0. Since `safe_mode` runs at priority 50 (`APPLICATION`), `IntervalSyncer` was never registered when entering safe mode.

Without `IntervalSyncer` registered:
1. `IntervalSyncer::on_shutdown()` is never called during `safe_reboot()`
2. Preferences queued by `clean_rtc()` are never synced to flash
3. The boot counter remains elevated after reboot
4. Device re-enters safe mode on next boot
5. Device is permanently stuck in safe mode

This was discovered while investigating a report of LibreTiny devices getting stuck in safe mode. The issue affects all platforms, but was more visible on LibreTiny due to other factors that made recovery harder.

## The Fix

Add a new `PREFERENCES` priority (51) that runs just before `APPLICATION` (50), ensuring `IntervalSyncer` is registered before safe_mode's early return. This allows preferences to be properly synced during shutdown even when in safe mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #12625 (made the issue more visible, but the underlying bug existed before)
- fixes https://ptb.discord.com/channels/429907082951524364/1458173199111032884/1458173202323869952

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - fix is automatic
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
