### PR TITLE
[text_sensor][text] Avoid heap allocation when state unchanged

### DIFF
--- a/esphome/components/text/text.cpp
+++ b/esphome/components/text/text.cpp
@@ -15,7 +15,10 @@ void Text::publish_state(const char *state) { this->publish_state(state, strlen(
 
 void Text::publish_state(const char *state, size_t len) {
   this->set_has_state(true);
-  this->state.assign(state, len);
+  // Only assign if changed to avoid heap allocation
+  if (len != this->state.size() || memcmp(state, this->state.data(), len) != 0) {
+    this->state.assign(state, len);
+  }
   if (this->traits.get_mode() == TEXT_MODE_PASSWORD) {
     ESP_LOGD(TAG, "'%s': Sending state " LOG_SECRET("'%s'"), this->get_name().c_str(), this->state.c_str());
   } else {

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -32,7 +32,10 @@ void TextSensor::publish_state(const char *state) { this->publish_state(state, s
 void TextSensor::publish_state(const char *state, size_t len) {
   if (this->filter_list_ == nullptr) {
     // No filters: raw_state == state, store once and use for both callbacks
-    this->state.assign(state, len);
+    // Only assign if changed to avoid heap allocation
+    if (len != this->state.size() || memcmp(state, this->state.data(), len) != 0) {
+      this->state.assign(state, len);
+    }
     this->raw_callback_.call(this->state);
     ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->state.c_str());
     this->notify_frontend_();
@@ -40,7 +43,10 @@ void TextSensor::publish_state(const char *state, size_t len) {
     // Has filters: need separate raw storage
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    this->raw_state.assign(state, len);
+    // Only assign if changed to avoid heap allocation
+    if (len != this->raw_state.size() || memcmp(state, this->raw_state.data(), len) != 0) {
+      this->raw_state.assign(state, len);
+    }
     this->raw_callback_.call(this->raw_state);
     ESP_LOGV(TAG, "'%s': Received new state %s", this->name_.c_str(), this->raw_state.c_str());
     this->filter_list_->input(this->raw_state);
@@ -101,7 +107,10 @@ void TextSensor::internal_send_state_to_frontend(const std::string &state) {
 }
 
 void TextSensor::internal_send_state_to_frontend(const char *state, size_t len) {
-  this->state.assign(state, len);
+  // Only assign if changed to avoid heap allocation
+  if (len != this->state.size() || memcmp(state, this->state.data(), len) != 0) {
+    this->state.assign(state, len);
+  }
   this->notify_frontend_();
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Avoid unnecessary heap allocations in `text_sensor` and `text` entities when the state value hasn't changed.

Previously, every call to `publish_state()` would call `std::string::assign()` unconditionally, which:
1. Always copies the data (even if identical)
2. Allocates heap memory if the new length exceeds current capacity

This change adds a check before assignment to skip the copy when the content is unchanged:
```cpp
if (len != this->state.size() || memcmp(state, this->state.data(), len) != 0) {
  this->state.assign(state, len);
}
```

This is similar to the deduplication pattern used by `binary_sensor` via `StatefulEntityBase`, but importantly **callbacks are still called every time** to preserve existing behavior. Only the heap allocation is avoided.

This benefits sensors that publish the same value repeatedly (e.g., status text sensors, connection state strings).

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
text_sensor:
  - platform: wifi_info
    ip_address:
      name: "IP Address"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- fully covered by integration tests

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
