### PR TITLE
[helpers] Add base85 support

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -617,6 +617,61 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
   return ret;
 }
 
+/// Encode int32 to 5 base85 characters
+/// Standard ASCII85 alphabet: '!' (33) = 0 through 'u' (117) = 84
+inline void base85_encode_int32(int32_t value, char *output) {
+  uint32_t v = static_cast<uint32_t>(value);
+  // Encode least significant digit first, then reverse
+  for (uint8_t i = 4; i >= 0; i--) {
+    output[i] = static_cast<char>('!' + (v % 85));
+    v /= 85;
+  }
+}
+
+inline std::string base85_encode_int32(int32_t value) {
+  char buf[6];
+  base85_encode_int32(value, buf);
+  buf[5] = '\0';
+  return std::string(buf, 5);
+}
+
+/// Decode 5 base85 characters to int32
+inline bool base85_decode_int32(const char *input, int32_t &out) {
+  uint8_t c0 = static_cast<uint8_t>(input[0] - '!');
+  uint8_t c1 = static_cast<uint8_t>(input[1] - '!');
+  uint8_t c2 = static_cast<uint8_t>(input[2] - '!');
+  uint8_t c3 = static_cast<uint8_t>(input[3] - '!');
+  uint8_t c4 = static_cast<uint8_t>(input[4] - '!');
+
+  // Each digit must be 0-84. Since uint8_t wraps, chars below '!' become > 84
+  if (c0 > 84 || c1 > 84 || c2 > 84 || c3 > 84 || c4 > 84)
+    return false;
+
+  // 85^4 = 52200625, 85^3 = 614125, 85^2 = 7225, 85^1 = 85
+  out = static_cast<int32_t>(c0 * 52200625u + c1 * 614125u + c2 * 7225u + c3 * 85u + c4);
+  return true;
+}
+
+/// Decode base85 string directly into vector (no intermediate buffer)
+bool base85_decode_int32_vector(const std::string &base85, std::vector<int32_t> &out) {
+  size_t len = base85.size();
+  if (len % 5 != 0)
+    return false;
+
+  out.clear();
+  const char *ptr = base85.data();
+  const char *end = ptr + len;
+
+  while (ptr < end) {
+    int32_t value;
+    if (!base85_decode_int32(ptr, value))
+      return false;
+    out.push_back(value);
+    ptr += 5;
+  }
+  return true;
+}
+
 // Colors
 
 float gamma_correct(float value, float gamma) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -628,11 +628,9 @@ inline void base85_encode_int32(int32_t value, char *output) {
   }
 }
 
-inline std::string base85_encode_int32(int32_t value) {
-  char buf[6];
-  base85_encode_int32(value, buf);
-  buf[5] = '\0';
-  return std::string(buf, 5);
+inline void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output) {
+  base85_encode_int32(value, output.data());
+  output[5] = '\0';
 }
 
 /// Decode 5 base85 characters to int32

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -617,19 +617,15 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
   return ret;
 }
 
-/// Encode int32 to 5 base85 characters
+/// Encode int32 to 5 base85 characters + null terminator
 /// Standard ASCII85 alphabet: '!' (33) = 0 through 'u' (117) = 84
-inline void base85_encode_int32(int32_t value, char *output) {
+inline void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output) {
   uint32_t v = static_cast<uint32_t>(value);
   // Encode least significant digit first, then reverse
   for (uint8_t i = 4; i >= 0; i--) {
     output[i] = static_cast<char>('!' + (v % 85));
     v /= 85;
   }
-}
-
-inline void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output) {
-  base85_encode_int32(value, output.data());
   output[5] = '\0';
 }
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -622,7 +622,7 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string) {
 inline void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output) {
   uint32_t v = static_cast<uint32_t>(value);
   // Encode least significant digit first, then reverse
-  for (uint8_t i = 4; i >= 0; i--) {
+  for (int i = 4; i >= 0; i--) {
     output[i] = static_cast<char>('!' + (v % 85));
     v /= 85;
   }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1086,6 +1086,12 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string);
 size_t base64_decode(std::string const &encoded_string, uint8_t *buf, size_t buf_len);
 size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *buf, size_t buf_len);
 
+void base85_encode_int32(int32_t value, char *output);
+std::string base85_encode_int32(int32_t value);
+
+bool base85_decode_int32(const char *input, int32_t &out);
+bool base85_decode_int32_vector(const std::string &base85, std::vector<int32_t> &out);
+
 ///@}
 
 /// @name Colors

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1089,7 +1089,6 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
 /// Size of buffer needed for base85 encoded int32 (5 chars + null terminator)
 static constexpr size_t BASE85_INT32_ENCODED_SIZE = 6;
 
-void base85_encode_int32(int32_t value, char *output);
 void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output);
 
 bool base85_decode_int32(const char *input, int32_t &out);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1086,8 +1086,11 @@ std::vector<uint8_t> base64_decode(const std::string &encoded_string);
 size_t base64_decode(std::string const &encoded_string, uint8_t *buf, size_t buf_len);
 size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *buf, size_t buf_len);
 
+/// Size of buffer needed for base85 encoded int32 (5 chars + null terminator)
+static constexpr size_t BASE85_INT32_ENCODED_SIZE = 6;
+
 void base85_encode_int32(int32_t value, char *output);
-std::string base85_encode_int32(int32_t value);
+void base85_encode_int32(int32_t value, std::span<char, BASE85_INT32_ENCODED_SIZE> output);
 
 bool base85_decode_int32(const char *input, int32_t &out);
 bool base85_decode_int32_vector(const std::string &base85, std::vector<int32_t> &out);


### PR DESCRIPTION
# What does this implement/fix?

Add basic `base85` encode/decode functions to be used by #13238 and #13202 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
