### PR TITLE
[helpers] Add format_hex_prefixed_to for "0x" prefixed hex formatting

### DIFF
--- a/esphome/components/one_wire/one_wire.cpp
+++ b/esphome/components/one_wire/one_wire.cpp
@@ -8,10 +8,7 @@ static const char *const TAG = "one_wire";
 const std::string &OneWireDevice::get_address_name() {
   if (this->address_name_.empty()) {
     char hex_buf[19];  // "0x" + 16 hex chars + null
-    hex_buf[0] = '0';
-    hex_buf[1] = 'x';
-    uint64_t be_address = convert_big_endian(this->address_);
-    format_hex_to(hex_buf + 2, 17, reinterpret_cast<const uint8_t *>(&be_address), sizeof(be_address));
+    format_hex_prefixed_to(hex_buf, this->address_);
     this->address_name_ = hex_buf;
   }
   return this->address_name_;

--- a/esphome/components/one_wire/one_wire.cpp
+++ b/esphome/components/one_wire/one_wire.cpp
@@ -6,8 +6,14 @@ namespace one_wire {
 static const char *const TAG = "one_wire";
 
 const std::string &OneWireDevice::get_address_name() {
-  if (this->address_name_.empty())
-    this->address_name_ = std::string("0x") + format_hex(this->address_);
+  if (this->address_name_.empty()) {
+    char hex_buf[19];  // "0x" + 16 hex chars + null
+    hex_buf[0] = '0';
+    hex_buf[1] = 'x';
+    uint64_t be_address = convert_big_endian(this->address_);
+    format_hex_to(hex_buf + 2, 17, reinterpret_cast<const uint8_t *>(&be_address), sizeof(be_address));
+    this->address_name_ = hex_buf;
+  }
   return this->address_name_;
 }
 

--- a/esphome/components/one_wire/one_wire.cpp
+++ b/esphome/components/one_wire/one_wire.cpp
@@ -8,8 +8,7 @@ static const char *const TAG = "one_wire";
 const std::string &OneWireDevice::get_address_name() {
   if (this->address_name_.empty()) {
     char hex_buf[19];  // "0x" + 16 hex chars + null
-    format_hex_prefixed_to(hex_buf, this->address_);
-    this->address_name_ = hex_buf;
+    this->address_name_ = format_hex_prefixed_to(hex_buf, this->address_);
   }
   return this->address_name_;
 }

--- a/esphome/components/sml/text_sensor/sml_text_sensor.cpp
+++ b/esphome/components/sml/text_sensor/sml_text_sensor.cpp
@@ -24,11 +24,9 @@ void SmlTextSensor::publish_val(const ObisInfo &obis_info) {
     case SML_HEX: {
       // Buffer for "0x" + up to 32 bytes as hex + null
       char buf[67];
-      buf[0] = '0';
-      buf[1] = 'x';
-      // Max 32 bytes of data fit in remaining buffer ((65-1)/2)
+      // Max 32 bytes of data fit in buffer ((67-3)/2)
       size_t hex_bytes = std::min(obis_info.value.size(), size_t(32));
-      format_hex_to(buf + 2, sizeof(buf) - 2, obis_info.value.begin(), hex_bytes);
+      format_hex_prefixed_to(buf, obis_info.value.begin(), hex_bytes);
       publish_state(buf, 2 + hex_bytes * 2);
       break;
     }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -759,6 +759,29 @@ inline char *format_hex_to(char (&buffer)[N], T val) {
 /// Calculate buffer size needed for format_hex_to: "XXXXXXXX...\0" = bytes * 2 + 1
 constexpr size_t format_hex_size(size_t byte_count) { return byte_count * 2 + 1; }
 
+/// Calculate buffer size needed for format_hex_prefixed_to: "0xXXXXXXXX...\0" = bytes * 2 + 3
+constexpr size_t format_hex_prefixed_size(size_t byte_count) { return byte_count * 2 + 3; }
+
+/// Format an unsigned integer as "0x" prefixed lowercase hex to buffer.
+template<size_t N, typename T, enable_if_t<std::is_unsigned<T>::value, int> = 0>
+inline char *format_hex_prefixed_to(char (&buffer)[N], T val) {
+  static_assert(N >= sizeof(T) * 2 + 3, "Buffer too small for prefixed hex");
+  buffer[0] = '0';
+  buffer[1] = 'x';
+  val = convert_big_endian(val);
+  format_hex_to(buffer + 2, N - 2, reinterpret_cast<const uint8_t *>(&val), sizeof(T));
+  return buffer;
+}
+
+/// Format byte array as "0x" prefixed lowercase hex to buffer.
+template<size_t N> inline char *format_hex_prefixed_to(char (&buffer)[N], const uint8_t *data, size_t length) {
+  static_assert(N >= 5, "Buffer must hold at least '0x' + one hex byte + null");
+  buffer[0] = '0';
+  buffer[1] = 'x';
+  format_hex_to(buffer + 2, N - 2, data, length);
+  return buffer;
+}
+
 /// Calculate buffer size needed for format_hex_pretty_to with separator: "XX:XX:...:XX\0"
 constexpr size_t format_hex_pretty_size(size_t byte_count) { return byte_count * 3; }
 


### PR DESCRIPTION
# What does this implement/fix?

Add `format_hex_prefixed_to` helper templates that format hex values with "0x" prefix to a stack buffer, avoiding heap allocations.

Changes:
1. Added `format_hex_prefixed_to` templates in `helpers.h`:
   - For unsigned integers: `format_hex_prefixed_to(char (&buffer)[N], T val)`
   - For byte arrays: `format_hex_prefixed_to(char (&buffer)[N], const uint8_t *data, size_t length)`
   - Both include compile-time buffer size validation via `static_assert`
2. Added `format_hex_prefixed_size(byte_count)` constexpr for calculating required buffer size
3. Updated `one_wire.cpp` to use the new helper
4. Updated `sml_text_sensor.cpp` to use the new helper

Before (`one_wire.cpp`):
```cpp
this->address_name_ = std::string("0x") + format_hex(this->address_);
```

After:
```cpp
char hex_buf[19];  // "0x" + 16 hex chars + null
this->address_name_ = format_hex_prefixed_to(hex_buf, this->address_);
```

This eliminates:
- Temporary `std::string` allocation from `format_hex()`
- String concatenation overhead

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
