### PR TITLE
[tuya] Avoid heap allocation in text sensor enum publish

### DIFF
--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -20,9 +20,10 @@ void TuyaTextSensor::setup() {
         break;
       }
       case TuyaDatapointType::ENUM: {
-        std::string data = to_string(datapoint.value_enum);
-        ESP_LOGD(TAG, "MCU reported text sensor %u is: %s", datapoint.id, data.c_str());
-        this->publish_state(data);
+        char buf[4];  // uint8_t max is 3 digits + null
+        snprintf(buf, sizeof(buf), "%u", datapoint.value_enum);
+        ESP_LOGD(TAG, "MCU reported text sensor %u is: %s", datapoint.id, buf);
+        this->publish_state(buf);
         break;
       }
       default:


### PR DESCRIPTION
# What does this implement/fix?

Replaces `std::to_string()` with stack-based `snprintf()` when publishing enum values as text sensor state.

`std::to_string()` allocates a heap string just to convert a uint8_t to text. Using a 4-byte stack buffer avoids this allocation on every datapoint update.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
