### PR TITLE
[ch422g][lc709203f][qmc5883l] Avoid heap allocation in status_set_warning calls

### DIFF
--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -93,7 +93,9 @@ bool CH422GComponent::read_inputs_() {
 bool CH422GComponent::write_reg_(uint8_t reg, uint8_t value) {
   auto err = this->bus_->write_readv(reg, &value, 1, nullptr, 0);
   if (err != i2c::ERROR_OK) {
-    this->status_set_warning(str_sprintf("write failed for register 0x%X, error %d", reg, err).c_str());
+    char buf[64];
+    snprintf(buf, sizeof(buf), "write failed for register 0x%X, error %d", reg, err);
+    this->status_set_warning(buf);
     return false;
   }
   this->status_clear_warning();
@@ -104,7 +106,9 @@ uint8_t CH422GComponent::read_reg_(uint8_t reg) {
   uint8_t value;
   auto err = this->bus_->write_readv(reg, nullptr, 0, &value, 1);
   if (err != i2c::ERROR_OK) {
-    this->status_set_warning(str_sprintf("read failed for register 0x%X, error %d", reg, err).c_str());
+    char buf[64];
+    snprintf(buf, sizeof(buf), "read failed for register 0x%X, error %d", reg, err);
+    this->status_set_warning(buf);
     return 0;
   }
   this->status_clear_warning();

--- a/esphome/components/lc709203f/lc709203f.cpp
+++ b/esphome/components/lc709203f/lc709203f.cpp
@@ -183,11 +183,14 @@ uint8_t Lc709203f::get_register_(uint8_t register_to_read, uint16_t *register_va
     return_code = this->read_register(register_to_read, &read_buffer[3], 3);
     if (return_code != i2c::NO_ERROR) {
       // Error on the i2c bus
-      this->status_set_warning(
-          str_sprintf("Error code %d when reading from register 0x%02X", return_code, register_to_read).c_str());
+      char buf[64];
+      snprintf(buf, sizeof(buf), "Error code %d when reading from register 0x%02X", return_code, register_to_read);
+      this->status_set_warning(buf);
     } else if (crc8(read_buffer, 5, 0x00, 0x07, true) != read_buffer[5]) {
       // I2C indicated OK, but the CRC of the data does not matcth.
-      this->status_set_warning(str_sprintf("CRC error reading from register 0x%02X", register_to_read).c_str());
+      char buf[64];
+      snprintf(buf, sizeof(buf), "CRC error reading from register 0x%02X", register_to_read);
+      this->status_set_warning(buf);
     } else {
       *register_value = ((uint16_t) read_buffer[4] << 8) | (uint16_t) read_buffer[3];
       return i2c::NO_ERROR;
@@ -225,8 +228,9 @@ uint8_t Lc709203f::set_register_(uint8_t register_to_set, uint16_t value_to_set)
     if (return_code == i2c::NO_ERROR) {
       return return_code;
     } else {
-      this->status_set_warning(
-          str_sprintf("Error code %d when writing to register 0x%02X", return_code, register_to_set).c_str());
+      char buf[64];
+      snprintf(buf, sizeof(buf), "Error code %d when writing to register 0x%02X", return_code, register_to_set);
+      this->status_set_warning(buf);
     }
   }
 

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -105,7 +105,9 @@ void QMC5883LComponent::update() {
   if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG) {
     err = this->read_register(QMC5883L_REGISTER_STATUS, &status, 1);
     if (err != i2c::ERROR_OK) {
-      this->status_set_warning(str_sprintf("status read failed (%d)", err).c_str());
+      char buf[32];
+      snprintf(buf, sizeof(buf), "status read failed (%d)", err);
+      this->status_set_warning(buf);
       return;
     }
   }
@@ -127,7 +129,9 @@ void QMC5883LComponent::update() {
   }
   err = this->read_bytes_16_le_(start, &raw[dest], 3 - dest);
   if (err != i2c::ERROR_OK) {
-    this->status_set_warning(str_sprintf("mag read failed (%d)", err).c_str());
+    char buf[32];
+    snprintf(buf, sizeof(buf), "mag read failed (%d)", err);
+    this->status_set_warning(buf);
     return;
   }
 
@@ -155,7 +159,9 @@ void QMC5883LComponent::update() {
     uint16_t raw_temp;
     err = this->read_bytes_16_le_(QMC5883L_REGISTER_TEMPERATURE_LSB, &raw_temp);
     if (err != i2c::ERROR_OK) {
-      this->status_set_warning(str_sprintf("temp read failed (%d)", err).c_str());
+      char buf[32];
+      snprintf(buf, sizeof(buf), "temp read failed (%d)", err);
+      this->status_set_warning(buf);
       return;
     }
     temp = int16_t(raw_temp) * 0.01f;


### PR DESCRIPTION
# What does this implement/fix?

Replace `str_sprintf(...).c_str()` with stack-allocated `snprintf` buffers when calling `status_set_warning()`.

The previous pattern heap-allocated a `std::string` only to immediately convert it back to `const char*` via `.c_str()`. Since `status_set_warning()` takes a `const char*` and uses it synchronously, we can skip the heap allocation entirely and format directly into a stack buffer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
