### PR TITLE
[ota] Ota abort & restart fix

### DIFF
--- a/esphome/components/ota/ota_backend_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_esp8266.cpp
@@ -51,6 +51,9 @@ static const char *const TAG = "ota.esp8266";
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ESP8266OTABackend>(); }
 
 OTAResponseTypes ESP8266OTABackend::begin(size_t image_size) {
+  // Make sure the memory from previous unfinished attempt is freed
+  this->buffer_.reset();
+
   // Handle UPDATE_SIZE_UNKNOWN (0) by calculating available space
   if (image_size == 0) {
     // Round down to sector boundary: subtract one sector, then mask to sector alignment

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -17,7 +17,7 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
   // in case begin() is called without matching end(), we need to free any previously allocated OTA context
   // this is safe to call even if update_handle_ was already freed
   (void) esp_ota_abort(this->update_handle_);
-  
+
   this->partition_ = esp_ota_get_next_update_partition(nullptr);
   if (this->partition_ == nullptr) {
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -14,6 +14,10 @@ namespace ota {
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::IDFOTABackend>(); }
 
 OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
+  // in case begin() is called without matching end(), we need to free any previously allocated OTA context
+  // this is safe to call even if update_handle_ was already freed
+  (void) esp_ota_abort(this->update_handle_);
+  
   this->partition_ = esp_ota_get_next_update_partition(nullptr);
   if (this->partition_ == nullptr) {
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;


### PR DESCRIPTION
# What does this implement/fix?

If OTA is aborted by the user, the backend's end() method is not called, which means any resources allocated during begin() are not freed.
I am not sure if such sequence is actually a bug, but restarting OTA leads to allocation of another context, so we should first try to free the previous one.

In esp8266 backed this only means we try to allocate the buffer while the previous one is not yet freed. As a unique_ptr is used, this will not be a memory leak. But in low-memory situations this might fail.

In esp_idf backed a new context is allocated and the old one (probably) is NOT freed. [The docs](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/ota.html) are not clear about that, but the handle mechanism would suggest that. If it is so, after a finite number of such ota restarts the framework will fail to allocate new context.

In libretiny backend the restarting fails completely. But there's [a PR that fixes it](https://github.com/libretiny-eu/libretiny/pull/343).


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
