### PR TITLE
[wifi] Warn when AP is configured without captive_portal or web_server

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -238,11 +238,20 @@ def _apply_min_auth_mode_default(config):
 def final_validate(config):
     has_sta = bool(config.get(CONF_NETWORKS, True))
     has_ap = CONF_AP in config
-    has_improv = "esp32_improv" in fv.full_config.get()
-    has_improv_serial = "improv_serial" in fv.full_config.get()
+    full_config = fv.full_config.get()
+    has_improv = "esp32_improv" in full_config
+    has_improv_serial = "improv_serial" in full_config
+    has_captive_portal = "captive_portal" in full_config
+    has_web_server = "web_server" in full_config
     if not (has_sta or has_ap or has_improv or has_improv_serial):
         raise cv.Invalid(
             "Please specify at least an SSID or an Access Point to create."
+        )
+    if has_ap and not has_captive_portal and not has_web_server:
+        _LOGGER.warning(
+            "WiFi AP is configured but neither captive_portal nor web_server is enabled. "
+            "The AP will not be usable for configuration or monitoring. "
+            "Add 'captive_portal:' or 'web_server:' to your configuration."
         )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a warning when WiFi AP mode is configured but neither `captive_portal` nor `web_server` is enabled.

Without either of these components, the AP serves no practical purpose - users cannot:
- Configure WiFi credentials via web interface (requires `captive_portal`)
- Monitor or control the device via web interface (requires `web_server`)

This mirrors the existing warning in `captive_portal` that warns when it's enabled without `wifi.ap`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config will trigger the warning:
wifi:
  ssid: "MyNetwork"
  password: "secret"
  ap:
    ssid: "Fallback AP"

# No captive_portal or web_server configured
```

Warning message:
```
WARNING WiFi AP is configured but neither captive_portal nor web_server is enabled. The AP will not be usable for configuration or monitoring. Add 'captive_portal:' or 'web_server:' to your configuration.
```

To fix, add either:
```yaml
captive_portal:
# or
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
