### PR TITLE
[esp32_ble_client] Reduce GATT data event logging to prevent firmware update failures

### DIFF
--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -193,8 +193,16 @@ void BLEClientBase::log_event_(const char *name) {
   ESP_LOGD(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_, name);
 }
 
-void BLEClientBase::log_gattc_event_(const char *name) {
+void BLEClientBase::log_gattc_lifecycle_event_(const char *name) {
   ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_%s_EVT", this->connection_index_, this->address_str_, name);
+}
+
+void BLEClientBase::log_gattc_data_event_(const char *name) {
+  // Data transfer events are logged at VERBOSE level because logging to UART creates
+  // delays that cause timing issues during time-sensitive BLE operations. This is
+  // especially problematic during pairing or firmware updates which require rapid
+  // writes to many characteristics - the log spam can cause these operations to fail.
+  ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_%s_EVT", this->connection_index_, this->address_str_, name);
 }
 
 void BLEClientBase::log_gattc_warning_(const char *operation, esp_gatt_status_t status) {
@@ -280,7 +288,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_OPEN_EVT: {
       if (!this->check_addr(param->open.remote_bda))
         return false;
-      this->log_gattc_event_("OPEN");
+      this->log_gattc_lifecycle_event_("OPEN");
       // conn_id was already set in ESP_GATTC_CONNECT_EVT
       this->service_count_ = 0;
 
@@ -331,7 +339,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
-      this->log_gattc_event_("CONNECT");
+      this->log_gattc_lifecycle_event_("CONNECT");
       this->conn_id_ = param->connect.conn_id;
       // Start MTU negotiation immediately as recommended by ESP-IDF examples
       // (gatt_client, ble_throughput) which call esp_ble_gattc_send_mtu_req in
@@ -376,7 +384,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CLOSE_EVT: {
       if (this->conn_id_ != param->close.conn_id)
         return false;
-      this->log_gattc_event_("CLOSE");
+      this->log_gattc_lifecycle_event_("CLOSE");
       this->release_services();
       this->set_state(espbt::ClientState::IDLE);
       this->conn_id_ = UNSET_CONN_ID;
@@ -404,7 +412,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       if (this->conn_id_ != param->search_cmpl.conn_id)
         return false;
-      this->log_gattc_event_("SEARCH_CMPL");
+      this->log_gattc_lifecycle_event_("SEARCH_CMPL");
       // For V3_WITHOUT_CACHE, switch back to medium connection parameters after service discovery
       // This balances performance with bandwidth usage after the critical discovery phase
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
@@ -431,35 +439,35 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_READ_DESCR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("READ_DESCR");
+      this->log_gattc_data_event_("READ_DESCR");
       break;
     }
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("WRITE_DESCR");
+      this->log_gattc_data_event_("WRITE_DESCR");
       break;
     }
     case ESP_GATTC_WRITE_CHAR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("WRITE_CHAR");
+      this->log_gattc_data_event_("WRITE_CHAR");
       break;
     }
     case ESP_GATTC_READ_CHAR_EVT: {
       if (this->conn_id_ != param->read.conn_id)
         return false;
-      this->log_gattc_event_("READ_CHAR");
+      this->log_gattc_data_event_("READ_CHAR");
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
       if (this->conn_id_ != param->notify.conn_id)
         return false;
-      this->log_gattc_event_("NOTIFY");
+      this->log_gattc_data_event_("NOTIFY");
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->log_gattc_event_("REG_FOR_NOTIFY");
+      this->log_gattc_data_event_("REG_FOR_NOTIFY");
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
           this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         // Client is responsible for flipping the descriptor value
@@ -491,7 +499,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       esp_err_t status =
           esp_ble_gattc_write_char_descr(this->gattc_if_, this->conn_id_, desc_result.handle, sizeof(notify_en),
                                          (uint8_t *) &notify_en, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-      ESP_LOGD(TAG, "Wrote notify descriptor %d, properties=%d", notify_en, char_result.properties);
+      ESP_LOGV(TAG, "Wrote notify descriptor %d, properties=%d", notify_en, char_result.properties);
       if (status) {
         this->log_gattc_warning_("esp_ble_gattc_write_char_descr", status);
       }
@@ -499,13 +507,13 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     }
 
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
-      this->log_gattc_event_("UNREG_FOR_NOTIFY");
+      this->log_gattc_data_event_("UNREG_FOR_NOTIFY");
       break;
     }
 
     default:
-      // ideally would check all other events for matching conn_id
-      ESP_LOGD(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_, event);
+      // Unknown events logged at VERBOSE to avoid UART delays during time-sensitive operations
+      ESP_LOGV(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_, event);
       break;
   }
   return true;

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -127,7 +127,8 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   // 6 bytes used, 2 bytes padding
 
   void log_event_(const char *name);
-  void log_gattc_event_(const char *name);
+  void log_gattc_lifecycle_event_(const char *name);
+  void log_gattc_data_event_(const char *name);
   void update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                            const char *param_type);
   void set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,


### PR DESCRIPTION
# What does this implement/fix?

Reduces BLE GATT event logging from DEBUG to VERBOSE level to prevent failures when updating firmware on BLE devices through Bluetooth Proxy.

When using Bluetooth Proxy to update firmware on end BLE devices (locks, sensors, etc.) or pair with them, data transfer events (notifications, reads, writes) fire rapidly. Previously these were logged at DEBUG level - a single firmware update pushed to an end device can generate 10,000+ log messages. The UART write delays from this log flood cause timing issues that make these operations fail.

**Changes:**
- Renamed `log_gattc_event_()` to `log_gattc_lifecycle_event_()` for clarity
- Added new `log_gattc_data_event_()` helper that logs at VERBOSE level
- Connection lifecycle events (OPEN, CONNECT, CLOSE, SEARCH_CMPL) remain at DEBUG level
- Data transfer events moved to VERBOSE level:
  - `ESP_GATTC_READ_CHAR_EVT`
  - `ESP_GATTC_WRITE_CHAR_EVT`
  - `ESP_GATTC_NOTIFY_EVT`
  - `ESP_GATTC_READ_DESCR_EVT`
  - `ESP_GATTC_WRITE_DESCR_EVT`
  - `ESP_GATTC_REG_FOR_NOTIFY_EVT`
  - `ESP_GATTC_UNREG_FOR_NOTIFY_EVT`
  - Unknown/default events

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Improves reliability of firmware updates to end BLE devices via Bluetooth Proxy and device pairing

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is a logging level fix
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
