### PR TITLE
[core] Improve minimum_chip_revision warning for PSRAM users

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -215,8 +215,13 @@ void Application::loop() {
 #if defined(USE_ESP32_VARIANT_ESP32) && !defined(USE_ESP32_MIN_CHIP_REVISION_SET)
       // Suggest optimization for chips that don't need the PSRAM cache workaround
       if (chip_info.revision >= 300) {
+#ifdef USE_PSRAM
+        ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to save ~10KB IRAM", chip_info.revision / 100,
+                 chip_info.revision % 100);
+#else
         ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to reduce binary size", chip_info.revision / 100,
                  chip_info.revision % 100);
+#endif
       }
 #endif
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Improves the `minimum_chip_revision` warning message for PSRAM users on ESP32 r3.0+ chips.

Previously, all users saw a generic "to reduce binary size" message. Now, when PSRAM is enabled, the warning specifically mentions the ~10KB IRAM savings, making the benefit much clearer for users who would gain the most from this optimization.

Before (PSRAM enabled):
```
[W][app:218]: Set minimum_chip_revision: "3.1" to reduce binary size
```

After (PSRAM enabled):
```
[W][app:219]: Set minimum_chip_revision: "3.1" to save ~10KB IRAM
```

Non-PSRAM users continue to see the original message about reducing binary size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp-wrover-kit
  framework:
    type: esp-idf
    advanced:
      minimum_chip_revision: "3.1"

psram:
  mode: quad
  speed: 80MHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
