### PR TITLE
[api] Use push_back for BatchItem now that MessageCreator is trivially copyable

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1911,6 +1911,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator c
   }
 
   // No existing item found, add new one
+  // NOLINTNEXTLINE(modernize-use-emplace) - emplace_back with 4 trivial args generates more template bloat
   items.push_back({entity, creator, message_type, estimated_size});
 }
 
@@ -1920,6 +1921,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCre
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
+  // NOLINTNEXTLINE(modernize-use-emplace) - emplace_back with 4 trivial args generates more template bloat
   items.push_back({entity, creator, message_type, estimated_size});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1911,7 +1911,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, MessageCreator c
   }
 
   // No existing item found, add new one
-  items.emplace_back(entity, creator, message_type, estimated_size);
+  items.push_back({entity, creator, message_type, estimated_size});
 }
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCreator creator, uint8_t message_type,
@@ -1920,7 +1920,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, MessageCre
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
-  items.emplace_back(entity, creator, message_type, estimated_size);
+  items.push_back({entity, creator, message_type, estimated_size});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front
     std::swap(items.front(), items.back());


### PR DESCRIPTION
# What does this implement/fix?

Completes the cleanup from #12295 which simplified `MessageCreator` to a trivially copyable type.

When `MessageCreator` was move-only, `emplace_back` was necessary to construct `BatchItem` in-place and avoid copies. Now that `MessageCreator` is just a union of two pointers (trivially copyable), `emplace_back` with 4 arguments generates unnecessary template bloat.

The 4-argument `emplace_back` instantiates:
```
_M_realloc_insert<EntityBase*&, MessageCreator&, unsigned char&, unsigned char&>  (283 bytes)
```

Switching to `push_back` with brace initialization instantiates the simpler:
```
_M_realloc_insert<BatchItem&&>  (263 bytes)
```

This saves 20 bytes of flash. Copying 4 trivial types (2 pointers + 2 uint8_t) is essentially free, so there's no runtime cost.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Follow-up to #12295

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
