### PR TITLE
[mqtt] Avoid intermediate string allocations in publish calls

### DIFF
--- a/esphome/components/mqtt/custom_mqtt_device.cpp
+++ b/esphome/components/mqtt/custom_mqtt_device.cpp
@@ -13,13 +13,13 @@ bool CustomMQTTDevice::publish(const std::string &topic, const std::string &payl
 }
 bool CustomMQTTDevice::publish(const std::string &topic, float value, int8_t number_decimals) {
   char buf[VALUE_ACCURACY_MAX_LEN];
-  value_accuracy_to_buf(buf, value, number_decimals);
-  return this->publish(topic, buf);
+  size_t len = value_accuracy_to_buf(buf, value, number_decimals);
+  return global_mqtt_client->publish(topic, buf, len);
 }
 bool CustomMQTTDevice::publish(const std::string &topic, int value) {
   char buffer[24];
-  sprintf(buffer, "%d", value);
-  return this->publish(topic, buffer);
+  int len = sprintf(buffer, "%d", value);
+  return global_mqtt_client->publish(topic, buffer, len);
 }
 bool CustomMQTTDevice::publish_json(const std::string &topic, const json::json_build_t &f, uint8_t qos, bool retain) {
   return global_mqtt_client->publish_json(topic, f, qos, retain);

--- a/esphome/components/mqtt/custom_mqtt_device.cpp
+++ b/esphome/components/mqtt/custom_mqtt_device.cpp
@@ -18,7 +18,7 @@ bool CustomMQTTDevice::publish(const std::string &topic, float value, int8_t num
 }
 bool CustomMQTTDevice::publish(const std::string &topic, int value) {
   char buffer[24];
-  int len = sprintf(buffer, "%d", value);
+  int len = snprintf(buffer, sizeof(buffer), "%d", value);
   return global_mqtt_client->publish(topic, buffer, len);
 }
 bool CustomMQTTDevice::publish_json(const std::string &topic, const json::json_build_t &f, uint8_t qos, bool retain) {

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -292,36 +292,37 @@ bool MQTTClimateComponent::publish_state_() {
   int8_t target_accuracy = traits.get_target_temperature_accuracy_decimals();
   int8_t current_accuracy = traits.get_current_temperature_accuracy_decimals();
   char payload[VALUE_ACCURACY_MAX_LEN];
+  size_t len;
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE) &&
       !std::isnan(this->device_->current_temperature)) {
-    value_accuracy_to_buf(payload, this->device_->current_temperature, current_accuracy);
-    if (!this->publish(this->get_current_temperature_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->current_temperature, current_accuracy);
+    if (!this->publish(this->get_current_temperature_state_topic(), payload, len))
       success = false;
   }
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE |
                                climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {
-    value_accuracy_to_buf(payload, this->device_->target_temperature_low, target_accuracy);
-    if (!this->publish(this->get_target_temperature_low_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->target_temperature_low, target_accuracy);
+    if (!this->publish(this->get_target_temperature_low_state_topic(), payload, len))
       success = false;
-    value_accuracy_to_buf(payload, this->device_->target_temperature_high, target_accuracy);
-    if (!this->publish(this->get_target_temperature_high_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->target_temperature_high, target_accuracy);
+    if (!this->publish(this->get_target_temperature_high_state_topic(), payload, len))
       success = false;
   } else {
-    value_accuracy_to_buf(payload, this->device_->target_temperature, target_accuracy);
-    if (!this->publish(this->get_target_temperature_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->target_temperature, target_accuracy);
+    if (!this->publish(this->get_target_temperature_state_topic(), payload, len))
       success = false;
   }
 
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_HUMIDITY) &&
       !std::isnan(this->device_->current_humidity)) {
-    value_accuracy_to_buf(payload, this->device_->current_humidity, 0);
-    if (!this->publish(this->get_current_humidity_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->current_humidity, 0);
+    if (!this->publish(this->get_current_humidity_state_topic(), payload, len))
       success = false;
   }
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_TARGET_HUMIDITY) &&
       !std::isnan(this->device_->target_humidity)) {
-    value_accuracy_to_buf(payload, this->device_->target_humidity, 0);
-    if (!this->publish(this->get_target_humidity_state_topic(), payload))
+    len = value_accuracy_to_buf(payload, this->device_->target_humidity, 0);
+    if (!this->publish(this->get_target_humidity_state_topic(), payload, len))
       success = false;
   }
 

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -106,9 +106,13 @@ std::string MQTTComponent::get_command_topic_() const {
 }
 
 bool MQTTComponent::publish(const std::string &topic, const std::string &payload) {
+  return this->publish(topic, payload.data(), payload.size());
+}
+
+bool MQTTComponent::publish(const std::string &topic, const char *payload, size_t payload_length) {
   if (topic.empty())
     return false;
-  return global_mqtt_client->publish(topic, payload, this->qos_, this->retain_);
+  return global_mqtt_client->publish(topic, payload, payload_length, this->qos_, this->retain_);
 }
 
 bool MQTTComponent::publish_json(const std::string &topic, const json::json_build_t &f) {

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -136,6 +136,14 @@ class MQTTComponent : public Component {
    */
   bool publish(const std::string &topic, const std::string &payload);
 
+  /** Send a MQTT message.
+   *
+   * @param topic The topic.
+   * @param payload The payload buffer.
+   * @param payload_length The length of the payload.
+   */
+  bool publish(const std::string &topic, const char *payload, size_t payload_length);
+
   /** Construct and send a JSON MQTT message.
    *
    * @param topic The topic.

--- a/esphome/components/mqtt/mqtt_cover.cpp
+++ b/esphome/components/mqtt/mqtt_cover.cpp
@@ -99,14 +99,14 @@ bool MQTTCoverComponent::publish_state() {
   bool success = true;
   if (traits.get_supports_position()) {
     char pos[VALUE_ACCURACY_MAX_LEN];
-    value_accuracy_to_buf(pos, roundf(this->cover_->position * 100), 0);
-    if (!this->publish(this->get_position_state_topic(), pos))
+    size_t len = value_accuracy_to_buf(pos, roundf(this->cover_->position * 100), 0);
+    if (!this->publish(this->get_position_state_topic(), pos, len))
       success = false;
   }
   if (traits.get_supports_tilt()) {
     char pos[VALUE_ACCURACY_MAX_LEN];
-    value_accuracy_to_buf(pos, roundf(this->cover_->tilt * 100), 0);
-    if (!this->publish(this->get_tilt_state_topic(), pos))
+    size_t len = value_accuracy_to_buf(pos, roundf(this->cover_->tilt * 100), 0);
+    if (!this->publish(this->get_tilt_state_topic(), pos, len))
       success = false;
   }
   const char *state_s = this->cover_->current_operation == COVER_OPERATION_OPENING   ? "opening"

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -174,7 +174,7 @@ bool MQTTFanComponent::publish_state() {
   }
   auto traits = this->state_->get_traits();
   if (traits.supports_speed()) {
-    char buf[4];
+    char buf[12];
     int len = snprintf(buf, sizeof(buf), "%d", this->state_->speed);
     bool success = this->publish(this->get_speed_level_state_topic(), buf, len);
     failed = failed || !success;

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -174,8 +174,9 @@ bool MQTTFanComponent::publish_state() {
   }
   auto traits = this->state_->get_traits();
   if (traits.supports_speed()) {
-    std::string payload = to_string(this->state_->speed);
-    bool success = this->publish(this->get_speed_level_state_topic(), payload);
+    char buf[4];
+    int len = snprintf(buf, sizeof(buf), "%d", this->state_->speed);
+    bool success = this->publish(this->get_speed_level_state_topic(), buf, len);
     failed = failed || !success;
   }
   return !failed;

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -80,11 +80,11 @@ bool MQTTSensorComponent::send_initial_state() {
 }
 bool MQTTSensorComponent::publish_state(float value) {
   if (mqtt::global_mqtt_client->is_publish_nan_as_none() && std::isnan(value))
-    return this->publish(this->get_state_topic_(), "None");
+    return this->publish(this->get_state_topic_(), "None", 4);
   int8_t accuracy = this->sensor_->get_accuracy_decimals();
   char buf[VALUE_ACCURACY_MAX_LEN];
-  value_accuracy_to_buf(buf, value, accuracy);
-  return this->publish(this->get_state_topic_(), buf);
+  size_t len = value_accuracy_to_buf(buf, value, accuracy);
+  return this->publish(this->get_state_topic_(), buf, len);
 }
 
 }  // namespace esphome::mqtt

--- a/esphome/components/mqtt/mqtt_valve.cpp
+++ b/esphome/components/mqtt/mqtt_valve.cpp
@@ -74,8 +74,8 @@ bool MQTTValveComponent::publish_state() {
   bool success = true;
   if (traits.get_supports_position()) {
     char pos[VALUE_ACCURACY_MAX_LEN];
-    value_accuracy_to_buf(pos, roundf(this->valve_->position * 100), 0);
-    if (!this->publish(this->get_position_state_topic(), pos))
+    size_t len = value_accuracy_to_buf(pos, roundf(this->valve_->position * 100), 0);
+    if (!this->publish(this->get_position_state_topic(), pos, len))
       success = false;
   }
   const char *state_s = this->valve_->current_operation == VALVE_OPERATION_OPENING   ? "opening"


### PR DESCRIPTION
# What does this implement/fix?

Add a `publish(topic, payload, length)` overload to `MQTTComponent` that routes directly to `MQTTClientComponent::publish()` without creating intermediate `std::string` objects.

Previously, publishing from a char buffer required an implicit conversion to `std::string`, which then got copied again inside `MQTTMessage`. This change allows callers with char buffers to skip the first allocation.

- Add `bool publish(const std::string &topic, const char *payload, size_t payload_length)` to `MQTTComponent`
- Make the existing `publish(topic, string)` overload wrap the new one (DRY)
- Update all `value_accuracy_to_buf()` callers to use the returned length
- Update `mqtt_fan` to use `snprintf` instead of `to_string()`
- Update `custom_mqtt_device` to call `global_mqtt_client->publish()` with length directly

Each updated call site saves one heap allocation per publish.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a - ongoing heap allocation reduction effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a - internal optimization, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
mqtt:
  broker: mqtt.example.com

sensor:
  - platform: template
    name: "Test Sensor"
    lambda: return 42.0;
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a)
