### PR TITLE
[ntc, resistance] change log level to verbose

### DIFF
--- a/esphome/components/ntc/ntc.cpp
+++ b/esphome/components/ntc/ntc.cpp
@@ -23,7 +23,7 @@ void NTC::process_(float value) {
   double v = this->a_ + this->b_ * lr + this->c_ * lr * lr * lr;
   auto temp = float(1.0 / v - 273.15);
 
-  ESP_LOGD(TAG, "'%s' - Temperature: %.1f°C", this->name_.c_str(), temp);
+  ESP_LOGV(TAG, "'%s' - Temperature: %.1f°C", this->name_.c_str(), temp);
   this->publish_state(temp);
 }
 

--- a/esphome/components/resistance/resistance_sensor.cpp
+++ b/esphome/components/resistance/resistance_sensor.cpp
@@ -39,7 +39,7 @@ void ResistanceSensor::process_(float value) {
   }
 
   res *= this->resistor_;
-  ESP_LOGD(TAG, "'%s' - Resistance %.1fΩ", this->name_.c_str(), res);
+  ESP_LOGV(TAG, "'%s' - Resistance %.1fΩ", this->name_.c_str(), res);
   this->publish_state(res);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Both components have debug log level statement to show the value and then use sensor publish_state which also shows the value with a debug log level statement. The ntc and resistance log level statements are changed to verbose, to reduce duplication of debug information. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
