### PR TITLE
[zephyr] Avoid heap allocation in preferences key formatting

### DIFF
--- a/esphome/components/zephyr/preferences.cpp
+++ b/esphome/components/zephyr/preferences.cpp
@@ -5,6 +5,8 @@
 #include "esphome/core/preferences.h"
 #include "esphome/core/log.h"
 #include <zephyr/settings/settings.h>
+#include <cinttypes>
+#include <cstring>
 
 namespace esphome {
 namespace zephyr {
@@ -12,6 +14,9 @@ namespace zephyr {
 static const char *const TAG = "zephyr.preferences";
 
 #define ESPHOME_SETTINGS_KEY "esphome"
+
+// Buffer size for key: "esphome/" (8) + hex uint32 (8) + null (1) = 17, rounded up
+static constexpr size_t KEY_BUFFER_SIZE = 20;
 
 class ZephyrPreferenceBackend : public ESPPreferenceBackend {
  public:
@@ -27,7 +32,9 @@ class ZephyrPreferenceBackend : public ESPPreferenceBackend {
 
   bool load(uint8_t *data, size_t len) override {
     if (len != this->data.size()) {
-      ESP_LOGE(TAG, "size of setting key %s changed, from: %u, to: %u", get_key().c_str(), this->data.size(), len);
+      char key_buf[KEY_BUFFER_SIZE];
+      this->format_key(key_buf, sizeof(key_buf));
+      ESP_LOGE(TAG, "size of setting key %s changed, from: %u, to: %u", key_buf, this->data.size(), len);
       return false;
     }
     std::memcpy(data, this->data.data(), len);
@@ -36,7 +43,7 @@ class ZephyrPreferenceBackend : public ESPPreferenceBackend {
   }
 
   uint32_t get_type() const { return this->type_; }
-  std::string get_key() const { return str_sprintf(ESPHOME_SETTINGS_KEY "/%" PRIx32, this->type_); }
+  void format_key(char *buf, size_t size) const { snprintf(buf, size, ESPHOME_SETTINGS_KEY "/%" PRIx32, this->type_); }
 
   std::vector<uint8_t> data;
 
@@ -85,7 +92,9 @@ class ZephyrPreferences : public ESPPreferences {
     }
     printf("type %u size %u\n", type, this->backends_.size());
     auto *pref = new ZephyrPreferenceBackend(type);  // NOLINT(cppcoreguidelines-owning-memory)
-    ESP_LOGD(TAG, "Add new setting %s.", pref->get_key().c_str());
+    char key_buf[KEY_BUFFER_SIZE];
+    pref->format_key(key_buf, sizeof(key_buf));
+    ESP_LOGD(TAG, "Add new setting %s.", key_buf);
     this->backends_.push_back(pref);
     return ESPPreferenceObject(pref);
   }
@@ -134,9 +143,10 @@ class ZephyrPreferences : public ESPPreferences {
 
   static int export_settings(int (*cb)(const char *name, const void *value, size_t val_len)) {
     for (auto *backend : static_cast<ZephyrPreferences *>(global_preferences)->backends_) {
-      auto name = backend->get_key();
-      int err = cb(name.c_str(), backend->data.data(), backend->data.size());
-      ESP_LOGD(TAG, "save in flash, name %s, len %u, err %d", name.c_str(), backend->data.size(), err);
+      char name[KEY_BUFFER_SIZE];
+      backend->format_key(name, sizeof(name));
+      int err = cb(name, backend->data.data(), backend->data.size());
+      ESP_LOGD(TAG, "save in flash, name %s, len %u, err %d", name, backend->data.size(), err);
     }
     return 0;
   }

--- a/esphome/components/zephyr/preferences.cpp
+++ b/esphome/components/zephyr/preferences.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "zephyr.preferences";
 
 #define ESPHOME_SETTINGS_KEY "esphome"
 
-// Buffer size for key: "esphome/" (8) + hex uint32 (8) + null (1) = 17, rounded up
+// Buffer size for key: "esphome/" (8) + max hex uint32 (8) + null terminator (1) = 17; use 20 for safety margin
 static constexpr size_t KEY_BUFFER_SIZE = 20;
 
 class ZephyrPreferenceBackend : public ESPPreferenceBackend {


### PR DESCRIPTION
# What does this implement/fix?

Replace `str_sprintf()` with stack-based formatting in Zephyr preferences to avoid heap allocation.

The `get_key()` method returned a heap-allocated `std::string` via `str_sprintf()`. This is called during settings save/load operations. Changed to `format_key(char *buf, size_t size)` which writes to a caller-provided stack buffer.

This matches the pattern used in esp32 and libretiny preferences implementations which use `snprintf` with `KEY_BUFFER_SIZE` stack buffers.

**Changes:**
- Added `KEY_BUFFER_SIZE = 20` constant (fits "esphome/" + 8 hex digits + null)
- Replaced `std::string get_key()` with `void format_key(char *buf, size_t size)`
- Updated all 3 call sites to use stack buffers
- Added `<cinttypes>` and `<cstring>` includes for consistency

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
