### PR TITLE
[core] Migrate callers and soft deprecate get_mac_address()/get_mac_address_pretty()

### DIFF
--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -322,6 +322,8 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
     return "Unspecified";
   };
 
+  char mac_pretty[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  get_mac_address_pretty_into_buffer(mac_pretty);
   ESP_LOGD(TAG,
            "Code page size: %u, code size: %u, device id: 0x%08x%08x\n"
            "Encryption root: 0x%08x%08x%08x%08x, Identity Root: 0x%08x%08x%08x%08x\n"
@@ -330,10 +332,10 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
            "RAM: %ukB, Flash: %ukB, production test: %sdone",
            NRF_FICR->CODEPAGESIZE, NRF_FICR->CODESIZE, NRF_FICR->DEVICEID[1], NRF_FICR->DEVICEID[0], NRF_FICR->ER[0],
            NRF_FICR->ER[1], NRF_FICR->ER[2], NRF_FICR->ER[3], NRF_FICR->IR[0], NRF_FICR->IR[1], NRF_FICR->IR[2],
-           NRF_FICR->IR[3], (NRF_FICR->DEVICEADDRTYPE & 0x1 ? "Random" : "Public"), get_mac_address_pretty().c_str(),
-           NRF_FICR->INFO.PART, NRF_FICR->INFO.VARIANT >> 24 & 0xFF, NRF_FICR->INFO.VARIANT >> 16 & 0xFF,
-           NRF_FICR->INFO.VARIANT >> 8 & 0xFF, NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE),
-           NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH, (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
+           NRF_FICR->IR[3], (NRF_FICR->DEVICEADDRTYPE & 0x1 ? "Random" : "Public"), mac_pretty, NRF_FICR->INFO.PART,
+           NRF_FICR->INFO.VARIANT >> 24 & 0xFF, NRF_FICR->INFO.VARIANT >> 16 & 0xFF, NRF_FICR->INFO.VARIANT >> 8 & 0xFF,
+           NRF_FICR->INFO.VARIANT & 0xFF, package(NRF_FICR->INFO.PACKAGE), NRF_FICR->INFO.RAM, NRF_FICR->INFO.FLASH,
+           (NRF_FICR->PRODTEST[0] == 0xBB42319F ? "" : "not "));
   bool n_reset_enabled = NRF_UICR->PSELRESET[0] == NRF_UICR->PSELRESET[1] &&
                          (NRF_UICR->PSELRESET[0] & UICR_PSELRESET_CONNECT_Msk) == UICR_PSELRESET_CONNECT_Connected
                                                                                       << UICR_PSELRESET_CONNECT_Pos;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -28,8 +28,9 @@ static const char *const TAG = "mqtt";
 
 MQTTClientComponent::MQTTClientComponent() {
   global_mqtt_client = this;
-  const std::string mac_addr = get_mac_address();
-  this->credentials_.client_id = make_name_with_suffix(App.get_name(), '-', mac_addr.c_str(), mac_addr.size());
+  char mac_addr[MAC_ADDRESS_BUFFER_SIZE];
+  get_mac_address_into_buffer(mac_addr);
+  this->credentials_.client_id = make_name_with_suffix(App.get_name(), '-', mac_addr, MAC_ADDRESS_BUFFER_SIZE - 1);
 }
 
 // Connection
@@ -102,7 +103,9 @@ void MQTTClientComponent::send_device_info_() {
         root[ESPHOME_F("port")] = api::global_api_server->get_port();
 #endif
         root[ESPHOME_F("version")] = ESPHOME_VERSION;
-        root[ESPHOME_F("mac")] = get_mac_address();
+        char mac_buf[MAC_ADDRESS_BUFFER_SIZE];
+        get_mac_address_into_buffer(mac_buf);
+        root[ESPHOME_F("mac")] = mac_buf;
 
 #ifdef USE_ESP8266
         root[ESPHOME_F("platform")] = ESPHOME_F("ESP8266");

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1303,14 +1303,13 @@ class HighFrequencyLoopRequester {
 void get_mac_address_raw(uint8_t *mac);  // NOLINT(readability-non-const-parameter)
 
 /// Get the device MAC address as a string, in lowercase hex notation.
-/// @deprecated Allocates heap memory. Use get_mac_address_into_buffer() instead. Removed in 2026.7.0.
-ESPDEPRECATED("Allocates heap memory. Use get_mac_address_into_buffer() instead. Removed in 2026.7.0.", "2026.1.0")
+/// @warning Allocates heap memory. Avoid in new code - causes heap fragmentation on long-running devices.
+/// Use get_mac_address_into_buffer() instead.
 std::string get_mac_address();
 
 /// Get the device MAC address as a string, in colon-separated uppercase hex notation.
-/// @deprecated Allocates heap memory. Use get_mac_address_pretty_into_buffer() instead. Removed in 2026.7.0.
-ESPDEPRECATED("Allocates heap memory. Use get_mac_address_pretty_into_buffer() instead. Removed in 2026.7.0.",
-              "2026.1.0")
+/// @warning Allocates heap memory. Avoid in new code - causes heap fragmentation on long-running devices.
+/// Use get_mac_address_pretty_into_buffer() instead.
 std::string get_mac_address_pretty();
 
 /// Get the device MAC address into the given buffer, in lowercase hex notation.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1303,9 +1303,14 @@ class HighFrequencyLoopRequester {
 void get_mac_address_raw(uint8_t *mac);  // NOLINT(readability-non-const-parameter)
 
 /// Get the device MAC address as a string, in lowercase hex notation.
+/// @deprecated Allocates heap memory. Use get_mac_address_into_buffer() instead. Removed in 2026.7.0.
+ESPDEPRECATED("Allocates heap memory. Use get_mac_address_into_buffer() instead. Removed in 2026.7.0.", "2026.1.0")
 std::string get_mac_address();
 
 /// Get the device MAC address as a string, in colon-separated uppercase hex notation.
+/// @deprecated Allocates heap memory. Use get_mac_address_pretty_into_buffer() instead. Removed in 2026.7.0.
+ESPDEPRECATED("Allocates heap memory. Use get_mac_address_pretty_into_buffer() instead. Removed in 2026.7.0.",
+              "2026.1.0")
 std::string get_mac_address_pretty();
 
 /// Get the device MAC address into the given buffer, in lowercase hex notation.


### PR DESCRIPTION
# What does this implement/fix?

Migrate all internal callers of `get_mac_address()` and `get_mac_address_pretty()` to use stack-based alternatives, then soft-deprecate the heap-allocating versions.

ESP devices run for months with small heaps shared between Wi-Fi, BLE, LWIP, and application code. Over time, repeated allocations of different sizes fragment the heap. Failures happen when the largest contiguous block shrinks, even if total free heap is still large. We have seen field crashes caused by this.

**Why soft deprecation instead of hard deprecation:**

These functions are widely used in user lambdas and documented in device examples. Lambdas returning `std::string` create identical heap fragmentation problems - there's no distinction from the allocator's perspective. Keeping allocating helpers available "for lambdas" doesn't contain the risk; it keeps the most copyable pattern alive in the most-used context. A future clang-tidy rule will prevent new internal usage from creeping back into the codebase.

**Migrated:**

| Location | Change |
|----------|--------|
| `mqtt/mqtt_client.cpp` (constructor) | Stack buffer for client_id generation |
| `mqtt/mqtt_client.cpp` (JSON) | Stack buffer for "mac" field |
| `mqtt/mqtt_component.cpp` (unique_id) | Stack buffer with `snprintf` using `ESPHOME_DOMAIN_MAX_LEN` |
| `mqtt/mqtt_component.cpp` (device_info) | Stack buffer for device identifiers |
| `debug/debug_zephyr.cpp` | Stack buffer before ESP_LOGD call |

**Soft-deprecated:**

| Function | Replacement |
|----------|-------------|
| `get_mac_address()` | `get_mac_address_into_buffer()` |
| `get_mac_address_pretty()` | `get_mac_address_pretty_into_buffer()` |

Functions include `@warning` documentation explaining heap fragmentation concerns and pointing to stack-based alternatives.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13156

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (internal API soft deprecation)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal API soft deprecation
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Migration guide for external component authors

If you are using the soft-deprecated functions, consider migrating to the stack-based alternatives to reduce heap fragmentation:

**Before:**
```cpp
std::string mac = get_mac_address();
ESP_LOGD(TAG, "MAC: %s", mac.c_str());
```

**After:**
```cpp
char mac[MAC_ADDRESS_BUFFER_SIZE];
get_mac_address_into_buffer(mac);
ESP_LOGD(TAG, "MAC: %s", mac);
```

**Before:**
```cpp
std::string mac = get_mac_address_pretty();
```

**After:**
```cpp
char mac[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
get_mac_address_pretty_into_buffer(mac);
```
