### PR TITLE
[light] Move LightColorValues::lerp() out of header to reduce code duplication

### DIFF
--- a/esphome/components/light/light_color_values.cpp
+++ b/esphome/components/light/light_color_values.cpp
@@ -1,0 +1,28 @@
+#include "light_color_values.h"
+
+#include <cmath>
+
+namespace esphome::light {
+
+LightColorValues LightColorValues::lerp(const LightColorValues &start, const LightColorValues &end, float completion) {
+  // Directly interpolate the raw values to avoid getter/setter overhead.
+  // This is safe because:
+  // - All LightColorValues have their values clamped when set via the setters
+  // - std::lerp guarantees output is in the same range as inputs
+  // - Therefore the output doesn't need clamping, so we can skip the setters
+  LightColorValues v;
+  v.color_mode_ = end.color_mode_;
+  v.state_ = std::lerp(start.state_, end.state_, completion);
+  v.brightness_ = std::lerp(start.brightness_, end.brightness_, completion);
+  v.color_brightness_ = std::lerp(start.color_brightness_, end.color_brightness_, completion);
+  v.red_ = std::lerp(start.red_, end.red_, completion);
+  v.green_ = std::lerp(start.green_, end.green_, completion);
+  v.blue_ = std::lerp(start.blue_, end.blue_, completion);
+  v.white_ = std::lerp(start.white_, end.white_, completion);
+  v.color_temperature_ = std::lerp(start.color_temperature_, end.color_temperature_, completion);
+  v.cold_white_ = std::lerp(start.cold_white_, end.cold_white_, completion);
+  v.warm_white_ = std::lerp(start.warm_white_, end.warm_white_, completion);
+  return v;
+}
+
+}  // namespace esphome::light

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -82,26 +82,7 @@ class LightColorValues {
    * @param completion The completion value. 0 -> start, 1 -> end.
    * @return The linearly interpolated LightColorValues.
    */
-  static LightColorValues lerp(const LightColorValues &start, const LightColorValues &end, float completion) {
-    // Directly interpolate the raw values to avoid getter/setter overhead.
-    // This is safe because:
-    // - All LightColorValues have their values clamped when set via the setters
-    // - std::lerp guarantees output is in the same range as inputs
-    // - Therefore the output doesn't need clamping, so we can skip the setters
-    LightColorValues v;
-    v.color_mode_ = end.color_mode_;
-    v.state_ = std::lerp(start.state_, end.state_, completion);
-    v.brightness_ = std::lerp(start.brightness_, end.brightness_, completion);
-    v.color_brightness_ = std::lerp(start.color_brightness_, end.color_brightness_, completion);
-    v.red_ = std::lerp(start.red_, end.red_, completion);
-    v.green_ = std::lerp(start.green_, end.green_, completion);
-    v.blue_ = std::lerp(start.blue_, end.blue_, completion);
-    v.white_ = std::lerp(start.white_, end.white_, completion);
-    v.color_temperature_ = std::lerp(start.color_temperature_, end.color_temperature_, completion);
-    v.cold_white_ = std::lerp(start.cold_white_, end.cold_white_, completion);
-    v.warm_white_ = std::lerp(start.warm_white_, end.warm_white_, completion);
-    return v;
-  }
+  static LightColorValues lerp(const LightColorValues &start, const LightColorValues &end, float completion);
 
   /** Normalize the color (RGB/W) component.
    *


### PR DESCRIPTION
# What does this implement/fix?

Move `LightColorValues::lerp()` from inline header implementation to a separate `.cpp` file to reduce code duplication across translation units.

When the `lerp()` function is defined inline in the header, the compiler generates a separate copy of the function in every translation unit that includes `light_color_values.h`. By moving the implementation to a `.cpp` file, there is only one copy of the function in the final binary.

**Measured savings (ESP8266):**
- `LightTransitionTransformer::apply()`: -112 bytes (-25.34%)
- `AddressableLightTransformer::apply()`: -128 bytes (-10.84%)
- New shared `lerp()`: +157 bytes
- **Net: -83 bytes flash (-0.40% of light component)**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
