### PR TITLE
[sun_gtil2] Eliminate heap allocations in text sensor publishing

### DIFF
--- a/esphome/components/sun_gtil2/sun_gtil2.cpp
+++ b/esphome/components/sun_gtil2/sun_gtil2.cpp
@@ -47,14 +47,15 @@ void SunGTIL2::loop() {
   }
 }
 
-std::string SunGTIL2::state_to_string_(uint8_t state) {
+const char *SunGTIL2::state_to_string_(uint8_t state, std::span<char, STATE_BUFFER_SIZE> buffer) {
   switch (state) {
     case 0x02:
       return "Starting voltage too low";
     case 0x07:
       return "Working";
     default:
-      return str_sprintf("Unknown (0x%02x)", state);
+      snprintf(buffer.data(), buffer.size(), "Unknown (0x%02x)", state);
+      return buffer.data();
   }
 }
 
@@ -106,12 +107,11 @@ void SunGTIL2::handle_char_(uint8_t c) {
 #endif
 #ifdef USE_TEXT_SENSOR
   if (this->state_ != nullptr) {
-    this->state_->publish_state(this->state_to_string_(msg.state));
+    char state_buffer[STATE_BUFFER_SIZE];
+    this->state_->publish_state(this->state_to_string_(msg.state, state_buffer));
   }
   if (this->serial_number_ != nullptr) {
-    std::string serial_number;
-    serial_number.assign(msg.serial_number, 10);
-    this->serial_number_->publish_state(serial_number);
+    this->serial_number_->publish_state(msg.serial_number, 10);
   }
 #endif
 }

--- a/esphome/components/sun_gtil2/sun_gtil2.h
+++ b/esphome/components/sun_gtil2/sun_gtil2.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
@@ -34,8 +36,10 @@ class SunGTIL2 : public Component, public uart::UARTDevice {
   void set_serial_number(text_sensor::TextSensor *text_sensor) { serial_number_ = text_sensor; }
 #endif
 
+  static constexpr size_t STATE_BUFFER_SIZE = 16;
+
  protected:
-  std::string state_to_string_(uint8_t state);
+  const char *state_to_string_(uint8_t state, std::span<char, STATE_BUFFER_SIZE> buffer);
 #ifdef USE_SENSOR
   sensor::Sensor *ac_voltage_{nullptr};
   sensor::Sensor *dc_voltage_{nullptr};

--- a/esphome/components/sun_gtil2/sun_gtil2.h
+++ b/esphome/components/sun_gtil2/sun_gtil2.h
@@ -36,7 +36,7 @@ class SunGTIL2 : public Component, public uart::UARTDevice {
   void set_serial_number(text_sensor::TextSensor *text_sensor) { serial_number_ = text_sensor; }
 #endif
 
-  static constexpr size_t STATE_BUFFER_SIZE = 16;
+  static constexpr size_t STATE_BUFFER_SIZE = 32;
 
  protected:
   const char *state_to_string_(uint8_t state, std::span<char, STATE_BUFFER_SIZE> buffer);


### PR DESCRIPTION
# What does this implement/fix?

Eliminate heap allocations in `sun_gtil2` text sensor publishing:

- **Serial number**: Use `publish_state(const char*, size_t)` directly instead of creating a temporary `std::string`
- **State string**: Use caller-provided stack buffer with `std::span` instead of returning `std::string` from `str_sprintf()`

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
uart:
  rx_pin: GPIO16
  baud_rate: 9600

sun_gtil2:
  state:
    name: "Inverter State"
  serial_number:
    name: "Serial Number"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
