### PR TITLE
[hub75] Fix gamma_correct to use enum value instead of key string

### DIFF
--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -555,7 +555,7 @@ async def to_code(config: ConfigType) -> None:
         cg.add_build_flag(f"-DHUB75_BIT_DEPTH={config[CONF_BIT_DEPTH]}")
 
     if CONF_GAMMA_CORRECT in config:
-        cg.add_build_flag(f"-DHUB75_GAMMA_MODE={config[CONF_GAMMA_CORRECT]}")
+        cg.add_build_flag(f"-DHUB75_GAMMA_MODE={config[CONF_GAMMA_CORRECT].enum_value}")
 
     # Await all pin expressions
     pin_expressions = {

--- a/tests/components/hub75/test.esp32-s3-idf-board.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf-board.yaml
@@ -6,6 +6,7 @@ display:
     panel_height: 32
     double_buffer: true
     brightness: 128
+    gamma_correct: gamma_2_2
     pages:
       - id: page1
         lambda: |-

--- a/tests/components/hub75/test.esp32-s3-idf.yaml
+++ b/tests/components/hub75/test.esp32-s3-idf.yaml
@@ -5,6 +5,7 @@ display:
     panel_height: 32
     double_buffer: true
     brightness: 128
+    gamma_correct: cie1931
     r1_pin: GPIO42
     g1_pin: GPIO41
     b1_pin: GPIO40


### PR DESCRIPTION
# What does this implement/fix?

The cv.enum validator returns the key string with the mapping value stored in .enum_value attribute. The build flag was using the string key directly (e.g., "CIE1931") instead of the integer value (e.g., 1) that the driver expects.

Also adds gamma_correct test coverage to the component tests.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
