### PR TITLE
[core] Fix platform subcomponents not filtering source files

### DIFF
--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -17,7 +17,11 @@ from esphome.const import (
     UNIT_PERCENT,
 )
 
-from . import CONF_DEBUG_ID, FILTER_SOURCE_FILES, DebugComponent  # noqa: F401
+from . import (  # noqa: F401  pylint: disable=unused-import
+    CONF_DEBUG_ID,
+    FILTER_SOURCE_FILES,
+    DebugComponent,
+)
 
 DEPENDENCIES = ["debug"]
 

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -17,7 +17,7 @@ from esphome.const import (
     UNIT_PERCENT,
 )
 
-from . import CONF_DEBUG_ID, DebugComponent
+from . import CONF_DEBUG_ID, FILTER_SOURCE_FILES, DebugComponent  # noqa: F401
 
 DEPENDENCIES = ["debug"]
 

--- a/esphome/components/debug/text_sensor.py
+++ b/esphome/components/debug/text_sensor.py
@@ -8,7 +8,11 @@ from esphome.const import (
     ICON_RESTART,
 )
 
-from . import CONF_DEBUG_ID, FILTER_SOURCE_FILES, DebugComponent  # noqa: F401
+from . import (  # noqa: F401  pylint: disable=unused-import
+    CONF_DEBUG_ID,
+    FILTER_SOURCE_FILES,
+    DebugComponent,
+)
 
 DEPENDENCIES = ["debug"]
 

--- a/esphome/components/debug/text_sensor.py
+++ b/esphome/components/debug/text_sensor.py
@@ -8,7 +8,7 @@ from esphome.const import (
     ICON_RESTART,
 )
 
-from . import CONF_DEBUG_ID, DebugComponent
+from . import CONF_DEBUG_ID, FILTER_SOURCE_FILES, DebugComponent  # noqa: F401
 
 DEPENDENCIES = ["debug"]
 

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -11,7 +11,12 @@ from esphome.const import (
 )
 from esphome.core import CORE, TimePeriod
 
-from . import FILTER_SOURCE_FILES, Nextion, nextion_ns, nextion_ref  # noqa: F401
+from . import (  # noqa: F401  pylint: disable=unused-import
+    FILTER_SOURCE_FILES,
+    Nextion,
+    nextion_ns,
+    nextion_ref,
+)
 from .base_component import (
     CONF_AUTO_WAKE_ON_TOUCH,
     CONF_COMMAND_SPACING,

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -11,7 +11,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, TimePeriod
 
-from . import Nextion, nextion_ns, nextion_ref
+from . import FILTER_SOURCE_FILES, Nextion, nextion_ns, nextion_ref  # noqa: F401
 from .base_component import (
     CONF_AUTO_WAKE_ON_TOUCH,
     CONF_COMMAND_SPACING,

--- a/esphome/components/remote_receiver/binary_sensor.py
+++ b/esphome/components/remote_receiver/binary_sensor.py
@@ -1,5 +1,7 @@
 from esphome.components import binary_sensor, remote_base
 
+from . import FILTER_SOURCE_FILES  # noqa: F401
+
 DEPENDENCIES = ["remote_receiver"]
 
 CONFIG_SCHEMA = remote_base.validate_binary_sensor

--- a/esphome/components/remote_receiver/binary_sensor.py
+++ b/esphome/components/remote_receiver/binary_sensor.py
@@ -1,6 +1,6 @@
 from esphome.components import binary_sensor, remote_base
 
-from . import FILTER_SOURCE_FILES  # noqa: F401
+from . import FILTER_SOURCE_FILES  # noqa: F401  pylint: disable=unused-import
 
 DEPENDENCIES = ["remote_receiver"]
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes platform subcomponents not inheriting the parent component's `FILTER_SOURCE_FILES` function, causing all platform-specific source files to be compiled instead of only the ones for the target platform.

When a component has platform-specific source files (like `debug_esp32.cpp`, `debug_esp8266.cpp`) and also has platform subcomponents (like `sensor.debug`, `text_sensor.debug`), the subcomponents share the same package directory but weren't inheriting the parent's `FILTER_SOURCE_FILES`. This caused the build system to compile all platform-specific files when iterating through the subcomponent's resources.

**Before this fix** (building for ESP8266 with `debug:` and `sensor: - platform: debug`):
```
Compiling debug_component.cpp
Compiling debug_esp32.cpp      # Wrong - not needed for ESP8266
Compiling debug_esp8266.cpp
Compiling debug_host.cpp       # Wrong - not needed for ESP8266
Compiling debug_libretiny.cpp  # Wrong - not needed for ESP8266
Compiling debug_rp2040.cpp     # Wrong - not needed for ESP8266
Compiling debug_zephyr.cpp     # Wrong - not needed for ESP8266
```

**After this fix**:
```
Compiling debug_component.cpp
Compiling debug_esp8266.cpp
```

The fix imports `FILTER_SOURCE_FILES` from the parent module into each affected subcomponent, making the filter function available as a module attribute.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #9354 (Don't compile unnecessary platform files)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config using debug sensors/text_sensors will benefit from this fix
esphome:
  name: test-device

esp8266:
  board: esp01_1m

logger:

debug:

sensor:
  - platform: debug
    free:
      name: "Free Heap"

text_sensor:
  - platform: debug
    device:
      name: "Device Info"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
