### PR TITLE
[mdns] Remove deprecated api password from test configuration

### DIFF
--- a/tests/components/mdns/test-comprehensive.esp8266-ard.yaml
+++ b/tests/components/mdns/test-comprehensive.esp8266-ard.yaml
@@ -42,4 +42,3 @@ status_led:
 
 # Include API at priority 40
 api:
-  password: "apipassword"


### PR DESCRIPTION
# What does this implement/fix?

Remove deprecated `api: password:` option from mdns test configuration.

The `api: password:` option was removed in ESPHome 2026.1.0, causing the mdns component test to fail with:

```
The 'password' option has been removed in ESPHome 2026.1.0.
Password authentication was deprecated in May 2022.
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - test fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
