### PR TITLE
[debug] Use shared buf_append_printf helper from core

### DIFF
--- a/esphome/components/debug/debug_component.cpp
+++ b/esphome/components/debug/debug_component.cpp
@@ -30,7 +30,7 @@ void DebugComponent::dump_config() {
 
   char device_info_buffer[DEVICE_INFO_BUFFER_SIZE];
   ESP_LOGD(TAG, "ESPHome version %s", ESPHOME_VERSION);
-  size_t pos = buf_append(device_info_buffer, DEVICE_INFO_BUFFER_SIZE, 0, "%s", ESPHOME_VERSION);
+  size_t pos = buf_append_printf(device_info_buffer, DEVICE_INFO_BUFFER_SIZE, 0, "%s", ESPHOME_VERSION);
 
   this->free_heap_ = get_free_heap_();
   ESP_LOGD(TAG, "Free Heap Size: %" PRIu32 " bytes", this->free_heap_);

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -35,8 +35,11 @@ class DebugComponent : public PollingComponent {
 #ifdef USE_SENSOR
   void set_free_sensor(sensor::Sensor *free_sensor) { free_sensor_ = free_sensor; }
   void set_block_sensor(sensor::Sensor *block_sensor) { block_sensor_ = block_sensor; }
-#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
+#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
   void set_fragmentation_sensor(sensor::Sensor *fragmentation_sensor) { fragmentation_sensor_ = fragmentation_sensor; }
+#endif
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  void set_min_free_sensor(sensor::Sensor *min_free_sensor) { min_free_sensor_ = min_free_sensor; }
 #endif
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
 #ifdef USE_ESP32
@@ -58,8 +61,11 @@ class DebugComponent : public PollingComponent {
 
   sensor::Sensor *free_sensor_{nullptr};
   sensor::Sensor *block_sensor_{nullptr};
-#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
+#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
   sensor::Sensor *fragmentation_sensor_{nullptr};
+#endif
+#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+  sensor::Sensor *min_free_sensor_{nullptr};
 #endif
   sensor::Sensor *loop_time_sensor_{nullptr};
 #ifdef USE_ESP32

--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -5,12 +5,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/macros.h"
 #include <span>
-#include <cstdarg>
-#include <cstdio>
-#include <algorithm>
-#ifdef USE_ESP8266
-#include <pgmspace.h>
-#endif
 
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
@@ -25,40 +19,7 @@ namespace debug {
 static constexpr size_t DEVICE_INFO_BUFFER_SIZE = 256;
 static constexpr size_t RESET_REASON_BUFFER_SIZE = 128;
 
-#ifdef USE_ESP8266
-// ESP8266: Use vsnprintf_P to keep format strings in flash (PROGMEM)
-// Format strings must be wrapped with PSTR() macro
-inline size_t buf_append_p(char *buf, size_t size, size_t pos, PGM_P fmt, ...) {
-  if (pos >= size) {
-    return size;
-  }
-  va_list args;
-  va_start(args, fmt);
-  int written = vsnprintf_P(buf + pos, size - pos, fmt, args);
-  va_end(args);
-  if (written < 0) {
-    return pos;  // encoding error
-  }
-  return std::min(pos + static_cast<size_t>(written), size);
-}
-#define buf_append(buf, size, pos, fmt, ...) buf_append_p(buf, size, pos, PSTR(fmt), ##__VA_ARGS__)
-#else
-/// Safely append formatted string to buffer, returning new position (capped at size)
-__attribute__((format(printf, 4, 5))) inline size_t buf_append(char *buf, size_t size, size_t pos, const char *fmt,
-                                                               ...) {
-  if (pos >= size) {
-    return size;
-  }
-  va_list args;
-  va_start(args, fmt);
-  int written = vsnprintf(buf + pos, size - pos, fmt, args);
-  va_end(args);
-  if (written < 0) {
-    return pos;  // encoding error
-  }
-  return std::min(pos + static_cast<size_t>(written), size);
-}
-#endif
+// buf_append_printf is now provided by esphome/core/helpers.h
 
 class DebugComponent : public PollingComponent {
  public:
@@ -74,11 +35,8 @@ class DebugComponent : public PollingComponent {
 #ifdef USE_SENSOR
   void set_free_sensor(sensor::Sensor *free_sensor) { free_sensor_ = free_sensor; }
   void set_block_sensor(sensor::Sensor *block_sensor) { block_sensor_ = block_sensor; }
-#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
+#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
   void set_fragmentation_sensor(sensor::Sensor *fragmentation_sensor) { fragmentation_sensor_ = fragmentation_sensor; }
-#endif
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
-  void set_min_free_sensor(sensor::Sensor *min_free_sensor) { min_free_sensor_ = min_free_sensor; }
 #endif
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
 #ifdef USE_ESP32
@@ -100,11 +58,8 @@ class DebugComponent : public PollingComponent {
 
   sensor::Sensor *free_sensor_{nullptr};
   sensor::Sensor *block_sensor_{nullptr};
-#if (defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)) || defined(USE_ESP32)
+#if defined(USE_ESP8266) && USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 5, 2)
   sensor::Sensor *fragmentation_sensor_{nullptr};
-#endif
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
-  sensor::Sensor *min_free_sensor_{nullptr};
 #endif
   sensor::Sensor *loop_time_sensor_{nullptr};
 #ifdef USE_ESP32

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -173,8 +173,8 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   uint32_t flash_size = ESP.getFlashChipSize() / 1024;       // NOLINT
   uint32_t flash_speed = ESP.getFlashChipSpeed() / 1000000;  // NOLINT
   ESP_LOGD(TAG, "Flash Chip: Size=%" PRIu32 "kB Speed=%" PRIu32 "MHz Mode=%s", flash_size, flash_speed, flash_mode);
-  pos = buf_append(buf, size, pos, "|Flash: %" PRIu32 "kB Speed:%" PRIu32 "MHz Mode:%s", flash_size, flash_speed,
-                   flash_mode);
+  pos = buf_append_printf(buf, size, pos, "|Flash: %" PRIu32 "kB Speed:%" PRIu32 "MHz Mode:%s", flash_size, flash_speed,
+                          flash_mode);
 #endif
 
   esp_chip_info_t info;
@@ -182,71 +182,60 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   const char *model = ESPHOME_VARIANT;
 
   // Build features string
-  pos = buf_append(buf, size, pos, "|Chip: %s Features:", model);
+  pos = buf_append_printf(buf, size, pos, "|Chip: %s Features:", model);
   bool first_feature = true;
   for (const auto &feature : CHIP_FEATURES) {
     if (info.features & feature.bit) {
-      pos = buf_append(buf, size, pos, "%s%s", first_feature ? "" : ", ", feature.name);
+      pos = buf_append_printf(buf, size, pos, "%s%s", first_feature ? "" : ", ", feature.name);
       first_feature = false;
       info.features &= ~feature.bit;
     }
   }
   if (info.features != 0) {
-    pos = buf_append(buf, size, pos, "%sOther:0x%" PRIx32, first_feature ? "" : ", ", info.features);
+    pos = buf_append_printf(buf, size, pos, "%sOther:0x%" PRIx32, first_feature ? "" : ", ", info.features);
   }
   ESP_LOGD(TAG, "Chip: Model=%s, Cores=%u, Revision=%u", model, info.cores, info.revision);
-  pos = buf_append(buf, size, pos, " Cores:%u Revision:%u", info.cores, info.revision);
+  pos = buf_append_printf(buf, size, pos, " Cores:%u Revision:%u", info.cores, info.revision);
 
   uint32_t cpu_freq_mhz = arch_get_cpu_freq_hz() / 1000000;
   ESP_LOGD(TAG, "CPU Frequency: %" PRIu32 " MHz", cpu_freq_mhz);
-  pos = buf_append(buf, size, pos, "|CPU Frequency: %" PRIu32 " MHz", cpu_freq_mhz);
+  pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32 " MHz", cpu_freq_mhz);
 
   // Framework detection
 #ifdef USE_ARDUINO
   ESP_LOGD(TAG, "Framework: Arduino");
-  pos = buf_append(buf, size, pos, "|Framework: Arduino");
+  pos = buf_append_printf(buf, size, pos, "|Framework: Arduino");
 #elif defined(USE_ESP32)
   ESP_LOGD(TAG, "Framework: ESP-IDF");
-  pos = buf_append(buf, size, pos, "|Framework: ESP-IDF");
+  pos = buf_append_printf(buf, size, pos, "|Framework: ESP-IDF");
 #else
   ESP_LOGW(TAG, "Framework: UNKNOWN");
-  pos = buf_append(buf, size, pos, "|Framework: UNKNOWN");
+  pos = buf_append_printf(buf, size, pos, "|Framework: UNKNOWN");
 #endif
 
   ESP_LOGD(TAG, "ESP-IDF Version: %s", esp_get_idf_version());
-  pos = buf_append(buf, size, pos, "|ESP-IDF: %s", esp_get_idf_version());
+  pos = buf_append_printf(buf, size, pos, "|ESP-IDF: %s", esp_get_idf_version());
 
   uint8_t mac[6];
   get_mac_address_raw(mac);
   ESP_LOGD(TAG, "EFuse MAC: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-  pos = buf_append(buf, size, pos, "|EFuse MAC: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4],
-                   mac[5]);
+  pos = buf_append_printf(buf, size, pos, "|EFuse MAC: %02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3],
+                          mac[4], mac[5]);
 
   char reason_buffer[RESET_REASON_BUFFER_SIZE];
   const char *reset_reason = get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE>(reason_buffer));
-  pos = buf_append(buf, size, pos, "|Reset: %s", reset_reason);
+  pos = buf_append_printf(buf, size, pos, "|Reset: %s", reset_reason);
 
   const char *wakeup_cause = get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE>(reason_buffer));
-  pos = buf_append(buf, size, pos, "|Wakeup: %s", wakeup_cause);
+  pos = buf_append_printf(buf, size, pos, "|Wakeup: %s", wakeup_cause);
 
   return pos;
 }
 
 void DebugComponent::update_platform_() {
 #ifdef USE_SENSOR
-  uint32_t max_alloc = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
   if (this->block_sensor_ != nullptr) {
-    this->block_sensor_->publish_state(max_alloc);
-  }
-  if (this->min_free_sensor_ != nullptr) {
-    this->min_free_sensor_->publish_state(heap_caps_get_minimum_free_size(MALLOC_CAP_INTERNAL));
-  }
-  if (this->fragmentation_sensor_ != nullptr) {
-    uint32_t free_heap = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
-    if (free_heap > 0) {
-      float fragmentation = 100.0f - (100.0f * max_alloc / free_heap);
-      this->fragmentation_sensor_->publish_state(fragmentation);
-    }
+    this->block_sensor_->publish_state(heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL));
   }
   if (this->psram_sensor_ != nullptr) {
     this->psram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_SPIRAM));

--- a/esphome/components/debug/debug_esp8266.cpp
+++ b/esphome/components/debug/debug_esp8266.cpp
@@ -53,8 +53,8 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   uint32_t flash_size = ESP.getFlashChipSize() / 1024;       // NOLINT
   uint32_t flash_speed = ESP.getFlashChipSpeed() / 1000000;  // NOLINT
   ESP_LOGD(TAG, "Flash Chip: Size=%" PRIu32 "kB Speed=%" PRIu32 "MHz Mode=%s", flash_size, flash_speed, flash_mode);
-  pos = buf_append(buf, size, pos, "|Flash: %" PRIu32 "kB Speed:%" PRIu32 "MHz Mode:%s", flash_size, flash_speed,
-                   flash_mode);
+  pos = buf_append_printf(buf, size, pos, "|Flash: %" PRIu32 "kB Speed:%" PRIu32 "MHz Mode:%s", flash_size, flash_speed,
+                          flash_mode);
 
 #if !defined(CLANG_TIDY)
   char reason_buffer[RESET_REASON_BUFFER_SIZE];
@@ -77,15 +77,15 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
            chip_id, ESP.getSdkVersion(), ESP.getCoreVersion().c_str(), boot_version, boot_mode, cpu_freq, flash_chip_id,
            reset_reason, ESP.getResetInfo().c_str());
 
-  pos = buf_append(buf, size, pos, "|Chip: 0x%08" PRIX32, chip_id);
-  pos = buf_append(buf, size, pos, "|SDK: %s", ESP.getSdkVersion());
-  pos = buf_append(buf, size, pos, "|Core: %s", ESP.getCoreVersion().c_str());
-  pos = buf_append(buf, size, pos, "|Boot: %u", boot_version);
-  pos = buf_append(buf, size, pos, "|Mode: %u", boot_mode);
-  pos = buf_append(buf, size, pos, "|CPU: %u", cpu_freq);
-  pos = buf_append(buf, size, pos, "|Flash: 0x%08" PRIX32, flash_chip_id);
-  pos = buf_append(buf, size, pos, "|Reset: %s", reset_reason);
-  pos = buf_append(buf, size, pos, "|%s", ESP.getResetInfo().c_str());
+  pos = buf_append_printf(buf, size, pos, "|Chip: 0x%08" PRIX32, chip_id);
+  pos = buf_append_printf(buf, size, pos, "|SDK: %s", ESP.getSdkVersion());
+  pos = buf_append_printf(buf, size, pos, "|Core: %s", ESP.getCoreVersion().c_str());
+  pos = buf_append_printf(buf, size, pos, "|Boot: %u", boot_version);
+  pos = buf_append_printf(buf, size, pos, "|Mode: %u", boot_mode);
+  pos = buf_append_printf(buf, size, pos, "|CPU: %u", cpu_freq);
+  pos = buf_append_printf(buf, size, pos, "|Flash: 0x%08" PRIX32, flash_chip_id);
+  pos = buf_append_printf(buf, size, pos, "|Reset: %s", reset_reason);
+  pos = buf_append_printf(buf, size, pos, "|%s", ESP.getResetInfo().c_str());
 #endif
 
   return pos;

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -51,6 +51,9 @@ void DebugComponent::update_platform_() {
   if (this->block_sensor_ != nullptr) {
     this->block_sensor_->publish_state(lt_heap_get_max_alloc());
   }
+  if (this->min_free_sensor_ != nullptr) {
+    this->min_free_sensor_->publish_state(lt_heap_get_min_free());
+  }
 #endif
 }
 

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -36,12 +36,12 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
            lt_get_version(), lt_cpu_get_model_name(), lt_cpu_get_model(), lt_cpu_get_freq_mhz(), mac_id,
            lt_get_board_code(), flash_kib, ram_kib, reset_reason);
 
-  pos = buf_append(buf, size, pos, "|Version: %s", LT_BANNER_STR + 10);
-  pos = buf_append(buf, size, pos, "|Reset Reason: %s", reset_reason);
-  pos = buf_append(buf, size, pos, "|Chip Name: %s", lt_cpu_get_model_name());
-  pos = buf_append(buf, size, pos, "|Chip ID: 0x%06" PRIX32, mac_id);
-  pos = buf_append(buf, size, pos, "|Flash: %" PRIu32 " KiB", flash_kib);
-  pos = buf_append(buf, size, pos, "|RAM: %" PRIu32 " KiB", ram_kib);
+  pos = buf_append_printf(buf, size, pos, "|Version: %s", LT_BANNER_STR + 10);
+  pos = buf_append_printf(buf, size, pos, "|Reset Reason: %s", reset_reason);
+  pos = buf_append_printf(buf, size, pos, "|Chip Name: %s", lt_cpu_get_model_name());
+  pos = buf_append_printf(buf, size, pos, "|Chip ID: 0x%06" PRIX32, mac_id);
+  pos = buf_append_printf(buf, size, pos, "|Flash: %" PRIu32 " KiB", flash_kib);
+  pos = buf_append_printf(buf, size, pos, "|RAM: %" PRIu32 " KiB", ram_kib);
 
   return pos;
 }
@@ -50,9 +50,6 @@ void DebugComponent::update_platform_() {
 #ifdef USE_SENSOR
   if (this->block_sensor_ != nullptr) {
     this->block_sensor_->publish_state(lt_heap_get_max_alloc());
-  }
-  if (this->min_free_sensor_ != nullptr) {
-    this->min_free_sensor_->publish_state(lt_heap_get_min_free());
   }
 #endif
 }

--- a/esphome/components/debug/debug_rp2040.cpp
+++ b/esphome/components/debug/debug_rp2040.cpp
@@ -19,7 +19,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
 
   uint32_t cpu_freq = rp2040.f_cpu();
   ESP_LOGD(TAG, "CPU Frequency: %" PRIu32, cpu_freq);
-  pos = buf_append(buf, size, pos, "|CPU Frequency: %" PRIu32, cpu_freq);
+  pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32, cpu_freq);
 
   return pos;
 }

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -20,9 +20,9 @@ static size_t append_reset_reason(char *buf, size_t size, size_t pos, bool set, 
     return pos;
   }
   if (pos > 0) {
-    pos = buf_append(buf, size, pos, ", ");
+    pos = buf_append_printf(buf, size, pos, ", ");
   }
-  return buf_append(buf, size, pos, "%s", reason);
+  return buf_append_printf(buf, size, pos, "%s", reason);
 }
 
 static inline uint32_t read_mem_u32(uintptr_t addr) {
@@ -140,7 +140,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   const char *supply_status =
       (nrf_power_mainregstatus_get(NRF_POWER) == NRF_POWER_MAINREGSTATUS_NORMAL) ? "Normal voltage." : "High voltage.";
   ESP_LOGD(TAG, "Main supply status: %s", supply_status);
-  pos = buf_append(buf, size, pos, "|Main supply status: %s", supply_status);
+  pos = buf_append_printf(buf, size, pos, "|Main supply status: %s", supply_status);
 
   // Regulator stage 0
   if (nrf_power_mainregstatus_get(NRF_POWER) == NRF_POWER_MAINREGSTATUS_HIGH) {
@@ -172,16 +172,16 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
         reg0_voltage = "???V";
     }
     ESP_LOGD(TAG, "Regulator stage 0: %s, %s", reg0_type, reg0_voltage);
-    pos = buf_append(buf, size, pos, "|Regulator stage 0: %s, %s", reg0_type, reg0_voltage);
+    pos = buf_append_printf(buf, size, pos, "|Regulator stage 0: %s, %s", reg0_type, reg0_voltage);
   } else {
     ESP_LOGD(TAG, "Regulator stage 0: disabled");
-    pos = buf_append(buf, size, pos, "|Regulator stage 0: disabled");
+    pos = buf_append_printf(buf, size, pos, "|Regulator stage 0: disabled");
   }
 
   // Regulator stage 1
   const char *reg1_type = nrf_power_dcdcen_get(NRF_POWER) ? "DC/DC" : "LDO";
   ESP_LOGD(TAG, "Regulator stage 1: %s", reg1_type);
-  pos = buf_append(buf, size, pos, "|Regulator stage 1: %s", reg1_type);
+  pos = buf_append_printf(buf, size, pos, "|Regulator stage 1: %s", reg1_type);
 
   // USB power state
   const char *usb_state;
@@ -195,7 +195,7 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
     usb_state = "disconnected";
   }
   ESP_LOGD(TAG, "USB power state: %s", usb_state);
-  pos = buf_append(buf, size, pos, "|USB power state: %s", usb_state);
+  pos = buf_append_printf(buf, size, pos, "|USB power state: %s", usb_state);
 
   // Power-fail comparator
   bool enabled;
@@ -300,14 +300,14 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
           break;
       }
       ESP_LOGD(TAG, "Power-fail comparator: %s, VDDH: %s", pof_voltage, vddh_voltage);
-      pos = buf_append(buf, size, pos, "|Power-fail comparator: %s, VDDH: %s", pof_voltage, vddh_voltage);
+      pos = buf_append_printf(buf, size, pos, "|Power-fail comparator: %s, VDDH: %s", pof_voltage, vddh_voltage);
     } else {
       ESP_LOGD(TAG, "Power-fail comparator: %s", pof_voltage);
-      pos = buf_append(buf, size, pos, "|Power-fail comparator: %s", pof_voltage);
+      pos = buf_append_printf(buf, size, pos, "|Power-fail comparator: %s", pof_voltage);
     }
   } else {
     ESP_LOGD(TAG, "Power-fail comparator: disabled");
-    pos = buf_append(buf, size, pos, "|Power-fail comparator: disabled");
+    pos = buf_append_printf(buf, size, pos, "|Power-fail comparator: disabled");
   }
 
   auto package = [](uint32_t value) {

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -11,9 +11,6 @@ from esphome.const import (
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_COUNTER,
     ICON_TIMER,
-    PLATFORM_BK72XX,
-    PLATFORM_LN882X,
-    PLATFORM_RTL87XX,
     UNIT_BYTES,
     UNIT_HERTZ,
     UNIT_MILLISECOND,
@@ -28,7 +25,6 @@ from . import (  # noqa: F401  pylint: disable=unused-import
 
 DEPENDENCIES = ["debug"]
 
-CONF_MIN_FREE = "min_free"
 CONF_PSRAM = "psram"
 
 CONFIG_SCHEMA = {
@@ -46,31 +42,12 @@ CONFIG_SCHEMA = {
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     cv.Optional(CONF_FRAGMENTATION): cv.All(
-        cv.Any(
-            cv.All(
-                cv.only_on_esp8266,
-                cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
-            ),
-            cv.only_on_esp32,
-            msg="This feature is only available on ESP8266 (Arduino 2.5.2+) and ESP32",
-        ),
+        cv.only_on_esp8266,
+        cv.require_framework_version(esp8266_arduino=cv.Version(2, 5, 2)),
         sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
             icon=ICON_COUNTER,
             accuracy_decimals=1,
-            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-        ),
-    ),
-    cv.Optional(CONF_MIN_FREE): cv.All(
-        cv.Any(
-            cv.only_on_esp32,
-            cv.only_on([PLATFORM_BK72XX, PLATFORM_LN882X, PLATFORM_RTL87XX]),
-            msg="This feature is only available on ESP32 and LibreTiny (BK72xx, LN882x, RTL87xx)",
-        ),
-        sensor.sensor_schema(
-            unit_of_measurement=UNIT_BYTES,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
     ),
@@ -115,10 +92,6 @@ async def to_code(config):
     if fragmentation_conf := config.get(CONF_FRAGMENTATION):
         sens = await sensor.new_sensor(fragmentation_conf)
         cg.add(debug_component.set_fragmentation_sensor(sens))
-
-    if min_free_conf := config.get(CONF_MIN_FREE):
-        sens = await sensor.new_sensor(min_free_conf)
-        cg.add(debug_component.set_min_free_sensor(sens))
 
     if loop_time_conf := config.get(CONF_LOOP_TIME):
         sens = await sensor.new_sensor(loop_time_conf)


### PR DESCRIPTION
# What does this implement/fix?

Migrate `debug` component from local `buf_append` helper to shared `buf_append_printf` from `esphome/core/helpers.h` (#13258).

**Changes:**
- Remove duplicate `buf_append`/`buf_append_p` definition from `debug_component.h`
- Rename all usages from `buf_append` to `buf_append_printf` across debug platform files
- No functional changes - just using the shared helper instead of a local copy

This reduces code duplication and allows other components to use the same safe buffer formatting helper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #13258 (merged)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactor)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
