### PR TITLE
[sprinkler] Fix scheduler deprecation warnings and heap churn with FixedVector

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -332,6 +332,7 @@ Sprinkler::Sprinkler(const std::string &name) {
   // The `name` is needed to set timers up, hence non-default constructor
   // replaces `set_name()` method previously existed
   this->name_ = name;
+  this->timer_.init(2);
   this->timer_.push_back({this->name_ + "sm", false, 0, 0, std::bind(&Sprinkler::sm_timer_callback_, this)});
   this->timer_.push_back({this->name_ + "vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
 }
@@ -1574,7 +1575,8 @@ const LogString *Sprinkler::state_as_str_(SprinklerState state) {
 
 void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
   if (this->timer_duration_(timer_index) > 0) {
-    this->set_timeout(this->timer_[timer_index].name, this->timer_duration_(timer_index),
+    // FixedVector ensures timer_ can't be resized, so .c_str() pointers remain valid
+    this->set_timeout(this->timer_[timer_index].name.c_str(), this->timer_duration_(timer_index),
                       this->timer_cbf_(timer_index));
     this->timer_[timer_index].start_time = millis();
     this->timer_[timer_index].active = true;
@@ -1585,7 +1587,7 @@ void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
 
 bool Sprinkler::cancel_timer_(const SprinklerTimerIndex timer_index) {
   this->timer_[timer_index].active = false;
-  return this->cancel_timeout(this->timer_[timer_index].name);
+  return this->cancel_timeout(this->timer_[timer_index].name.c_str());
 }
 
 bool Sprinkler::timer_active_(const SprinklerTimerIndex timer_index) { return this->timer_[timer_index].active; }

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -3,6 +3,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 
@@ -553,8 +554,8 @@ class Sprinkler : public Component {
   /// Sprinkler valve operator objects
   std::vector<SprinklerValveOperator> valve_op_{2};
 
-  /// Valve control timers
-  std::vector<SprinklerTimer> timer_{};
+  /// Valve control timers - FixedVector enforces that this can never grow beyond init() size
+  FixedVector<SprinklerTimer> timer_;
 
   /// Other Sprinkler instances we should be aware of (used to check if pumps are in use)
   std::vector<Sprinkler *> other_controllers_;


### PR DESCRIPTION
# What does this implement/fix?

Fix deprecation warnings and eliminate hidden heap churn in sprinkler component by using `const char*` overload of `set_timeout()` and `cancel_timeout()` instead of the deprecated `std::string` overloads.

The timer names are stored in `SprinklerTimer` structs with `const std::string name` members. Since these are initialized once in the constructor and never modified, calling `.c_str()` on them is safe.

**Key change:** Migrated `timer_` from `std::vector<SprinklerTimer>` to `FixedVector<SprinklerTimer>`.

While `std::vector` would have worked (the vector was only populated in the constructor), using `FixedVector` enforces this invariant at the type level. This prevents future refactoring from accidentally adding `push_back()` calls elsewhere that could invalidate the `.c_str()` pointers. The type system now guarantees the safety property we're relying on.

**Before:** Each `set_timeout()` and `cancel_timeout()` call caused heap allocation when the scheduler copied the string name.

**After:** Zero heap allocation - the scheduler stores pointers to the persistent member strings. `FixedVector` ensures these pointers remain valid.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes deprecation warning for `set_timeout(const std::string&, ...)` and `cancel_timeout(const std::string&, ...)` in sprinkler

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing sprinkler configurations work without changes
switch:
  - platform: template
    id: pump_switch
    optimistic: true
  - platform: template
    id: valve_switch
    optimistic: true

sprinkler:
  - id: test_sprinkler
    main_switch: Test Sprinklers
    valves:
      - valve_switch: Valve 1
        pump_switch_id: pump_switch
        run_duration: 10s
        valve_switch_id: valve_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
