### PR TITLE
[esphome] Fix OTA backend abort not being called on error

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -370,11 +370,13 @@ void ESPHomeOTAComponent::handle_data_() {
 
 error:
   this->write_byte_(static_cast<uint8_t>(error_code));
-  this->cleanup_connection_();
 
+  // Abort backend before cleanup - cleanup_connection_() destroys the backend
   if (this->backend_ != nullptr && update_started) {
     this->backend_->abort();
   }
+
+  this->cleanup_connection_();
 
   this->status_momentary_error("err", 5000);
 #ifdef USE_OTA_STATE_LISTENER


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where `abort()` was never called on the OTA backend when an update failed or was interrupted.

The error handler was calling `cleanup_connection_()` before checking if `abort()` should be called. Since `cleanup_connection_()` sets `backend_` to `nullptr`, the subsequent `abort()` check always failed and the call was never reached.

This caused resource leaks on platforms where the OTA backend allocates resources during `begin()`:
- **ESP-IDF**: OTA handle not freed, repeated aborts could exhaust available context allocations
- **ESP8266**: Memory buffer not freed
- **LibreTiny**: Restart attempts could fail

The fix reorders the error handler to call `abort()` before `cleanup_connection_()` destroys the backend.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13180

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard OTA configuration - no changes required
ota:
  platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
