### PR TITLE
[core] Add integer overload for fnv1a_hash_extend

### DIFF
--- a/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
+++ b/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
@@ -32,7 +32,9 @@ void BME68xBSEC2I2CComponent::dump_config() {
 }
 
 uint32_t BME68xBSEC2I2CComponent::get_hash() {
-  return fnv1_hash_extend(fnv1_hash("bme68x_bsec_state_"), static_cast<uint32_t>(this->address_));
+  char buf[22];  // "bme68x_bsec_state_" (18) + uint8_t max (3) + null
+  snprintf(buf, sizeof(buf), "bme68x_bsec_state_%u", this->address_);
+  return fnv1_hash(buf);
 }
 
 int8_t BME68xBSEC2I2CComponent::read_bytes_wrapper(uint8_t a_register, uint8_t *data, uint32_t len, void *intfPtr) {

--- a/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
+++ b/esphome/components/bme68x_bsec2_i2c/bme68x_bsec2_i2c.cpp
@@ -31,7 +31,9 @@ void BME68xBSEC2I2CComponent::dump_config() {
   BME68xBSEC2Component::dump_config();
 }
 
-uint32_t BME68xBSEC2I2CComponent::get_hash() { return fnv1_hash("bme68x_bsec_state_" + to_string(this->address_)); }
+uint32_t BME68xBSEC2I2CComponent::get_hash() {
+  return fnv1_hash_extend(fnv1_hash("bme68x_bsec_state_"), static_cast<uint32_t>(this->address_));
+}
 
 int8_t BME68xBSEC2I2CComponent::read_bytes_wrapper(uint8_t a_register, uint8_t *data, uint32_t len, void *intfPtr) {
   ESP_LOGVV(TAG, "read_bytes_wrapper: reg = %u", a_register);

--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -158,7 +158,7 @@ void SEN5XComponent::setup() {
         // Hash with config hash, version, and serial number
         // This ensures the baseline storage is cleared after OTA
         // Serial numbers are unique to each sensor, so multiple sensors can be used without conflict
-        uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), std::to_string(combined_serial));
+        uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), combined_serial);
         this->pref_ = global_preferences->make_preference<Sen5xBaselines>(hash, true);
 
         if (this->pref_.load(&this->voc_baselines_storage_)) {

--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -75,7 +75,7 @@ void SGP30Component::setup() {
   // Hash with config hash, version, and serial number
   // This ensures the baseline storage is cleared after OTA
   // Serial numbers are unique to each sensor, so multiple sensors can be used without conflict
-  uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), std::to_string(this->serial_number_));
+  uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), this->serial_number_);
   this->pref_ = global_preferences->make_preference<SGP30Baselines>(hash, true);
 
   if (this->store_baseline_ && this->pref_.load(&this->baselines_storage_)) {

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -60,7 +60,7 @@ void SGP4xComponent::setup() {
     // Hash with config hash, version, and serial number
     // This ensures the baseline storage is cleared after OTA
     // Serial numbers are unique to each sensor, so multiple sensors can be used without conflict
-    uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), std::to_string(this->serial_number_));
+    uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), this->serial_number_);
     this->pref_ = global_preferences->make_preference<SGP4xBaselines>(hash, true);
 
     if (this->pref_.load(&this->voc_baselines_storage_)) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -391,15 +391,6 @@ constexpr uint32_t FNV1_OFFSET_BASIS = 2166136261UL;
 /// FNV-1 32-bit prime
 constexpr uint32_t FNV1_PRIME = 16777619UL;
 
-/// Extend a FNV-1 hash with an integer (hashes each byte).
-template<std::integral T> constexpr uint32_t fnv1_hash_extend(uint32_t hash, T value) {
-  for (size_t i = 0; i < sizeof(T); i++) {
-    hash *= FNV1_PRIME;
-    hash ^= (value >> (i * 8)) & 0xFF;
-  }
-  return hash;
-}
-
 /// Extend a FNV-1a hash with additional string data.
 constexpr uint32_t fnv1a_hash_extend(uint32_t hash, const char *str) {
   if (str) {
@@ -415,8 +406,10 @@ inline uint32_t fnv1a_hash_extend(uint32_t hash, const std::string &str) {
 }
 /// Extend a FNV-1a hash with an integer (hashes each byte).
 template<std::integral T> constexpr uint32_t fnv1a_hash_extend(uint32_t hash, T value) {
+  using UnsignedT = std::make_unsigned_t<T>;
+  UnsignedT uvalue = static_cast<UnsignedT>(value);
   for (size_t i = 0; i < sizeof(T); i++) {
-    hash ^= (value >> (i * 8)) & 0xFF;
+    hash ^= (uvalue >> (i * 8)) & 0xFF;
     hash *= FNV1_PRIME;
   }
   return hash;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -391,6 +391,15 @@ constexpr uint32_t FNV1_OFFSET_BASIS = 2166136261UL;
 /// FNV-1 32-bit prime
 constexpr uint32_t FNV1_PRIME = 16777619UL;
 
+/// Extend a FNV-1 hash with an integer (hashes each byte).
+template<std::integral T> constexpr uint32_t fnv1_hash_extend(uint32_t hash, T value) {
+  for (size_t i = 0; i < sizeof(T); i++) {
+    hash *= FNV1_PRIME;
+    hash ^= (value >> (i * 8)) & 0xFF;
+  }
+  return hash;
+}
+
 /// Extend a FNV-1a hash with additional string data.
 constexpr uint32_t fnv1a_hash_extend(uint32_t hash, const char *str) {
   if (str) {
@@ -403,6 +412,14 @@ constexpr uint32_t fnv1a_hash_extend(uint32_t hash, const char *str) {
 }
 inline uint32_t fnv1a_hash_extend(uint32_t hash, const std::string &str) {
   return fnv1a_hash_extend(hash, str.c_str());
+}
+/// Extend a FNV-1a hash with an integer (hashes each byte).
+template<std::integral T> constexpr uint32_t fnv1a_hash_extend(uint32_t hash, T value) {
+  for (size_t i = 0; i < sizeof(T); i++) {
+    hash ^= (value >> (i * 8)) & 0xFF;
+    hash *= FNV1_PRIME;
+  }
+  return hash;
 }
 /// Calculate a FNV-1a hash of \p str.
 constexpr uint32_t fnv1a_hash(const char *str) { return fnv1a_hash_extend(FNV1_OFFSET_BASIS, str); }


### PR DESCRIPTION
# What does this implement/fix?

Adds an integer overload for `fnv1a_hash_extend` to avoid heap allocation when extending hashes with numeric values.

PR #12425 introduced `fnv1a_hash_extend` for combining config hashes with serial numbers, but the sensor components were using `std::to_string()` as a workaround since there was no integer overload:

```cpp
// Before: heap allocation via std::to_string
uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), std::to_string(this->serial_number_));

// After: direct integer hashing, no heap allocation
uint32_t hash = fnv1a_hash_extend(App.get_config_version_hash(), this->serial_number_);
```

The PR description for #12425 showed the intended API but the integer overload wasn't added.

**Changes:**
- Add `template<std::integral T> fnv1a_hash_extend(uint32_t hash, T value)` with proper unsigned cast to avoid UB on signed types
- Update sgp4x, sgp30, sen5x to use integer overload directly
- Update bme68x_bsec2_i2c to use snprintf (preserves hash compatibility with existing stored calibration data)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #12425

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal API change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
