### PR TITLE
[safe_mode] Conditionally compile callback when on_safe_mode is configured

### DIFF
--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -59,9 +59,11 @@ async def to_code(config):
         var = cg.new_Pvariable(config[CONF_ID])
         await cg.register_component(var, config)
 
-        for conf in config.get(CONF_ON_SAFE_MODE, []):
-            trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-            await automation.build_automation(trigger, [], conf)
+        if on_safe_mode_config := config.get(CONF_ON_SAFE_MODE):
+            cg.add_define("USE_SAFE_MODE_CALLBACK")
+            for conf in on_safe_mode_config:
+                trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+                await automation.build_automation(trigger, [], conf)
 
         condition = var.should_enter_safe_mode(
             config[CONF_NUM_ATTEMPTS],

--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -1,4 +1,7 @@
 #pragma once
+#include "esphome/core/defines.h"
+
+#ifdef USE_SAFE_MODE_CALLBACK
 #include "safe_mode.h"
 
 #include "esphome/core/automation.h"
@@ -15,3 +18,5 @@ class SafeModeTrigger : public Trigger<> {
 
 }  // namespace safe_mode
 }  // namespace esphome
+
+#endif  // USE_SAFE_MODE_CALLBACK

--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -6,8 +6,7 @@
 
 #include "esphome/core/automation.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 class SafeModeTrigger : public Trigger<> {
  public:
@@ -16,7 +15,6 @@ class SafeModeTrigger : public Trigger<> {
   }
 };
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode
 
 #endif  // USE_SAFE_MODE_CALLBACK

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -126,7 +126,9 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
 
   ESP_LOGW(TAG, "SAFE MODE IS ACTIVE");
 
+#ifdef USE_SAFE_MODE_CALLBACK
   this->safe_mode_callback_.call();
+#endif
 
   return true;
 }

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -13,8 +13,7 @@
 #include <esp_ota_ops.h>
 #endif
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 static const char *const TAG = "safe_mode";
 
@@ -159,5 +158,4 @@ void SafeModeComponent::on_safe_shutdown() {
     this->clean_rtc();
 }
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace safe_mode {
+namespace esphome::safe_mode {
 
 /// SafeModeComponent provides a safe way to recover from repeated boot failures
 class SafeModeComponent : public Component {
@@ -53,5 +52,4 @@ class SafeModeComponent : public Component {
       0x5afe5afe;  ///< a magic number to indicate that safe mode should be entered on next boot
 };
 
-}  // namespace safe_mode
-}  // namespace esphome
+}  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -25,9 +25,11 @@ class SafeModeComponent : public Component {
 
   void on_safe_shutdown() override;
 
+#ifdef USE_SAFE_MODE_CALLBACK
   void add_on_safe_mode_callback(std::function<void()> &&callback) {
     this->safe_mode_callback_.add(std::move(callback));
   }
+#endif
 
  protected:
   void write_rtc_(uint32_t val);
@@ -43,7 +45,9 @@ class SafeModeComponent : public Component {
   uint8_t safe_mode_num_attempts_{0};
   // Larger objects at the end
   ESPPreferenceObject rtc_;
+#ifdef USE_SAFE_MODE_CALLBACK
   CallbackManager<void()> safe_mode_callback_{};
+#endif
 
   static const uint32_t ENTER_SAFE_MODE_MAGIC =
       0x5afe5afe;  ///< a magic number to indicate that safe mode should be entered on next boot

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -100,6 +100,7 @@
 #define USE_OUTPUT
 #define USE_POWER_SUPPLY
 #define USE_QR_CODE
+#define USE_SAFE_MODE_CALLBACK
 #define USE_SELECT
 #define USE_SENSOR
 #define USE_STATUS_LED


### PR DESCRIPTION
# What does this implement/fix?

1. Wraps the `on_safe_mode` callback infrastructure in `#ifdef USE_SAFE_MODE_CALLBACK` to eliminate memory overhead when no `on_safe_mode:` automation is configured (which is the common case).

2. Updates to C++17 nested namespace syntax (`namespace esphome::safe_mode`).

This follows the same pattern used by `esp32_improv` component (`USE_ESP32_IMPROV_STATE_CALLBACK`). The `#ifdef` approach works well here because the callback usage is entirely self-contained within the safe_mode component - only the internal `SafeModeTrigger` uses `add_on_safe_mode_callback()`, with no external components depending on it.

**Memory savings when `on_safe_mode:` is not configured:**
- 12 bytes heap (empty `CallbackManager` with `std::vector`)
- ~32-38 bytes flash (callback infrastructure code)

The define is only added when `on_safe_mode:` is present in the configuration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal optimization, no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# The callback is automatically included only when on_safe_mode is used:

safe_mode:

# With callback (USE_SAFE_MODE_CALLBACK defined):
safe_mode:
  on_safe_mode:
    - logger.log: "Safe mode activated!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
