### PR TITLE
[ld24xx] add id to support extending

### DIFF
--- a/esphome/components/ld2410/binary_sensor.py
+++ b/esphome/components/ld2410/binary_sensor.py
@@ -20,7 +20,7 @@ DEPENDENCIES = ["ld2410"]
 CONF_OUT_PIN_PRESENCE_STATUS = "out_pin_presence_status"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,

--- a/esphome/components/ld2410/binary_sensor.py
+++ b/esphome/components/ld2410/binary_sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_HAS_MOVING_TARGET,
     CONF_HAS_STILL_TARGET,
     CONF_HAS_TARGET,
+    CONF_ID,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
     DEVICE_CLASS_PRESENCE,
@@ -19,6 +20,7 @@ DEPENDENCIES = ["ld2410"]
 CONF_OUT_PIN_PRESENCE_STATUS = "out_pin_presence_status"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,

--- a/esphome/components/ld2410/button/__init__.py
+++ b/esphome/components/ld2410/button/__init__.py
@@ -22,7 +22,7 @@ RestartButton = ld2410_ns.class_("RestartButton", button.Button)
 CONF_QUERY_PARAMS = "query_params"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2410/button/__init__.py
+++ b/esphome/components/ld2410/button/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FACTORY_RESET,
+    CONF_ID,
     CONF_RESTART,
     DEVICE_CLASS_RESTART,
     ENTITY_CATEGORY_CONFIG,
@@ -21,6 +22,7 @@ RestartButton = ld2410_ns.class_("RestartButton", button.Button)
 CONF_QUERY_PARAMS = "query_params"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2410/number/__init__.py
+++ b/esphome/components/ld2410/number/__init__.py
@@ -31,7 +31,7 @@ TIMEOUT_GROUP = "timeout"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Inclusive(CONF_TIMEOUT, TIMEOUT_GROUP): number.number_schema(
             MaxDistanceTimeoutNumber,

--- a/esphome/components/ld2410/number/__init__.py
+++ b/esphome/components/ld2410/number/__init__.py
@@ -31,6 +31,7 @@ TIMEOUT_GROUP = "timeout"
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Inclusive(CONF_TIMEOUT, TIMEOUT_GROUP): number.number_schema(
             MaxDistanceTimeoutNumber,

--- a/esphome/components/ld2410/select/__init__.py
+++ b/esphome/components/ld2410/select/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import select
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BAUD_RATE,
+    CONF_ID,
     ENTITY_CATEGORY_CONFIG,
     ICON_LIGHTBULB,
     ICON_RULER,
@@ -22,6 +23,7 @@ CONF_OUT_PIN_LEVEL = "out_pin_level"
 
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_DISTANCE_RESOLUTION): select.select_schema(
         DistanceResolutionSelect,

--- a/esphome/components/ld2410/select/__init__.py
+++ b/esphome/components/ld2410/select/__init__.py
@@ -23,7 +23,7 @@ CONF_OUT_PIN_LEVEL = "out_pin_level"
 
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_DISTANCE_RESOLUTION): select.select_schema(
         DistanceResolutionSelect,

--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -29,7 +29,7 @@ CONF_STILL_ENERGY = "still_energy"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,

--- a/esphome/components/ld2410/sensor.py
+++ b/esphome/components/ld2410/sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ID,
     CONF_LIGHT,
     CONF_MOVING_DISTANCE,
     DEVICE_CLASS_DISTANCE,
@@ -28,6 +29,7 @@ CONF_STILL_ENERGY = "still_energy"
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
         cv.Optional(CONF_MOVING_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,

--- a/esphome/components/ld2410/switch/__init__.py
+++ b/esphome/components/ld2410/switch/__init__.py
@@ -18,7 +18,7 @@ EngineeringModeSwitch = ld2410_ns.class_("EngineeringModeSwitch", switch.Switch)
 CONF_ENGINEERING_MODE = "engineering_mode"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_ENGINEERING_MODE): switch.switch_schema(
         EngineeringModeSwitch,

--- a/esphome/components/ld2410/switch/__init__.py
+++ b/esphome/components/ld2410/switch/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BLUETOOTH,
+    CONF_ID,
     DEVICE_CLASS_SWITCH,
     ENTITY_CATEGORY_CONFIG,
     ICON_BLUETOOTH,
@@ -17,6 +18,7 @@ EngineeringModeSwitch = ld2410_ns.class_("EngineeringModeSwitch", switch.Switch)
 CONF_ENGINEERING_MODE = "engineering_mode"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_ENGINEERING_MODE): switch.switch_schema(
         EngineeringModeSwitch,

--- a/esphome/components/ld2410/text_sensor.py
+++ b/esphome/components/ld2410/text_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_VERSION,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -14,6 +15,7 @@ from . import CONF_LD2410_ID, LD2410Component
 DEPENDENCIES = ["ld2410"]
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon=ICON_CHIP

--- a/esphome/components/ld2410/text_sensor.py
+++ b/esphome/components/ld2410/text_sensor.py
@@ -15,7 +15,7 @@ from . import CONF_LD2410_ID, LD2410Component
 DEPENDENCIES = ["ld2410"]
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2410_ID): cv.use_id(LD2410Component),
     cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon=ICON_CHIP

--- a/esphome/components/ld2412/binary_sensor.py
+++ b/esphome/components/ld2412/binary_sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_HAS_MOVING_TARGET,
     CONF_HAS_STILL_TARGET,
     CONF_HAS_TARGET,
+    CONF_ID,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
     DEVICE_CLASS_RUNNING,
@@ -20,6 +21,7 @@ DEPENDENCIES = ["ld2412"]
 CONF_DYNAMIC_BACKGROUND_CORRECTION_STATUS = "dynamic_background_correction_status"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(
         CONF_DYNAMIC_BACKGROUND_CORRECTION_STATUS

--- a/esphome/components/ld2412/binary_sensor.py
+++ b/esphome/components/ld2412/binary_sensor.py
@@ -21,7 +21,7 @@ DEPENDENCIES = ["ld2412"]
 CONF_DYNAMIC_BACKGROUND_CORRECTION_STATUS = "dynamic_background_correction_status"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(
         CONF_DYNAMIC_BACKGROUND_CORRECTION_STATUS

--- a/esphome/components/ld2412/button/__init__.py
+++ b/esphome/components/ld2412/button/__init__.py
@@ -27,7 +27,7 @@ CONF_QUERY_PARAMS = "query_params"
 CONF_START_DYNAMIC_BACKGROUND_CORRECTION = "start_dynamic_background_correction"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2412/button/__init__.py
+++ b/esphome/components/ld2412/button/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FACTORY_RESET,
+    CONF_ID,
     CONF_RESTART,
     DEVICE_CLASS_RESTART,
     ENTITY_CATEGORY_CONFIG,
@@ -26,6 +27,7 @@ CONF_QUERY_PARAMS = "query_params"
 CONF_START_DYNAMIC_BACKGROUND_CORRECTION = "start_dynamic_background_correction"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2412/number/__init__.py
+++ b/esphome/components/ld2412/number/__init__.py
@@ -31,7 +31,7 @@ TIMEOUT_GROUP = "timeout"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_LIGHT_THRESHOLD): number.number_schema(
             LightThresholdNumber,

--- a/esphome/components/ld2412/number/__init__.py
+++ b/esphome/components/ld2412/number/__init__.py
@@ -31,6 +31,7 @@ TIMEOUT_GROUP = "timeout"
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_LIGHT_THRESHOLD): number.number_schema(
             LightThresholdNumber,

--- a/esphome/components/ld2412/select/__init__.py
+++ b/esphome/components/ld2412/select/__init__.py
@@ -23,7 +23,7 @@ CONF_OUT_PIN_LEVEL = "out_pin_level"
 
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_BAUD_RATE): select.select_schema(
         BaudRateSelect,

--- a/esphome/components/ld2412/select/__init__.py
+++ b/esphome/components/ld2412/select/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import select
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BAUD_RATE,
+    CONF_ID,
     ENTITY_CATEGORY_CONFIG,
     ICON_LIGHTBULB,
     ICON_RULER,
@@ -22,6 +23,7 @@ CONF_OUT_PIN_LEVEL = "out_pin_level"
 
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_BAUD_RATE): select.select_schema(
         BaudRateSelect,

--- a/esphome/components/ld2412/sensor.py
+++ b/esphome/components/ld2412/sensor.py
@@ -29,7 +29,7 @@ CONF_STILL_ENERGY = "still_energy"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,

--- a/esphome/components/ld2412/sensor.py
+++ b/esphome/components/ld2412/sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ID,
     CONF_LIGHT,
     CONF_MOVING_DISTANCE,
     DEVICE_CLASS_DISTANCE,
@@ -28,6 +29,7 @@ CONF_STILL_ENERGY = "still_energy"
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
         cv.Optional(CONF_DETECTION_DISTANCE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_DISTANCE,

--- a/esphome/components/ld2412/switch/__init__.py
+++ b/esphome/components/ld2412/switch/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BLUETOOTH,
+    CONF_ID,
     DEVICE_CLASS_SWITCH,
     ENTITY_CATEGORY_CONFIG,
     ICON_BLUETOOTH,
@@ -17,6 +18,7 @@ EngineeringModeSwitch = LD2412_ns.class_("EngineeringModeSwitch", switch.Switch)
 CONF_ENGINEERING_MODE = "engineering_mode"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         BluetoothSwitch,

--- a/esphome/components/ld2412/switch/__init__.py
+++ b/esphome/components/ld2412/switch/__init__.py
@@ -18,7 +18,7 @@ EngineeringModeSwitch = LD2412_ns.class_("EngineeringModeSwitch", switch.Switch)
 CONF_ENGINEERING_MODE = "engineering_mode"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         BluetoothSwitch,

--- a/esphome/components/ld2412/text_sensor.py
+++ b/esphome/components/ld2412/text_sensor.py
@@ -15,7 +15,7 @@ from . import CONF_LD2412_ID, LD2412Component
 DEPENDENCIES = ["ld2412"]
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon=ICON_CHIP

--- a/esphome/components/ld2412/text_sensor.py
+++ b/esphome/components/ld2412/text_sensor.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_VERSION,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -14,6 +15,7 @@ from . import CONF_LD2412_ID, LD2412Component
 DEPENDENCIES = ["ld2412"]
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2412_ID): cv.use_id(LD2412Component),
     cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC, icon=ICON_CHIP

--- a/esphome/components/ld2450/binary_sensor.py
+++ b/esphome/components/ld2450/binary_sensor.py
@@ -19,7 +19,7 @@ ICON_SHIELD_ACCOUNT = "mdi:shield-account"
 ICON_TARGET_ACCOUNT = "mdi:target-account"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,

--- a/esphome/components/ld2450/binary_sensor.py
+++ b/esphome/components/ld2450/binary_sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     CONF_HAS_MOVING_TARGET,
     CONF_HAS_STILL_TARGET,
     CONF_HAS_TARGET,
+    CONF_ID,
     DEVICE_CLASS_MOTION,
     DEVICE_CLASS_OCCUPANCY,
 )
@@ -18,6 +19,7 @@ ICON_SHIELD_ACCOUNT = "mdi:shield-account"
 ICON_TARGET_ACCOUNT = "mdi:target-account"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_HAS_TARGET): binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_OCCUPANCY,

--- a/esphome/components/ld2450/button/__init__.py
+++ b/esphome/components/ld2450/button/__init__.py
@@ -18,7 +18,7 @@ FactoryResetButton = ld2450_ns.class_("FactoryResetButton", button.Button)
 RestartButton = ld2450_ns.class_("RestartButton", button.Button)
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2450/button/__init__.py
+++ b/esphome/components/ld2450/button/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import button
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_FACTORY_RESET,
+    CONF_ID,
     CONF_RESTART,
     DEVICE_CLASS_RESTART,
     ENTITY_CATEGORY_CONFIG,
@@ -17,6 +18,7 @@ FactoryResetButton = ld2450_ns.class_("FactoryResetButton", button.Button)
 RestartButton = ld2450_ns.class_("RestartButton", button.Button)
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_FACTORY_RESET): button.button_schema(
         FactoryResetButton,

--- a/esphome/components/ld2450/number/__init__.py
+++ b/esphome/components/ld2450/number/__init__.py
@@ -28,6 +28,7 @@ ZoneCoordinateNumber = ld2450_ns.class_("ZoneCoordinateNumber", number.Number)
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Required(CONF_PRESENCE_TIMEOUT): number.number_schema(
             PresenceTimeoutNumber,

--- a/esphome/components/ld2450/number/__init__.py
+++ b/esphome/components/ld2450/number/__init__.py
@@ -28,7 +28,7 @@ ZoneCoordinateNumber = ld2450_ns.class_("ZoneCoordinateNumber", number.Number)
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Required(CONF_PRESENCE_TIMEOUT): number.number_schema(
             PresenceTimeoutNumber,

--- a/esphome/components/ld2450/select/__init__.py
+++ b/esphome/components/ld2450/select/__init__.py
@@ -1,7 +1,12 @@
 import esphome.codegen as cg
 from esphome.components import select
 import esphome.config_validation as cv
-from esphome.const import CONF_BAUD_RATE, ENTITY_CATEGORY_CONFIG, ICON_THERMOMETER
+from esphome.const import (
+    CONF_BAUD_RATE,
+    CONF_ID,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_THERMOMETER,
+)
 
 from .. import CONF_LD2450_ID, LD2450Component, ld2450_ns
 
@@ -11,6 +16,7 @@ BaudRateSelect = ld2450_ns.class_("BaudRateSelect", select.Select)
 ZoneTypeSelect = ld2450_ns.class_("ZoneTypeSelect", select.Select)
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_BAUD_RATE): select.select_schema(
         BaudRateSelect,

--- a/esphome/components/ld2450/select/__init__.py
+++ b/esphome/components/ld2450/select/__init__.py
@@ -16,7 +16,7 @@ BaudRateSelect = ld2450_ns.class_("BaudRateSelect", select.Select)
 ZoneTypeSelect = ld2450_ns.class_("ZoneTypeSelect", select.Select)
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_BAUD_RATE): select.select_schema(
         BaudRateSelect,

--- a/esphome/components/ld2450/sensor.py
+++ b/esphome/components/ld2450/sensor.py
@@ -4,6 +4,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ANGLE,
     CONF_DISTANCE,
+    CONF_ID,
     CONF_RESOLUTION,
     CONF_SPEED,
     CONF_X,
@@ -40,6 +41,7 @@ UNIT_MILLIMETER_PER_SECOND = "mm/s"
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
             accuracy_decimals=0,

--- a/esphome/components/ld2450/sensor.py
+++ b/esphome/components/ld2450/sensor.py
@@ -41,7 +41,7 @@ UNIT_MILLIMETER_PER_SECOND = "mm/s"
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_TARGET_COUNT): sensor.sensor_schema(
             accuracy_decimals=0,

--- a/esphome/components/ld2450/switch/__init__.py
+++ b/esphome/components/ld2450/switch/__init__.py
@@ -3,6 +3,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BLUETOOTH,
+    CONF_ID,
     DEVICE_CLASS_SWITCH,
     ENTITY_CATEGORY_CONFIG,
     ICON_BLUETOOTH,
@@ -17,6 +18,7 @@ MultiTargetSwitch = ld2450_ns.class_("MultiTargetSwitch", switch.Switch)
 CONF_MULTI_TARGET = "multi_target"
 
 CONFIG_SCHEMA = {
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         BluetoothSwitch,

--- a/esphome/components/ld2450/switch/__init__.py
+++ b/esphome/components/ld2450/switch/__init__.py
@@ -18,7 +18,7 @@ MultiTargetSwitch = ld2450_ns.class_("MultiTargetSwitch", switch.Switch)
 CONF_MULTI_TARGET = "multi_target"
 
 CONFIG_SCHEMA = {
-    cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+    cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
     cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
     cv.Optional(CONF_BLUETOOTH): switch.switch_schema(
         BluetoothSwitch,

--- a/esphome/components/ld2450/text_sensor.py
+++ b/esphome/components/ld2450/text_sensor.py
@@ -21,7 +21,7 @@ MAX_TARGETS = 3
 
 CONFIG_SCHEMA = cv.Schema(
     {
-        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/esphome/components/ld2450/text_sensor.py
+++ b/esphome/components/ld2450/text_sensor.py
@@ -3,6 +3,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_DIRECTION,
+    CONF_ID,
     CONF_MAC_ADDRESS,
     CONF_VERSION,
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -20,6 +21,7 @@ MAX_TARGETS = 3
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.GenerateID(CONF_ID): cv.declare_id(cg.Component),
         cv.GenerateID(CONF_LD2450_ID): cv.use_id(LD2450Component),
         cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/tests/components/ld2410/common.yaml
+++ b/tests/components/ld2410/common.yaml
@@ -3,6 +3,7 @@ ld2410:
 
 binary_sensor:
   - platform: ld2410
+    id: ld2410_binary
     has_target:
       name: presence
     has_moving_target:
@@ -14,6 +15,7 @@ binary_sensor:
 
 button:
   - platform: ld2410
+    id: ld2410_button
     factory_reset:
       name: factory reset
     restart:
@@ -23,6 +25,7 @@ button:
 
 number:
   - platform: ld2410
+    id: ld2410_number
     light_threshold:
       name: light threshold
     timeout:
@@ -79,6 +82,7 @@ number:
 
 select:
   - platform: ld2410
+    id: ld2410_select
     distance_resolution:
       name: distance resolution
     baud_rate:
@@ -90,6 +94,7 @@ select:
 
 sensor:
   - platform: ld2410
+    id: ld2410_sensor
     light:
       name: light
     moving_distance:
@@ -150,6 +155,7 @@ sensor:
 
 switch:
   - platform: ld2410
+    id: ld2410_switch
     engineering_mode:
       name: control ld2410 engineering mode
     bluetooth:
@@ -157,6 +163,7 @@ switch:
 
 text_sensor:
   - platform: ld2410
+    id: ld2410_textsensor
     version:
       name: presenece sensor version
     mac_address:

--- a/tests/components/ld2412/common.yaml
+++ b/tests/components/ld2412/common.yaml
@@ -3,6 +3,7 @@ ld2412:
 
 binary_sensor:
   - platform: ld2412
+    id: ld2412_binary
     dynamic_background_correction_status:
       name: Dynamic Background Correction Status
     has_target:
@@ -14,6 +15,7 @@ binary_sensor:
 
 button:
   - platform: ld2412
+    id: ld2412_button
     factory_reset:
       name: Factory reset
     restart:
@@ -25,6 +27,7 @@ button:
 
 number:
   - platform: ld2412
+    id: ld2412_number
     light_threshold:
       name: Light Threshold
     timeout:
@@ -106,6 +109,7 @@ number:
 
 select:
   - platform: ld2412
+    id: ld2412_select
     light_function:
       name: Light Function
     out_pin_level:
@@ -129,6 +133,7 @@ select:
 
 sensor:
   - platform: ld2412
+    id: ld2412_sensor
     light:
       name: Light
     moving_distance:
@@ -214,6 +219,7 @@ sensor:
 
 switch:
   - platform: ld2412
+    id: ld2412_switch
     bluetooth:
       name: Bluetooth
     engineering_mode:
@@ -221,6 +227,7 @@ switch:
 
 text_sensor:
   - platform: ld2412
+    id: ld2412_textsensor
     version:
       name: Firmware version
     mac_address:

--- a/tests/components/ld2450/common.yaml
+++ b/tests/components/ld2450/common.yaml
@@ -3,6 +3,7 @@ ld2450:
 
 button:
   - platform: ld2450
+    id: ld2450_button
     ld2450_id: ld2450_radar
     factory_reset:
       name: LD2450 Factory Reset
@@ -13,6 +14,7 @@ button:
 
 sensor:
   - platform: ld2450
+    id: ld2450_sensor
     ld2450_id: ld2450_radar
     target_count:
       name: Presence Target Count
@@ -83,6 +85,7 @@ sensor:
 
 binary_sensor:
   - platform: ld2450
+    id: ld2450_binary
     ld2450_id: ld2450_radar
     has_target:
       name: Presence
@@ -93,6 +96,7 @@ binary_sensor:
 
 switch:
   - platform: ld2450
+    id: ld2450_switch
     ld2450_id: ld2450_radar
     bluetooth:
       name: Bluetooth
@@ -101,6 +105,7 @@ switch:
 
 text_sensor:
   - platform: ld2450
+    id: ld2450_textsensor
     ld2450_id: ld2450_radar
     version:
       name: LD2450 Firmware
@@ -118,6 +123,7 @@ text_sensor:
 
 number:
   - platform: ld2450
+    id: ld2450_number
     ld2450_id: ld2450_radar
     presence_timeout:
       name: Timeout
@@ -151,6 +157,7 @@ number:
 
 select:
   - platform: ld2450
+    id: ld2450_select
     ld2450_id: ld2450_radar
     baud_rate:
       name: Baud Rate


### PR DESCRIPTION
# What does this implement/fix?

Adds `id:` to all the sub-components so they can be `!extend` targets.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13181
- fixes https://github.com/esphome/issues/issues/5728

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
