### PR TITLE
[zwave_proxy] Add logging if client sends zero-length message

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -182,11 +182,15 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
     ESP_LOGV(TAG, "Skipping sending duplicate response: 0x%02X", data[0]);
     return;
   }
+  if (length && data != nullptr) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-  char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
+    char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
 #endif
-  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, length));
-  this->write_array(data, length);
+    ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, length));
+    this->write_array(data, length);
+  } else {
+    ESP_LOGE(TAG, "Null pointer or length 0");
+  }
 }
 
 void ZWaveProxy::send_homeid_changed_msg_(api::APIConnection *conn) {


### PR DESCRIPTION
# What does this implement/fix?

Small change to log a message in the event that a client attempts to send a zero-length message.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
