### PR TITLE
[ssd1306_i2c] fix "SSD1306 72x40" display initialization (add SSD1306B Iref setup)

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -32,6 +32,8 @@ static const uint8_t SSD1306_COMMAND_PAGE_ADDRESS = 0x22;
 static const uint8_t SSD1306_COMMAND_NORMAL_DISPLAY = 0xA6;
 static const uint8_t SSD1306_COMMAND_INVERSE_DISPLAY = 0xA7;
 
+static const uint8_t SSD1306B_COMMAND_SELECT_IREF = 0xAD;
+
 static const uint8_t SSD1305_COMMAND_SET_BRIGHTNESS = 0x82;
 static const uint8_t SSD1305_COMMAND_SET_AREA_COLOR = 0xD8;
 
@@ -95,6 +97,12 @@ void SSD1306::setup() {
       this->command(0x8B);
     }
   } else {
+    if (this->is_ssd1306b_()) {
+      // Select external or internal Iref (0xAD)
+      this->command(SSD1306B_COMMAND_SELECT_IREF);
+      // Enable internal Iref and change from 19ua (POR) to 30uA
+      this->command(0x20 | 0x10);
+    }
     // Enable charge pump (0x8D)
     this->command(SSD1306_COMMAND_CHARGE_PUMP);
     if (this->external_vcc_) {
@@ -226,6 +234,8 @@ bool SSD1306::is_sh1107_() const { return this->model_ == SH1107_MODEL_128_64 ||
 bool SSD1306::is_ssd1305_() const {
   return this->model_ == SSD1305_MODEL_128_64 || this->model_ == SSD1305_MODEL_128_32;
 }
+bool SSD1306::is_ssd1306b_() const { return this->model_ == SSD1306_MODEL_72_40; }
+
 void SSD1306::update() {
   this->do_update_();
   this->display();

--- a/esphome/components/ssd1306_base/ssd1306_base.h
+++ b/esphome/components/ssd1306_base/ssd1306_base.h
@@ -63,6 +63,7 @@ class SSD1306 : public display::DisplayBuffer {
   bool is_sh1106_() const;
   bool is_sh1107_() const;
   bool is_ssd1305_() const;
+  bool is_ssd1306b_() const;
 
   void draw_absolute_pixel_internal(int x, int y, Color color) override;
 

--- a/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
+++ b/esphome/components/ssd1306_i2c/ssd1306_i2c.cpp
@@ -62,9 +62,9 @@ void HOT I2CSSD1306::write_display_data() {
     }
   } else {
     size_t block_size = 16;
-    if ((this->get_buffer_length_() & 8) == 8) {
-      // use smaller block size for e.g. 72x40 displays where buffer size is multiple of 8, not 16
-      block_size = 8;
+    if ((this->get_buffer_length_() % 24) == 0) {
+      // use 24 byte block size for e.g. 72x40 displays where buffer size is multiple of 24, not 16
+      block_size = 24;
     }
 
     for (uint32_t i = 0; i < this->get_buffer_length_();) {


### PR DESCRIPTION
# What does this implement/fix?

[SSD1306 72x40](https://www.buydisplay.com/white-0-42-inch-oled-display-panel-72x40-iic-i2c-serial-spi-ssd1306) display uses SSD1306B IC and needs Iref change to show high contrast (bright) pixels. Refer to section 7.8 of datasheet.

This patch also increases data transfer from 8 byte to 24 byte chunks for display update. Default 16 byte transfer didn't work because total amount of bytes is 72×40/8 = 360 which is not divisible by 16. With this change, it takes 8 bytes more RAM (than default 16) but it needs only 15 transfers instead of 45.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #13144

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  frequency: 400kHz #Defaults to 50kHz
  sda: GPIO5
  scl: GPIO6

display:
  - platform: ssd1306_i2c
    model: "SSD1306 72x40"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
