### PR TITLE
[libretiny] Disable BLE stack on BK7231N to save ~21KB RAM

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -50,6 +50,17 @@ CODEOWNERS = ["@kuba2k2"]
 AUTO_LOAD = ["preferences"]
 IS_TARGET_PLATFORM = True
 
+# BK72XX SDK options to disable unused features.
+# Disabling BLE saves ~21KB RAM and ~200KB Flash because BLE init code is
+# called unconditionally by the SDK. ESPHome doesn't use BLE on LibreTiny.
+#
+# Other options like CFG_TX_EVM_TEST, CFG_RX_SENSITIVITY_TEST, CFG_SUPPORT_BKREG,
+# CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no
+# measurable benefit - the linker already strips unreferenced code via -gc-sections.
+_BK72XX_SYS_CONFIG_OPTIONS = [
+    "CFG_SUPPORT_BLE=0",
+]
+
 
 def _detect_variant(value):
     if KEY_LIBRETINY not in CORE.data:
@@ -345,5 +356,11 @@ async def component_to_code(config):
     else:
         cg.add_platformio_option("custom_fw_name", "esphome")
         cg.add_platformio_option("custom_fw_version", __version__)
+
+    # Apply chip-specific SDK options to reduce compile time
+    if CORE.is_bk72xx:
+        cg.add_platformio_option(
+            "custom_options.sys_config#h", _BK72XX_SYS_CONFIG_OPTIONS
+        )
 
     await cg.register_component(var, config)

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_SDK_SILENT,
     CONF_UART_PORT,
     FAMILIES,
+    FAMILY_BK7231N,
     FAMILY_COMPONENT,
     FAMILY_FRIENDLY,
     KEY_BOARD,
@@ -50,14 +51,18 @@ CODEOWNERS = ["@kuba2k2"]
 AUTO_LOAD = ["preferences"]
 IS_TARGET_PLATFORM = True
 
-# BK72XX SDK options to disable unused features.
+# BK7231N SDK options to disable unused features.
 # Disabling BLE saves ~21KB RAM and ~200KB Flash because BLE init code is
 # called unconditionally by the SDK. ESPHome doesn't use BLE on LibreTiny.
+#
+# This only works on BK7231N (BLE 5.x). Other BK72XX chips using BLE 4.2
+# (BK7231T, BK7251, BK7252) have a bug where the BLE library still links and
+# references undefined symbols when CFG_SUPPORT_BLE=0.
 #
 # Other options like CFG_TX_EVM_TEST, CFG_RX_SENSITIVITY_TEST, CFG_SUPPORT_BKREG,
 # CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no
 # measurable benefit - the linker already strips unreferenced code via -gc-sections.
-_BK72XX_SYS_CONFIG_OPTIONS = [
+_BK7231N_SYS_CONFIG_OPTIONS = [
     "CFG_SUPPORT_BLE=0",
 ]
 
@@ -357,10 +362,10 @@ async def component_to_code(config):
         cg.add_platformio_option("custom_fw_name", "esphome")
         cg.add_platformio_option("custom_fw_version", __version__)
 
-    # Apply chip-specific SDK options to reduce compile time
-    if CORE.is_bk72xx:
+    # Apply chip-specific SDK options to save RAM/Flash
+    if config[CONF_FAMILY] == FAMILY_BK7231N:
         cg.add_platformio_option(
-            "custom_options.sys_config#h", _BK72XX_SYS_CONFIG_OPTIONS
+            "custom_options.sys_config#h", _BK7231N_SYS_CONFIG_OPTIONS
         )
 
     await cg.register_component(var, config)

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -60,7 +60,7 @@ IS_TARGET_PLATFORM = True
 # references undefined symbols when CFG_SUPPORT_BLE=0.
 #
 # Other options like CFG_TX_EVM_TEST, CFG_RX_SENSITIVITY_TEST, CFG_SUPPORT_BKREG,
-# CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no
+# CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no  # NOLINT
 # measurable benefit - the linker already strips unreferenced code via -gc-sections.
 _BK7231N_SYS_CONFIG_OPTIONS = [
     "CFG_SUPPORT_BLE=0",

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -56,8 +56,9 @@ IS_TARGET_PLATFORM = True
 # called unconditionally by the SDK. ESPHome doesn't use BLE on LibreTiny.
 #
 # This only works on BK7231N (BLE 5.x). Other BK72XX chips using BLE 4.2
-# (BK7231T, BK7251, BK7252) have a bug where the BLE library still links and
-# references undefined symbols when CFG_SUPPORT_BLE=0.
+# (BK7231T, BK7231Q, BK7251; BK7252 boards use the BK7251 family) have a bug
+# where the BLE library still links and references undefined symbols when
+# CFG_SUPPORT_BLE=0.
 #
 # Other options like CFG_TX_EVM_TEST, CFG_RX_SENSITIVITY_TEST, CFG_SUPPORT_BKREG,
 # CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no  # NOLINT


### PR DESCRIPTION
# What does this implement/fix?

Disables the BLE stack on BK7231N to save ~21KB RAM and ~200KB Flash.

ESPHome currently has no BLE support on LibreTiny platforms, so the BLE stack is pure waste. The Beken SDK unconditionally initializes it when `CFG_SUPPORT_BLE=1` (the default), consuming significant RAM on memory-constrained devices.

This can be flipped back on in a future PR when BLE support is added for BK7231N.

Before this change, users with typical configurations (WiFi, API, web_server, a few sensors) were seeing only ~10-13KB free heap at runtime, risking crashes under load. After this change, free heap increases to ~30KB+, providing a much safer margin.

**Memory savings (BK7231N):**
| Metric | Before | After | Savings |
|--------|--------|-------|---------|
| RAM | 94,948 bytes (36.2%) | 73,332 bytes (28.0%) | ~21KB |
| Flash | 802,024 bytes (74.0%) | 577,030 bytes (53.3%) | ~225KB |

**Why only BK7231N?**
Other BK72XX chips (BK7231T, BK7251, BK7252) use BLE 4.2 which has a bug where the BLE library still links and references undefined symbols when `CFG_SUPPORT_BLE=0`. BK7231N uses BLE 5.x which doesn't have this issue.

**Re-enabling BLE (for development/testing):**
Users can override this default via platformio_options if needed:
```yaml
esphome:
  platformio_options:
    "custom_options.sys_config#h":
      - "CFG_SUPPORT_BLE=1"
```

Other SDK options (`CFG_TX_EVM_TEST`, `CFG_RX_SENSITIVITY_TEST`, `CFG_SUPPORT_BKREG`, `CFG_SUPPORT_OTA_HTTP`, `CFG_USE_SPI_SLAVE`) were evaluated but provide no measurable benefit - the linker already strips unreferenced code via `-gc-sections`. Only BLE has an impact because its init code is called unconditionally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves memory situation for BK72XX users experiencing heap exhaustion

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration needed - BLE is now disabled automatically on BK7231N
bk72xx:
  board: cb3s

wifi:
  ssid: "MySSID"
  password: "MyPassword"

api:
ota:
  - platform: esphome
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
