### PR TITLE
[infrared, remote_base] Optimize IR transmit path for `web_server` base85 data

### DIFF
--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -18,7 +18,15 @@ InfraredCall &InfraredCall::set_carrier_frequency(uint32_t frequency) {
 
 InfraredCall &InfraredCall::set_raw_timings(const std::vector<int32_t> &timings) {
   this->raw_timings_ = &timings;
-  this->packed_data_ = nullptr;  // Clear packed if vector is set
+  this->packed_data_ = nullptr;
+  this->base64_data_.clear();
+  return *this;
+}
+
+InfraredCall &InfraredCall::set_raw_timings_base64(std::string &&base64) {
+  this->base64_data_ = std::move(base64);
+  this->raw_timings_ = nullptr;
+  this->packed_data_ = nullptr;
   return *this;
 }
 
@@ -26,7 +34,8 @@ InfraredCall &InfraredCall::set_raw_timings_packed(const uint8_t *data, uint16_t
   this->packed_data_ = data;
   this->packed_length_ = length;
   this->packed_count_ = count;
-  this->raw_timings_ = nullptr;  // Clear vector if packed is set
+  this->raw_timings_ = nullptr;
+  this->base64_data_.clear();
   return *this;
 }
 
@@ -92,6 +101,17 @@ void Infrared::control(const InfraredCall &call) {
                                                call.get_packed_count());
     ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%u", call.get_packed_count(),
              call.get_repeat_count());
+  } else if (call.is_base64()) {
+    // Decode base64 and parse directly into transmit buffer
+    constexpr size_t max_ir_bytes = 1024;
+    uint8_t decoded[max_ir_bytes];
+    size_t decoded_len = base64_decode(call.get_base64_data(), decoded, sizeof(decoded));
+    if (decoded_len == 0 || decoded_len % 4 != 0) {
+      ESP_LOGE(TAG, "Invalid base64 data");
+      return;
+    }
+    transmit_data->set_data_from_le_int32_buffer(decoded, decoded_len);
+    ESP_LOGD(TAG, "Transmitting base64 raw timings: count=%zu, repeat=%u", decoded_len / 4, call.get_repeat_count());
   } else {
     // From vector (lambdas/automations)
     transmit_data->set_data(call.get_raw_timings());

--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -19,12 +19,12 @@ InfraredCall &InfraredCall::set_carrier_frequency(uint32_t frequency) {
 InfraredCall &InfraredCall::set_raw_timings(const std::vector<int32_t> &timings) {
   this->raw_timings_ = &timings;
   this->packed_data_ = nullptr;
-  this->base64_data_.clear();
+  this->base64_ptr_ = nullptr;
   return *this;
 }
 
-InfraredCall &InfraredCall::set_raw_timings_base64(std::string &&base64) {
-  this->base64_data_ = std::move(base64);
+InfraredCall &InfraredCall::set_raw_timings_base64(const std::string &base64) {
+  this->base64_ptr_ = &base64;
   this->raw_timings_ = nullptr;
   this->packed_data_ = nullptr;
   return *this;
@@ -35,7 +35,7 @@ InfraredCall &InfraredCall::set_raw_timings_packed(const uint8_t *data, uint16_t
   this->packed_length_ = length;
   this->packed_count_ = count;
   this->raw_timings_ = nullptr;
-  this->base64_data_.clear();
+  this->base64_ptr_ = nullptr;
   return *this;
 }
 
@@ -103,15 +103,12 @@ void Infrared::control(const InfraredCall &call) {
              call.get_repeat_count());
   } else if (call.is_base64()) {
     // Decode base64 and parse directly into transmit buffer
-    constexpr size_t max_ir_bytes = 1024;
-    uint8_t decoded[max_ir_bytes];
-    size_t decoded_len = base64_decode(call.get_base64_data(), decoded, sizeof(decoded));
-    if (decoded_len == 0 || decoded_len % 4 != 0) {
+    if (!transmit_data->set_data_from_base64_le_int32(call.get_base64_data())) {
       ESP_LOGE(TAG, "Invalid base64 data");
       return;
     }
-    transmit_data->set_data_from_le_int32_buffer(decoded, decoded_len);
-    ESP_LOGD(TAG, "Transmitting base64 raw timings: count=%zu, repeat=%u", decoded_len / 4, call.get_repeat_count());
+    ESP_LOGD(TAG, "Transmitting base64 raw timings: count=%zu, repeat=%u", transmit_data->get_data().size(),
+             call.get_repeat_count());
   } else {
     // From vector (lambdas/automations)
     transmit_data->set_data(call.get_raw_timings());

--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -19,12 +19,12 @@ InfraredCall &InfraredCall::set_carrier_frequency(uint32_t frequency) {
 InfraredCall &InfraredCall::set_raw_timings(const std::vector<int32_t> &timings) {
   this->raw_timings_ = &timings;
   this->packed_data_ = nullptr;
-  this->base64_ptr_ = nullptr;
+  this->base85_ptr_ = nullptr;
   return *this;
 }
 
-InfraredCall &InfraredCall::set_raw_timings_base64(const std::string &base64) {
-  this->base64_ptr_ = &base64;
+InfraredCall &InfraredCall::set_raw_timings_base85(const std::string &base85) {
+  this->base85_ptr_ = &base85;
   this->raw_timings_ = nullptr;
   this->packed_data_ = nullptr;
   return *this;
@@ -35,7 +35,7 @@ InfraredCall &InfraredCall::set_raw_timings_packed(const uint8_t *data, uint16_t
   this->packed_length_ = length;
   this->packed_count_ = count;
   this->raw_timings_ = nullptr;
-  this->base64_ptr_ = nullptr;
+  this->base85_ptr_ = nullptr;
   return *this;
 }
 
@@ -101,13 +101,13 @@ void Infrared::control(const InfraredCall &call) {
                                                call.get_packed_count());
     ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%u", call.get_packed_count(),
              call.get_repeat_count());
-  } else if (call.is_base64()) {
-    // Decode base64 and parse directly into transmit buffer
-    if (!transmit_data->set_data_from_base64_le_int32(call.get_base64_data())) {
-      ESP_LOGE(TAG, "Invalid base64 data");
+  } else if (call.is_base85()) {
+    // Decode base85 directly into transmit buffer (zero heap allocations)
+    if (!transmit_data->set_data_from_base85(call.get_base85_data())) {
+      ESP_LOGE(TAG, "Invalid base85 data");
       return;
     }
-    ESP_LOGD(TAG, "Transmitting base64 raw timings: count=%zu, repeat=%u", transmit_data->get_data().size(),
+    ESP_LOGD(TAG, "Transmitting base85 raw timings: count=%zu, repeat=%u", transmit_data->get_data().size(),
              call.get_repeat_count());
   } else {
     // From vector (lambdas/automations)

--- a/esphome/components/infrared/infrared.h
+++ b/esphome/components/infrared/infrared.h
@@ -31,10 +31,10 @@ class InfraredCall {
   /// Set the raw timings (positive = mark, negative = space)
   /// Note: The timings vector must outlive the InfraredCall (zero-copy reference)
   InfraredCall &set_raw_timings(const std::vector<int32_t> &timings);
-  /// Set the raw timings from base64-encoded little-endian int32 data
+  /// Set the raw timings from base85-encoded int32 data
   /// Note: The string must outlive the InfraredCall (zero-copy pointer)
   /// Decoded directly into transmit buffer at perform() time
-  InfraredCall &set_raw_timings_base64(const std::string &base64);
+  InfraredCall &set_raw_timings_base85(const std::string &base85);
   /// Set the raw timings from packed protobuf sint32 data (zero-copy from wire)
   /// Note: The data must outlive the InfraredCall
   InfraredCall &set_raw_timings_packed(const uint8_t *data, uint16_t length, uint16_t count);
@@ -46,18 +46,18 @@ class InfraredCall {
 
   /// Get the carrier frequency
   const optional<uint32_t> &get_carrier_frequency() const { return this->carrier_frequency_; }
-  /// Get the raw timings (only valid if set via set_raw_timings, not packed or base64)
+  /// Get the raw timings (only valid if set via set_raw_timings, not packed or base85)
   const std::vector<int32_t> &get_raw_timings() const { return *this->raw_timings_; }
-  /// Check if raw timings have been set (vector, packed, or base64)
+  /// Check if raw timings have been set (vector, packed, or base85)
   bool has_raw_timings() const {
-    return this->raw_timings_ != nullptr || this->packed_data_ != nullptr || this->base64_ptr_ != nullptr;
+    return this->raw_timings_ != nullptr || this->packed_data_ != nullptr || this->base85_ptr_ != nullptr;
   }
   /// Check if using packed data format
   bool is_packed() const { return this->packed_data_ != nullptr; }
-  /// Check if using base64 data format
-  bool is_base64() const { return this->base64_ptr_ != nullptr; }
-  /// Get the base64 data string
-  const std::string &get_base64_data() const { return *this->base64_ptr_; }
+  /// Check if using base85 data format
+  bool is_base85() const { return this->base85_ptr_ != nullptr; }
+  /// Get the base85 data string
+  const std::string &get_base85_data() const { return *this->base85_ptr_; }
   /// Get packed data (only valid if set via set_raw_timings_packed)
   const uint8_t *get_packed_data() const { return this->packed_data_; }
   uint16_t get_packed_length() const { return this->packed_length_; }
@@ -71,8 +71,8 @@ class InfraredCall {
   optional<uint32_t> carrier_frequency_;
   // Vector-based timings (for lambdas/automations)
   const std::vector<int32_t> *raw_timings_{nullptr};
-  // Base64-encoded data pointer (for web_server - decoded directly into transmit buffer)
-  const std::string *base64_ptr_{nullptr};
+  // Base85-encoded data pointer (for web_server - decoded directly into transmit buffer)
+  const std::string *base85_ptr_{nullptr};
   // Packed protobuf timings (for API zero-copy)
   const uint8_t *packed_data_{nullptr};
   uint16_t packed_length_{0};

--- a/esphome/components/infrared/infrared.h
+++ b/esphome/components/infrared/infrared.h
@@ -32,8 +32,9 @@ class InfraredCall {
   /// Note: The timings vector must outlive the InfraredCall (zero-copy reference)
   InfraredCall &set_raw_timings(const std::vector<int32_t> &timings);
   /// Set the raw timings from base64-encoded little-endian int32 data
-  /// The base64 string is stored and decoded directly into transmit buffer at perform() time
-  InfraredCall &set_raw_timings_base64(std::string &&base64);
+  /// Note: The string must outlive the InfraredCall (zero-copy pointer)
+  /// Decoded directly into transmit buffer at perform() time
+  InfraredCall &set_raw_timings_base64(const std::string &base64);
   /// Set the raw timings from packed protobuf sint32 data (zero-copy from wire)
   /// Note: The data must outlive the InfraredCall
   InfraredCall &set_raw_timings_packed(const uint8_t *data, uint16_t length, uint16_t count);
@@ -49,14 +50,14 @@ class InfraredCall {
   const std::vector<int32_t> &get_raw_timings() const { return *this->raw_timings_; }
   /// Check if raw timings have been set (vector, packed, or base64)
   bool has_raw_timings() const {
-    return this->raw_timings_ != nullptr || this->packed_data_ != nullptr || !this->base64_data_.empty();
+    return this->raw_timings_ != nullptr || this->packed_data_ != nullptr || this->base64_ptr_ != nullptr;
   }
   /// Check if using packed data format
   bool is_packed() const { return this->packed_data_ != nullptr; }
   /// Check if using base64 data format
-  bool is_base64() const { return !this->base64_data_.empty(); }
+  bool is_base64() const { return this->base64_ptr_ != nullptr; }
   /// Get the base64 data string
-  const std::string &get_base64_data() const { return this->base64_data_; }
+  const std::string &get_base64_data() const { return *this->base64_ptr_; }
   /// Get packed data (only valid if set via set_raw_timings_packed)
   const uint8_t *get_packed_data() const { return this->packed_data_; }
   uint16_t get_packed_length() const { return this->packed_length_; }
@@ -70,8 +71,8 @@ class InfraredCall {
   optional<uint32_t> carrier_frequency_;
   // Vector-based timings (for lambdas/automations)
   const std::vector<int32_t> *raw_timings_{nullptr};
-  // Base64-encoded data (for web_server - decoded directly into transmit buffer)
-  std::string base64_data_;
+  // Base64-encoded data pointer (for web_server - decoded directly into transmit buffer)
+  const std::string *base64_ptr_{nullptr};
   // Packed protobuf timings (for API zero-copy)
   const uint8_t *packed_data_{nullptr};
   uint16_t packed_length_{0};

--- a/esphome/components/infrared/infrared.h
+++ b/esphome/components/infrared/infrared.h
@@ -31,6 +31,9 @@ class InfraredCall {
   /// Set the raw timings (positive = mark, negative = space)
   /// Note: The timings vector must outlive the InfraredCall (zero-copy reference)
   InfraredCall &set_raw_timings(const std::vector<int32_t> &timings);
+  /// Set the raw timings from base64-encoded little-endian int32 data
+  /// The base64 string is stored and decoded directly into transmit buffer at perform() time
+  InfraredCall &set_raw_timings_base64(std::string &&base64);
   /// Set the raw timings from packed protobuf sint32 data (zero-copy from wire)
   /// Note: The data must outlive the InfraredCall
   InfraredCall &set_raw_timings_packed(const uint8_t *data, uint16_t length, uint16_t count);
@@ -42,12 +45,18 @@ class InfraredCall {
 
   /// Get the carrier frequency
   const optional<uint32_t> &get_carrier_frequency() const { return this->carrier_frequency_; }
-  /// Get the raw timings (only valid if set via set_raw_timings, not packed)
+  /// Get the raw timings (only valid if set via set_raw_timings, not packed or base64)
   const std::vector<int32_t> &get_raw_timings() const { return *this->raw_timings_; }
-  /// Check if raw timings have been set (either vector or packed)
-  bool has_raw_timings() const { return this->raw_timings_ != nullptr || this->packed_data_ != nullptr; }
+  /// Check if raw timings have been set (vector, packed, or base64)
+  bool has_raw_timings() const {
+    return this->raw_timings_ != nullptr || this->packed_data_ != nullptr || !this->base64_data_.empty();
+  }
   /// Check if using packed data format
   bool is_packed() const { return this->packed_data_ != nullptr; }
+  /// Check if using base64 data format
+  bool is_base64() const { return !this->base64_data_.empty(); }
+  /// Get the base64 data string
+  const std::string &get_base64_data() const { return this->base64_data_; }
   /// Get packed data (only valid if set via set_raw_timings_packed)
   const uint8_t *get_packed_data() const { return this->packed_data_; }
   uint16_t get_packed_length() const { return this->packed_length_; }
@@ -61,6 +70,8 @@ class InfraredCall {
   optional<uint32_t> carrier_frequency_;
   // Vector-based timings (for lambdas/automations)
   const std::vector<int32_t> *raw_timings_{nullptr};
+  // Base64-encoded data (for web_server - decoded directly into transmit buffer)
+  std::string base64_data_;
   // Packed protobuf timings (for API zero-copy)
   const uint8_t *packed_data_{nullptr};
   uint16_t packed_length_{0};

--- a/esphome/components/infrared/infrared.h
+++ b/esphome/components/infrared/infrared.h
@@ -28,16 +28,29 @@ class InfraredCall {
 
   /// Set the carrier frequency in Hz
   InfraredCall &set_carrier_frequency(uint32_t frequency);
-  /// Set the raw timings (positive = mark, negative = space)
-  /// Note: The timings vector must outlive the InfraredCall (zero-copy reference)
+
+  // ===== Raw Timings Methods =====
+  // All set_raw_timings_* methods store pointers/references to external data.
+  // The referenced data must remain valid until perform() completes.
+  // Safe pattern:   call.set_raw_timings_xxx(data); call.perform();  // synchronous
+  // Unsafe pattern: call.set_raw_timings_xxx(data); defer([call]() { call.perform(); });  // data may be gone!
+
+  /// Set the raw timings from a vector (positive = mark, negative = space)
+  /// @note Lifetime: Stores a pointer to the vector. The vector must outlive perform().
+  /// @note Usage: Primarily for lambdas/automations where the vector is in scope.
   InfraredCall &set_raw_timings(const std::vector<int32_t> &timings);
+
   /// Set the raw timings from base85-encoded int32 data
-  /// Note: The string must outlive the InfraredCall (zero-copy pointer)
-  /// Decoded directly into transmit buffer at perform() time
+  /// @note Lifetime: Stores a pointer to the string. The string must outlive perform().
+  /// @note Usage: For web_server where the encoded string is on the stack.
+  /// @note Decoding happens at perform() time, directly into the transmit buffer.
   InfraredCall &set_raw_timings_base85(const std::string &base85);
-  /// Set the raw timings from packed protobuf sint32 data (zero-copy from wire)
-  /// Note: The data must outlive the InfraredCall
+
+  /// Set the raw timings from packed protobuf sint32 data (zigzag + varint encoded)
+  /// @note Lifetime: Stores a pointer to the buffer. The buffer must outlive perform().
+  /// @note Usage: For API component where data comes directly from the protobuf message.
   InfraredCall &set_raw_timings_packed(const uint8_t *data, uint16_t length, uint16_t count);
+
   /// Set the number of times to repeat transmission (1 = transmit once, 2 = transmit twice, etc.)
   InfraredCall &set_repeat_count(uint32_t count);
 
@@ -69,11 +82,11 @@ class InfraredCall {
   uint32_t repeat_count_{1};
   Infrared *parent_;
   optional<uint32_t> carrier_frequency_;
-  // Vector-based timings (for lambdas/automations)
+  // Pointer to vector-based timings (caller-owned, must outlive perform())
   const std::vector<int32_t> *raw_timings_{nullptr};
-  // Base85-encoded data pointer (for web_server - decoded directly into transmit buffer)
+  // Pointer to base85-encoded string (caller-owned, must outlive perform())
   const std::string *base85_ptr_{nullptr};
-  // Packed protobuf timings (for API zero-copy)
+  // Pointer to packed protobuf buffer (caller-owned, must outlive perform())
   const uint8_t *packed_data_{nullptr};
   uint16_t packed_length_{0};
   uint16_t packed_count_{0};

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -159,6 +159,16 @@ void RemoteTransmitData::set_data_from_packed_sint32(const uint8_t *data, size_t
   }
 }
 
+void RemoteTransmitData::set_data_from_le_int32_buffer(const uint8_t *data, size_t len) {
+  this->data_.clear();
+  this->data_.reserve(len / 4);
+  // Parse little-endian int32 values
+  for (size_t i = 0; i + 3 < len; i += 4) {
+    int32_t timing = static_cast<int32_t>(encode_uint32(data[i + 3], data[i + 2], data[i + 1], data[i]));
+    this->data_.push_back(timing);
+  }
+}
+
 /* RemoteTransmitterBase */
 
 void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -169,6 +169,18 @@ void RemoteTransmitData::set_data_from_le_int32_buffer(const uint8_t *data, size
   }
 }
 
+bool RemoteTransmitData::set_data_from_base64_le_int32(const std::string &base64) {
+  // Decode base64 into stack buffer, then parse into data_
+  constexpr size_t max_ir_bytes = 1024;
+  uint8_t decoded[max_ir_bytes];
+  size_t decoded_len = base64_decode(base64, decoded, sizeof(decoded));
+  if (decoded_len == 0 || decoded_len % 4 != 0) {
+    return false;
+  }
+  this->set_data_from_le_int32_buffer(decoded, decoded_len);
+  return true;
+}
+
 /* RemoteTransmitterBase */
 
 void RemoteTransmitterBase::send_(uint32_t send_times, uint32_t send_wait) {

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -160,22 +160,7 @@ void RemoteTransmitData::set_data_from_packed_sint32(const uint8_t *data, size_t
 }
 
 bool RemoteTransmitData::set_data_from_base85(const std::string &base85) {
-  size_t len = base85.size();
-  if (len % 5 != 0)
-    return false;
-
-  this->data_.clear();  // Retains capacity!
-  const char *ptr = base85.data();
-  const char *end = ptr + len;
-
-  while (ptr < end) {
-    int32_t value;
-    if (!base85_decode_int32(ptr, value))
-      return false;
-    this->data_.push_back(value);
-    ptr += 5;
-  }
-  return true;
+  return base85_decode_int32_vector(base85, this->data_);
 }
 
 /* RemoteTransmitterBase */

--- a/esphome/components/remote_base/remote_base.cpp
+++ b/esphome/components/remote_base/remote_base.cpp
@@ -159,25 +159,22 @@ void RemoteTransmitData::set_data_from_packed_sint32(const uint8_t *data, size_t
   }
 }
 
-void RemoteTransmitData::set_data_from_le_int32_buffer(const uint8_t *data, size_t len) {
-  this->data_.clear();
-  this->data_.reserve(len / 4);
-  // Parse little-endian int32 values
-  for (size_t i = 0; i + 3 < len; i += 4) {
-    int32_t timing = static_cast<int32_t>(encode_uint32(data[i + 3], data[i + 2], data[i + 1], data[i]));
-    this->data_.push_back(timing);
-  }
-}
-
-bool RemoteTransmitData::set_data_from_base64_le_int32(const std::string &base64) {
-  // Decode base64 into stack buffer, then parse into data_
-  constexpr size_t max_ir_bytes = 1024;
-  uint8_t decoded[max_ir_bytes];
-  size_t decoded_len = base64_decode(base64, decoded, sizeof(decoded));
-  if (decoded_len == 0 || decoded_len % 4 != 0) {
+bool RemoteTransmitData::set_data_from_base85(const std::string &base85) {
+  size_t len = base85.size();
+  if (len % 5 != 0)
     return false;
+
+  this->data_.clear();  // Retains capacity!
+  const char *ptr = base85.data();
+  const char *end = ptr + len;
+
+  while (ptr < end) {
+    int32_t value;
+    if (!base85_decode_int32(ptr, value))
+      return false;
+    this->data_.push_back(value);
+    ptr += 5;
   }
-  this->set_data_from_le_int32_buffer(decoded, decoded_len);
   return true;
 }
 

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -40,6 +40,11 @@ class RemoteTransmitData {
   /// @param data Pointer to little-endian int32 values
   /// @param len Length of the buffer in bytes (must be multiple of 4)
   void set_data_from_le_int32_buffer(const uint8_t *data, size_t len);
+  /// Set data from base64-encoded little-endian int32 values
+  /// Decodes and parses directly into internal buffer (zero intermediate copies)
+  /// @param base64 Base64-encoded string of little-endian int32 values
+  /// @return true if successful, false if decode failed or invalid size
+  bool set_data_from_base64_le_int32(const std::string &base64);
   void reset() {
     this->data_.clear();
     this->carrier_frequency_ = 0;

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -36,6 +36,10 @@ class RemoteTransmitData {
   /// @param len Length of the buffer in bytes
   /// @param count Number of values (for reserve optimization)
   void set_data_from_packed_sint32(const uint8_t *data, size_t len, size_t count);
+  /// Set data from little-endian int32 buffer (e.g., decoded from base64)
+  /// @param data Pointer to little-endian int32 values
+  /// @param len Length of the buffer in bytes (must be multiple of 4)
+  void set_data_from_le_int32_buffer(const uint8_t *data, size_t len);
   void reset() {
     this->data_.clear();
     this->carrier_frequency_ = 0;

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -36,15 +36,11 @@ class RemoteTransmitData {
   /// @param len Length of the buffer in bytes
   /// @param count Number of values (for reserve optimization)
   void set_data_from_packed_sint32(const uint8_t *data, size_t len, size_t count);
-  /// Set data from little-endian int32 buffer (e.g., decoded from base64)
-  /// @param data Pointer to little-endian int32 values
-  /// @param len Length of the buffer in bytes (must be multiple of 4)
-  void set_data_from_le_int32_buffer(const uint8_t *data, size_t len);
-  /// Set data from base64-encoded little-endian int32 values
-  /// Decodes and parses directly into internal buffer (zero intermediate copies)
-  /// @param base64 Base64-encoded string of little-endian int32 values
+  /// Set data from base85-encoded int32 values
+  /// Decodes directly into internal buffer (zero heap allocations)
+  /// @param base85 Base85-encoded string (5 chars per int32 value)
   /// @return true if successful, false if decode failed or invalid size
-  bool set_data_from_base64_le_int32(const std::string &base64);
+  bool set_data_from_base85(const std::string &base85);
   void reset() {
     this->data_.clear();
     this->carrier_frequency_ = 0;


### PR DESCRIPTION
# What does this implement/fix?

Adds a zero-copy path for transmitting IR data from the web server. Base85-encoded timing data is decoded directly into the `RemoteTransmitData` transmit buffer with zero heap allocations. This is useful for the changes in #13202.

### Changes

**`remote_base`**: Added `set_data_from_base85()` method that decodes base85 directly into the internal timings vector using `base85_decode_int32_vector()`. The vector retains capacity across calls, eliminating reallocations for repeated transmissions.

**`infrared`**: Added `set_raw_timings_base85()` method to `InfraredCall` that stores a pointer to the base85 string (8 bytes, zero-copy). Decoding happens directly into the transmit buffer at `perform()` time. Added comprehensive lifetime safety documentation for all `set_raw_timings_*` methods.

**`web_server`**: Simplified infrared handler to call `perform()` synchronously while the base85 string is in scope, eliminating the need for deferred execution.

### Why base85?

Base85 encodes 4 bytes into 5 characters (80% efficiency) versus base64's 4 bytes into ~5.33 characters (75% efficiency). For IR timing data:
- **Smaller payloads**: ~6% reduction in encoded string size
- **Direct int32 decode**: Each 5-character group decodes to exactly one int32 timing value
- **Zero intermediate buffers**: No need for a separate decode step followed by LE parsing

### Memory optimization

| Before | After |
|--------|-------|
| Decode base85 → stack buffer | _(no intermediate buffer)_ |
| Parse LE int32s → vector (heap alloc) | ~~removed~~ |
| Move vector into lambda capture | Store pointer (8 bytes) |
| Defer execution | Synchronous execution |
| Copy vector to transmit buffer | Decode directly into transmit buffer |

**Result**: Zero intermediate heap allocations. The transmit buffer's internal vector retains its capacity across calls, further reducing reallocations for repeated transmissions.

### Lifetime safety

All `set_raw_timings_*` methods store pointers to caller-owned data. The referenced data must remain valid until `perform()` completes:

```cpp
// Safe pattern - synchronous execution
std::string encoded = get_base85_data();
call.set_raw_timings_base85(encoded);
call.perform();  // encoded is still in scope

// Unsafe pattern - deferred execution
call.set_raw_timings_base85(encoded);
defer([call]() { call.perform(); });  // encoded may be gone!
```

This is documented in the header with `@note Lifetime:` comments on each method.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
