### PR TITLE
[safe_mode] Detect bootloader rollback support at runtime

### DIFF
--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -26,6 +26,9 @@ void SafeModeComponent::dump_config() {
                 this->safe_mode_boot_is_good_after_ / 1000,  // because milliseconds
                 this->safe_mode_num_attempts_,
                 this->safe_mode_enable_time_ / 1000);  // because milliseconds
+#ifdef USE_OTA_ROLLBACK
+  ESP_LOGCONFIG(TAG, "  Bootloader rollback: %s", this->rollback_support_);
+#endif
 
   if (this->safe_mode_rtc_value_ > 1 && this->safe_mode_rtc_value_ != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
     auto remaining_restarts = this->safe_mode_num_attempts_ - this->safe_mode_rtc_value_;
@@ -89,6 +92,19 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   this->safe_mode_boot_is_good_after_ = boot_is_good_after;
   this->safe_mode_num_attempts_ = num_attempts;
   this->rtc_ = global_preferences->make_preference<uint32_t>(233825507UL, false);
+
+#ifdef USE_OTA_ROLLBACK
+  // Check partition state to detect if bootloader supports rollback
+  const esp_partition_t *running = esp_ota_get_running_partition();
+  esp_ota_img_states_t state;
+  if (esp_ota_get_state_partition(running, &state) == ESP_OK) {
+    if (state == ESP_OTA_IMG_NEW) {
+      this->rollback_support_ = "not supported";
+    } else if (state == ESP_OTA_IMG_PENDING_VERIFY) {
+      this->rollback_support_ = "supported";
+    }
+  }
+#endif
 
   uint32_t rtc_val = this->read_rtc_();
   this->safe_mode_rtc_value_ = rtc_val;

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -9,7 +9,7 @@
 #include <cinttypes>
 #include <cstdio>
 
-#ifdef USE_OTA_ROLLBACK
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
 #include <esp_ota_ops.h>
 #endif
 
@@ -26,8 +26,16 @@ void SafeModeComponent::dump_config() {
                 this->safe_mode_boot_is_good_after_ / 1000,  // because milliseconds
                 this->safe_mode_num_attempts_,
                 this->safe_mode_enable_time_ / 1000);  // because milliseconds
-#ifdef USE_OTA_ROLLBACK
-  ESP_LOGCONFIG(TAG, "  Bootloader rollback: %s", this->rollback_support_);
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
+  const char *state_str;
+  if (this->ota_state_ == ESP_OTA_IMG_NEW) {
+    state_str = "not supported";
+  } else if (this->ota_state_ == ESP_OTA_IMG_PENDING_VERIFY) {
+    state_str = "supported";
+  } else {
+    state_str = "support unknown";
+  }
+  ESP_LOGCONFIG(TAG, "  Bootloader rollback: %s", state_str);
 #endif
 
   if (this->safe_mode_rtc_value_ > 1 && this->safe_mode_rtc_value_ != SafeModeComponent::ENTER_SAFE_MODE_MAGIC) {
@@ -39,7 +47,7 @@ void SafeModeComponent::dump_config() {
     }
   }
 
-#ifdef USE_OTA_ROLLBACK
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
   const esp_partition_t *last_invalid = esp_ota_get_last_invalid_partition();
   if (last_invalid != nullptr) {
     ESP_LOGW(TAG,
@@ -58,7 +66,7 @@ void SafeModeComponent::loop() {
     ESP_LOGI(TAG, "Boot seems successful; resetting boot loop counter");
     this->clean_rtc();
     this->boot_successful_ = true;
-#ifdef USE_OTA_ROLLBACK
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
     // Mark OTA partition as valid to prevent rollback
     esp_ota_mark_app_valid_cancel_rollback();
 #endif
@@ -93,17 +101,10 @@ bool SafeModeComponent::should_enter_safe_mode(uint8_t num_attempts, uint32_t en
   this->safe_mode_num_attempts_ = num_attempts;
   this->rtc_ = global_preferences->make_preference<uint32_t>(233825507UL, false);
 
-#ifdef USE_OTA_ROLLBACK
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
   // Check partition state to detect if bootloader supports rollback
   const esp_partition_t *running = esp_ota_get_running_partition();
-  esp_ota_img_states_t state;
-  if (esp_ota_get_state_partition(running, &state) == ESP_OK) {
-    if (state == ESP_OTA_IMG_NEW) {
-      this->rollback_support_ = "not supported";
-    } else if (state == ESP_OTA_IMG_PENDING_VERIFY) {
-      this->rollback_support_ = "supported";
-    }
-  }
+  esp_ota_get_state_partition(running, &this->ota_state_);
 #endif
 
   uint32_t rtc_val = this->read_rtc_();

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -42,6 +42,9 @@ class SafeModeComponent : public Component {
   // Group 1-byte members together to minimize padding
   bool boot_successful_{false};  ///< set to true after boot is considered successful
   uint8_t safe_mode_num_attempts_{0};
+#ifdef USE_OTA_ROLLBACK
+  const char *rollback_support_{"support unknown"};
+#endif
   // Larger objects at the end
   ESPPreferenceObject rtc_;
 #ifdef USE_SAFE_MODE_CALLBACK

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -5,6 +5,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
+#include <esp_ota_ops.h>
+#endif
+
 namespace esphome::safe_mode {
 
 /// SafeModeComponent provides a safe way to recover from repeated boot failures
@@ -42,8 +46,8 @@ class SafeModeComponent : public Component {
   // Group 1-byte members together to minimize padding
   bool boot_successful_{false};  ///< set to true after boot is considered successful
   uint8_t safe_mode_num_attempts_{0};
-#ifdef USE_OTA_ROLLBACK
-  const char *rollback_support_{"support unknown"};
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
+  esp_ota_img_states_t ota_state_{ESP_OTA_IMG_UNDEFINED};
 #endif
   // Larger objects at the end
   ESPPreferenceObject rtc_;


### PR DESCRIPTION
# What does this implement/fix?

Detect at boot if the bootloader supports OTA rollback by checking the partition state:
- `ESP_OTA_IMG_NEW`: Bootloader didn't transition to PENDING_VERIFY → **not supported**
- `ESP_OTA_IMG_PENDING_VERIFY`: Bootloader is tracking state → **supported**
- Other states: **support unknown**

**Note:** Detection only works on the first boot after an OTA update. After safe_mode marks the partition as valid, subsequent boots will show "support unknown".

**Note:** Detection requires the device to have been OTA'd from a build with rollback enabled. If upgrading from an older build without rollback support, a second OTA may be needed before "supported" is shown.

This helps users identify when their bootloader doesn't support the rollback feature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - detection is automatic when using:
esp32:
  framework:
    type: esp-idf
    advanced:
      enable_ota_rollback: true

safe_mode:

ota:
  platform: esphome
```

Example output in logs:
```
[C][safe_mode:030]:   Bootloader rollback: supported
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)