### PR TITLE
[esp32_camera][uart] Add missing wake_loop_threadsafe() preprocessor guards

### DIFF
--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -429,9 +429,11 @@ void ESP32Camera::framebuffer_task(void *pv) {
     camera_fb_t *framebuffer = esp_camera_fb_get();
     xQueueSend(that->framebuffer_get_queue_, &framebuffer, portMAX_DELAY);
     // Only wake the main loop if there's a pending request to consume the frame
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
     if (that->has_requested_image_()) {
       App.wake_loop_threadsafe();
     }
+#endif
     // return is no-op for config with 1 fb
     xQueueReceive(that->framebuffer_return_queue_, &framebuffer, portMAX_DELAY);
     esp_camera_fb_return(framebuffer);

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -398,14 +398,18 @@ void IDFUARTComponent::rx_event_task_func(void *param) {
         case UART_DATA:
           // Data available in UART RX buffer - wake the main loop
           ESP_LOGVV(TAG, "Data event: %d bytes", event.size);
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
           App.wake_loop_threadsafe();
+#endif
           break;
 
         case UART_FIFO_OVF:
         case UART_BUFFER_FULL:
           ESP_LOGW(TAG, "FIFO overflow or ring buffer full - clearing");
           uart_flush_input(self->uart_num_);
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
           App.wake_loop_threadsafe();
+#endif
           break;
 
         default:


### PR DESCRIPTION
# What does this implement/fix?

Adds missing preprocessor guards around `App.wake_loop_threadsafe()` calls in `esp32_camera` and `uart` components.

After #12891 made `socket.require_wake_loop_threadsafe()` a no-op when no networking is configured, components that call `App.wake_loop_threadsafe()` without guards will fail to compile when used without wifi/ethernet/openthread.

The `wake_loop_threadsafe()` method is only defined when both `USE_SOCKET_SELECT_SUPPORT` and `USE_WAKE_LOOP_THREADSAFE` are set, so callers must guard their calls with the same conditions.

**Components fixed:**
- `esp32_camera` - Added guard around `App.wake_loop_threadsafe()` in `framebuffer_task()`
- `uart` (ESP-IDF) - Added guards around `App.wake_loop_threadsafe()` calls in RX event task

**Components already correctly guarded:**
- `esp32_ble`
- `micro_wake_word`
- `espnow`
- `usb_uart`
- `usb_cdc_acm`
- `usb_host`
- `mqtt` (requires `network` dependency, so always has networking)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes compilation failure when using esp32_camera or uart with esp32_ble but without networking

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This configuration now compiles (previously failed):
esphome:
  name: ble-camera-no-wifi

esp32:
  board: esp32-pico-devkitm-2
  framework:
    type: esp-idf

esp32_ble:

esp32_camera:
  # ... camera pin configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
