### PR TITLE
[es8388] Use index-based select publish_state to avoid heap allocations

### DIFF
--- a/esphome/components/es8388/es8388.cpp
+++ b/esphome/components/es8388/es8388.cpp
@@ -116,9 +116,8 @@ void ES8388::setup() {
   if (this->dac_output_select_ != nullptr) {
     auto dac_power = this->get_dac_power();
     if (dac_power.has_value()) {
-      auto dac_power_str = this->dac_output_select_->at(dac_power.value());
-      if (dac_power_str.has_value()) {
-        this->dac_output_select_->publish_state(dac_power_str.value());
+      if (this->dac_output_select_->has_index(dac_power.value())) {
+        this->dac_output_select_->publish_state(dac_power.value());
       } else {
         ESP_LOGW(TAG, "Unknown DAC output power value: %d", dac_power.value());
       }
@@ -127,9 +126,8 @@ void ES8388::setup() {
   if (this->adc_input_mic_select_ != nullptr) {
     auto mic_input = this->get_mic_input();
     if (mic_input.has_value()) {
-      auto mic_input_str = this->adc_input_mic_select_->at(mic_input.value());
-      if (mic_input_str.has_value()) {
-        this->adc_input_mic_select_->publish_state(mic_input_str.value());
+      if (this->adc_input_mic_select_->has_index(mic_input.value())) {
+        this->adc_input_mic_select_->publish_state(mic_input.value());
       } else {
         ESP_LOGW(TAG, "Unknown ADC input mic value: %d", mic_input.value());
       }


### PR DESCRIPTION
# What does this implement/fix?

Use `has_index()` + `publish_state(size_t)` instead of `at()` which returns `optional<std::string>`, avoiding heap allocation when publishing DAC output and ADC input mic select states.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
