### PR TITLE
[web_server] Fix select compilation error in v1

### DIFF
--- a/esphome/components/web_server/web_server_v1.cpp
+++ b/esphome/components/web_server/web_server_v1.cpp
@@ -202,7 +202,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
         stream.print("<option></option>");
         for (auto const &option : select->traits.get_options()) {
           stream.print("<option>");
-          stream.print(option.c_str());
+          stream.print(option);
           stream.print("</option>");
         }
         stream.print("</select>");


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation error in web_server v1 when using select component on ESP-IDF.

After #13153 changed `SelectTraits::get_options()` to return `FixedVector<const char *>` instead of `std::vector<std::string>`, the iteration variable `option` is now a `const char*` rather than `std::string`. Calling `.c_str()` on a pointer type causes a compilation error:

```
src/esphome/components/web_server/web_server_v1.cpp:205:31: error: request for member 'c_str'
in 'option', which is of non-class type 'const char* const'
205 |           stream.print(option.c_str());
```

The fix removes the redundant `.c_str()` call since `option` is already a `const char*`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #13153

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  port: 80
  version: 1

select:
  - platform: template
    name: "Test Select"
    options:
      - "Option 1"
      - "Option 2"
    initial_option: "Option 1"
    optimistic: true
    set_action:
      - logger.log:
          format: "Selected: %s"
          args: ['x.c_str()']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
