### PR TITLE
[sensor] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/sensor/automation.cpp
+++ b/esphome/components/sensor/automation.cpp
@@ -1,10 +1,8 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 static const char *const TAG = "sensor.automation";
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor

--- a/esphome/components/sensor/automation.h
+++ b/esphome/components/sensor/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 class SensorStateTrigger : public Trigger<float> {
  public:
@@ -107,5 +106,4 @@ template<typename... Ts> class SensorInRangeCondition : public Condition<Ts...> 
   float max_{NAN};
 };
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include "sensor.h"
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 static const char *const TAG = "sensor.filter";
 
@@ -574,5 +573,4 @@ void StreamingMovingAverageFilter::reset_batch() {
   this->valid_count_ = 0;
 }
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -7,8 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 class Sensor;
 
@@ -632,5 +631,4 @@ class StreamingMovingAverageFilter : public StreamingFilter {
   size_t valid_count_{0};
 };
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 static const char *const TAG = "sensor";
 
@@ -135,5 +134,4 @@ void Sensor::internal_send_state_to_frontend(float state) {
 #endif
 }
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -9,8 +9,7 @@
 #include <initializer_list>
 #include <memory>
 
-namespace esphome {
-namespace sensor {
+namespace esphome::sensor {
 
 void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *obj);
 
@@ -143,5 +142,4 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
   } sensor_flags_{};
 };
 
-}  // namespace sensor
-}  // namespace esphome
+}  // namespace esphome::sensor


### PR DESCRIPTION
# What does this implement/fix?

Converts the sensor component to use C++17 nested namespace syntax.

Changes from:
```cpp
namespace esphome {
namespace sensor {
...
}  // namespace sensor
}  // namespace esphome
```

To:
```cpp
namespace esphome::sensor {
...
}  // namespace esphome::sensor
```

This is a code modernization change that takes advantage of C++17 features (ESPHome uses `gnu++20`). The nested namespace syntax is more concise and reduces indentation.

Files updated:
- `sensor.h`
- `sensor.cpp`
- `filter.h`
- `filter.cpp`
- `automation.h`
- `automation.cpp`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Code modernization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No documentation changes needed

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal code modernization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
