### PR TITLE
[infrared] Use set_data() for vector timings in control()

### DIFF
--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -88,27 +88,15 @@ void Infrared::control(const InfraredCall &call) {
   // Set timings based on format
   if (call.is_packed()) {
     // Zero-copy from packed protobuf data
-    ESP_LOGD(TAG, "Transmitting raw timings: timing_count=%u, repeat_count=%u", call.get_packed_count(),
-             call.get_repeat_count());
     transmit_data->set_data_from_packed_sint32(call.get_packed_data(), call.get_packed_length(),
                                                call.get_packed_count());
+    ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%u", call.get_packed_count(),
+             call.get_repeat_count());
   } else {
     // From vector (lambdas/automations)
-    const auto &timings = call.get_raw_timings();
-    if (timings.empty()) {
-      ESP_LOGE(TAG, "Raw timings array is empty");
-      return;
-    }
-    ESP_LOGD(TAG, "Transmitting raw timings: timing_count=%zu, repeat_count=%u", timings.size(),
+    transmit_data->set_data(call.get_raw_timings());
+    ESP_LOGD(TAG, "Transmitting raw timings: count=%zu, repeat=%u", call.get_raw_timings().size(),
              call.get_repeat_count());
-    // Timings format: positive values = mark (LED on), negative values = space (LED off)
-    for (const auto &timing : timings) {
-      if (timing > 0) {
-        transmit_data->mark(static_cast<uint32_t>(timing));
-      } else {
-        transmit_data->space(static_cast<uint32_t>(-timing));
-      }
-    }
   }
 
   // Set repeat count


### PR DESCRIPTION
# What does this implement/fix?

Simplifies the `Infrared::control()` method by using `set_data()` directly instead of iterating through timings with `mark()`/`space()` calls.

Before:
```cpp
for (const auto &timing : timings) {
  if (timing > 0) {
    transmit_data->mark(static_cast<uint32_t>(timing));
  } else {
    transmit_data->space(static_cast<uint32_t>(-timing));
  }
}
```

After:
```cpp
transmit_data->set_data(call.get_raw_timings());
```

This is cleaner and matches how the `ir_rf_proxy` platform implementation works (#12985).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of #12985 (ir_rf_proxy component)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal cleanup)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal implementation detail
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A)
