### PR TITLE
[zwave_proxy] Make `send_frame` safer, make `set_home_id` protected

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -195,11 +195,9 @@ void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
   }
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-  // Only allocate buffer if actually logging (size optimization)
-  const size_t log_len = std::min(length, ZWAVE_MAX_LOG_BYTES);
   char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
-  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, log_len));
 #endif
+  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, length));
 
   this->write_array(data, length);
 }

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -105,7 +105,7 @@ void ZWaveProxy::process_uart_() {
           this->buffer_[1] >= ZWAVE_MIN_GET_NETWORK_IDS_LENGTH && this->buffer_[0] == ZWAVE_FRAME_TYPE_START) {
         // Store the 4-byte Home ID, which starts at offset 4, and notify connected clients if it changed
         // The frame parser has already validated the checksum and ensured all bytes are present
-        if (this->set_home_id(&this->buffer_[4])) {
+        if (this->set_home_id_(&this->buffer_[4])) {
           this->send_homeid_changed_msg_();
         }
       }
@@ -165,7 +165,7 @@ void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::en
   }
 }
 
-bool ZWaveProxy::set_home_id(const uint8_t *new_home_id) {
+bool ZWaveProxy::set_home_id_(const uint8_t *new_home_id) {
   if (std::memcmp(this->home_id_.data(), new_home_id, this->home_id_.size()) == 0) {
     ESP_LOGV(TAG, "Home ID unchanged");
     return false;  // No change
@@ -178,14 +178,29 @@ bool ZWaveProxy::set_home_id(const uint8_t *new_home_id) {
 }
 
 void ZWaveProxy::send_frame(const uint8_t *data, size_t length) {
-  if (length == 1 && data[0] == this->last_response_) {
-    ESP_LOGV(TAG, "Skipping sending duplicate response: 0x%02X", data[0]);
+  // Safety: validate pointer before any access
+  if (data == nullptr) {
+    ESP_LOGE(TAG, "Null data pointer");
     return;
   }
+  if (length == 0) {
+    ESP_LOGE(TAG, "Length 0");
+    return;
+  }
+
+  // Skip duplicate single-byte responses (ACK/NAK/CAN)
+  if (length == 1 && data[0] == this->last_response_) {
+    ESP_LOGV(TAG, "Response already sent: 0x%02X", data[0]);
+    return;
+  }
+
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  // Only allocate buffer if actually logging (size optimization)
+  const size_t log_len = std::min(length, ZWAVE_MAX_LOG_BYTES);
   char hex_buf[format_hex_pretty_size(ZWAVE_MAX_LOG_BYTES)];
+  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, log_len));
 #endif
-  ESP_LOGVV(TAG, "Sending: %s", format_hex_pretty_to(hex_buf, data, length));
+
   this->write_array(data, length);
 }
 

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -60,11 +60,11 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   uint32_t get_home_id() {
     return encode_uint32(this->home_id_[0], this->home_id_[1], this->home_id_[2], this->home_id_[3]);
   }
-  bool set_home_id(const uint8_t *new_home_id);  // Store a new home ID. Returns true if it changed.
 
   void send_frame(const uint8_t *data, size_t length);
 
  protected:
+  bool set_home_id_(const uint8_t *new_home_id);  // Store a new home ID. Returns true if it changed.
   void send_homeid_changed_msg_(api::APIConnection *conn = nullptr);
   void send_simple_command_(uint8_t command_id);
   bool parse_byte_(uint8_t byte);  // Returns true if frame parsing was completed (a frame is ready in the buffer)


### PR DESCRIPTION
# What does this implement/fix?

Implements two minor changes:

- Makes `send_frame()` safer
- Make `set_home_id()` protected & renames it to `set_home_id_()` accordingly

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
