### PR TITLE
[tuya][rc522][remote_base] Migrate format_hex_pretty() to stack-based alternatives

### DIFF
--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -492,7 +492,10 @@ bool RC522BinarySensor::process(std::vector<uint8_t> &data) {
   this->found_ = result;
   return result;
 }
-void RC522Trigger::process(std::vector<uint8_t> &data) { this->trigger(format_hex_pretty(data, '-', false)); }
+void RC522Trigger::process(std::vector<uint8_t> &data) {
+  char uid_buf[format_hex_pretty_size(RC522_MAX_UID_SIZE)];
+  this->trigger(format_hex_pretty_to(uid_buf, data.data(), data.size(), '-'));
+}
 
 }  // namespace rc522
 }  // namespace esphome

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -29,6 +29,8 @@ class MideaData {
   bool is_valid() const { return this->data_[OFFSET_CS] == this->calc_cs_(); }
   void finalize() { this->data_[OFFSET_CS] = this->calc_cs_(); }
   bool is_compliment(const MideaData &rhs) const;
+  /// @deprecated Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.
+  ESPDEPRECATED("Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.", "2026.1.0")
   std::string to_string() const { return format_hex_pretty(this->data_.data(), this->data_.size()); }
   /// Buffer size for to_str(): 6 bytes = "AA.BB.CC.DD.EE.FF\0"
   static constexpr size_t TO_STR_BUFFER_SIZE = format_hex_pretty_size(6);

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -1,4 +1,5 @@
 #include "tuya_text_sensor.h"
+#include "esphome/core/entity_base.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -14,9 +15,10 @@ void TuyaTextSensor::setup() {
         this->publish_state(datapoint.value_string);
         break;
       case TuyaDatapointType::RAW: {
-        // Text sensor state is limited to 255 bytes, use 256 byte buffer
-        char hex_buf[256];
-        const char *formatted = format_hex_pretty_to(hex_buf, sizeof(hex_buf), datapoint.value_raw);
+        // Text sensor state is limited to MAX_STATE_LEN bytes
+        char hex_buf[MAX_STATE_LEN + 1];
+        const char *formatted =
+            format_hex_pretty_to(hex_buf, sizeof(hex_buf), datapoint.value_raw.data(), datapoint.value_raw.size());
         ESP_LOGD(TAG, "MCU reported text sensor %u is: %s", datapoint.id, formatted);
         this->publish_state(formatted);
         break;

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -15,7 +15,6 @@ void TuyaTextSensor::setup() {
         this->publish_state(datapoint.value_string);
         break;
       case TuyaDatapointType::RAW: {
-        // Text sensor state is limited to MAX_STATE_LEN bytes
         char hex_buf[MAX_STATE_LEN + 1];
         const char *formatted =
             format_hex_pretty_to(hex_buf, sizeof(hex_buf), datapoint.value_raw.data(), datapoint.value_raw.size());

--- a/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
+++ b/esphome/components/tuya/text_sensor/tuya_text_sensor.cpp
@@ -14,9 +14,11 @@ void TuyaTextSensor::setup() {
         this->publish_state(datapoint.value_string);
         break;
       case TuyaDatapointType::RAW: {
-        std::string data = format_hex_pretty(datapoint.value_raw);
-        ESP_LOGD(TAG, "MCU reported text sensor %u is: %s", datapoint.id, data.c_str());
-        this->publish_state(data);
+        // Text sensor state is limited to 255 bytes, use 256 byte buffer
+        char hex_buf[256];
+        const char *formatted = format_hex_pretty_to(hex_buf, sizeof(hex_buf), datapoint.value_raw);
+        ESP_LOGD(TAG, "MCU reported text sensor %u is: %s", datapoint.id, formatted);
+        this->publish_state(formatted);
         break;
       }
       case TuyaDatapointType::ENUM: {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -26,7 +26,7 @@ static constexpr size_t ESPHOME_DOMAIN_MAX_LEN = 20;
 // Maximum size for object_id buffer (friendly_name + null + margin)
 static constexpr size_t OBJECT_ID_MAX_LEN = 128;
 
-// Maximum state length for text sensors and similar entities
+// Maximum state length that Home Assistant will accept without raising ValueError
 static constexpr size_t MAX_STATE_LEN = 255;
 
 enum EntityCategory : uint8_t {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -26,6 +26,9 @@ static constexpr size_t ESPHOME_DOMAIN_MAX_LEN = 20;
 // Maximum size for object_id buffer (friendly_name + null + margin)
 static constexpr size_t OBJECT_ID_MAX_LEN = 128;
 
+// Maximum state length for text sensors and similar entities
+static constexpr size_t MAX_STATE_LEN = 255;
+
 enum EntityCategory : uint8_t {
   ENTITY_CATEGORY_NONE = 0,
   ENTITY_CATEGORY_CONFIG = 1,


### PR DESCRIPTION
# What does this implement/fix?

Migrate direct `format_hex_pretty()` usages to stack-based `format_hex_pretty_to()` to reduce heap allocations.

ESP devices run for months with small heaps shared between Wi-Fi, BLE, LWIP, and application code. Over time, repeated allocations of different sizes fragment the heap. Failures happen when the largest contiguous block shrinks, even if total free heap is still large. We have seen field crashes caused by this.

**Migrated:**

| Location | Change |
|----------|--------|
| `tuya/text_sensor/tuya_text_sensor.cpp` | Stack buffer (256 bytes matches text sensor limit) |
| `rc522/rc522.cpp` | Stack buffer for trigger automation |

**Deprecated:**

| Function | Replacement |
|----------|-------------|
| `MideaData::to_string()` | `MideaData::to_str()` (stack buffer) |

Note: `format_hex_pretty()` itself is not deprecated yet because NFC wrapper functions (`format_uid`, `format_bytes`) use it with many downstream callers. The API debug dump code (`api_pb2_dump.cpp`) also uses it but is generated and debug-only.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13156

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (internal API deprecation)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal API change
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Migration guide for external component authors

If you are using `MideaData::to_string()`, migrate to the stack-based alternative:

**Before:**
```cpp
MideaData data;
std::string str = data.to_string();
ESP_LOGD(TAG, "Data: %s", str.c_str());
```

**After:**
```cpp
MideaData data;
char buf[MideaData::TO_STR_BUFFER_SIZE];
ESP_LOGD(TAG, "Data: %s", data.to_str(buf));
```
