### PR TITLE
[esp32_hosted] Bump component versions

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -93,9 +93,9 @@ async def to_code(config):
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"
     if framework_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.2.2")
-        esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.3")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.7.0")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.2.4")
+        esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.4")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.9.3")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -6,15 +6,15 @@ dependencies:
   espressif/mdns:
     version: 1.9.1
   espressif/esp_wifi_remote:
-    version: 1.2.2
+    version: 1.2.4
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/eppp_link:
-    version: 1.1.3
+    version: 1.1.4
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.7.0
+    version: 2.9.3
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:


### PR DESCRIPTION
# What does this implement/fix?

Updates the ESP component versions used for ESP-IDF 5.5+:
- esp_wifi_remote: 1.2.2 → 1.2.4
- eppp_link: 1.1.3 → 1.1.4
- esp_hosted: 2.7.0 → 2.9.3

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).