### PR TITLE
[logger] Enable loop disable optimization for LibreTiny task log buffer

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -197,8 +197,8 @@ void Logger::init_log_buffer(size_t total_buffer_size) {
   this->log_buffer_ = esphome::make_unique<logger::TaskLogBufferLibreTiny>(total_buffer_size);
 #endif
 
-#ifdef USE_ESP32
-  // Start with loop disabled when using task buffer (unless using USB CDC)
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  // Start with loop disabled when using task buffer (unless using USB CDC on ESP32)
   // The loop will be enabled automatically when messages arrive
   this->disable_loop_when_buffer_empty_();
 #endif
@@ -247,7 +247,7 @@ void Logger::process_messages_() {
     }
 #endif
   }
-#ifdef USE_ESP32
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
   else {
     // No messages to process, disable loop if appropriate
     // This reduces overhead when there's no async logging activity

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -609,8 +609,8 @@ class Logger : public Component {
     this->write_body_to_buffer_(ESPHOME_LOG_RESET_COLOR, RESET_COLOR_LEN, buffer, buffer_at, buffer_size);
   }
 
-#ifdef USE_ESP32
-  // Disable loop when task buffer is empty (with USB CDC check)
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  // Disable loop when task buffer is empty (with USB CDC check on ESP32)
   inline void disable_loop_when_buffer_empty_() {
     // Thread safety note: This is safe even if another task calls enable_loop_soon_any_context()
     // concurrently. If that happens between our check and disable_loop(), the enable request


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #13062 - adds the `disable_loop_when_buffer_empty_()` optimization for LibreTiny.

When #13062 added thread-safe logging support for LibreTiny, the loop disable optimization was missed. On ESP32, when the task log buffer is empty, the logger disables its loop to save CPU cycles - the loop is only re-enabled when a message arrives from another task via `enable_loop_soon_any_context()`.

This PR extends that optimization to LibreTiny by changing:
- `#ifdef USE_ESP32` to `#if defined(USE_ESP32) || defined(USE_LIBRETINY)`

in three places:
1. `disable_loop_when_buffer_empty_()` method definition in `logger.h`
2. Initial loop disable in `init_log_buffer()` in `logger.cpp`
3. Loop disable when buffer becomes empty in `process_messages_()` in `logger.cpp`

Without this fix, the logger loop runs every iteration (~7000/min) even when there are no buffered messages to process.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13062

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A
