### PR TITLE
[light] Return StringRef from LightEffect::get_name() and LightState::get_effect_name()

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -522,7 +522,8 @@ uint16_t APIConnection::try_send_light_info(EntityBase *entity, APIConnection *c
     effects_list.init(light_effects.size() + 1);
     effects_list.push_back("None");
     for (auto *effect : light_effects) {
-      effects_list.push_back(effect->get_name());
+      // data() is safe as effect names are null-terminated strings from codegen
+      effects_list.push_back(effect->get_name().data());
     }
   }
   msg.effects = &effects_list;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -522,8 +522,8 @@ uint16_t APIConnection::try_send_light_info(EntityBase *entity, APIConnection *c
     effects_list.init(light_effects.size() + 1);
     effects_list.push_back("None");
     for (auto *effect : light_effects) {
-      // data() is safe as effect names are null-terminated strings from codegen
-      effects_list.push_back(effect->get_name().data());
+      // c_str() is safe as effect names are null-terminated strings from codegen
+      effects_list.push_back(effect->get_name().c_str());
     }
   }
   msg.effects = &effects_list;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -499,7 +499,7 @@ uint16_t APIConnection::try_send_light_state(EntityBase *entity, APIConnection *
   resp.cold_white = values.get_cold_white();
   resp.warm_white = values.get_warm_white();
   if (light->supports_effects()) {
-    resp.effect = light->get_effect_name_ref();
+    resp.effect = light->get_effect_name();
   }
   return fill_and_encode_entity_state(light, resp, LightStateResponse::MESSAGE_TYPE, conn, remaining_size, is_single);
 }

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -83,7 +83,7 @@ void E131Component::add_effect(E131AddressableLightEffect *light_effect) {
   }
 
   auto effect_name = light_effect->get_name();
-  ESP_LOGD(TAG, "Registering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.data(),
+  ESP_LOGD(TAG, "Registering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.c_str(),
            light_effect->get_first_universe(), light_effect->get_last_universe());
 
   light_effects_.push_back(light_effect);
@@ -100,7 +100,7 @@ void E131Component::remove_effect(E131AddressableLightEffect *light_effect) {
   }
 
   auto effect_name = light_effect->get_name();
-  ESP_LOGD(TAG, "Unregistering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.data(),
+  ESP_LOGD(TAG, "Unregistering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.c_str(),
            light_effect->get_first_universe(), light_effect->get_last_universe());
 
   // Swap with last element and pop for O(1) removal (order doesn't matter)

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -82,8 +82,9 @@ void E131Component::add_effect(E131AddressableLightEffect *light_effect) {
     return;
   }
 
-  ESP_LOGD(TAG, "Registering '%s' for universes %d-%d.", light_effect->get_name(), light_effect->get_first_universe(),
-           light_effect->get_last_universe());
+  auto effect_name = light_effect->get_name();
+  ESP_LOGD(TAG, "Registering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.data(),
+           light_effect->get_first_universe(), light_effect->get_last_universe());
 
   light_effects_.push_back(light_effect);
 
@@ -98,8 +99,9 @@ void E131Component::remove_effect(E131AddressableLightEffect *light_effect) {
     return;
   }
 
-  ESP_LOGD(TAG, "Unregistering '%s' for universes %d-%d.", light_effect->get_name(), light_effect->get_first_universe(),
-           light_effect->get_last_universe());
+  auto effect_name = light_effect->get_name();
+  ESP_LOGD(TAG, "Unregistering '%.*s' for universes %d-%d.", (int) effect_name.size(), effect_name.data(),
+           light_effect->get_first_universe(), light_effect->get_last_universe());
 
   // Swap with last element and pop for O(1) removal (order doesn't matter)
   *it = light_effects_.back();

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -60,7 +60,7 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
   auto effect_name = get_name();
   ESP_LOGV(TAG, "Applying data for '%.*s' on %d universe, for %" PRId32 "-%d.", (int) effect_name.size(),
-           effect_name.data(), universe, output_offset, output_end);
+           effect_name.c_str(), universe, output_offset, output_end);
 
   switch (channels_) {
     case E131_MONO:

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -58,8 +58,9 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
       std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
   auto *input_data = packet.values + 1;
 
-  ESP_LOGV(TAG, "Applying data for '%s' on %d universe, for %" PRId32 "-%d.", get_name(), universe, output_offset,
-           output_end);
+  auto effect_name = get_name();
+  ESP_LOGV(TAG, "Applying data for '%.*s' on %d universe, for %" PRId32 "-%d.", (int) effect_name.size(),
+           effect_name.data(), universe, output_offset, output_end);
 
   switch (channels_) {
     case E131_MONO:

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -1,5 +1,4 @@
 #include <cinttypes>
-#include <string_view>
 
 #include "light_call.h"
 #include "light_state.h"
@@ -155,15 +154,15 @@ void LightCall::perform() {
 
   } else if (this->has_effect_()) {
     // EFFECT
-    std::string_view effect_s;
+    StringRef effect_s;
     if (this->effect_ == 0u) {
-      effect_s = "None";
+      effect_s = StringRef::from_lit("None");
     } else {
       effect_s = this->parent_->effects_[this->effect_ - 1]->get_name();
     }
 
     if (publish) {
-      ESP_LOGD(TAG, "  Effect: '%.*s'", (int) effect_s.size(), effect_s.data());
+      ESP_LOGD(TAG, "  Effect: '%.*s'", (int) effect_s.size(), effect_s.c_str());
     }
 
     this->parent_->start_effect_(this->effect_);
@@ -513,9 +512,9 @@ LightCall &LightCall::set_effect(const char *effect, size_t len) {
   }
 
   bool found = false;
-  std::string_view effect_sv(effect, len);
+  StringRef effect_ref(effect, len);
   for (uint32_t i = 0; i < this->parent_->effects_.size(); i++) {
-    if (str_equals_case_insensitive(effect_sv, this->parent_->effects_[i]->get_name())) {
+    if (str_equals_case_insensitive(effect_ref, this->parent_->effects_[i]->get_name())) {
       this->set_effect(i + 1);
       found = true;
       break;

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -1,4 +1,6 @@
 #include <cinttypes>
+#include <string_view>
+
 #include "light_call.h"
 #include "light_state.h"
 #include "esphome/core/log.h"
@@ -153,7 +155,7 @@ void LightCall::perform() {
 
   } else if (this->has_effect_()) {
     // EFFECT
-    const char *effect_s;
+    std::string_view effect_s;
     if (this->effect_ == 0u) {
       effect_s = "None";
     } else {
@@ -161,7 +163,7 @@ void LightCall::perform() {
     }
 
     if (publish) {
-      ESP_LOGD(TAG, "  Effect: '%s'", effect_s);
+      ESP_LOGD(TAG, "  Effect: '%.*s'", (int) effect_s.size(), effect_s.data());
     }
 
     this->parent_->start_effect_(this->effect_);
@@ -511,11 +513,9 @@ LightCall &LightCall::set_effect(const char *effect, size_t len) {
   }
 
   bool found = false;
+  std::string_view effect_sv(effect, len);
   for (uint32_t i = 0; i < this->parent_->effects_.size(); i++) {
-    LightEffect *e = this->parent_->effects_[i];
-    const char *name = e->get_name();
-
-    if (strncasecmp(effect, name, len) == 0 && name[len] == '\0') {
+    if (str_equals_case_insensitive(effect_sv, this->parent_->effects_[i]->get_name())) {
       this->set_effect(i + 1);
       found = true;
       break;

--- a/esphome/components/light/light_effect.h
+++ b/esphome/components/light/light_effect.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include <string_view>
-
 #include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
 
 namespace esphome::light {
 
@@ -27,7 +26,7 @@ class LightEffect {
    * Returns the name of this effect.
    * The underlying data is valid for the lifetime of the program (static string from codegen).
    */
-  std::string_view get_name() const { return this->name_; }
+  StringRef get_name() const { return StringRef(this->name_); }
 
   /// Internal method called by the LightState when this light effect is registered in it.
   virtual void init() {}

--- a/esphome/components/light/light_effect.h
+++ b/esphome/components/light/light_effect.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "esphome/core/component.h"
 
 namespace esphome::light {
@@ -23,9 +25,9 @@ class LightEffect {
 
   /**
    * Returns the name of this effect.
-   * The returned pointer is valid for the lifetime of the program and must not be freed.
+   * The underlying data is valid for the lifetime of the program (static string from codegen).
    */
-  const char *get_name() const { return this->name_; }
+  std::string_view get_name() const { return this->name_; }
 
   /// Internal method called by the LightState when this light effect is registered in it.
   virtual void init() {}

--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -36,7 +36,7 @@ static const char *get_color_mode_json_str(ColorMode mode) {
 void LightJSONSchema::dump_json(LightState &state, JsonObject root) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   if (state.supports_effects()) {
-    root[ESPHOME_F("effect")] = state.get_effect_name_ref();
+    root[ESPHOME_F("effect")] = state.get_effect_name().c_str();
     root[ESPHOME_F("effect_index")] = state.get_current_effect_index();
     root[ESPHOME_F("effect_count")] = state.get_effect_count();
   }

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -165,7 +165,7 @@ LightOutput *LightState::get_output() const { return this->output_; }
 static constexpr const char *EFFECT_NONE = "None";
 static constexpr auto EFFECT_NONE_REF = StringRef::from_lit("None");
 
-std::string LightState::get_effect_name() {
+std::string_view LightState::get_effect_name() {
   if (this->active_effect_index_ > 0) {
     return this->effects_[this->active_effect_index_ - 1]->get_name();
   }
@@ -174,7 +174,8 @@ std::string LightState::get_effect_name() {
 
 StringRef LightState::get_effect_name_ref() {
   if (this->active_effect_index_ > 0) {
-    return StringRef(this->effects_[this->active_effect_index_ - 1]->get_name());
+    auto name = this->effects_[this->active_effect_index_ - 1]->get_name();
+    return StringRef(name.data(), name.size());
   }
   return EFFECT_NONE_REF;
 }

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -162,20 +162,11 @@ void LightState::publish_state() {
 
 LightOutput *LightState::get_output() const { return this->output_; }
 
-static constexpr const char *EFFECT_NONE = "None";
 static constexpr auto EFFECT_NONE_REF = StringRef::from_lit("None");
 
-std::string_view LightState::get_effect_name() {
+StringRef LightState::get_effect_name() {
   if (this->active_effect_index_ > 0) {
     return this->effects_[this->active_effect_index_ - 1]->get_name();
-  }
-  return EFFECT_NONE;
-}
-
-StringRef LightState::get_effect_name_ref() {
-  if (this->active_effect_index_ > 0) {
-    auto name = this->effects_[this->active_effect_index_ - 1]->get_name();
-    return StringRef(name.data(), name.size());
   }
   return EFFECT_NONE_REF;
 }

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/optional.h"
@@ -140,7 +142,7 @@ class LightState : public EntityBase, public Component {
   LightOutput *get_output() const;
 
   /// Return the name of the current effect, or if no effect is active "None".
-  std::string get_effect_name();
+  std::string_view get_effect_name();
   /// Return the name of the current effect as StringRef (for API usage)
   StringRef get_effect_name_ref();
 
@@ -191,11 +193,11 @@ class LightState : public EntityBase, public Component {
 
   /// Get effect index by name. Returns 0 if effect not found.
   uint32_t get_effect_index(const std::string &effect_name) const {
-    if (strcasecmp(effect_name.c_str(), "none") == 0) {
+    if (str_equals_case_insensitive(effect_name, std::string("none"))) {
       return 0;
     }
     for (size_t i = 0; i < this->effects_.size(); i++) {
-      if (strcasecmp(effect_name.c_str(), this->effects_[i]->get_name()) == 0) {
+      if (str_equals_case_insensitive(std::string_view(effect_name), this->effects_[i]->get_name())) {
         return i + 1;  // Effects are 1-indexed in active_effect_index_
       }
     }
@@ -218,7 +220,7 @@ class LightState : public EntityBase, public Component {
     if (index > this->effects_.size()) {
       return "";  // Invalid index
     }
-    return this->effects_[index - 1]->get_name();
+    return std::string(this->effects_[index - 1]->get_name());
   }
 
   /// The result of all the current_values_as_* methods have gamma correction applied.

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <string_view>
-
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/optional.h"
@@ -142,9 +140,7 @@ class LightState : public EntityBase, public Component {
   LightOutput *get_output() const;
 
   /// Return the name of the current effect, or if no effect is active "None".
-  std::string_view get_effect_name();
-  /// Return the name of the current effect as StringRef (for API usage)
-  StringRef get_effect_name_ref();
+  StringRef get_effect_name();
 
   /** Add a listener for remote values changes.
    * Listener is notified when the light's remote values change (state, brightness, color, etc.)

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -193,11 +193,11 @@ class LightState : public EntityBase, public Component {
 
   /// Get effect index by name. Returns 0 if effect not found.
   uint32_t get_effect_index(const std::string &effect_name) const {
-    if (str_equals_case_insensitive(effect_name, std::string("none"))) {
+    if (str_equals_case_insensitive(effect_name, "none")) {
       return 0;
     }
     for (size_t i = 0; i < this->effects_.size(); i++) {
-      if (str_equals_case_insensitive(std::string_view(effect_name), this->effects_[i]->get_name())) {
+      if (str_equals_case_insensitive(effect_name, this->effects_[i]->get_name())) {
         return i + 1;  // Effects are 1-indexed in active_effect_index_
       }
     }

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -80,9 +80,10 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
   if (this->state_->supports_effects()) {
     root[ESPHOME_F("effect")] = true;
     JsonArray effect_list = root[MQTT_EFFECT_LIST].to<JsonArray>();
-    for (auto *effect : this->state_->get_effects())
+    for (auto *effect : this->state_->get_effects()) {
       // data() is safe as effect names are null-terminated strings from codegen
       effect_list.add(effect->get_name().data());
+    }
     effect_list.add(ESPHOME_F("None"));
   }
 }

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -81,7 +81,8 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
     root[ESPHOME_F("effect")] = true;
     JsonArray effect_list = root[MQTT_EFFECT_LIST].to<JsonArray>();
     for (auto *effect : this->state_->get_effects())
-      effect_list.add(effect->get_name());
+      // data() is safe as effect names are null-terminated strings from codegen
+      effect_list.add(effect->get_name().data());
     effect_list.add(ESPHOME_F("None"));
   }
 }

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -81,8 +81,8 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
     root[ESPHOME_F("effect")] = true;
     JsonArray effect_list = root[MQTT_EFFECT_LIST].to<JsonArray>();
     for (auto *effect : this->state_->get_effects()) {
-      // data() is safe as effect names are null-terminated strings from codegen
-      effect_list.add(effect->get_name().data());
+      // c_str() is safe as effect names are null-terminated strings from codegen
+      effect_list.add(effect->get_name().c_str());
     }
     effect_list.add(ESPHOME_F("None"));
   }

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -370,7 +370,8 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
     if (effect == "None") {
       stream->print(ESPHOME_F("None\"} 0\n"));
     } else {
-      stream->write(effect.c_str(), effect.size());
+      // c_str() is safe as effect names are null-terminated strings from codegen
+      stream->print(effect.c_str());
       stream->print(ESPHOME_F("\"} 1\n"));
     }
   }

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -363,14 +363,15 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   // Skip effect metrics if light has no effects
   if (!obj->get_effects().empty()) {
     // Effect
-    std::string effect = obj->get_effect_name();
+    std::string_view effect = obj->get_effect_name();
     print_metric_labels_(stream, ESPHOME_F("esphome_light_effect_active"), obj, area, node, friendly_name);
     stream->print(ESPHOME_F("\",effect=\""));
     // Only vary based on effect
     if (effect == "None") {
       stream->print(ESPHOME_F("None\"} 0\n"));
     } else {
-      stream->print(effect.c_str());
+      // data() is safe as effect names are null-terminated strings from codegen
+      stream->print(effect.data());
       stream->print(ESPHOME_F("\"} 1\n"));
     }
   }

--- a/esphome/components/prometheus/prometheus_handler.cpp
+++ b/esphome/components/prometheus/prometheus_handler.cpp
@@ -363,15 +363,14 @@ void PrometheusHandler::light_row_(AsyncResponseStream *stream, light::LightStat
   // Skip effect metrics if light has no effects
   if (!obj->get_effects().empty()) {
     // Effect
-    std::string_view effect = obj->get_effect_name();
+    StringRef effect = obj->get_effect_name();
     print_metric_labels_(stream, ESPHOME_F("esphome_light_effect_active"), obj, area, node, friendly_name);
     stream->print(ESPHOME_F("\",effect=\""));
     // Only vary based on effect
     if (effect == "None") {
       stream->print(ESPHOME_F("None\"} 0\n"));
     } else {
-      // data() is safe as effect names are null-terminated strings from codegen
-      stream->print(effect.data());
+      stream->write(effect.c_str(), effect.size());
       stream->print(ESPHOME_F("\"} 1\n"));
     }
   }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -162,8 +162,8 @@ float random_float() { return static_cast<float>(random_uint32()) / static_cast<
 bool str_equals_case_insensitive(const std::string &a, const std::string &b) {
   return strcasecmp(a.c_str(), b.c_str()) == 0;
 }
-bool str_equals_case_insensitive(std::string_view a, std::string_view b) {
-  return a.size() == b.size() && strncasecmp(a.data(), b.data(), a.size()) == 0;
+bool str_equals_case_insensitive(StringRef a, StringRef b) {
+  return a.size() == b.size() && strncasecmp(a.c_str(), b.c_str(), a.size()) == 0;
 }
 #if __cplusplus >= 202002L
 bool str_startswith(const std::string &str, const std::string &start) { return str.starts_with(start); }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -162,6 +162,9 @@ float random_float() { return static_cast<float>(random_uint32()) / static_cast<
 bool str_equals_case_insensitive(const std::string &a, const std::string &b) {
   return strcasecmp(a.c_str(), b.c_str()) == 0;
 }
+bool str_equals_case_insensitive(std::string_view a, std::string_view b) {
+  return a.size() == b.size() && strncasecmp(a.data(), b.data(), a.size()) == 0;
+}
 #if __cplusplus >= 202002L
 bool str_startswith(const std::string &str, const std::string &start) { return str.starts_with(start); }
 bool str_endswith(const std::string &str, const std::string &end) { return str.ends_with(end); }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -511,6 +511,8 @@ template<typename T> constexpr T convert_little_endian(T val) {
 
 /// Compare strings for equality in case-insensitive manner.
 bool str_equals_case_insensitive(const std::string &a, const std::string &b);
+/// Compare string_views for equality in case-insensitive manner.
+bool str_equals_case_insensitive(std::string_view a, std::string_view b);
 
 /// Check whether a string starts with a value.
 bool str_startswith(const std::string &str, const std::string &start);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -511,8 +511,8 @@ template<typename T> constexpr T convert_little_endian(T val) {
 
 /// Compare strings for equality in case-insensitive manner.
 bool str_equals_case_insensitive(const std::string &a, const std::string &b);
-/// Compare string_views for equality in case-insensitive manner.
-bool str_equals_case_insensitive(std::string_view a, std::string_view b);
+/// Compare StringRefs for equality in case-insensitive manner.
+bool str_equals_case_insensitive(StringRef a, StringRef b);
 
 /// Check whether a string starts with a value.
 bool str_startswith(const std::string &str, const std::string &start);

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -3,19 +3,63 @@ esphome:
     then:
       # Test LightEffect::get_name() returns string_view
       - lambda: |-
-          // Test get_name() returns string_view
+          // Test LightEffect::get_name() returns std::string_view
           auto &effects = id(test_monochromatic_light).get_effects();
           if (!effects.empty()) {
+            // Test: get_name() returns string_view
             std::string_view name = effects[0]->get_name();
-            // Test comparison with string literal
+
+            // Test: comparison with string literal works directly
             if (name == "Strobe") {
               ESP_LOGI("test", "Found Strobe effect");
             }
-            // Safe logging with size-limited format
+
+            // Test: safe logging with %.*s format
             ESP_LOGI("test", "Effect name: %.*s", (int) name.size(), name.data());
-            // Test .data() for null-terminated functions (safe because names are from codegen)
+
+            // Test: .data() for functions expecting const char*
             ESP_LOGI("test", "Effect: %s", name.data());
+
+            // Test: explicit conversion to std::string
+            std::string name_str(name);
+            ESP_LOGI("test", "As string: %s", name_str.c_str());
+
+            // Test: size() method
+            ESP_LOGI("test", "Name length: %d", (int) name.size());
           }
+
+      # Test LightState::get_effect_name() returns string_view
+      - lambda: |-
+          // Test LightState::get_effect_name() returns std::string_view
+          std::string_view current_effect = id(test_monochromatic_light).get_effect_name();
+
+          // Test: comparison with "None" works directly
+          if (current_effect == "None") {
+            ESP_LOGI("test", "No effect active");
+          }
+
+          // Test: safe logging
+          ESP_LOGI("test", "Current effect: %.*s", (int) current_effect.size(), current_effect.data());
+
+      # Test str_equals_case_insensitive with string_view
+      - lambda: |-
+          // Test str_equals_case_insensitive(string_view, string_view)
+          auto &effects = id(test_monochromatic_light).get_effects();
+          if (!effects.empty()) {
+            std::string_view name = effects[0]->get_name();
+
+            // Test: case-insensitive comparison
+            if (str_equals_case_insensitive(name, "STROBE")) {
+              ESP_LOGI("test", "Case-insensitive match works");
+            }
+
+            // Test: case-insensitive with string_view from string
+            std::string search = "strobe";
+            if (str_equals_case_insensitive(std::string_view(search), name)) {
+              ESP_LOGI("test", "Reverse comparison works");
+            }
+          }
+
       - light.toggle: test_binary_light
       - light.turn_off: test_rgb_light
       - light.turn_on:

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -1,6 +1,21 @@
 esphome:
   on_boot:
     then:
+      # Test LightEffect::get_name() returns string_view
+      - lambda: |-
+          // Test get_name() returns string_view
+          auto &effects = id(test_monochromatic_light).get_effects();
+          if (!effects.empty()) {
+            std::string_view name = effects[0]->get_name();
+            // Test comparison with string literal
+            if (name == "Strobe") {
+              ESP_LOGI("test", "Found Strobe effect");
+            }
+            // Safe logging with size-limited format
+            ESP_LOGI("test", "Effect name: %.*s", (int) name.size(), name.data());
+            // Test .data() for null-terminated functions (safe because names are from codegen)
+            ESP_LOGI("test", "Effect: %s", name.data());
+          }
       - light.toggle: test_binary_light
       - light.turn_off: test_rgb_light
       - light.turn_on:

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -1,13 +1,13 @@
 esphome:
   on_boot:
     then:
-      # Test LightEffect::get_name() returns string_view
+      # Test LightEffect::get_name() returns StringRef
       - lambda: |-
-          // Test LightEffect::get_name() returns std::string_view
+          // Test LightEffect::get_name() returns StringRef
           auto &effects = id(test_monochromatic_light).get_effects();
           if (!effects.empty()) {
-            // Test: get_name() returns string_view
-            std::string_view name = effects[0]->get_name();
+            // Test: get_name() returns StringRef
+            StringRef name = effects[0]->get_name();
 
             // Test: comparison with string literal works directly
             if (name == "Strobe") {
@@ -15,23 +15,23 @@ esphome:
             }
 
             // Test: safe logging with %.*s format
-            ESP_LOGI("test", "Effect name: %.*s", (int) name.size(), name.data());
+            ESP_LOGI("test", "Effect name: %.*s", (int) name.size(), name.c_str());
 
-            // Test: .data() for functions expecting const char*
-            ESP_LOGI("test", "Effect: %s", name.data());
+            // Test: .c_str() for functions expecting const char*
+            ESP_LOGI("test", "Effect: %s", name.c_str());
 
             // Test: explicit conversion to std::string
-            std::string name_str(name);
+            std::string name_str(name.c_str(), name.size());
             ESP_LOGI("test", "As string: %s", name_str.c_str());
 
             // Test: size() method
             ESP_LOGI("test", "Name length: %d", (int) name.size());
           }
 
-      # Test LightState::get_effect_name() returns string_view
+      # Test LightState::get_effect_name() returns StringRef
       - lambda: |-
-          // Test LightState::get_effect_name() returns std::string_view
-          std::string_view current_effect = id(test_monochromatic_light).get_effect_name();
+          // Test LightState::get_effect_name() returns StringRef
+          StringRef current_effect = id(test_monochromatic_light).get_effect_name();
 
           // Test: comparison with "None" works directly
           if (current_effect == "None") {
@@ -39,23 +39,23 @@ esphome:
           }
 
           // Test: safe logging
-          ESP_LOGI("test", "Current effect: %.*s", (int) current_effect.size(), current_effect.data());
+          ESP_LOGI("test", "Current effect: %.*s", (int) current_effect.size(), current_effect.c_str());
 
-      # Test str_equals_case_insensitive with string_view
+      # Test str_equals_case_insensitive with StringRef
       - lambda: |-
-          // Test str_equals_case_insensitive(string_view, string_view)
+          // Test str_equals_case_insensitive(StringRef, StringRef)
           auto &effects = id(test_monochromatic_light).get_effects();
           if (!effects.empty()) {
-            std::string_view name = effects[0]->get_name();
+            StringRef name = effects[0]->get_name();
 
             // Test: case-insensitive comparison
             if (str_equals_case_insensitive(name, "STROBE")) {
               ESP_LOGI("test", "Case-insensitive match works");
             }
 
-            // Test: case-insensitive with string_view from string
+            // Test: case-insensitive with StringRef from string
             std::string search = "strobe";
-            if (str_equals_case_insensitive(std::string_view(search), name)) {
+            if (str_equals_case_insensitive(StringRef(search.c_str(), search.size()), name)) {
               ESP_LOGI("test", "Reverse comparison works");
             }
           }


### PR DESCRIPTION
# What does this implement/fix?

**Breaking Change** for users with lambdas and external component developers.

Modernize `LightEffect::get_name()` and `LightState::get_effect_name()` to return `StringRef` instead of `const char*`/`std::string`.

This change:
- Improves API safety by returning `StringRef` which has explicit size
- Uses `StringRef` to signal static lifetime semantics (effect names are from codegen)
- Adds `str_equals_case_insensitive(StringRef, StringRef)` helper for cleaner comparisons
- Maintains backward compatibility - underlying data is null-terminated from codegen

## Background

Per Discord discussion: https://discord.com/channels/429907082951524364/1450953700620374081

Using `StringRef` instead of `std::string_view` because:
- StringRef has similar API to std::string_view
- StringRef signals static lifetime semantics - effect names come from codegen and live for the program lifetime
- StringRef is already used in the API layer
- Lambda authors won't usually spell this type (they can use `auto`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of StringRef API modernization effort (see also #13092, #13103, #13104)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5889

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an API change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Migration Guide

### For users with lambdas

#### Getting effect name:

```cpp
// Before
const char *name = effect->get_name();

// After - returns StringRef
StringRef name = effect->get_name();
// or use auto:
auto name = effect->get_name();
```

#### Logging effect name:

```cpp
// Before
ESP_LOGD("tag", "Effect: %s", effect->get_name());

// After - Use %.*s format with explicit size (recommended)
auto name = effect->get_name();
ESP_LOGD("tag", "Effect: %.*s", (int) name.size(), name.c_str());
```

#### Stream printing:

```cpp
// Use write() with explicit length (preferred)
auto name = effect->get_name();
stream->write(name.c_str(), name.size());

// Or use .c_str() for print (if null-termination is acceptable)
stream->print(effect->get_name().c_str());
```

#### Comparing effect names:

```cpp
// Before
if (strcmp(effect->get_name(), "Rainbow") == 0) { ... }

// After - direct comparison works with string literals
if (effect->get_name() == "Rainbow") { ... }
```

#### Getting current effect from light state:

```cpp
// Before
std::string effect = id(my_light).get_effect_name();
if (effect == "None") { ... }

// After - returns StringRef instead of std::string
StringRef effect = id(my_light).get_effect_name();
if (effect == "None") { ... }  // Comparison still works
```

#### If you need a std::string:

```cpp
// Before
std::string name = effect->get_name();

// After - explicit conversion needed
std::string name(effect->get_name().c_str(), effect->get_name().size());
// or
auto ref = effect->get_name();
std::string name(ref.c_str(), ref.size());
```

### For external component developers

#### Storing effect names:

```cpp
// Before - storing const char*
const char *cached_name = effect->get_name();

// After - store as StringRef or use .c_str() for const char*
StringRef cached_name = effect->get_name();
// or if you need const char* (safe because effect names are from codegen):
const char *cached_name = effect->get_name().c_str();
```

#### Case-insensitive comparison:

A new helper is available for case-insensitive StringRef comparison:

```cpp
#include "esphome/core/helpers.h"

// New helper function
if (str_equals_case_insensitive(effect->get_name(), "rainbow")) {
  // Found rainbow effect (case-insensitive)
}
```

#### Passing to functions expecting const char*:

```cpp
// Use .c_str() - safe because StringRef guarantees null-termination
some_function(effect->get_name().c_str());
```

#### Passing to functions expecting std::string:

```cpp
// Explicit conversion
auto ref = effect->get_name();
some_function(std::string(ref.c_str(), ref.size()));
```