### PR TITLE
[api] Use stack buffer for VERY_VERBOSE proto message dumps

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -305,7 +305,8 @@ uint16_t APIConnection::encode_message_to_buffer(ProtoMessage &msg, uint8_t mess
 #ifdef HAS_PROTO_MESSAGE_DUMP
   // If in log-only mode, just log and return
   if (conn->flags_.log_only_mode) {
-    conn->log_send_message_(msg.message_name(), msg.dump());
+    DumpBuffer dump_buf;
+    conn->log_send_message_(msg.message_name(), msg.dump_to(dump_buf));
     return 1;  // Return non-zero to indicate "success" for logging
   }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -362,7 +362,7 @@ class HelloRequest final : public ProtoDecodableMessage {
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -383,7 +383,7 @@ class HelloResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -396,7 +396,7 @@ class DisconnectRequest final : public ProtoMessage {
   const char *message_name() const override { return "disconnect_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -409,7 +409,7 @@ class DisconnectResponse final : public ProtoMessage {
   const char *message_name() const override { return "disconnect_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -422,7 +422,7 @@ class PingRequest final : public ProtoMessage {
   const char *message_name() const override { return "ping_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -435,7 +435,7 @@ class PingResponse final : public ProtoMessage {
   const char *message_name() const override { return "ping_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -448,7 +448,7 @@ class DeviceInfoRequest final : public ProtoMessage {
   const char *message_name() const override { return "device_info_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -461,7 +461,7 @@ class AreaInfo final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -476,7 +476,7 @@ class DeviceInfo final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -541,7 +541,7 @@ class DeviceInfoResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -554,7 +554,7 @@ class ListEntitiesRequest final : public ProtoMessage {
   const char *message_name() const override { return "list_entities_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -567,7 +567,7 @@ class ListEntitiesDoneResponse final : public ProtoMessage {
   const char *message_name() const override { return "list_entities_done_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -580,7 +580,7 @@ class SubscribeStatesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -598,7 +598,7 @@ class ListEntitiesBinarySensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -615,7 +615,7 @@ class BinarySensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -637,7 +637,7 @@ class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -655,7 +655,7 @@ class CoverStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -673,7 +673,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
   float tilt{0.0f};
   bool stop{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -697,7 +697,7 @@ class ListEntitiesFanResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -717,7 +717,7 @@ class FanStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -740,7 +740,7 @@ class FanCommandRequest final : public CommandProtoMessage {
   bool has_preset_mode{false};
   StringRef preset_mode{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -764,7 +764,7 @@ class ListEntitiesLightResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -791,7 +791,7 @@ class LightStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -830,7 +830,7 @@ class LightCommandRequest final : public CommandProtoMessage {
   bool has_effect{false};
   StringRef effect{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -855,7 +855,7 @@ class ListEntitiesSensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -872,7 +872,7 @@ class SensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -891,7 +891,7 @@ class ListEntitiesSwitchResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -907,7 +907,7 @@ class SwitchStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -921,7 +921,7 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 #endif
   bool state{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -941,7 +941,7 @@ class ListEntitiesTextSensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -958,7 +958,7 @@ class TextSensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -974,7 +974,7 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
   enums::LogLevel level{};
   bool dump_config{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -997,7 +997,7 @@ class SubscribeLogsResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1013,7 +1013,7 @@ class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
   const uint8_t *key{nullptr};
   uint16_t key_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1030,7 +1030,7 @@ class NoiseEncryptionSetKeyResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1045,7 +1045,7 @@ class SubscribeHomeassistantServicesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_homeassistant_services_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1057,7 +1057,7 @@ class HomeassistantServiceMap final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1086,7 +1086,7 @@ class HomeassistantActionRequest final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1108,7 +1108,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
   uint16_t response_data_len{0};
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1125,7 +1125,7 @@ class SubscribeHomeAssistantStatesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_home_assistant_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1143,7 +1143,7 @@ class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1159,7 +1159,7 @@ class HomeAssistantStateResponse final : public ProtoDecodableMessage {
   StringRef state{};
   StringRef attribute{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1174,7 +1174,7 @@ class GetTimeRequest final : public ProtoMessage {
   const char *message_name() const override { return "get_time_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1189,7 +1189,7 @@ class GetTimeResponse final : public ProtoDecodableMessage {
   uint32_t epoch_seconds{0};
   StringRef timezone{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1204,7 +1204,7 @@ class ListEntitiesServicesArgument final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1223,7 +1223,7 @@ class ListEntitiesServicesResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1241,7 +1241,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
   FixedVector<std::string> string_array{};
   void decode(const uint8_t *buffer, size_t length) override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1266,7 +1266,7 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
 #endif
   void decode(const uint8_t *buffer, size_t length) override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1293,7 +1293,7 @@ class ExecuteServiceResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1310,7 +1310,7 @@ class ListEntitiesCameraResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1332,7 +1332,7 @@ class CameraImageResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1347,7 +1347,7 @@ class CameraImageRequest final : public ProtoDecodableMessage {
   bool single{false};
   bool stream{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1383,7 +1383,7 @@ class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1411,7 +1411,7 @@ class ClimateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1444,7 +1444,7 @@ class ClimateCommandRequest final : public CommandProtoMessage {
   bool has_target_humidity{false};
   float target_humidity{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1469,7 +1469,7 @@ class ListEntitiesWaterHeaterResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1490,7 +1490,7 @@ class WaterHeaterStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1509,7 +1509,7 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
   float target_temperature_low{0.0f};
   float target_temperature_high{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1534,7 +1534,7 @@ class ListEntitiesNumberResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1551,7 +1551,7 @@ class NumberStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1565,7 +1565,7 @@ class NumberCommandRequest final : public CommandProtoMessage {
 #endif
   float state{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1585,7 +1585,7 @@ class ListEntitiesSelectResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1602,7 +1602,7 @@ class SelectStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1616,7 +1616,7 @@ class SelectCommandRequest final : public CommandProtoMessage {
 #endif
   StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1639,7 +1639,7 @@ class ListEntitiesSirenResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1655,7 +1655,7 @@ class SirenStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1676,7 +1676,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
   bool has_volume{false};
   float volume{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1700,7 +1700,7 @@ class ListEntitiesLockResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1716,7 +1716,7 @@ class LockStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1732,7 +1732,7 @@ class LockCommandRequest final : public CommandProtoMessage {
   bool has_code{false};
   StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1753,7 +1753,7 @@ class ListEntitiesButtonResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1766,7 +1766,7 @@ class ButtonCommandRequest final : public CommandProtoMessage {
   const char *message_name() const override { return "button_command_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1785,7 +1785,7 @@ class MediaPlayerSupportedFormat final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1803,7 +1803,7 @@ class ListEntitiesMediaPlayerResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1821,7 +1821,7 @@ class MediaPlayerStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1842,7 +1842,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
   bool has_announcement{false};
   bool announcement{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1861,7 +1861,7 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
 #endif
   uint32_t flags{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1877,7 +1877,7 @@ class BluetoothLERawAdvertisement final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1894,7 +1894,7 @@ class BluetoothLERawAdvertisementsResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1911,7 +1911,7 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
   bool has_address_type{false};
   uint32_t address_type{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1931,7 +1931,7 @@ class BluetoothDeviceConnectionResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1945,7 +1945,7 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
 #endif
   uint64_t address{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1959,7 +1959,7 @@ class BluetoothGATTDescriptor final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1974,7 +1974,7 @@ class BluetoothGATTCharacteristic final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1988,7 +1988,7 @@ class BluetoothGATTService final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2005,7 +2005,7 @@ class BluetoothGATTGetServicesResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2021,7 +2021,7 @@ class BluetoothGATTGetServicesDoneResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2036,7 +2036,7 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
   uint64_t address{0};
   uint32_t handle{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2060,7 +2060,7 @@ class BluetoothGATTReadResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2078,7 +2078,7 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2095,7 +2095,7 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
   uint64_t address{0};
   uint32_t handle{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2113,7 +2113,7 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2131,7 +2131,7 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
   uint32_t handle{0};
   bool enable{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2155,7 +2155,7 @@ class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2168,7 +2168,7 @@ class SubscribeBluetoothConnectionsFreeRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_bluetooth_connections_free_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2186,7 +2186,7 @@ class BluetoothConnectionsFreeResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2204,7 +2204,7 @@ class BluetoothGATTErrorResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2221,7 +2221,7 @@ class BluetoothGATTWriteResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2238,7 +2238,7 @@ class BluetoothGATTNotifyResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2256,7 +2256,7 @@ class BluetoothDevicePairingResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2274,7 +2274,7 @@ class BluetoothDeviceUnpairingResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2287,7 +2287,7 @@ class UnsubscribeBluetoothLEAdvertisementsRequest final : public ProtoMessage {
   const char *message_name() const override { return "unsubscribe_bluetooth_le_advertisements_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2305,7 +2305,7 @@ class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2323,7 +2323,7 @@ class BluetoothScannerStateResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2337,7 +2337,7 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #endif
   enums::BluetoothScannerMode mode{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2355,7 +2355,7 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
   bool subscribe{false};
   uint32_t flags{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2369,7 +2369,7 @@ class VoiceAssistantAudioSettings final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2389,7 +2389,7 @@ class VoiceAssistantRequest final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2404,7 +2404,7 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
   uint32_t port{0};
   bool error{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2415,7 +2415,7 @@ class VoiceAssistantEventData final : public ProtoDecodableMessage {
   StringRef name{};
   StringRef value{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2431,7 +2431,7 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
   enums::VoiceAssistantEvent event_type{};
   std::vector<VoiceAssistantEventData> data{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2451,7 +2451,7 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2472,7 +2472,7 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
   uint32_t seconds_left{0};
   bool is_active{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2491,7 +2491,7 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
   StringRef preannounce_media_id{};
   bool start_conversation{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2509,7 +2509,7 @@ class VoiceAssistantAnnounceFinished final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2522,7 +2522,7 @@ class VoiceAssistantWakeWord final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2537,7 +2537,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
   StringRef model_hash{};
   StringRef url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2553,7 +2553,7 @@ class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
 #endif
   std::vector<VoiceAssistantExternalWakeWord> external_wake_words{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2572,7 +2572,7 @@ class VoiceAssistantConfigurationResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2586,7 +2586,7 @@ class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
 #endif
   std::vector<std::string> active_wake_words{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2607,7 +2607,7 @@ class ListEntitiesAlarmControlPanelResponse final : public InfoResponseProtoMess
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2623,7 +2623,7 @@ class AlarmControlPanelStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2638,7 +2638,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
   enums::AlarmControlPanelStateCommand command{};
   StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2662,7 +2662,7 @@ class ListEntitiesTextResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2679,7 +2679,7 @@ class TextStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2693,7 +2693,7 @@ class TextCommandRequest final : public CommandProtoMessage {
 #endif
   StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2713,7 +2713,7 @@ class ListEntitiesDateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2732,7 +2732,7 @@ class DateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2748,7 +2748,7 @@ class DateCommandRequest final : public CommandProtoMessage {
   uint32_t month{0};
   uint32_t day{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2767,7 +2767,7 @@ class ListEntitiesTimeResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2786,7 +2786,7 @@ class TimeStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2802,7 +2802,7 @@ class TimeCommandRequest final : public CommandProtoMessage {
   uint32_t minute{0};
   uint32_t second{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2823,7 +2823,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2839,7 +2839,7 @@ class EventResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2860,7 +2860,7 @@ class ListEntitiesValveResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2877,7 +2877,7 @@ class ValveStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2893,7 +2893,7 @@ class ValveCommandRequest final : public CommandProtoMessage {
   float position{0.0f};
   bool stop{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2912,7 +2912,7 @@ class ListEntitiesDateTimeResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2929,7 +2929,7 @@ class DateTimeStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2943,7 +2943,7 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 #endif
   uint32_t epoch_seconds{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2963,7 +2963,7 @@ class ListEntitiesUpdateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2987,7 +2987,7 @@ class UpdateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3001,7 +3001,7 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 #endif
   enums::UpdateCommand command{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3022,7 +3022,7 @@ class ZWaveProxyFrame final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3041,7 +3041,7 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3061,7 +3061,7 @@ class ListEntitiesInfraredResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3085,7 +3085,7 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
   uint16_t timings_length_{0};
   uint16_t timings_count_{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3108,7 +3108,7 @@ class InfraredRFReceiveEvent final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(DumpBuffer &out) const override;
+  const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -362,7 +362,7 @@ class HelloRequest final : public ProtoDecodableMessage {
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -383,7 +383,7 @@ class HelloResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -396,7 +396,7 @@ class DisconnectRequest final : public ProtoMessage {
   const char *message_name() const override { return "disconnect_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -409,7 +409,7 @@ class DisconnectResponse final : public ProtoMessage {
   const char *message_name() const override { return "disconnect_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -422,7 +422,7 @@ class PingRequest final : public ProtoMessage {
   const char *message_name() const override { return "ping_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -435,7 +435,7 @@ class PingResponse final : public ProtoMessage {
   const char *message_name() const override { return "ping_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -448,7 +448,7 @@ class DeviceInfoRequest final : public ProtoMessage {
   const char *message_name() const override { return "device_info_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -461,7 +461,7 @@ class AreaInfo final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -476,7 +476,7 @@ class DeviceInfo final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -541,7 +541,7 @@ class DeviceInfoResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -554,7 +554,7 @@ class ListEntitiesRequest final : public ProtoMessage {
   const char *message_name() const override { return "list_entities_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -567,7 +567,7 @@ class ListEntitiesDoneResponse final : public ProtoMessage {
   const char *message_name() const override { return "list_entities_done_response"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -580,7 +580,7 @@ class SubscribeStatesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -598,7 +598,7 @@ class ListEntitiesBinarySensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -615,7 +615,7 @@ class BinarySensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -637,7 +637,7 @@ class ListEntitiesCoverResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -655,7 +655,7 @@ class CoverStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -673,7 +673,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
   float tilt{0.0f};
   bool stop{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -697,7 +697,7 @@ class ListEntitiesFanResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -717,7 +717,7 @@ class FanStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -740,7 +740,7 @@ class FanCommandRequest final : public CommandProtoMessage {
   bool has_preset_mode{false};
   StringRef preset_mode{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -764,7 +764,7 @@ class ListEntitiesLightResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -791,7 +791,7 @@ class LightStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -830,7 +830,7 @@ class LightCommandRequest final : public CommandProtoMessage {
   bool has_effect{false};
   StringRef effect{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -855,7 +855,7 @@ class ListEntitiesSensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -872,7 +872,7 @@ class SensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -891,7 +891,7 @@ class ListEntitiesSwitchResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -907,7 +907,7 @@ class SwitchStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -921,7 +921,7 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 #endif
   bool state{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -941,7 +941,7 @@ class ListEntitiesTextSensorResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -958,7 +958,7 @@ class TextSensorStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -974,7 +974,7 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
   enums::LogLevel level{};
   bool dump_config{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -997,7 +997,7 @@ class SubscribeLogsResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1013,7 +1013,7 @@ class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
   const uint8_t *key{nullptr};
   uint16_t key_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1030,7 +1030,7 @@ class NoiseEncryptionSetKeyResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1045,7 +1045,7 @@ class SubscribeHomeassistantServicesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_homeassistant_services_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1057,7 +1057,7 @@ class HomeassistantServiceMap final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1086,7 +1086,7 @@ class HomeassistantActionRequest final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1108,7 +1108,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
   uint16_t response_data_len{0};
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1125,7 +1125,7 @@ class SubscribeHomeAssistantStatesRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_home_assistant_states_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1143,7 +1143,7 @@ class SubscribeHomeAssistantStateResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1159,7 +1159,7 @@ class HomeAssistantStateResponse final : public ProtoDecodableMessage {
   StringRef state{};
   StringRef attribute{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1174,7 +1174,7 @@ class GetTimeRequest final : public ProtoMessage {
   const char *message_name() const override { return "get_time_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1189,7 +1189,7 @@ class GetTimeResponse final : public ProtoDecodableMessage {
   uint32_t epoch_seconds{0};
   StringRef timezone{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1204,7 +1204,7 @@ class ListEntitiesServicesArgument final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1223,7 +1223,7 @@ class ListEntitiesServicesResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1241,7 +1241,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
   FixedVector<std::string> string_array{};
   void decode(const uint8_t *buffer, size_t length) override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1266,7 +1266,7 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
 #endif
   void decode(const uint8_t *buffer, size_t length) override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1293,7 +1293,7 @@ class ExecuteServiceResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1310,7 +1310,7 @@ class ListEntitiesCameraResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1332,7 +1332,7 @@ class CameraImageResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1347,7 +1347,7 @@ class CameraImageRequest final : public ProtoDecodableMessage {
   bool single{false};
   bool stream{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1383,7 +1383,7 @@ class ListEntitiesClimateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1411,7 +1411,7 @@ class ClimateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1444,7 +1444,7 @@ class ClimateCommandRequest final : public CommandProtoMessage {
   bool has_target_humidity{false};
   float target_humidity{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1469,7 +1469,7 @@ class ListEntitiesWaterHeaterResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1490,7 +1490,7 @@ class WaterHeaterStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1509,7 +1509,7 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
   float target_temperature_low{0.0f};
   float target_temperature_high{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1534,7 +1534,7 @@ class ListEntitiesNumberResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1551,7 +1551,7 @@ class NumberStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1565,7 +1565,7 @@ class NumberCommandRequest final : public CommandProtoMessage {
 #endif
   float state{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1585,7 +1585,7 @@ class ListEntitiesSelectResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1602,7 +1602,7 @@ class SelectStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1616,7 +1616,7 @@ class SelectCommandRequest final : public CommandProtoMessage {
 #endif
   StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1639,7 +1639,7 @@ class ListEntitiesSirenResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1655,7 +1655,7 @@ class SirenStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1676,7 +1676,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
   bool has_volume{false};
   float volume{0.0f};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1700,7 +1700,7 @@ class ListEntitiesLockResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1716,7 +1716,7 @@ class LockStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1732,7 +1732,7 @@ class LockCommandRequest final : public CommandProtoMessage {
   bool has_code{false};
   StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1753,7 +1753,7 @@ class ListEntitiesButtonResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1766,7 +1766,7 @@ class ButtonCommandRequest final : public CommandProtoMessage {
   const char *message_name() const override { return "button_command_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1785,7 +1785,7 @@ class MediaPlayerSupportedFormat final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1803,7 +1803,7 @@ class ListEntitiesMediaPlayerResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1821,7 +1821,7 @@ class MediaPlayerStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1842,7 +1842,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
   bool has_announcement{false};
   bool announcement{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1861,7 +1861,7 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
 #endif
   uint32_t flags{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1877,7 +1877,7 @@ class BluetoothLERawAdvertisement final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1894,7 +1894,7 @@ class BluetoothLERawAdvertisementsResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1911,7 +1911,7 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
   bool has_address_type{false};
   uint32_t address_type{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1931,7 +1931,7 @@ class BluetoothDeviceConnectionResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1945,7 +1945,7 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
 #endif
   uint64_t address{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1959,7 +1959,7 @@ class BluetoothGATTDescriptor final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1974,7 +1974,7 @@ class BluetoothGATTCharacteristic final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -1988,7 +1988,7 @@ class BluetoothGATTService final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2005,7 +2005,7 @@ class BluetoothGATTGetServicesResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2021,7 +2021,7 @@ class BluetoothGATTGetServicesDoneResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2036,7 +2036,7 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
   uint64_t address{0};
   uint32_t handle{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2060,7 +2060,7 @@ class BluetoothGATTReadResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2078,7 +2078,7 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2095,7 +2095,7 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
   uint64_t address{0};
   uint32_t handle{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2113,7 +2113,7 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2131,7 +2131,7 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
   uint32_t handle{0};
   bool enable{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2155,7 +2155,7 @@ class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2168,7 +2168,7 @@ class SubscribeBluetoothConnectionsFreeRequest final : public ProtoMessage {
   const char *message_name() const override { return "subscribe_bluetooth_connections_free_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2186,7 +2186,7 @@ class BluetoothConnectionsFreeResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2204,7 +2204,7 @@ class BluetoothGATTErrorResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2221,7 +2221,7 @@ class BluetoothGATTWriteResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2238,7 +2238,7 @@ class BluetoothGATTNotifyResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2256,7 +2256,7 @@ class BluetoothDevicePairingResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2274,7 +2274,7 @@ class BluetoothDeviceUnpairingResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2287,7 +2287,7 @@ class UnsubscribeBluetoothLEAdvertisementsRequest final : public ProtoMessage {
   const char *message_name() const override { return "unsubscribe_bluetooth_le_advertisements_request"; }
 #endif
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2305,7 +2305,7 @@ class BluetoothDeviceClearCacheResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2323,7 +2323,7 @@ class BluetoothScannerStateResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2337,7 +2337,7 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #endif
   enums::BluetoothScannerMode mode{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2355,7 +2355,7 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
   bool subscribe{false};
   uint32_t flags{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2369,7 +2369,7 @@ class VoiceAssistantAudioSettings final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2389,7 +2389,7 @@ class VoiceAssistantRequest final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2404,7 +2404,7 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
   uint32_t port{0};
   bool error{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2415,7 +2415,7 @@ class VoiceAssistantEventData final : public ProtoDecodableMessage {
   StringRef name{};
   StringRef value{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2431,7 +2431,7 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
   enums::VoiceAssistantEvent event_type{};
   std::vector<VoiceAssistantEventData> data{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2451,7 +2451,7 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2472,7 +2472,7 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
   uint32_t seconds_left{0};
   bool is_active{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2491,7 +2491,7 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
   StringRef preannounce_media_id{};
   bool start_conversation{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2509,7 +2509,7 @@ class VoiceAssistantAnnounceFinished final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2522,7 +2522,7 @@ class VoiceAssistantWakeWord final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2537,7 +2537,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
   StringRef model_hash{};
   StringRef url{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2553,7 +2553,7 @@ class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
 #endif
   std::vector<VoiceAssistantExternalWakeWord> external_wake_words{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2572,7 +2572,7 @@ class VoiceAssistantConfigurationResponse final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2586,7 +2586,7 @@ class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
 #endif
   std::vector<std::string> active_wake_words{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2607,7 +2607,7 @@ class ListEntitiesAlarmControlPanelResponse final : public InfoResponseProtoMess
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2623,7 +2623,7 @@ class AlarmControlPanelStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2638,7 +2638,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
   enums::AlarmControlPanelStateCommand command{};
   StringRef code{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2662,7 +2662,7 @@ class ListEntitiesTextResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2679,7 +2679,7 @@ class TextStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2693,7 +2693,7 @@ class TextCommandRequest final : public CommandProtoMessage {
 #endif
   StringRef state{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2713,7 +2713,7 @@ class ListEntitiesDateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2732,7 +2732,7 @@ class DateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2748,7 +2748,7 @@ class DateCommandRequest final : public CommandProtoMessage {
   uint32_t month{0};
   uint32_t day{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2767,7 +2767,7 @@ class ListEntitiesTimeResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2786,7 +2786,7 @@ class TimeStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2802,7 +2802,7 @@ class TimeCommandRequest final : public CommandProtoMessage {
   uint32_t minute{0};
   uint32_t second{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2823,7 +2823,7 @@ class ListEntitiesEventResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2839,7 +2839,7 @@ class EventResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2860,7 +2860,7 @@ class ListEntitiesValveResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2877,7 +2877,7 @@ class ValveStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2893,7 +2893,7 @@ class ValveCommandRequest final : public CommandProtoMessage {
   float position{0.0f};
   bool stop{false};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2912,7 +2912,7 @@ class ListEntitiesDateTimeResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2929,7 +2929,7 @@ class DateTimeStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2943,7 +2943,7 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 #endif
   uint32_t epoch_seconds{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2963,7 +2963,7 @@ class ListEntitiesUpdateResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -2987,7 +2987,7 @@ class UpdateStateResponse final : public StateResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3001,7 +3001,7 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 #endif
   enums::UpdateCommand command{};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3022,7 +3022,7 @@ class ZWaveProxyFrame final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3041,7 +3041,7 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3061,7 +3061,7 @@ class ListEntitiesInfraredResponse final : public InfoResponseProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3085,7 +3085,7 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
   uint16_t timings_length_{0};
   uint16_t timings_count_{0};
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
@@ -3108,7 +3108,7 @@ class InfraredRFReceiveEvent final : public ProtoMessage {
   void encode(ProtoWriteBuffer buffer) const override;
   void calculate_size(ProtoSize &size) const override;
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  void dump_to(std::string &out) const override;
+  void dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -10,7 +10,7 @@
 namespace esphome::api {
 
 // Helper function to append a quoted string, handling empty StringRef
-static inline void append_quoted_string(std::string &out, const StringRef &ref) {
+static inline void append_quoted_string(DumpBuffer &out, const StringRef &ref) {
   out.append("'");
   if (!ref.empty()) {
     out.append(ref.c_str());
@@ -19,11 +19,11 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
 }
 
 // Common helpers for dump_field functions
-static inline void append_field_prefix(std::string &out, const char *field_name, int indent) {
+static inline void append_field_prefix(DumpBuffer &out, const char *field_name, int indent) {
   out.append(indent, ' ').append(field_name).append(": ");
 }
 
-static inline void append_with_newline(std::string &out, const char *str) {
+static inline void append_with_newline(DumpBuffer &out, const char *str) {
   out.append(str);
   out.append("\n");
 }
@@ -31,70 +31,70 @@ static inline void append_with_newline(std::string &out, const char *str) {
 // RAII helper for message dump formatting
 class MessageDumpHelper {
  public:
-  MessageDumpHelper(std::string &out, const char *message_name) : out_(out) {
+  MessageDumpHelper(DumpBuffer &out, const char *message_name) : out_(out) {
     out_.append(message_name);
     out_.append(" {\n");
   }
   ~MessageDumpHelper() { out_.append(" }"); }
 
  private:
-  std::string &out_;
+  DumpBuffer &out_;
 };
 
 // Helper functions to reduce code duplication in dump methods
-static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRId32, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, uint32_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu32, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, float value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu64, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, bool value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append(YESNO(value));
   out.append("\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, const std::string &value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
-  out.append("'").append(value).append("'");
+  out.append("'").append(value.c_str()).append("'");
   out.append("\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, StringRef value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   append_quoted_string(out, value);
   out.append("\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, const char *value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, const char *value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append("'").append(value).append("'");
   out.append("\n");
 }
 
-template<typename T> static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
+template<typename T> static void dump_field(DumpBuffer &out, const char *field_name, T value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append(proto_enum_to_string<T>(value));
   out.append("\n");
@@ -102,8 +102,7 @@ template<typename T> static void dump_field(std::string &out, const char *field_
 
 // Helper for bytes fields - uses stack buffer to avoid heap allocation
 // Buffer sized for 160 bytes of data (480 chars with separators) to fit typical log buffer
-static void dump_bytes_field(std::string &out, const char *field_name, const uint8_t *data, size_t len,
-                             int indent = 2) {
+static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint8_t *data, size_t len, int indent = 2) {
   char hex_buf[format_hex_pretty_size(160)];
   append_field_prefix(out, field_name, indent);
   format_hex_pretty_to(hex_buf, data, len);
@@ -743,40 +742,40 @@ template<> const char *proto_enum_to_string<enums::ZWaveProxyRequestType>(enums:
 }
 #endif
 
-void HelloRequest::dump_to(std::string &out) const {
+void HelloRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HelloRequest");
   dump_field(out, "client_info", this->client_info);
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
 }
-void HelloResponse::dump_to(std::string &out) const {
+void HelloResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HelloResponse");
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
   dump_field(out, "server_info", this->server_info);
   dump_field(out, "name", this->name);
 }
-void DisconnectRequest::dump_to(std::string &out) const { out.append("DisconnectRequest {}"); }
-void DisconnectResponse::dump_to(std::string &out) const { out.append("DisconnectResponse {}"); }
-void PingRequest::dump_to(std::string &out) const { out.append("PingRequest {}"); }
-void PingResponse::dump_to(std::string &out) const { out.append("PingResponse {}"); }
-void DeviceInfoRequest::dump_to(std::string &out) const { out.append("DeviceInfoRequest {}"); }
+void DisconnectRequest::dump_to(DumpBuffer &out) const { out.append("DisconnectRequest {}"); }
+void DisconnectResponse::dump_to(DumpBuffer &out) const { out.append("DisconnectResponse {}"); }
+void PingRequest::dump_to(DumpBuffer &out) const { out.append("PingRequest {}"); }
+void PingResponse::dump_to(DumpBuffer &out) const { out.append("PingResponse {}"); }
+void DeviceInfoRequest::dump_to(DumpBuffer &out) const { out.append("DeviceInfoRequest {}"); }
 #ifdef USE_AREAS
-void AreaInfo::dump_to(std::string &out) const {
+void AreaInfo::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AreaInfo");
   dump_field(out, "area_id", this->area_id);
   dump_field(out, "name", this->name);
 }
 #endif
 #ifdef USE_DEVICES
-void DeviceInfo::dump_to(std::string &out) const {
+void DeviceInfo::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DeviceInfo");
   dump_field(out, "device_id", this->device_id);
   dump_field(out, "name", this->name);
   dump_field(out, "area_id", this->area_id);
 }
 #endif
-void DeviceInfoResponse::dump_to(std::string &out) const {
+void DeviceInfoResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DeviceInfoResponse");
   dump_field(out, "name", this->name);
   dump_field(out, "mac_address", this->mac_address);
@@ -838,11 +837,11 @@ void DeviceInfoResponse::dump_to(std::string &out) const {
   dump_field(out, "zwave_home_id", this->zwave_home_id);
 #endif
 }
-void ListEntitiesRequest::dump_to(std::string &out) const { out.append("ListEntitiesRequest {}"); }
-void ListEntitiesDoneResponse::dump_to(std::string &out) const { out.append("ListEntitiesDoneResponse {}"); }
-void SubscribeStatesRequest::dump_to(std::string &out) const { out.append("SubscribeStatesRequest {}"); }
+void ListEntitiesRequest::dump_to(DumpBuffer &out) const { out.append("ListEntitiesRequest {}"); }
+void ListEntitiesDoneResponse::dump_to(DumpBuffer &out) const { out.append("ListEntitiesDoneResponse {}"); }
+void SubscribeStatesRequest::dump_to(DumpBuffer &out) const { out.append("SubscribeStatesRequest {}"); }
 #ifdef USE_BINARY_SENSOR
-void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
+void ListEntitiesBinarySensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesBinarySensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -858,7 +857,7 @@ void ListEntitiesBinarySensorResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void BinarySensorStateResponse::dump_to(std::string &out) const {
+void BinarySensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BinarySensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -869,7 +868,7 @@ void BinarySensorStateResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_COVER
-void ListEntitiesCoverResponse::dump_to(std::string &out) const {
+void ListEntitiesCoverResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesCoverResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -888,7 +887,7 @@ void ListEntitiesCoverResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void CoverStateResponse::dump_to(std::string &out) const {
+void CoverStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CoverStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
@@ -898,7 +897,7 @@ void CoverStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void CoverCommandRequest::dump_to(std::string &out) const {
+void CoverCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CoverCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
@@ -912,7 +911,7 @@ void CoverCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_FAN
-void ListEntitiesFanResponse::dump_to(std::string &out) const {
+void ListEntitiesFanResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesFanResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -933,7 +932,7 @@ void ListEntitiesFanResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void FanStateResponse::dump_to(std::string &out) const {
+void FanStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "FanStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -945,7 +944,7 @@ void FanStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void FanCommandRequest::dump_to(std::string &out) const {
+void FanCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "FanCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -964,7 +963,7 @@ void FanCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_LIGHT
-void ListEntitiesLightResponse::dump_to(std::string &out) const {
+void ListEntitiesLightResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesLightResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -986,7 +985,7 @@ void ListEntitiesLightResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void LightStateResponse::dump_to(std::string &out) const {
+void LightStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LightStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1005,7 +1004,7 @@ void LightStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void LightCommandRequest::dump_to(std::string &out) const {
+void LightCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LightCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -1040,7 +1039,7 @@ void LightCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_SENSOR
-void ListEntitiesSensorResponse::dump_to(std::string &out) const {
+void ListEntitiesSensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1059,7 +1058,7 @@ void ListEntitiesSensorResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SensorStateResponse::dump_to(std::string &out) const {
+void SensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1070,7 +1069,7 @@ void SensorStateResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_SWITCH
-void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
+void ListEntitiesSwitchResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSwitchResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1086,7 +1085,7 @@ void ListEntitiesSwitchResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SwitchStateResponse::dump_to(std::string &out) const {
+void SwitchStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SwitchStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1094,7 +1093,7 @@ void SwitchStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SwitchCommandRequest::dump_to(std::string &out) const {
+void SwitchCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SwitchCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1104,7 +1103,7 @@ void SwitchCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_TEXT_SENSOR
-void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
+void ListEntitiesTextSensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTextSensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1119,7 +1118,7 @@ void ListEntitiesTextSensorResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void TextSensorStateResponse::dump_to(std::string &out) const {
+void TextSensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextSensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1129,36 +1128,36 @@ void TextSensorStateResponse::dump_to(std::string &out) const {
 #endif
 }
 #endif
-void SubscribeLogsRequest::dump_to(std::string &out) const {
+void SubscribeLogsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeLogsRequest");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   dump_field(out, "dump_config", this->dump_config);
 }
-void SubscribeLogsResponse::dump_to(std::string &out) const {
+void SubscribeLogsResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeLogsResponse");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   dump_bytes_field(out, "message", this->message_ptr_, this->message_len_);
 }
 #ifdef USE_API_NOISE
-void NoiseEncryptionSetKeyRequest::dump_to(std::string &out) const {
+void NoiseEncryptionSetKeyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyRequest");
   dump_bytes_field(out, "key", this->key, this->key_len);
 }
-void NoiseEncryptionSetKeyResponse::dump_to(std::string &out) const {
+void NoiseEncryptionSetKeyResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyResponse");
   dump_field(out, "success", this->success);
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-void SubscribeHomeassistantServicesRequest::dump_to(std::string &out) const {
+void SubscribeHomeassistantServicesRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
 }
-void HomeassistantServiceMap::dump_to(std::string &out) const {
+void HomeassistantServiceMap::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantServiceMap");
   dump_field(out, "key", this->key);
   dump_field(out, "value", this->value);
 }
-void HomeassistantActionRequest::dump_to(std::string &out) const {
+void HomeassistantActionRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantActionRequest");
   dump_field(out, "service", this->service);
   for (const auto &it : this->data) {
@@ -1189,7 +1188,7 @@ void HomeassistantActionRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
-void HomeassistantActionResponse::dump_to(std::string &out) const {
+void HomeassistantActionResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantActionResponse");
   dump_field(out, "call_id", this->call_id);
   dump_field(out, "success", this->success);
@@ -1200,35 +1199,35 @@ void HomeassistantActionResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
-void SubscribeHomeAssistantStatesRequest::dump_to(std::string &out) const {
+void SubscribeHomeAssistantStatesRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
 }
-void SubscribeHomeAssistantStateResponse::dump_to(std::string &out) const {
+void SubscribeHomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeHomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id);
   dump_field(out, "attribute", this->attribute);
   dump_field(out, "once", this->once);
 }
-void HomeAssistantStateResponse::dump_to(std::string &out) const {
+void HomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id);
   dump_field(out, "state", this->state);
   dump_field(out, "attribute", this->attribute);
 }
 #endif
-void GetTimeRequest::dump_to(std::string &out) const { out.append("GetTimeRequest {}"); }
-void GetTimeResponse::dump_to(std::string &out) const {
+void GetTimeRequest::dump_to(DumpBuffer &out) const { out.append("GetTimeRequest {}"); }
+void GetTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "GetTimeResponse");
   dump_field(out, "epoch_seconds", this->epoch_seconds);
   dump_field(out, "timezone", this->timezone);
 }
 #ifdef USE_API_USER_DEFINED_ACTIONS
-void ListEntitiesServicesArgument::dump_to(std::string &out) const {
+void ListEntitiesServicesArgument::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesServicesArgument");
   dump_field(out, "name", this->name);
   dump_field(out, "type", static_cast<enums::ServiceArgType>(this->type));
 }
-void ListEntitiesServicesResponse::dump_to(std::string &out) const {
+void ListEntitiesServicesResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesServicesResponse");
   dump_field(out, "name", this->name);
   dump_field(out, "key", this->key);
@@ -1239,7 +1238,7 @@ void ListEntitiesServicesResponse::dump_to(std::string &out) const {
   }
   dump_field(out, "supports_response", static_cast<enums::SupportsResponseType>(this->supports_response));
 }
-void ExecuteServiceArgument::dump_to(std::string &out) const {
+void ExecuteServiceArgument::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceArgument");
   dump_field(out, "bool_", this->bool_);
   dump_field(out, "legacy_int", this->legacy_int);
@@ -1259,7 +1258,7 @@ void ExecuteServiceArgument::dump_to(std::string &out) const {
     dump_field(out, "string_array", it, 4);
   }
 }
-void ExecuteServiceRequest::dump_to(std::string &out) const {
+void ExecuteServiceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceRequest");
   dump_field(out, "key", this->key);
   for (const auto &it : this->args) {
@@ -1276,7 +1275,7 @@ void ExecuteServiceRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-void ExecuteServiceResponse::dump_to(std::string &out) const {
+void ExecuteServiceResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceResponse");
   dump_field(out, "call_id", this->call_id);
   dump_field(out, "success", this->success);
@@ -1287,7 +1286,7 @@ void ExecuteServiceResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_CAMERA
-void ListEntitiesCameraResponse::dump_to(std::string &out) const {
+void ListEntitiesCameraResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesCameraResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1301,7 +1300,7 @@ void ListEntitiesCameraResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void CameraImageResponse::dump_to(std::string &out) const {
+void CameraImageResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CameraImageResponse");
   dump_field(out, "key", this->key);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
@@ -1310,14 +1309,14 @@ void CameraImageResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void CameraImageRequest::dump_to(std::string &out) const {
+void CameraImageRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CameraImageRequest");
   dump_field(out, "single", this->single);
   dump_field(out, "stream", this->stream);
 }
 #endif
 #ifdef USE_CLIMATE
-void ListEntitiesClimateResponse::dump_to(std::string &out) const {
+void ListEntitiesClimateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesClimateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1361,7 +1360,7 @@ void ListEntitiesClimateResponse::dump_to(std::string &out) const {
 #endif
   dump_field(out, "feature_flags", this->feature_flags);
 }
-void ClimateStateResponse::dump_to(std::string &out) const {
+void ClimateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ClimateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
@@ -1381,7 +1380,7 @@ void ClimateStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void ClimateCommandRequest::dump_to(std::string &out) const {
+void ClimateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ClimateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_mode", this->has_mode);
@@ -1410,7 +1409,7 @@ void ClimateCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_WATER_HEATER
-void ListEntitiesWaterHeaterResponse::dump_to(std::string &out) const {
+void ListEntitiesWaterHeaterResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesWaterHeaterResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1431,7 +1430,7 @@ void ListEntitiesWaterHeaterResponse::dump_to(std::string &out) const {
   }
   dump_field(out, "supported_features", this->supported_features);
 }
-void WaterHeaterStateResponse::dump_to(std::string &out) const {
+void WaterHeaterStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "WaterHeaterStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "current_temperature", this->current_temperature);
@@ -1444,7 +1443,7 @@ void WaterHeaterStateResponse::dump_to(std::string &out) const {
   dump_field(out, "target_temperature_low", this->target_temperature_low);
   dump_field(out, "target_temperature_high", this->target_temperature_high);
 }
-void WaterHeaterCommandRequest::dump_to(std::string &out) const {
+void WaterHeaterCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "WaterHeaterCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_fields", this->has_fields);
@@ -1459,7 +1458,7 @@ void WaterHeaterCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_NUMBER
-void ListEntitiesNumberResponse::dump_to(std::string &out) const {
+void ListEntitiesNumberResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesNumberResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1479,7 +1478,7 @@ void ListEntitiesNumberResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void NumberStateResponse::dump_to(std::string &out) const {
+void NumberStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NumberStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1488,7 +1487,7 @@ void NumberStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void NumberCommandRequest::dump_to(std::string &out) const {
+void NumberCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NumberCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1498,7 +1497,7 @@ void NumberCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_SELECT
-void ListEntitiesSelectResponse::dump_to(std::string &out) const {
+void ListEntitiesSelectResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSelectResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1515,7 +1514,7 @@ void ListEntitiesSelectResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SelectStateResponse::dump_to(std::string &out) const {
+void SelectStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SelectStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1524,7 +1523,7 @@ void SelectStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SelectCommandRequest::dump_to(std::string &out) const {
+void SelectCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SelectCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1534,7 +1533,7 @@ void SelectCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_SIREN
-void ListEntitiesSirenResponse::dump_to(std::string &out) const {
+void ListEntitiesSirenResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSirenResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1553,7 +1552,7 @@ void ListEntitiesSirenResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SirenStateResponse::dump_to(std::string &out) const {
+void SirenStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SirenStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1561,7 +1560,7 @@ void SirenStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void SirenCommandRequest::dump_to(std::string &out) const {
+void SirenCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SirenCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -1578,7 +1577,7 @@ void SirenCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_LOCK
-void ListEntitiesLockResponse::dump_to(std::string &out) const {
+void ListEntitiesLockResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesLockResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1596,7 +1595,7 @@ void ListEntitiesLockResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void LockStateResponse::dump_to(std::string &out) const {
+void LockStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LockStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::LockState>(this->state));
@@ -1604,7 +1603,7 @@ void LockStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void LockCommandRequest::dump_to(std::string &out) const {
+void LockCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LockCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
@@ -1616,7 +1615,7 @@ void LockCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_BUTTON
-void ListEntitiesButtonResponse::dump_to(std::string &out) const {
+void ListEntitiesButtonResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesButtonResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1631,7 +1630,7 @@ void ListEntitiesButtonResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void ButtonCommandRequest::dump_to(std::string &out) const {
+void ButtonCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ButtonCommandRequest");
   dump_field(out, "key", this->key);
 #ifdef USE_DEVICES
@@ -1640,7 +1639,7 @@ void ButtonCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
-void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
+void MediaPlayerSupportedFormat::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerSupportedFormat");
   dump_field(out, "format", this->format);
   dump_field(out, "sample_rate", this->sample_rate);
@@ -1648,7 +1647,7 @@ void MediaPlayerSupportedFormat::dump_to(std::string &out) const {
   dump_field(out, "purpose", static_cast<enums::MediaPlayerFormatPurpose>(this->purpose));
   dump_field(out, "sample_bytes", this->sample_bytes);
 }
-void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
+void ListEntitiesMediaPlayerResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesMediaPlayerResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1669,7 +1668,7 @@ void ListEntitiesMediaPlayerResponse::dump_to(std::string &out) const {
 #endif
   dump_field(out, "feature_flags", this->feature_flags);
 }
-void MediaPlayerStateResponse::dump_to(std::string &out) const {
+void MediaPlayerStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::MediaPlayerState>(this->state));
@@ -1679,7 +1678,7 @@ void MediaPlayerStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void MediaPlayerCommandRequest::dump_to(std::string &out) const {
+void MediaPlayerCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_command", this->has_command);
@@ -1696,18 +1695,18 @@ void MediaPlayerCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-void SubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
+void SubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeBluetoothLEAdvertisementsRequest");
   dump_field(out, "flags", this->flags);
 }
-void BluetoothLERawAdvertisement::dump_to(std::string &out) const {
+void BluetoothLERawAdvertisement::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothLERawAdvertisement");
   dump_field(out, "address", this->address);
   dump_field(out, "rssi", this->rssi);
   dump_field(out, "address_type", this->address_type);
   dump_bytes_field(out, "data", this->data, this->data_len);
 }
-void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
+void BluetoothLERawAdvertisementsResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothLERawAdvertisementsResponse");
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     out.append("  advertisements: ");
@@ -1715,25 +1714,25 @@ void BluetoothLERawAdvertisementsResponse::dump_to(std::string &out) const {
     out.append("\n");
   }
 }
-void BluetoothDeviceRequest::dump_to(std::string &out) const {
+void BluetoothDeviceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "request_type", static_cast<enums::BluetoothDeviceRequestType>(this->request_type));
   dump_field(out, "has_address_type", this->has_address_type);
   dump_field(out, "address_type", this->address_type);
 }
-void BluetoothDeviceConnectionResponse::dump_to(std::string &out) const {
+void BluetoothDeviceConnectionResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceConnectionResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "connected", this->connected);
   dump_field(out, "mtu", this->mtu);
   dump_field(out, "error", this->error);
 }
-void BluetoothGATTGetServicesRequest::dump_to(std::string &out) const {
+void BluetoothGATTGetServicesRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesRequest");
   dump_field(out, "address", this->address);
 }
-void BluetoothGATTDescriptor::dump_to(std::string &out) const {
+void BluetoothGATTDescriptor::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTDescriptor");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
@@ -1741,7 +1740,7 @@ void BluetoothGATTDescriptor::dump_to(std::string &out) const {
   dump_field(out, "handle", this->handle);
   dump_field(out, "short_uuid", this->short_uuid);
 }
-void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
+void BluetoothGATTCharacteristic::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTCharacteristic");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
@@ -1755,7 +1754,7 @@ void BluetoothGATTCharacteristic::dump_to(std::string &out) const {
   }
   dump_field(out, "short_uuid", this->short_uuid);
 }
-void BluetoothGATTService::dump_to(std::string &out) const {
+void BluetoothGATTService::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTService");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
@@ -1768,7 +1767,7 @@ void BluetoothGATTService::dump_to(std::string &out) const {
   }
   dump_field(out, "short_uuid", this->short_uuid);
 }
-void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
+void BluetoothGATTGetServicesResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesResponse");
   dump_field(out, "address", this->address);
   for (const auto &it : this->services) {
@@ -1777,55 +1776,55 @@ void BluetoothGATTGetServicesResponse::dump_to(std::string &out) const {
     out.append("\n");
   }
 }
-void BluetoothGATTGetServicesDoneResponse::dump_to(std::string &out) const {
+void BluetoothGATTGetServicesDoneResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesDoneResponse");
   dump_field(out, "address", this->address);
 }
-void BluetoothGATTReadRequest::dump_to(std::string &out) const {
+void BluetoothGATTReadRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
 }
-void BluetoothGATTReadResponse::dump_to(std::string &out) const {
+void BluetoothGATTReadResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
 }
-void BluetoothGATTWriteRequest::dump_to(std::string &out) const {
+void BluetoothGATTWriteRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "response", this->response);
   dump_bytes_field(out, "data", this->data, this->data_len);
 }
-void BluetoothGATTReadDescriptorRequest::dump_to(std::string &out) const {
+void BluetoothGATTReadDescriptorRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
 }
-void BluetoothGATTWriteDescriptorRequest::dump_to(std::string &out) const {
+void BluetoothGATTWriteDescriptorRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data, this->data_len);
 }
-void BluetoothGATTNotifyRequest::dump_to(std::string &out) const {
+void BluetoothGATTNotifyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "enable", this->enable);
 }
-void BluetoothGATTNotifyDataResponse::dump_to(std::string &out) const {
+void BluetoothGATTNotifyDataResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyDataResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
 }
-void SubscribeBluetoothConnectionsFreeRequest::dump_to(std::string &out) const {
+void SubscribeBluetoothConnectionsFreeRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
 }
-void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
+void BluetoothConnectionsFreeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothConnectionsFreeResponse");
   dump_field(out, "free", this->free);
   dump_field(out, "limit", this->limit);
@@ -1833,67 +1832,67 @@ void BluetoothConnectionsFreeResponse::dump_to(std::string &out) const {
     dump_field(out, "allocated", it, 4);
   }
 }
-void BluetoothGATTErrorResponse::dump_to(std::string &out) const {
+void BluetoothGATTErrorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTErrorResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "error", this->error);
 }
-void BluetoothGATTWriteResponse::dump_to(std::string &out) const {
+void BluetoothGATTWriteResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
 }
-void BluetoothGATTNotifyResponse::dump_to(std::string &out) const {
+void BluetoothGATTNotifyResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
 }
-void BluetoothDevicePairingResponse::dump_to(std::string &out) const {
+void BluetoothDevicePairingResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDevicePairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "paired", this->paired);
   dump_field(out, "error", this->error);
 }
-void BluetoothDeviceUnpairingResponse::dump_to(std::string &out) const {
+void BluetoothDeviceUnpairingResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceUnpairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
 }
-void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(std::string &out) const {
+void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
 }
-void BluetoothDeviceClearCacheResponse::dump_to(std::string &out) const {
+void BluetoothDeviceClearCacheResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceClearCacheResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
 }
-void BluetoothScannerStateResponse::dump_to(std::string &out) const {
+void BluetoothScannerStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerStateResponse");
   dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
   dump_field(out, "configured_mode", static_cast<enums::BluetoothScannerMode>(this->configured_mode));
 }
-void BluetoothScannerSetModeRequest::dump_to(std::string &out) const {
+void BluetoothScannerSetModeRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerSetModeRequest");
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
-void SubscribeVoiceAssistantRequest::dump_to(std::string &out) const {
+void SubscribeVoiceAssistantRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeVoiceAssistantRequest");
   dump_field(out, "subscribe", this->subscribe);
   dump_field(out, "flags", this->flags);
 }
-void VoiceAssistantAudioSettings::dump_to(std::string &out) const {
+void VoiceAssistantAudioSettings::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAudioSettings");
   dump_field(out, "noise_suppression_level", this->noise_suppression_level);
   dump_field(out, "auto_gain", this->auto_gain);
   dump_field(out, "volume_multiplier", this->volume_multiplier);
 }
-void VoiceAssistantRequest::dump_to(std::string &out) const {
+void VoiceAssistantRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantRequest");
   dump_field(out, "start", this->start);
   dump_field(out, "conversation_id", this->conversation_id);
@@ -1903,17 +1902,17 @@ void VoiceAssistantRequest::dump_to(std::string &out) const {
   out.append("\n");
   dump_field(out, "wake_word_phrase", this->wake_word_phrase);
 }
-void VoiceAssistantResponse::dump_to(std::string &out) const {
+void VoiceAssistantResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantResponse");
   dump_field(out, "port", this->port);
   dump_field(out, "error", this->error);
 }
-void VoiceAssistantEventData::dump_to(std::string &out) const {
+void VoiceAssistantEventData::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventData");
   dump_field(out, "name", this->name);
   dump_field(out, "value", this->value);
 }
-void VoiceAssistantEventResponse::dump_to(std::string &out) const {
+void VoiceAssistantEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantEvent>(this->event_type));
   for (const auto &it : this->data) {
@@ -1922,12 +1921,12 @@ void VoiceAssistantEventResponse::dump_to(std::string &out) const {
     out.append("\n");
   }
 }
-void VoiceAssistantAudio::dump_to(std::string &out) const {
+void VoiceAssistantAudio::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAudio");
   dump_bytes_field(out, "data", this->data, this->data_len);
   dump_field(out, "end", this->end);
 }
-void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
+void VoiceAssistantTimerEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantTimerEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
   dump_field(out, "timer_id", this->timer_id);
@@ -1936,18 +1935,18 @@ void VoiceAssistantTimerEventResponse::dump_to(std::string &out) const {
   dump_field(out, "seconds_left", this->seconds_left);
   dump_field(out, "is_active", this->is_active);
 }
-void VoiceAssistantAnnounceRequest::dump_to(std::string &out) const {
+void VoiceAssistantAnnounceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAnnounceRequest");
   dump_field(out, "media_id", this->media_id);
   dump_field(out, "text", this->text);
   dump_field(out, "preannounce_media_id", this->preannounce_media_id);
   dump_field(out, "start_conversation", this->start_conversation);
 }
-void VoiceAssistantAnnounceFinished::dump_to(std::string &out) const {
+void VoiceAssistantAnnounceFinished::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAnnounceFinished");
   dump_field(out, "success", this->success);
 }
-void VoiceAssistantWakeWord::dump_to(std::string &out) const {
+void VoiceAssistantWakeWord::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantWakeWord");
   dump_field(out, "id", this->id);
   dump_field(out, "wake_word", this->wake_word);
@@ -1955,7 +1954,7 @@ void VoiceAssistantWakeWord::dump_to(std::string &out) const {
     dump_field(out, "trained_languages", it, 4);
   }
 }
-void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
+void VoiceAssistantExternalWakeWord::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantExternalWakeWord");
   dump_field(out, "id", this->id);
   dump_field(out, "wake_word", this->wake_word);
@@ -1967,7 +1966,7 @@ void VoiceAssistantExternalWakeWord::dump_to(std::string &out) const {
   dump_field(out, "model_hash", this->model_hash);
   dump_field(out, "url", this->url);
 }
-void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
+void VoiceAssistantConfigurationRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationRequest");
   for (const auto &it : this->external_wake_words) {
     out.append("  external_wake_words: ");
@@ -1975,7 +1974,7 @@ void VoiceAssistantConfigurationRequest::dump_to(std::string &out) const {
     out.append("\n");
   }
 }
-void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
+void VoiceAssistantConfigurationResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationResponse");
   for (const auto &it : this->available_wake_words) {
     out.append("  available_wake_words: ");
@@ -1987,7 +1986,7 @@ void VoiceAssistantConfigurationResponse::dump_to(std::string &out) const {
   }
   dump_field(out, "max_active_wake_words", this->max_active_wake_words);
 }
-void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
+void VoiceAssistantSetConfiguration::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantSetConfiguration");
   for (const auto &it : this->active_wake_words) {
     dump_field(out, "active_wake_words", it, 4);
@@ -1995,7 +1994,7 @@ void VoiceAssistantSetConfiguration::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
+void ListEntitiesAlarmControlPanelResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesAlarmControlPanelResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2012,7 +2011,7 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
+void AlarmControlPanelStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AlarmControlPanelStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::AlarmControlPanelState>(this->state));
@@ -2020,7 +2019,7 @@ void AlarmControlPanelStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
+void AlarmControlPanelCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AlarmControlPanelCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
@@ -2031,7 +2030,7 @@ void AlarmControlPanelCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_TEXT
-void ListEntitiesTextResponse::dump_to(std::string &out) const {
+void ListEntitiesTextResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTextResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2049,7 +2048,7 @@ void ListEntitiesTextResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void TextStateResponse::dump_to(std::string &out) const {
+void TextStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -2058,7 +2057,7 @@ void TextStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void TextCommandRequest::dump_to(std::string &out) const {
+void TextCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -2068,7 +2067,7 @@ void TextCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_DATETIME_DATE
-void ListEntitiesDateResponse::dump_to(std::string &out) const {
+void ListEntitiesDateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesDateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2082,7 +2081,7 @@ void ListEntitiesDateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void DateStateResponse::dump_to(std::string &out) const {
+void DateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2093,7 +2092,7 @@ void DateStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void DateCommandRequest::dump_to(std::string &out) const {
+void DateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "year", this->year);
@@ -2105,7 +2104,7 @@ void DateCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_DATETIME_TIME
-void ListEntitiesTimeResponse::dump_to(std::string &out) const {
+void ListEntitiesTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTimeResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2119,7 +2118,7 @@ void ListEntitiesTimeResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void TimeStateResponse::dump_to(std::string &out) const {
+void TimeStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2130,7 +2129,7 @@ void TimeStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void TimeCommandRequest::dump_to(std::string &out) const {
+void TimeCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "hour", this->hour);
@@ -2142,7 +2141,7 @@ void TimeCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_EVENT
-void ListEntitiesEventResponse::dump_to(std::string &out) const {
+void ListEntitiesEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesEventResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2160,7 +2159,7 @@ void ListEntitiesEventResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void EventResponse::dump_to(std::string &out) const {
+void EventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "EventResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "event_type", this->event_type);
@@ -2170,7 +2169,7 @@ void EventResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_VALVE
-void ListEntitiesValveResponse::dump_to(std::string &out) const {
+void ListEntitiesValveResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesValveResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2188,7 +2187,7 @@ void ListEntitiesValveResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void ValveStateResponse::dump_to(std::string &out) const {
+void ValveStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ValveStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
@@ -2197,7 +2196,7 @@ void ValveStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void ValveCommandRequest::dump_to(std::string &out) const {
+void ValveCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ValveCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
@@ -2209,7 +2208,7 @@ void ValveCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
-void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
+void ListEntitiesDateTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesDateTimeResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2223,7 +2222,7 @@ void ListEntitiesDateTimeResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void DateTimeStateResponse::dump_to(std::string &out) const {
+void DateTimeStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateTimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2232,7 +2231,7 @@ void DateTimeStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void DateTimeCommandRequest::dump_to(std::string &out) const {
+void DateTimeCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateTimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "epoch_seconds", this->epoch_seconds);
@@ -2242,7 +2241,7 @@ void DateTimeCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_UPDATE
-void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
+void ListEntitiesUpdateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesUpdateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2257,7 +2256,7 @@ void ListEntitiesUpdateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void UpdateStateResponse::dump_to(std::string &out) const {
+void UpdateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "UpdateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2273,7 +2272,7 @@ void UpdateStateResponse::dump_to(std::string &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
 }
-void UpdateCommandRequest::dump_to(std::string &out) const {
+void UpdateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "UpdateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::UpdateCommand>(this->command));
@@ -2283,18 +2282,18 @@ void UpdateCommandRequest::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_ZWAVE_PROXY
-void ZWaveProxyFrame::dump_to(std::string &out) const {
+void ZWaveProxyFrame::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyFrame");
   dump_bytes_field(out, "data", this->data, this->data_len);
 }
-void ZWaveProxyRequest::dump_to(std::string &out) const {
+void ZWaveProxyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyRequest");
   dump_field(out, "type", static_cast<enums::ZWaveProxyRequestType>(this->type));
   dump_bytes_field(out, "data", this->data, this->data_len);
 }
 #endif
 #ifdef USE_INFRARED
-void ListEntitiesInfraredResponse::dump_to(std::string &out) const {
+void ListEntitiesInfraredResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesInfraredResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2311,7 +2310,7 @@ void ListEntitiesInfraredResponse::dump_to(std::string &out) const {
 }
 #endif
 #ifdef USE_IR_RF
-void InfraredRFTransmitRawTimingsRequest::dump_to(std::string &out) const {
+void InfraredRFTransmitRawTimingsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "InfraredRFTransmitRawTimingsRequest");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -2326,7 +2325,7 @@ void InfraredRFTransmitRawTimingsRequest::dump_to(std::string &out) const {
   out.append(std::to_string(this->timings_length_));
   out.append(" bytes]\n");
 }
-void InfraredRFReceiveEvent::dump_to(std::string &out) const {
+void InfraredRFReceiveEvent::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "InfraredRFReceiveEvent");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -28,6 +28,12 @@ static inline void append_with_newline(DumpBuffer &out, const char *str) {
   out.append("\n");
 }
 
+static inline void append_uint(DumpBuffer &out, uint32_t value) {
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%" PRIu32, value);
+  out.append(buf);
+}
+
 // RAII helper for message dump formatting
 class MessageDumpHelper {
  public:
@@ -2484,9 +2490,9 @@ const char *InfraredRFTransmitRawTimingsRequest::dump_to(DumpBuffer &out) const 
   dump_field(out, "repeat_count", this->repeat_count);
   out.append("  timings: ");
   out.append("packed buffer [");
-  out.append(std::to_string(this->timings_count_));
+  append_uint(out, this->timings_count_);
   out.append(" values, ");
-  out.append(std::to_string(this->timings_length_));
+  append_uint(out, this->timings_length_);
   out.append(" bytes]\n");
   return out.c_str();
 }

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -742,40 +742,59 @@ template<> const char *proto_enum_to_string<enums::ZWaveProxyRequestType>(enums:
 }
 #endif
 
-void HelloRequest::dump_to(DumpBuffer &out) const {
+const char *HelloRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HelloRequest");
   dump_field(out, "client_info", this->client_info);
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
+  return out.c_str();
 }
-void HelloResponse::dump_to(DumpBuffer &out) const {
+const char *HelloResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HelloResponse");
   dump_field(out, "api_version_major", this->api_version_major);
   dump_field(out, "api_version_minor", this->api_version_minor);
   dump_field(out, "server_info", this->server_info);
   dump_field(out, "name", this->name);
+  return out.c_str();
 }
-void DisconnectRequest::dump_to(DumpBuffer &out) const { out.append("DisconnectRequest {}"); }
-void DisconnectResponse::dump_to(DumpBuffer &out) const { out.append("DisconnectResponse {}"); }
-void PingRequest::dump_to(DumpBuffer &out) const { out.append("PingRequest {}"); }
-void PingResponse::dump_to(DumpBuffer &out) const { out.append("PingResponse {}"); }
-void DeviceInfoRequest::dump_to(DumpBuffer &out) const { out.append("DeviceInfoRequest {}"); }
+const char *DisconnectRequest::dump_to(DumpBuffer &out) const {
+  out.append("DisconnectRequest {}");
+  return out.c_str();
+}
+const char *DisconnectResponse::dump_to(DumpBuffer &out) const {
+  out.append("DisconnectResponse {}");
+  return out.c_str();
+}
+const char *PingRequest::dump_to(DumpBuffer &out) const {
+  out.append("PingRequest {}");
+  return out.c_str();
+}
+const char *PingResponse::dump_to(DumpBuffer &out) const {
+  out.append("PingResponse {}");
+  return out.c_str();
+}
+const char *DeviceInfoRequest::dump_to(DumpBuffer &out) const {
+  out.append("DeviceInfoRequest {}");
+  return out.c_str();
+}
 #ifdef USE_AREAS
-void AreaInfo::dump_to(DumpBuffer &out) const {
+const char *AreaInfo::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AreaInfo");
   dump_field(out, "area_id", this->area_id);
   dump_field(out, "name", this->name);
+  return out.c_str();
 }
 #endif
 #ifdef USE_DEVICES
-void DeviceInfo::dump_to(DumpBuffer &out) const {
+const char *DeviceInfo::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DeviceInfo");
   dump_field(out, "device_id", this->device_id);
   dump_field(out, "name", this->name);
   dump_field(out, "area_id", this->area_id);
+  return out.c_str();
 }
 #endif
-void DeviceInfoResponse::dump_to(DumpBuffer &out) const {
+const char *DeviceInfoResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DeviceInfoResponse");
   dump_field(out, "name", this->name);
   dump_field(out, "mac_address", this->mac_address);
@@ -836,12 +855,22 @@ void DeviceInfoResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_ZWAVE_PROXY
   dump_field(out, "zwave_home_id", this->zwave_home_id);
 #endif
+  return out.c_str();
 }
-void ListEntitiesRequest::dump_to(DumpBuffer &out) const { out.append("ListEntitiesRequest {}"); }
-void ListEntitiesDoneResponse::dump_to(DumpBuffer &out) const { out.append("ListEntitiesDoneResponse {}"); }
-void SubscribeStatesRequest::dump_to(DumpBuffer &out) const { out.append("SubscribeStatesRequest {}"); }
+const char *ListEntitiesRequest::dump_to(DumpBuffer &out) const {
+  out.append("ListEntitiesRequest {}");
+  return out.c_str();
+}
+const char *ListEntitiesDoneResponse::dump_to(DumpBuffer &out) const {
+  out.append("ListEntitiesDoneResponse {}");
+  return out.c_str();
+}
+const char *SubscribeStatesRequest::dump_to(DumpBuffer &out) const {
+  out.append("SubscribeStatesRequest {}");
+  return out.c_str();
+}
 #ifdef USE_BINARY_SENSOR
-void ListEntitiesBinarySensorResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesBinarySensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesBinarySensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -856,8 +885,9 @@ void ListEntitiesBinarySensorResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void BinarySensorStateResponse::dump_to(DumpBuffer &out) const {
+const char *BinarySensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BinarySensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -865,10 +895,11 @@ void BinarySensorStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_COVER
-void ListEntitiesCoverResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesCoverResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesCoverResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -886,8 +917,9 @@ void ListEntitiesCoverResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void CoverStateResponse::dump_to(DumpBuffer &out) const {
+const char *CoverStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CoverStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
@@ -896,8 +928,9 @@ void CoverStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void CoverCommandRequest::dump_to(DumpBuffer &out) const {
+const char *CoverCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CoverCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
@@ -908,10 +941,11 @@ void CoverCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_FAN
-void ListEntitiesFanResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesFanResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesFanResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -931,8 +965,9 @@ void ListEntitiesFanResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void FanStateResponse::dump_to(DumpBuffer &out) const {
+const char *FanStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "FanStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -943,8 +978,9 @@ void FanStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void FanCommandRequest::dump_to(DumpBuffer &out) const {
+const char *FanCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "FanCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -960,10 +996,11 @@ void FanCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_LIGHT
-void ListEntitiesLightResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesLightResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesLightResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -984,8 +1021,9 @@ void ListEntitiesLightResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void LightStateResponse::dump_to(DumpBuffer &out) const {
+const char *LightStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LightStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1003,8 +1041,9 @@ void LightStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void LightCommandRequest::dump_to(DumpBuffer &out) const {
+const char *LightCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LightCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -1036,10 +1075,11 @@ void LightCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_SENSOR
-void ListEntitiesSensorResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesSensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1057,8 +1097,9 @@ void ListEntitiesSensorResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SensorStateResponse::dump_to(DumpBuffer &out) const {
+const char *SensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1066,10 +1107,11 @@ void SensorStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_SWITCH
-void ListEntitiesSwitchResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesSwitchResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSwitchResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1084,26 +1126,29 @@ void ListEntitiesSwitchResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SwitchStateResponse::dump_to(DumpBuffer &out) const {
+const char *SwitchStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SwitchStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SwitchCommandRequest::dump_to(DumpBuffer &out) const {
+const char *SwitchCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SwitchCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_TEXT_SENSOR
-void ListEntitiesTextSensorResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesTextSensorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTextSensorResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1117,8 +1162,9 @@ void ListEntitiesTextSensorResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void TextSensorStateResponse::dump_to(DumpBuffer &out) const {
+const char *TextSensorStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextSensorStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1126,38 +1172,45 @@ void TextSensorStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
-void SubscribeLogsRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeLogsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeLogsRequest");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   dump_field(out, "dump_config", this->dump_config);
+  return out.c_str();
 }
-void SubscribeLogsResponse::dump_to(DumpBuffer &out) const {
+const char *SubscribeLogsResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeLogsResponse");
   dump_field(out, "level", static_cast<enums::LogLevel>(this->level));
   dump_bytes_field(out, "message", this->message_ptr_, this->message_len_);
+  return out.c_str();
 }
 #ifdef USE_API_NOISE
-void NoiseEncryptionSetKeyRequest::dump_to(DumpBuffer &out) const {
+const char *NoiseEncryptionSetKeyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyRequest");
   dump_bytes_field(out, "key", this->key, this->key_len);
+  return out.c_str();
 }
-void NoiseEncryptionSetKeyResponse::dump_to(DumpBuffer &out) const {
+const char *NoiseEncryptionSetKeyResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NoiseEncryptionSetKeyResponse");
   dump_field(out, "success", this->success);
+  return out.c_str();
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_SERVICES
-void SubscribeHomeassistantServicesRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeHomeassistantServicesRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeHomeassistantServicesRequest {}");
+  return out.c_str();
 }
-void HomeassistantServiceMap::dump_to(DumpBuffer &out) const {
+const char *HomeassistantServiceMap::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantServiceMap");
   dump_field(out, "key", this->key);
   dump_field(out, "value", this->value);
+  return out.c_str();
 }
-void HomeassistantActionRequest::dump_to(DumpBuffer &out) const {
+const char *HomeassistantActionRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantActionRequest");
   dump_field(out, "service", this->service);
   for (const auto &it : this->data) {
@@ -1185,10 +1238,11 @@ void HomeassistantActionRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   dump_field(out, "response_template", this->response_template);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
-void HomeassistantActionResponse::dump_to(DumpBuffer &out) const {
+const char *HomeassistantActionResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeassistantActionResponse");
   dump_field(out, "call_id", this->call_id);
   dump_field(out, "success", this->success);
@@ -1196,38 +1250,47 @@ void HomeassistantActionResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   dump_bytes_field(out, "response_data", this->response_data, this->response_data_len);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
-void SubscribeHomeAssistantStatesRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeHomeAssistantStatesRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeHomeAssistantStatesRequest {}");
+  return out.c_str();
 }
-void SubscribeHomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
+const char *SubscribeHomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeHomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id);
   dump_field(out, "attribute", this->attribute);
   dump_field(out, "once", this->once);
+  return out.c_str();
 }
-void HomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
+const char *HomeAssistantStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HomeAssistantStateResponse");
   dump_field(out, "entity_id", this->entity_id);
   dump_field(out, "state", this->state);
   dump_field(out, "attribute", this->attribute);
+  return out.c_str();
 }
 #endif
-void GetTimeRequest::dump_to(DumpBuffer &out) const { out.append("GetTimeRequest {}"); }
-void GetTimeResponse::dump_to(DumpBuffer &out) const {
+const char *GetTimeRequest::dump_to(DumpBuffer &out) const {
+  out.append("GetTimeRequest {}");
+  return out.c_str();
+}
+const char *GetTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "GetTimeResponse");
   dump_field(out, "epoch_seconds", this->epoch_seconds);
   dump_field(out, "timezone", this->timezone);
+  return out.c_str();
 }
 #ifdef USE_API_USER_DEFINED_ACTIONS
-void ListEntitiesServicesArgument::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesServicesArgument::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesServicesArgument");
   dump_field(out, "name", this->name);
   dump_field(out, "type", static_cast<enums::ServiceArgType>(this->type));
+  return out.c_str();
 }
-void ListEntitiesServicesResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesServicesResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesServicesResponse");
   dump_field(out, "name", this->name);
   dump_field(out, "key", this->key);
@@ -1237,8 +1300,9 @@ void ListEntitiesServicesResponse::dump_to(DumpBuffer &out) const {
     out.append("\n");
   }
   dump_field(out, "supports_response", static_cast<enums::SupportsResponseType>(this->supports_response));
+  return out.c_str();
 }
-void ExecuteServiceArgument::dump_to(DumpBuffer &out) const {
+const char *ExecuteServiceArgument::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceArgument");
   dump_field(out, "bool_", this->bool_);
   dump_field(out, "legacy_int", this->legacy_int);
@@ -1257,8 +1321,9 @@ void ExecuteServiceArgument::dump_to(DumpBuffer &out) const {
   for (const auto &it : this->string_array) {
     dump_field(out, "string_array", it, 4);
   }
+  return out.c_str();
 }
-void ExecuteServiceRequest::dump_to(DumpBuffer &out) const {
+const char *ExecuteServiceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceRequest");
   dump_field(out, "key", this->key);
   for (const auto &it : this->args) {
@@ -1272,10 +1337,11 @@ void ExecuteServiceRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
   dump_field(out, "return_response", this->return_response);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-void ExecuteServiceResponse::dump_to(DumpBuffer &out) const {
+const char *ExecuteServiceResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ExecuteServiceResponse");
   dump_field(out, "call_id", this->call_id);
   dump_field(out, "success", this->success);
@@ -1283,10 +1349,11 @@ void ExecuteServiceResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
   dump_bytes_field(out, "response_data", this->response_data, this->response_data_len);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_CAMERA
-void ListEntitiesCameraResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesCameraResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesCameraResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1299,8 +1366,9 @@ void ListEntitiesCameraResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void CameraImageResponse::dump_to(DumpBuffer &out) const {
+const char *CameraImageResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CameraImageResponse");
   dump_field(out, "key", this->key);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
@@ -1308,15 +1376,17 @@ void CameraImageResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void CameraImageRequest::dump_to(DumpBuffer &out) const {
+const char *CameraImageRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "CameraImageRequest");
   dump_field(out, "single", this->single);
   dump_field(out, "stream", this->stream);
+  return out.c_str();
 }
 #endif
 #ifdef USE_CLIMATE
-void ListEntitiesClimateResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesClimateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesClimateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1359,8 +1429,9 @@ void ListEntitiesClimateResponse::dump_to(DumpBuffer &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
   dump_field(out, "feature_flags", this->feature_flags);
+  return out.c_str();
 }
-void ClimateStateResponse::dump_to(DumpBuffer &out) const {
+const char *ClimateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ClimateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "mode", static_cast<enums::ClimateMode>(this->mode));
@@ -1379,8 +1450,9 @@ void ClimateStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void ClimateCommandRequest::dump_to(DumpBuffer &out) const {
+const char *ClimateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ClimateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_mode", this->has_mode);
@@ -1406,10 +1478,11 @@ void ClimateCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_WATER_HEATER
-void ListEntitiesWaterHeaterResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesWaterHeaterResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesWaterHeaterResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1429,8 +1502,9 @@ void ListEntitiesWaterHeaterResponse::dump_to(DumpBuffer &out) const {
     dump_field(out, "supported_modes", static_cast<enums::WaterHeaterMode>(it), 4);
   }
   dump_field(out, "supported_features", this->supported_features);
+  return out.c_str();
 }
-void WaterHeaterStateResponse::dump_to(DumpBuffer &out) const {
+const char *WaterHeaterStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "WaterHeaterStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "current_temperature", this->current_temperature);
@@ -1442,8 +1516,9 @@ void WaterHeaterStateResponse::dump_to(DumpBuffer &out) const {
   dump_field(out, "state", this->state);
   dump_field(out, "target_temperature_low", this->target_temperature_low);
   dump_field(out, "target_temperature_high", this->target_temperature_high);
+  return out.c_str();
 }
-void WaterHeaterCommandRequest::dump_to(DumpBuffer &out) const {
+const char *WaterHeaterCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "WaterHeaterCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_fields", this->has_fields);
@@ -1455,10 +1530,11 @@ void WaterHeaterCommandRequest::dump_to(DumpBuffer &out) const {
   dump_field(out, "state", this->state);
   dump_field(out, "target_temperature_low", this->target_temperature_low);
   dump_field(out, "target_temperature_high", this->target_temperature_high);
+  return out.c_str();
 }
 #endif
 #ifdef USE_NUMBER
-void ListEntitiesNumberResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesNumberResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesNumberResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1477,8 +1553,9 @@ void ListEntitiesNumberResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void NumberStateResponse::dump_to(DumpBuffer &out) const {
+const char *NumberStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NumberStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1486,18 +1563,20 @@ void NumberStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void NumberCommandRequest::dump_to(DumpBuffer &out) const {
+const char *NumberCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "NumberCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_SELECT
-void ListEntitiesSelectResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesSelectResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSelectResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1513,8 +1592,9 @@ void ListEntitiesSelectResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SelectStateResponse::dump_to(DumpBuffer &out) const {
+const char *SelectStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SelectStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -1522,18 +1602,20 @@ void SelectStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SelectCommandRequest::dump_to(DumpBuffer &out) const {
+const char *SelectCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SelectCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_SIREN
-void ListEntitiesSirenResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesSirenResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesSirenResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1551,16 +1633,18 @@ void ListEntitiesSirenResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SirenStateResponse::dump_to(DumpBuffer &out) const {
+const char *SirenStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SirenStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void SirenCommandRequest::dump_to(DumpBuffer &out) const {
+const char *SirenCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SirenCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_state", this->has_state);
@@ -1574,10 +1658,11 @@ void SirenCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_LOCK
-void ListEntitiesLockResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesLockResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesLockResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1594,16 +1679,18 @@ void ListEntitiesLockResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void LockStateResponse::dump_to(DumpBuffer &out) const {
+const char *LockStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LockStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::LockState>(this->state));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void LockCommandRequest::dump_to(DumpBuffer &out) const {
+const char *LockCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "LockCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::LockCommand>(this->command));
@@ -1612,10 +1699,11 @@ void LockCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_BUTTON
-void ListEntitiesButtonResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesButtonResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesButtonResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1629,25 +1717,28 @@ void ListEntitiesButtonResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void ButtonCommandRequest::dump_to(DumpBuffer &out) const {
+const char *ButtonCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ButtonCommandRequest");
   dump_field(out, "key", this->key);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_MEDIA_PLAYER
-void MediaPlayerSupportedFormat::dump_to(DumpBuffer &out) const {
+const char *MediaPlayerSupportedFormat::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerSupportedFormat");
   dump_field(out, "format", this->format);
   dump_field(out, "sample_rate", this->sample_rate);
   dump_field(out, "num_channels", this->num_channels);
   dump_field(out, "purpose", static_cast<enums::MediaPlayerFormatPurpose>(this->purpose));
   dump_field(out, "sample_bytes", this->sample_bytes);
+  return out.c_str();
 }
-void ListEntitiesMediaPlayerResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesMediaPlayerResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesMediaPlayerResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -1667,8 +1758,9 @@ void ListEntitiesMediaPlayerResponse::dump_to(DumpBuffer &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
   dump_field(out, "feature_flags", this->feature_flags);
+  return out.c_str();
 }
-void MediaPlayerStateResponse::dump_to(DumpBuffer &out) const {
+const char *MediaPlayerStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::MediaPlayerState>(this->state));
@@ -1677,8 +1769,9 @@ void MediaPlayerStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void MediaPlayerCommandRequest::dump_to(DumpBuffer &out) const {
+const char *MediaPlayerCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "MediaPlayerCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_command", this->has_command);
@@ -1692,55 +1785,63 @@ void MediaPlayerCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-void SubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeBluetoothLEAdvertisementsRequest");
   dump_field(out, "flags", this->flags);
+  return out.c_str();
 }
-void BluetoothLERawAdvertisement::dump_to(DumpBuffer &out) const {
+const char *BluetoothLERawAdvertisement::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothLERawAdvertisement");
   dump_field(out, "address", this->address);
   dump_field(out, "rssi", this->rssi);
   dump_field(out, "address_type", this->address_type);
   dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
 }
-void BluetoothLERawAdvertisementsResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothLERawAdvertisementsResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothLERawAdvertisementsResponse");
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     out.append("  advertisements: ");
     this->advertisements[i].dump_to(out);
     out.append("\n");
   }
+  return out.c_str();
 }
-void BluetoothDeviceRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothDeviceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "request_type", static_cast<enums::BluetoothDeviceRequestType>(this->request_type));
   dump_field(out, "has_address_type", this->has_address_type);
   dump_field(out, "address_type", this->address_type);
+  return out.c_str();
 }
-void BluetoothDeviceConnectionResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothDeviceConnectionResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceConnectionResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "connected", this->connected);
   dump_field(out, "mtu", this->mtu);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void BluetoothGATTGetServicesRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTGetServicesRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesRequest");
   dump_field(out, "address", this->address);
+  return out.c_str();
 }
-void BluetoothGATTDescriptor::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTDescriptor::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTDescriptor");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
   }
   dump_field(out, "handle", this->handle);
   dump_field(out, "short_uuid", this->short_uuid);
+  return out.c_str();
 }
-void BluetoothGATTCharacteristic::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTCharacteristic::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTCharacteristic");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
@@ -1753,8 +1854,9 @@ void BluetoothGATTCharacteristic::dump_to(DumpBuffer &out) const {
     out.append("\n");
   }
   dump_field(out, "short_uuid", this->short_uuid);
+  return out.c_str();
 }
-void BluetoothGATTService::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTService::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTService");
   for (const auto &it : this->uuid) {
     dump_field(out, "uuid", it, 4);
@@ -1766,8 +1868,9 @@ void BluetoothGATTService::dump_to(DumpBuffer &out) const {
     out.append("\n");
   }
   dump_field(out, "short_uuid", this->short_uuid);
+  return out.c_str();
 }
-void BluetoothGATTGetServicesResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTGetServicesResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesResponse");
   dump_field(out, "address", this->address);
   for (const auto &it : this->services) {
@@ -1775,124 +1878,146 @@ void BluetoothGATTGetServicesResponse::dump_to(DumpBuffer &out) const {
     it.dump_to(out);
     out.append("\n");
   }
+  return out.c_str();
 }
-void BluetoothGATTGetServicesDoneResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTGetServicesDoneResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTGetServicesDoneResponse");
   dump_field(out, "address", this->address);
+  return out.c_str();
 }
-void BluetoothGATTReadRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTReadRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
+  return out.c_str();
 }
-void BluetoothGATTReadResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTReadResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
+  return out.c_str();
 }
-void BluetoothGATTWriteRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTWriteRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "response", this->response);
   dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
 }
-void BluetoothGATTReadDescriptorRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTReadDescriptorRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTReadDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
+  return out.c_str();
 }
-void BluetoothGATTWriteDescriptorRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTWriteDescriptorRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteDescriptorRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
 }
-void BluetoothGATTNotifyRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTNotifyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyRequest");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "enable", this->enable);
+  return out.c_str();
 }
-void BluetoothGATTNotifyDataResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTNotifyDataResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyDataResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
+  return out.c_str();
 }
-void SubscribeBluetoothConnectionsFreeRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeBluetoothConnectionsFreeRequest::dump_to(DumpBuffer &out) const {
   out.append("SubscribeBluetoothConnectionsFreeRequest {}");
+  return out.c_str();
 }
-void BluetoothConnectionsFreeResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothConnectionsFreeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothConnectionsFreeResponse");
   dump_field(out, "free", this->free);
   dump_field(out, "limit", this->limit);
   for (const auto &it : this->allocated) {
     dump_field(out, "allocated", it, 4);
   }
+  return out.c_str();
 }
-void BluetoothGATTErrorResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTErrorResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTErrorResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void BluetoothGATTWriteResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTWriteResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTWriteResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
+  return out.c_str();
 }
-void BluetoothGATTNotifyResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothGATTNotifyResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothGATTNotifyResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "handle", this->handle);
+  return out.c_str();
 }
-void BluetoothDevicePairingResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothDevicePairingResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDevicePairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "paired", this->paired);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void BluetoothDeviceUnpairingResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothDeviceUnpairingResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceUnpairingResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
+const char *UnsubscribeBluetoothLEAdvertisementsRequest::dump_to(DumpBuffer &out) const {
   out.append("UnsubscribeBluetoothLEAdvertisementsRequest {}");
+  return out.c_str();
 }
-void BluetoothDeviceClearCacheResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothDeviceClearCacheResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothDeviceClearCacheResponse");
   dump_field(out, "address", this->address);
   dump_field(out, "success", this->success);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void BluetoothScannerStateResponse::dump_to(DumpBuffer &out) const {
+const char *BluetoothScannerStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerStateResponse");
   dump_field(out, "state", static_cast<enums::BluetoothScannerState>(this->state));
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
   dump_field(out, "configured_mode", static_cast<enums::BluetoothScannerMode>(this->configured_mode));
+  return out.c_str();
 }
-void BluetoothScannerSetModeRequest::dump_to(DumpBuffer &out) const {
+const char *BluetoothScannerSetModeRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "BluetoothScannerSetModeRequest");
   dump_field(out, "mode", static_cast<enums::BluetoothScannerMode>(this->mode));
+  return out.c_str();
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
-void SubscribeVoiceAssistantRequest::dump_to(DumpBuffer &out) const {
+const char *SubscribeVoiceAssistantRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "SubscribeVoiceAssistantRequest");
   dump_field(out, "subscribe", this->subscribe);
   dump_field(out, "flags", this->flags);
+  return out.c_str();
 }
-void VoiceAssistantAudioSettings::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantAudioSettings::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAudioSettings");
   dump_field(out, "noise_suppression_level", this->noise_suppression_level);
   dump_field(out, "auto_gain", this->auto_gain);
   dump_field(out, "volume_multiplier", this->volume_multiplier);
+  return out.c_str();
 }
-void VoiceAssistantRequest::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantRequest");
   dump_field(out, "start", this->start);
   dump_field(out, "conversation_id", this->conversation_id);
@@ -1901,18 +2026,21 @@ void VoiceAssistantRequest::dump_to(DumpBuffer &out) const {
   this->audio_settings.dump_to(out);
   out.append("\n");
   dump_field(out, "wake_word_phrase", this->wake_word_phrase);
+  return out.c_str();
 }
-void VoiceAssistantResponse::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantResponse");
   dump_field(out, "port", this->port);
   dump_field(out, "error", this->error);
+  return out.c_str();
 }
-void VoiceAssistantEventData::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantEventData::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventData");
   dump_field(out, "name", this->name);
   dump_field(out, "value", this->value);
+  return out.c_str();
 }
-void VoiceAssistantEventResponse::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantEvent>(this->event_type));
   for (const auto &it : this->data) {
@@ -1920,13 +2048,15 @@ void VoiceAssistantEventResponse::dump_to(DumpBuffer &out) const {
     it.dump_to(out);
     out.append("\n");
   }
+  return out.c_str();
 }
-void VoiceAssistantAudio::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantAudio::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAudio");
   dump_bytes_field(out, "data", this->data, this->data_len);
   dump_field(out, "end", this->end);
+  return out.c_str();
 }
-void VoiceAssistantTimerEventResponse::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantTimerEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantTimerEventResponse");
   dump_field(out, "event_type", static_cast<enums::VoiceAssistantTimerEvent>(this->event_type));
   dump_field(out, "timer_id", this->timer_id);
@@ -1934,27 +2064,31 @@ void VoiceAssistantTimerEventResponse::dump_to(DumpBuffer &out) const {
   dump_field(out, "total_seconds", this->total_seconds);
   dump_field(out, "seconds_left", this->seconds_left);
   dump_field(out, "is_active", this->is_active);
+  return out.c_str();
 }
-void VoiceAssistantAnnounceRequest::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantAnnounceRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAnnounceRequest");
   dump_field(out, "media_id", this->media_id);
   dump_field(out, "text", this->text);
   dump_field(out, "preannounce_media_id", this->preannounce_media_id);
   dump_field(out, "start_conversation", this->start_conversation);
+  return out.c_str();
 }
-void VoiceAssistantAnnounceFinished::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantAnnounceFinished::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantAnnounceFinished");
   dump_field(out, "success", this->success);
+  return out.c_str();
 }
-void VoiceAssistantWakeWord::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantWakeWord::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantWakeWord");
   dump_field(out, "id", this->id);
   dump_field(out, "wake_word", this->wake_word);
   for (const auto &it : this->trained_languages) {
     dump_field(out, "trained_languages", it, 4);
   }
+  return out.c_str();
 }
-void VoiceAssistantExternalWakeWord::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantExternalWakeWord::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantExternalWakeWord");
   dump_field(out, "id", this->id);
   dump_field(out, "wake_word", this->wake_word);
@@ -1965,16 +2099,18 @@ void VoiceAssistantExternalWakeWord::dump_to(DumpBuffer &out) const {
   dump_field(out, "model_size", this->model_size);
   dump_field(out, "model_hash", this->model_hash);
   dump_field(out, "url", this->url);
+  return out.c_str();
 }
-void VoiceAssistantConfigurationRequest::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantConfigurationRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationRequest");
   for (const auto &it : this->external_wake_words) {
     out.append("  external_wake_words: ");
     it.dump_to(out);
     out.append("\n");
   }
+  return out.c_str();
 }
-void VoiceAssistantConfigurationResponse::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantConfigurationResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantConfigurationResponse");
   for (const auto &it : this->available_wake_words) {
     out.append("  available_wake_words: ");
@@ -1985,16 +2121,18 @@ void VoiceAssistantConfigurationResponse::dump_to(DumpBuffer &out) const {
     dump_field(out, "active_wake_words", it, 4);
   }
   dump_field(out, "max_active_wake_words", this->max_active_wake_words);
+  return out.c_str();
 }
-void VoiceAssistantSetConfiguration::dump_to(DumpBuffer &out) const {
+const char *VoiceAssistantSetConfiguration::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "VoiceAssistantSetConfiguration");
   for (const auto &it : this->active_wake_words) {
     dump_field(out, "active_wake_words", it, 4);
   }
+  return out.c_str();
 }
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-void ListEntitiesAlarmControlPanelResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesAlarmControlPanelResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesAlarmControlPanelResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2010,16 +2148,18 @@ void ListEntitiesAlarmControlPanelResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void AlarmControlPanelStateResponse::dump_to(DumpBuffer &out) const {
+const char *AlarmControlPanelStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AlarmControlPanelStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", static_cast<enums::AlarmControlPanelState>(this->state));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void AlarmControlPanelCommandRequest::dump_to(DumpBuffer &out) const {
+const char *AlarmControlPanelCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "AlarmControlPanelCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::AlarmControlPanelStateCommand>(this->command));
@@ -2027,10 +2167,11 @@ void AlarmControlPanelCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_TEXT
-void ListEntitiesTextResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesTextResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTextResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2047,8 +2188,9 @@ void ListEntitiesTextResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void TextStateResponse::dump_to(DumpBuffer &out) const {
+const char *TextStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
@@ -2056,18 +2198,20 @@ void TextStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void TextCommandRequest::dump_to(DumpBuffer &out) const {
+const char *TextCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TextCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "state", this->state);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_DATETIME_DATE
-void ListEntitiesDateResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesDateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesDateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2080,8 +2224,9 @@ void ListEntitiesDateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void DateStateResponse::dump_to(DumpBuffer &out) const {
+const char *DateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2091,8 +2236,9 @@ void DateStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void DateCommandRequest::dump_to(DumpBuffer &out) const {
+const char *DateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "year", this->year);
@@ -2101,10 +2247,11 @@ void DateCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_DATETIME_TIME
-void ListEntitiesTimeResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesTimeResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2117,8 +2264,9 @@ void ListEntitiesTimeResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void TimeStateResponse::dump_to(DumpBuffer &out) const {
+const char *TimeStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2128,8 +2276,9 @@ void TimeStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void TimeCommandRequest::dump_to(DumpBuffer &out) const {
+const char *TimeCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "TimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "hour", this->hour);
@@ -2138,10 +2287,11 @@ void TimeCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_EVENT
-void ListEntitiesEventResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesEventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesEventResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2158,18 +2308,20 @@ void ListEntitiesEventResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void EventResponse::dump_to(DumpBuffer &out) const {
+const char *EventResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "EventResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "event_type", this->event_type);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_VALVE
-void ListEntitiesValveResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesValveResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesValveResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2186,8 +2338,9 @@ void ListEntitiesValveResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void ValveStateResponse::dump_to(DumpBuffer &out) const {
+const char *ValveStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ValveStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "position", this->position);
@@ -2195,8 +2348,9 @@ void ValveStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void ValveCommandRequest::dump_to(DumpBuffer &out) const {
+const char *ValveCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ValveCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "has_position", this->has_position);
@@ -2205,10 +2359,11 @@ void ValveCommandRequest::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_DATETIME_DATETIME
-void ListEntitiesDateTimeResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesDateTimeResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesDateTimeResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2221,8 +2376,9 @@ void ListEntitiesDateTimeResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void DateTimeStateResponse::dump_to(DumpBuffer &out) const {
+const char *DateTimeStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateTimeStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2230,18 +2386,20 @@ void DateTimeStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void DateTimeCommandRequest::dump_to(DumpBuffer &out) const {
+const char *DateTimeCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "DateTimeCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "epoch_seconds", this->epoch_seconds);
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_UPDATE
-void ListEntitiesUpdateResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesUpdateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesUpdateResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2255,8 +2413,9 @@ void ListEntitiesUpdateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void UpdateStateResponse::dump_to(DumpBuffer &out) const {
+const char *UpdateStateResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "UpdateStateResponse");
   dump_field(out, "key", this->key);
   dump_field(out, "missing_state", this->missing_state);
@@ -2271,29 +2430,33 @@ void UpdateStateResponse::dump_to(DumpBuffer &out) const {
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
-void UpdateCommandRequest::dump_to(DumpBuffer &out) const {
+const char *UpdateCommandRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "UpdateCommandRequest");
   dump_field(out, "key", this->key);
   dump_field(out, "command", static_cast<enums::UpdateCommand>(this->command));
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
 #endif
+  return out.c_str();
 }
 #endif
 #ifdef USE_ZWAVE_PROXY
-void ZWaveProxyFrame::dump_to(DumpBuffer &out) const {
+const char *ZWaveProxyFrame::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyFrame");
   dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
 }
-void ZWaveProxyRequest::dump_to(DumpBuffer &out) const {
+const char *ZWaveProxyRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ZWaveProxyRequest");
   dump_field(out, "type", static_cast<enums::ZWaveProxyRequestType>(this->type));
   dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
 }
 #endif
 #ifdef USE_INFRARED
-void ListEntitiesInfraredResponse::dump_to(DumpBuffer &out) const {
+const char *ListEntitiesInfraredResponse::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "ListEntitiesInfraredResponse");
   dump_field(out, "object_id", this->object_id);
   dump_field(out, "key", this->key);
@@ -2307,10 +2470,11 @@ void ListEntitiesInfraredResponse::dump_to(DumpBuffer &out) const {
   dump_field(out, "device_id", this->device_id);
 #endif
   dump_field(out, "capabilities", this->capabilities);
+  return out.c_str();
 }
 #endif
 #ifdef USE_IR_RF
-void InfraredRFTransmitRawTimingsRequest::dump_to(DumpBuffer &out) const {
+const char *InfraredRFTransmitRawTimingsRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "InfraredRFTransmitRawTimingsRequest");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -2324,8 +2488,9 @@ void InfraredRFTransmitRawTimingsRequest::dump_to(DumpBuffer &out) const {
   out.append(" values, ");
   out.append(std::to_string(this->timings_length_));
   out.append(" bytes]\n");
+  return out.c_str();
 }
-void InfraredRFReceiveEvent::dump_to(DumpBuffer &out) const {
+const char *InfraredRFReceiveEvent::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "InfraredRFReceiveEvent");
 #ifdef USE_DEVICES
   dump_field(out, "device_id", this->device_id);
@@ -2334,6 +2499,7 @@ void InfraredRFReceiveEvent::dump_to(DumpBuffer &out) const {
   for (const auto &it : *this->timings) {
     dump_field(out, "timings", it, 4);
   }
+  return out.c_str();
 }
 #endif
 

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -8,8 +8,8 @@ namespace esphome::api {
 static const char *const TAG = "api.service";
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
-void APIServerConnectionBase::log_send_message_(const char *name, const std::string &dump) {
-  ESP_LOGVV(TAG, "send_message %s: %s", name, dump.c_str());
+void APIServerConnectionBase::log_send_message_(const char *name, const char *dump) {
+  ESP_LOGVV(TAG, "send_message %s: %s", name, dump);
 }
 #endif
 
@@ -19,7 +19,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HelloRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump());
 #endif
       this->on_hello_request(msg);
       break;
@@ -28,7 +28,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump());
 #endif
       this->on_disconnect_request(msg);
       break;
@@ -37,7 +37,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump());
 #endif
       this->on_disconnect_response(msg);
       break;
@@ -46,7 +46,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump());
 #endif
       this->on_ping_request(msg);
       break;
@@ -55,7 +55,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump());
 #endif
       this->on_ping_response(msg);
       break;
@@ -64,7 +64,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DeviceInfoRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump());
 #endif
       this->on_device_info_request(msg);
       break;
@@ -73,7 +73,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ListEntitiesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump());
 #endif
       this->on_list_entities_request(msg);
       break;
@@ -82,7 +82,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump());
 #endif
       this->on_subscribe_states_request(msg);
       break;
@@ -91,7 +91,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeLogsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump());
 #endif
       this->on_subscribe_logs_request(msg);
       break;
@@ -101,7 +101,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CoverCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump());
 #endif
       this->on_cover_command_request(msg);
       break;
@@ -112,7 +112,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       FanCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump());
 #endif
       this->on_fan_command_request(msg);
       break;
@@ -123,7 +123,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LightCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump());
 #endif
       this->on_light_command_request(msg);
       break;
@@ -134,7 +134,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SwitchCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump());
 #endif
       this->on_switch_command_request(msg);
       break;
@@ -145,7 +145,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeassistantServicesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump());
 #endif
       this->on_subscribe_homeassistant_services_request(msg);
       break;
@@ -155,7 +155,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump());
 #endif
       this->on_get_time_response(msg);
       break;
@@ -165,7 +165,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeAssistantStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump());
 #endif
       this->on_subscribe_home_assistant_states_request(msg);
       break;
@@ -176,7 +176,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeAssistantStateResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump());
 #endif
       this->on_home_assistant_state_response(msg);
       break;
@@ -187,7 +187,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump());
 #endif
       this->on_execute_service_request(msg);
       break;
@@ -198,7 +198,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CameraImageRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump());
 #endif
       this->on_camera_image_request(msg);
       break;
@@ -209,7 +209,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ClimateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump());
 #endif
       this->on_climate_command_request(msg);
       break;
@@ -220,7 +220,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NumberCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump());
 #endif
       this->on_number_command_request(msg);
       break;
@@ -231,7 +231,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SelectCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump());
 #endif
       this->on_select_command_request(msg);
       break;
@@ -242,7 +242,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SirenCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_siren_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_siren_command_request: %s", msg.dump());
 #endif
       this->on_siren_command_request(msg);
       break;
@@ -253,7 +253,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LockCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump());
 #endif
       this->on_lock_command_request(msg);
       break;
@@ -264,7 +264,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ButtonCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump());
 #endif
       this->on_button_command_request(msg);
       break;
@@ -275,7 +275,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       MediaPlayerCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump());
 #endif
       this->on_media_player_command_request(msg);
       break;
@@ -286,7 +286,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothLEAdvertisementsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump());
 #endif
       this->on_subscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -297,7 +297,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothDeviceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump());
 #endif
       this->on_bluetooth_device_request(msg);
       break;
@@ -308,7 +308,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTGetServicesRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_get_services_request(msg);
       break;
@@ -319,7 +319,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_read_request(msg);
       break;
@@ -330,7 +330,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_write_request(msg);
       break;
@@ -341,7 +341,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_read_descriptor_request(msg);
       break;
@@ -352,7 +352,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_write_descriptor_request(msg);
       break;
@@ -363,7 +363,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTNotifyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump());
 #endif
       this->on_bluetooth_gatt_notify_request(msg);
       break;
@@ -374,7 +374,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothConnectionsFreeRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump());
 #endif
       this->on_subscribe_bluetooth_connections_free_request(msg);
       break;
@@ -385,7 +385,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UnsubscribeBluetoothLEAdvertisementsRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump());
 #endif
       this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -396,7 +396,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeVoiceAssistantRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump());
 #endif
       this->on_subscribe_voice_assistant_request(msg);
       break;
@@ -407,7 +407,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump());
 #endif
       this->on_voice_assistant_response(msg);
       break;
@@ -418,7 +418,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump());
 #endif
       this->on_voice_assistant_event_response(msg);
       break;
@@ -429,7 +429,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       AlarmControlPanelCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump());
 #endif
       this->on_alarm_control_panel_command_request(msg);
       break;
@@ -440,7 +440,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TextCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump());
 #endif
       this->on_text_command_request(msg);
       break;
@@ -451,7 +451,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump());
 #endif
       this->on_date_command_request(msg);
       break;
@@ -462,7 +462,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump());
 #endif
       this->on_time_command_request(msg);
       break;
@@ -473,7 +473,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAudio msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump());
 #endif
       this->on_voice_assistant_audio(msg);
       break;
@@ -484,7 +484,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ValveCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump());
 #endif
       this->on_valve_command_request(msg);
       break;
@@ -495,7 +495,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateTimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump());
 #endif
       this->on_date_time_command_request(msg);
       break;
@@ -506,7 +506,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantTimerEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump());
 #endif
       this->on_voice_assistant_timer_event_response(msg);
       break;
@@ -517,7 +517,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UpdateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump());
 #endif
       this->on_update_command_request(msg);
       break;
@@ -528,7 +528,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump());
 #endif
       this->on_voice_assistant_announce_request(msg);
       break;
@@ -539,7 +539,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantConfigurationRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump());
 #endif
       this->on_voice_assistant_configuration_request(msg);
       break;
@@ -550,7 +550,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantSetConfiguration msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_set_configuration: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_voice_assistant_set_configuration: %s", msg.dump());
 #endif
       this->on_voice_assistant_set_configuration(msg);
       break;
@@ -561,7 +561,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NoiseEncryptionSetKeyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_noise_encryption_set_key_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_noise_encryption_set_key_request: %s", msg.dump());
 #endif
       this->on_noise_encryption_set_key_request(msg);
       break;
@@ -572,7 +572,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothScannerSetModeRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_scanner_set_mode_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_bluetooth_scanner_set_mode_request: %s", msg.dump());
 #endif
       this->on_bluetooth_scanner_set_mode_request(msg);
       break;
@@ -583,7 +583,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyFrame msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_z_wave_proxy_frame: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_z_wave_proxy_frame: %s", msg.dump());
 #endif
       this->on_z_wave_proxy_frame(msg);
       break;
@@ -594,7 +594,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_z_wave_proxy_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_z_wave_proxy_request: %s", msg.dump());
 #endif
       this->on_z_wave_proxy_request(msg);
       break;
@@ -605,7 +605,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeassistantActionResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_homeassistant_action_response: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_homeassistant_action_response: %s", msg.dump());
 #endif
       this->on_homeassistant_action_response(msg);
       break;
@@ -616,7 +616,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       WaterHeaterCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_water_heater_command_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_water_heater_command_request: %s", msg.dump());
 #endif
       this->on_water_heater_command_request(msg);
       break;
@@ -627,7 +627,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       InfraredRFTransmitRawTimingsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_infrared_rf_transmit_raw_timings_request: %s", msg.dump().c_str());
+      ESP_LOGVV(TAG, "on_infrared_rf_transmit_raw_timings_request: %s", msg.dump());
 #endif
       this->on_infrared_rf_transmit_raw_timings_request(msg);
       break;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -19,7 +19,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HelloRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_hello_request(msg);
       break;
@@ -28,7 +29,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_disconnect_request(msg);
       break;
@@ -37,7 +39,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_disconnect_response(msg);
       break;
@@ -46,7 +49,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_ping_request(msg);
       break;
@@ -55,7 +59,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_ping_response(msg);
       break;
@@ -64,7 +69,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DeviceInfoRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_device_info_request(msg);
       break;
@@ -73,7 +79,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ListEntitiesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_list_entities_request(msg);
       break;
@@ -82,7 +89,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_states_request(msg);
       break;
@@ -91,7 +99,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeLogsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_logs_request(msg);
       break;
@@ -101,7 +110,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CoverCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_cover_command_request(msg);
       break;
@@ -112,7 +122,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       FanCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_fan_command_request(msg);
       break;
@@ -123,7 +134,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LightCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_light_command_request(msg);
       break;
@@ -134,7 +146,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SwitchCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_switch_command_request(msg);
       break;
@@ -145,7 +158,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeassistantServicesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_homeassistant_services_request(msg);
       break;
@@ -155,7 +169,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_get_time_response(msg);
       break;
@@ -165,7 +180,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeAssistantStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_home_assistant_states_request(msg);
       break;
@@ -176,7 +192,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeAssistantStateResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_home_assistant_state_response(msg);
       break;
@@ -187,7 +204,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_execute_service_request(msg);
       break;
@@ -198,7 +216,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CameraImageRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_camera_image_request(msg);
       break;
@@ -209,7 +228,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ClimateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_climate_command_request(msg);
       break;
@@ -220,7 +240,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NumberCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_number_command_request(msg);
       break;
@@ -231,7 +252,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SelectCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_select_command_request(msg);
       break;
@@ -242,7 +264,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SirenCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_siren_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_siren_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_siren_command_request(msg);
       break;
@@ -253,7 +276,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LockCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_lock_command_request(msg);
       break;
@@ -264,7 +288,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ButtonCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_button_command_request(msg);
       break;
@@ -275,7 +300,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       MediaPlayerCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_media_player_command_request(msg);
       break;
@@ -286,7 +312,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothLEAdvertisementsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -297,7 +324,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothDeviceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_device_request(msg);
       break;
@@ -308,7 +336,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTGetServicesRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_get_services_request(msg);
       break;
@@ -319,7 +348,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_read_request(msg);
       break;
@@ -330,7 +360,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_write_request(msg);
       break;
@@ -341,7 +372,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_read_descriptor_request(msg);
       break;
@@ -352,7 +384,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_write_descriptor_request(msg);
       break;
@@ -363,7 +396,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTNotifyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_gatt_notify_request(msg);
       break;
@@ -374,7 +408,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothConnectionsFreeRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_bluetooth_connections_free_request(msg);
       break;
@@ -385,7 +420,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UnsubscribeBluetoothLEAdvertisementsRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -396,7 +432,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeVoiceAssistantRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_subscribe_voice_assistant_request(msg);
       break;
@@ -407,7 +444,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_response(msg);
       break;
@@ -418,7 +456,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_event_response(msg);
       break;
@@ -429,7 +468,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       AlarmControlPanelCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_alarm_control_panel_command_request(msg);
       break;
@@ -440,7 +480,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TextCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_text_command_request(msg);
       break;
@@ -451,7 +492,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_date_command_request(msg);
       break;
@@ -462,7 +504,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_time_command_request(msg);
       break;
@@ -473,7 +516,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAudio msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_audio(msg);
       break;
@@ -484,7 +528,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ValveCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_valve_command_request(msg);
       break;
@@ -495,7 +540,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateTimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_date_time_command_request(msg);
       break;
@@ -506,7 +552,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantTimerEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_timer_event_response(msg);
       break;
@@ -517,7 +564,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UpdateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_update_command_request(msg);
       break;
@@ -528,7 +576,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_announce_request(msg);
       break;
@@ -539,7 +588,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantConfigurationRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_configuration_request(msg);
       break;
@@ -550,7 +600,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantSetConfiguration msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_voice_assistant_set_configuration: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_voice_assistant_set_configuration: %s", msg.dump_to(dump_buf));
 #endif
       this->on_voice_assistant_set_configuration(msg);
       break;
@@ -561,7 +612,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NoiseEncryptionSetKeyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_noise_encryption_set_key_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_noise_encryption_set_key_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_noise_encryption_set_key_request(msg);
       break;
@@ -572,7 +624,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothScannerSetModeRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_bluetooth_scanner_set_mode_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_bluetooth_scanner_set_mode_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_bluetooth_scanner_set_mode_request(msg);
       break;
@@ -583,7 +636,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyFrame msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_z_wave_proxy_frame: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_z_wave_proxy_frame: %s", msg.dump_to(dump_buf));
 #endif
       this->on_z_wave_proxy_frame(msg);
       break;
@@ -594,7 +648,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_z_wave_proxy_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_z_wave_proxy_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_z_wave_proxy_request(msg);
       break;
@@ -605,7 +660,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeassistantActionResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_homeassistant_action_response: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_homeassistant_action_response: %s", msg.dump_to(dump_buf));
 #endif
       this->on_homeassistant_action_response(msg);
       break;
@@ -616,7 +672,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       WaterHeaterCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_water_heater_command_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_water_heater_command_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_water_heater_command_request(msg);
       break;
@@ -627,7 +684,8 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       InfraredRFTransmitRawTimingsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      ESP_LOGVV(TAG, "on_infrared_rf_transmit_raw_timings_request: %s", msg.dump());
+      DumpBuffer dump_buf;
+      ESP_LOGVV(TAG, "on_infrared_rf_transmit_raw_timings_request: %s", msg.dump_to(dump_buf));
 #endif
       this->on_infrared_rf_transmit_raw_timings_request(msg);
       break;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -11,6 +11,10 @@ static const char *const TAG = "api.service";
 void APIServerConnectionBase::log_send_message_(const char *name, const char *dump) {
   ESP_LOGVV(TAG, "send_message %s: %s", name, dump);
 }
+void APIServerConnectionBase::log_receive_message_(const char *name, const ProtoMessage &msg) {
+  DumpBuffer dump_buf;
+  ESP_LOGVV(TAG, "%s: %s", name, msg.dump_to(dump_buf));
+}
 #endif
 
 void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) {
@@ -19,8 +23,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HelloRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_hello_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_hello_request", msg);
 #endif
       this->on_hello_request(msg);
       break;
@@ -29,8 +32,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_disconnect_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_disconnect_request", msg);
 #endif
       this->on_disconnect_request(msg);
       break;
@@ -39,8 +41,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_disconnect_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_disconnect_response", msg);
 #endif
       this->on_disconnect_response(msg);
       break;
@@ -49,8 +50,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_ping_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_ping_request", msg);
 #endif
       this->on_ping_request(msg);
       break;
@@ -59,8 +59,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_ping_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_ping_response", msg);
 #endif
       this->on_ping_response(msg);
       break;
@@ -69,8 +68,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DeviceInfoRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_device_info_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_device_info_request", msg);
 #endif
       this->on_device_info_request(msg);
       break;
@@ -79,8 +77,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ListEntitiesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_list_entities_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_list_entities_request", msg);
 #endif
       this->on_list_entities_request(msg);
       break;
@@ -89,8 +86,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_states_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_states_request", msg);
 #endif
       this->on_subscribe_states_request(msg);
       break;
@@ -99,8 +95,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeLogsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_logs_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_logs_request", msg);
 #endif
       this->on_subscribe_logs_request(msg);
       break;
@@ -110,8 +105,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CoverCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_cover_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_cover_command_request", msg);
 #endif
       this->on_cover_command_request(msg);
       break;
@@ -122,8 +116,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       FanCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_fan_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_fan_command_request", msg);
 #endif
       this->on_fan_command_request(msg);
       break;
@@ -134,8 +127,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LightCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_light_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_light_command_request", msg);
 #endif
       this->on_light_command_request(msg);
       break;
@@ -146,8 +138,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SwitchCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_switch_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_switch_command_request", msg);
 #endif
       this->on_switch_command_request(msg);
       break;
@@ -158,8 +149,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeassistantServicesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_homeassistant_services_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_homeassistant_services_request", msg);
 #endif
       this->on_subscribe_homeassistant_services_request(msg);
       break;
@@ -169,8 +159,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_get_time_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_get_time_response", msg);
 #endif
       this->on_get_time_response(msg);
       break;
@@ -180,8 +169,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeAssistantStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_home_assistant_states_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_home_assistant_states_request", msg);
 #endif
       this->on_subscribe_home_assistant_states_request(msg);
       break;
@@ -192,8 +180,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeAssistantStateResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_home_assistant_state_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_home_assistant_state_response", msg);
 #endif
       this->on_home_assistant_state_response(msg);
       break;
@@ -204,8 +191,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_execute_service_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_execute_service_request", msg);
 #endif
       this->on_execute_service_request(msg);
       break;
@@ -216,8 +202,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CameraImageRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_camera_image_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_camera_image_request", msg);
 #endif
       this->on_camera_image_request(msg);
       break;
@@ -228,8 +213,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ClimateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_climate_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_climate_command_request", msg);
 #endif
       this->on_climate_command_request(msg);
       break;
@@ -240,8 +224,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NumberCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_number_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_number_command_request", msg);
 #endif
       this->on_number_command_request(msg);
       break;
@@ -252,8 +235,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SelectCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_select_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_select_command_request", msg);
 #endif
       this->on_select_command_request(msg);
       break;
@@ -264,8 +246,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SirenCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_siren_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_siren_command_request", msg);
 #endif
       this->on_siren_command_request(msg);
       break;
@@ -276,8 +257,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LockCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_lock_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_lock_command_request", msg);
 #endif
       this->on_lock_command_request(msg);
       break;
@@ -288,8 +268,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ButtonCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_button_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_button_command_request", msg);
 #endif
       this->on_button_command_request(msg);
       break;
@@ -300,8 +279,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       MediaPlayerCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_media_player_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_media_player_command_request", msg);
 #endif
       this->on_media_player_command_request(msg);
       break;
@@ -312,8 +290,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothLEAdvertisementsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_le_advertisements_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_bluetooth_le_advertisements_request", msg);
 #endif
       this->on_subscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -324,8 +301,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothDeviceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_device_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_device_request", msg);
 #endif
       this->on_bluetooth_device_request(msg);
       break;
@@ -336,8 +312,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTGetServicesRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_get_services_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_get_services_request", msg);
 #endif
       this->on_bluetooth_gatt_get_services_request(msg);
       break;
@@ -348,8 +323,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_read_request", msg);
 #endif
       this->on_bluetooth_gatt_read_request(msg);
       break;
@@ -360,8 +334,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_write_request", msg);
 #endif
       this->on_bluetooth_gatt_write_request(msg);
       break;
@@ -372,8 +345,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_read_descriptor_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_read_descriptor_request", msg);
 #endif
       this->on_bluetooth_gatt_read_descriptor_request(msg);
       break;
@@ -384,8 +356,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_write_descriptor_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_write_descriptor_request", msg);
 #endif
       this->on_bluetooth_gatt_write_descriptor_request(msg);
       break;
@@ -396,8 +367,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTNotifyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_gatt_notify_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_gatt_notify_request", msg);
 #endif
       this->on_bluetooth_gatt_notify_request(msg);
       break;
@@ -408,8 +378,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothConnectionsFreeRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_bluetooth_connections_free_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_bluetooth_connections_free_request", msg);
 #endif
       this->on_subscribe_bluetooth_connections_free_request(msg);
       break;
@@ -420,8 +389,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UnsubscribeBluetoothLEAdvertisementsRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_unsubscribe_bluetooth_le_advertisements_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_unsubscribe_bluetooth_le_advertisements_request", msg);
 #endif
       this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -432,8 +400,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeVoiceAssistantRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_subscribe_voice_assistant_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_subscribe_voice_assistant_request", msg);
 #endif
       this->on_subscribe_voice_assistant_request(msg);
       break;
@@ -444,8 +411,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_response", msg);
 #endif
       this->on_voice_assistant_response(msg);
       break;
@@ -456,8 +422,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_event_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_event_response", msg);
 #endif
       this->on_voice_assistant_event_response(msg);
       break;
@@ -468,8 +433,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       AlarmControlPanelCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_alarm_control_panel_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_alarm_control_panel_command_request", msg);
 #endif
       this->on_alarm_control_panel_command_request(msg);
       break;
@@ -480,8 +444,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TextCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_text_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_text_command_request", msg);
 #endif
       this->on_text_command_request(msg);
       break;
@@ -492,8 +455,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_date_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_date_command_request", msg);
 #endif
       this->on_date_command_request(msg);
       break;
@@ -504,8 +466,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_time_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_time_command_request", msg);
 #endif
       this->on_time_command_request(msg);
       break;
@@ -516,8 +477,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAudio msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_audio: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_audio", msg);
 #endif
       this->on_voice_assistant_audio(msg);
       break;
@@ -528,8 +488,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ValveCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_valve_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_valve_command_request", msg);
 #endif
       this->on_valve_command_request(msg);
       break;
@@ -540,8 +499,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateTimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_date_time_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_date_time_command_request", msg);
 #endif
       this->on_date_time_command_request(msg);
       break;
@@ -552,8 +510,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantTimerEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_timer_event_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_timer_event_response", msg);
 #endif
       this->on_voice_assistant_timer_event_response(msg);
       break;
@@ -564,8 +521,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UpdateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_update_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_update_command_request", msg);
 #endif
       this->on_update_command_request(msg);
       break;
@@ -576,8 +532,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_announce_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_announce_request", msg);
 #endif
       this->on_voice_assistant_announce_request(msg);
       break;
@@ -588,8 +543,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantConfigurationRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_configuration_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_configuration_request", msg);
 #endif
       this->on_voice_assistant_configuration_request(msg);
       break;
@@ -600,8 +554,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantSetConfiguration msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_voice_assistant_set_configuration: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_voice_assistant_set_configuration", msg);
 #endif
       this->on_voice_assistant_set_configuration(msg);
       break;
@@ -612,8 +565,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NoiseEncryptionSetKeyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_noise_encryption_set_key_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_noise_encryption_set_key_request", msg);
 #endif
       this->on_noise_encryption_set_key_request(msg);
       break;
@@ -624,8 +576,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothScannerSetModeRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_bluetooth_scanner_set_mode_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_bluetooth_scanner_set_mode_request", msg);
 #endif
       this->on_bluetooth_scanner_set_mode_request(msg);
       break;
@@ -636,8 +587,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyFrame msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_z_wave_proxy_frame: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_z_wave_proxy_frame", msg);
 #endif
       this->on_z_wave_proxy_frame(msg);
       break;
@@ -648,8 +598,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_z_wave_proxy_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_z_wave_proxy_request", msg);
 #endif
       this->on_z_wave_proxy_request(msg);
       break;
@@ -660,8 +609,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeassistantActionResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_homeassistant_action_response: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_homeassistant_action_response", msg);
 #endif
       this->on_homeassistant_action_response(msg);
       break;
@@ -672,8 +620,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       WaterHeaterCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_water_heater_command_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_water_heater_command_request", msg);
 #endif
       this->on_water_heater_command_request(msg);
       break;
@@ -684,8 +631,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       InfraredRFTransmitRawTimingsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      DumpBuffer dump_buf;
-      ESP_LOGVV(TAG, "on_infrared_rf_transmit_raw_timings_request: %s", msg.dump_to(dump_buf));
+      this->log_receive_message_("on_infrared_rf_transmit_raw_timings_request", msg);
 #endif
       this->on_infrared_rf_transmit_raw_timings_request(msg);
       break;

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -11,9 +11,9 @@ static const char *const TAG = "api.service";
 void APIServerConnectionBase::log_send_message_(const char *name, const char *dump) {
   ESP_LOGVV(TAG, "send_message %s: %s", name, dump);
 }
-void APIServerConnectionBase::log_receive_message_(const char *name, const ProtoMessage &msg) {
+void APIServerConnectionBase::log_receive_message_(const LogString *name, const ProtoMessage &msg) {
   DumpBuffer dump_buf;
-  ESP_LOGVV(TAG, "%s: %s", name, msg.dump_to(dump_buf));
+  ESP_LOGVV(TAG, "%s: %s", LOG_STR_ARG(name), msg.dump_to(dump_buf));
 }
 #endif
 
@@ -23,7 +23,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HelloRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_hello_request", msg);
+      this->log_receive_message_(LOG_STR("on_hello_request"), msg);
 #endif
       this->on_hello_request(msg);
       break;
@@ -32,7 +32,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_disconnect_request", msg);
+      this->log_receive_message_(LOG_STR("on_disconnect_request"), msg);
 #endif
       this->on_disconnect_request(msg);
       break;
@@ -41,7 +41,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DisconnectResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_disconnect_response", msg);
+      this->log_receive_message_(LOG_STR("on_disconnect_response"), msg);
 #endif
       this->on_disconnect_response(msg);
       break;
@@ -50,7 +50,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_ping_request", msg);
+      this->log_receive_message_(LOG_STR("on_ping_request"), msg);
 #endif
       this->on_ping_request(msg);
       break;
@@ -59,7 +59,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       PingResponse msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_ping_response", msg);
+      this->log_receive_message_(LOG_STR("on_ping_response"), msg);
 #endif
       this->on_ping_response(msg);
       break;
@@ -68,7 +68,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DeviceInfoRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_device_info_request", msg);
+      this->log_receive_message_(LOG_STR("on_device_info_request"), msg);
 #endif
       this->on_device_info_request(msg);
       break;
@@ -77,7 +77,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ListEntitiesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_list_entities_request", msg);
+      this->log_receive_message_(LOG_STR("on_list_entities_request"), msg);
 #endif
       this->on_list_entities_request(msg);
       break;
@@ -86,7 +86,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_states_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_states_request"), msg);
 #endif
       this->on_subscribe_states_request(msg);
       break;
@@ -95,7 +95,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeLogsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_logs_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_logs_request"), msg);
 #endif
       this->on_subscribe_logs_request(msg);
       break;
@@ -105,7 +105,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CoverCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_cover_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_cover_command_request"), msg);
 #endif
       this->on_cover_command_request(msg);
       break;
@@ -116,7 +116,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       FanCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_fan_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_fan_command_request"), msg);
 #endif
       this->on_fan_command_request(msg);
       break;
@@ -127,7 +127,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LightCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_light_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_light_command_request"), msg);
 #endif
       this->on_light_command_request(msg);
       break;
@@ -138,7 +138,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SwitchCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_switch_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_switch_command_request"), msg);
 #endif
       this->on_switch_command_request(msg);
       break;
@@ -149,7 +149,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeassistantServicesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_homeassistant_services_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_homeassistant_services_request"), msg);
 #endif
       this->on_subscribe_homeassistant_services_request(msg);
       break;
@@ -159,7 +159,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       GetTimeResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_get_time_response", msg);
+      this->log_receive_message_(LOG_STR("on_get_time_response"), msg);
 #endif
       this->on_get_time_response(msg);
       break;
@@ -169,7 +169,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeHomeAssistantStatesRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_home_assistant_states_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_home_assistant_states_request"), msg);
 #endif
       this->on_subscribe_home_assistant_states_request(msg);
       break;
@@ -180,7 +180,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeAssistantStateResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_home_assistant_state_response", msg);
+      this->log_receive_message_(LOG_STR("on_home_assistant_state_response"), msg);
 #endif
       this->on_home_assistant_state_response(msg);
       break;
@@ -191,7 +191,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ExecuteServiceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_execute_service_request", msg);
+      this->log_receive_message_(LOG_STR("on_execute_service_request"), msg);
 #endif
       this->on_execute_service_request(msg);
       break;
@@ -202,7 +202,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       CameraImageRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_camera_image_request", msg);
+      this->log_receive_message_(LOG_STR("on_camera_image_request"), msg);
 #endif
       this->on_camera_image_request(msg);
       break;
@@ -213,7 +213,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ClimateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_climate_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_climate_command_request"), msg);
 #endif
       this->on_climate_command_request(msg);
       break;
@@ -224,7 +224,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NumberCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_number_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_number_command_request"), msg);
 #endif
       this->on_number_command_request(msg);
       break;
@@ -235,7 +235,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SelectCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_select_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_select_command_request"), msg);
 #endif
       this->on_select_command_request(msg);
       break;
@@ -246,7 +246,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SirenCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_siren_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_siren_command_request"), msg);
 #endif
       this->on_siren_command_request(msg);
       break;
@@ -257,7 +257,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       LockCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_lock_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_lock_command_request"), msg);
 #endif
       this->on_lock_command_request(msg);
       break;
@@ -268,7 +268,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ButtonCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_button_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_button_command_request"), msg);
 #endif
       this->on_button_command_request(msg);
       break;
@@ -279,7 +279,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       MediaPlayerCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_media_player_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_media_player_command_request"), msg);
 #endif
       this->on_media_player_command_request(msg);
       break;
@@ -290,7 +290,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothLEAdvertisementsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_bluetooth_le_advertisements_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_bluetooth_le_advertisements_request"), msg);
 #endif
       this->on_subscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -301,7 +301,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothDeviceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_device_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_device_request"), msg);
 #endif
       this->on_bluetooth_device_request(msg);
       break;
@@ -312,7 +312,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTGetServicesRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_get_services_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_get_services_request"), msg);
 #endif
       this->on_bluetooth_gatt_get_services_request(msg);
       break;
@@ -323,7 +323,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_read_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_read_request"), msg);
 #endif
       this->on_bluetooth_gatt_read_request(msg);
       break;
@@ -334,7 +334,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_write_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_write_request"), msg);
 #endif
       this->on_bluetooth_gatt_write_request(msg);
       break;
@@ -345,7 +345,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTReadDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_read_descriptor_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_read_descriptor_request"), msg);
 #endif
       this->on_bluetooth_gatt_read_descriptor_request(msg);
       break;
@@ -356,7 +356,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTWriteDescriptorRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_write_descriptor_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_write_descriptor_request"), msg);
 #endif
       this->on_bluetooth_gatt_write_descriptor_request(msg);
       break;
@@ -367,7 +367,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothGATTNotifyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_gatt_notify_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_gatt_notify_request"), msg);
 #endif
       this->on_bluetooth_gatt_notify_request(msg);
       break;
@@ -378,7 +378,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeBluetoothConnectionsFreeRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_bluetooth_connections_free_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_bluetooth_connections_free_request"), msg);
 #endif
       this->on_subscribe_bluetooth_connections_free_request(msg);
       break;
@@ -389,7 +389,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UnsubscribeBluetoothLEAdvertisementsRequest msg;
       // Empty message: no decode needed
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_unsubscribe_bluetooth_le_advertisements_request", msg);
+      this->log_receive_message_(LOG_STR("on_unsubscribe_bluetooth_le_advertisements_request"), msg);
 #endif
       this->on_unsubscribe_bluetooth_le_advertisements_request(msg);
       break;
@@ -400,7 +400,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       SubscribeVoiceAssistantRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_subscribe_voice_assistant_request", msg);
+      this->log_receive_message_(LOG_STR("on_subscribe_voice_assistant_request"), msg);
 #endif
       this->on_subscribe_voice_assistant_request(msg);
       break;
@@ -411,7 +411,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_response", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_response"), msg);
 #endif
       this->on_voice_assistant_response(msg);
       break;
@@ -422,7 +422,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_event_response", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_event_response"), msg);
 #endif
       this->on_voice_assistant_event_response(msg);
       break;
@@ -433,7 +433,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       AlarmControlPanelCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_alarm_control_panel_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_alarm_control_panel_command_request"), msg);
 #endif
       this->on_alarm_control_panel_command_request(msg);
       break;
@@ -444,7 +444,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TextCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_text_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_text_command_request"), msg);
 #endif
       this->on_text_command_request(msg);
       break;
@@ -455,7 +455,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_date_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_date_command_request"), msg);
 #endif
       this->on_date_command_request(msg);
       break;
@@ -466,7 +466,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       TimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_time_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_time_command_request"), msg);
 #endif
       this->on_time_command_request(msg);
       break;
@@ -477,7 +477,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAudio msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_audio", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_audio"), msg);
 #endif
       this->on_voice_assistant_audio(msg);
       break;
@@ -488,7 +488,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ValveCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_valve_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_valve_command_request"), msg);
 #endif
       this->on_valve_command_request(msg);
       break;
@@ -499,7 +499,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       DateTimeCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_date_time_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_date_time_command_request"), msg);
 #endif
       this->on_date_time_command_request(msg);
       break;
@@ -510,7 +510,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantTimerEventResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_timer_event_response", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_timer_event_response"), msg);
 #endif
       this->on_voice_assistant_timer_event_response(msg);
       break;
@@ -521,7 +521,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       UpdateCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_update_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_update_command_request"), msg);
 #endif
       this->on_update_command_request(msg);
       break;
@@ -532,7 +532,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantAnnounceRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_announce_request", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_announce_request"), msg);
 #endif
       this->on_voice_assistant_announce_request(msg);
       break;
@@ -543,7 +543,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantConfigurationRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_configuration_request", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_configuration_request"), msg);
 #endif
       this->on_voice_assistant_configuration_request(msg);
       break;
@@ -554,7 +554,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       VoiceAssistantSetConfiguration msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_voice_assistant_set_configuration", msg);
+      this->log_receive_message_(LOG_STR("on_voice_assistant_set_configuration"), msg);
 #endif
       this->on_voice_assistant_set_configuration(msg);
       break;
@@ -565,7 +565,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       NoiseEncryptionSetKeyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_noise_encryption_set_key_request", msg);
+      this->log_receive_message_(LOG_STR("on_noise_encryption_set_key_request"), msg);
 #endif
       this->on_noise_encryption_set_key_request(msg);
       break;
@@ -576,7 +576,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       BluetoothScannerSetModeRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_bluetooth_scanner_set_mode_request", msg);
+      this->log_receive_message_(LOG_STR("on_bluetooth_scanner_set_mode_request"), msg);
 #endif
       this->on_bluetooth_scanner_set_mode_request(msg);
       break;
@@ -587,7 +587,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyFrame msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_z_wave_proxy_frame", msg);
+      this->log_receive_message_(LOG_STR("on_z_wave_proxy_frame"), msg);
 #endif
       this->on_z_wave_proxy_frame(msg);
       break;
@@ -598,7 +598,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       ZWaveProxyRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_z_wave_proxy_request", msg);
+      this->log_receive_message_(LOG_STR("on_z_wave_proxy_request"), msg);
 #endif
       this->on_z_wave_proxy_request(msg);
       break;
@@ -609,7 +609,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       HomeassistantActionResponse msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_homeassistant_action_response", msg);
+      this->log_receive_message_(LOG_STR("on_homeassistant_action_response"), msg);
 #endif
       this->on_homeassistant_action_response(msg);
       break;
@@ -620,7 +620,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       WaterHeaterCommandRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_water_heater_command_request", msg);
+      this->log_receive_message_(LOG_STR("on_water_heater_command_request"), msg);
 #endif
       this->on_water_heater_command_request(msg);
       break;
@@ -631,7 +631,7 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       InfraredRFTransmitRawTimingsRequest msg;
       msg.decode(msg_data, msg_size);
 #ifdef HAS_PROTO_MESSAGE_DUMP
-      this->log_receive_message_("on_infrared_rf_transmit_raw_timings_request", msg);
+      this->log_receive_message_(LOG_STR("on_infrared_rf_transmit_raw_timings_request"), msg);
 #endif
       this->on_infrared_rf_transmit_raw_timings_request(msg);
       break;

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -12,7 +12,7 @@ class APIServerConnectionBase : public ProtoService {
  public:
 #ifdef HAS_PROTO_MESSAGE_DUMP
  protected:
-  void log_send_message_(const char *name, const std::string &dump);
+  void log_send_message_(const char *name, const char *dump);
 
  public:
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -13,6 +13,7 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef HAS_PROTO_MESSAGE_DUMP
  protected:
   void log_send_message_(const char *name, const char *dump);
+  void log_receive_message_(const char *name, const ProtoMessage &msg);
 
  public:
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -13,7 +13,7 @@ class APIServerConnectionBase : public ProtoService {
 #ifdef HAS_PROTO_MESSAGE_DUMP
  protected:
   void log_send_message_(const char *name, const char *dump);
-  void log_receive_message_(const char *name, const ProtoMessage &msg);
+  void log_receive_message_(const LogString *name, const ProtoMessage &msg);
 
  public:
 #endif

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -19,7 +19,8 @@ class APIServerConnectionBase : public ProtoService {
 
   bool send_message(const ProtoMessage &msg, uint8_t message_type) {
 #ifdef HAS_PROTO_MESSAGE_DUMP
-    this->log_send_message_(msg.message_name(), msg.dump());
+    DumpBuffer dump_buf;
+    this->log_send_message_(msg.message_name(), msg.dump_to(dump_buf));
 #endif
     return this->send_message_(msg, message_type);
   }

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -139,13 +139,4 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
   }
 }
 
-#ifdef HAS_PROTO_MESSAGE_DUMP
-const char *ProtoMessage::dump() const {
-  static DumpBuffer buf;
-  buf = DumpBuffer();  // Reset buffer
-  this->dump_to(buf);
-  return buf.c_str();
-}
-#endif
-
 }  // namespace esphome::api

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -140,10 +140,11 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
 }
 
 #ifdef HAS_PROTO_MESSAGE_DUMP
-std::string ProtoMessage::dump() const {
-  std::string out;
-  this->dump_to(out);
-  return out;
+const char *ProtoMessage::dump() const {
+  static DumpBuffer buf;
+  buf = DumpBuffer();  // Reset buffer
+  this->dump_to(buf);
+  return buf.c_str();
 }
 #endif
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -427,8 +427,7 @@ class ProtoMessage {
   // Default implementation for messages with no fields
   virtual void calculate_size(ProtoSize &size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  const char *dump() const;
-  virtual void dump_to(DumpBuffer &out) const = 0;
+  virtual const char *dump_to(DumpBuffer &out) const = 0;
   virtual const char *message_name() const { return "unknown"; }
 #endif
 };

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -362,6 +362,63 @@ class ProtoWriteBuffer {
   std::vector<uint8_t> *buffer_;
 };
 
+#ifdef HAS_PROTO_MESSAGE_DUMP
+/**
+ * Fixed-size buffer for message dumps - avoids heap allocation.
+ * Sized to match the logger's default tx_buffer_size (512 bytes)
+ * since anything larger gets truncated anyway.
+ */
+class DumpBuffer {
+ public:
+  // Matches default tx_buffer_size in logger component
+  static constexpr size_t CAPACITY = 512;
+
+  DumpBuffer() : pos_(0) { buf_[0] = '\0'; }
+
+  DumpBuffer &append(const char *str) {
+    if (str) {
+      append_impl_(str, strlen(str));
+    }
+    return *this;
+  }
+
+  DumpBuffer &append(const char *str, size_t len) {
+    append_impl_(str, len);
+    return *this;
+  }
+
+  DumpBuffer &append(size_t n, char c) {
+    size_t space = CAPACITY - 1 - pos_;
+    if (n > space)
+      n = space;
+    if (n > 0) {
+      memset(buf_ + pos_, c, n);
+      pos_ += n;
+      buf_[pos_] = '\0';
+    }
+    return *this;
+  }
+
+  const char *c_str() const { return buf_; }
+  size_t size() const { return pos_; }
+
+ private:
+  void append_impl_(const char *str, size_t len) {
+    size_t space = CAPACITY - 1 - pos_;
+    if (len > space)
+      len = space;
+    if (len > 0) {
+      memcpy(buf_ + pos_, str, len);
+      pos_ += len;
+      buf_[pos_] = '\0';
+    }
+  }
+
+  char buf_[CAPACITY];
+  size_t pos_;
+};
+#endif
+
 class ProtoMessage {
  public:
   virtual ~ProtoMessage() = default;
@@ -370,8 +427,8 @@ class ProtoMessage {
   // Default implementation for messages with no fields
   virtual void calculate_size(ProtoSize &size) const {}
 #ifdef HAS_PROTO_MESSAGE_DUMP
-  std::string dump() const;
-  virtual void dump_to(std::string &out) const = 0;
+  const char *dump() const;
+  virtual void dump_to(DumpBuffer &out) const = 0;
   virtual const char *message_name() const { return "unknown"; }
 #endif
 };

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -990,9 +990,9 @@ class PackedBufferTypeInfo(TypeInfo):
         return (
             f'out.append("  {self.name}: ");\n'
             + 'out.append("packed buffer [");\n'
-            + f"out.append(std::to_string(this->{self.field_name}_count_));\n"
+            + f"append_uint(out, this->{self.field_name}_count_);\n"
             + 'out.append(" values, ");\n'
-            + f"out.append(std::to_string(this->{self.field_name}_length_));\n"
+            + f"append_uint(out, this->{self.field_name}_length_);\n"
             + 'out.append(" bytes]\\n");'
         )
 
@@ -2602,6 +2602,12 @@ static inline void append_field_prefix(DumpBuffer &out, const char *field_name, 
 static inline void append_with_newline(DumpBuffer &out, const char *str) {
   out.append(str);
   out.append("\\n");
+}
+
+static inline void append_uint(DumpBuffer &out, uint32_t value) {
+  char buf[16];
+  snprintf(buf, sizeof(buf), "%" PRIu32, value);
+  out.append(buf);
 }
 
 // RAII helper for message dump formatting

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2216,24 +2216,22 @@ def build_message_type(
 
     # dump_to method declaration in header
     prot = "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-    prot += "void dump_to(DumpBuffer &out) const override;\n"
+    prot += "const char *dump_to(DumpBuffer &out) const override;\n"
     prot += "#endif\n"
     public_content.append(prot)
 
     # dump_to implementation will go in dump_cpp
-    dump_impl = f"void {desc.name}::dump_to(DumpBuffer &out) const {{"
+    dump_impl = f"const char *{desc.name}::dump_to(DumpBuffer &out) const {{"
     if dump:
         # Always use MessageDumpHelper for consistent output formatting
         dump_impl += "\n"
         dump_impl += f'  MessageDumpHelper helper(out, "{desc.name}");\n'
         dump_impl += indent("\n".join(dump)) + "\n"
+        dump_impl += "  return out.c_str();\n"
     else:
-        o2 = f'out.append("{desc.name} {{}}");'
-        if len(dump_impl) + len(o2) + 3 < 120:
-            dump_impl += f" {o2} "
-        else:
-            dump_impl += "\n"
-            dump_impl += f"  {o2}\n"
+        dump_impl += "\n"
+        dump_impl += f'  out.append("{desc.name} {{}}");\n'
+        dump_impl += "  return out.c_str();\n"
     dump_impl += "}\n"
 
     if base_class:
@@ -2521,7 +2519,8 @@ def build_service_message_type(
             case += "// Empty message: no decode needed\n"
         if log:
             case += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-            case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump());\n'
+            case += "DumpBuffer dump_buf;\n"
+            case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump_to(dump_buf));\n'
             case += "#endif\n"
         case += f"this->{func}(msg);\n"
         case += "break;"
@@ -2853,7 +2852,8 @@ static const char *const TAG = "api.service";
     # Add non-template send_message method
     hpp += "  bool send_message(const ProtoMessage &msg, uint8_t message_type) {\n"
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-    hpp += "    this->log_send_message_(msg.message_name(), msg.dump());\n"
+    hpp += "    DumpBuffer dump_buf;\n"
+    hpp += "    this->log_send_message_(msg.message_name(), msg.dump_to(dump_buf));\n"
     hpp += "#endif\n"
     hpp += "    return this->send_message_(msg, message_type);\n"
     hpp += "  }\n\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2216,12 +2216,12 @@ def build_message_type(
 
     # dump_to method declaration in header
     prot = "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-    prot += "void dump_to(std::string &out) const override;\n"
+    prot += "void dump_to(DumpBuffer &out) const override;\n"
     prot += "#endif\n"
     public_content.append(prot)
 
     # dump_to implementation will go in dump_cpp
-    dump_impl = f"void {desc.name}::dump_to(std::string &out) const {{"
+    dump_impl = f"void {desc.name}::dump_to(DumpBuffer &out) const {{"
     if dump:
         # Always use MessageDumpHelper for consistent output formatting
         dump_impl += "\n"
@@ -2521,7 +2521,7 @@ def build_service_message_type(
             case += "// Empty message: no decode needed\n"
         if log:
             case += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-            case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump().c_str());\n'
+            case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump());\n'
             case += "#endif\n"
         case += f"this->{func}(msg);\n"
         case += "break;"
@@ -2588,7 +2588,7 @@ namespace esphome::api {
 namespace esphome::api {
 
 // Helper function to append a quoted string, handling empty StringRef
-static inline void append_quoted_string(std::string &out, const StringRef &ref) {
+static inline void append_quoted_string(DumpBuffer &out, const StringRef &ref) {
   out.append("'");
   if (!ref.empty()) {
     out.append(ref.c_str());
@@ -2597,11 +2597,11 @@ static inline void append_quoted_string(std::string &out, const StringRef &ref) 
 }
 
 // Common helpers for dump_field functions
-static inline void append_field_prefix(std::string &out, const char *field_name, int indent) {
+static inline void append_field_prefix(DumpBuffer &out, const char *field_name, int indent) {
   out.append(indent, ' ').append(field_name).append(": ");
 }
 
-static inline void append_with_newline(std::string &out, const char *str) {
+static inline void append_with_newline(DumpBuffer &out, const char *str) {
   out.append(str);
   out.append("\\n");
 }
@@ -2609,71 +2609,71 @@ static inline void append_with_newline(std::string &out, const char *str) {
 // RAII helper for message dump formatting
 class MessageDumpHelper {
  public:
-  MessageDumpHelper(std::string &out, const char *message_name) : out_(out) {
+  MessageDumpHelper(DumpBuffer &out, const char *message_name) : out_(out) {
     out_.append(message_name);
     out_.append(" {\\n");
   }
   ~MessageDumpHelper() { out_.append(" }"); }
 
  private:
-  std::string &out_;
+  DumpBuffer &out_;
 };
 
 // Helper functions to reduce code duplication in dump methods
-static void dump_field(std::string &out, const char *field_name, int32_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRId32, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, uint32_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, uint32_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu32, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, float value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, float value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%g", value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, uint64_t value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, uint64_t value, int indent = 2) {
   char buffer[64];
   append_field_prefix(out, field_name, indent);
   snprintf(buffer, 64, "%" PRIu64, value);
   append_with_newline(out, buffer);
 }
 
-static void dump_field(std::string &out, const char *field_name, bool value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, bool value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append(YESNO(value));
   out.append("\\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, const std::string &value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, const std::string &value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
-  out.append("'").append(value).append("'");
+  out.append("'").append(value.c_str()).append("'");
   out.append("\\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, StringRef value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, StringRef value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   append_quoted_string(out, value);
   out.append("\\n");
 }
 
-static void dump_field(std::string &out, const char *field_name, const char *value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, const char *value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append("'").append(value).append("'");
   out.append("\\n");
 }
 
 template<typename T>
-static void dump_field(std::string &out, const char *field_name, T value, int indent = 2) {
+static void dump_field(DumpBuffer &out, const char *field_name, T value, int indent = 2) {
   append_field_prefix(out, field_name, indent);
   out.append(proto_enum_to_string<T>(value));
   out.append("\\n");
@@ -2681,7 +2681,7 @@ static void dump_field(std::string &out, const char *field_name, T value, int in
 
 // Helper for bytes fields - uses stack buffer to avoid heap allocation
 // Buffer sized for 160 bytes of data (480 chars with separators) to fit typical log buffer
-static void dump_bytes_field(std::string &out, const char *field_name, const uint8_t *data, size_t len, int indent = 2) {
+static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint8_t *data, size_t len, int indent = 2) {
   char hex_buf[format_hex_pretty_size(160)];
   append_field_prefix(out, field_name, indent);
   format_hex_pretty_to(hex_buf, data, len);
@@ -2846,7 +2846,7 @@ static const char *const TAG = "api.service";
     # Add logging helper method declaration
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     hpp += " protected:\n"
-    hpp += "  void log_send_message_(const char *name, const std::string &dump);\n"
+    hpp += "  void log_send_message_(const char *name, const char *dump);\n"
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
@@ -2860,8 +2860,10 @@ static const char *const TAG = "api.service";
 
     # Add logging helper method implementation to cpp
     cpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-    cpp += f"void {class_name}::log_send_message_(const char *name, const std::string &dump) {{\n"
-    cpp += '  ESP_LOGVV(TAG, "send_message %s: %s", name, dump.c_str());\n'
+    cpp += (
+        f"void {class_name}::log_send_message_(const char *name, const char *dump) {{\n"
+    )
+    cpp += '  ESP_LOGVV(TAG, "send_message %s: %s", name, dump);\n'
     cpp += "}\n"
     cpp += "#endif\n\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2519,7 +2519,7 @@ def build_service_message_type(
             case += "// Empty message: no decode needed\n"
         if log:
             case += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-            case += f'this->log_receive_message_("{func}", msg);\n'
+            case += f'this->log_receive_message_(LOG_STR("{func}"), msg);\n'
             case += "#endif\n"
         case += f"this->{func}(msg);\n"
         case += "break;"
@@ -2845,7 +2845,9 @@ static const char *const TAG = "api.service";
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     hpp += " protected:\n"
     hpp += "  void log_send_message_(const char *name, const char *dump);\n"
-    hpp += "  void log_receive_message_(const char *name, const ProtoMessage &msg);\n"
+    hpp += (
+        "  void log_receive_message_(const LogString *name, const ProtoMessage &msg);\n"
+    )
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
@@ -2865,9 +2867,9 @@ static const char *const TAG = "api.service";
     )
     cpp += '  ESP_LOGVV(TAG, "send_message %s: %s", name, dump);\n'
     cpp += "}\n"
-    cpp += f"void {class_name}::log_receive_message_(const char *name, const ProtoMessage &msg) {{\n"
+    cpp += f"void {class_name}::log_receive_message_(const LogString *name, const ProtoMessage &msg) {{\n"
     cpp += "  DumpBuffer dump_buf;\n"
-    cpp += '  ESP_LOGVV(TAG, "%s: %s", name, msg.dump_to(dump_buf));\n'
+    cpp += '  ESP_LOGVV(TAG, "%s: %s", LOG_STR_ARG(name), msg.dump_to(dump_buf));\n'
     cpp += "}\n"
     cpp += "#endif\n\n"
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2519,8 +2519,7 @@ def build_service_message_type(
             case += "// Empty message: no decode needed\n"
         if log:
             case += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
-            case += "DumpBuffer dump_buf;\n"
-            case += f'ESP_LOGVV(TAG, "{func}: %s", msg.dump_to(dump_buf));\n'
+            case += f'this->log_receive_message_("{func}", msg);\n'
             case += "#endif\n"
         case += f"this->{func}(msg);\n"
         case += "break;"
@@ -2842,10 +2841,11 @@ static const char *const TAG = "api.service";
     hpp += f"class {class_name} : public ProtoService {{\n"
     hpp += " public:\n"
 
-    # Add logging helper method declaration
+    # Add logging helper method declarations
     hpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     hpp += " protected:\n"
     hpp += "  void log_send_message_(const char *name, const char *dump);\n"
+    hpp += "  void log_receive_message_(const char *name, const ProtoMessage &msg);\n"
     hpp += " public:\n"
     hpp += "#endif\n\n"
 
@@ -2858,12 +2858,16 @@ static const char *const TAG = "api.service";
     hpp += "    return this->send_message_(msg, message_type);\n"
     hpp += "  }\n\n"
 
-    # Add logging helper method implementation to cpp
+    # Add logging helper method implementations to cpp
     cpp += "#ifdef HAS_PROTO_MESSAGE_DUMP\n"
     cpp += (
         f"void {class_name}::log_send_message_(const char *name, const char *dump) {{\n"
     )
     cpp += '  ESP_LOGVV(TAG, "send_message %s: %s", name, dump);\n'
+    cpp += "}\n"
+    cpp += f"void {class_name}::log_receive_message_(const char *name, const ProtoMessage &msg) {{\n"
+    cpp += "  DumpBuffer dump_buf;\n"
+    cpp += '  ESP_LOGVV(TAG, "%s: %s", name, msg.dump_to(dump_buf));\n'
     cpp += "}\n"
     cpp += "#endif\n\n"
 


### PR DESCRIPTION
# What does this implement/fix?

Replaces heap-allocated `std::string` with a 512-byte stack buffer (`DumpBuffer`) for VERY_VERBOSE proto message dumps.

Previously, every VV log of a proto message allocated a `std::string` on the heap. With BLE or other high-traffic components, this caused heap fragmentation and eventually crashes. Now the dump uses a stack-allocated buffer sized to match the logger's default `tx_buffer_size` (512 bytes). In practice, proto message dumps fit well within this limit - the only exceptions are Bluetooth proxy advertisement groups, which would crash the system if fully logged anyway.

Additional optimizations:
- Centralized `log_receive_message_()` helper to reduce code duplication across ~60 message handlers
- Uses `LOG_STR()` for message names to store strings in flash on ESP8266

**Where to review:**
- `esphome/components/api/proto.h` - `DumpBuffer` class (~55 lines)
- `script/api_protobuf/api_protobuf.py` - generator changes

The remaining files (`api_pb2*.cpp/h`, `api_connection.cpp`) are generated or reflect the pattern change above.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Enable VERY_VERBOSE logging to see proto message dumps
logger:
  level: VERY_VERBOSE

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
