### PR TITLE
[seeed_mr24hpc1] Add ifdef guards for conditional entity types

### DIFF
--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -400,145 +400,154 @@ void MR24HPC1Component::r24_frame_parse_product_information_(uint8_t *data) {
 
 // Parsing the underlying open parameters
 void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *data) {
-  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
-  if (cmd == 0x00) {
+  switch (data[FRAME_COMMAND_WORD_INDEX]) {
+    case 0x00:
+    case 0x80:
 #ifdef USE_SWITCH
-    if (this->underlying_open_function_switch_ != nullptr) {
-      this->underlying_open_function_switch_->publish_state(
-          data[FRAME_DATA_INDEX]);  // Underlying Open Parameter Switch Status Updates
-    }
+      if (this->underlying_open_function_switch_ != nullptr) {
+        this->underlying_open_function_switch_->publish_state(data[FRAME_DATA_INDEX]);
+      }
 #endif
-    if (data[FRAME_DATA_INDEX]) {
-      this->s_output_info_switch_flag_ = OUTPUT_SWITCH_ON;
-    } else {
-      this->s_output_info_switch_flag_ = OUTPUT_SWTICH_OFF;
-    }
-  } else if (cmd == 0x01) {
+      this->s_output_info_switch_flag_ = data[FRAME_DATA_INDEX] ? OUTPUT_SWITCH_ON : OUTPUT_SWTICH_OFF;
+      break;
+    case 0x01:
 #ifdef USE_SENSOR
-    if (this->custom_spatial_static_value_sensor_ != nullptr) {
-      this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-    if (this->custom_presence_of_detection_sensor_ != nullptr) {
-      this->custom_presence_of_detection_sensor_->publish_state(data[FRAME_DATA_INDEX + 1] * 0.5f);
-    }
-    if (this->custom_spatial_motion_value_sensor_ != nullptr) {
-      this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX + 2]);
-    }
-    if (this->custom_motion_distance_sensor_ != nullptr) {
-      this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX + 3] * 0.5f);
-    }
-    if (this->custom_motion_speed_sensor_ != nullptr) {
-      this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX + 4] - 10) * 0.5f);
-    }
+      if (this->custom_spatial_static_value_sensor_ != nullptr) {
+        this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      if (this->custom_presence_of_detection_sensor_ != nullptr) {
+        this->custom_presence_of_detection_sensor_->publish_state(data[FRAME_DATA_INDEX + 1] * 0.5f);
+      }
+      if (this->custom_spatial_motion_value_sensor_ != nullptr) {
+        this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX + 2]);
+      }
+      if (this->custom_motion_distance_sensor_ != nullptr) {
+        this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX + 3] * 0.5f);
+      }
+      if (this->custom_motion_speed_sensor_ != nullptr) {
+        this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX + 4] - 10) * 0.5f);
+      }
 #endif
-  } else if ((cmd == 0x06) || (cmd == 0x86)) {
-    // none:0x00  close_to:0x01  far_away:0x02
+      break;
+    case 0x06:
+    case 0x86:
+      // none:0x00  close_to:0x01  far_away:0x02
 #ifdef USE_TEXT_SENSOR
-    if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
-      this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
-    }
-#endif
-  } else if ((cmd == 0x07) || (cmd == 0x87)) {
-#ifdef USE_SENSOR
-    if (this->movement_signs_sensor_ != nullptr) {
-      this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if ((cmd == 0x08) || (cmd == 0x88)) {
-#ifdef USE_NUMBER
-    if (this->existence_threshold_number_ != nullptr) {
-      this->existence_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if ((cmd == 0x09) || (cmd == 0x89)) {
-#ifdef USE_NUMBER
-    if (this->motion_threshold_number_ != nullptr) {
-      this->motion_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if ((cmd == 0x0a) || (cmd == 0x8a)) {
-#ifdef USE_SELECT
-    if (this->existence_boundary_select_ != nullptr) {
-      if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-        this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+      if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
+        this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
       }
-    }
 #endif
-  } else if ((cmd == 0x0b) || (cmd == 0x8b)) {
-#ifdef USE_SELECT
-    if (this->motion_boundary_select_ != nullptr) {
-      if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-        this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+      break;
+    case 0x07:
+    case 0x87:
+#ifdef USE_SENSOR
+      if (this->movement_signs_sensor_ != nullptr) {
+        this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
-    }
 #endif
-  } else if ((cmd == 0x0c) || (cmd == 0x8c)) {
+      break;
+    case 0x08:
+    case 0x88:
 #ifdef USE_NUMBER
-    if (this->motion_trigger_number_ != nullptr) {
-      uint32_t motion_trigger_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+      if (this->existence_threshold_number_ != nullptr) {
+        this->existence_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+#endif
+      break;
+    case 0x09:
+    case 0x89:
+#ifdef USE_NUMBER
+      if (this->motion_threshold_number_ != nullptr) {
+        this->motion_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+#endif
+      break;
+    case 0x0a:
+    case 0x8a:
+#ifdef USE_SELECT
+      if (this->existence_boundary_select_ != nullptr) {
+        if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+          this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+        }
+      }
+#endif
+      break;
+    case 0x0b:
+    case 0x8b:
+#ifdef USE_SELECT
+      if (this->motion_boundary_select_ != nullptr) {
+        if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+          this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+        }
+      }
+#endif
+      break;
+    case 0x0c:
+    case 0x8c:
+#ifdef USE_NUMBER
+      if (this->motion_trigger_number_ != nullptr) {
+        uint32_t motion_trigger_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+                                                     data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
+        this->motion_trigger_number_->publish_state(motion_trigger_time);
+      }
+#endif
+      break;
+    case 0x0d:
+    case 0x8d:
+#ifdef USE_NUMBER
+      if (this->motion_to_rest_number_ != nullptr) {
+        uint32_t move_to_rest_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
                                                    data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-      this->motion_trigger_number_->publish_state(motion_trigger_time);
-    }
+        this->motion_to_rest_number_->publish_state(move_to_rest_time);
+      }
 #endif
-  } else if ((cmd == 0x0d) || (cmd == 0x8d)) {
+      break;
+    case 0x0e:
+    case 0x8e:
 #ifdef USE_NUMBER
-    if (this->motion_to_rest_number_ != nullptr) {
-      uint32_t move_to_rest_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
-                                                 data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-      this->motion_to_rest_number_->publish_state(move_to_rest_time);
-    }
+      if (this->custom_unman_time_number_ != nullptr) {
+        uint32_t enter_unmanned_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+                                                     data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
+        this->custom_unman_time_number_->publish_state(enter_unmanned_time / 1000.0f);
+      }
 #endif
-  } else if ((cmd == 0x0e) || (cmd == 0x8e)) {
-#ifdef USE_NUMBER
-    if (this->custom_unman_time_number_ != nullptr) {
-      uint32_t enter_unmanned_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
-                                                   data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-      float custom_unmanned_time = enter_unmanned_time / 1000.0;
-      this->custom_unman_time_number_->publish_state(custom_unmanned_time);
-    }
-#endif
-  } else if (cmd == 0x80) {
-    if (data[FRAME_DATA_INDEX]) {
-      this->s_output_info_switch_flag_ = OUTPUT_SWITCH_ON;
-    } else {
-      this->s_output_info_switch_flag_ = OUTPUT_SWTICH_OFF;
-    }
-#ifdef USE_SWITCH
-    if (this->underlying_open_function_switch_ != nullptr) {
-      this->underlying_open_function_switch_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if (cmd == 0x81) {
+      break;
+    case 0x81:
 #ifdef USE_SENSOR
-    if (this->custom_spatial_static_value_sensor_ != nullptr) {
-      this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
+      if (this->custom_spatial_static_value_sensor_ != nullptr) {
+        this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
 #endif
-  } else if (cmd == 0x82) {
+      break;
+    case 0x82:
 #ifdef USE_SENSOR
-    if (this->custom_spatial_motion_value_sensor_ != nullptr) {
-      this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
+      if (this->custom_spatial_motion_value_sensor_ != nullptr) {
+        this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
 #endif
-  } else if (cmd == 0x83) {
+      break;
+    case 0x83:
 #ifdef USE_SENSOR
-    if (this->custom_presence_of_detection_sensor_ != nullptr) {
-      this->custom_presence_of_detection_sensor_->publish_state(
-          S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
-    }
+      if (this->custom_presence_of_detection_sensor_ != nullptr) {
+        this->custom_presence_of_detection_sensor_->publish_state(
+            S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
+      }
 #endif
-  } else if (cmd == 0x84) {
+      break;
+    case 0x84:
 #ifdef USE_SENSOR
-    if (this->custom_motion_distance_sensor_ != nullptr) {
-      this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
-    }
+      if (this->custom_motion_distance_sensor_ != nullptr) {
+        this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
+      }
 #endif
-  } else if (cmd == 0x85) {
+      break;
+    case 0x85:
 #ifdef USE_SENSOR
-    if (this->custom_motion_speed_sensor_ != nullptr) {
-      this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
-    }
+      if (this->custom_motion_speed_sensor_ != nullptr) {
+        this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
+      }
 #endif
+      break;
   }
 }
 

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -64,15 +64,21 @@ void MR24HPC1Component::dump_config() {
 void MR24HPC1Component::setup() {
   this->check_uart_settings(115200);
 
+#ifdef USE_NUMBER
   if (this->custom_mode_number_ != nullptr) {
     this->custom_mode_number_->publish_state(0);  // Zero out the custom mode
   }
+#endif
+#ifdef USE_SENSOR
   if (this->custom_mode_num_sensor_ != nullptr) {
     this->custom_mode_num_sensor_->publish_state(0);
   }
+#endif
+#ifdef USE_TEXT_SENSOR
   if (this->custom_mode_end_text_sensor_ != nullptr) {
     this->custom_mode_end_text_sensor_->publish_state("Not in custom mode");
   }
+#endif
   this->set_custom_end_mode();
   this->poll_time_base_func_check_ = true;
   this->check_dev_inf_sign_ = true;
@@ -354,6 +360,7 @@ void MR24HPC1Component::r24_split_data_frame_(uint8_t value) {
 // Parses data frames related to product information
 void MR24HPC1Component::r24_frame_parse_product_information_(uint8_t *data) {
   uint16_t product_len = encode_uint16(data[FRAME_COMMAND_WORD_INDEX + 1], data[FRAME_COMMAND_WORD_INDEX + 2]);
+#ifdef USE_TEXT_SENSOR
   if (data[FRAME_COMMAND_WORD_INDEX] == COMMAND_PRODUCT_MODE) {
     if ((this->product_model_text_sensor_ != nullptr) && (product_len < PRODUCT_BUF_MAX_SIZE)) {
       memset(this->c_product_mode_, 0, PRODUCT_BUF_MAX_SIZE);
@@ -388,21 +395,28 @@ void MR24HPC1Component::r24_frame_parse_product_information_(uint8_t *data) {
       ESP_LOGD(TAG, "Reply: get firmwareVersion error!");
     }
   }
+#else
+  (void) product_len;
+#endif
 }
 
 // Parsing the underlying open parameters
 void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *data) {
-  if (data[FRAME_COMMAND_WORD_INDEX] == 0x00) {
+  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
+  if (cmd == 0x00) {
+#ifdef USE_SWITCH
     if (this->underlying_open_function_switch_ != nullptr) {
       this->underlying_open_function_switch_->publish_state(
           data[FRAME_DATA_INDEX]);  // Underlying Open Parameter Switch Status Updates
     }
+#endif
     if (data[FRAME_DATA_INDEX]) {
       this->s_output_info_switch_flag_ = OUTPUT_SWITCH_ON;
     } else {
       this->s_output_info_switch_flag_ = OUTPUT_SWTICH_OFF;
     }
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x01) {
+  } else if (cmd == 0x01) {
+#ifdef USE_SENSOR
     if (this->custom_spatial_static_value_sensor_ != nullptr) {
       this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
     }
@@ -418,78 +432,135 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
     if (this->custom_motion_speed_sensor_ != nullptr) {
       this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX + 4] - 10) * 0.5f);
     }
-  } else if ((data[FRAME_COMMAND_WORD_INDEX] == 0x06) || (data[FRAME_COMMAND_WORD_INDEX] == 0x86)) {
+#endif
+  } else if ((cmd == 0x06) || (cmd == 0x86)) {
     // none:0x00  close_to:0x01  far_away:0x02
+#ifdef USE_TEXT_SENSOR
     if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
       this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
     }
-  } else if ((this->movement_signs_sensor_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x07) || (data[FRAME_COMMAND_WORD_INDEX] == 0x87))) {
-    this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->existence_threshold_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x08) || (data[FRAME_COMMAND_WORD_INDEX] == 0x88))) {
-    this->existence_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->motion_threshold_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x09) || (data[FRAME_COMMAND_WORD_INDEX] == 0x89))) {
-    this->motion_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->existence_boundary_select_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0a) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8a))) {
-    if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-      this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+#endif
+  } else if ((cmd == 0x07) || (cmd == 0x87)) {
+#ifdef USE_SENSOR
+    if (this->movement_signs_sensor_ != nullptr) {
+      this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
     }
-  } else if ((this->motion_boundary_select_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0b) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8b))) {
-    if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-      this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+#endif
+  } else if ((cmd == 0x08) || (cmd == 0x88)) {
+#ifdef USE_NUMBER
+    if (this->existence_threshold_number_ != nullptr) {
+      this->existence_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
     }
-  } else if ((this->motion_trigger_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0c) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8c))) {
-    uint32_t motion_trigger_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+#endif
+  } else if ((cmd == 0x09) || (cmd == 0x89)) {
+#ifdef USE_NUMBER
+    if (this->motion_threshold_number_ != nullptr) {
+      this->motion_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
+    }
+#endif
+  } else if ((cmd == 0x0a) || (cmd == 0x8a)) {
+#ifdef USE_SELECT
+    if (this->existence_boundary_select_ != nullptr) {
+      if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+        this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+      }
+    }
+#endif
+  } else if ((cmd == 0x0b) || (cmd == 0x8b)) {
+#ifdef USE_SELECT
+    if (this->motion_boundary_select_ != nullptr) {
+      if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+        this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+      }
+    }
+#endif
+  } else if ((cmd == 0x0c) || (cmd == 0x8c)) {
+#ifdef USE_NUMBER
+    if (this->motion_trigger_number_ != nullptr) {
+      uint32_t motion_trigger_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+                                                   data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
+      this->motion_trigger_number_->publish_state(motion_trigger_time);
+    }
+#endif
+  } else if ((cmd == 0x0d) || (cmd == 0x8d)) {
+#ifdef USE_NUMBER
+    if (this->motion_to_rest_number_ != nullptr) {
+      uint32_t move_to_rest_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
                                                  data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-    this->motion_trigger_number_->publish_state(motion_trigger_time);
-  } else if ((this->motion_to_rest_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0d) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8d))) {
-    uint32_t move_to_rest_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
-                                               data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-    this->motion_to_rest_number_->publish_state(move_to_rest_time);
-  } else if ((this->custom_unman_time_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0e) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8e))) {
-    uint32_t enter_unmanned_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
-                                                 data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
-    float custom_unmanned_time = enter_unmanned_time / 1000.0;
-    this->custom_unman_time_number_->publish_state(custom_unmanned_time);
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x80) {
+      this->motion_to_rest_number_->publish_state(move_to_rest_time);
+    }
+#endif
+  } else if ((cmd == 0x0e) || (cmd == 0x8e)) {
+#ifdef USE_NUMBER
+    if (this->custom_unman_time_number_ != nullptr) {
+      uint32_t enter_unmanned_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
+                                                   data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
+      float custom_unmanned_time = enter_unmanned_time / 1000.0;
+      this->custom_unman_time_number_->publish_state(custom_unmanned_time);
+    }
+#endif
+  } else if (cmd == 0x80) {
     if (data[FRAME_DATA_INDEX]) {
       this->s_output_info_switch_flag_ = OUTPUT_SWITCH_ON;
     } else {
       this->s_output_info_switch_flag_ = OUTPUT_SWTICH_OFF;
     }
+#ifdef USE_SWITCH
     if (this->underlying_open_function_switch_ != nullptr) {
       this->underlying_open_function_switch_->publish_state(data[FRAME_DATA_INDEX]);
     }
-  } else if ((this->custom_spatial_static_value_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x81)) {
-    this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->custom_spatial_motion_value_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x82)) {
-    this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->custom_presence_of_detection_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x83)) {
-    this->custom_presence_of_detection_sensor_->publish_state(
-        S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
-  } else if ((this->custom_motion_distance_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x84)) {
-    this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
-  } else if ((this->custom_motion_speed_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x85)) {
-    this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
+#endif
+  } else if (cmd == 0x81) {
+#ifdef USE_SENSOR
+    if (this->custom_spatial_static_value_sensor_ != nullptr) {
+      this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+    }
+#endif
+  } else if (cmd == 0x82) {
+#ifdef USE_SENSOR
+    if (this->custom_spatial_motion_value_sensor_ != nullptr) {
+      this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+    }
+#endif
+  } else if (cmd == 0x83) {
+#ifdef USE_SENSOR
+    if (this->custom_presence_of_detection_sensor_ != nullptr) {
+      this->custom_presence_of_detection_sensor_->publish_state(
+          S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
+    }
+#endif
+  } else if (cmd == 0x84) {
+#ifdef USE_SENSOR
+    if (this->custom_motion_distance_sensor_ != nullptr) {
+      this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
+    }
+#endif
+  } else if (cmd == 0x85) {
+#ifdef USE_SENSOR
+    if (this->custom_motion_speed_sensor_ != nullptr) {
+      this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
+    }
+#endif
   }
 }
 
 void MR24HPC1Component::r24_parse_data_frame_(uint8_t *data, uint8_t len) {
   switch (data[FRAME_CONTROL_WORD_INDEX]) {
     case 0x01: {
-      if ((this->heartbeat_state_text_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x01)) {
-        this->heartbeat_state_text_sensor_->publish_state("Equipment Normal");
+      if (data[FRAME_COMMAND_WORD_INDEX] == 0x01) {
+#ifdef USE_TEXT_SENSOR
+        if (this->heartbeat_state_text_sensor_ != nullptr) {
+          this->heartbeat_state_text_sensor_->publish_state("Equipment Normal");
+        }
+#endif
       } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x02) {
         ESP_LOGD(TAG, "Reply: query restart packet");
-      } else if (this->heartbeat_state_text_sensor_ != nullptr) {
-        this->heartbeat_state_text_sensor_->publish_state("Equipment Abnormal");
+      } else {
+#ifdef USE_TEXT_SENSOR
+        if (this->heartbeat_state_text_sensor_ != nullptr) {
+          this->heartbeat_state_text_sensor_->publish_state("Equipment Abnormal");
+        }
+#endif
       }
     } break;
     case 0x02: {
@@ -511,54 +582,80 @@ void MR24HPC1Component::r24_parse_data_frame_(uint8_t *data, uint8_t len) {
 }
 
 void MR24HPC1Component::r24_frame_parse_work_status_(uint8_t *data) {
-  if (data[FRAME_COMMAND_WORD_INDEX] == 0x01) {
+  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
+  if (cmd == 0x01) {
     ESP_LOGD(TAG, "Reply: get radar init status 0x%02X", data[FRAME_DATA_INDEX]);
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x07) {
+  } else if (cmd == 0x07) {
+#ifdef USE_SELECT
     if ((this->scene_mode_select_ != nullptr) && (this->scene_mode_select_->has_index(data[FRAME_DATA_INDEX]))) {
       this->scene_mode_select_->publish_state(data[FRAME_DATA_INDEX]);
     } else {
       ESP_LOGD(TAG, "Select has index offset %d Error", data[FRAME_DATA_INDEX]);
     }
-  } else if ((this->sensitivity_number_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x08) || (data[FRAME_COMMAND_WORD_INDEX] == 0x88))) {
+#endif
+  } else if ((cmd == 0x08) || (cmd == 0x88)) {
+#ifdef USE_NUMBER
     // 1-3
-    this->sensitivity_number_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x09) {
+    if (this->sensitivity_number_ != nullptr) {
+      this->sensitivity_number_->publish_state(data[FRAME_DATA_INDEX]);
+    }
+#endif
+  } else if (cmd == 0x09) {
     // 1-4
+#ifdef USE_SENSOR
     if (this->custom_mode_num_sensor_ != nullptr) {
       this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
     }
+#endif
+#ifdef USE_NUMBER
     if (this->custom_mode_number_ != nullptr) {
       this->custom_mode_number_->publish_state(0);
     }
+#endif
+#ifdef USE_TEXT_SENSOR
     if (this->custom_mode_end_text_sensor_ != nullptr) {
       this->custom_mode_end_text_sensor_->publish_state("Setup in progress");
     }
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x81) {
+#endif
+  } else if (cmd == 0x81) {
     ESP_LOGD(TAG, "Reply: get radar init status 0x%02X", data[FRAME_DATA_INDEX]);
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x87) {
+  } else if (cmd == 0x87) {
+#ifdef USE_SELECT
     if ((this->scene_mode_select_ != nullptr) && (this->scene_mode_select_->has_index(data[FRAME_DATA_INDEX]))) {
       this->scene_mode_select_->publish_state(data[FRAME_DATA_INDEX]);
     } else {
       ESP_LOGD(TAG, "Select has index offset %d Error", data[FRAME_DATA_INDEX]);
     }
-  } else if ((this->custom_mode_end_text_sensor_ != nullptr) && (data[FRAME_COMMAND_WORD_INDEX] == 0x0A)) {
-    this->custom_mode_end_text_sensor_->publish_state("Set Success!");
-  } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x89) {
+#endif
+  } else if (cmd == 0x0A) {
+#ifdef USE_TEXT_SENSOR
+    if (this->custom_mode_end_text_sensor_ != nullptr) {
+      this->custom_mode_end_text_sensor_->publish_state("Set Success!");
+    }
+#endif
+  } else if (cmd == 0x89) {
     if (data[FRAME_DATA_INDEX] == 0) {
+#ifdef USE_TEXT_SENSOR
       if (this->custom_mode_end_text_sensor_ != nullptr) {
         this->custom_mode_end_text_sensor_->publish_state("Not in custom mode");
       }
+#endif
+#ifdef USE_NUMBER
       if (this->custom_mode_number_ != nullptr) {
         this->custom_mode_number_->publish_state(0);
       }
+#endif
+#ifdef USE_SENSOR
       if (this->custom_mode_num_sensor_ != nullptr) {
         this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
+#endif
     } else {
+#ifdef USE_SENSOR
       if (this->custom_mode_num_sensor_ != nullptr) {
         this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
+#endif
     }
   } else {
     ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
@@ -566,29 +663,45 @@ void MR24HPC1Component::r24_frame_parse_work_status_(uint8_t *data) {
 }
 
 void MR24HPC1Component::r24_frame_parse_human_information_(uint8_t *data) {
-  if ((this->has_target_binary_sensor_ != nullptr) &&
-      ((data[FRAME_COMMAND_WORD_INDEX] == 0x01) || (data[FRAME_COMMAND_WORD_INDEX] == 0x81))) {
-    this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
-  } else if ((this->motion_status_text_sensor_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x02) || (data[FRAME_COMMAND_WORD_INDEX] == 0x82))) {
-    if (data[FRAME_DATA_INDEX] < 3) {
-      this->motion_status_text_sensor_->publish_state(S_MOTION_STATUS_STR[data[FRAME_DATA_INDEX]]);
+  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
+  if ((cmd == 0x01) || (cmd == 0x81)) {
+#ifdef USE_BINARY_SENSOR
+    if (this->has_target_binary_sensor_ != nullptr) {
+      this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
     }
-  } else if ((this->movement_signs_sensor_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x03) || (data[FRAME_COMMAND_WORD_INDEX] == 0x83))) {
-    this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-  } else if ((this->unman_time_select_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0A) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8A))) {
+#endif
+  } else if ((cmd == 0x02) || (cmd == 0x82)) {
+#ifdef USE_TEXT_SENSOR
+    if (this->motion_status_text_sensor_ != nullptr) {
+      if (data[FRAME_DATA_INDEX] < 3) {
+        this->motion_status_text_sensor_->publish_state(S_MOTION_STATUS_STR[data[FRAME_DATA_INDEX]]);
+      }
+    }
+#endif
+  } else if ((cmd == 0x03) || (cmd == 0x83)) {
+#ifdef USE_SENSOR
+    if (this->movement_signs_sensor_ != nullptr) {
+      this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+    }
+#endif
+  } else if ((cmd == 0x0A) || (cmd == 0x8A)) {
+#ifdef USE_SELECT
     // none:0x00  1s:0x01 30s:0x02 1min:0x03 2min:0x04 5min:0x05 10min:0x06 30min:0x07 1hour:0x08
-    if (data[FRAME_DATA_INDEX] < 9) {
-      this->unman_time_select_->publish_state(data[FRAME_DATA_INDEX]);
+    if (this->unman_time_select_ != nullptr) {
+      if (data[FRAME_DATA_INDEX] < 9) {
+        this->unman_time_select_->publish_state(data[FRAME_DATA_INDEX]);
+      }
     }
-  } else if ((this->keep_away_text_sensor_ != nullptr) &&
-             ((data[FRAME_COMMAND_WORD_INDEX] == 0x0B) || (data[FRAME_COMMAND_WORD_INDEX] == 0x8B))) {
+#endif
+  } else if ((cmd == 0x0B) || (cmd == 0x8B)) {
+#ifdef USE_TEXT_SENSOR
     // none:0x00  close_to:0x01  far_away:0x02
-    if (data[FRAME_DATA_INDEX] < 3) {
-      this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
+    if (this->keep_away_text_sensor_ != nullptr) {
+      if (data[FRAME_DATA_INDEX] < 3) {
+        this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
+      }
     }
+#endif
   } else {
     ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
   }
@@ -695,12 +808,15 @@ void MR24HPC1Component::set_underlying_open_function(bool enable) {
   } else {
     this->send_query_(UNDERLYING_SWITCH_OFF, sizeof(UNDERLYING_SWITCH_OFF));
   }
+#ifdef USE_TEXT_SENSOR
   if (this->keep_away_text_sensor_ != nullptr) {
     this->keep_away_text_sensor_->publish_state("");
   }
   if (this->motion_status_text_sensor_ != nullptr) {
     this->motion_status_text_sensor_->publish_state("");
   }
+#endif
+#ifdef USE_SENSOR
   if (this->custom_spatial_static_value_sensor_ != nullptr) {
     this->custom_spatial_static_value_sensor_->publish_state(NAN);
   }
@@ -716,6 +832,7 @@ void MR24HPC1Component::set_underlying_open_function(bool enable) {
   if (this->custom_motion_speed_sensor_ != nullptr) {
     this->custom_motion_speed_sensor_->publish_state(NAN);
   }
+#endif
 }
 
 void MR24HPC1Component::set_scene_mode(uint8_t value) {
@@ -723,12 +840,16 @@ void MR24HPC1Component::set_scene_mode(uint8_t value) {
   uint8_t send_data[10] = {0x53, 0x59, 0x05, 0x07, 0x00, 0x01, value, 0x00, 0x54, 0x43};
   send_data[7] = get_frame_crc_sum(send_data, send_data_len);
   this->send_query_(send_data, send_data_len);
+#ifdef USE_NUMBER
   if (this->custom_mode_number_ != nullptr) {
     this->custom_mode_number_->publish_state(0);
   }
+#endif
+#ifdef USE_SENSOR
   if (this->custom_mode_num_sensor_ != nullptr) {
     this->custom_mode_num_sensor_->publish_state(0);
   }
+#endif
   this->get_scene_mode();
   this->get_sensitivity();
   this->get_custom_mode();
@@ -768,9 +889,11 @@ void MR24HPC1Component::set_unman_time(uint8_t value) {
 void MR24HPC1Component::set_custom_mode(uint8_t mode) {
   if (mode == 0) {
     this->set_custom_end_mode();  // Equivalent to end setting
+#ifdef USE_NUMBER
     if (this->custom_mode_number_ != nullptr) {
       this->custom_mode_number_->publish_state(0);
     }
+#endif
     return;
   }
   uint8_t send_data_len = 10;
@@ -793,9 +916,11 @@ void MR24HPC1Component::set_custom_end_mode() {
   uint8_t send_data_len = 10;
   uint8_t send_data[10] = {0x53, 0x59, 0x05, 0x0a, 0x00, 0x01, 0x0F, 0xCB, 0x54, 0x43};
   this->send_query_(send_data, send_data_len);
+#ifdef USE_NUMBER
   if (this->custom_mode_number_ != nullptr) {
     this->custom_mode_number_->publish_state(0);  // Clear setpoints
   }
+#endif
   this->get_existence_boundary();
   this->get_motion_boundary();
   this->get_existence_threshold();
@@ -809,8 +934,10 @@ void MR24HPC1Component::set_custom_end_mode() {
 }
 
 void MR24HPC1Component::set_existence_boundary(uint8_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t send_data_len = 10;
   uint8_t send_data[10] = {0x53, 0x59, 0x08, 0x0A, 0x00, 0x01, (uint8_t) (value + 1), 0x00, 0x54, 0x43};
   send_data[7] = get_frame_crc_sum(send_data, send_data_len);
@@ -819,8 +946,10 @@ void MR24HPC1Component::set_existence_boundary(uint8_t value) {
 }
 
 void MR24HPC1Component::set_motion_boundary(uint8_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t send_data_len = 10;
   uint8_t send_data[10] = {0x53, 0x59, 0x08, 0x0B, 0x00, 0x01, (uint8_t) (value + 1), 0x00, 0x54, 0x43};
   send_data[7] = get_frame_crc_sum(send_data, send_data_len);
@@ -829,8 +958,10 @@ void MR24HPC1Component::set_motion_boundary(uint8_t value) {
 }
 
 void MR24HPC1Component::set_existence_threshold(uint8_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t send_data_len = 10;
   uint8_t send_data[10] = {0x53, 0x59, 0x08, 0x08, 0x00, 0x01, value, 0x00, 0x54, 0x43};
   send_data[7] = get_frame_crc_sum(send_data, send_data_len);
@@ -839,8 +970,10 @@ void MR24HPC1Component::set_existence_threshold(uint8_t value) {
 }
 
 void MR24HPC1Component::set_motion_threshold(uint8_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t send_data_len = 10;
   uint8_t send_data[10] = {0x53, 0x59, 0x08, 0x09, 0x00, 0x01, value, 0x00, 0x54, 0x43};
   send_data[7] = get_frame_crc_sum(send_data, send_data_len);
@@ -849,8 +982,10 @@ void MR24HPC1Component::set_motion_threshold(uint8_t value) {
 }
 
 void MR24HPC1Component::set_motion_trigger_time(uint8_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t send_data_len = 13;
   uint8_t send_data[13] = {0x53, 0x59, 0x08, 0x0C, 0x00, 0x04, 0x00, 0x00, 0x00, value, 0x00, 0x54, 0x43};
   send_data[10] = get_frame_crc_sum(send_data, send_data_len);
@@ -859,8 +994,10 @@ void MR24HPC1Component::set_motion_trigger_time(uint8_t value) {
 }
 
 void MR24HPC1Component::set_motion_to_rest_time(uint16_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint8_t h8_num = (value >> 8) & 0xff;
   uint8_t l8_num = value & 0xff;
   uint8_t send_data_len = 13;
@@ -871,8 +1008,10 @@ void MR24HPC1Component::set_motion_to_rest_time(uint16_t value) {
 }
 
 void MR24HPC1Component::set_custom_unman_time(uint16_t value) {
+#ifdef USE_SENSOR
   if ((this->custom_mode_num_sensor_ != nullptr) && (this->custom_mode_num_sensor_->state == 0))
     return;  // You'll have to check that you're in custom mode to set it up
+#endif
   uint32_t value_ms = value * 1000;
   uint8_t h24_num = (value_ms >> 24) & 0xff;
   uint8_t h16_num = (value_ms >> 16) & 0xff;

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -562,62 +562,15 @@ void MR24HPC1Component::r24_parse_data_frame_(uint8_t *data, uint8_t len) {
 }
 
 void MR24HPC1Component::r24_frame_parse_work_status_(uint8_t *data) {
-  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
-  if (cmd == 0x01) {
-    ESP_LOGD(TAG, "Reply: get radar init status 0x%02X", data[FRAME_DATA_INDEX]);
-  } else if (cmd == 0x07) {
-#ifdef USE_SELECT
-    if ((this->scene_mode_select_ != nullptr) && (this->scene_mode_select_->has_index(data[FRAME_DATA_INDEX]))) {
-      this->scene_mode_select_->publish_state(data[FRAME_DATA_INDEX]);
-    } else {
-      ESP_LOGD(TAG, "Select has index offset %d Error", data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if ((cmd == 0x08) || (cmd == 0x88)) {
-#ifdef USE_NUMBER
-    // 1-3
-    if (this->sensitivity_number_ != nullptr) {
-      this->sensitivity_number_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if (cmd == 0x09) {
-    // 1-4
+  switch (data[FRAME_COMMAND_WORD_INDEX]) {
+    case 0x01:
+    case 0x81:
+      ESP_LOGD(TAG, "Reply: get radar init status 0x%02X", data[FRAME_DATA_INDEX]);
+      break;
+    case 0x09:
 #ifdef USE_SENSOR
-    if (this->custom_mode_num_sensor_ != nullptr) {
-      this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-#ifdef USE_NUMBER
-    if (this->custom_mode_number_ != nullptr) {
-      this->custom_mode_number_->publish_state(0);
-    }
-#endif
-#ifdef USE_TEXT_SENSOR
-    if (this->custom_mode_end_text_sensor_ != nullptr) {
-      this->custom_mode_end_text_sensor_->publish_state("Setup in progress");
-    }
-#endif
-  } else if (cmd == 0x81) {
-    ESP_LOGD(TAG, "Reply: get radar init status 0x%02X", data[FRAME_DATA_INDEX]);
-  } else if (cmd == 0x87) {
-#ifdef USE_SELECT
-    if ((this->scene_mode_select_ != nullptr) && (this->scene_mode_select_->has_index(data[FRAME_DATA_INDEX]))) {
-      this->scene_mode_select_->publish_state(data[FRAME_DATA_INDEX]);
-    } else {
-      ESP_LOGD(TAG, "Select has index offset %d Error", data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if (cmd == 0x0A) {
-#ifdef USE_TEXT_SENSOR
-    if (this->custom_mode_end_text_sensor_ != nullptr) {
-      this->custom_mode_end_text_sensor_->publish_state("Set Success!");
-    }
-#endif
-  } else if (cmd == 0x89) {
-    if (data[FRAME_DATA_INDEX] == 0) {
-#ifdef USE_TEXT_SENSOR
-      if (this->custom_mode_end_text_sensor_ != nullptr) {
-        this->custom_mode_end_text_sensor_->publish_state("Not in custom mode");
+      if (this->custom_mode_num_sensor_ != nullptr) {
+        this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
 #endif
 #ifdef USE_NUMBER
@@ -625,65 +578,107 @@ void MR24HPC1Component::r24_frame_parse_work_status_(uint8_t *data) {
         this->custom_mode_number_->publish_state(0);
       }
 #endif
+#ifdef USE_TEXT_SENSOR
+      if (this->custom_mode_end_text_sensor_ != nullptr) {
+        this->custom_mode_end_text_sensor_->publish_state("Setup in progress");
+      }
+#endif
+      break;
+    case 0x89:
 #ifdef USE_SENSOR
       if (this->custom_mode_num_sensor_ != nullptr) {
         this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
 #endif
-    } else {
-#ifdef USE_SENSOR
-      if (this->custom_mode_num_sensor_ != nullptr) {
-        this->custom_mode_num_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-      }
+      if (data[FRAME_DATA_INDEX] == 0) {
+#ifdef USE_TEXT_SENSOR
+        if (this->custom_mode_end_text_sensor_ != nullptr) {
+          this->custom_mode_end_text_sensor_->publish_state("Not in custom mode");
+        }
 #endif
-    }
-  } else {
-    ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
+#ifdef USE_NUMBER
+        if (this->custom_mode_number_ != nullptr) {
+          this->custom_mode_number_->publish_state(0);
+        }
+#endif
+      }
+      break;
+#ifdef USE_SELECT
+    case 0x07:
+    case 0x87:
+      if ((this->scene_mode_select_ != nullptr) && (this->scene_mode_select_->has_index(data[FRAME_DATA_INDEX]))) {
+        this->scene_mode_select_->publish_state(data[FRAME_DATA_INDEX]);
+      } else {
+        ESP_LOGD(TAG, "Select has index offset %d Error", data[FRAME_DATA_INDEX]);
+      }
+      break;
+#endif
+#ifdef USE_NUMBER
+    case 0x08:
+    case 0x88:
+      if (this->sensitivity_number_ != nullptr) {
+        this->sensitivity_number_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      break;
+#endif
+#ifdef USE_TEXT_SENSOR
+    case 0x0A:
+      if (this->custom_mode_end_text_sensor_ != nullptr) {
+        this->custom_mode_end_text_sensor_->publish_state("Set Success!");
+      }
+      break;
+#endif
+    default:
+      ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
+      break;
   }
 }
 
 void MR24HPC1Component::r24_frame_parse_human_information_(uint8_t *data) {
-  uint8_t cmd = data[FRAME_COMMAND_WORD_INDEX];
-  if ((cmd == 0x01) || (cmd == 0x81)) {
+  switch (data[FRAME_COMMAND_WORD_INDEX]) {
 #ifdef USE_BINARY_SENSOR
-    if (this->has_target_binary_sensor_ != nullptr) {
-      this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
-    }
+    case 0x01:
+    case 0x81:
+      if (this->has_target_binary_sensor_ != nullptr) {
+        this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
+      }
+      break;
 #endif
-  } else if ((cmd == 0x02) || (cmd == 0x82)) {
+#ifdef USE_SENSOR
+    case 0x03:
+    case 0x83:
+      if (this->movement_signs_sensor_ != nullptr) {
+        this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      break;
+#endif
 #ifdef USE_TEXT_SENSOR
-    if (this->motion_status_text_sensor_ != nullptr) {
-      if (data[FRAME_DATA_INDEX] < 3) {
+    case 0x02:
+    case 0x82:
+      if ((this->motion_status_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
         this->motion_status_text_sensor_->publish_state(S_MOTION_STATUS_STR[data[FRAME_DATA_INDEX]]);
       }
-    }
-#endif
-  } else if ((cmd == 0x03) || (cmd == 0x83)) {
-#ifdef USE_SENSOR
-    if (this->movement_signs_sensor_ != nullptr) {
-      this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
-    }
-#endif
-  } else if ((cmd == 0x0A) || (cmd == 0x8A)) {
-#ifdef USE_SELECT
-    // none:0x00  1s:0x01 30s:0x02 1min:0x03 2min:0x04 5min:0x05 10min:0x06 30min:0x07 1hour:0x08
-    if (this->unman_time_select_ != nullptr) {
-      if (data[FRAME_DATA_INDEX] < 9) {
-        this->unman_time_select_->publish_state(data[FRAME_DATA_INDEX]);
-      }
-    }
-#endif
-  } else if ((cmd == 0x0B) || (cmd == 0x8B)) {
-#ifdef USE_TEXT_SENSOR
-    // none:0x00  close_to:0x01  far_away:0x02
-    if (this->keep_away_text_sensor_ != nullptr) {
-      if (data[FRAME_DATA_INDEX] < 3) {
+      break;
+    case 0x0B:
+    case 0x8B:
+      // none:0x00  close_to:0x01  far_away:0x02
+      if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
         this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
       }
-    }
+      break;
 #endif
-  } else {
-    ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
+#ifdef USE_SELECT
+    case 0x0A:
+    case 0x8A:
+      // none:0x00  1s:0x01 30s:0x02 1min:0x03 2min:0x04 5min:0x05 10min:0x06 30min:0x07 1hour:0x08
+      if ((this->unman_time_select_ != nullptr) && (data[FRAME_DATA_INDEX] < 9)) {
+        this->unman_time_select_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      break;
+#endif
+    default:
+      ESP_LOGD(TAG, "[%s] No found COMMAND_WORD(%02X) in Frame", __FUNCTION__, data[FRAME_COMMAND_WORD_INDEX]);
+      break;
   }
 }
 

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -410,8 +410,8 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
 #endif
       this->s_output_info_switch_flag_ = data[FRAME_DATA_INDEX] ? OUTPUT_SWITCH_ON : OUTPUT_SWTICH_OFF;
       break;
-    case 0x01:
 #ifdef USE_SENSOR
+    case 0x01:
       if (this->custom_spatial_static_value_sensor_ != nullptr) {
         this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
@@ -427,127 +427,105 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
       if (this->custom_motion_speed_sensor_ != nullptr) {
         this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX + 4] - 10) * 0.5f);
       }
-#endif
-      break;
-    case 0x06:
-    case 0x86:
-      // none:0x00  close_to:0x01  far_away:0x02
-#ifdef USE_TEXT_SENSOR
-      if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
-        this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
-      }
-#endif
       break;
     case 0x07:
     case 0x87:
-#ifdef USE_SENSOR
       if (this->movement_signs_sensor_ != nullptr) {
         this->movement_signs_sensor_->publish_state(data[FRAME_DATA_INDEX]);
       }
-#endif
       break;
+    case 0x81:
+      if (this->custom_spatial_static_value_sensor_ != nullptr) {
+        this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      break;
+    case 0x82:
+      if (this->custom_spatial_motion_value_sensor_ != nullptr) {
+        this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+      }
+      break;
+    case 0x83:
+      if (this->custom_presence_of_detection_sensor_ != nullptr) {
+        this->custom_presence_of_detection_sensor_->publish_state(
+            S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
+      }
+      break;
+    case 0x84:
+      if (this->custom_motion_distance_sensor_ != nullptr) {
+        this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
+      }
+      break;
+    case 0x85:
+      if (this->custom_motion_speed_sensor_ != nullptr) {
+        this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
+      }
+      break;
+#endif
+#ifdef USE_TEXT_SENSOR
+    case 0x06:
+    case 0x86:
+      // none:0x00  close_to:0x01  far_away:0x02
+      if ((this->keep_away_text_sensor_ != nullptr) && (data[FRAME_DATA_INDEX] < 3)) {
+        this->keep_away_text_sensor_->publish_state(S_KEEP_AWAY_STR[data[FRAME_DATA_INDEX]]);
+      }
+      break;
+#endif
+#ifdef USE_NUMBER
     case 0x08:
     case 0x88:
-#ifdef USE_NUMBER
       if (this->existence_threshold_number_ != nullptr) {
         this->existence_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
       }
-#endif
       break;
     case 0x09:
     case 0x89:
-#ifdef USE_NUMBER
       if (this->motion_threshold_number_ != nullptr) {
         this->motion_threshold_number_->publish_state(data[FRAME_DATA_INDEX]);
       }
-#endif
-      break;
-    case 0x0a:
-    case 0x8a:
-#ifdef USE_SELECT
-      if (this->existence_boundary_select_ != nullptr) {
-        if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-          this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
-        }
-      }
-#endif
-      break;
-    case 0x0b:
-    case 0x8b:
-#ifdef USE_SELECT
-      if (this->motion_boundary_select_ != nullptr) {
-        if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
-          this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
-        }
-      }
-#endif
       break;
     case 0x0c:
     case 0x8c:
-#ifdef USE_NUMBER
       if (this->motion_trigger_number_ != nullptr) {
         uint32_t motion_trigger_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
                                                      data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
         this->motion_trigger_number_->publish_state(motion_trigger_time);
       }
-#endif
       break;
     case 0x0d:
     case 0x8d:
-#ifdef USE_NUMBER
       if (this->motion_to_rest_number_ != nullptr) {
         uint32_t move_to_rest_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
                                                    data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
         this->motion_to_rest_number_->publish_state(move_to_rest_time);
       }
-#endif
       break;
     case 0x0e:
     case 0x8e:
-#ifdef USE_NUMBER
       if (this->custom_unman_time_number_ != nullptr) {
         uint32_t enter_unmanned_time = encode_uint32(data[FRAME_DATA_INDEX], data[FRAME_DATA_INDEX + 1],
                                                      data[FRAME_DATA_INDEX + 2], data[FRAME_DATA_INDEX + 3]);
         this->custom_unman_time_number_->publish_state(enter_unmanned_time / 1000.0f);
       }
-#endif
       break;
-    case 0x81:
-#ifdef USE_SENSOR
-      if (this->custom_spatial_static_value_sensor_ != nullptr) {
-        this->custom_spatial_static_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+#endif
+#ifdef USE_SELECT
+    case 0x0a:
+    case 0x8a:
+      if (this->existence_boundary_select_ != nullptr) {
+        if (this->existence_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+          this->existence_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+        }
       }
-#endif
       break;
-    case 0x82:
-#ifdef USE_SENSOR
-      if (this->custom_spatial_motion_value_sensor_ != nullptr) {
-        this->custom_spatial_motion_value_sensor_->publish_state(data[FRAME_DATA_INDEX]);
+    case 0x0b:
+    case 0x8b:
+      if (this->motion_boundary_select_ != nullptr) {
+        if (this->motion_boundary_select_->has_index(data[FRAME_DATA_INDEX] - 1)) {
+          this->motion_boundary_select_->publish_state(data[FRAME_DATA_INDEX] - 1);
+        }
       }
-#endif
       break;
-    case 0x83:
-#ifdef USE_SENSOR
-      if (this->custom_presence_of_detection_sensor_ != nullptr) {
-        this->custom_presence_of_detection_sensor_->publish_state(
-            S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
-      }
 #endif
-      break;
-    case 0x84:
-#ifdef USE_SENSOR
-      if (this->custom_motion_distance_sensor_ != nullptr) {
-        this->custom_motion_distance_sensor_->publish_state(data[FRAME_DATA_INDEX] * 0.5f);
-      }
-#endif
-      break;
-    case 0x85:
-#ifdef USE_SENSOR
-      if (this->custom_motion_speed_sensor_ != nullptr) {
-        this->custom_motion_speed_sensor_->publish_state((data[FRAME_DATA_INDEX] - 10) * 0.5f);
-      }
-#endif
-      break;
   }
 }
 

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -532,21 +532,16 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
 void MR24HPC1Component::r24_parse_data_frame_(uint8_t *data, uint8_t len) {
   switch (data[FRAME_CONTROL_WORD_INDEX]) {
     case 0x01: {
-      if (data[FRAME_COMMAND_WORD_INDEX] == 0x01) {
-#ifdef USE_TEXT_SENSOR
-        if (this->heartbeat_state_text_sensor_ != nullptr) {
-          this->heartbeat_state_text_sensor_->publish_state("Equipment Normal");
-        }
-#endif
-      } else if (data[FRAME_COMMAND_WORD_INDEX] == 0x02) {
+      if (data[FRAME_COMMAND_WORD_INDEX] == 0x02) {
         ESP_LOGD(TAG, "Reply: query restart packet");
-      } else {
-#ifdef USE_TEXT_SENSOR
-        if (this->heartbeat_state_text_sensor_ != nullptr) {
-          this->heartbeat_state_text_sensor_->publish_state("Equipment Abnormal");
-        }
-#endif
+        break;
       }
+#ifdef USE_TEXT_SENSOR
+      if (this->heartbeat_state_text_sensor_ != nullptr) {
+        this->heartbeat_state_text_sensor_->publish_state(
+            data[FRAME_COMMAND_WORD_INDEX] == 0x01 ? "Equipment Normal" : "Equipment Abnormal");
+      }
+#endif
     } break;
     case 0x02: {
       this->r24_frame_parse_product_information_(data);

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -359,8 +359,8 @@ void MR24HPC1Component::r24_split_data_frame_(uint8_t value) {
 
 // Parses data frames related to product information
 void MR24HPC1Component::r24_frame_parse_product_information_(uint8_t *data) {
-  uint16_t product_len = encode_uint16(data[FRAME_COMMAND_WORD_INDEX + 1], data[FRAME_COMMAND_WORD_INDEX + 2]);
 #ifdef USE_TEXT_SENSOR
+  uint16_t product_len = encode_uint16(data[FRAME_COMMAND_WORD_INDEX + 1], data[FRAME_COMMAND_WORD_INDEX + 2]);
   if (data[FRAME_COMMAND_WORD_INDEX] == COMMAND_PRODUCT_MODE) {
     if ((this->product_model_text_sensor_ != nullptr) && (product_len < PRODUCT_BUF_MAX_SIZE)) {
       memset(this->c_product_mode_, 0, PRODUCT_BUF_MAX_SIZE);
@@ -395,8 +395,6 @@ void MR24HPC1Component::r24_frame_parse_product_information_(uint8_t *data) {
       ESP_LOGD(TAG, "Reply: get firmwareVersion error!");
     }
   }
-#else
-  (void) product_len;
 #endif
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation failure when users don't include all entity types in their configuration.

The header file correctly guards member definitions with `#ifdef USE_*` macros (via `SUB_*` macros), but the `.cpp` file was accessing these members without corresponding guards, causing compilation errors.

Changes:
- Added `#ifdef` guards throughout `seeed_mr24hpc1.cpp` to match the conditional member definitions in the header
- Refactored several parse functions to use switch statements with cases grouped by entity type inside `#ifdef` blocks
- Combined duplicate `#ifdef` blocks where possible for cleaner code

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13137

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Minimal config that previously failed to compile
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

seeed_mr24hpc1:
  binary_sensor:
    - name: "Has Target"
      has_target:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).