### PR TITLE
[scheduler] Replace resize() with erase() to save ~ 436 bytes flash

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -403,7 +403,9 @@ class Scheduler {
       for (size_t i = 0; i < remaining; i++) {
         this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
       }
-      this->defer_queue_.resize(remaining);
+      // Use erase() instead of resize() to avoid instantiating _M_default_append
+      // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
+      this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
     }
     this->defer_queue_front_ = 0;
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace `resize()` with `erase()` when shrinking the scheduler's defer queue to avoid instantiating `_M_default_append` template code.

When shrinking a `std::vector`, both `resize(n)` and `erase(begin+n, end)` produce identical results - they destroy elements from position n onwards and update the size. However, `resize()` instantiates `_M_default_append` because the compiler cannot know at compile time whether the new size will be larger or smaller than the current size.

By using `erase()` from the end instead, we eliminate the `_M_default_append` instantiation entirely since `erase()` only ever removes elements, never adds them.

**Savings:** ~176 bytes flash on LN882x (and similar savings on other multi-core platforms)

**Note:** This optimization only affects multi-core platforms (ESP32, LN882x, BK72xx, etc.) since the defer queue is compiled out for single-threaded platforms like ESP8266 (`#ifndef ESPHOME_THREAD_SINGLE`). The `_M_default_append` symbol won't appear in ESP8266 memory analysis.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
