### PR TITLE
[api] Fix state updates being sent to clients that did not subscribe

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -241,8 +241,10 @@ void APIServer::handle_disconnect(APIConnection *conn) {}
   void APIServer::on_##entity_name##_update(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
     if (obj->is_internal()) \
       return; \
-    for (auto &c : this->clients_) \
-      c->send_##entity_name##_state(obj); \
+    for (auto &c : this->clients_) { \
+      if (c->flags_.state_subscription) \
+        c->send_##entity_name##_state(obj); \
+    } \
   }
 
 #ifdef USE_BINARY_SENSOR
@@ -321,8 +323,10 @@ API_DISPATCH_UPDATE(water_heater::WaterHeater, water_heater)
 void APIServer::on_event(event::Event *obj) {
   if (obj->is_internal())
     return;
-  for (auto &c : this->clients_)
-    c->send_event(obj);
+  for (auto &c : this->clients_) {
+    if (c->flags_.state_subscription)
+      c->send_event(obj);
+  }
 }
 #endif
 
@@ -331,8 +335,10 @@ void APIServer::on_event(event::Event *obj) {
 void APIServer::on_update(update::UpdateEntity *obj) {
   if (obj->is_internal())
     return;
-  for (auto &c : this->clients_)
-    c->send_update_state(obj);
+  for (auto &c : this->clients_) {
+    if (c->flags_.state_subscription)
+      c->send_update_state(obj);
+  }
 }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where entity state updates were sent to ALL connected API clients, regardless of whether they subscribed to state updates via `SubscribeStatesRequest`.

## The Problem

The `API_DISPATCH_UPDATE` macro and special-case handlers for `on_event()` and `on_update()` were iterating over all clients and sending state updates without checking the `state_subscription` flag:

```cpp
// Before: Sends to ALL clients
for (auto &c : this->clients_)
  c->send_sensor_state(obj);

// After: Only sends to clients that subscribed
for (auto &c : this->clients_) {
  if (c->flags_.state_subscription)
    c->send_sensor_state(obj);
}
```

## Impact

**Log-only connections (e.g., `esphome logs`) were receiving all entity state updates:**

Before fix - packet capture from `esphome logs` connection:
```
Packet 4:  type 0x1d (29) SubscribeLogsResponse - log message
Packet 7:  type 0x1d (29) SubscribeLogsResponse - log message
Packet 10: type 0x1d (29) SubscribeLogsResponse - log message
Packet 14: type 0x19 (25) SensorStateResponse   - UNWANTED!
Packet 17: type 0x1d (29) SubscribeLogsResponse - log message
```

After fix - same connection:
```
Packet 1:  type 0x1d (29) SubscribeLogsResponse - log message
Packet 3:  type 0x1d (29) SubscribeLogsResponse - log message
Packet 8:  type 0x1d (29) SubscribeLogsResponse - log message
Packet 13: type 0x1d (29) SubscribeLogsResponse - log message
(No more SensorStateResponse packets!)
```

**This was a significant resource leak affecting every log connection since the API was created:**

Every `esphome logs` connection received the full firehose of state updates - every sensor reading, every switch toggle, every climate update - continuously for the entire session. On a typical device with 30-50 entities updating every few seconds, this meant:

- **RAM**: Each state update queued 8 bytes in `DeferredBatch` (was 12 bytes until recently). The batch queue grew continuously with unwanted items, causing heap fragmentation on memory-constrained devices.
- **CPU**: Protobuf encoding computed for every state message, only to be discarded by the client
- **Bandwidth**: Constant stream of unwanted packets competing with the log messages users actually wanted
- **Heap churn**: The batch queue `std::vector` repeatedly grew and reallocated to hold unwanted items
- **Per-connection**: All of this multiplied by each concurrent log connection
- **Nagle defeated**: State updates set `TCP_NODELAY=true` to ensure low-latency delivery, which **forced a flush** of any buffered log messages. This defeated Nagle's algorithm batching for logs - each unwanted state update flushed the TCP buffer, generating far more packets than necessary.

On an ESP8266 with 30 entities updating every 5 seconds, a single log connection was processing ~360 unwanted state updates per minute - encoding them, buffering them, transmitting them, all for nothing. And each one forced a TCP flush, fragmenting log messages into many small packets instead of allowing them to batch.

**After the fix, Nagle batching works correctly:**

Before fix - each log was a separate TCP packet:
```
Packet 4:  [D][sensor:129]: 'Temperature' >> 23.5 °C
Packet 7:  [D][sensor:129]: 'Humidity' >> 65 %
Packet 10: [D][switch:065]: 'Relay' >> ON
```

After fix - multiple logs batch into single packets:
```
Packet 520 (1460 bytes) contains 15+ log messages:
  [I][app:213]: ESP32 Chip: ESP32-S3...
  [C][logger:316]: Logger: Max Level: VERBOSE...
  [C][logger:322]: Log Baud Rate: 115200...
  [C][uptime.sensor:016]: Uptime Sensor 'Uptime'...
  ... and many more in the same packet
```

**Extended Connection Verification:**

A longer packet capture (packets 504 through 32441) confirmed the fix completely eliminates unwanted state traffic. Over the entire session, every packet was one of:

- `0x1d` (29) = `SubscribeLogsResponse` - the logs the client requested
- `0x07` = `PingRequest` - connection keepalive
- `0x08` = `PingResponse` - connection keepalive

Zero `SensorStateResponse` (`0x19`/25) packets in the entire session - the log connection received exactly what it asked for: logs and ping keepalives. No state updates polluting the stream, no wasted bandwidth, no unnecessary Nagle flushes.

**The worst part:** All this resource usage - the heap fragmentation, the CPU cycles encoding protobuf messages, the bandwidth, the Nagle flush defeats - was for data the client immediately discarded. The client never subscribed to states, so it silently ignored every state packet. The device side was doing all this work, fragmenting its limited heap, for data that was never seen or used.

**Silver lining:** Log-only connections aren't that common - most connections are from Home Assistant, which subscribes to states anyway. However, `esphome logs` is typically used when *debugging problems*. The irony is that connecting to diagnose an issue would cause additional heap fragmentation and CPU load, potentially making the device perform worse while you're trying to figure out what's wrong with it.

## Why This Wasn't Caught Before

- Log subscriptions correctly check `log_subscription` level before sending
- Camera state correctly checks `state_subscription` inside `set_camera_state()`
- But the main `API_DISPATCH_UPDATE` macro (used by 17 entity types) never had this check
- This bug was only caught by examining raw packet captures while testing #13236 - the extra packets aren't visible at the application layer since clients simply ignore messages they didn't request
- **All tests pass** - we test that we receive what we expect, but we don't have tests for packets we *don't* expect. The client receives logs correctly, so tests pass. The unwanted state updates are silently discarded.

**This explains why log connections have been more RAM-expensive since 2025.5.** The assumption was it was just `APIConnection` object overhead, but a significant portion was the batch queue filling with state updates the client never requested.

## Entities Fixed

All entities using `API_DISPATCH_UPDATE` macro:
- binary_sensor, cover, fan, light, sensor, switch, text_sensor, climate, number, date, time, datetime, text, select, lock, valve, media_player, water_heater, alarm_control_panel

Plus special-case handlers:
- event (`on_event()`)
- update (`on_update()`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered via packet capture analysis while testing #13236

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal bug fix, no user-facing documentation needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this fixes internal API behavior
# All existing configurations benefit automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - internal fix)
