### PR TITLE
[core] Add --device hint when DNS resolution fails

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -222,8 +222,13 @@ def choose_upload_log_host(
             else:
                 resolved.append(device)
         if not resolved:
+            if CORE.dashboard:
+                hint = "If you know the IP, set 'use_address' in your network config."
+            else:
+                hint = "If you know the IP, try --device <IP>"
             raise EsphomeError(
-                f"All specified devices {defaults} could not be resolved. Is the device connected to the network?"
+                f"All specified devices {defaults} could not be resolved. "
+                f"Is the device connected to the network? {hint}"
             )
         return resolved
 

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -400,6 +400,8 @@ def run_ota_impl_(
             "Error resolving IP address of %s. Is it connected to WiFi?",
             remote_host,
         )
+        if not CORE.dashboard:
+            _LOGGER.error("(If you know the IP, try --device <IP>)")
         _LOGGER.error(
             "(If this error persists, please set a static IP address: "
             "https://esphome.io/components/wifi/#manual-ips)"


### PR DESCRIPTION
# What does this implement/fix?

When DNS resolution fails during `esphome upload`, users are shown error messages but aren't told how to work around the issue. This PR adds helpful hints about using `--device <IP>` when running from CLI.

**Before:**
```
ERROR Error resolving IP address of ['device.local']. Is it connected to WiFi?
ERROR (If this error persists, please set a static IP address: https://esphome.io/components/wifi/#manual-ips)
```

**After (CLI):**
```
ERROR Error resolving IP address of ['device.local']. Is it connected to WiFi?
ERROR (If you know the IP, try --device <IP>)
ERROR (If this error persists, please set a static IP address: https://esphome.io/components/wifi/#manual-ips)
```

The `--device` hint is only shown for CLI usage (not dashboard, where it doesn't apply).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves discoverability of `--device` CLI option when DNS resolution fails

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no docs changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a CLI/tooling improvement, not a configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
