### PR TITLE
[uart] Add error message when initializing UART with unsupported configuration

### DIFF
--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -110,7 +110,7 @@ void LibreTinyUARTComponent::setup() {
 #if LT_HW_UART2
     ESP_LOGE(TAG, "    TX=%u, RX=%u", PIN_SERIAL2_TX, PIN_SERIAL2_RX);
 #endif
-    this->mark_failed();
+    this->mark_failed(LOG_STR("SoftwareSerial is not implemented for this chip."));
     return;
 #endif
   }


### PR DESCRIPTION
# What does this implement/fix?

Add an error message when initializing a software UART on Libretiny on a board which does not support software UART.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: ${device_id}
  friendly_name: ${device_friendly_name}
  min_version: 2026.01.0

rtl87xx:
  board: generic-rtl8720cf-2mb-992k

uart:
  - tx_pin: PA07
    rx_pin: PA08
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
