### PR TITLE
[core] Fix ESP32-S2/S3 hardware SHA crash by aligning HashBase digest buffer

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -294,8 +294,7 @@ bool Esp32HostedUpdate::stream_firmware_to_coprocessor_() {
   }
 
   // Stream firmware to coprocessor while computing SHA256
-  // Hardware SHA acceleration requires 32-byte alignment on some chips (ESP32-S3 with IDF 5.5.x+)
-  alignas(32) sha256::SHA256 hasher;
+  sha256::SHA256 hasher;
   hasher.init();
 
   uint8_t buffer[CHUNK_SIZE];
@@ -352,8 +351,7 @@ bool Esp32HostedUpdate::write_embedded_firmware_to_coprocessor_() {
   }
 
   // Verify SHA256 before writing
-  // Hardware SHA acceleration requires 32-byte alignment on some chips (ESP32-S3 with IDF 5.5.x+)
-  alignas(32) sha256::SHA256 hasher;
+  sha256::SHA256 hasher;
   hasher.init();
   hasher.add(this->firmware_data_, this->firmware_size_);
   hasher.calculate();

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -563,11 +563,9 @@ bool ESPHomeOTAComponent::handle_auth_send_() {
     //   [1+hex_size...1+2*hex_size-1]: cnonce (hex_size bytes) - client's nonce
     //   [1+2*hex_size...1+3*hex_size-1]: response (hex_size bytes) - client's hash
 
-    // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
+    // CRITICAL ESP32-S2/S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
     // (no passing to other functions). All hash operations must happen in this function.
-    // NOTE: On ESP32-S3 with IDF 5.5.x, the SHA256 context must be properly aligned for
-    // hardware SHA acceleration DMA operations.
-    alignas(32) sha256::SHA256 hasher;
+    sha256::SHA256 hasher;
 
     const size_t hex_size = hasher.get_size() * 2;
     const size_t nonce_len = hasher.get_size() / 4;
@@ -639,11 +637,9 @@ bool ESPHomeOTAComponent::handle_auth_read_() {
   const char *cnonce = nonce + hex_size;
   const char *response = cnonce + hex_size;
 
-  // CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
+  // CRITICAL ESP32-S2/S3 HARDWARE SHA ACCELERATION: Hash object must stay in same stack frame
   // (no passing to other functions). All hash operations must happen in this function.
-  // NOTE: On ESP32-S3 with IDF 5.5.x, the SHA256 context must be properly aligned for
-  // hardware SHA acceleration DMA operations.
-  alignas(32) sha256::SHA256 hasher;
+  sha256::SHA256 hasher;
 
   hasher.init();
   hasher.add(this->password_.c_str(), this->password_.length());

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -10,26 +10,24 @@ namespace esphome::sha256 {
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
 
-// CRITICAL ESP32-S3 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
+// CRITICAL ESP32-S2/S3 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
 //
-// The ESP32-S3 uses hardware DMA for SHA acceleration. The mbedtls_sha256_context structure contains
-// internal state that the DMA engine references. This imposes three critical constraints:
+// The ESP32-S2/S3 uses hardware DMA for SHA acceleration. The DMA engine requires proper
+// alignment of the digest output buffer. This is handled automatically via HashBase::digest_
+// which has alignas(32). This imposes two critical constraints:
 //
-// 1. ALIGNMENT: The SHA256 object MUST be declared with `alignas(32)` for proper DMA alignment.
-//    Without this, the DMA engine may crash with an abort in sha_hal_read_digest().
-//
-// 2. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
+// 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
 //    write to incorrect memory locations. This results in null pointer dereferences and crashes.
 //    ALWAYS use fixed-size arrays (e.g., char buf[65], not char buf[size+1]).
 //
-// 3. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
+// 2. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
 //    function. NEVER pass the SHA256 object or HashBase pointer to another function. When the stack
 //    frame changes (function call/return), the DMA references become invalid and will produce
 //    truncated hash output (20 bytes instead of 32) or corrupt memory.
 //
 // CORRECT USAGE:
 //   void my_function() {
-//     alignas(32) sha256::SHA256 hasher;  // Created locally with proper alignment
+//     sha256::SHA256 hasher;
 //     hasher.init();
 //     hasher.add(data, len);  // Any size, no chunking needed
 //     hasher.calculate();
@@ -37,9 +35,9 @@ namespace esphome::sha256 {
 //     // hasher destroyed when function returns
 //   }
 //
-// INCORRECT USAGE (WILL FAIL ON ESP32-S3):
+// INCORRECT USAGE (WILL FAIL ON ESP32-S2/S3):
 //   void my_function() {
-//     sha256::SHA256 hasher;  // WRONG: Missing alignas(32)
+//     sha256::SHA256 hasher;
 //     helper(&hasher);  // WRONG: Passed to different stack frame
 //   }
 //   void helper(HashBase *h) {

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -10,11 +10,11 @@ namespace esphome::sha256 {
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
 
-// CRITICAL ESP32-S2/S3 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
+// CRITICAL ESP32 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
 //
-// The ESP32-S2/S3 uses hardware DMA for SHA acceleration. The DMA engine requires proper
-// alignment of the digest output buffer. This is handled automatically via HashBase::digest_
-// which has alignas(32). This imposes two critical constraints:
+// ESP32 variants (except original ESP32) use DMA-based hardware SHA acceleration that requires
+// 32-byte aligned digest buffers. This is handled automatically via HashBase::digest_ which has
+// alignas(32) on these platforms. Two additional constraints apply:
 //
 // 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
 //    write to incorrect memory locations. This results in null pointer dereferences and crashes.
@@ -35,7 +35,7 @@ namespace esphome::sha256 {
 //     // hasher destroyed when function returns
 //   }
 //
-// INCORRECT USAGE (WILL FAIL ON ESP32-S2/S3):
+// INCORRECT USAGE (WILL FAIL):
 //   void my_function() {
 //     sha256::SHA256 hasher;
 //     helper(&hasher);  // WRONG: Passed to different stack frame

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -24,7 +24,7 @@ namespace esphome::sha256 {
 
 /// SHA256 hash implementation.
 ///
-/// CRITICAL for ESP32-S2/S3 with IDF 5.5.x hardware SHA acceleration:
+/// CRITICAL for ESP32 variants (except original) with IDF 5.5.x hardware SHA acceleration:
 /// 1. The object MUST stay in the same stack frame (no passing to other functions)
 /// 2. NO Variable Length Arrays (VLAs) in the same function
 ///

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -24,13 +24,14 @@ namespace esphome::sha256 {
 
 /// SHA256 hash implementation.
 ///
-/// CRITICAL for ESP32-S3 with IDF 5.5.x hardware SHA acceleration:
-/// 1. SHA256 objects MUST be declared with `alignas(32)` for proper DMA alignment
-/// 2. The object MUST stay in the same stack frame (no passing to other functions)
-/// 3. NO Variable Length Arrays (VLAs) in the same function
+/// CRITICAL for ESP32-S2/S3 with IDF 5.5.x hardware SHA acceleration:
+/// 1. The object MUST stay in the same stack frame (no passing to other functions)
+/// 2. NO Variable Length Arrays (VLAs) in the same function
+///
+/// Note: Alignment is handled automatically via the HashBase::digest_ member.
 ///
 /// Example usage:
-///   alignas(32) sha256::SHA256 hasher;
+///   sha256::SHA256 hasher;
 ///   hasher.init();
 ///   hasher.add(data, len);
 ///   hasher.calculate();

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -44,7 +44,9 @@ class HashBase {
   virtual size_t get_size() const = 0;
 
  protected:
-  uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes
+  // 32-byte alignment required for ESP32-S2/S3 hardware SHA DMA operations.
+  // This also sets the class alignment to 32, ensuring derived objects are properly aligned.
+  alignas(32) uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes
 };
 
 }  // namespace esphome

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -44,9 +44,10 @@ class HashBase {
   virtual size_t get_size() const = 0;
 
  protected:
-// ESP32-S2/S3 hardware SHA uses DMA that requires 32-byte aligned buffers.
-// Other platforms either don't have hardware SHA or don't require alignment.
-#if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+// ESP32 variants with DMA-based hardware SHA (all except original ESP32) require 32-byte aligned buffers.
+// Original ESP32 uses a different hardware SHA implementation without DMA alignment requirements.
+// Other platforms (ESP8266, RP2040, LibreTiny) use software SHA and don't need alignment.
+#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)
   alignas(32)
 #endif
       uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -47,12 +47,12 @@ class HashBase {
 // ESP32 variants with DMA-based hardware SHA (all except original ESP32) require 32-byte aligned buffers.
 // Original ESP32 uses a different hardware SHA implementation without DMA alignment requirements.
 // Other platforms (ESP8266, RP2040, LibreTiny) use software SHA and don't need alignment.
-  // Storage sized for max(MD5=16, SHA256=32) bytes
+// Storage sized for max(MD5=16, SHA256=32) bytes
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)
   alignas(32) uint8_t digest_[32];
 #else
   uint8_t digest_[32];
-#endif    
+#endif
 };
 
 }  // namespace esphome

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -44,9 +44,12 @@ class HashBase {
   virtual size_t get_size() const = 0;
 
  protected:
-  // 32-byte alignment required for ESP32-S2/S3 hardware SHA DMA operations.
-  // This also sets the class alignment to 32, ensuring derived objects are properly aligned.
-  alignas(32) uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes
+// ESP32-S2/S3 hardware SHA uses DMA that requires 32-byte aligned buffers.
+// Other platforms either don't have hardware SHA or don't require alignment.
+#if defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+  alignas(32)
+#endif
+      uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes
 };
 
 }  // namespace esphome

--- a/esphome/core/hash_base.h
+++ b/esphome/core/hash_base.h
@@ -47,10 +47,12 @@ class HashBase {
 // ESP32 variants with DMA-based hardware SHA (all except original ESP32) require 32-byte aligned buffers.
 // Original ESP32 uses a different hardware SHA implementation without DMA alignment requirements.
 // Other platforms (ESP8266, RP2040, LibreTiny) use software SHA and don't need alignment.
+  // Storage sized for max(MD5=16, SHA256=32) bytes
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)
-  alignas(32)
-#endif
-      uint8_t digest_[32];  // Storage sized for max(MD5=16, SHA256=32) bytes
+  alignas(32) uint8_t digest_[32];
+#else
+  uint8_t digest_[32];
+#endif    
 };
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Fixes ESP32-S2/S3 OTA crashes with hardware SHA acceleration by aligning the digest buffer in `HashBase`.

**This is the third attempt to fix this issue, and finally addresses the actual root cause.** Previous fixes aligned the SHA256 object but not the internal buffer that DMA writes to. This fix aligns the `digest_` buffer itself, which is what the hardware SHA DMA engine actually requires.

## History of Fix Attempts

### PR #11011 (Oct 2025) - First attempt
Added documentation about VLA and stack frame requirements for ESP32-S3 hardware SHA. The theory was that passing SHA256 objects across stack frames caused DMA corruption. This fixed some issues but crashes continued.

### PR #13021 (Jan 2026) - Second attempt
Added `alignas(32)` to SHA256 object instantiations in OTA code. The theory was that the SHA256 object itself needed 32-byte alignment for DMA. However, users on ESP32-S2 and ESP32-S3 continued to report crashes.

### PR #13050 (Jan 2026) - Extended second fix
Extended the `alignas(32)` pattern to `esp32_hosted` component.

### This PR - Third attempt (root cause fix)
The actual issue: `alignas(32)` on the SHA256 object only aligns the object's start address. But the `digest_[32]` buffer in `HashBase` is at offset 4/8 (after the vtable pointer), so it's **NOT** 32-byte aligned even when the object is.

The crash occurs in `sha_hal_read_digest()` when the hardware DMA writes to the unaligned `digest_` buffer.

## Technical Details

Class layout with `alignas(32)` on object (previous fix):
```
SHA256 object at address 0x3FFD3200 (32-byte aligned):
  +0:  vtable pointer (4 bytes)
  +4:  digest_[32] (32 bytes) ← NOT 32-byte aligned!
  +36: ctx_ (mbedtls_sha256_context)
```

Class layout with `alignas(32)` on `digest_` member (this fix):
```
SHA256 object at address 0x3FFD3200 (32-byte aligned due to member alignment):
  +0:  vtable pointer (4 bytes)
  +4:  padding (28 bytes)
  +32: digest_[32] (32 bytes) ← 32-byte aligned!
  +64: ctx_ (mbedtls_sha256_context)
```

By adding `alignas(32)` to `digest_` in `HashBase`:
1. The member is placed at a 32-byte aligned offset within the class
2. The class alignment requirement propagates to 32 bytes
3. All `HashBase`-derived objects are automatically properly aligned
4. No need for callers to manually specify `alignas(32)` on instantiation

## Testing

**Tested and verified on both ESP32-S2 and ESP32-S3** (previous fixes only worked intermittently on S3, not on S2):

- ESP32-S2: `esp32-s2-saola-1` with ESP-IDF 5.5.2 - **multiple successful OTA uploads**
- ESP32-S3: `esp32-s3-devkitc-1` with ESP-IDF 5.5.2 - **multiple successful OTA uploads**

The previous `alignas(32)` on object instantiation approach was insufficient because it only aligned the object's base address, not the internal `digest_` buffer that the DMA actually writes to. This fix aligns the buffer itself, which is the correct solution.

## Changes

- **hash_base.h**: Add `alignas(32)` to `digest_[32]` member for ESP32 variants with DMA-based hardware SHA - the actual fix
- **ota_esphome.cpp**: Remove now-unnecessary `alignas(32)` from SHA256 instantiations
- **esp32_hosted_update.cpp**: Remove now-unnecessary `alignas(32)` from SHA256 instantiations
- **sha256.h/cpp**: Update documentation to reflect the fix

Note: Alignment is conditional (`#if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32)`) covering all ESP32 variants with DMA-based hardware SHA (S2, S3, C3, C5, C6, C61, H2, P4). Original ESP32 uses different hardware SHA without DMA. ESP8266/RP2040/LibreTiny use software SHA and don't need alignment (ESP8266 also lacks `memalign`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13009

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test-device

esp32:
  board: esp32-s2-saola-1  # or esp32-s3-devkitc-1
  framework:
    type: esp-idf

ota:
  - platform: esphome
    password: "my_ota_password"  # Password triggers SHA256 auth path
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
