### PR TITLE
[wifi] Fix ESP8266 disconnect callback order to set error flag before notifying listeners

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -543,6 +543,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       }
       s_sta_connected = false;
       s_sta_connecting = false;
+      // Set error flag BEFORE notifying listeners so is_connected() returns
+      // correct state during listener callbacks (matches ESP-IDF behavior)
+      global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_LISTENERS
       static constexpr uint8_t EMPTY_BSSID[6] = {};
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
@@ -633,10 +636,6 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
 #endif
     default:
       break;
-  }
-
-  if (event->event == EVENT_STAMODE_DISCONNECTED) {
-    global_wifi_component->error_from_callback_ = true;
   }
 
   WiFiMockClass::_event_callback(event);

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -543,10 +543,12 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       }
       s_sta_connected = false;
       s_sta_connecting = false;
-      // Set error flag BEFORE notifying listeners so is_connected() returns
-      // correct state during listener callbacks (matches ESP-IDF behavior)
+      // IMPORTANT: Set error flag BEFORE notifying listeners.
+      // This ensures is_connected() returns false during listener callbacks,
+      // which is critical for proper reconnection logic (e.g., roaming).
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_LISTENERS
+      // Notify listeners AFTER setting error flag so they see correct state
       static constexpr uint8_t EMPTY_BSSID[6] = {};
       for (auto *listener : global_wifi_component->connect_state_listeners_) {
         listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);


### PR DESCRIPTION
# What does this implement/fix?

Fix WiFi disconnect callback order on ESP8266 to set `error_from_callback_` before notifying listeners, matching ESP-IDF and LibreTiny behavior.

Previously, `error_from_callback_` was set AFTER the switch statement, which meant listeners were called before the flag was set. If a listener checked `is_connected()` during the disconnect callback, it would incorrectly return `true` because `error_from_callback_` was still `false`.

This caused issues with WiFi roaming where the device would think it was still connected after a disconnect event, preventing proper reconnection logic from triggering.

**Before (incorrect):**
```cpp
case EVENT_STAMODE_DISCONNECTED:
  // ... logging ...
  for (auto *listener : connect_state_listeners_) {
    listener->on_wifi_connect_state(...);  // Listeners called FIRST
  }
  break;
}

if (event->event == EVENT_STAMODE_DISCONNECTED) {
  error_from_callback_ = true;  // Flag set AFTER listeners!
}
```

**After (correct, matches ESP-IDF):**
```cpp
case EVENT_STAMODE_DISCONNECTED:
  // ... logging ...
  error_from_callback_ = true;  // Flag set FIRST
  for (auto *listener : connect_state_listeners_) {
    listener->on_wifi_connect_state(...);  // Listeners called AFTER
  }
  break;
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported in Discord by szupi_ipuzs - WiFi roaming not reconnecting properly on ESP8266

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal fix
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional Context

### Bug Timeline

| Date | Commit | Event | Impact |
|------|--------|-------|--------|
| April 17, 2019 | `6682c43d` | Original ESP8266 WiFi code created | `error_from_callback_` set after switch - **latent bug** (no callbacks yet) |
| July 27, 2020 | `08c8fa2c` | CVE-2020-12638 mitigation added | Added `error_from_callback_` for authmode downgrade, set correctly inside case |
| November 24, 2025 | `2bc8a4a7` | Callbacks added to disconnect handler (PR #10748) | **Bug became active** - callbacks called before flag is set |
| November 28, 2025 | `26e979d3` | Converted to listener interfaces (PR #12155) | Bug continued with new listener pattern |

The bug was latent for ~6 years but only became an actual problem in November 2025 when disconnect callbacks were added inside the switch case while `error_from_callback_ = true` remained after the switch.
