### PR TITLE
[lvgl] Use stack buffer for event code formatting, document justified str_sprintf usage

### DIFF
--- a/esphome/components/lvgl/lv_validation.py
+++ b/esphome/components/lvgl/lv_validation.py
@@ -413,6 +413,7 @@ class TextValidator(LValidator):
                 str_args = [str(x) for x in value[CONF_ARGS]]
                 arg_expr = cg.RawExpression(",".join(str_args))
                 format_str = cpp_string_escape(format_str)
+                # str_sprintf justified: user-defined format, can't optimize without permanent RAM cost
                 sprintf_str = f"str_sprintf({format_str}, {arg_expr}).c_str()"
                 if nanval := value.get(CONF_IF_NAN):
                     nanval = cpp_string_escape(nanval)

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -65,9 +65,9 @@ std::string lv_event_code_name_for(uint8_t event_code) {
   if (event_code < sizeof(EVENT_NAMES) / sizeof(EVENT_NAMES[0])) {
     return EVENT_NAMES[event_code];
   }
-  // max 4 bytes: "%2d" with uint8_t (max 255, 3 digits) + null
+  // max 4 bytes: "%u" with uint8_t (max 255, 3 digits) + null
   char buf[4];
-  snprintf(buf, sizeof(buf), "%2u", event_code);
+  snprintf(buf, sizeof(buf), "%u", event_code);
   return buf;
 }
 

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -67,7 +67,7 @@ std::string lv_event_code_name_for(uint8_t event_code) {
   }
   // max 4 bytes: "%2d" with uint8_t (max 255, 3 digits) + null
   char buf[4];
-  snprintf(buf, sizeof(buf), "%2d", event_code);
+  snprintf(buf, sizeof(buf), "%2u", event_code);
   return buf;
 }
 

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -65,7 +65,10 @@ std::string lv_event_code_name_for(uint8_t event_code) {
   if (event_code < sizeof(EVENT_NAMES) / sizeof(EVENT_NAMES[0])) {
     return EVENT_NAMES[event_code];
   }
-  return str_sprintf("%2d", event_code);
+  // max 4 bytes: "%2d" with uint8_t (max 255, 3 digits) + null
+  char buf[4];
+  snprintf(buf, sizeof(buf), "%2d", event_code);
+  return buf;
 }
 
 static void rounder_cb(lv_disp_drv_t *disp_drv, lv_area_t *area) {


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `str_sprintf()` with stack-based `snprintf()` in the LVGL component's event code name lookup, and document justified `str_sprintf()` usage in code generation.

This is part of the ongoing effort to deprecate `str_sprintf()` in favor of stack-based formatting with `snprintf()`.

**Changes:**

1. **lvgl_esphome.cpp** - Replace `str_sprintf("%2d", event_code)` with stack buffer + snprintf
   - Buffer size: 4 bytes (uint8_t max 255 = 3 digits + null)
   - Function returns `std::string` so one allocation still occurs on return, but eliminates intermediate `str_sprintf()` heap allocation

2. **lv_validation.py** - Add comment documenting justified `str_sprintf()` usage
   - User-defined format strings from YAML config
   - Cannot optimize without permanent RAM cost (static buffer per usage)
   - Will need exclude in ci-custom.py when `str_sprintf` is added to deprecated helpers

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
# LVGL is only supported on ESP32
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
