### PR TITLE
[core][mqtt] Add str_sanitize_to(), soft-deprecate str_sanitize()

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -636,7 +636,7 @@ const MQTTDiscoveryInfo &MQTTClientComponent::get_discovery_info() const { retur
 void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix, const std::string &check_topic_prefix) {
   if (App.is_name_add_mac_suffix_enabled() && (topic_prefix == check_topic_prefix)) {
     char buf[ESPHOME_DEVICE_NAME_MAX_LEN + 1];
-    this->topic_prefix_ = str_sanitize_to(buf, App.get_name());
+    this->topic_prefix_ = str_sanitize_to(buf, App.get_name().c_str());
   } else {
     this->topic_prefix_ = topic_prefix;
   }

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -635,7 +635,8 @@ void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) { this
 const MQTTDiscoveryInfo &MQTTClientComponent::get_discovery_info() const { return this->discovery_info_; }
 void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix, const std::string &check_topic_prefix) {
   if (App.is_name_add_mac_suffix_enabled() && (topic_prefix == check_topic_prefix)) {
-    this->topic_prefix_ = str_sanitize(App.get_name());
+    char buf[ESPHOME_DEVICE_NAME_MAX_LEN + 1];
+    this->topic_prefix_ = str_sanitize_to(buf, App.get_name());
   } else {
     this->topic_prefix_ = topic_prefix;
   }

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -49,7 +49,7 @@ void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
   char sanitized_name[ESPHOME_DEVICE_NAME_MAX_LEN + 1];
-  str_sanitize_to(sanitized_name, App.get_name());
+  str_sanitize_to(sanitized_name, App.get_name().c_str());
   const char *comp_type = this->component_type();
   char object_id_buf[OBJECT_ID_MAX_LEN];
   StringRef object_id = this->get_default_object_id_to_(object_id_buf);

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -48,7 +48,8 @@ void MQTTComponent::set_subscribe_qos(uint8_t qos) { this->subscribe_qos_ = qos;
 void MQTTComponent::set_retain(bool retain) { this->retain_ = retain; }
 
 std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discovery_info) const {
-  std::string sanitized_name = str_sanitize(App.get_name());
+  char sanitized_name[ESPHOME_DEVICE_NAME_MAX_LEN + 1];
+  str_sanitize_to(sanitized_name, App.get_name());
   const char *comp_type = this->component_type();
   char object_id_buf[OBJECT_ID_MAX_LEN];
   StringRef object_id = this->get_default_object_id_to_(object_id_buf);
@@ -60,7 +61,7 @@ std::string MQTTComponent::get_discovery_topic_(const MQTTDiscoveryInfo &discove
   p = append_char(p, '/');
   p = append_str(p, comp_type, strlen(comp_type));
   p = append_char(p, '/');
-  p = append_str(p, sanitized_name.data(), sanitized_name.size());
+  p = append_str(p, sanitized_name, strlen(sanitized_name));
   p = append_char(p, '/');
   p = append_str(p, object_id.c_str(), object_id.size());
   p = append_str(p, "/config", 7);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -199,11 +199,22 @@ std::string str_snake_case(const std::string &str) {
   }
   return result;
 }
-std::string str_sanitize(const std::string &str) {
-  std::string result = str;
-  for (char &c : result) {
-    c = to_sanitized_char(c);
+char *str_sanitize_to(char *buffer, size_t buffer_size, const char *str) {
+  if (buffer_size == 0) {
+    return buffer;
   }
+  size_t i = 0;
+  while (*str && i < buffer_size - 1) {
+    buffer[i++] = to_sanitized_char(*str++);
+  }
+  buffer[i] = '\0';
+  return buffer;
+}
+
+std::string str_sanitize(const std::string &str) {
+  std::string result;
+  result.resize(str.size());
+  str_sanitize_to(&result[0], str.size() + 1, str.c_str());
   return result;
 }
 std::string str_snprintf(const char *fmt, size_t len, ...) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -545,7 +545,25 @@ std::string str_snake_case(const std::string &str);
 constexpr char to_sanitized_char(char c) {
   return (c == '-' || c == '_' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) ? c : '_';
 }
+
+/** Sanitize a string to buffer, keeping only alphanumerics, dashes, and underscores.
+ *
+ * @param buffer Output buffer to write to.
+ * @param buffer_size Size of the output buffer.
+ * @param str Input string to sanitize.
+ * @return Pointer to buffer.
+ *
+ * Buffer size needed: strlen(str) + 1.
+ */
+char *str_sanitize_to(char *buffer, size_t buffer_size, const char *str);
+
+/// Sanitize a string to buffer. Automatically deduces buffer size.
+template<size_t N> inline char *str_sanitize_to(char (&buffer)[N], const char *str) {
+  return str_sanitize_to(buffer, N, str);
+}
+
 /// Sanitizes the input string by removing all characters but alphanumerics, dashes and underscores.
+/// @warning Allocates heap memory. Use str_sanitize_to() with a stack buffer instead.
 std::string str_sanitize(const std::string &str);
 
 /// Calculate FNV-1 hash of a string while applying snake_case + sanitize transformations.

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -687,6 +687,7 @@ HEAP_ALLOCATING_HELPERS = {
     "format_mac_address_pretty": "format_mac_addr_upper() with a stack buffer",
     "get_mac_address": "get_mac_address_into_buffer() with a stack buffer",
     "get_mac_address_pretty": "get_mac_address_pretty_into_buffer() with a stack buffer",
+    "str_sanitize": "str_sanitize_to() with a stack buffer",
     "str_truncate": "removal (function is unused)",
     "str_upper_case": "removal (function is unused)",
     "str_snake_case": "removal (function is unused)",
@@ -704,6 +705,7 @@ HEAP_ALLOCATING_HELPERS = {
     r"format_mac_address_pretty|"
     r"get_mac_address_pretty(?!_)|"
     r"get_mac_address(?!_)|"
+    r"str_sanitize(?!_)|"
     r"str_truncate|"
     r"str_upper_case|"
     r"str_snake_case"


### PR DESCRIPTION
# What does this implement/fix?

Add stack-based `str_sanitize_to()` function and soft-deprecate heap-allocating `str_sanitize()`.

On long-running embedded devices, repeated heap allocations fragment memory over time. This adds a buffer-based alternative that writes to caller-provided stack buffers, avoiding heap allocation entirely.

**Changes:**
- Add `str_sanitize_to(buffer, buffer_size, str)` - overflow-safe buffer-based implementation
- Add `str_sanitize_to(char(&)[N], str)` template overload with compile-time size checking
- Update `str_sanitize()` to use `str_sanitize_to()` internally
- Add `@warning` documentation to `str_sanitize()`
- Add `str_sanitize` to ci-custom.py soft-deprecation lint check
- Convert MQTT component usages to use stack buffers with `ESPHOME_DEVICE_NAME_MAX_LEN`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce heap fragmentation on embedded devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal API change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
