### PR TITLE
[runtime_stats] Fix log output formatting alignment

### DIFF
--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -29,7 +29,7 @@ void RuntimeStatsCollector::record_component_time(Component *component, uint32_t
 void RuntimeStatsCollector::log_stats_() {
   ESP_LOGI(TAG,
            "Component Runtime Statistics\n"
-           "Period stats (last %" PRIu32 "ms):",
+           " Period stats (last %" PRIu32 "ms):",
            this->log_interval_);
 
   // First collect stats we want to display
@@ -55,7 +55,7 @@ void RuntimeStatsCollector::log_stats_() {
   }
 
   // Log total stats since boot
-  ESP_LOGI(TAG, "Total stats (since boot):");
+  ESP_LOGI(TAG, " Total stats (since boot):");
 
   // Re-sort by total runtime for all-time stats
   std::sort(stats_to_display.begin(), stats_to_display.end(),


### PR DESCRIPTION
# What does this implement/fix?

Fixes log output formatting for the `runtime_stats` component by adding consistent 1-space indentation to the "Period stats" and "Total stats" section headers.

Before:
```
[16:23:37.352][I][runtime_stats:030]: Component Runtime Statistics
[16:23:37.355]Period stats (last 60000ms):
[16:23:37.363][I][runtime_stats:052]:   debug: count=6620, ...
...
[16:23:37.408][I][runtime_stats:058]: Total stats (since boot):
```

After:
```
[16:31:06.674][I][runtime_stats:030]: Component Runtime Statistics
[16:31:06.677][I][runtime_stats:030]:  Period stats (last 60000ms):
[16:31:06.685][I][runtime_stats:052]:   wifi: count=6136, ...
...
[16:31:06.738][I][runtime_stats:058]:  Total stats (since boot):
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
