### PR TITLE
[api] Use StringRef for HomeassistantServiceMap.value to eliminate heap allocations

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -763,7 +763,7 @@ message SubscribeHomeassistantServicesRequest {
 
 message HomeassistantServiceMap {
   string key = 1;
-  string value = 2 [(no_zero_copy) = true];
+  string value = 2;
 }
 
 message HomeassistantActionRequest {
@@ -779,7 +779,7 @@ message HomeassistantActionRequest {
   bool is_event = 5;
   uint32 call_id = 6 [(field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES"];
   bool wants_response = 7 [(field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON"];
-  string response_template = 8 [(no_zero_copy) = true, (field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON"];
+  string response_template = 8 [(field_ifdef) = "USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON"];
 }
 
 // Message sent by Home Assistant to ESPHome with service call response data

--- a/esphome/components/api/api_options.proto
+++ b/esphome/components/api/api_options.proto
@@ -27,7 +27,6 @@ extend google.protobuf.MessageOptions {
 extend google.protobuf.FieldOptions {
     optional string field_ifdef = 1042;
     optional uint32 fixed_array_size = 50007;
-    optional bool no_zero_copy = 50008 [default=false];
     optional bool fixed_array_skip_zero = 50009 [default=false];
     optional string fixed_array_size_define = 50010;
     optional string fixed_array_with_length_define = 50011;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1053,7 +1053,7 @@ class SubscribeHomeassistantServicesRequest final : public ProtoMessage {
 class HomeassistantServiceMap final : public ProtoMessage {
  public:
   StringRef key{};
-  std::string value{};
+  StringRef value{};
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -1081,7 +1081,7 @@ class HomeassistantActionRequest final : public ProtoMessage {
   bool wants_response{false};
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-  std::string response_template{};
+  StringRef response_template{};
 #endif
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;

--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -265,7 +265,7 @@ class CustomAPIDevice {
     for (auto &it : data) {
       auto &kv = resp.data.emplace_back();
       kv.key = StringRef(it.first);
-      kv.value = it.second;  // value is std::string (no_zero_copy), assign directly
+      kv.value = StringRef(it.second);  // data map lives until send completes
     }
     global_api_server->send_homeassistant_action(resp);
   }
@@ -308,7 +308,7 @@ class CustomAPIDevice {
     for (auto &it : data) {
       auto &kv = resp.data.emplace_back();
       kv.key = StringRef(it.first);
-      kv.value = it.second;  // value is std::string (no_zero_copy), assign directly
+      kv.value = StringRef(it.second);  // data map lives until send completes
     }
     global_api_server->send_homeassistant_action(resp);
   }

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -149,11 +149,21 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
     std::string service_value = this->service_.value(x...);
     resp.service = StringRef(service_value);
     resp.is_event = this->flags_.is_event;
-    this->populate_service_map(resp.data, this->data_, x...);
-    this->populate_service_map(resp.data_template, this->data_template_, x...);
-    this->populate_service_map(resp.variables, this->variables_, x...);
+
+    // Local storage for lambda-evaluated strings - lives until after send
+    FixedVector<std::string> data_storage;
+    FixedVector<std::string> data_template_storage;
+    FixedVector<std::string> variables_storage;
+
+    this->populate_service_map(resp.data, this->data_, data_storage, x...);
+    this->populate_service_map(resp.data_template, this->data_template_, data_template_storage, x...);
+    this->populate_service_map(resp.variables, this->variables_, variables_storage, x...);
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
+#ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
+    // IMPORTANT: Declare at outer scope so it lives until send_homeassistant_action returns.
+    std::string response_template_value;
+#endif
     if (this->flags_.wants_status) {
       // Generate a unique call ID for this service call
       static uint32_t call_id_counter = 1;
@@ -164,8 +174,7 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
         resp.wants_response = true;
         // Set response template if provided
         if (this->flags_.has_response_template) {
-          std::string response_template_value = this->response_template_.value(x...);
-          resp.response_template = response_template_value;
+          resp.response_template = StringRef(response_template_value = this->response_template_.value(x...));
         }
       }
 #endif
@@ -205,12 +214,23 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   }
 
   template<typename VectorType, typename SourceType>
-  static void populate_service_map(VectorType &dest, SourceType &source, Ts... x) {
+  static void populate_service_map(VectorType &dest, SourceType &source, FixedVector<std::string> &value_storage,
+                                   Ts... x) {
     dest.init(source.size());
+    value_storage.init(source.size());  // Max possible, single allocation
+
     for (auto &it : source) {
       auto &kv = dest.emplace_back();
       kv.key = StringRef(it.key);
-      kv.value = it.value.value(x...);
+
+      if (it.value.is_static_string()) {
+        // Static string from YAML - zero allocation
+        kv.value = StringRef(it.value.get_static_string());
+      } else {
+        // Lambda evaluation - store result, reference it
+        value_storage.push_back(it.value.value(x...));
+        kv.value = StringRef(value_storage.back());
+      }
     }
   }
 

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -217,7 +217,15 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   static void populate_service_map(VectorType &dest, SourceType &source, FixedVector<std::string> &value_storage,
                                    Ts... x) {
     dest.init(source.size());
-    value_storage.init(source.size());  // Max possible, single allocation
+
+    // Count non-static strings to allocate exact storage needed
+    size_t lambda_count = 0;
+    for (const auto &it : source) {
+      if (!it.value.is_static_string()) {
+        lambda_count++;
+      }
+    }
+    value_storage.init(lambda_count);
 
     for (auto &it : source) {
       auto &kv = dest.emplace_back();

--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -174,7 +174,8 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
         resp.wants_response = true;
         // Set response template if provided
         if (this->flags_.has_response_template) {
-          resp.response_template = StringRef(response_template_value = this->response_template_.value(x...));
+          response_template_value = this->response_template_.value(x...);
+          resp.response_template = StringRef(response_template_value);
         }
       }
 #endif

--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -91,11 +91,14 @@ void HomeassistantNumber::control(float value) {
   resp.data.init(2);
   auto &entity_id = resp.data.emplace_back();
   entity_id.key = ENTITY_ID_KEY;
-  entity_id.value = this->entity_id_;
+  entity_id.value = StringRef(this->entity_id_);
 
   auto &entity_value = resp.data.emplace_back();
   entity_value.key = VALUE_KEY;
-  entity_value.value = to_string(value);
+  // Stack buffer - no heap allocation; %g produces shortest representation
+  char value_buf[16];
+  snprintf(value_buf, sizeof(value_buf), "%g", value);
+  entity_value.value = StringRef(value_buf);
 
   api::global_api_server->send_homeassistant_action(resp);
 }

--- a/esphome/components/homeassistant/switch/homeassistant_switch.cpp
+++ b/esphome/components/homeassistant/switch/homeassistant_switch.cpp
@@ -55,7 +55,7 @@ void HomeassistantSwitch::write_state(bool state) {
   resp.data.init(1);
   auto &entity_id_kv = resp.data.emplace_back();
   entity_id_kv.key = ENTITY_ID_KEY;
-  entity_id_kv.value = this->entity_id_;
+  entity_id_kv.value = StringRef(this->entity_id_);
 
   api::global_api_server->send_homeassistant_action(resp);
 }

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -159,6 +159,12 @@ template<typename T, typename... X> class TemplatableValue {
     return this->value(x...);
   }
 
+  /// Check if this holds a static string (const char* stored without allocation)
+  bool is_static_string() const { return this->type_ == STATIC_STRING; }
+
+  /// Get the static string pointer (only valid if is_static_string() returns true)
+  const char *get_static_string() const { return this->static_str_; }
+
  protected:
   enum : uint8_t {
     NONE,


### PR DESCRIPTION
# What does this implement/fix?

Completes the zero-copy API conversion by removing the last two `no_zero_copy` usages from `HomeassistantServiceMap.value` and `HomeassistantActionRequest.response_template`. With these final conversions done, the `no_zero_copy` protobuf option is no longer used anywhere and has been removed from both `api_options.proto` and `api_protobuf.py`.

These fields were the last edge cases using `std::string` instead of `StringRef`. Since `HomeassistantActionRequest` is `SOURCE_SERVER` (ESPHome only sends, never receives), the data only needs to live until the synchronous send completes, making `StringRef` safe to use.

**This PR:**
- Converts `HomeassistantServiceMap.value` from `std::string` to `StringRef`
- Converts `HomeassistantActionRequest.response_template` from `std::string` to `StringRef`
- Removes the `no_zero_copy` protobuf option entirely (no longer needed)
- Adds `is_static_string()` and `get_static_string()` to `TemplatableValue` to detect and use static YAML strings directly without allocation
- Uses `FixedVector<std::string>` in `populate_service_map()` to store lambda-evaluated values (exact allocation, no reallocation)
- Updates `homeassistant_number.cpp` to use stack buffer for float formatting

**Benefits:**
| Scenario | Before | After |
|----------|--------|-------|
| Static YAML value `"on"` | 1 heap alloc | 0 allocs |
| Lambda returning string | 1 heap alloc | 1 heap alloc (same) |
| Float formatting (number) | 1 heap alloc | 0 allocs (stack buffer) |
| `entity_id` (const char*) | 1 heap alloc | 0 allocs |

**Cleanup:**
- Removes `no_zero_copy` field option from `api_options.proto`
- Removes all `no_zero_copy` handling code from `api_protobuf.py`

The API is now fully zero-copy for all string fields.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - performance optimization completing zero-copy API conversion

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Existing homeassistant service calls continue to work:

api:

esphome:
  on_boot:
    then:
      - homeassistant.action:
          action: notify.html5
          data:
            message: Button was pressed
      - homeassistant.action:
          action: notify.html5
          data:
            title: New Humidity
          data_template:
            message: The humidity is {{ my_variable }}%.
          variables:
            my_variable: "return id(some_sensor).state;"

switch:
  - platform: homeassistant
    entity_id: switch.my_switch
    id: my_switch

number:
  - platform: homeassistant
    entity_id: number.my_number
    id: my_number
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- integrations tests full cover this.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
