### PR TITLE
[sml] Use stack buffers instead of str_sprintf

### DIFF
--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -106,7 +106,7 @@ std::string bytes_repr(const BytesView &buffer) {
   for (auto const value : buffer) {
     // max 3: 2 hex digits + null
     char hex_buf[3];
-    snprintf(hex_buf, sizeof(hex_buf), "%02x", value & 0xff);
+    snprintf(hex_buf, sizeof(hex_buf), "%02x", static_cast<unsigned int>(value));
     repr += hex_buf;
   }
   return repr;

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -104,7 +104,10 @@ std::vector<ObisInfo> SmlFile::get_obis_info() {
 std::string bytes_repr(const BytesView &buffer) {
   std::string repr;
   for (auto const value : buffer) {
-    repr += str_sprintf("%02x", value & 0xff);
+    // max 3: 2 hex digits + null
+    char hex_buf[3];
+    snprintf(hex_buf, sizeof(hex_buf), "%02x", value & 0xff);
+    repr += hex_buf;
   }
   return repr;
 }
@@ -146,7 +149,11 @@ ObisInfo::ObisInfo(const BytesView &server_id, const SmlNode &val_list_entry) : 
 }
 
 std::string ObisInfo::code_repr() const {
-  return str_sprintf("%d-%d:%d.%d.%d", this->code[0], this->code[1], this->code[2], this->code[3], this->code[4]);
+  // max 20: "255-255:255.255.255" (19 chars) + null
+  char buf[20];
+  snprintf(buf, sizeof(buf), "%d-%d:%d.%d.%d", this->code[0], this->code[1], this->code[2], this->code[3],
+           this->code[4]);
+  return buf;
 }
 
 }  // namespace sml


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `str_sprintf()` with stack-based `snprintf()` in the SML parser component.

This is part of the ongoing effort to deprecate `str_sprintf()` in favor of stack-based formatting with `snprintf()`.

**Changes:**

1. **bytes_repr()** - Loop building hex string representation
   - Replace `str_sprintf("%02x", ...)` with 3-byte stack buffer
   - Eliminates heap allocation per loop iteration

2. **code_repr()** - Returns OBIS code format "X-X:X.X.X"
   - Replace `str_sprintf("%d-%d:%d.%d.%d", ...)` with 20-byte stack buffer
   - Max output: "255-255:255.255.255" (19 chars) + null

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
