### PR TITLE
[socket] Eliminate heap allocations in set_sockaddr()

### DIFF
--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -107,9 +107,9 @@ std::unique_ptr<Socket> socket_ip_loop_monitored(int type, int protocol) {
 #endif /* USE_NETWORK_IPV6 */
 }
 
-socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port) {
+socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const char *ip_address, uint16_t port) {
 #if USE_NETWORK_IPV6
-  if (ip_address.find(':') != std::string::npos) {
+  if (strchr(ip_address, ':') != nullptr) {
     if (addrlen < sizeof(sockaddr_in6)) {
       errno = EINVAL;
       return 0;
@@ -121,14 +121,14 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
 
 #ifdef USE_SOCKET_IMPL_BSD_SOCKETS
     // Use standard inet_pton for BSD sockets
-    if (inet_pton(AF_INET6, ip_address.c_str(), &server->sin6_addr) != 1) {
+    if (inet_pton(AF_INET6, ip_address, &server->sin6_addr) != 1) {
       errno = EINVAL;
       return 0;
     }
 #else
     // Use LWIP-specific functions
     ip6_addr_t ip6;
-    inet6_aton(ip_address.c_str(), &ip6);
+    inet6_aton(ip_address, &ip6);
     memcpy(server->sin6_addr.un.u32_addr, ip6.addr, sizeof(ip6.addr));
 #endif
     return sizeof(sockaddr_in6);
@@ -141,7 +141,7 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::stri
   auto *server = reinterpret_cast<sockaddr_in *>(addr);
   memset(server, 0, sizeof(sockaddr_in));
   server->sin_family = AF_INET;
-  server->sin_addr.s_addr = inet_addr(ip_address.c_str());
+  server->sin_addr.s_addr = inet_addr(ip_address);
   server->sin_port = htons(port);
   return sizeof(sockaddr_in);
 }

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -87,7 +87,17 @@ std::unique_ptr<Socket> socket_loop_monitored(int domain, int type, int protocol
 std::unique_ptr<Socket> socket_ip_loop_monitored(int type, int protocol);
 
 /// Set a sockaddr to the specified address and port for the IP version used by socket_ip().
-socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port);
+/// @param addr Destination sockaddr structure
+/// @param addrlen Size of the addr buffer
+/// @param ip_address Null-terminated IP address string (IPv4 or IPv6)
+/// @param port Port number in host byte order
+/// @return Size of the sockaddr structure used, or 0 on error
+socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const char *ip_address, uint16_t port);
+
+/// Convenience overload for std::string (backward compatible).
+inline socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const std::string &ip_address, uint16_t port) {
+  return set_sockaddr(addr, addrlen, ip_address.c_str(), port);
+}
 
 /// Set a sockaddr to the any address and specified port for the IP version used by socket_ip().
 socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port);


### PR DESCRIPTION
# What does this implement/fix?

Eliminate hidden heap allocations in `socket::set_sockaddr()` by changing the function signature from `const std::string &` to `const char *` with an inline backward-compatible overload.

**Problem:**

The previous signature `set_sockaddr(..., const std::string &ip_address, ...)` caused hidden heap allocations when callers passed:
- String literals: `"255.255.255.255"` → temporary `std::string` constructed (heap allocation)
- C strings: `const char *host` → temporary `std::string` constructed (heap allocation)

**Solution:**

Two overloads:
1. **Core implementation:** `set_sockaddr(..., const char *ip_address, uint16_t port)`
   - Uses `strchr()` instead of `std::string::find()` for IPv6 colon detection
   - Passes IP string directly to `inet_addr()`/`inet_pton()` (already null-terminated)
   - No heap allocations

2. **Backward compatible overload:** `set_sockaddr(..., const std::string &ip_address, uint16_t port)`
   - Inline function that calls core with `.c_str()`
   - Existing callers continue to work unchanged

**Callers affected:**
- `wake_on_lan.cpp`: `"255.255.255.255"` → no heap allocation (was: temp std::string)
- `async_tcp_socket.cpp`: `const char *host` → no heap allocation (was: temp std::string)
- `udp_component.cpp`: `std::string` → unchanged behavior via inline overload

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
# Tested via components that use set_sockaddr:
wake_on_lan:
  target_mac_address: AA:BB:CC:DD:EE:FF
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
