### PR TITLE
[api] Fire on_client_disconnected trigger after removing client from list

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -211,7 +211,7 @@ void APIServer::loop() {
 
 #ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
     // Fire trigger after client is removed so api.connected reflects the true state
-    this->client_disconnected_trigger_->trigger(std::move(client_name), std::move(client_peername));
+    this->client_disconnected_trigger_->trigger(client_name, client_peername);
 #endif
     // Don't increment client_index since we need to process the swapped element
   }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -186,13 +186,16 @@ void APIServer::loop() {
     }
 
     // Rare case: handle disconnection
-#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
-    this->client_disconnected_trigger_->trigger(std::string(client->get_name()), std::string(client->get_peername()));
-#endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
     this->unregister_active_action_calls_for_connection(client.get());
 #endif
     ESP_LOGV(TAG, "Remove connection %s", client->get_name());
+
+#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
+    // Save client info before removal for the trigger
+    std::string client_name(client->get_name());
+    std::string client_peername(client->get_peername());
+#endif
 
     // Swap with the last element and pop (avoids expensive vector shifts)
     if (client_index < this->clients_.size() - 1) {
@@ -205,6 +208,11 @@ void APIServer::loop() {
       this->status_set_warning();
       this->last_connected_ = App.get_loop_component_start_time();
     }
+
+#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
+    // Fire trigger after client is removed so api.connected reflects the true state
+    this->client_disconnected_trigger_->trigger(std::move(client_name), std::move(client_peername));
+#endif
     // Don't increment client_index since we need to process the swapped element
   }
 }

--- a/tests/integration/fixtures/api_conditional_memory.yaml
+++ b/tests/integration/fixtures/api_conditional_memory.yaml
@@ -24,6 +24,14 @@ api:
     - logger.log:
         format: "Client %s disconnected from %s"
         args: [client_info.c_str(), client_address.c_str()]
+    # Verify fix for issue #11131: api.connected should reflect true state in trigger
+    - if:
+        condition:
+          api.connected:
+        then:
+          - logger.log: "Other clients still connected"
+        else:
+          - logger.log: "No clients remaining"
 
 logger:
   level: DEBUG


### PR DESCRIPTION
# What does this implement/fix?

Fire `on_client_disconnected` trigger after removing the client from the connection list, so that `api.connected` reflects the true connection state when the trigger executes.

Previously, the trigger fired before the client was removed, causing `api.connected` to incorrectly return `true` even when the last client had disconnected. This made it impossible to reliably detect "no clients connected" in the disconnection handler without using a workaround delay.

**Before (broken):**
```yaml
api:
  on_client_disconnected:
    - if:
        condition:
          not:
            api.connected:  # Always false - client not yet removed!
        then:
          - logger.log: "No clients connected"  # Never executed
```

**Workaround that was required:**
```yaml
api:
  on_client_disconnected:
    - delay: 1ms  # Wait for client to be removed
    - if:
        condition:
          not:
            api.connected:
        then:
          - logger.log: "No clients connected"
```

**After (fixed):**
```yaml
api:
  on_client_disconnected:
    - if:
        condition:
          not:
            api.connected:  # Now correctly returns true when last client disconnects
        then:
          - logger.log: "No clients connected"  # Works as expected
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11131

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed - this corrects behavior to match documented expectations)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
api:
  on_client_disconnected:
    - if:
        condition:
          api.connected:
        then:
          - logger.log: "Other clients still connected"
        else:
          - logger.log: "No clients remaining"
```

## Breaking Change Migration

**Who is affected:** Users with `on_client_disconnected` automations that:
1. Used the `delay: 1ms` workaround - this is no longer needed and can be removed
2. Relied on `api.connected` returning `true` during disconnection (unlikely, but possible)

**Migration:** Remove any workaround delays that were added to work around this bug. If your automation logic depended on the old (buggy) behavior where the disconnecting client was still counted, you may need to adjust your logic.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
