### PR TITLE
[wifi] Disable SoftAP support on Arduino ESP32 when ap: not configured

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -466,7 +466,7 @@ async def to_code(config):
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
         cg.add_define("USE_WIFI_AP")
-    elif CORE.is_esp32 and not CORE.using_arduino:
+    elif CORE.is_esp32:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 


### PR DESCRIPTION
# What does this implement/fix?

Enables `CONFIG_ESP_WIFI_SOFTAP_SUPPORT` and `CONFIG_LWIP_DHCPS` to be disabled on ESP32 Arduino builds when no `ap:` is configured.

The `not CORE.using_arduino` check was preserved in #12623 as a mechanical refactor from `CORE.using_esp_idf` to maintain identical behavior. Since Arduino ESP32 3.x builds ESP-IDF as a component, sdkconfig options work correctly and the Arduino restriction is unnecessary.

This saves RAM on Arduino ESP32 builds that don't use AP mode by not including SoftAP and DHCP server code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# WiFi without ap: configured - SOFTAP will now be disabled on Arduino too
esp32:
  board: esp32dev
  framework:
    type: arduino

wifi:
  ssid: "test"
  password: "testtest"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tested on real hardware (ESP32-WROVER with Arduino framework) - device boots and operates correctly.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
