### PR TITLE
[web_server] Fix v1 compilation on ESP-IDF by adding missing write method

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -80,6 +80,7 @@ class AsyncResponseStream : public AsyncWebServerResponse {
   void print(const std::string &str) { this->content_.append(str); }
   void print(float value);
   void printf(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void write(uint8_t c) { this->content_.push_back(static_cast<char>(c)); }
 
  protected:
   std::string content_;

--- a/tests/components/web_server/test_v1.esp32-idf.yaml
+++ b/tests/components/web_server/test_v1.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common_v1.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation failure for `web_server` version 1 on ESP32 with ESP-IDF framework.

The `AsyncResponseStream` class in `web_server_idf.h` was missing a `write()` method that is called by the `write_html_escaped()` function in `web_server_v1.cpp`. This was introduced in #12627 when HTML escaping was added.

The error was:
```
error: 'class esphome::web_server_idf::AsyncResponseStream' has no member named 'write'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13123

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  version: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
