### PR TITLE
[dfrobot_sen0395] Reduce heap allocations in command building

### DIFF
--- a/esphome/components/dfrobot_sen0395/commands.cpp
+++ b/esphome/components/dfrobot_sen0395/commands.cpp
@@ -127,7 +127,9 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->min2_ = min2 = this->max2_ = max2 = this->min3_ = min3 = this->max3_ = max3 = this->min4_ = min4 =
         this->max4_ = max4 = -1;
 
-    this->cmd_ = str_sprintf("detRangeCfg -1 %.0f %.0f", min1 / 0.15, max1 / 0.15);
+    char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f", min1 / 0.15, max1 / 0.15);
+    this->cmd_ = buf;
   } else if (min3 < 0 || max3 < 0) {
     this->min1_ = min1 = round(min1 / 0.15) * 0.15;
     this->max1_ = max1 = round(max1 / 0.15) * 0.15;
@@ -135,7 +137,10 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->max2_ = max2 = round(max2 / 0.15) * 0.15;
     this->min3_ = min3 = this->max3_ = max3 = this->min4_ = min4 = this->max4_ = max4 = -1;
 
-    this->cmd_ = str_sprintf("detRangeCfg -1 %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15, max2 / 0.15);
+    char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
+             max2 / 0.15);
+    this->cmd_ = buf;
   } else if (min4 < 0 || max4 < 0) {
     this->min1_ = min1 = round(min1 / 0.15) * 0.15;
     this->max1_ = max1 = round(max1 / 0.15) * 0.15;
@@ -145,9 +150,10 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->max3_ = max3 = round(max3 / 0.15) * 0.15;
     this->min4_ = min4 = this->max4_ = max4 = -1;
 
-    this->cmd_ = str_sprintf("detRangeCfg -1 "
-                             "%.0f %.0f %.0f %.0f %.0f %.0f",
-                             min1 / 0.15, max1 / 0.15, min2 / 0.15, max2 / 0.15, min3 / 0.15, max3 / 0.15);
+    char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15, min2 / 0.15,
+             max2 / 0.15, min3 / 0.15, max3 / 0.15);
+    this->cmd_ = buf;
   } else {
     this->min1_ = min1 = round(min1 / 0.15) * 0.15;
     this->max1_ = max1 = round(max1 / 0.15) * 0.15;
@@ -158,10 +164,10 @@ DetRangeCfgCommand::DetRangeCfgCommand(float min1, float max1, float min2, float
     this->min4_ = min4 = round(min4 / 0.15) * 0.15;
     this->max4_ = max4 = round(max4 / 0.15) * 0.15;
 
-    this->cmd_ = str_sprintf("detRangeCfg -1 "
-                             "%.0f %.0f %.0f %.0f %.0f %.0f %.0f %.0f",
-                             min1 / 0.15, max1 / 0.15, min2 / 0.15, max2 / 0.15, min3 / 0.15, max3 / 0.15, min4 / 0.15,
-                             max4 / 0.15);
+    char buf[72];  // max 72: "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
+    snprintf(buf, sizeof(buf), "detRangeCfg -1 %.0f %.0f %.0f %.0f %.0f %.0f %.0f %.0f", min1 / 0.15, max1 / 0.15,
+             min2 / 0.15, max2 / 0.15, min3 / 0.15, max3 / 0.15, min4 / 0.15, max4 / 0.15);
+    this->cmd_ = buf;
   }
 
   this->min1_ = min1;
@@ -203,7 +209,10 @@ SetLatencyCommand::SetLatencyCommand(float delay_after_detection, float delay_af
   delay_after_disappear = std::round(delay_after_disappear / 0.025f) * 0.025f;
   this->delay_after_detection_ = clamp(delay_after_detection, 0.0f, 1638.375f);
   this->delay_after_disappear_ = clamp(delay_after_disappear, 0.0f, 1638.375f);
-  this->cmd_ = str_sprintf("setLatency %.03f %.03f", this->delay_after_detection_, this->delay_after_disappear_);
+  // max 32: "setLatency "(11) + float(8) + " "(1) + float(8) + null, rounded to 32
+  char buf[32];
+  snprintf(buf, sizeof(buf), "setLatency %.03f %.03f", this->delay_after_detection_, this->delay_after_disappear_);
+  this->cmd_ = buf;
 };
 
 uint8_t SetLatencyCommand::on_message(std::string &message) {


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `str_sprintf()` calls with stack-based buffers in the DFRobot SEN0395 radar sensor component.

This is part of the ongoing effort to deprecate `str_sprintf()` in favor of stack-based formatting with `snprintf()`.

**Changes:**
- Replace 5 `str_sprintf()` calls with `snprintf()` + stack buffers
- `detRangeCfg` commands: 72-byte buffer
- `setLatency` command: 32-byte buffer

**Buffer size calculations:**
- `detRangeCfg`: max 72 = "detRangeCfg -1 "(15) + 8 * (float(5) + space(1)) + null
- `setLatency`: max 32 = "setLatency "(11) + float(8) + " "(1) + float(8) + null

**Note:** `this->cmd_` is `std::string`, so one allocation still occurs when assigning the buffer. Eliminating this would require deeper refactoring of the command infrastructure.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

binary_sensor:
  - platform: dfrobot_sen0395
    id: mmwave_sensor
    detected:
      name: "Presence"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
