### PR TITLE
[api] Fix clock conflicts when multiple clients connected to homeassistant time

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -558,8 +558,10 @@ bool APIServer::clear_noise_psk(bool make_active) {
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {
   for (auto &client : this->clients_) {
-    if (!client->flags_.remove && client->is_authenticated())
+    if (!client->flags_.remove && client->is_authenticated()) {
       client->send_time_request();
+      return;  // Only request from one client to avoid clock conflicts
+    }
   }
 }
 #endif

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -31,6 +31,14 @@ void RealTimeClock::dump_config() {
 
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   ESP_LOGVV(TAG, "Got epoch %" PRIu32, epoch);
+  // Skip if time is already synchronized to avoid unnecessary writes and log spam
+  auto current = this->utcnow();
+  if (current.is_valid()) {
+    int32_t diff = static_cast<int32_t>(epoch) - static_cast<int32_t>(current.timestamp);
+    if (diff >= -1 && diff <= 1) {
+      return;
+    }
+  }
   // Update UTC epoch time.
 #ifdef USE_ZEPHYR
   struct timespec ts;

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -33,10 +33,12 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   ESP_LOGVV(TAG, "Got epoch %" PRIu32, epoch);
   // Skip if time is already synchronized to avoid unnecessary writes, log spam,
   // and prevent clock jumping backwards due to network latency
-  auto current = this->utcnow();
-  if (current.is_valid()) {
+  constexpr time_t MIN_VALID_EPOCH = 1546300800;  // January 1, 2019
+  time_t current_time = this->timestamp_now();
+  // Check if time is valid (year >= 2019) before comparing
+  if (current_time >= MIN_VALID_EPOCH) {
     // Unsigned subtraction handles wraparound correctly, then cast to signed
-    int32_t diff = static_cast<int32_t>(epoch - current.timestamp);
+    int32_t diff = static_cast<int32_t>(epoch - static_cast<uint32_t>(current_time));
     if (diff >= -1 && diff <= 1) {
       return;
     }

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -35,7 +35,8 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   // and prevent clock jumping backwards due to network latency
   auto current = this->utcnow();
   if (current.is_valid()) {
-    int32_t diff = static_cast<int32_t>(epoch) - static_cast<int32_t>(current.timestamp);
+    // Unsigned subtraction handles wraparound correctly, then cast to signed
+    int32_t diff = static_cast<int32_t>(epoch - current.timestamp);
     if (diff >= -1 && diff <= 1) {
       return;
     }

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -33,10 +33,10 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   ESP_LOGVV(TAG, "Got epoch %" PRIu32, epoch);
   // Skip if time is already synchronized to avoid unnecessary writes, log spam,
   // and prevent clock jumping backwards due to network latency
-  constexpr time_t MIN_VALID_EPOCH = 1546300800;  // January 1, 2019
+  constexpr time_t min_valid_epoch = 1546300800;  // January 1, 2019
   time_t current_time = this->timestamp_now();
   // Check if time is valid (year >= 2019) before comparing
-  if (current_time >= MIN_VALID_EPOCH) {
+  if (current_time >= min_valid_epoch) {
     // Unsigned subtraction handles wraparound correctly, then cast to signed
     int32_t diff = static_cast<int32_t>(epoch - static_cast<uint32_t>(current_time));
     if (diff >= -1 && diff <= 1) {

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -31,7 +31,8 @@ void RealTimeClock::dump_config() {
 
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   ESP_LOGVV(TAG, "Got epoch %" PRIu32, epoch);
-  // Skip if time is already synchronized to avoid unnecessary writes and log spam
+  // Skip if time is already synchronized to avoid unnecessary writes, log spam,
+  // and prevent clock jumping backwards due to network latency
   auto current = this->utcnow();
   if (current.is_valid()) {
     int32_t diff = static_cast<int32_t>(epoch) - static_cast<int32_t>(current.timestamp);


### PR DESCRIPTION
# What does this implement/fix?

Fix clock conflicts when multiple API clients are connected and reduce unnecessary time sync operations.

**Issue 1: Clock ping-pong with multiple clients**

Previously, `request_time()` sent time requests to ALL connected API clients. When multiple clients were connected (e.g., Home Assistant + ESPHome dashboard logs), each client would respond with its own time, causing the device clock to flip-flop between different time sources every sync interval.

**Issue 2: Unnecessary sync operations and clock jumping backwards**

Every sync interval, `synchronize_epoch_()` would unconditionally:
- Call `settimeofday()`
- Log "Synchronized time"
- Fire all time sync callbacks

This happened even when the clock was already accurate, causing log spam and unnecessary syscalls.

Worse, network latency could cause the clock to jump backwards. For example:
1. Device time: 12:00:01.500
2. HA sends epoch for 12:00:01.000 (arrives after 500ms network delay)
3. Clock jumps backward 500ms

Since automations use monotonic time, this is primarily a display/logging issue, but it's still undesirable behavior.

**Fixes:**
1. Request time from only the first authenticated client instead of all clients
2. Skip the sync entirely if current time is already within 1 second of the incoming epoch

**Note:** This code path (`synchronize_epoch_()`) is only used by time sources with single-second precision like Home Assistant time (which sends a `uint32_t` epoch). High-precision sources like SNTP bypass this entirely and use the platform's SNTP implementation which handles sub-second precision (~10-100ms) and round-trip time compensation internally.

**Y2106:** The epoch parameter is `uint32_t` so this check has a Y2106 problem (unsigned 32-bit overflow). This PR does not attempt to solve that.

Before (log spam every 30s even when time is correct):
```
[12:56:21.166][D][time:067]: Synchronized time: 2026-01-15 12:56:21
[12:56:21.172][D][time:067]: Synchronized time: 2026-01-15 12:56:21
[12:56:51.168][D][time:067]: Synchronized time: 2026-01-15 12:56:51
[12:56:51.174][D][time:067]: Synchronized time: 2026-01-15 12:56:51
```

After: Only logs when time actually needs adjustment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config using homeassistant time with multiple API connections
time:
  - platform: homeassistant
    id: homeassistant_time
    update_interval: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
