### PR TITLE
[web_server] Skip defer on ESP8266 where callbacks already run in main loop

### DIFF
--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -42,6 +42,14 @@ using ParamNameType = const __FlashStringHelper *;
 using ParamNameType = const char *;
 #endif
 
+// ESP8266 is single-threaded, so actions can execute directly in request context.
+// Multi-core platforms need to defer to main loop thread for thread safety.
+#ifdef USE_ESP8266
+#define DEFER_ACTION(capture, action) action
+#else
+#define DEFER_ACTION(capture, action) this->defer([capture]() mutable { action; })
+#endif
+
 /// Result of matching a URL against an entity
 struct EntityMatchResult {
   bool matched;          ///< True if entity matched the URL


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266, ESPAsyncWebServer callbacks already run in the main loop context (via lwIP polling during `yield()`/`delay()`), so deferring to the main loop is unnecessary overhead. This eliminates scheduler overhead for web server actions on ESP8266.

**Historical context:** The `this->defer()` pattern for action handlers has been part of web_server since its original implementation. At the time, defer was needed for ESP32 where the HTTP server runs on a separate task, but ESP8266 didn't need it since callbacks already execute in the main loop. This distinction was recognized in #12981 when `captive_portal` was optimized with the `#ifdef USE_ESP8266` pattern, which this PR now applies to web_server:

```cpp
#ifdef USE_ESP8266
  // ESP8266 is single-threaded, call directly
  wifi::global_wifi_component->save_wifi_sta(ssid, psk);
#else
  // Defer save to main loop thread to avoid NVS operations from HTTP thread
  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
#endif
```

**Changes:**
- Add `DEFER_ACTION(capture, action)` macro that executes directly on ESP8266, defers on other platforms
- Convert 17 simple defer calls to use the macro (button press, toggle, call.perform(), etc.)
- Extract switch and lock action enums/handlers to static functions to avoid code duplication in the complex cases

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (performance optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
