### PR TITLE
[esp32_hosted] Use stack buffer instead of str_sprintf for version string

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -69,7 +69,10 @@ void Esp32HostedUpdate::setup() {
   // Get coprocessor version
   esp_hosted_coprocessor_fwver_t ver_info;
   if (esp_hosted_get_coprocessor_fwversion(&ver_info) == ESP_OK) {
-    this->update_info_.current_version = str_sprintf("%d.%d.%d", ver_info.major1, ver_info.minor1, ver_info.patch1);
+    // 16 bytes: "255.255.255" (11 chars) + null + safety margin
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%d.%d.%d", ver_info.major1, ver_info.minor1, ver_info.patch1);
+    this->update_info_.current_version = buf;
   } else {
     this->update_info_.current_version = "unknown";
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `str_sprintf()` with stack-based `snprintf()` for version string formatting in the ESP32 Hosted update component.

**Before:**
```cpp
this->update_info_.current_version = str_sprintf("%d.%d.%d", ver_info.major1, ver_info.minor1, ver_info.patch1);
```
- `str_sprintf()` allocates intermediate std::string on heap
- Assignment copies/moves to `current_version`

**After:**
```cpp
char buf[16];
snprintf(buf, sizeof(buf), "%d.%d.%d", ver_info.major1, ver_info.minor1, ver_info.patch1);
this->update_info_.current_version = buf;
```
- `snprintf()` writes to 16-byte stack buffer (max "255.255.255" + null + margin)
- Assignment constructs string directly from buffer (one allocation vs two)

This is a one-time setup operation, but eliminating the intermediate allocation reduces heap fragmentation.

This is part of the ongoing effort to deprecate `str_sprintf()` in favor of stack-based formatting.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Note: This component only compiles for ESP32-H2 and ESP32-P4 variants.

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
