### PR TITLE
[core] Rename FixedVector::shrink_to_fit() to release() for clarity

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2014,8 +2014,8 @@ void WiFiComponent::release_scan_results_() {
     // std::vector - use swap trick since shrink_to_fit is non-binding
     decltype(this->scan_result_)().swap(this->scan_result_);
 #else
-    // FixedVector::shrink_to_fit() actually frees all memory
-    this->scan_result_.shrink_to_fit();
+    // FixedVector::release() frees all memory
+    this->scan_result_.release();
 #endif
   }
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -293,8 +293,8 @@ template<typename T> class FixedVector {
     size_ = 0;
   }
 
-  // Shrink capacity to fit current size (frees all memory)
-  void shrink_to_fit() {
+  // Release all memory (destroys elements and frees memory)
+  void release() {
     cleanup_();
     reset_();
   }


### PR DESCRIPTION
# What does this implement/fix?

Rename `FixedVector::shrink_to_fit()` to `FixedVector::release()` to accurately reflect its behavior.

The previous name was misleading because `shrink_to_fit()` (in `std::vector` semantics) implies shrinking capacity to match the current size while preserving elements. However, the actual implementation destroys all elements and frees all memory.

The new name `release()` clearly communicates that the method releases all resources.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, not user-facing)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal API change, no configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
