### PR TITLE
[scheduler] Eliminate heap allocations for std::string names and add uint32_t ID API

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -191,15 +191,15 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
     // instead of std::bind to avoid bind overhead (~16 bytes heap + faster execution)
     if constexpr (sizeof...(Ts) == 0) {
       App.scheduler.set_timer_common_(
-          this, Scheduler::SchedulerItem::TIMEOUT,
-          /* is_static_string= */ true, "delay", this->delay_.value(), [this]() { this->play_next_(); },
+          this, Scheduler::SchedulerItem::TIMEOUT, Scheduler::NameType::STATIC_STRING, "delay", 0, this->delay_.value(),
+          [this]() { this->play_next_(); },
           /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
     } else {
       // For delays with arguments, use std::bind to preserve argument values
       // Arguments must be copied because original references may be invalid after delay
       auto f = std::bind(&DelayAction<Ts...>::play_next_, this, x...);
-      App.scheduler.set_timer_common_(this, Scheduler::SchedulerItem::TIMEOUT,
-                                      /* is_static_string= */ true, "delay", this->delay_.value(x...), std::move(f),
+      App.scheduler.set_timer_common_(this, Scheduler::SchedulerItem::TIMEOUT, Scheduler::NameType::STATIC_STRING,
+                                      "delay", 0, this->delay_.value(x...), std::move(f),
                                       /* is_retry= */ false, /* skip_cancel= */ this->num_running_ > 1);
     }
   }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -118,7 +118,10 @@ void Component::setup() {}
 void Component::loop() {}
 
 void Component::set_interval(const std::string &name, uint32_t interval, std::function<void()> &&f) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_interval(this, name, interval, std::move(f));
+#pragma GCC diagnostic pop
 }
 
 void Component::set_interval(const char *name, uint32_t interval, std::function<void()> &&f) {  // NOLINT
@@ -126,7 +129,10 @@ void Component::set_interval(const char *name, uint32_t interval, std::function<
 }
 
 bool Component::cancel_interval(const std::string &name) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return App.scheduler.cancel_interval(this, name);
+#pragma GCC diagnostic pop
 }
 
 bool Component::cancel_interval(const char *name) {  // NOLINT
@@ -135,7 +141,10 @@ bool Component::cancel_interval(const char *name) {  // NOLINT
 
 void Component::set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
                           std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_retry(this, name, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+#pragma GCC diagnostic pop
 }
 
 void Component::set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
@@ -144,7 +153,10 @@ void Component::set_retry(const char *name, uint32_t initial_wait_time, uint8_t 
 }
 
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return App.scheduler.cancel_retry(this, name);
+#pragma GCC diagnostic pop
 }
 
 bool Component::cancel_retry(const char *name) {  // NOLINT
@@ -152,7 +164,10 @@ bool Component::cancel_retry(const char *name) {  // NOLINT
 }
 
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_timeout(this, name, timeout, std::move(f));
+#pragma GCC diagnostic pop
 }
 
 void Component::set_timeout(const char *name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
@@ -160,7 +175,10 @@ void Component::set_timeout(const char *name, uint32_t timeout, std::function<vo
 }
 
 bool Component::cancel_timeout(const std::string &name) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return App.scheduler.cancel_timeout(this, name);
+#pragma GCC diagnostic pop
 }
 
 bool Component::cancel_timeout(const char *name) {  // NOLINT
@@ -321,13 +339,19 @@ void Component::defer(std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), 0, std::move(f));
 }
 bool Component::cancel_defer(const std::string &name) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return App.scheduler.cancel_timeout(this, name);
+#pragma GCC diagnostic pop
 }
 bool Component::cancel_defer(const char *name) {  // NOLINT
   return App.scheduler.cancel_timeout(this, name);
 }
 void Component::defer(const std::string &name, std::function<void()> &&f) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_timeout(this, name, 0, std::move(f));
+#pragma GCC diagnostic pop
 }
 void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -167,6 +167,26 @@ bool Component::cancel_timeout(const char *name) {  // NOLINT
   return App.scheduler.cancel_timeout(this, name);
 }
 
+// uint32_t (numeric ID) overloads - zero heap allocation
+void Component::set_timeout(uint32_t id, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
+  App.scheduler.set_timeout(this, id, timeout, std::move(f));
+}
+
+bool Component::cancel_timeout(uint32_t id) { return App.scheduler.cancel_timeout(this, id); }
+
+void Component::set_interval(uint32_t id, uint32_t interval, std::function<void()> &&f) {  // NOLINT
+  App.scheduler.set_interval(this, id, interval, std::move(f));
+}
+
+bool Component::cancel_interval(uint32_t id) { return App.scheduler.cancel_interval(this, id); }
+
+void Component::set_retry(uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
+                          std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor) {  // NOLINT
+  App.scheduler.set_retry(this, id, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+}
+
+bool Component::cancel_retry(uint32_t id) { return App.scheduler.cancel_retry(this, id); }
+
 void Component::call_loop() { this->loop(); }
 void Component::call_setup() { this->setup(); }
 void Component::call_dump_config() {
@@ -301,6 +321,9 @@ void Component::defer(std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), 0, std::move(f));
 }
 bool Component::cancel_defer(const std::string &name) {  // NOLINT
+  return App.scheduler.cancel_timeout(this, name);
+}
+bool Component::cancel_defer(const char *name) {  // NOLINT
   return App.scheduler.cancel_timeout(this, name);
 }
 void Component::defer(const std::string &name, std::function<void()> &&f) {  // NOLINT

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -306,6 +306,8 @@ class Component {
    *
    * @see cancel_interval()
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   void set_interval(const std::string &name, uint32_t interval, std::function<void()> &&f);  // NOLINT
 
   /** Set an interval function with a const char* name.
@@ -324,6 +326,14 @@ class Component {
    */
   void set_interval(const char *name, uint32_t interval, std::function<void()> &&f);  // NOLINT
 
+  /** Set an interval function with a numeric ID (zero heap allocation).
+   *
+   * @param id The numeric identifier for this interval function
+   * @param interval The interval in ms
+   * @param f The function to call
+   */
+  void set_interval(uint32_t id, uint32_t interval, std::function<void()> &&f);  // NOLINT
+
   void set_interval(uint32_t interval, std::function<void()> &&f);  // NOLINT
 
   /** Cancel an interval function.
@@ -331,8 +341,11 @@ class Component {
    * @param name The identifier for this interval function.
    * @return Whether an interval functions was deleted.
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_interval(const std::string &name);  // NOLINT
   bool cancel_interval(const char *name);         // NOLINT
+  bool cancel_interval(uint32_t id);              // NOLINT
 
   /** Set an retry function with a unique name. Empty name means no cancelling possible.
    *
@@ -364,10 +377,23 @@ class Component {
    * @param backoff_increase_factor time between retries is multiplied by this factor on every retry after the first
    * @see cancel_retry()
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,       // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
   void set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,              // NOLINT
+                 std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
+
+  /** Set a retry function with a numeric ID (zero heap allocation).
+   *
+   * @param id The numeric identifier for this retry function
+   * @param initial_wait_time The wait time after the first execution
+   * @param max_attempts The max number of attempts
+   * @param f The function to call
+   * @param backoff_increase_factor The factor to increase the retry interval by
+   */
+  void set_retry(uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,                   // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
   void set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,  // NOLINT
@@ -378,8 +404,11 @@ class Component {
    * @param name The identifier for this retry function.
    * @return Whether a retry function was deleted.
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_retry(const std::string &name);  // NOLINT
   bool cancel_retry(const char *name);         // NOLINT
+  bool cancel_retry(uint32_t id);              // NOLINT
 
   /** Set a timeout function with a unique name.
    *
@@ -395,6 +424,8 @@ class Component {
    *
    * @see cancel_timeout()
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   void set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f);  // NOLINT
 
   /** Set a timeout function with a const char* name.
@@ -413,6 +444,14 @@ class Component {
    */
   void set_timeout(const char *name, uint32_t timeout, std::function<void()> &&f);  // NOLINT
 
+  /** Set a timeout function with a numeric ID (zero heap allocation).
+   *
+   * @param id The numeric identifier for this timeout function
+   * @param timeout The timeout in ms
+   * @param f The function to call
+   */
+  void set_timeout(uint32_t id, uint32_t timeout, std::function<void()> &&f);  // NOLINT
+
   void set_timeout(uint32_t timeout, std::function<void()> &&f);  // NOLINT
 
   /** Cancel a timeout function.
@@ -420,8 +459,11 @@ class Component {
    * @param name The identifier for this timeout function.
    * @return Whether a timeout functions was deleted.
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_timeout(const std::string &name);  // NOLINT
   bool cancel_timeout(const char *name);         // NOLINT
+  bool cancel_timeout(uint32_t id);              // NOLINT
 
   /** Defer a callback to the next loop() call.
    *
@@ -430,6 +472,8 @@ class Component {
    * @param name The name of the defer function.
    * @param f The callback.
    */
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* overload instead. Removed in 2026.7.0", "2026.1.0")
   void defer(const std::string &name, std::function<void()> &&f);  // NOLINT
 
   /** Defer a callback to the next loop() call with a const char* name.
@@ -451,7 +495,10 @@ class Component {
   void defer(std::function<void()> &&f);  // NOLINT
 
   /// Cancel a defer callback using the specified name, name must not be empty.
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_defer(const std::string &name);  // NOLINT
+  bool cancel_defer(const char *name);         // NOLINT
 
   // Ordered for optimal packing on 32-bit systems
   const LogString *component_source_{nullptr};

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -8,11 +8,15 @@
 // ESP8266 uses Arduino macros
 #define ESPHOME_F(string_literal) F(string_literal)
 #define ESPHOME_PGM_P PGM_P
+#define ESPHOME_PSTR(s) PSTR(s)
 #define ESPHOME_strncpy_P strncpy_P
 #define ESPHOME_strncat_P strncat_P
+#define ESPHOME_snprintf_P snprintf_P
 #else
 #define ESPHOME_F(string_literal) (string_literal)
 #define ESPHOME_PGM_P const char *
+#define ESPHOME_PSTR(s) (s)
 #define ESPHOME_strncpy_P strncpy
 #define ESPHOME_strncat_P strncat
+#define ESPHOME_snprintf_P snprintf
 #endif

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -175,8 +175,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   }
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
-  this->debug_log_timer_(item.get(), name_type == NameType::STATIC_STRING,
-                         name_type == NameType::STATIC_STRING ? static_name : nullptr, type, delay, now);
+  this->debug_log_timer_(item.get(), name_type, static_name, hash_or_id, type, delay, now);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
   // For retries, check if there's a cancelled timeout first
@@ -854,21 +853,22 @@ void Scheduler::recycle_item_main_loop_(std::unique_ptr<SchedulerItem> item) {
 }
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
-void Scheduler::debug_log_timer_(const SchedulerItem *item, bool is_static_string, const char *name_cstr,
-                                 SchedulerItem::Type type, uint32_t delay, uint64_t now) {
+void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, const char *static_name,
+                                 uint32_t hash_or_id, SchedulerItem::Type type, uint32_t delay, uint64_t now) {
   // Validate static strings in debug mode
-  if (is_static_string && name_cstr != nullptr) {
-    validate_static_string(name_cstr);
+  if (name_type == NameType::STATIC_STRING && static_name != nullptr) {
+    validate_static_string(static_name);
   }
 
   // Debug logging
+  SchedulerNameLog name_log;
   const char *type_str = (type == SchedulerItem::TIMEOUT) ? "timeout" : "interval";
   if (type == SchedulerItem::TIMEOUT) {
     ESP_LOGD(TAG, "set_%s(name='%s/%s', %s=%" PRIu32 ")", type_str, LOG_STR_ARG(item->get_source()),
-             name_cstr ? name_cstr : "(null)", type_str, delay);
+             name_log.format(name_type, static_name, hash_or_id), type_str, delay);
   } else {
     ESP_LOGD(TAG, "set_%s(name='%s/%s', %s=%" PRIu32 ", offset=%" PRIu32 ")", type_str, LOG_STR_ARG(item->get_source()),
-             name_cstr ? name_cstr : "(null)", type_str, delay,
+             name_log.format(name_type, static_name, hash_or_id), type_str, delay,
              static_cast<uint32_t>(item->get_next_execution() - now));
   }
 }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -446,10 +446,11 @@ void HOT Scheduler::call(uint32_t now) {
         item = this->pop_raw_locked_();
       }
 
-      const char *name = item->get_name();
+      SchedulerNameLog name_log;
       bool is_cancelled = is_item_removed_(item.get());
       ESP_LOGD(TAG, "  %s '%s/%s' interval=%" PRIu32 " next_execution in %" PRIu64 "ms at %" PRIu64 "%s",
-               item->get_type_str(), LOG_STR_ARG(item->get_source()), name ? name : "(null)", item->interval,
+               item->get_type_str(), LOG_STR_ARG(item->get_source()),
+               name_log.format(item->get_name_type(), item->get_name(), item->get_name_hash_or_id()), item->interval,
                item->get_next_execution() - now_64, item->get_next_execution(), is_cancelled ? " [CANCELLED]" : "");
 
       old_items.push_back(std::move(item));
@@ -513,10 +514,13 @@ void HOT Scheduler::call(uint32_t now) {
 #endif
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    const char *item_name = item->get_name();
-    ESP_LOGV(TAG, "Running %s '%s/%s' with interval=%" PRIu32 " next_execution=%" PRIu64 " (now=%" PRIu64 ")",
-             item->get_type_str(), LOG_STR_ARG(item->get_source()), item_name ? item_name : "(null)", item->interval,
-             item->get_next_execution(), now_64);
+    {
+      SchedulerNameLog name_log;
+      ESP_LOGV(TAG, "Running %s '%s/%s' with interval=%" PRIu32 " next_execution=%" PRIu64 " (now=%" PRIu64 ")",
+               item->get_type_str(), LOG_STR_ARG(item->get_source()),
+               name_log.format(item->get_name_type(), item->get_name(), item->get_name_hash_or_id()), item->interval,
+               item->get_next_execution(), now_64);
+    }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
     // Warning: During callback(), a lot of stuff can happen, including:

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include <algorithm>
 #include <cinttypes>
 #include <cstring>
@@ -32,26 +33,33 @@ static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max()
 // max delay to start an interval sequence
 static constexpr uint32_t MAX_INTERVAL_DELAY = 5000;
 
+#if defined(ESPHOME_LOG_HAS_VERBOSE) || defined(ESPHOME_DEBUG_SCHEDULER)
 // Helper struct for formatting scheduler item names consistently in logs
 // Uses a stack buffer to avoid heap allocation
+// Uses ESPHOME_snprintf_P/ESPHOME_PSTR for ESP8266 to keep format strings in flash
 struct SchedulerNameLog {
-  char buffer[20];  // Enough for "id:4294967295" or "hash:0xFFFFFFFF"
+  char buffer[20];  // Enough for "id:4294967295" or "hash:0xFFFFFFFF" or "(null)"
 
   // Format a scheduler item name for logging
   // Returns pointer to formatted string (either static_name or internal buffer)
   const char *format(Scheduler::NameType name_type, const char *static_name, uint32_t hash_or_id) {
     using NameType = Scheduler::NameType;
     if (name_type == NameType::STATIC_STRING) {
-      return static_name ? static_name : "(null)";
+      if (static_name)
+        return static_name;
+      // Copy "(null)" to buffer to keep it in flash on ESP8266
+      ESPHOME_strncpy_P(buffer, ESPHOME_PSTR("(null)"), sizeof(buffer));
+      return buffer;
     } else if (name_type == NameType::HASHED_STRING) {
-      snprintf(buffer, sizeof(buffer), "hash:0x%08" PRIX32, hash_or_id);
+      ESPHOME_snprintf_P(buffer, sizeof(buffer), ESPHOME_PSTR("hash:0x%08" PRIX32), hash_or_id);
       return buffer;
     } else {  // NUMERIC_ID
-      snprintf(buffer, sizeof(buffer), "id:%" PRIu32, hash_or_id);
+      ESPHOME_snprintf_P(buffer, sizeof(buffer), ESPHOME_PSTR("id:%" PRIu32), hash_or_id);
       return buffer;
     }
   }
 };
+#endif
 
 // Uncomment to debug scheduler
 // #define ESPHOME_DEBUG_SCHEDULER
@@ -156,9 +164,11 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     // Calculate random offset (0 to min(interval/2, 5s))
     uint32_t offset = (uint32_t) (std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
     item->set_next_execution(now + offset);
+#ifdef ESPHOME_LOG_HAS_VERBOSE
     SchedulerNameLog name_log;
     ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms",
              name_log.format(name_type, static_name, hash_or_id), delay, offset);
+#endif
   } else {
     item->interval = 0;
     item->set_next_execution(now + delay);
@@ -284,16 +294,20 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
 
-  SchedulerNameLog name_log;
-  ESP_LOGVV(TAG, "set_retry(name='%s', initial_wait_time=%" PRIu32 ", max_attempts=%u, backoff_factor=%0.1f)",
-            name_log.format(name_type, static_name, hash_or_id), initial_wait_time, max_attempts,
-            backoff_increase_factor);
-
   if (backoff_increase_factor < 0.0001) {
-    ESP_LOGE(TAG, "backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
-             name_log.format(name_type, static_name, hash_or_id));
+    ESP_LOGE(TAG, "set_retry: backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
+             (name_type == NameType::STATIC_STRING && static_name) ? static_name : "");
     backoff_increase_factor = 1;
   }
+
+#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
+  {
+    SchedulerNameLog name_log;
+    ESP_LOGVV(TAG, "set_retry(name='%s', initial_wait_time=%" PRIu32 ", max_attempts=%u, backoff_factor=%0.1f)",
+              name_log.format(name_type, static_name, hash_or_id), initial_wait_time, max_attempts,
+              backoff_increase_factor);
+  }
+#endif
 
   auto args = std::make_shared<RetryArgs>();
   args->func = std::move(func);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -161,6 +161,11 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     item->set_next_execution(now + delay);
   }
 
+#ifdef ESPHOME_DEBUG_SCHEDULER
+  this->debug_log_timer_(item.get(), name_type == NameType::STATIC_STRING,
+                         name_type == NameType::STATIC_STRING ? static_name : nullptr, type, delay, now);
+#endif /* ESPHOME_DEBUG_SCHEDULER */
+
   // For retries, check if there's a cancelled timeout first
   if (is_retry && type == SchedulerItem::TIMEOUT) {
     if (has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
@@ -175,19 +180,43 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     }
   }
 
-  // Cancel existing items with same name/id (unless skip_cancel is true)
+  // If name is provided, do atomic cancel-and-add (unless skip_cancel is true)
+  // Cancel existing items
   if (!skip_cancel) {
     this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
   }
-
-  // Add new item directly to to_add_ since we have the lock held
+  // Add new item directly to to_add_
+  // since we have the lock held
   this->to_add_.push_back(std::move(item));
 }
 
-// Public API - const char* (static string) versions
 void HOT Scheduler::set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func) {
   this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::STATIC_STRING, name, 0, timeout,
                           std::move(func));
+}
+
+void HOT Scheduler::set_timeout(Component *component, const std::string &name, uint32_t timeout,
+                                std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                          timeout, std::move(func));
+}
+void HOT Scheduler::set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::NUMERIC_ID, nullptr, id, timeout,
+                          std::move(func));
+}
+bool HOT Scheduler::cancel_timeout(Component *component, const std::string &name) {
+  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::TIMEOUT);
+}
+bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
+  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT);
+}
+bool HOT Scheduler::cancel_timeout(Component *component, uint32_t id) {
+  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
+}
+void HOT Scheduler::set_interval(Component *component, const std::string &name, uint32_t interval,
+                                 std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                          interval, std::move(func));
 }
 
 void HOT Scheduler::set_interval(Component *component, const char *name, uint32_t interval,
@@ -195,58 +224,16 @@ void HOT Scheduler::set_interval(Component *component, const char *name, uint32_
   this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::STATIC_STRING, name, 0, interval,
                           std::move(func));
 }
-
-// Common implementation for cancel operations - handles locking
-bool HOT Scheduler::cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
-                                 SchedulerItem::Type type, bool match_retry) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type, match_retry);
-}
-
-bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
-  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT);
-}
-
-bool HOT Scheduler::cancel_interval(Component *component, const char *name) {
-  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::INTERVAL);
-}
-
-// Public API - std::string (hashed) versions - computes FNV-1a hash internally
-void HOT Scheduler::set_timeout(Component *component, const std::string &name, uint32_t timeout,
-                                std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
-                          timeout, std::move(func));
-}
-
-void HOT Scheduler::set_interval(Component *component, const std::string &name, uint32_t interval,
-                                 std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
-                          interval, std::move(func));
-}
-
-bool HOT Scheduler::cancel_timeout(Component *component, const std::string &name) {
-  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::TIMEOUT);
-}
-
-bool HOT Scheduler::cancel_interval(Component *component, const std::string &name) {
-  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::INTERVAL);
-}
-
-// Public API - uint32_t (numeric ID) versions
-void HOT Scheduler::set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::NUMERIC_ID, nullptr, id, timeout,
-                          std::move(func));
-}
-
 void HOT Scheduler::set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func) {
   this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::NUMERIC_ID, nullptr, id, interval,
                           std::move(func));
 }
-
-bool HOT Scheduler::cancel_timeout(Component *component, uint32_t id) {
-  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
+bool HOT Scheduler::cancel_interval(Component *component, const std::string &name) {
+  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::INTERVAL);
 }
-
+bool HOT Scheduler::cancel_interval(Component *component, const char *name) {
+  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::INTERVAL);
+}
 bool HOT Scheduler::cancel_interval(Component *component, uint32_t id) {
   return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::INTERVAL);
 }
@@ -271,8 +258,9 @@ void retry_handler(const std::shared_ptr<RetryArgs> &args) {
   RetryResult const retry_result = args->func(--args->retry_countdown);
   if (retry_result == RetryResult::DONE || args->retry_countdown <= 0)
     return;
-  // Second execution of `func` happens after `initial_wait_time`
-  // static_name is owned by the shared_ptr<RetryArgs> which is captured in the lambda
+  // second execution of `func` happens after `initial_wait_time`
+  // args->name_ is owned by the shared_ptr<RetryArgs>
+  // which is captured in the lambda and outlives the SchedulerItem
   const char *static_name = (args->name_type == Scheduler::NameType::STATIC_STRING) ? args->name_.static_name : nullptr;
   uint32_t hash_or_id = (args->name_type != Scheduler::NameType::STATIC_STRING) ? args->name_.hash_or_id : 0;
   args->scheduler->set_timer_common_(
@@ -283,17 +271,10 @@ void retry_handler(const std::shared_ptr<RetryArgs> &args) {
   args->current_interval *= args->backoff_increase_factor;
 }
 
-// Common implementation for retry
-// name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
 void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, const char *static_name,
                                       uint32_t hash_or_id, uint32_t initial_wait_time, uint8_t max_attempts,
                                       std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
-  // Cancel existing retry with same name/id
-  {
-    LockGuard guard{this->lock_};
-    this->cancel_item_locked_(component, name_type, static_name, hash_or_id, SchedulerItem::TIMEOUT,
-                              /* match_retry= */ true);
-  }
+  this->cancel_retry(component, name_type, static_name, hash_or_id);
 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
@@ -327,19 +308,21 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
       /* is_retry= */ true);
 }
 
-// Public API - const char* (static string) versions
 void HOT Scheduler::set_retry(Component *component, const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                               std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
   this->set_retry_common_(component, NameType::STATIC_STRING, name, 0, initial_wait_time, max_attempts, std::move(func),
                           backoff_increase_factor);
 }
 
-bool HOT Scheduler::cancel_retry(Component *component, const char *name) {
-  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT,
+bool HOT Scheduler::cancel_retry(Component *component, NameType name_type, const char *static_name,
+                                 uint32_t hash_or_id) {
+  return this->cancel_item_(component, name_type, static_name, hash_or_id, SchedulerItem::TIMEOUT,
                             /* match_retry= */ true);
 }
+bool HOT Scheduler::cancel_retry(Component *component, const char *name) {
+  return this->cancel_retry(component, NameType::STATIC_STRING, name, 0);
+}
 
-// Public API - std::string (hashed) versions
 void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t initial_wait_time,
                               uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
                               float backoff_increase_factor) {
@@ -348,11 +331,9 @@ void HOT Scheduler::set_retry(Component *component, const std::string &name, uin
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) {
-  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::TIMEOUT,
-                            /* match_retry= */ true);
+  return this->cancel_retry(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name));
 }
 
-// Public API - uint32_t (numeric ID) versions
 void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
                               std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
   this->set_retry_common_(component, NameType::NUMERIC_ID, nullptr, id, initial_wait_time, max_attempts,
@@ -360,8 +341,7 @@ void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initia
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
-  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT,
-                            /* match_retry= */ true);
+  return this->cancel_retry(component, NameType::NUMERIC_ID, nullptr, id);
 }
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
@@ -612,6 +592,13 @@ uint32_t HOT Scheduler::execute_item_(SchedulerItem *item, uint32_t now) {
   WarnIfComponentBlockingGuard guard{item->component, now};
   item->callback();
   return guard.finish();
+}
+
+// Common implementation for cancel operations - handles locking
+bool HOT Scheduler::cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                                 SchedulerItem::Type type, bool match_retry) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type, match_retry);
 }
 
 // Helper to cancel items - must be called with lock held

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -32,6 +32,27 @@ static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max()
 // max delay to start an interval sequence
 static constexpr uint32_t MAX_INTERVAL_DELAY = 5000;
 
+// Helper struct for formatting scheduler item names consistently in logs
+// Uses a stack buffer to avoid heap allocation
+struct SchedulerNameLog {
+  char buffer[20];  // Enough for "id:4294967295" or "hash:0xFFFFFFFF"
+
+  // Format a scheduler item name for logging
+  // Returns pointer to formatted string (either static_name or internal buffer)
+  const char *format(Scheduler::NameType name_type, const char *static_name, uint32_t hash_or_id) {
+    using NameType = Scheduler::NameType;
+    if (name_type == NameType::STATIC_STRING) {
+      return static_name ? static_name : "(null)";
+    } else if (name_type == NameType::HASHED_STRING) {
+      snprintf(buffer, sizeof(buffer), "hash:0x%08" PRIX32, hash_or_id);
+      return buffer;
+    } else {  // NUMERIC_ID
+      snprintf(buffer, sizeof(buffer), "id:%" PRIu32, hash_or_id);
+      return buffer;
+    }
+  }
+};
+
 // Uncomment to debug scheduler
 // #define ESPHOME_DEBUG_SCHEDULER
 
@@ -135,8 +156,9 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     // Calculate random offset (0 to min(interval/2, 5s))
     uint32_t offset = (uint32_t) (std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
     item->set_next_execution(now + offset);
+    SchedulerNameLog name_log;
     ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms",
-             name_type == NameType::STATIC_STRING ? static_name : "(id)", delay, offset);
+             name_log.format(name_type, static_name, hash_or_id), delay, offset);
   } else {
     item->interval = 0;
     item->set_next_execution(now + delay);
@@ -156,7 +178,9 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
                                                   /* match_retry= */ true))) {
     // Skip scheduling - the retry was cancelled
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Skipping retry - found cancelled item");
+    SchedulerNameLog skip_name_log;
+    ESP_LOGD(TAG, "Skipping retry '%s' - found cancelled item",
+             skip_name_log.format(name_type, static_name, hash_or_id));
 #endif
     return;
   }
@@ -260,12 +284,14 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
 
+  SchedulerNameLog name_log;
   ESP_LOGVV(TAG, "set_retry(name='%s', initial_wait_time=%" PRIu32 ", max_attempts=%u, backoff_factor=%0.1f)",
-            name_type == NameType::STATIC_STRING ? static_name : "(id)", initial_wait_time, max_attempts,
+            name_log.format(name_type, static_name, hash_or_id), initial_wait_time, max_attempts,
             backoff_increase_factor);
 
   if (backoff_increase_factor < 0.0001) {
-    ESP_LOGE(TAG, "backoff_factor %0.1f too small, using 1.0", backoff_increase_factor);
+    ESP_LOGE(TAG, "backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
+             name_log.format(name_type, static_name, hash_or_id));
     backoff_increase_factor = 1;
   }
 

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -294,12 +294,6 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
 
-  if (backoff_increase_factor < 0.0001) {
-    ESP_LOGE(TAG, "set_retry: backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
-             (name_type == NameType::STATIC_STRING && static_name) ? static_name : "");
-    backoff_increase_factor = 1;
-  }
-
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
   {
     SchedulerNameLog name_log;
@@ -308,6 +302,12 @@ void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, 
               backoff_increase_factor);
   }
 #endif
+
+  if (backoff_increase_factor < 0.0001) {
+    ESP_LOGE(TAG, "set_retry: backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
+             (name_type == NameType::STATIC_STRING && static_name) ? static_name : "");
+    backoff_increase_factor = 1;
+  }
 
   auto args = std::make_shared<RetryArgs>();
   args->func = std::move(func);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -75,25 +75,6 @@ static void validate_static_string(const char *name) {
 // iterating over them from the loop task is fine; but iterating from any other context requires the lock to be held to
 // avoid the main thread modifying the list while it is being accessed.
 
-// Helper to get or create a scheduler item from the pool
-// IMPORTANT: Caller must hold the scheduler lock before calling this function.
-std::unique_ptr<Scheduler::SchedulerItem> Scheduler::get_item_from_pool_locked_() {
-  std::unique_ptr<SchedulerItem> item;
-  if (!this->scheduler_item_pool_.empty()) {
-    item = std::move(this->scheduler_item_pool_.back());
-    this->scheduler_item_pool_.pop_back();
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
-#endif
-  } else {
-    item = make_unique<SchedulerItem>();
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Allocated new item (pool empty)");
-#endif
-  }
-  return item;
-}
-
 // Common implementation for both timeout and interval
 // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
 void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type,
@@ -167,17 +148,17 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
   // For retries, check if there's a cancelled timeout first
-  if (is_retry && type == SchedulerItem::TIMEOUT) {
-    if (has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
-                                                   /* match_retry= */ true) ||
-        has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_type, static_name, hash_or_id,
-                                                   /* match_retry= */ true)) {
-      // Skip scheduling - the retry was cancelled
+  // Skip check for anonymous retries (STATIC_STRING with nullptr) - they can't be cancelled by name
+  if (is_retry && (name_type != NameType::STATIC_STRING || static_name != nullptr) && type == SchedulerItem::TIMEOUT &&
+      (has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
+                                                  /* match_retry= */ true) ||
+       has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_type, static_name, hash_or_id,
+                                                  /* match_retry= */ true))) {
+    // Skip scheduling - the retry was cancelled
 #ifdef ESPHOME_DEBUG_SCHEDULER
-      ESP_LOGD(TAG, "Skipping retry - found cancelled item");
+    ESP_LOGD(TAG, "Skipping retry - found cancelled item");
 #endif
-      return;
-    }
+    return;
   }
 
   // If name is provided, do atomic cancel-and-add (unless skip_cancel is true)
@@ -848,5 +829,24 @@ void Scheduler::debug_log_timer_(const SchedulerItem *item, bool is_static_strin
   }
 }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
+
+// Helper to get or create a scheduler item from the pool
+// IMPORTANT: Caller must hold the scheduler lock before calling this function.
+std::unique_ptr<Scheduler::SchedulerItem> Scheduler::get_item_from_pool_locked_() {
+  std::unique_ptr<SchedulerItem> item;
+  if (!this->scheduler_item_pool_.empty()) {
+    item = std::move(this->scheduler_item_pool_.back());
+    this->scheduler_item_pool_.pop_back();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+#endif
+  } else {
+    item = make_unique<SchedulerItem>();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Allocated new item (pool empty)");
+#endif
+  }
+  return item;
+}
 
 }  // namespace esphome

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -196,14 +196,19 @@ void HOT Scheduler::set_interval(Component *component, const char *name, uint32_
                           std::move(func));
 }
 
-bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
+// Common implementation for cancel operations - handles locking
+bool HOT Scheduler::cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                                 SchedulerItem::Type type, bool match_retry) {
   LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT);
+  return this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type, match_retry);
+}
+
+bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
+  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT);
 }
 
 bool HOT Scheduler::cancel_interval(Component *component, const char *name) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::INTERVAL);
+  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::INTERVAL);
 }
 
 // Public API - std::string (hashed) versions - computes FNV-1a hash internally
@@ -220,15 +225,11 @@ void HOT Scheduler::set_interval(Component *component, const std::string &name, 
 }
 
 bool HOT Scheduler::cancel_timeout(Component *component, const std::string &name) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
-                                   SchedulerItem::TIMEOUT);
+  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::TIMEOUT);
 }
 
 bool HOT Scheduler::cancel_interval(Component *component, const std::string &name) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
-                                   SchedulerItem::INTERVAL);
+  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::INTERVAL);
 }
 
 // Public API - uint32_t (numeric ID) versions
@@ -243,13 +244,11 @@ void HOT Scheduler::set_interval(Component *component, uint32_t id, uint32_t int
 }
 
 bool HOT Scheduler::cancel_timeout(Component *component, uint32_t id) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
+  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
 }
 
 bool HOT Scheduler::cancel_interval(Component *component, uint32_t id) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::INTERVAL);
+  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::INTERVAL);
 }
 
 struct RetryArgs {
@@ -336,9 +335,8 @@ void HOT Scheduler::set_retry(Component *component, const char *name, uint32_t i
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, const char *name) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT,
-                                   /* match_retry= */ true);
+  return this->cancel_item_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT,
+                            /* match_retry= */ true);
 }
 
 // Public API - std::string (hashed) versions
@@ -350,9 +348,8 @@ void HOT Scheduler::set_retry(Component *component, const std::string &name, uin
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
-                                   SchedulerItem::TIMEOUT, /* match_retry= */ true);
+  return this->cancel_item_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), SchedulerItem::TIMEOUT,
+                            /* match_retry= */ true);
 }
 
 // Public API - uint32_t (numeric ID) versions
@@ -363,9 +360,8 @@ void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initia
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT,
-                                   /* match_retry= */ true);
+  return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT,
+                            /* match_retry= */ true);
 }
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -279,7 +279,7 @@ void retry_handler(const std::shared_ptr<RetryArgs> &args) {
 void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, const char *static_name,
                                       uint32_t hash_or_id, uint32_t initial_wait_time, uint8_t max_attempts,
                                       std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
-  this->cancel_retry(component, name_type, static_name, hash_or_id);
+  this->cancel_retry_(component, name_type, static_name, hash_or_id);
 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
@@ -321,13 +321,13 @@ void HOT Scheduler::set_retry(Component *component, const char *name, uint32_t i
                           backoff_increase_factor);
 }
 
-bool HOT Scheduler::cancel_retry(Component *component, NameType name_type, const char *static_name,
-                                 uint32_t hash_or_id) {
+bool HOT Scheduler::cancel_retry_(Component *component, NameType name_type, const char *static_name,
+                                  uint32_t hash_or_id) {
   return this->cancel_item_(component, name_type, static_name, hash_or_id, SchedulerItem::TIMEOUT,
                             /* match_retry= */ true);
 }
 bool HOT Scheduler::cancel_retry(Component *component, const char *name) {
-  return this->cancel_retry(component, NameType::STATIC_STRING, name, 0);
+  return this->cancel_retry_(component, NameType::STATIC_STRING, name, 0);
 }
 
 void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t initial_wait_time,
@@ -338,7 +338,7 @@ void HOT Scheduler::set_retry(Component *component, const std::string &name, uin
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) {
-  return this->cancel_retry(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name));
+  return this->cancel_retry_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name));
 }
 
 void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
@@ -348,7 +348,7 @@ void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initia
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
-  return this->cancel_retry(component, NameType::NUMERIC_ID, nullptr, id);
+  return this->cancel_retry_(component, NameType::NUMERIC_ID, nullptr, id);
 }
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -75,18 +75,35 @@ static void validate_static_string(const char *name) {
 // iterating over them from the loop task is fine; but iterating from any other context requires the lock to be held to
 // avoid the main thread modifying the list while it is being accessed.
 
-// Common implementation for both timeout and interval
-void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type type, bool is_static_string,
-                                      const void *name_ptr, uint32_t delay, std::function<void()> func, bool is_retry,
-                                      bool skip_cancel) {
-  // Get the name as const char*
-  const char *name_cstr = this->get_name_cstr_(is_static_string, name_ptr);
+// Helper to get or create a scheduler item from the pool
+// IMPORTANT: Caller must hold the scheduler lock before calling this function.
+std::unique_ptr<Scheduler::SchedulerItem> Scheduler::get_item_from_pool_locked_() {
+  std::unique_ptr<SchedulerItem> item;
+  if (!this->scheduler_item_pool_.empty()) {
+    item = std::move(this->scheduler_item_pool_.back());
+    this->scheduler_item_pool_.pop_back();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+#endif
+  } else {
+    item = make_unique<SchedulerItem>();
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    ESP_LOGD(TAG, "Allocated new item (pool empty)");
+#endif
+  }
+  return item;
+}
 
+// Common implementation for both timeout and interval
+// name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
+void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type,
+                                      const char *static_name, uint32_t hash_or_id, uint32_t delay,
+                                      std::function<void()> func, bool is_retry, bool skip_cancel) {
   if (delay == SCHEDULER_DONT_RUN) {
-    // Still need to cancel existing timer if name is not empty
+    // Still need to cancel existing timer if we have a name/id
     if (!skip_cancel) {
       LockGuard guard{this->lock_};
-      this->cancel_item_locked_(component, name_cstr, type);
+      this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
     }
     return;
   }
@@ -98,23 +115,19 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   LockGuard guard{this->lock_};
 
   // Create and populate the scheduler item
-  std::unique_ptr<SchedulerItem> item;
-  if (!this->scheduler_item_pool_.empty()) {
-    // Reuse from pool
-    item = std::move(this->scheduler_item_pool_.back());
-    this->scheduler_item_pool_.pop_back();
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
-#endif
-  } else {
-    // Allocate new if pool is empty
-    item = make_unique<SchedulerItem>();
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Allocated new item (pool empty)");
-#endif
-  }
+  auto item = this->get_item_from_pool_locked_();
   item->component = component;
-  item->set_name(name_cstr, !is_static_string);
+  switch (name_type) {
+    case NameType::STATIC_STRING:
+      item->set_static_name(static_name);
+      break;
+    case NameType::HASHED_STRING:
+      item->set_hashed_name(hash_or_id);
+      break;
+    case NameType::NUMERIC_ID:
+      item->set_numeric_id(hash_or_id);
+      break;
+  }
   item->type = type;
   item->callback = std::move(func);
   // Reset remove flag - recycled items may have been cancelled (remove=true) in previous use
@@ -127,7 +140,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
     // Put in defer queue for guaranteed FIFO execution
     if (!skip_cancel) {
-      this->cancel_item_locked_(component, name_cstr, type);
+      this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
     }
     this->defer_queue_.push_back(std::move(item));
     return;
@@ -141,66 +154,102 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     // Calculate random offset (0 to min(interval/2, 5s))
     uint32_t offset = (uint32_t) (std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
     item->set_next_execution(now + offset);
-    ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms", name_cstr ? name_cstr : "", delay,
-             offset);
+    ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms",
+             name_type == NameType::STATIC_STRING ? static_name : "(id)", delay, offset);
   } else {
     item->interval = 0;
     item->set_next_execution(now + delay);
   }
 
-#ifdef ESPHOME_DEBUG_SCHEDULER
-  this->debug_log_timer_(item.get(), is_static_string, name_cstr, type, delay, now);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
-
   // For retries, check if there's a cancelled timeout first
-  if (is_retry && name_cstr != nullptr && type == SchedulerItem::TIMEOUT &&
-      (has_cancelled_timeout_in_container_locked_(this->items_, component, name_cstr, /* match_retry= */ true) ||
-       has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_cstr, /* match_retry= */ true))) {
-    // Skip scheduling - the retry was cancelled
+  if (is_retry && type == SchedulerItem::TIMEOUT) {
+    if (has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
+                                                   /* match_retry= */ true) ||
+        has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_type, static_name, hash_or_id,
+                                                   /* match_retry= */ true)) {
+      // Skip scheduling - the retry was cancelled
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Skipping retry '%s' - found cancelled item", name_cstr);
+      ESP_LOGD(TAG, "Skipping retry - found cancelled item");
 #endif
-    return;
+      return;
+    }
   }
 
-  // If name is provided, do atomic cancel-and-add (unless skip_cancel is true)
-  // Cancel existing items
+  // Cancel existing items with same name/id (unless skip_cancel is true)
   if (!skip_cancel) {
-    this->cancel_item_locked_(component, name_cstr, type);
+    this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
   }
-  // Add new item directly to to_add_
-  // since we have the lock held
+
+  // Add new item directly to to_add_ since we have the lock held
   this->to_add_.push_back(std::move(item));
 }
 
+// Public API - const char* (static string) versions
 void HOT Scheduler::set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::TIMEOUT, true, name, timeout, std::move(func));
-}
-
-void HOT Scheduler::set_timeout(Component *component, const std::string &name, uint32_t timeout,
-                                std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::TIMEOUT, false, &name, timeout, std::move(func));
-}
-bool HOT Scheduler::cancel_timeout(Component *component, const std::string &name) {
-  return this->cancel_item_(component, false, &name, SchedulerItem::TIMEOUT);
-}
-bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
-  return this->cancel_item_(component, true, name, SchedulerItem::TIMEOUT);
-}
-void HOT Scheduler::set_interval(Component *component, const std::string &name, uint32_t interval,
-                                 std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::INTERVAL, false, &name, interval, std::move(func));
+  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::STATIC_STRING, name, 0, timeout,
+                          std::move(func));
 }
 
 void HOT Scheduler::set_interval(Component *component, const char *name, uint32_t interval,
                                  std::function<void()> func) {
-  this->set_timer_common_(component, SchedulerItem::INTERVAL, true, name, interval, std::move(func));
+  this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::STATIC_STRING, name, 0, interval,
+                          std::move(func));
 }
-bool HOT Scheduler::cancel_interval(Component *component, const std::string &name) {
-  return this->cancel_item_(component, false, &name, SchedulerItem::INTERVAL);
+
+bool HOT Scheduler::cancel_timeout(Component *component, const char *name) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT);
 }
+
 bool HOT Scheduler::cancel_interval(Component *component, const char *name) {
-  return this->cancel_item_(component, true, name, SchedulerItem::INTERVAL);
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::INTERVAL);
+}
+
+// Public API - std::string (hashed) versions - computes FNV-1a hash internally
+void HOT Scheduler::set_timeout(Component *component, const std::string &name, uint32_t timeout,
+                                std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                          timeout, std::move(func));
+}
+
+void HOT Scheduler::set_interval(Component *component, const std::string &name, uint32_t interval,
+                                 std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                          interval, std::move(func));
+}
+
+bool HOT Scheduler::cancel_timeout(Component *component, const std::string &name) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                                   SchedulerItem::TIMEOUT);
+}
+
+bool HOT Scheduler::cancel_interval(Component *component, const std::string &name) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                                   SchedulerItem::INTERVAL);
+}
+
+// Public API - uint32_t (numeric ID) versions
+void HOT Scheduler::set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::NUMERIC_ID, nullptr, id, timeout,
+                          std::move(func));
+}
+
+void HOT Scheduler::set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func) {
+  this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::NUMERIC_ID, nullptr, id, interval,
+                          std::move(func));
+}
+
+bool HOT Scheduler::cancel_timeout(Component *component, uint32_t id) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
+}
+
+bool HOT Scheduler::cancel_interval(Component *component, uint32_t id) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::INTERVAL);
 }
 
 struct RetryArgs {
@@ -208,49 +257,54 @@ struct RetryArgs {
   std::function<RetryResult(uint8_t)> func;
   Component *component;
   Scheduler *scheduler;
-  const char *name;  // Points to static string or owned copy
+  // Union for name storage - only one is used based on name_type
+  union {
+    const char *static_name;  // For STATIC_STRING
+    uint32_t hash_or_id;      // For HASHED_STRING or NUMERIC_ID
+  } name_;
   uint32_t current_interval;
   float backoff_increase_factor;
+  Scheduler::NameType name_type;  // Discriminator for name_ union
   uint8_t retry_countdown;
-  bool name_is_dynamic;  // True if name needs delete[]
-
-  ~RetryArgs() {
-    if (this->name_is_dynamic && this->name) {
-      delete[] this->name;
-    }
-  }
 };
 
 void retry_handler(const std::shared_ptr<RetryArgs> &args) {
   RetryResult const retry_result = args->func(--args->retry_countdown);
   if (retry_result == RetryResult::DONE || args->retry_countdown <= 0)
     return;
-  // second execution of `func` happens after `initial_wait_time`
-  // Pass is_static_string=true because args->name is owned by the shared_ptr<RetryArgs>
-  // which is captured in the lambda and outlives the SchedulerItem
+  // Second execution of `func` happens after `initial_wait_time`
+  // static_name is owned by the shared_ptr<RetryArgs> which is captured in the lambda
+  const char *static_name = (args->name_type == Scheduler::NameType::STATIC_STRING) ? args->name_.static_name : nullptr;
+  uint32_t hash_or_id = (args->name_type != Scheduler::NameType::STATIC_STRING) ? args->name_.hash_or_id : 0;
   args->scheduler->set_timer_common_(
-      args->component, Scheduler::SchedulerItem::TIMEOUT, true, args->name, args->current_interval,
-      [args]() { retry_handler(args); }, /* is_retry= */ true);
+      args->component, Scheduler::SchedulerItem::TIMEOUT, args->name_type, static_name, hash_or_id,
+      args->current_interval, [args]() { retry_handler(args); },
+      /* is_retry= */ true);
   // backoff_increase_factor applied to third & later executions
   args->current_interval *= args->backoff_increase_factor;
 }
 
-void HOT Scheduler::set_retry_common_(Component *component, bool is_static_string, const void *name_ptr,
-                                      uint32_t initial_wait_time, uint8_t max_attempts,
+// Common implementation for retry
+// name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
+void HOT Scheduler::set_retry_common_(Component *component, NameType name_type, const char *static_name,
+                                      uint32_t hash_or_id, uint32_t initial_wait_time, uint8_t max_attempts,
                                       std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
-  const char *name_cstr = this->get_name_cstr_(is_static_string, name_ptr);
-
-  if (name_cstr != nullptr)
-    this->cancel_retry(component, name_cstr);
+  // Cancel existing retry with same name/id
+  {
+    LockGuard guard{this->lock_};
+    this->cancel_item_locked_(component, name_type, static_name, hash_or_id, SchedulerItem::TIMEOUT,
+                              /* match_retry= */ true);
+  }
 
   if (initial_wait_time == SCHEDULER_DONT_RUN)
     return;
 
   ESP_LOGVV(TAG, "set_retry(name='%s', initial_wait_time=%" PRIu32 ", max_attempts=%u, backoff_factor=%0.1f)",
-            name_cstr ? name_cstr : "", initial_wait_time, max_attempts, backoff_increase_factor);
+            name_type == NameType::STATIC_STRING ? static_name : "(id)", initial_wait_time, max_attempts,
+            backoff_increase_factor);
 
   if (backoff_increase_factor < 0.0001) {
-    ESP_LOGE(TAG, "backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor, name_cstr ? name_cstr : "");
+    ESP_LOGE(TAG, "backoff_factor %0.1f too small, using 1.0", backoff_increase_factor);
     backoff_increase_factor = 1;
   }
 
@@ -258,56 +312,60 @@ void HOT Scheduler::set_retry_common_(Component *component, bool is_static_strin
   args->func = std::move(func);
   args->component = component;
   args->scheduler = this;
+  args->name_type = name_type;
+  if (name_type == NameType::STATIC_STRING) {
+    args->name_.static_name = static_name;
+  } else {
+    args->name_.hash_or_id = hash_or_id;
+  }
   args->current_interval = initial_wait_time;
   args->backoff_increase_factor = backoff_increase_factor;
   args->retry_countdown = max_attempts;
 
-  // Store name - either as static pointer or owned copy
-  if (name_cstr == nullptr || name_cstr[0] == '\0') {
-    // Empty or null name - use empty string literal
-    args->name = "";
-    args->name_is_dynamic = false;
-  } else if (is_static_string) {
-    // Static string - just store the pointer
-    args->name = name_cstr;
-    args->name_is_dynamic = false;
-  } else {
-    // Dynamic string - make a copy
-    size_t len = strlen(name_cstr);
-    char *copy = new char[len + 1];
-    memcpy(copy, name_cstr, len + 1);
-    args->name = copy;
-    args->name_is_dynamic = true;
-  }
-
   // First execution of `func` immediately - use set_timer_common_ with is_retry=true
-  // Pass is_static_string=true because args->name is owned by the shared_ptr<RetryArgs>
-  // which is captured in the lambda and outlives the SchedulerItem
   this->set_timer_common_(
-      component, SchedulerItem::TIMEOUT, true, args->name, 0, [args]() { retry_handler(args); },
+      component, SchedulerItem::TIMEOUT, name_type, static_name, hash_or_id, 0, [args]() { retry_handler(args); },
       /* is_retry= */ true);
 }
 
-void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t initial_wait_time,
-                              uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
-                              float backoff_increase_factor) {
-  this->set_retry_common_(component, false, &name, initial_wait_time, max_attempts, std::move(func),
-                          backoff_increase_factor);
-}
-
+// Public API - const char* (static string) versions
 void HOT Scheduler::set_retry(Component *component, const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                               std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
-  this->set_retry_common_(component, true, name, initial_wait_time, max_attempts, std::move(func),
+  this->set_retry_common_(component, NameType::STATIC_STRING, name, 0, initial_wait_time, max_attempts, std::move(func),
                           backoff_increase_factor);
-}
-bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) {
-  return this->cancel_retry(component, name.c_str());
 }
 
 bool HOT Scheduler::cancel_retry(Component *component, const char *name) {
-  // Cancel timeouts that have is_retry flag set
   LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, name, SchedulerItem::TIMEOUT, /* match_retry= */ true);
+  return this->cancel_item_locked_(component, NameType::STATIC_STRING, name, 0, SchedulerItem::TIMEOUT,
+                                   /* match_retry= */ true);
+}
+
+// Public API - std::string (hashed) versions
+void HOT Scheduler::set_retry(Component *component, const std::string &name, uint32_t initial_wait_time,
+                              uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
+                              float backoff_increase_factor) {
+  this->set_retry_common_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name), initial_wait_time,
+                          max_attempts, std::move(func), backoff_increase_factor);
+}
+
+bool HOT Scheduler::cancel_retry(Component *component, const std::string &name) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
+                                   SchedulerItem::TIMEOUT, /* match_retry= */ true);
+}
+
+// Public API - uint32_t (numeric ID) versions
+void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
+                              std::function<RetryResult(uint8_t)> func, float backoff_increase_factor) {
+  this->set_retry_common_(component, NameType::NUMERIC_ID, nullptr, id, initial_wait_time, max_attempts,
+                          std::move(func), backoff_increase_factor);
+}
+
+bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
+  LockGuard guard{this->lock_};
+  return this->cancel_item_locked_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT,
+                                   /* match_retry= */ true);
 }
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
@@ -560,33 +618,22 @@ uint32_t HOT Scheduler::execute_item_(SchedulerItem *item, uint32_t now) {
   return guard.finish();
 }
 
-// Common implementation for cancel operations
-bool HOT Scheduler::cancel_item_(Component *component, bool is_static_string, const void *name_ptr,
-                                 SchedulerItem::Type type) {
-  // Get the name as const char*
-  const char *name_cstr = this->get_name_cstr_(is_static_string, name_ptr);
-
-  // obtain lock because this function iterates and can be called from non-loop task context
-  LockGuard guard{this->lock_};
-  return this->cancel_item_locked_(component, name_cstr, type);
-}
-
-// Helper to cancel items by name - must be called with lock held
-bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_cstr, SchedulerItem::Type type,
-                                        bool match_retry) {
-  // Early return if name is invalid - no items to cancel
-  if (name_cstr == nullptr) {
+// Helper to cancel items - must be called with lock held
+// name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
+bool HOT Scheduler::cancel_item_locked_(Component *component, NameType name_type, const char *static_name,
+                                        uint32_t hash_or_id, SchedulerItem::Type type, bool match_retry) {
+  // Early return if static string name is invalid
+  if (name_type == NameType::STATIC_STRING && static_name == nullptr) {
     return false;
   }
 
   size_t total_cancelled = 0;
 
-  // Check all containers for matching items
 #ifndef ESPHOME_THREAD_SINGLE
   // Mark items in defer queue as cancelled (they'll be skipped when processed)
   if (type == SchedulerItem::TIMEOUT) {
-    total_cancelled +=
-        this->mark_matching_items_removed_locked_(this->defer_queue_, component, name_cstr, type, match_retry);
+    total_cancelled += this->mark_matching_items_removed_locked_(this->defer_queue_, component, name_type, static_name,
+                                                                 hash_or_id, type, match_retry);
   }
 #endif /* not ESPHOME_THREAD_SINGLE */
 
@@ -596,14 +643,15 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, const char *name_c
   // would destroy the callback while it's running (use-after-free).
   // Only the main loop in call() should recycle items after execution completes.
   if (!this->items_.empty()) {
-    size_t heap_cancelled =
-        this->mark_matching_items_removed_locked_(this->items_, component, name_cstr, type, match_retry);
+    size_t heap_cancelled = this->mark_matching_items_removed_locked_(this->items_, component, name_type, static_name,
+                                                                      hash_or_id, type, match_retry);
     total_cancelled += heap_cancelled;
     this->to_remove_ += heap_cancelled;
   }
 
   // Cancel items in to_add_
-  total_cancelled += this->mark_matching_items_removed_locked_(this->to_add_, component, name_cstr, type, match_retry);
+  total_cancelled += this->mark_matching_items_removed_locked_(this->to_add_, component, name_type, static_name,
+                                                               hash_or_id, type, match_retry);
 
   return total_cancelled > 0;
 }
@@ -785,8 +833,6 @@ void Scheduler::recycle_item_main_loop_(std::unique_ptr<SchedulerItem> item) {
   if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
     // Clear callback to release captured resources
     item->callback = nullptr;
-    // Clear dynamic name if any
-    item->clear_dynamic_name();
     this->scheduler_item_pool_.push_back(std::move(item));
 #ifdef ESPHOME_DEBUG_SCHEDULER
     ESP_LOGD(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_.size());

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -317,7 +317,7 @@ class Scheduler {
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
   // Helper for debug logging in set_timer_common_ - extracted to reduce code size
-  void debug_log_timer_(const SchedulerItem *item, bool is_static_string, const char *name_cstr,
+  void debug_log_timer_(const SchedulerItem *item, NameType name_type, const char *static_name, uint32_t hash_or_id,
                         SchedulerItem::Type type, uint32_t delay, uint64_t now);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -30,21 +30,10 @@ class Scheduler {
   template<typename... Ts> friend class DelayAction;
 
  public:
-  // std::string overloads - deprecated, use const char* or uint32_t instead
+  // std::string overload - deprecated, use const char* or uint32_t instead
   // Remove before 2026.7.0
   ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   void set_timeout(Component *component, const std::string &name, uint32_t timeout, std::function<void()> func);
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  bool cancel_timeout(Component *component, const std::string &name);
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> func);
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  bool cancel_interval(Component *component, const std::string &name);
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
-                 std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  bool cancel_retry(Component *component, const std::string &name);
 
   /** Set a timeout with a const char* name.
    *
@@ -55,11 +44,16 @@ class Scheduler {
    *   - A pointer with lifetime >= the scheduled task
    */
   void set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func);
-  bool cancel_timeout(Component *component, const char *name);
-
   /// Set a timeout with a numeric ID (zero heap allocation)
   void set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func);
+
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_timeout(Component *component, const std::string &name);
+  bool cancel_timeout(Component *component, const char *name);
   bool cancel_timeout(Component *component, uint32_t id);
+
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> func);
 
   /** Set an interval with a const char* name.
    *
@@ -70,19 +64,26 @@ class Scheduler {
    *   - A pointer with lifetime >= the scheduled task
    */
   void set_interval(Component *component, const char *name, uint32_t interval, std::function<void()> func);
-  bool cancel_interval(Component *component, const char *name);
-
   /// Set an interval with a numeric ID (zero heap allocation)
   void set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func);
+
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_interval(Component *component, const std::string &name);
+  bool cancel_interval(Component *component, const char *name);
   bool cancel_interval(Component *component, uint32_t id);
 
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
+                 std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
   void set_retry(Component *component, const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
-  bool cancel_retry(Component *component, const char *name);
-
   /// Set a retry with a numeric ID (zero heap allocation)
   void set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
+
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_retry(Component *component, const std::string &name);
+  bool cancel_retry(Component *component, const char *name);
   bool cancel_retry(Component *component, uint32_t id);
 
   // Calculate when the next scheduled item should run

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -249,6 +249,9 @@ class Scheduler {
   std::unique_ptr<SchedulerItem> get_item_from_pool_locked_();
 
  private:
+  // Common implementation for cancel operations - handles locking
+  bool cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                    SchedulerItem::Type type, bool match_retry = false);
   // Helper to cancel items - must be called with lock held
   // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   bool cancel_item_locked_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "esphome/core/defines.h"
-#include <vector>
-#include <memory>
 #include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
 #include <atomic>
 #endif
@@ -29,8 +30,21 @@ class Scheduler {
   template<typename... Ts> friend class DelayAction;
 
  public:
-  // Public API - accepts std::string for backward compatibility
+  // std::string overloads - deprecated, use const char* or uint32_t instead
+  // Remove before 2026.7.0
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
   void set_timeout(Component *component, const std::string &name, uint32_t timeout, std::function<void()> func);
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_timeout(Component *component, const std::string &name);
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> func);
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_interval(Component *component, const std::string &name);
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
+                 std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
+  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  bool cancel_retry(Component *component, const std::string &name);
 
   /** Set a timeout with a const char* name.
    *
@@ -39,15 +53,13 @@ class Scheduler {
    *   - A string literal (e.g., "update")
    *   - A static const char* variable
    *   - A pointer with lifetime >= the scheduled task
-   *
-   * For dynamic strings, use the std::string overload instead.
    */
   void set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func);
-
-  bool cancel_timeout(Component *component, const std::string &name);
   bool cancel_timeout(Component *component, const char *name);
 
-  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> func);
+  /// Set a timeout with a numeric ID (zero heap allocation)
+  void set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func);
+  bool cancel_timeout(Component *component, uint32_t id);
 
   /** Set an interval with a const char* name.
    *
@@ -56,19 +68,22 @@ class Scheduler {
    *   - A string literal (e.g., "update")
    *   - A static const char* variable
    *   - A pointer with lifetime >= the scheduled task
-   *
-   * For dynamic strings, use the std::string overload instead.
    */
   void set_interval(Component *component, const char *name, uint32_t interval, std::function<void()> func);
-
-  bool cancel_interval(Component *component, const std::string &name);
   bool cancel_interval(Component *component, const char *name);
-  void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
-                 std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
+
+  /// Set an interval with a numeric ID (zero heap allocation)
+  void set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func);
+  bool cancel_interval(Component *component, uint32_t id);
+
   void set_retry(Component *component, const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
-  bool cancel_retry(Component *component, const std::string &name);
   bool cancel_retry(Component *component, const char *name);
+
+  /// Set a retry with a numeric ID (zero heap allocation)
+  void set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
+                 std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
+  bool cancel_retry(Component *component, uint32_t id);
 
   // Calculate when the next scheduled item should run
   // @param now Fresh timestamp from millis() - must not be stale/cached
@@ -83,14 +98,22 @@ class Scheduler {
 
   void process_to_add();
 
+  // Name storage type discriminator for SchedulerItem
+  // Used to distinguish between static strings, hashed strings, and numeric IDs
+  enum class NameType : uint8_t {
+    STATIC_STRING = 0,  // const char* pointer to static/flash storage
+    HASHED_STRING = 1,  // uint32_t FNV-1a hash of a runtime string
+    NUMERIC_ID = 2      // uint32_t numeric identifier
+  };
+
  protected:
   struct SchedulerItem {
     // Ordered by size to minimize padding
     Component *component;
-    // Optimized name storage using tagged union
+    // Optimized name storage using tagged union - zero heap allocation
     union {
-      const char *static_name;  // For string literals (no allocation)
-      char *dynamic_name;       // For allocated strings
+      const char *static_name;  // For STATIC_STRING (string literals, no allocation)
+      uint32_t hash_or_id;      // For HASHED_STRING or NUMERIC_ID
     } name_;
     uint32_t interval;
     // Split time to handle millis() rollover. The scheduler combines the 32-bit millis()
@@ -109,19 +132,19 @@ class Scheduler {
     // Place atomic<bool> separately since it can't be packed with bit fields
     std::atomic<bool> remove{false};
 
-    // Bit-packed fields (3 bits used, 5 bits padding in 1 byte)
-    enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
-    bool name_is_dynamic : 1;  // True if name was dynamically allocated (needs delete[])
-    bool is_retry : 1;         // True if this is a retry timeout
-                               // 5 bits padding
-#else
-    // Single-threaded or multi-threaded without atomics: can pack all fields together
     // Bit-packed fields (4 bits used, 4 bits padding in 1 byte)
     enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
+    NameType name_type_ : 2;  // Discriminator for name_ union (STATIC_STRING, HASHED_STRING, NUMERIC_ID)
+    bool is_retry : 1;        // True if this is a retry timeout
+                              // 4 bits padding
+#else
+    // Single-threaded or multi-threaded without atomics: can pack all fields together
+    // Bit-packed fields (5 bits used, 3 bits padding in 1 byte)
+    enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
     bool remove : 1;
-    bool name_is_dynamic : 1;  // True if name was dynamically allocated (needs delete[])
-    bool is_retry : 1;         // True if this is a retry timeout
-                               // 4 bits padding
+    NameType name_type_ : 2;  // Discriminator for name_ union (STATIC_STRING, HASHED_STRING, NUMERIC_ID)
+    bool is_retry : 1;        // True if this is a retry timeout
+                              // 3 bits padding
 #endif
 
     // Constructor
@@ -133,19 +156,19 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
           // remove is initialized in the member declaration as std::atomic<bool>{false}
           type(TIMEOUT),
-          name_is_dynamic(false),
+          name_type_(NameType::STATIC_STRING),
           is_retry(false) {
 #else
           type(TIMEOUT),
           remove(false),
-          name_is_dynamic(false),
+          name_type_(NameType::STATIC_STRING),
           is_retry(false) {
 #endif
       name_.static_name = nullptr;
     }
 
-    // Destructor to clean up dynamic names
-    ~SchedulerItem() { clear_dynamic_name(); }
+    // Destructor - no dynamic memory to clean up
+    ~SchedulerItem() = default;
 
     // Delete copy operations to prevent accidental copies
     SchedulerItem(const SchedulerItem &) = delete;
@@ -155,36 +178,31 @@ class Scheduler {
     SchedulerItem(SchedulerItem &&) = delete;
     SchedulerItem &operator=(SchedulerItem &&) = delete;
 
-    // Helper to get the name regardless of storage type
-    const char *get_name() const { return name_is_dynamic ? name_.dynamic_name : name_.static_name; }
+    // Helper to get the static name (only valid for STATIC_STRING type)
+    const char *get_name() const { return (name_type_ == NameType::STATIC_STRING) ? name_.static_name : nullptr; }
 
-    // Helper to clear dynamic name if allocated
-    void clear_dynamic_name() {
-      if (name_is_dynamic && name_.dynamic_name) {
-        delete[] name_.dynamic_name;
-        name_.dynamic_name = nullptr;
-        name_is_dynamic = false;
-      }
+    // Helper to get the hash or numeric ID (only valid for HASHED_STRING or NUMERIC_ID types)
+    uint32_t get_name_hash_or_id() const { return (name_type_ != NameType::STATIC_STRING) ? name_.hash_or_id : 0; }
+
+    // Helper to get the name type
+    NameType get_name_type() const { return name_type_; }
+
+    // Helper to set a static string name (no allocation)
+    void set_static_name(const char *name) {
+      name_.static_name = name;
+      name_type_ = NameType::STATIC_STRING;
     }
 
-    // Helper to set name with proper ownership
-    void set_name(const char *name, bool make_copy = false) {
-      // Clean up old dynamic name if any
-      clear_dynamic_name();
+    // Helper to set a hashed string name (hash computed from std::string)
+    void set_hashed_name(uint32_t hash) {
+      name_.hash_or_id = hash;
+      name_type_ = NameType::HASHED_STRING;
+    }
 
-      if (!name) {
-        // nullptr case - no name provided
-        name_.static_name = nullptr;
-      } else if (make_copy) {
-        // Make a copy for dynamic strings (including empty strings)
-        size_t len = strlen(name);
-        name_.dynamic_name = new char[len + 1];
-        memcpy(name_.dynamic_name, name, len + 1);
-        name_is_dynamic = true;
-      } else {
-        // Use static string directly (including empty strings)
-        name_.static_name = name;
-      }
+    // Helper to set a numeric ID name
+    void set_numeric_id(uint32_t id) {
+      name_.hash_or_id = id;
+      name_type_ = NameType::NUMERIC_ID;
     }
 
     static bool cmp(const std::unique_ptr<SchedulerItem> &a, const std::unique_ptr<SchedulerItem> &b);
@@ -207,12 +225,16 @@ class Scheduler {
   };
 
   // Common implementation for both timeout and interval
-  void set_timer_common_(Component *component, SchedulerItem::Type type, bool is_static_string, const void *name_ptr,
-                         uint32_t delay, std::function<void()> func, bool is_retry = false, bool skip_cancel = false);
+  // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
+  void set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type, const char *static_name,
+                         uint32_t hash_or_id, uint32_t delay, std::function<void()> func, bool is_retry = false,
+                         bool skip_cancel = false);
 
   // Common implementation for retry
-  void set_retry_common_(Component *component, bool is_static_string, const void *name_ptr, uint32_t initial_wait_time,
-                         uint8_t max_attempts, std::function<RetryResult(uint8_t)> func, float backoff_increase_factor);
+  // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
+  void set_retry_common_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                         uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
+                         float backoff_increase_factor);
 
   uint64_t millis_64_(uint32_t now);
   // Cleanup logically deleted items from the scheduler
@@ -222,38 +244,31 @@ class Scheduler {
   // Remove and return the front item from the heap
   // IMPORTANT: Caller must hold the scheduler lock before calling this function.
   std::unique_ptr<SchedulerItem> pop_raw_locked_();
+  // Get or create a scheduler item from the pool
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
+  std::unique_ptr<SchedulerItem> get_item_from_pool_locked_();
 
  private:
-  // Helper to cancel items by name - must be called with lock held
-  bool cancel_item_locked_(Component *component, const char *name, SchedulerItem::Type type, bool match_retry = false);
+  // Helper to cancel items - must be called with lock held
+  // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
+  bool cancel_item_locked_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                           SchedulerItem::Type type, bool match_retry = false);
 
-  // Helper to extract name as const char* from either static string or std::string
-  inline const char *get_name_cstr_(bool is_static_string, const void *name_ptr) {
-    return is_static_string ? static_cast<const char *>(name_ptr) : static_cast<const std::string *>(name_ptr)->c_str();
-  }
-
-  // Common implementation for cancel operations
-  bool cancel_item_(Component *component, bool is_static_string, const void *name_ptr, SchedulerItem::Type type);
-
-  // Helper to check if two scheduler item names match
-  inline bool HOT names_match_(const char *name1, const char *name2) const {
+  // Helper to check if two static string names match
+  inline bool HOT names_match_static_(const char *name1, const char *name2) const {
     // Check pointer equality first (common for static strings), then string contents
-    // The core ESPHome codebase uses static strings (const char*) for component names,
-    // making pointer comparison effective. The std::string overloads exist only for
-    // compatibility with external components but are rarely used in practice.
     return (name1 != nullptr && name2 != nullptr) && ((name1 == name2) || (strcmp(name1, name2) == 0));
   }
 
   // Helper function to check if item matches criteria for cancellation
+  // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   // IMPORTANT: Must be called with scheduler lock held
   inline bool HOT matches_item_locked_(const std::unique_ptr<SchedulerItem> &item, Component *component,
-                                       const char *name_cstr, SchedulerItem::Type type, bool match_retry,
-                                       bool skip_removed = true) const {
+                                       NameType name_type, const char *static_name, uint32_t hash_or_id,
+                                       SchedulerItem::Type type, bool match_retry, bool skip_removed = true) const {
     // THREAD SAFETY: Check for nullptr first to prevent LoadProhibited crashes. On multi-threaded
     // platforms, items can be moved out of defer_queue_ during processing, leaving nullptr entries.
-    // PR #11305 added nullptr checks in callers (mark_matching_items_removed_locked_() and
-    // has_cancelled_timeout_in_container_locked_()), but this check provides defense-in-depth: helper
-    // functions should be safe regardless of caller behavior.
+    // This check provides defense-in-depth: helper functions should be safe regardless of caller behavior.
     // Fixes: https://github.com/esphome/esphome/issues/11940
     if (!item)
       return false;
@@ -261,7 +276,14 @@ class Scheduler {
         (match_retry && !item->is_retry)) {
       return false;
     }
-    return this->names_match_(item->get_name(), name_cstr);
+    // Name type must match
+    if (item->get_name_type() != name_type)
+      return false;
+    // For static strings, compare the string content; for hash/ID, compare the value
+    if (name_type == NameType::STATIC_STRING) {
+      return this->names_match_static_(item->get_name(), static_name);
+    }
+    return item->get_name_hash_or_id() == hash_or_id;
   }
 
   // Helper to execute a scheduler item
@@ -410,11 +432,13 @@ class Scheduler {
   }
 
   // Helper to mark matching items in a container as removed
+  // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   // Returns the number of items marked for removal
   // IMPORTANT: Must be called with scheduler lock held
   template<typename Container>
-  size_t mark_matching_items_removed_locked_(Container &container, Component *component, const char *name_cstr,
-                                             SchedulerItem::Type type, bool match_retry) {
+  size_t mark_matching_items_removed_locked_(Container &container, Component *component, NameType name_type,
+                                             const char *static_name, uint32_t hash_or_id, SchedulerItem::Type type,
+                                             bool match_retry) {
     size_t count = 0;
     for (auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)
@@ -423,8 +447,7 @@ class Scheduler {
       // the vector can still contain nullptr items from the processing loop. This check prevents crashes.
       if (!item)
         continue;
-      if (this->matches_item_locked_(item, component, name_cstr, type, match_retry)) {
-        // Mark item for removal (platform-specific)
+      if (this->matches_item_locked_(item, component, name_type, static_name, hash_or_id, type, match_retry)) {
         this->set_item_removed_(item.get(), true);
         count++;
       }
@@ -433,10 +456,12 @@ class Scheduler {
   }
 
   // Template helper to check if any item in a container matches our criteria
+  // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   // IMPORTANT: Must be called with scheduler lock held
   template<typename Container>
-  bool has_cancelled_timeout_in_container_locked_(const Container &container, Component *component,
-                                                  const char *name_cstr, bool match_retry) const {
+  bool has_cancelled_timeout_in_container_locked_(const Container &container, Component *component, NameType name_type,
+                                                  const char *static_name, uint32_t hash_or_id,
+                                                  bool match_retry) const {
     for (const auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)
       // The defer_queue_ uses index-based processing: items are std::moved out but left in the
@@ -445,8 +470,8 @@ class Scheduler {
       if (!item)
         continue;
       if (is_item_removed_(item.get()) &&
-          this->matches_item_locked_(item, component, name_cstr, SchedulerItem::TIMEOUT, match_retry,
-                                     /* skip_removed= */ false)) {
+          this->matches_item_locked_(item, component, name_type, static_name, hash_or_id, SchedulerItem::TIMEOUT,
+                                     match_retry, /* skip_removed= */ false)) {
         return true;
       }
     }

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -237,7 +237,7 @@ class Scheduler {
                          uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
                          float backoff_increase_factor);
   // Common implementation for cancel_retry
-  bool cancel_retry(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id);
+  bool cancel_retry_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id);
 
   uint64_t millis_64_(uint32_t now);
   // Cleanup logically deleted items from the scheduler

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -264,6 +264,9 @@ class Scheduler {
   // Helper to check if two static string names match
   inline bool HOT names_match_static_(const char *name1, const char *name2) const {
     // Check pointer equality first (common for static strings), then string contents
+    // The core ESPHome codebase uses static strings (const char*) for component names,
+    // making pointer comparison effective. The std::string overloads exist only for
+    // compatibility with external components but are rarely used in practice.
     return (name1 != nullptr && name2 != nullptr) && ((name1 == name2) || (strcmp(name1, name2) == 0));
   }
 
@@ -275,7 +278,9 @@ class Scheduler {
                                        SchedulerItem::Type type, bool match_retry, bool skip_removed = true) const {
     // THREAD SAFETY: Check for nullptr first to prevent LoadProhibited crashes. On multi-threaded
     // platforms, items can be moved out of defer_queue_ during processing, leaving nullptr entries.
-    // This check provides defense-in-depth: helper functions should be safe regardless of caller behavior.
+    // PR #11305 added nullptr checks in callers (mark_matching_items_removed_locked_() and
+    // has_cancelled_timeout_in_container_locked_()), but this check provides defense-in-depth: helper
+    // functions should be safe regardless of caller behavior.
     // Fixes: https://github.com/esphome/esphome/issues/11940
     if (!item)
       return false;

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -235,6 +235,8 @@ class Scheduler {
   void set_retry_common_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
                          uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
                          float backoff_increase_factor);
+  // Common implementation for cancel_retry
+  bool cancel_retry(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id);
 
   uint64_t millis_64_(uint32_t now);
   // Cleanup logically deleted items from the scheduler
@@ -249,13 +251,14 @@ class Scheduler {
   std::unique_ptr<SchedulerItem> get_item_from_pool_locked_();
 
  private:
-  // Common implementation for cancel operations - handles locking
-  bool cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
-                    SchedulerItem::Type type, bool match_retry = false);
   // Helper to cancel items - must be called with lock held
   // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   bool cancel_item_locked_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
                            SchedulerItem::Type type, bool match_retry = false);
+
+  // Common implementation for cancel operations - handles locking
+  bool cancel_item_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
+                    SchedulerItem::Type type, bool match_retry = false);
 
   // Helper to check if two static string names match
   inline bool HOT names_match_static_(const char *name1, const char *name2) const {

--- a/tests/integration/fixtures/scheduler_numeric_id_test.yaml
+++ b/tests/integration/fixtures/scheduler_numeric_id_test.yaml
@@ -17,6 +17,9 @@ globals:
   - id: interval_counter
     type: int
     initial_value: '0'
+  - id: retry_counter
+    type: int
+    initial_value: '0'
   - id: tests_done
     type: bool
     initial_value: 'false'
@@ -109,11 +112,33 @@ script:
             id(timeout_counter) += 1;
           });
 
+          // Test 10: set_retry with numeric ID
+          App.scheduler.set_retry(component1, 6001U, 50, 3,
+            [](uint8_t retry_countdown) {
+              id(retry_counter)++;
+              ESP_LOGI("test", "Numeric retry 6001 attempt %d (countdown=%d)",
+                       id(retry_counter), retry_countdown);
+              if (id(retry_counter) >= 2) {
+                ESP_LOGI("test", "Numeric retry 6001 done");
+                return RetryResult::DONE;
+              }
+              return RetryResult::RETRY;
+            });
+
+          // Test 11: cancel_retry with numeric ID
+          App.scheduler.set_retry(component1, 6002U, 100, 5,
+            [](uint8_t retry_countdown) {
+              ESP_LOGE("test", "ERROR: Numeric retry 6002 should have been cancelled");
+              return RetryResult::RETRY;
+            });
+          App.scheduler.cancel_retry(component1, 6002U);
+          ESP_LOGI("test", "Cancelled numeric retry 6002");
+
   - id: report_results
     then:
       - lambda: |-
-          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d",
-                   id(timeout_counter), id(interval_counter));
+          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d, Retries: %d",
+                   id(timeout_counter), id(interval_counter), id(retry_counter));
 
 sensor:
   - platform: template

--- a/tests/integration/fixtures/scheduler_numeric_id_test.yaml
+++ b/tests/integration/fixtures/scheduler_numeric_id_test.yaml
@@ -88,11 +88,13 @@ script:
               });
 
               // Test set_interval with uint32_t ID
-              this->set_interval(5002U, 400, []() {
+              // Capture 'this' pointer so we can cancel with correct component
+              auto *self = this;
+              this->set_interval(5002U, 400, [self]() {
                 ESP_LOGI("test", "Component numeric interval 5002 fired");
                 id(interval_counter) += 1;
-                // Cancel after first fire
-                App.scheduler.cancel_interval(nullptr, 5002U);
+                // Cancel after first fire - must use same component pointer
+                App.scheduler.cancel_interval(self, 5002U);
               });
             }
           };

--- a/tests/integration/fixtures/scheduler_numeric_id_test.yaml
+++ b/tests/integration/fixtures/scheduler_numeric_id_test.yaml
@@ -1,0 +1,146 @@
+esphome:
+  name: scheduler-numeric-id-test
+  on_boot:
+    priority: -100
+    then:
+      - logger.log: "Starting scheduler numeric ID tests"
+
+host:
+api:
+logger:
+  level: VERBOSE
+
+globals:
+  - id: timeout_counter
+    type: int
+    initial_value: '0'
+  - id: interval_counter
+    type: int
+    initial_value: '0'
+  - id: tests_done
+    type: bool
+    initial_value: 'false'
+  - id: results_reported
+    type: bool
+    initial_value: 'false'
+
+script:
+  - id: test_numeric_ids
+    then:
+      - logger.log: "Testing numeric ID timeouts and intervals"
+      - lambda: |-
+          auto *component1 = id(test_sensor1);
+
+          // Test 1: Numeric ID with set_timeout (uint32_t)
+          App.scheduler.set_timeout(component1, 1001U, 50, []() {
+            ESP_LOGI("test", "Numeric timeout 1001 fired");
+            id(timeout_counter) += 1;
+          });
+
+          // Test 2: Another numeric ID timeout
+          App.scheduler.set_timeout(component1, 1002U, 100, []() {
+            ESP_LOGI("test", "Numeric timeout 1002 fired");
+            id(timeout_counter) += 1;
+          });
+
+          // Test 3: Numeric ID with set_interval
+          App.scheduler.set_interval(component1, 2001U, 200, []() {
+            ESP_LOGI("test", "Numeric interval 2001 fired, count: %d", id(interval_counter));
+            id(interval_counter) += 1;
+            if (id(interval_counter) >= 3) {
+              App.scheduler.cancel_interval(id(test_sensor1), 2001U);
+              ESP_LOGI("test", "Cancelled numeric interval 2001");
+            }
+          });
+
+          // Test 4: Cancel timeout with numeric ID
+          App.scheduler.set_timeout(component1, 3001U, 5000, []() {
+            ESP_LOGE("test", "ERROR: Timeout 3001 should have been cancelled");
+          });
+          App.scheduler.cancel_timeout(component1, 3001U);
+          ESP_LOGI("test", "Cancelled numeric timeout 3001");
+
+          // Test 5: Multiple timeouts with same numeric ID - only last should execute
+          for (int i = 0; i < 5; i++) {
+            App.scheduler.set_timeout(component1, 4001U, 300 + i*10, [i]() {
+              ESP_LOGI("test", "Duplicate numeric timeout %d fired", i);
+              id(timeout_counter) += 1;
+            });
+          }
+          ESP_LOGI("test", "Created 5 timeouts with same numeric ID 4001");
+
+          // Test 6: Cancel non-existent numeric ID
+          bool cancelled_nonexistent = App.scheduler.cancel_timeout(component1, 9999U);
+          ESP_LOGI("test", "Cancel non-existent numeric ID result: %s",
+                   cancelled_nonexistent ? "true (unexpected!)" : "false (expected)");
+
+          // Test 7: Component method uint32_t overloads
+          class TestNumericComponent : public Component {
+          public:
+            void test_numeric_methods() {
+              // Test set_timeout with uint32_t ID
+              this->set_timeout(5001U, 150, []() {
+                ESP_LOGI("test", "Component numeric timeout 5001 fired");
+                id(timeout_counter) += 1;
+              });
+
+              // Test set_interval with uint32_t ID
+              this->set_interval(5002U, 400, []() {
+                ESP_LOGI("test", "Component numeric interval 5002 fired");
+                id(interval_counter) += 1;
+                // Cancel after first fire
+                App.scheduler.cancel_interval(nullptr, 5002U);
+              });
+            }
+          };
+
+          static TestNumericComponent test_component;
+          test_component.test_numeric_methods();
+
+          // Test 8: Zero ID (edge case)
+          App.scheduler.set_timeout(component1, 0U, 200, []() {
+            ESP_LOGI("test", "Numeric timeout with ID 0 fired");
+            id(timeout_counter) += 1;
+          });
+
+          // Test 9: Max uint32_t ID (edge case)
+          App.scheduler.set_timeout(component1, 0xFFFFFFFFU, 250, []() {
+            ESP_LOGI("test", "Numeric timeout with max ID fired");
+            id(timeout_counter) += 1;
+          });
+
+  - id: report_results
+    then:
+      - lambda: |-
+          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d",
+                   id(timeout_counter), id(interval_counter));
+
+sensor:
+  - platform: template
+    name: Test Sensor 1
+    id: test_sensor1
+    lambda: return 1.0;
+    update_interval: never
+
+interval:
+  # Run numeric ID tests after boot
+  - interval: 0.1s
+    then:
+      - if:
+          condition:
+            lambda: 'return id(tests_done) == false;'
+          then:
+            - lambda: 'id(tests_done) = true;'
+            - script.execute: test_numeric_ids
+            - logger.log: "Started numeric ID tests"
+
+  # Report results after tests complete
+  - interval: 0.2s
+    then:
+      - if:
+          condition:
+            lambda: 'return id(tests_done) && !id(results_reported);'
+          then:
+            - lambda: 'id(results_reported) = true;'
+            - delay: 1.5s
+            - script.execute: report_results

--- a/tests/integration/fixtures/scheduler_retry_test.yaml
+++ b/tests/integration/fixtures/scheduler_retry_test.yaml
@@ -43,9 +43,6 @@ globals:
   - id: static_char_retry_counter
     type: int
     initial_value: '0'
-  - id: mixed_cancel_result
-    type: bool
-    initial_value: 'false'
 
 # Using different component types for each test to ensure isolation
 sensor:
@@ -271,23 +268,6 @@ script:
             ESP_LOGI("test", "Static cancel result: %s", result ? "true" : "false");
           });
 
-      # Test 10: Mix string and const char* cancel
-      - logger.log: "=== Test 10: Mixed string/const char* ==="
-      - lambda: |-
-          auto *component = id(immediate_done_sensor);
-
-          // Set with std::string
-          std::string str_name = "mixed_retry";
-          App.scheduler.set_retry(component, str_name, 40, 3,
-            [](uint8_t retry_countdown) {
-              ESP_LOGI("test", "Mixed retry - should be cancelled");
-              return RetryResult::RETRY;
-            });
-
-          // Cancel with const char*
-          id(mixed_cancel_result) = App.scheduler.cancel_retry(component, "mixed_retry");
-          ESP_LOGI("test", "Mixed cancel result: %s", id(mixed_cancel_result) ? "true" : "false");
-
       # Wait for all tests to complete before reporting
       - delay: 500ms
 
@@ -303,5 +283,4 @@ script:
           ESP_LOGI("test", "Multiple same name counter: %d (expected 20+)", id(multiple_same_name_counter));
           ESP_LOGI("test", "Const char retry counter: %d (expected 1)", id(const_char_retry_counter));
           ESP_LOGI("test", "Static char retry counter: %d (expected 1)", id(static_char_retry_counter));
-          ESP_LOGI("test", "Mixed cancel result: %s (expected true)", id(mixed_cancel_result) ? "true" : "false");
           ESP_LOGI("test", "All retry tests completed");

--- a/tests/integration/test_scheduler_numeric_id_test.py
+++ b/tests/integration/test_scheduler_numeric_id_test.py
@@ -1,0 +1,177 @@
+"""Test scheduler numeric ID (uint32_t) overloads."""
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_numeric_id_test(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that scheduler handles numeric IDs (uint32_t) correctly."""
+    # Track counts
+    timeout_count = 0
+    interval_count = 0
+
+    # Events for each test completion
+    numeric_timeout_1001_fired = asyncio.Event()
+    numeric_timeout_1002_fired = asyncio.Event()
+    numeric_interval_2001_fired = asyncio.Event()
+    numeric_interval_cancelled = asyncio.Event()
+    numeric_timeout_cancelled = asyncio.Event()
+    duplicate_timeout_fired = asyncio.Event()
+    component_timeout_fired = asyncio.Event()
+    component_interval_fired = asyncio.Event()
+    zero_id_timeout_fired = asyncio.Event()
+    max_id_timeout_fired = asyncio.Event()
+    final_results_logged = asyncio.Event()
+
+    # Track interval counts
+    numeric_interval_count = 0
+
+    def on_log_line(line: str) -> None:
+        nonlocal timeout_count, interval_count, numeric_interval_count
+
+        # Strip ANSI color codes
+        clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
+
+        # Check for numeric timeout completions
+        if "Numeric timeout 1001 fired" in clean_line:
+            numeric_timeout_1001_fired.set()
+            timeout_count += 1
+
+        elif "Numeric timeout 1002 fired" in clean_line:
+            numeric_timeout_1002_fired.set()
+            timeout_count += 1
+
+        # Check for numeric interval
+        elif "Numeric interval 2001 fired" in clean_line:
+            match = re.search(r"count: (\d+)", clean_line)
+            if match:
+                numeric_interval_count = int(match.group(1))
+                numeric_interval_2001_fired.set()
+
+        elif "Cancelled numeric interval 2001" in clean_line:
+            numeric_interval_cancelled.set()
+
+        elif "Cancelled numeric timeout 3001" in clean_line:
+            numeric_timeout_cancelled.set()
+
+        # Check for duplicate timeout (only last should fire)
+        elif "Duplicate numeric timeout" in clean_line:
+            match = re.search(r"timeout (\d+) fired", clean_line)
+            if match and match.group(1) == "4":
+                duplicate_timeout_fired.set()
+                timeout_count += 1
+
+        # Check for component method tests
+        elif "Component numeric timeout 5001 fired" in clean_line:
+            component_timeout_fired.set()
+            timeout_count += 1
+
+        elif "Component numeric interval 5002 fired" in clean_line:
+            component_interval_fired.set()
+            interval_count += 1
+
+        # Check for edge case tests
+        elif "Numeric timeout with ID 0 fired" in clean_line:
+            zero_id_timeout_fired.set()
+            timeout_count += 1
+
+        elif "Numeric timeout with max ID fired" in clean_line:
+            max_id_timeout_fired.set()
+            timeout_count += 1
+
+        # Check for final results
+        elif "Final results" in clean_line:
+            match = re.search(r"Timeouts: (\d+), Intervals: (\d+)", clean_line)
+            if match:
+                timeout_count = int(match.group(1))
+                interval_count = int(match.group(2))
+                final_results_logged.set()
+
+    async with (
+        run_compiled(yaml_config, line_callback=on_log_line),
+        api_client_connected() as client,
+    ):
+        # Verify we can connect
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "scheduler-numeric-id-test"
+
+        # Wait for numeric timeout tests
+        try:
+            await asyncio.wait_for(numeric_timeout_1001_fired.wait(), timeout=0.5)
+        except TimeoutError:
+            pytest.fail("Numeric timeout 1001 did not fire within 0.5 seconds")
+
+        try:
+            await asyncio.wait_for(numeric_timeout_1002_fired.wait(), timeout=0.5)
+        except TimeoutError:
+            pytest.fail("Numeric timeout 1002 did not fire within 0.5 seconds")
+
+        try:
+            await asyncio.wait_for(numeric_interval_2001_fired.wait(), timeout=1.0)
+        except TimeoutError:
+            pytest.fail("Numeric interval 2001 did not fire within 1 second")
+
+        try:
+            await asyncio.wait_for(numeric_interval_cancelled.wait(), timeout=2.0)
+        except TimeoutError:
+            pytest.fail("Numeric interval 2001 was not cancelled within 2 seconds")
+
+        # Verify numeric interval ran at least twice
+        assert numeric_interval_count >= 2, (
+            f"Expected numeric interval to run at least 2 times, got {numeric_interval_count}"
+        )
+
+        # Verify numeric timeout was cancelled
+        assert numeric_timeout_cancelled.is_set(), (
+            "Numeric timeout 3001 should have been cancelled"
+        )
+
+        # Wait for duplicate timeout (only last one should fire)
+        try:
+            await asyncio.wait_for(duplicate_timeout_fired.wait(), timeout=1.0)
+        except TimeoutError:
+            pytest.fail("Duplicate numeric timeout did not fire within 1 second")
+
+        # Wait for component method tests
+        try:
+            await asyncio.wait_for(component_timeout_fired.wait(), timeout=0.5)
+        except TimeoutError:
+            pytest.fail("Component numeric timeout did not fire within 0.5 seconds")
+
+        try:
+            await asyncio.wait_for(component_interval_fired.wait(), timeout=1.0)
+        except TimeoutError:
+            pytest.fail("Component numeric interval did not fire within 1 second")
+
+        # Wait for edge case tests
+        try:
+            await asyncio.wait_for(zero_id_timeout_fired.wait(), timeout=0.5)
+        except TimeoutError:
+            pytest.fail("Zero ID timeout did not fire within 0.5 seconds")
+
+        try:
+            await asyncio.wait_for(max_id_timeout_fired.wait(), timeout=0.5)
+        except TimeoutError:
+            pytest.fail("Max ID timeout did not fire within 0.5 seconds")
+
+        # Wait for final results
+        try:
+            await asyncio.wait_for(final_results_logged.wait(), timeout=3.0)
+        except TimeoutError:
+            pytest.fail("Final results were not logged within 3 seconds")
+
+        # Verify results
+        assert timeout_count >= 6, f"Expected at least 6 timeouts, got {timeout_count}"
+        assert interval_count >= 3, (
+            f"Expected at least 3 interval fires, got {interval_count}"
+        )

--- a/tests/integration/test_scheduler_numeric_id_test.py
+++ b/tests/integration/test_scheduler_numeric_id_test.py
@@ -18,6 +18,7 @@ async def test_scheduler_numeric_id_test(
     # Track counts
     timeout_count = 0
     interval_count = 0
+    retry_count = 0
 
     # Events for each test completion
     numeric_timeout_1001_fired = asyncio.Event()
@@ -30,13 +31,17 @@ async def test_scheduler_numeric_id_test(
     component_interval_fired = asyncio.Event()
     zero_id_timeout_fired = asyncio.Event()
     max_id_timeout_fired = asyncio.Event()
+    numeric_retry_done = asyncio.Event()
+    numeric_retry_cancelled = asyncio.Event()
     final_results_logged = asyncio.Event()
 
     # Track interval counts
     numeric_interval_count = 0
+    numeric_retry_count = 0
 
     def on_log_line(line: str) -> None:
-        nonlocal timeout_count, interval_count, numeric_interval_count
+        nonlocal timeout_count, interval_count, retry_count
+        nonlocal numeric_interval_count, numeric_retry_count
 
         # Strip ANSI color codes
         clean_line = re.sub(r"\x1b\[[0-9;]*m", "", line)
@@ -88,12 +93,27 @@ async def test_scheduler_numeric_id_test(
             max_id_timeout_fired.set()
             timeout_count += 1
 
+        # Check for numeric retry tests
+        elif "Numeric retry 6001 attempt" in clean_line:
+            match = re.search(r"attempt (\d+)", clean_line)
+            if match:
+                numeric_retry_count = int(match.group(1))
+
+        elif "Numeric retry 6001 done" in clean_line:
+            numeric_retry_done.set()
+
+        elif "Cancelled numeric retry 6002" in clean_line:
+            numeric_retry_cancelled.set()
+
         # Check for final results
         elif "Final results" in clean_line:
-            match = re.search(r"Timeouts: (\d+), Intervals: (\d+)", clean_line)
+            match = re.search(
+                r"Timeouts: (\d+), Intervals: (\d+), Retries: (\d+)", clean_line
+            )
             if match:
                 timeout_count = int(match.group(1))
                 interval_count = int(match.group(2))
+                retry_count = int(match.group(3))
                 final_results_logged.set()
 
     async with (
@@ -164,6 +184,23 @@ async def test_scheduler_numeric_id_test(
         except TimeoutError:
             pytest.fail("Max ID timeout did not fire within 0.5 seconds")
 
+        # Wait for numeric retry tests
+        try:
+            await asyncio.wait_for(numeric_retry_done.wait(), timeout=1.0)
+        except TimeoutError:
+            pytest.fail(
+                f"Numeric retry 6001 did not complete. Count: {numeric_retry_count}"
+            )
+
+        assert numeric_retry_count >= 2, (
+            f"Expected at least 2 numeric retry attempts, got {numeric_retry_count}"
+        )
+
+        # Verify numeric retry was cancelled
+        assert numeric_retry_cancelled.is_set(), (
+            "Numeric retry 6002 should have been cancelled"
+        )
+
         # Wait for final results
         try:
             await asyncio.wait_for(final_results_logged.wait(), timeout=3.0)
@@ -174,4 +211,7 @@ async def test_scheduler_numeric_id_test(
         assert timeout_count >= 6, f"Expected at least 6 timeouts, got {timeout_count}"
         assert interval_count >= 3, (
             f"Expected at least 3 interval fires, got {interval_count}"
+        )
+        assert retry_count >= 2, (
+            f"Expected at least 2 retry attempts, got {retry_count}"
         )


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocations in the scheduler for `std::string` names by using FNV-1a hashing and adds zero-allocation `uint32_t` ID overloads for all scheduler APIs.

## Background

The scheduler previously allocated heap memory when `std::string` names were passed to `set_timeout`, `set_interval`, `set_retry`, and their cancel counterparts. This caused heap fragmentation on long-running devices, especially on ESP8266 where memory is constrained.

## Changes

### Zero-allocation name storage

- **SchedulerItem union**: Changed from `(static_name, dynamic_name)` to `(static_name, hash_or_id)` - no more `new char[]` allocations
- **NameType enum**: Added discriminator `(STATIC_STRING, HASHED_STRING, NUMERIC_ID)` to distinguish storage types
- **FNV-1a hashing**: Deprecated `std::string` names are now hashed at the call site - only the 4-byte hash is stored, not the string. Hash collisions are theoretically possible but practically negligible (~0.0001% with 100 items), and only affect the deprecated API being removed in 2026.7.0. The `std::string` API is unused in the ESPHome codebase and we are not aware of any external components using it. The recommended `const char*` and `uint32_t` APIs have zero collision risk.

### New uint32_t ID API

Added zero-allocation overloads that accept numeric IDs instead of string names:

```cpp
// New API - zero heap allocation
void set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func);
bool cancel_timeout(Component *component, uint32_t id);
void set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func);
bool cancel_interval(Component *component, uint32_t id);
void set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
               std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
bool cancel_retry(Component *component, uint32_t id);
```

The same overloads are available on `Component` as protected methods.

Note: `defer`/`cancel_defer` only have `const char*` overloads (no `uint32_t`) since defers fire on the next loop run and are rarely cancelled. Can be added in the future if needed.

### Migration: api_server.cpp

The "Device defined action responses" feature (#12136) required dynamic timeout names for tracking action calls, which motivated the addition of this `uint32_t` API. Migrated to use the numeric ID directly:
```cpp
// Before - heap allocation every call
this->set_timeout(str_sprintf("action_call_%u", action_call_id), timeout, ...);
this->cancel_timeout(str_sprintf("action_call_%u", action_call_id));

// After - zero allocation
this->set_timeout(action_call_id, timeout, ...);
this->cancel_timeout(action_call_id);
```

### Deprecations

All `std::string` overloads are now deprecated with `ESPDEPRECATED`:
- `set_timeout(component, std::string, ...)`
- `cancel_timeout(component, std::string)`
- `set_interval(component, std::string, ...)`
- `cancel_interval(component, std::string)`
- `set_retry(component, std::string, ...)`
- `cancel_retry(component, std::string)`
- `defer(std::string, ...)`
- `cancel_defer(std::string)`

**Migration path**: Use `const char*` for static strings or `uint32_t` for numeric IDs. The deprecated overloads will be removed in 2026.7.0.

### No more complex memory management

The scheduler no longer needs any dynamic memory management for names:

- Removed `name_is_dynamic` flag and `clear_dynamic_name()` method
- Removed `~SchedulerItem()` destructor logic (now `= default`)
- Removed `~RetryArgs()` destructor (no dynamic memory to clean up)
- Removed `get_name_cstr_()` helper (no longer needed without void pointer indirection)
- No `new char[]` allocations, no `delete[]` cleanup, no ownership tracking

### Why std::string is no longer needed

The `std::string` API was originally added for dynamic/computed names. With the new `uint32_t` ID API, this use case is better served by numeric IDs:

- Use an incrementing counter with natural uint32_t rollover
- If a component needs multiple ID namespaces, section the uint32_t space (e.g., IDs 0-999 for one purpose, 1000-1999 for another)
- In practice, no ESPHome component needs this level of complexity

The only internal user of dynamic names was `api_server.cpp`, which was already using an incrementing `uint32_t` (`action_call_id`) - it had to wrap it in a string to accommodate the scheduler API, generating heap churn in the process. The migration to the new `uint32_t` API was trivial.

The `std::string` API is fully unused in the ESPHome codebase. The deprecated overloads exist only for external component compatibility and will be removed in 2026.7.0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/backlog/issues/52 (heap fragmentation)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, not user-facing)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - internal API changes
# External components using std::string scheduler names will see deprecation warnings
# and should migrate to const char* or uint32_t overloads
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal API)

## Breaking Change Notes

**For external component authors:**

If your component uses `std::string` with scheduler functions, you will see deprecation warnings. Migrate to:

1. **Static string literals** (preferred for named timeouts/intervals):
   ```cpp
   // Before
   this->set_timeout(std::string("my_timeout"), 1000, []() { ... });

   // After
   this->set_timeout("my_timeout", 1000, []() { ... });
   ```

2. **Numeric IDs** (preferred for dynamic/computed names):
   ```cpp
   // Before
   this->set_timeout("timeout_" + std::to_string(id), 1000, []() { ... });

   // After
   this->set_timeout(id, 1000, []() { ... });  // Use the ID directly
   ```

The `std::string` overloads still work (via FNV-1a hashing) but will be removed in 2026.7.0.

**Important**: `std::string` and `const char*` names are now stored differently and cannot cancel each other:
- `const char*` names compare by pointer value (for string literals in flash)
- `std::string` names are hashed with FNV-1a and compare by hash value

This means code like this will no longer work:
```cpp
// This will NOT cancel a timeout set with std::string name
this->set_timeout(std::string("my_timeout"), 1000, []() { ... });
this->cancel_timeout("my_timeout");  // Won't cancel - different namespace!

// Fix: Use const char* consistently
this->set_timeout("my_timeout", 1000, []() { ... });
this->cancel_timeout("my_timeout");  // Works - both use const char*
```

All internal uses of `std::string` with scheduler functions have been removed over the past year (the only remaining ones were in `api_server.cpp`, which were migrated to `uint32_t` in this PR). This breaking change is very unlikely to affect any existing code.
