### PR TITLE
[web_server][captive_portal] Change default compression from Brotli to gzip

### DIFF
--- a/esphome/components/captive_portal/__init__.py
+++ b/esphome/components/captive_portal/__init__.py
@@ -44,7 +44,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(CONF_WEB_SERVER_BASE_ID): cv.use_id(
                 web_server_base.WebServerBase
             ),
-            cv.Optional(CONF_COMPRESSION, default="br"): cv.one_of("br", "gzip"),
+            cv.Optional(CONF_COMPRESSION, default="gzip"): cv.one_of("gzip", "br"),
         }
     ).extend(cv.COMPONENT_SCHEMA),
     cv.only_on(

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -203,7 +203,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_OTA): cv.boolean,
             cv.Optional(CONF_LOG, default=True): cv.boolean,
             cv.Optional(CONF_LOCAL): cv.boolean,
-            cv.Optional(CONF_COMPRESSION, default="br"): cv.one_of("br", "gzip"),
+            cv.Optional(CONF_COMPRESSION, default="gzip"): cv.one_of("gzip", "br"),
             cv.Optional(CONF_SORTING_GROUPS): cv.ensure_list(sorting_group),
         }
     ).extend(cv.COMPONENT_SCHEMA),


### PR DESCRIPTION
# What does this implement/fix?

Changes the default compression algorithm for `web_server` and `captive_portal` components from Brotli (`br`) to `gzip`.

Some browsers only support Brotli decompression over HTTPS connections. Since ESPHome devices typically serve their web interface over plain HTTP, using Brotli as the default causes these browsers to fail with `ERR_CONTENT_DECODING_FAILED` or display garbage characters.

https://bugzilla.mozilla.org/show_bug.cgi?id=1719155

The server sends valid Brotli-compressed data with the correct `Content-Encoding: br` header, but browsers that don't advertise `br` in their `Accept-Encoding` header (because the connection is HTTP, not HTTPS) cannot decode the response.

Gzip is universally supported over both HTTP and HTTPS, making it the safer default choice.

Users who need to save flash space and are accessing their devices via HTTPS (or using browsers that support Brotli over HTTP) can still explicitly set `compression: br`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported in Discord by nagyrobi

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5924

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Uses gzip by default (recommended)
web_server:
  local: true

# Explicitly use Brotli if needed to save ~10% flash
# (may not work on all browsers over HTTP)
web_server:
  local: true
  compression: br
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
