### PR TITLE
[dallas_temp] Use const char* for set_timeout to fix deprecation warning and heap churn

### DIFF
--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -44,7 +44,7 @@ void DallasTemperatureSensor::update() {
 
   this->send_command_(DALLAS_COMMAND_START_CONVERSION);
 
-  this->set_timeout(this->get_address_name(), this->millis_to_wait_for_conversion_(), [this] {
+  this->set_timeout(this->get_address_name().c_str(), this->millis_to_wait_for_conversion_(), [this] {
     if (!this->read_scratch_pad_() || !this->check_scratch_pad_()) {
       this->publish_state(NAN);
       return;


### PR DESCRIPTION
# What does this implement/fix?

Fix deprecation warning and eliminate hidden heap churn in dallas_temp component by using `const char*` overload of `set_timeout()` instead of the deprecated `std::string` overload.

The `get_address_name()` method returns a reference to a member variable (`address_name_`) that persists for the lifetime of the sensor object. Since ESPHome components have program lifetime, calling `.c_str()` on this reference is safe and avoids the heap allocation that occurred when passing the `std::string` to the scheduler.

**Before:** Each `update()` call caused a heap allocation when the scheduler copied the string name.

**After:** Zero heap allocation - the scheduler stores the pointer to the persistent member string.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes deprecation warning for `set_timeout(const std::string&, ...)` in dallas_temp

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing dallas_temp configurations work without changes
one_wire:
  - platform: gpio
    pin: GPIO4

sensor:
  - platform: dallas_temp
    address: 0x1234567890ABCDEF
    name: "Temperature"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
