### PR TITLE
[http_request] Store JSON keys in flash for ESP8266

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -93,35 +93,36 @@ void HttpRequestUpdate::update_task(void *params) {
     container.reset();  // Release ownership of the container's shared_ptr
 
     valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
-      if (!root["name"].is<const char *>() || !root["version"].is<const char *>() || !root["builds"].is<JsonArray>()) {
+      if (!root[ESPHOME_F("name")].is<const char *>() || !root[ESPHOME_F("version")].is<const char *>() ||
+          !root[ESPHOME_F("builds")].is<JsonArray>()) {
         ESP_LOGE(TAG, "Manifest does not contain required fields");
         return false;
       }
-      this_update->update_info_.title = root["name"].as<std::string>();
-      this_update->update_info_.latest_version = root["version"].as<std::string>();
+      this_update->update_info_.title = root[ESPHOME_F("name")].as<std::string>();
+      this_update->update_info_.latest_version = root[ESPHOME_F("version")].as<std::string>();
 
-      for (auto build : root["builds"].as<JsonArray>()) {
-        if (!build["chipFamily"].is<const char *>()) {
+      for (auto build : root[ESPHOME_F("builds")].as<JsonArray>()) {
+        if (!build[ESPHOME_F("chipFamily")].is<const char *>()) {
           ESP_LOGE(TAG, "Manifest does not contain required fields");
           return false;
         }
-        if (build["chipFamily"] == ESPHOME_VARIANT) {
-          if (!build["ota"].is<JsonObject>()) {
+        if (build[ESPHOME_F("chipFamily")] == ESPHOME_VARIANT) {
+          if (!build[ESPHOME_F("ota")].is<JsonObject>()) {
             ESP_LOGE(TAG, "Manifest does not contain required fields");
             return false;
           }
-          JsonObject ota = build["ota"].as<JsonObject>();
-          if (!ota["path"].is<const char *>() || !ota["md5"].is<const char *>()) {
+          JsonObject ota = build[ESPHOME_F("ota")].as<JsonObject>();
+          if (!ota[ESPHOME_F("path")].is<const char *>() || !ota[ESPHOME_F("md5")].is<const char *>()) {
             ESP_LOGE(TAG, "Manifest does not contain required fields");
             return false;
           }
-          this_update->update_info_.firmware_url = ota["path"].as<std::string>();
-          this_update->update_info_.md5 = ota["md5"].as<std::string>();
+          this_update->update_info_.firmware_url = ota[ESPHOME_F("path")].as<std::string>();
+          this_update->update_info_.md5 = ota[ESPHOME_F("md5")].as<std::string>();
 
-          if (ota["summary"].is<const char *>())
-            this_update->update_info_.summary = ota["summary"].as<std::string>();
-          if (ota["release_url"].is<const char *>())
-            this_update->update_info_.release_url = ota["release_url"].as<std::string>();
+          if (ota[ESPHOME_F("summary")].is<const char *>())
+            this_update->update_info_.summary = ota[ESPHOME_F("summary")].as<std::string>();
+          if (ota[ESPHOME_F("release_url")].is<const char *>())
+            this_update->update_info_.release_url = ota[ESPHOME_F("release_url")].as<std::string>();
 
           return true;
         }


### PR DESCRIPTION
# What does this implement/fix?

Use `ESPHOME_F()` macro for JSON keys in http_request update component to store string literals in flash instead of RAM on ESP8266.

On ESP8266 (Harvard architecture), bare string literals like `root["name"]` are copied to RAM at startup. By wrapping them with `ESPHOME_F()`, these strings remain in flash memory, saving approximately 80-100 bytes of precious RAM.

The `ESPHOME_F()` macro is a no-op on ESP32 and other platforms where string literals are already read directly from flash.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a - no user-facing changes)
