### PR TITLE
[api] Use stack buffer for bytes field dumping in proto message logs

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -100,6 +100,16 @@ template<typename T> static void dump_field(std::string &out, const char *field_
   out.append("\n");
 }
 
+// Helper for bytes fields - uses stack buffer to avoid heap allocation
+// Buffer sized for 160 bytes of data (480 chars with separators) to fit typical log buffer
+static void dump_bytes_field(std::string &out, const char *field_name, const uint8_t *data, size_t len,
+                             int indent = 2) {
+  char hex_buf[format_hex_pretty_size(160)];
+  append_field_prefix(out, field_name, indent);
+  format_hex_pretty_to(hex_buf, data, len);
+  append_with_newline(out, hex_buf);
+}
+
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
     case enums::ENTITY_CATEGORY_NONE:
@@ -1127,16 +1137,12 @@ void SubscribeLogsRequest::dump_to(std::string &out) const {
 void SubscribeLogsResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "SubscribeLogsResponse");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
-  out.append("  message: ");
-  out.append(format_hex_pretty(this->message_ptr_, this->message_len_));
-  out.append("\n");
+  dump_bytes_field(out, "message", this->message_ptr_, this->message_len_);
 }
 #ifdef USE_API_NOISE
 void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyRequest");
-  out.append("  key: ");
-  out.append(format_hex_pretty(this->key, this->key_len));
-  out.append("\n");
+  dump_bytes_field(out, "key", this->key, this->key_len);
 }
 void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyResponse");
@@ -1189,9 +1195,7 @@ void HomeassistantActionResponse::dump_to(std::string &out) const {
   dump_field(out, "success", this->success);
   dump_field(out, "error_message", this->error_message);
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-  out.append("  response_data: ");
-  out.append(format_hex_pretty(this->response_data, this->response_data_len));
-  out.append("\n");
+  dump_bytes_field(out, "response_data", this->response_data, this->response_data_len);
 #endif
 }
 #endif
@@ -1278,9 +1282,7 @@ void ExecuteServiceResponse::dump_to(std::string &out) const {
   dump_field(out, "success", this->success);
   dump_field(out, "error_message", this->error_message);
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
-  out.append("  response_data: ");
-  out.append(format_hex_pretty(this->response_data, this->response_data_len));
-  out.append("\n");
+  dump_bytes_field(out, "response_data", this->response_data, this->response_data_len);
 #endif
 }
 #endif
@@ -1302,9 +1304,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
 void CameraImageResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "CameraImageResponse");
   dump_field(out, "key", this->key);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
   dump_field(out, "done", this->done);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -1705,9 +1705,7 @@ void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
   dump_field(out, "address", this->address);
   dump_field(out, "rssi", this->rssi);
   dump_field(out, "address_type", this->address_type);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
 }
 void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothLERawAdvertisementsResponse");
@@ -1792,18 +1790,14 @@ void BluetoothGATTReadResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
 }
 void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "response", this->response);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
 }
 void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadDescriptorRequest");
@@ -1814,9 +1808,7 @@ void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
 }
 void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyRequest");
@@ -1828,9 +1820,7 @@ void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyDataResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data_ptr_, this->data_len_));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
 }
 void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
@@ -1934,9 +1924,7 @@ void VoiceAssistantEventResponse::dump_to(std::string &out) const {
 }
 void VoiceAssistantAudio::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAudio");
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
   dump_field(out, "end", this->end);
 }
 void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
@@ -2297,16 +2285,12 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
 #ifdef USE_ZWAVE_PROXY
 void ZWaveProxyFrame::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyFrame");
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
 }
 void ZWaveProxyRequest::dump_to(std::string &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyRequest");
   dump_field(out, "type", static_cast<enums::ZWaveProxyRequestType>(this->type));
-  out.append("  data: ");
-  out.append(format_hex_pretty(this->data, this->data_len));
-  out.append("\n");
+  dump_bytes_field(out, "data", this->data, this->data_len);
 }
 #endif
 


### PR DESCRIPTION

# What does this implement/fix?

Updates the API protobuf codegen to use `format_hex_pretty_to()` with a stack buffer instead of heap-allocating `format_hex_pretty()` when dumping bytes fields in proto message logs.

This eliminates heap allocations in the VV logging path for 13 messages with bytes fields:

| Message | Field | Use Case |
|---------|-------|----------|
| `SubscribeLogsResponse` | `message` | Log message content |
| `NoiseEncryptionSetKeyRequest` | `key` | Encryption key |
| `HomeassistantActionResponse` | `response_data` | HA action JSON response |
| `ExecuteServiceResponse` | `response_data` | User service JSON response |
| `CameraImageResponse` | `data` | Camera image data |
| `BluetoothLERawAdvertisement` | `data` | BLE advertisement (max 62 bytes) |
| `BluetoothGATTReadResponse` | `data` | BLE GATT read result |
| `BluetoothGATTWriteRequest` | `data` | BLE GATT write payload |
| `BluetoothGATTWriteDescriptorRequest` | `data` | BLE descriptor write |
| `BluetoothGATTNotifyDataResponse` | `data` | BLE notification data |
| `VoiceAssistantAudio` | `data` | Voice audio chunks |
| `ZWaveProxyFrame` | `data` | Z-Wave frame data |
| `ZWaveProxyRequest` | `data` | Z-Wave request data |

The stack buffer is sized for 160 bytes of data (480 chars with separators), which covers typical BLE advertisements and most other use cases. Longer data is automatically truncated.

**Example VV log output showing bytes field formatting:**
```
[19:56:44.399][VV][api.service:012]: send_message bluetooth_le_raw_advertisements_response: BluetoothLERawAdvertisementsResponse {
[19:56:44.400][VV][api.service:012]:   advertisements: BluetoothLERawAdvertisement {
[19:56:44.401][VV][api.service:012]:   address: 77508651861370
[19:56:44.401][VV][api.service:012]:   rssi: -70
[19:56:44.401][VV][api.service:012]:   address_type: 1
[19:56:44.402][VV][api.service:012]:   data: 02:01:1A:0E:FF:4C:00:0F:05:90:00:55:DD:E7:10:02:2C:04:02:0A:00
[19:56:44.403][VV][api.service:012]:  }
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce heap allocations in hot paths

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal codegen change)

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# Enable VV logging to see bytes field dumps
logger:
  level: VERY_VERBOSE

# BLE proxy will generate BluetoothLERawAdvertisement messages with bytes data field
esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
