### PR TITLE
[ezo] Replace str_sprintf with stack-based formatting

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -160,7 +160,7 @@ void EZOSensor::loop() {
   this->commands_.pop_front();
 }
 
-void EZOSensor::add_command_(const std::string &command, EzoCommandType command_type, uint16_t delay_ms) {
+void EZOSensor::add_command_(const char *command, EzoCommandType command_type, uint16_t delay_ms) {
   std::unique_ptr<EzoCommand> ezo_command(new EzoCommand);
   ezo_command->command = command;
   ezo_command->command_type = command_type;
@@ -169,13 +169,17 @@ void EZOSensor::add_command_(const std::string &command, EzoCommandType command_
 }
 
 void EZOSensor::set_calibration_point_(EzoCalibrationType type, float value) {
-  std::string payload = str_sprintf("Cal,%s,%0.2f", EZO_CALIBRATION_TYPE_STRINGS[type], value);
+  // max 20: "Cal,"(4) + type(4) + ","(1) + float(10) + null
+  char payload[20];
+  snprintf(payload, sizeof(payload), "Cal,%s,%0.2f", EZO_CALIBRATION_TYPE_STRINGS[type], value);
   this->add_command_(payload, EzoCommandType::EZO_CALIBRATION, 900);
 }
 
 void EZOSensor::set_address(uint8_t address) {
   if (address > 0 && address < 128) {
-    std::string payload = str_sprintf("I2C,%u", address);
+    // max 8: "I2C,"(4) + uint8(3) + null
+    char payload[8];
+    snprintf(payload, sizeof(payload), "I2C,%u", address);
     this->new_address_ = address;
     this->add_command_(payload, EzoCommandType::EZO_I2C);
   } else {
@@ -194,7 +198,9 @@ void EZOSensor::get_slope() { this->add_command_("Slope,?", EzoCommandType::EZO_
 void EZOSensor::get_t() { this->add_command_("T,?", EzoCommandType::EZO_T); }
 
 void EZOSensor::set_t(float value) {
-  std::string payload = str_sprintf("T,%0.2f", value);
+  // max 14: "T,"(2) + float(10) + null, rounded to 16
+  char payload[16];
+  snprintf(payload, sizeof(payload), "T,%0.2f", value);
   this->add_command_(payload, EzoCommandType::EZO_T);
 }
 
@@ -215,7 +221,9 @@ void EZOSensor::set_calibration_point_high(float value) {
 }
 
 void EZOSensor::set_calibration_generic(float value) {
-  std::string payload = str_sprintf("Cal,%0.2f", value);
+  // max 16: "Cal,"(4) + float(10) + null, rounded to 16
+  char payload[16];
+  snprintf(payload, sizeof(payload), "Cal,%0.2f", value);
   this->add_command_(payload, EzoCommandType::EZO_CALIBRATION, 900);
 }
 
@@ -223,13 +231,11 @@ void EZOSensor::clear_calibration() { this->add_command_("Cal,clear", EzoCommand
 
 void EZOSensor::get_led_state() { this->add_command_("L,?", EzoCommandType::EZO_LED); }
 
-void EZOSensor::set_led_state(bool on) {
-  std::string to_send = "L,";
-  to_send += on ? "1" : "0";
-  this->add_command_(to_send, EzoCommandType::EZO_LED);
-}
+void EZOSensor::set_led_state(bool on) { this->add_command_(on ? "L,1" : "L,0", EzoCommandType::EZO_LED); }
 
-void EZOSensor::send_custom(const std::string &to_send) { this->add_command_(to_send, EzoCommandType::EZO_CUSTOM); }
+void EZOSensor::send_custom(const std::string &to_send) {
+  this->add_command_(to_send.c_str(), EzoCommandType::EZO_CUSTOM);
+}
 
 }  // namespace ezo
 }  // namespace esphome

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -198,7 +198,7 @@ void EZOSensor::get_slope() { this->add_command_("Slope,?", EzoCommandType::EZO_
 void EZOSensor::get_t() { this->add_command_("T,?", EzoCommandType::EZO_T); }
 
 void EZOSensor::set_t(float value) {
-  // max 14: "T,"(2) + float(10) + null, rounded to 16
+  // max 14 bytes: "T,"(2) + float with "%0.2f" (up to 11 chars) + null(1); use 16 for alignment
   char payload[16];
   snprintf(payload, sizeof(payload), "T,%0.2f", value);
   this->add_command_(payload, EzoCommandType::EZO_T);

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -221,7 +221,7 @@ void EZOSensor::set_calibration_point_high(float value) {
 }
 
 void EZOSensor::set_calibration_generic(float value) {
-  // max 16: "Cal,"(4) + float(10) + null, rounded to 16
+  // exact 16 bytes: "Cal," (4) + float with "%0.2f" (up to 11 chars, e.g. "-9999999.99") + null (1) = 16
   char payload[16];
   snprintf(payload, sizeof(payload), "Cal,%0.2f", value);
   this->add_command_(payload, EzoCommandType::EZO_CALIBRATION, 900);

--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -169,8 +169,8 @@ void EZOSensor::add_command_(const char *command, EzoCommandType command_type, u
 }
 
 void EZOSensor::set_calibration_point_(EzoCalibrationType type, float value) {
-  // max 20: "Cal,"(4) + type(4) + ","(1) + float(10) + null
-  char payload[20];
+  // max 21: "Cal,"(4) + type(4) + ","(1) + float(11) + null; use 24 for safety
+  char payload[24];
   snprintf(payload, sizeof(payload), "Cal,%s,%0.2f", EZO_CALIBRATION_TYPE_STRINGS[type], value);
   this->add_command_(payload, EzoCommandType::EZO_CALIBRATION, 900);
 }

--- a/esphome/components/ezo/ezo.h
+++ b/esphome/components/ezo/ezo.h
@@ -92,7 +92,7 @@ class EZOSensor : public sensor::Sensor, public PollingComponent, public i2c::I2
   std::deque<std::unique_ptr<EzoCommand>> commands_;
   int new_address_;
 
-  void add_command_(const std::string &command, EzoCommandType command_type, uint16_t delay_ms = 300);
+  void add_command_(const char *command, EzoCommandType command_type, uint16_t delay_ms = 300);
 
   void set_calibration_point_(EzoCalibrationType type, float value);
 


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `str_sprintf()` calls with stack-based buffers in the EZO sensor component.

**Changes:**
- Replace 4 `str_sprintf()` calls with `snprintf()` + stack buffers
- Change `add_command_()` signature from `const std::string&` to `const char*` to eliminate implicit string construction
- Simplify `set_led_state()` to use string literals directly (`"L,1"` / `"L,0"`)
- Update `send_custom()` to pass `.c_str()`

**Buffer sizes:**
- `set_calibration_point_()`: max 20 = "Cal,"(4) + type(4) + ","(1) + float(10) + null
- `set_address()`: max 8 = "I2C,"(4) + uint8(3) + null
- `set_t()`: max 16 = "T,"(2) + float(10) + null, rounded to 16
- `set_calibration_generic()`: max 16 = "Cal,"(4) + float(10) + null, rounded to 16

**Future optimization opportunities (out of scope for this PR):**
- `EzoCommand::command` is `std::string` - could use a fixed-size buffer
- `std::deque<std::unique_ptr<EzoCommand>>` - deque allocates 512-byte blocks minimum, could use vector or ring buffer
- Multiple `CallbackManager<void(std::string)>` instances

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
i2c:
  sda: GPIO21
  scl: GPIO22

sensor:
  - platform: ezo
    id: ph_sensor
    address: 0x63
    unit_of_measurement: "pH"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
