### PR TITLE
[tuya] add color_type_lowercase option

### DIFF
--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -26,6 +26,7 @@ CONF_RGB_DATAPOINT = "rgb_datapoint"
 CONF_HSV_DATAPOINT = "hsv_datapoint"
 CONF_COLOR_DATAPOINT = "color_datapoint"
 CONF_COLOR_TYPE = "color_type"
+CONF_COLOR_TYPE_LOWERCASE = "color_type_lowercase"
 
 TuyaColorType = tuya_ns.enum("TuyaColorType")
 
@@ -33,7 +34,6 @@ COLOR_TYPES = {
     "RGB": TuyaColorType.RGB,
     "HSV": TuyaColorType.HSV,
     "RGBHSV": TuyaColorType.RGBHSV,
-    "RGB_LOWERCASE": TuyaColorType.RGB_LOWERCASE,
 }
 
 TuyaLight = tuya_ns.class_("TuyaLight", light.LightOutput, cg.Component)
@@ -48,6 +48,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SWITCH_DATAPOINT): cv.uint8_t,
             cv.Inclusive(CONF_COLOR_DATAPOINT, "color"): cv.uint8_t,
             cv.Inclusive(CONF_COLOR_TYPE, "color"): cv.enum(COLOR_TYPES, upper=True),
+            cv.Optional(CONF_COLOR_TYPE_LOWERCASE, default=False): cv.boolean,
             cv.Optional(CONF_COLOR_INTERLOCK, default=False): cv.boolean,
             cv.Inclusive(
                 CONF_COLOR_TEMPERATURE_DATAPOINT, "color_temperature"
@@ -92,6 +93,7 @@ async def to_code(config):
     if CONF_COLOR_DATAPOINT in config:
         cg.add(var.set_color_id(config[CONF_COLOR_DATAPOINT]))
         cg.add(var.set_color_type(config[CONF_COLOR_TYPE]))
+        cg.add(var.set_color_type_lowercase(config[CONF_COLOR_TYPE_LOWERCASE]))
     if CONF_COLOR_TEMPERATURE_DATAPOINT in config:
         cg.add(var.set_color_temperature_id(config[CONF_COLOR_TEMPERATURE_DATAPOINT]))
         cg.add(var.set_color_temperature_invert(config[CONF_COLOR_TEMPERATURE_INVERT]))

--- a/esphome/components/tuya/light/__init__.py
+++ b/esphome/components/tuya/light/__init__.py
@@ -33,6 +33,7 @@ COLOR_TYPES = {
     "RGB": TuyaColorType.RGB,
     "HSV": TuyaColorType.HSV,
     "RGBHSV": TuyaColorType.RGBHSV,
+    "RGB_LOWERCASE": TuyaColorType.RGB_LOWERCASE,
 }
 
 TuyaLight = tuya_ns.class_("TuyaLight", light.LightOutput, cg.Component)

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -60,7 +60,6 @@ void TuyaLight::setup() {
       float red, green, blue;
       switch (*this->color_type_) {
         case TuyaColorType::RGBHSV:
-        case TuyaColorType::RGB_LOWERCASE:
         case TuyaColorType::RGB: {
           auto rgb = parse_hex<uint32_t>(datapoint.value_string.substr(0, 6));
           if (!rgb.has_value())
@@ -191,13 +190,8 @@ void TuyaLight::write_state(light::LightState *state) {
     switch (*this->color_type_) {
       case TuyaColorType::RGB: {
         char buffer[7];
-        sprintf(buffer, "%02X%02X%02X", int(red * 255), int(green * 255), int(blue * 255));
-        color_value = buffer;
-        break;
-      }
-      case TuyaColorType::RGB_LOWERCASE: {
-        char buffer[7];
-        sprintf(buffer, "%02x%02x%02x", int(red * 255), int(green * 255), int(blue * 255));
+        const char *format_str = this->color_type_lowercase_ ? "%02x%02x%02x" : "%02X%02X%02X";
+        sprintf(buffer, format_str, int(red * 255), int(green * 255), int(blue * 255));
         color_value = buffer;
         break;
       }
@@ -206,7 +200,8 @@ void TuyaLight::write_state(light::LightState *state) {
         float saturation, value;
         rgb_to_hsv(red, green, blue, hue, saturation, value);
         char buffer[13];
-        sprintf(buffer, "%04X%04X%04X", hue, int(saturation * 1000), int(value * 1000));
+        const char *format_str = this->color_type_lowercase_ ? "%04x%04x%04x" : "%04X%04X%04X";
+        sprintf(buffer, format_str, hue, int(saturation * 1000), int(value * 1000));
         color_value = buffer;
         break;
       }
@@ -215,8 +210,9 @@ void TuyaLight::write_state(light::LightState *state) {
         float saturation, value;
         rgb_to_hsv(red, green, blue, hue, saturation, value);
         char buffer[15];
-        sprintf(buffer, "%02X%02X%02X%04X%02X%02X", int(red * 255), int(green * 255), int(blue * 255), hue,
-                int(saturation * 255), int(value * 255));
+        const char *format_str = this->color_type_lowercase_ ? "%02x%02x%02x%04x%02x%02x" : "%02X%02X%02X%04X%02X%02X";
+        sprintf(buffer, format_str, int(red * 255), int(green * 255), int(blue * 255), hue, int(saturation * 255),
+                int(value * 255));
         color_value = buffer;
         break;
       }

--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -60,6 +60,7 @@ void TuyaLight::setup() {
       float red, green, blue;
       switch (*this->color_type_) {
         case TuyaColorType::RGBHSV:
+        case TuyaColorType::RGB_LOWERCASE:
         case TuyaColorType::RGB: {
           auto rgb = parse_hex<uint32_t>(datapoint.value_string.substr(0, 6));
           if (!rgb.has_value())
@@ -191,6 +192,12 @@ void TuyaLight::write_state(light::LightState *state) {
       case TuyaColorType::RGB: {
         char buffer[7];
         sprintf(buffer, "%02X%02X%02X", int(red * 255), int(green * 255), int(blue * 255));
+        color_value = buffer;
+        break;
+      }
+      case TuyaColorType::RGB_LOWERCASE: {
+        char buffer[7];
+        sprintf(buffer, "%02x%02x%02x", int(red * 255), int(green * 255), int(blue * 255));
         color_value = buffer;
         break;
       }

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -7,11 +7,7 @@
 namespace esphome {
 namespace tuya {
 
-enum TuyaColorType {
-  RGB,
-  HSV,
-  RGBHSV,
-};
+enum TuyaColorType { RGB, HSV, RGBHSV, RGB_LOWERCASE };
 
 class TuyaLight : public Component, public light::LightOutput {
  public:

--- a/esphome/components/tuya/light/tuya_light.h
+++ b/esphome/components/tuya/light/tuya_light.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace tuya {
 
-enum TuyaColorType { RGB, HSV, RGBHSV, RGB_LOWERCASE };
+enum TuyaColorType { RGB, HSV, RGBHSV };
 
 class TuyaLight : public Component, public light::LightOutput {
  public:
@@ -24,6 +24,7 @@ class TuyaLight : public Component, public light::LightOutput {
   void set_color_temperature_invert(bool color_temperature_invert) {
     this->color_temperature_invert_ = color_temperature_invert;
   }
+  void set_color_type_lowercase(bool color_type_lowercase) { this->color_type_lowercase_ = color_type_lowercase; }
   void set_tuya_parent(Tuya *parent) { this->parent_ = parent; }
   void set_min_value(uint32_t min_value) { min_value_ = min_value; }
   void set_max_value(uint32_t max_value) { max_value_ = max_value; }
@@ -59,6 +60,7 @@ class TuyaLight : public Component, public light::LightOutput {
   float cold_white_temperature_;
   float warm_white_temperature_;
   bool color_temperature_invert_{false};
+  bool color_type_lowercase_{false};
   bool color_interlock_{false};
   light::LightState *state_{nullptr};
 };

--- a/tests/components/tuya/common.yaml
+++ b/tests/components/tuya/common.yaml
@@ -44,7 +44,8 @@ light:
     cold_white_color_temperature: 153 mireds
     warm_white_color_temperature: 500 mireds
     gamma_correct: 1
-    color_type: RGB_LOWERCASE
+    color_type: RGB
+    color_type_lowercase: true
 
 number:
   - platform: tuya

--- a/tests/components/tuya/common.yaml
+++ b/tests/components/tuya/common.yaml
@@ -38,11 +38,13 @@ light:
     dimmer_datapoint: 2
     min_value_datapoint: 3
     color_temperature_datapoint: 4
+    color_datapoint: 5
     min_value: 1
     max_value: 100
     cold_white_color_temperature: 153 mireds
     warm_white_color_temperature: 500 mireds
     gamma_correct: 1
+    color_type: RGB_LOWERCASE
 
 number:
   - platform: tuya


### PR DESCRIPTION
# What does this implement/fix?
Some lights will not work with the regular colortypes, they require the hex string to be lowercase.
This adds the `color_type_lowercase` option.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5884

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: tuya
    name: "Light"
    id: main_light
    switch_datapoint: 1
    dimmer_datapoint: 3
    color_temperature_datapoint: 4
    color_datapoint: 5
    color_temperature_invert: true
    cold_white_color_temperature: 6500 K
    warm_white_color_temperature: 2700 K
    color_type: RGB
    color_type_lowercase: true
    color_interlock: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
