### PR TITLE
[ci] Add format_hex_pretty to heap-allocating helper lint check

### DIFF
--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -18,9 +18,9 @@ char *format_bytes_to(char *buffer, const std::vector<uint8_t> &bytes) {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-std::string format_uid(const std::vector<uint8_t> &uid) { return format_hex_pretty(uid, '-', false); }
-
-std::string format_bytes(const std::vector<uint8_t> &bytes) { return format_hex_pretty(bytes, ' ', false); }
+// Deprecated wrappers intentionally use heap-allocating version for backward compatibility
+std::string format_uid(const std::vector<uint8_t> &uid) { return format_hex_pretty(uid, '-', false); }        // NOLINT
+std::string format_bytes(const std::vector<uint8_t> &bytes) { return format_hex_pretty(bytes, ' ', false); }  // NOLINT
 #pragma GCC diagnostic pop
 
 uint8_t guess_tag_type(uint8_t uid_length) {

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -220,7 +220,7 @@ void RC522::loop() {
 
       std::vector<uint8_t> rfid_uid(std::begin(uid_buffer_), std::begin(uid_buffer_) + uid_idx_);
       uid_idx_ = 0;
-      // ESP_LOGD(TAG, "Processing '%s'", format_hex_pretty(rfid_uid, '-', false).c_str());
+      // ESP_LOGD(TAG, "Processing '%s'", format_hex_pretty(rfid_uid, '-', false).c_str());  // NOLINT
       pcd_antenna_off_();
       state_ = STATE_INIT;  // scan again on next update
       bool report = true;

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -31,7 +31,7 @@ class MideaData {
   bool is_compliment(const MideaData &rhs) const;
   /// @deprecated Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.
   ESPDEPRECATED("Allocates heap memory. Use to_str() instead. Removed in 2026.7.0.", "2026.1.0")
-  std::string to_string() const { return format_hex_pretty(this->data_.data(), this->data_.size()); }
+  std::string to_string() const { return format_hex_pretty(this->data_.data(), this->data_.size()); }  // NOLINT
   /// Buffer size for to_str(): 6 bytes = "AA.BB.CC.DD.EE.FF\0"
   static constexpr size_t TO_STR_BUFFER_SIZE = format_hex_pretty_size(6);
   /// Format to buffer, returns pointer to buffer

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -697,6 +697,7 @@ HEAP_ALLOCATING_HELPERS = {
     # Use negative lookahead to exclude _to/_into_buffer variants
     # format_hex(?!_) ensures we don't match format_hex_to, format_hex_pretty_to, etc.
     # get_mac_address(?!_) ensures we don't match get_mac_address_into_buffer, etc.
+    # CPP_RE_EOL captures rest of line so NOLINT comments are detected
     r"[^\w]("
     r"format_hex(?!_)|"
     r"format_hex_pretty(?!_)|"
@@ -706,7 +707,7 @@ HEAP_ALLOCATING_HELPERS = {
     r"str_truncate|"
     r"str_upper_case|"
     r"str_snake_case"
-    r")\s*\(",
+    r")\s*\(" + CPP_RE_EOL,
     include=cpp_include,
     exclude=[
         # The definitions themselves

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -683,6 +683,7 @@ def lint_trailing_whitespace(fname, match):
 # These return std::string and should be replaced with stack-based alternatives.
 HEAP_ALLOCATING_HELPERS = {
     "format_hex": "format_hex_to() with a stack buffer",
+    "format_hex_pretty": "format_hex_pretty_to() with a stack buffer",
     "format_mac_address_pretty": "format_mac_addr_upper() with a stack buffer",
     "get_mac_address": "get_mac_address_into_buffer() with a stack buffer",
     "get_mac_address_pretty": "get_mac_address_pretty_into_buffer() with a stack buffer",
@@ -698,6 +699,7 @@ HEAP_ALLOCATING_HELPERS = {
     # get_mac_address(?!_) ensures we don't match get_mac_address_into_buffer, etc.
     r"[^\w]("
     r"format_hex(?!_)|"
+    r"format_hex_pretty(?!_)|"
     r"format_mac_address_pretty|"
     r"get_mac_address_pretty(?!_)|"
     r"get_mac_address(?!_)|"


### PR DESCRIPTION
# What does this implement/fix?

Add `format_hex_pretty()` to the CI lint check for heap-allocating helpers.

This function was missed when the heap-allocating helper checks were added. Like `format_hex()`, it returns `std::string` and causes heap fragmentation on long-running embedded devices. The stack-based alternative `format_hex_pretty_to()` should be used instead.

The regex uses `format_hex_pretty(?!_)` to match `format_hex_pretty()` but not `format_hex_pretty_to()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# n/a - CI tooling change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
