### PR TITLE
[image] Correctly handle dimensions in physical units

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -689,6 +689,11 @@ async def write_image(config, all_frames=False):
                 ratio = min(new_width_max / width, new_height_max / height)
                 width, height = int(width * ratio), int(height * ratio)
     except (OSError, UnidentifiedImageError, ValueError) as exc:
+        if str(exc) == "SVG has an invalid size":
+            raise core.EsphomeError(
+                f"SVG image file {path} has an invalid size. "
+                "Ensure the SVG defines width and height in absolute units (e.g., px, not mm)."
+            ) from exc
         raise core.EsphomeError(f"Could not read image file {path}: {exc}") from exc
 
     if not resize and (width > 500 or height > 500):

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -660,20 +660,14 @@ async def write_image(config, all_frames=False):
     if not path.is_file():
         raise core.EsphomeError(f"Could not load image file {path}")
 
-    resize = config.get(CONF_RESIZE)
+    resize = config.get(CONF_RESIZE, (None, None))
     try:
         if is_svg_file(path):
             import resvg_py
 
-            if resize:
-                width, height = resize
-                # resvg-py allows rendering by width/height directly
-                image_data = resvg_py.svg_to_bytes(
-                    svg_path=str(path), width=int(width), height=int(height), dpi=100
-                )
-            else:
-                # Default size
-                image_data = resvg_py.svg_to_bytes(svg_path=str(path), dpi=100)
+            image_data = resvg_py.svg_to_bytes(
+                svg_path=str(path), width=resize[0], height=resize[1], dpi=100
+            )
 
             # Convert bytes to Pillow Image
             image = Image.open(io.BytesIO(image_data))

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -669,11 +669,11 @@ async def write_image(config, all_frames=False):
                 width, height = resize
                 # resvg-py allows rendering by width/height directly
                 image_data = resvg_py.svg_to_bytes(
-                    svg_path=str(path), width=int(width), height=int(height)
+                    svg_path=str(path), width=int(width), height=int(height), dpi=100
                 )
             else:
                 # Default size
-                image_data = resvg_py.svg_to_bytes(svg_path=str(path))
+                image_data = resvg_py.svg_to_bytes(svg_path=str(path), dpi=100)
 
             # Convert bytes to Pillow Image
             image = Image.open(io.BytesIO(image_data))

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -669,11 +669,11 @@ async def write_image(config, all_frames=False):
                 width, height = resize
                 # resvg-py allows rendering by width/height directly
                 image_data = resvg_py.svg_to_bytes(
-                    svg_path=str(path), width=int(width), height=int(height), dpi=100
+                    svg_path=str(path), width=int(width), height=int(height)
                 )
             else:
                 # Default size
-                image_data = resvg_py.svg_to_bytes(svg_path=str(path), dpi=100)
+                image_data = resvg_py.svg_to_bytes(svg_path=str(path))
 
             # Convert bytes to Pillow Image
             image = Image.open(io.BytesIO(image_data))
@@ -689,11 +689,6 @@ async def write_image(config, all_frames=False):
                 ratio = min(new_width_max / width, new_height_max / height)
                 width, height = int(width * ratio), int(height * ratio)
     except (OSError, UnidentifiedImageError, ValueError) as exc:
-        if str(exc) == "SVG has an invalid size":
-            raise core.EsphomeError(
-                f"SVG image file {path} has an invalid size. "
-                "Ensure the SVG defines width and height in absolute units (e.g., px, not mm)."
-            ) from exc
         raise core.EsphomeError(f"Could not read image file {path}: {exc}") from exc
 
     if not resize and (width > 500 or height > 500):

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -660,11 +660,12 @@ async def write_image(config, all_frames=False):
     if not path.is_file():
         raise core.EsphomeError(f"Could not load image file {path}")
 
-    resize = config.get(CONF_RESIZE, (None, None))
+    resize = config.get(CONF_RESIZE)
     try:
         if is_svg_file(path):
             import resvg_py
 
+            resize = resize or (None, None)
             image_data = resvg_py.svg_to_bytes(
                 svg_path=str(path), width=resize[0], height=resize[1], dpi=100
             )

--- a/tests/component_tests/image/config/invalid_dimensions.svg
+++ b/tests/component_tests/image/config/invalid_dimensions.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100mm" viewBox="0 0 100 100">
-  <rect x="0" y="0" width="100" height="100" fill="#FF0000"/>
-</svg>

--- a/tests/component_tests/image/config/invalid_dimensions.svg
+++ b/tests/component_tests/image/config/invalid_dimensions.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100mm" height="100mm" viewBox="0 0 100 100">
+  <rect x="0" y="0" width="100" height="100" fill="#FF0000"/>
+</svg>

--- a/tests/component_tests/image/config/mm_dimensions.svg
+++ b/tests/component_tests/image/config/mm_dimensions.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="10mm" height="10mm" viewBox="0 0 100 100">
+  <rect x="0" y="0" width="100" height="100" fill="#00FF00"/>
+  <circle cx="50" cy="50" r="30" fill="#0000FF"/>
+</svg>

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -5,17 +5,21 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from esphome import config_validation as cv
 from esphome.components.image import (
+    CONF_INVERT_ALPHA,
+    CONF_OPAQUE,
     CONF_TRANSPARENCY,
     CONFIG_SCHEMA,
     get_all_image_metadata,
     get_image_metadata,
+    write_image,
 )
-from esphome.const import CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
+from esphome.const import CONF_DITHER, CONF_FILE, CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
 from esphome.core import CORE
 
 
@@ -350,3 +354,47 @@ def test_get_all_image_metadata_empty() -> None:
         "get_all_image_metadata should always return a dict"
     )
     # Length could be 0 or more depending on what's in CORE at test time
+
+
+@pytest.mark.asyncio
+async def test_svg_with_mm_dimensions_succeeds(
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that SVG files with dimensions in mm are successfully processed."""
+    # Mock progmem_array to avoid needing a proper ID object
+    with patch("esphome.components.image.cg.progmem_array") as mock_progmem:
+        mock_progmem.return_value = MagicMock()
+
+        # Create a config for write_image without CONF_RESIZE
+        config = {
+            CONF_FILE: component_config_path("mm_dimensions.svg"),
+            CONF_TYPE: "BINARY",
+            CONF_TRANSPARENCY: CONF_OPAQUE,
+            CONF_DITHER: "NONE",
+            CONF_INVERT_ALPHA: False,
+            CONF_RAW_DATA_ID: "test_raw_data_id",
+        }
+
+        # This should succeed without raising an error
+        result = await write_image(config)
+
+        # Verify that write_image returns the expected tuple
+        assert isinstance(result, tuple), "write_image should return a tuple"
+        assert len(result) == 6, "write_image should return 6 values"
+
+        prog_arr, width, height, image_type, trans_value, frame_count = result
+
+        # Verify the dimensions are positive integers
+        # At 100 DPI, 10mm = ~39 pixels (10mm * 100dpi / 25.4mm_per_inch)
+        assert isinstance(width, int), "Width should be an integer"
+        assert isinstance(height, int), "Height should be an integer"
+        assert width > 0, "Width should be positive"
+        assert height > 0, "Height should be positive"
+        assert frame_count == 1, "Single image should have frame_count of 1"
+        # Verify we got reasonable dimensions from the mm-based SVG
+        assert 30 < width < 50, (
+            f"Width should be around 39 pixels for 10mm at 100dpi, got {width}"
+        )
+        assert 30 < height < 50, (
+            f"Height should be around 39 pixels for 10mm at 100dpi, got {height}"
+        )

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -356,45 +356,50 @@ def test_get_all_image_metadata_empty() -> None:
     # Length could be 0 or more depending on what's in CORE at test time
 
 
+@pytest.fixture
+def mock_progmem_array():
+    """Mock progmem_array to avoid needing a proper ID object in tests."""
+    with patch("esphome.components.image.cg.progmem_array") as mock_progmem:
+        mock_progmem.return_value = MagicMock()
+        yield mock_progmem
+
+
 @pytest.mark.asyncio
 async def test_svg_with_mm_dimensions_succeeds(
     component_config_path: Callable[[str], Path],
+    mock_progmem_array: MagicMock,
 ) -> None:
     """Test that SVG files with dimensions in mm are successfully processed."""
-    # Mock progmem_array to avoid needing a proper ID object
-    with patch("esphome.components.image.cg.progmem_array") as mock_progmem:
-        mock_progmem.return_value = MagicMock()
+    # Create a config for write_image without CONF_RESIZE
+    config = {
+        CONF_FILE: component_config_path("mm_dimensions.svg"),
+        CONF_TYPE: "BINARY",
+        CONF_TRANSPARENCY: CONF_OPAQUE,
+        CONF_DITHER: "NONE",
+        CONF_INVERT_ALPHA: False,
+        CONF_RAW_DATA_ID: "test_raw_data_id",
+    }
 
-        # Create a config for write_image without CONF_RESIZE
-        config = {
-            CONF_FILE: component_config_path("mm_dimensions.svg"),
-            CONF_TYPE: "BINARY",
-            CONF_TRANSPARENCY: CONF_OPAQUE,
-            CONF_DITHER: "NONE",
-            CONF_INVERT_ALPHA: False,
-            CONF_RAW_DATA_ID: "test_raw_data_id",
-        }
+    # This should succeed without raising an error
+    result = await write_image(config)
 
-        # This should succeed without raising an error
-        result = await write_image(config)
+    # Verify that write_image returns the expected tuple
+    assert isinstance(result, tuple), "write_image should return a tuple"
+    assert len(result) == 6, "write_image should return 6 values"
 
-        # Verify that write_image returns the expected tuple
-        assert isinstance(result, tuple), "write_image should return a tuple"
-        assert len(result) == 6, "write_image should return 6 values"
+    prog_arr, width, height, image_type, trans_value, frame_count = result
 
-        prog_arr, width, height, image_type, trans_value, frame_count = result
-
-        # Verify the dimensions are positive integers
-        # At 100 DPI, 10mm = ~39 pixels (10mm * 100dpi / 25.4mm_per_inch)
-        assert isinstance(width, int), "Width should be an integer"
-        assert isinstance(height, int), "Height should be an integer"
-        assert width > 0, "Width should be positive"
-        assert height > 0, "Height should be positive"
-        assert frame_count == 1, "Single image should have frame_count of 1"
-        # Verify we got reasonable dimensions from the mm-based SVG
-        assert 30 < width < 50, (
-            f"Width should be around 39 pixels for 10mm at 100dpi, got {width}"
-        )
-        assert 30 < height < 50, (
-            f"Height should be around 39 pixels for 10mm at 100dpi, got {height}"
-        )
+    # Verify the dimensions are positive integers
+    # At 100 DPI, 10mm = ~39 pixels (10mm * 100dpi / 25.4mm_per_inch)
+    assert isinstance(width, int), "Width should be an integer"
+    assert isinstance(height, int), "Height should be an integer"
+    assert width > 0, "Width should be positive"
+    assert height > 0, "Height should be positive"
+    assert frame_count == 1, "Single image should have frame_count of 1"
+    # Verify we got reasonable dimensions from the mm-based SVG
+    assert 30 < width < 50, (
+        f"Width should be around 39 pixels for 10mm at 100dpi, got {width}"
+    )
+    assert 30 < height < 50, (
+        f"Height should be around 39 pixels for 10mm at 100dpi, got {height}"
+    )

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -373,7 +373,7 @@ async def test_svg_with_mm_dimensions_error(
     # Verify that the correct error message is raised
     with pytest.raises(
         EsphomeError,
-        match=r"SVG image file .* has an invalid size\. "
+        match=r"SVG image file .*invalid_dimensions.svg has an invalid size\. "
         r"Ensure the SVG defines width and height in absolute units \(e\.g\., px, not mm\)\.",
     ):
         await write_image(config)

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -10,13 +10,16 @@ import pytest
 
 from esphome import config_validation as cv
 from esphome.components.image import (
+    CONF_INVERT_ALPHA,
+    CONF_OPAQUE,
     CONF_TRANSPARENCY,
     CONFIG_SCHEMA,
     get_all_image_metadata,
     get_image_metadata,
+    write_image,
 )
-from esphome.const import CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
-from esphome.core import CORE
+from esphome.const import CONF_DITHER, CONF_FILE, CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
+from esphome.core import CORE, EsphomeError
 
 
 @pytest.mark.parametrize(
@@ -350,3 +353,27 @@ def test_get_all_image_metadata_empty() -> None:
         "get_all_image_metadata should always return a dict"
     )
     # Length could be 0 or more depending on what's in CORE at test time
+
+
+@pytest.mark.asyncio
+async def test_svg_with_mm_dimensions_error(
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that SVG files with dimensions in mm produce the correct error message."""
+    # Create a minimal config for write_image
+    config = {
+        CONF_FILE: component_config_path("invalid_dimensions.svg"),
+        CONF_TYPE: "BINARY",
+        CONF_TRANSPARENCY: CONF_OPAQUE,
+        CONF_DITHER: "NONE",
+        CONF_INVERT_ALPHA: False,
+        CONF_RAW_DATA_ID: "test_raw_data_id",
+    }
+
+    # Verify that the correct error message is raised
+    with pytest.raises(
+        EsphomeError,
+        match=r"SVG image file .* has an invalid size\. "
+        r"Ensure the SVG defines width and height in absolute units \(e\.g\., px, not mm\)\.",
+    ):
+        await write_image(config)

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -10,16 +10,13 @@ import pytest
 
 from esphome import config_validation as cv
 from esphome.components.image import (
-    CONF_INVERT_ALPHA,
-    CONF_OPAQUE,
     CONF_TRANSPARENCY,
     CONFIG_SCHEMA,
     get_all_image_metadata,
     get_image_metadata,
-    write_image,
 )
-from esphome.const import CONF_DITHER, CONF_FILE, CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
-from esphome.core import CORE, EsphomeError
+from esphome.const import CONF_ID, CONF_RAW_DATA_ID, CONF_TYPE
+from esphome.core import CORE
 
 
 @pytest.mark.parametrize(
@@ -353,27 +350,3 @@ def test_get_all_image_metadata_empty() -> None:
         "get_all_image_metadata should always return a dict"
     )
     # Length could be 0 or more depending on what's in CORE at test time
-
-
-@pytest.mark.asyncio
-async def test_svg_with_mm_dimensions_error(
-    component_config_path: Callable[[str], Path],
-) -> None:
-    """Test that SVG files with dimensions in mm produce the correct error message."""
-    # Create a minimal config for write_image
-    config = {
-        CONF_FILE: component_config_path("invalid_dimensions.svg"),
-        CONF_TYPE: "BINARY",
-        CONF_TRANSPARENCY: CONF_OPAQUE,
-        CONF_DITHER: "NONE",
-        CONF_INVERT_ALPHA: False,
-        CONF_RAW_DATA_ID: "test_raw_data_id",
-    }
-
-    # Verify that the correct error message is raised
-    with pytest.raises(
-        EsphomeError,
-        match=r"SVG image file .*invalid_dimensions.svg has an invalid size\. "
-        r"Ensure the SVG defines width and height in absolute units \(e\.g\., px, not mm\)\.",
-    ):
-        await write_image(config)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add a dpi parameter to the resvg conversion call to allow dimensions in mm etc. to be handled
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #13204 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
