### PR TITLE
[CI] skip endpoint check due to test grouping

### DIFF
--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -69,7 +69,7 @@ def validate_number_of_ep(config: ConfigType) -> None:
         raise cv.Invalid(
             "Single endpoint is not supported https://github.com/Koenkk/zigbee2mqtt/issues/29888"
         )
-    if count > CONF_MAX_EP_NUMBER:
+    if count > CONF_MAX_EP_NUMBER and not CORE.testing_mode:
         raise cv.Invalid(f"Maximum number of end points is {CONF_MAX_EP_NUMBER}")
 
 


### PR DESCRIPTION
# What does this implement/fix?

`script/test_build_components.py -c uptime,zigbee -t nrf52-mcumgr -e config`
ends with
`Maximum number of end points is 8.`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
