### PR TITLE
[i2s_audio] Bugfix: Buffer overflow in software volume control

### DIFF
--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -340,8 +340,8 @@ void I2SAudioSpeaker::speaker_task(void *params) {
       const uint32_t read_delay =
           (this_speaker->current_stream_info_.frames_to_microseconds(frames_written) / 1000) / 2;
 
-      uint8_t *new_data = transfer_buffer->get_buffer_end();  // track start of any newly copied bytes
       size_t bytes_read = transfer_buffer->transfer_data_from_source(pdMS_TO_TICKS(read_delay));
+      uint8_t *new_data = transfer_buffer->get_buffer_end() - bytes_read;
 
       if (bytes_read > 0) {
         if (this_speaker->q15_volume_factor_ < INT16_MAX) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a buffer overflow when using software volume control. 

When you are not using an ``audio_dac`` component with hardware volume control, the ``i2s_audio`` speaker falls back to using software volume control. Previously, it would store the end of the existing data as separate pointer and then have the transfer buffer read more audio from the ring buffer. But, as part of the transferring/reading process, the AudioTransferBuffer shifts existing data to the start of its internal buffer, making the old pointer invalid. This PR instead determines the where the new data starts by subtracting the amount of bytes transferred from the new end.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin: GPIO25
    i2s_bclk_pin: GPIO5

speaker:
  - platform: i2s_audio
    id: i2s_audio_speaker
    dac_type: external
    i2s_dout_pin: GPIO26
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: stereo
    timeout: never
    buffer_duration: 200ms
    # Note there is no audio_dac specified
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
