### PR TITLE
[mapping] Fix test SPI data rate for RP2040

### DIFF
--- a/tests/components/mapping/test.rp2040-ard.yaml
+++ b/tests/components/mapping/test.rp2040-ard.yaml
@@ -7,6 +7,7 @@ display:
   platform: ili9xxx
   id: main_lcd
   model: ili9342
+  data_rate: 31.25MHz
   cs_pin: 20
   dc_pin: 21
   reset_pin: 22


### PR DESCRIPTION
# What does this implement/fix?

Fix mapping component test for RP2040 by setting compatible SPI data rate.

The ili9xxx display component defaults to 40MHz SPI data rate, but RP2040 doesn't support this rate - the closest available is 31.25MHz. This caused the test to fail with:

```
The configured SPI data rate (40MHz) is not available for this chip - closest is 31.25MHz.
```

Added explicit `data_rate: 31.25MHz` to the display configuration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - test fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
