### PR TITLE
Revert "[wifi] Disable SoftAP support on Arduino ESP32 when ap: not configured"

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -475,7 +475,7 @@ async def to_code(config):
         )
         cg.add(var.set_ap_timeout(conf[CONF_AP_TIMEOUT]))
         cg.add_define("USE_WIFI_AP")
-    elif CORE.is_esp32:
+    elif CORE.is_esp32 and not CORE.using_arduino:
         add_idf_sdkconfig_option("CONFIG_ESP_WIFI_SOFTAP_SUPPORT", False)
         add_idf_sdkconfig_option("CONFIG_LWIP_DHCPS", False)
 


### PR DESCRIPTION
Reverts esphome/esphome#13076

Still has issues -- see https://github.com/esphome/esphome/pull/13098#issuecomment-3728284480