### PR TITLE
[socket] Call lwip_read/lwip_write directly on ESP32 to reduce network I/O latency

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -79,7 +79,13 @@ class BSDSocketImpl final : public Socket {
     return ::setsockopt(this->fd_, level, optname, optval, optlen);
   }
   int listen(int backlog) override { return ::listen(this->fd_, backlog); }
-  ssize_t read(void *buf, size_t len) override { return ::read(this->fd_, buf, len); }
+  ssize_t read(void *buf, size_t len) override {
+#ifdef USE_ESP32
+    return ::lwip_read(this->fd_, buf, len);
+#else
+    return ::read(this->fd_, buf, len);
+#endif
+  }
   ssize_t recvfrom(void *buf, size_t len, sockaddr *addr, socklen_t *addr_len) override {
 #if defined(USE_ESP32) || defined(USE_HOST)
     return ::recvfrom(this->fd_, buf, len, 0, addr, addr_len);
@@ -94,7 +100,13 @@ class BSDSocketImpl final : public Socket {
     return ::readv(this->fd_, iov, iovcnt);
 #endif
   }
-  ssize_t write(const void *buf, size_t len) override { return ::write(this->fd_, buf, len); }
+  ssize_t write(const void *buf, size_t len) override {
+#ifdef USE_ESP32
+    return ::lwip_write(this->fd_, buf, len);
+#else
+    return ::write(this->fd_, buf, len);
+#endif
+  }
   ssize_t send(void *buf, size_t len, int flags) { return ::send(this->fd_, buf, len, flags); }
   ssize_t writev(const struct iovec *iov, int iovcnt) override {
 #if defined(USE_ESP32)


### PR DESCRIPTION
# What does this implement/fix?

Call `lwip_read()` and `lwip_write()` directly on ESP32 instead of going through the POSIX wrappers (`::read()`, `::write()`), which route through ESP-IDF's VFS (Virtual File System) layer before reaching LwIP.

Note: `readv()` and `writev()` already call `lwip_readv()` and `lwip_writev()` directly, but that was because ESP-IDF doesn't expose POSIX `readv()`/`writev()` symbols at all - only the lwip versions exist. For `read()`/`write()`, ESP-IDF does provide POSIX wrappers, but they route through VFS. This change bypasses VFS for performance.

The VFS layer adds overhead for every socket read/write operation by:
1. Looking up the file descriptor in the VFS table (`s_fd_table[fd].vfs_index`)
2. Looking up the VFS entry in the VFS array (`s_vfs[index]`)
3. Reading the local fd from the table again (`s_fd_table[fd].local_fd`)
4. Checking if the function pointer is NULL
5. Checking the context pointer flag
6. Dispatching through a function pointer to `lwip_read()`/`lwip_write()`

Since socket operations are in the hot path (called every loop iteration for API connections, async_tcp, voice_assistant, etc.), bypassing VFS reduces latency for network I/O.

### Why this is safe

Reviewed ESP-IDF's VFS implementation (`components/vfs/vfs.c`):

- **VFS adds no functionality for sockets** — `vfs_lwip.c` registers `.read = &lwip_read`, `.write = &lwip_write` directly, so after all the table lookups, it just calls the lwip function anyway
- **No thread safety added** — VFS comments say "single read → no locking is required"
- **errno handling is equivalent** — both VFS and lwip set errno properly
- **Already done for `readv()`/`writev()`** — we've been calling `lwip_readv()`/`lwip_writev()` directly since the code was written (because ESP-IDF doesn't even provide POSIX wrappers for those)
- **Already done for `select()`** — `application.cpp` calls `lwip_select()` directly for socket select support

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

None needed - internal optimization only.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any ESP32 config using the API or other socket-based components benefits automatically
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
