### PR TITLE
[debug] Add min_free heap sensor for ESP32 and LibreTiny, add fragmentation for ESP32

### DIFF
--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -74,8 +74,11 @@ class DebugComponent : public PollingComponent {
 #ifdef USE_SENSOR
   void set_free_sensor(sensor::Sensor *free_sensor) { free_sensor_ = free_sensor; }
   void set_block_sensor(sensor::Sensor *block_sensor) { block_sensor_ = block_sensor; }
-#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
+#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
   void set_fragmentation_sensor(sensor::Sensor *fragmentation_sensor) { fragmentation_sensor_ = fragmentation_sensor; }
+#endif
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  void set_min_free_sensor(sensor::Sensor *min_free_sensor) { min_free_sensor_ = min_free_sensor; }
 #endif
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
 #ifdef USE_ESP32
@@ -97,8 +100,11 @@ class DebugComponent : public PollingComponent {
 
   sensor::Sensor *free_sensor_{nullptr};
   sensor::Sensor *block_sensor_{nullptr};
-#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
+#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
   sensor::Sensor *fragmentation_sensor_{nullptr};
+#endif
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  sensor::Sensor *min_free_sensor_{nullptr};
 #endif
   sensor::Sensor *loop_time_sensor_{nullptr};
 #ifdef USE_ESP32

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -51,6 +51,9 @@ void DebugComponent::update_platform_() {
   if (this->block_sensor_ != nullptr) {
     this->block_sensor_->publish_state(lt_heap_get_max_alloc());
   }
+  if (this->min_free_sensor_ != nullptr) {
+    this->min_free_sensor_->publish_state(lt_heap_get_min_free());
+  }
 #endif
 }
 

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -11,6 +11,10 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_COUNTER,
     ICON_TIMER,
+    PLATFORM_BK72XX,
+    PLATFORM_ESP32,
+    PLATFORM_LN882X,
+    PLATFORM_RTL87XX,
     UNIT_BYTES,
     UNIT_HERTZ,
     UNIT_MILLISECOND,
@@ -45,6 +49,7 @@ CONFIG_SCHEMA = {
                 cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
             ),
             cv.only_on_esp32,
+            msg="This feature is only available on ESP8266 (Arduino 2.5.2+) and ESP32",
         ),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
@@ -54,7 +59,9 @@ CONFIG_SCHEMA = {
         ),
     ),
     cv.Optional(CONF_MIN_FREE): cv.All(
-        cv.Any(cv.only_on_esp32, cv.only_on_libretiny),
+        cv.only_on(
+            [PLATFORM_ESP32, PLATFORM_BK72XX, PLATFORM_LN882X, PLATFORM_RTL87XX]
+        ),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_BYTES,
             icon=ICON_COUNTER,

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -21,6 +21,7 @@ from . import CONF_DEBUG_ID, DebugComponent
 
 DEPENDENCIES = ["debug"]
 
+CONF_MIN_FREE = "min_free"
 CONF_PSRAM = "psram"
 
 CONFIG_SCHEMA = {
@@ -38,12 +39,26 @@ CONFIG_SCHEMA = {
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     cv.Optional(CONF_FRAGMENTATION): cv.All(
-        cv.only_on_esp8266,
-        cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
+        cv.Any(
+            cv.All(
+                cv.only_on_esp8266,
+                cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
+            ),
+            cv.only_on_esp32,
+        ),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
             icon=ICON_COUNTER,
             accuracy_decimals=1,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+    ),
+    cv.Optional(CONF_MIN_FREE): cv.All(
+        cv.Any(cv.only_on_esp32, cv.only_on_libretiny),
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_BYTES,
+            icon=ICON_COUNTER,
+            accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     ),
@@ -88,6 +103,10 @@ async def to_code(config):
     if fragmentation_conf := config.get(CONF_FRAGMENTATION):
         sens = await sensor.new_sensor(fragmentation_conf)
         cg.add(debug_component.set_fragmentation_sensor(sens))
+
+    if min_free_conf := config.get(CONF_MIN_FREE):
+        sens = await sensor.new_sensor(min_free_conf)
+        cg.add(debug_component.set_min_free_sensor(sens))
 
     if loop_time_conf := config.get(CONF_LOOP_TIME):
         sens = await sensor.new_sensor(loop_time_conf)

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -12,7 +12,6 @@ from esphome.const import (
     ICON_COUNTER,
     ICON_TIMER,
     PLATFORM_BK72XX,
-    PLATFORM_ESP32,
     PLATFORM_LN882X,
     PLATFORM_RTL87XX,
     UNIT_BYTES,
@@ -59,8 +58,10 @@ CONFIG_SCHEMA = {
         ),
     ),
     cv.Optional(CONF_MIN_FREE): cv.All(
-        cv.only_on(
-            [PLATFORM_ESP32, PLATFORM_BK72XX, PLATFORM_LN882X, PLATFORM_RTL87XX]
+        cv.Any(
+            cv.only_on_esp32,
+            cv.only_on([PLATFORM_BK72XX, PLATFORM_LN882X, PLATFORM_RTL87XX]),
+            msg="This feature is only available on ESP32 and LibreTiny (BK72xx, LN882x, RTL87xx)",
         ),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_BYTES,

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -68,9 +68,12 @@ from esphome.const import (
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
+    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
+    PLATFORM_LN882X,
     PLATFORM_RP2040,
+    PLATFORM_RTL87XX,
     SCHEDULER_DONT_RUN,
     TYPE_GIT,
     TYPE_LOCAL,
@@ -696,6 +699,7 @@ def only_with_framework(
 only_on_esp32 = only_on(PLATFORM_ESP32)
 only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
+only_on_libretiny = only_on([PLATFORM_BK72XX, PLATFORM_RTL87XX, PLATFORM_LN882X])
 only_with_arduino = only_with_framework(Framework.ARDUINO)
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -68,12 +68,9 @@ from esphome.const import (
     KEY_CORE,
     KEY_FRAMEWORK_VERSION,
     KEY_TARGET_FRAMEWORK,
-    PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
-    PLATFORM_LN882X,
     PLATFORM_RP2040,
-    PLATFORM_RTL87XX,
     SCHEDULER_DONT_RUN,
     TYPE_GIT,
     TYPE_LOCAL,
@@ -699,7 +696,6 @@ def only_with_framework(
 only_on_esp32 = only_on(PLATFORM_ESP32)
 only_on_esp8266 = only_on(PLATFORM_ESP8266)
 only_on_rp2040 = only_on(PLATFORM_RP2040)
-only_on_libretiny = only_on([PLATFORM_BK72XX, PLATFORM_RTL87XX, PLATFORM_LN882X])
 only_with_arduino = only_with_framework(Framework.ARDUINO)
 
 

--- a/tests/components/debug/common.yaml
+++ b/tests/components/debug/common.yaml
@@ -11,6 +11,8 @@ sensor:
   - platform: debug
     free:
       name: "Heap Free"
+    block:
+      name: "Heap Block"
     loop_time:
       name: "Loop Time"
     cpu_frequency:

--- a/tests/components/debug/test.bk72xx-ard.yaml
+++ b/tests/components/debug/test.bk72xx-ard.yaml
@@ -1,1 +1,6 @@
 <<: !include common.yaml
+
+sensor:
+  - platform: debug
+    min_free:
+      name: "Heap Min Free"

--- a/tests/components/debug/test.esp32-ard.yaml
+++ b/tests/components/debug/test.esp32-ard.yaml
@@ -2,3 +2,10 @@
 
 esp32:
   cpu_frequency: 240MHz
+
+sensor:
+  - platform: debug
+    fragmentation:
+      name: "Heap Fragmentation"
+    min_free:
+      name: "Heap Min Free"

--- a/tests/components/debug/test.esp32-idf.yaml
+++ b/tests/components/debug/test.esp32-idf.yaml
@@ -9,5 +9,9 @@ sensor:
       name: "Heap Free"
     psram:
       name: "Free PSRAM"
+    fragmentation:
+      name: "Heap Fragmentation"
+    min_free:
+      name: "Heap Min Free"
 
 psram:

--- a/tests/components/debug/test.esp32-s2-idf.yaml
+++ b/tests/components/debug/test.esp32-s2-idf.yaml
@@ -1,1 +1,8 @@
 <<: !include common.yaml
+
+sensor:
+  - platform: debug
+    fragmentation:
+      name: "Heap Fragmentation"
+    min_free:
+      name: "Heap Min Free"

--- a/tests/components/debug/test.esp8266-ard.yaml
+++ b/tests/components/debug/test.esp8266-ard.yaml
@@ -1,1 +1,6 @@
 <<: !include common.yaml
+
+sensor:
+  - platform: debug
+    fragmentation:
+      name: "Heap Fragmentation"

--- a/tests/components/debug/test.ln882x-ard.yaml
+++ b/tests/components/debug/test.ln882x-ard.yaml
@@ -1,1 +1,6 @@
 <<: !include common.yaml
+
+sensor:
+  - platform: debug
+    min_free:
+      name: "Heap Min Free"

--- a/tests/components/debug/test.rtl87xx-ard.yaml
+++ b/tests/components/debug/test.rtl87xx-ard.yaml
@@ -1,0 +1,6 @@
+<<: !include common.yaml
+
+sensor:
+  - platform: debug
+    min_free:
+      name: "Heap Min Free"


### PR DESCRIPTION
# What does this implement/fix?

Add `min_free` heap sensor for ESP32 and LibreTiny platforms, and extend `fragmentation` sensor support to ESP32.

The `min_free` sensor reports the minimum free heap size since boot, which is useful for detecting memory high-water-mark usage and identifying potential memory leaks over time.

Also adds `cv.only_on_libretiny` validator to `config_validation.py` for use by components that need LibreTiny-specific validation.

**Note:** LibreTiny does not support `fragmentation` because `lt_heap_get_max_alloc()` is not implemented on BK72xx or RTL87xx platforms (returns 0).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5921

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP32 - all sensors available
debug:
  update_interval: 5s

sensor:
  - platform: debug
    free:
      name: "Heap Free"
    block:
      name: "Heap Max Block"
    min_free:
      name: "Heap Min Free"
    fragmentation:
      name: "Heap Fragmentation"
```

```yaml
# LibreTiny - min_free available, fragmentation not supported
debug:
  update_interval: 5s

sensor:
  - platform: debug
    free:
      name: "Heap Free"
    min_free:
      name: "Heap Min Free"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
