### PR TITLE
[ota] Mark partition valid when OTA begins to prevent rollback blocking

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -8,6 +8,7 @@
 #include <esp_app_desc.h>
 #include <esp_hosted.h>
 #include <esp_hosted_host_fw_ver.h>
+#include <esp_ota_ops.h>
 
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
 #include "esphome/components/json/json_util.h"
@@ -441,6 +442,12 @@ void Esp32HostedUpdate::perform(bool force) {
   this->state_ = update::UPDATE_STATE_NO_UPDATE;
   this->status_clear_error();
   this->publish_state();
+
+#ifdef USE_OTA_ROLLBACK
+  // Mark the host partition as valid before rebooting, in case the safe mode
+  // timer hasn't expired yet.
+  esp_ota_mark_app_valid_cancel_rollback();
+#endif
 
   // Schedule a restart to ensure everything is in sync
   ESP_LOGI(TAG, "Restarting in 1 second");

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -14,6 +14,13 @@ namespace ota {
 std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::IDFOTABackend>(); }
 
 OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
+#ifdef USE_OTA_ROLLBACK
+  // If we're starting an OTA, the current boot is good enough - mark it valid
+  // to prevent rollback and allow the OTA to proceed even if the safe mode
+  // timer hasn't expired yet.
+  esp_ota_mark_app_valid_cancel_rollback();
+#endif
+
   this->partition_ = esp_ota_get_next_update_partition(nullptr);
   if (this->partition_ == nullptr) {
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;


### PR DESCRIPTION
# What does this implement/fix?

When `USE_OTA_ROLLBACK` is enabled (via `safe_mode` component), the ESP32 partition isn't marked as valid until one minute after boot (the safe mode timer). If an OTA update is attempted before that timer expires, OTA would fail because the rollback mechanism could trigger.

This fix marks the partition as valid at the start of OTA operations by calling `esp_ota_mark_app_valid_cancel_rollback()`. The logic is: if we're confident enough to start an OTA update, the current boot is good enough to cancel rollback.

**Components affected:**
- `ota/ota_backend_esp_idf.cpp` - Main ESP32 OTA backend (covers HTTP OTA, web server OTA, and native OTA)
- `esp32_hosted/update/esp32_hosted_update.cpp` - Coprocessor update component that reboots after updating (needs the fix before reboot)

**Other reboot locations analyzed (no fix needed):**
- User-triggered reboots (restart button/switch, factory reset) - Intentional user actions
- Error recovery reboots (BLE, MQTT, WiFi, etc.) - Rollback may be desired if device is having issues

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Enable safe mode with OTA rollback
safe_mode:

# Standard OTA
ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).