### PR TITLE
[gdk101] Use stack buffer to eliminate heap allocation for firmware version

### DIFF
--- a/esphome/components/gdk101/gdk101.cpp
+++ b/esphome/components/gdk101/gdk101.cpp
@@ -163,9 +163,10 @@ bool GDK101Component::read_fw_version_(uint8_t *data) {
       return false;
     }
 
-    const std::string fw_version_str = str_sprintf("%d.%d", data[0], data[1]);
-
-    this->fw_version_text_sensor_->publish_state(fw_version_str);
+    // max 8: "255.255" (7 chars) + null
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%d.%d", data[0], data[1]);
+    this->fw_version_text_sensor_->publish_state(buf);
   }
 #endif  // USE_TEXT_SENSOR
   return true;


### PR DESCRIPTION
# What does this implement/fix?

Eliminate heap allocation when publishing firmware version string in the GDK101 component.

**Before:**
```cpp
const std::string fw_version_str = str_sprintf("%d.%d", data[0], data[1]);
this->fw_version_text_sensor_->publish_state(fw_version_str);
```
- `str_sprintf()` always allocates std::string on heap
- `publish_state()` then compares/copies internally

**After:**
```cpp
char buf[8];
snprintf(buf, sizeof(buf), "%d.%d", data[0], data[1]);
this->fw_version_text_sensor_->publish_state(buf);
```
- `snprintf()` writes to 8-byte stack buffer (max "255.255" + null)
- `publish_state(const char*)` can compare directly without allocation
- If value unchanged: no allocation
- If value changed: reuses existing capacity when possible

This eliminates the unconditional `str_sprintf()` heap allocation. Combined with `publish_state()`'s smart handling (skip if unchanged, reuse capacity), this minimizes heap churn.

This is part of the ongoing effort to deprecate `str_sprintf()` in favor of stack-based formatting.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
