### PR TITLE
[thermostat] Allow `heat_cool_mode` without an automation

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -153,7 +153,7 @@ def generate_comparable_preset(config, name):
     return comparable_preset
 
 
-def validate_heat_cool_mode(value):
+def validate_heat_cool_mode(value) -> list:
     """Validate heat_cool_mode - accepts either True or an automation."""
     if value is True:
         # Convert True to empty automation list

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -839,7 +839,7 @@ async def to_code(config):
         )
         cg.add(var.set_supports_heat(True))
     if CONF_HEAT_COOL_MODE in config:
-        # Only build automation if it's not an empty list (user provided automation actions)
+        # Build automation only if user provided actions (not just `true`)
         if config[CONF_HEAT_COOL_MODE]:
             await automation.build_automation(
                 var.get_heat_cool_mode_trigger(), [], config[CONF_HEAT_COOL_MODE]

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -153,6 +153,19 @@ def generate_comparable_preset(config, name):
     return comparable_preset
 
 
+def validate_heat_cool_mode(value):
+    """Validate heat_cool_mode - accepts either True or an automation."""
+    if value is True:
+        # Convert True to empty automation list
+        return []
+    if value is False:
+        raise cv.Invalid(
+            "heat_cool_mode cannot be 'false'. Specify 'true' to enable the mode or provide an automation"
+        )
+    # Otherwise validate as automation
+    return automation.validate_automation(single=True)(value)
+
+
 def validate_thermostat(config):
     # verify corresponding action(s) exist(s) for any defined climate mode or action
     requirements = {
@@ -554,9 +567,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_FAN_ONLY_MODE): automation.validate_automation(
                 single=True
             ),
-            cv.Optional(CONF_HEAT_COOL_MODE): automation.validate_automation(
-                single=True
-            ),
+            cv.Optional(CONF_HEAT_COOL_MODE): validate_heat_cool_mode,
             cv.Optional(CONF_HEAT_MODE): automation.validate_automation(single=True),
             cv.Optional(CONF_OFF_MODE): automation.validate_automation(single=True),
             cv.Optional(CONF_FAN_MODE_ON_ACTION): automation.validate_automation(
@@ -828,9 +839,11 @@ async def to_code(config):
         )
         cg.add(var.set_supports_heat(True))
     if CONF_HEAT_COOL_MODE in config:
-        await automation.build_automation(
-            var.get_heat_cool_mode_trigger(), [], config[CONF_HEAT_COOL_MODE]
-        )
+        # Only build automation if it's not an empty list (user provided automation actions)
+        if config[CONF_HEAT_COOL_MODE]:
+            await automation.build_automation(
+                var.get_heat_cool_mode_trigger(), [], config[CONF_HEAT_COOL_MODE]
+            )
         cg.add(var.set_supports_heat_cool(True))
     if CONF_OFF_MODE in config:
         await automation.build_automation(

--- a/tests/components/thermostat/common.yaml
+++ b/tests/components/thermostat/common.yaml
@@ -41,6 +41,7 @@ climate:
       - logger.log: dry_mode
     fan_only_mode:
       - logger.log: fan_only_mode
+    heat_cool_mode: true
     fan_mode_auto_action:
       - logger.log: fan_mode_auto_action
     fan_mode_on_action:


### PR DESCRIPTION
# What does this implement/fix?

Allow `heat_cool_mode` to accept either `true` or an automation, simplifying setup for users who don't need custom automation actions for this climate mode.

## Changes
- Modified `heat_cool_mode` configuration validator to accept boolean `true` (or YAML equivalents like `yes`, `on`)
- When `true` is specified, the mode is enabled without requiring automation actions
- Existing automation syntax continues to work unchanged
- Added validation to reject `false` with a helpful error message

### Example Usage

New boolean syntax:

```yaml
climate:
  - platform: thermostat
    heat_cool_mode: true
```

Existing automation syntax (still works):

```yaml
climate:
  - platform: thermostat
    heat_cool_mode:
      - logger.log: "Entering heat_cool mode"
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5875

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
