### PR TITLE
[daikin_arc] Fix undefined behavior in sprintf calls

### DIFF
--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -375,7 +375,6 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
         if (j > 0) {
           ESP_LOGD(TAG, "DATA %04x: %s", (j - 16 > 0xffff ? 0 : j - 16), sbuf);
         }
-        sbuf[0] = '\0';
         sbuf_pos = 0;
       }
       char type_ch = ' ';

--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -258,8 +258,9 @@ bool DaikinArcClimate::parse_state_frame_(const uint8_t frame[]) {
   }
 
   char buf[DAIKIN_STATE_FRAME_SIZE * 3 + 1] = {0};
+  size_t pos = 0;
   for (size_t i = 0; i < DAIKIN_STATE_FRAME_SIZE; i++) {
-    sprintf(buf, "%s%02x ", buf, frame[i]);
+    pos = buf_append_printf(buf, sizeof(buf), pos, "%02x ", frame[i]);
   }
   ESP_LOGD(TAG, "FRAME %s", buf);
 
@@ -349,8 +350,9 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     valid_daikin_frame = true;
     size_t bytes_count = data.size() / 2 / 8;
-    std::unique_ptr<char[]> buf(new char[bytes_count * 3 + 1]);
-    buf[0] = '\0';
+    size_t buf_size = bytes_count * 3 + 1;
+    std::unique_ptr<char[]> buf(new char[buf_size]());  // value-initialize (zero-fill)
+    size_t buf_pos = 0;
     for (size_t i = 0; i < bytes_count; i++) {
       uint8_t byte = 0;
       for (int8_t bit = 0; bit < 8; bit++) {
@@ -361,19 +363,20 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
           break;
         }
       }
-      sprintf(buf.get(), "%s%02x ", buf.get(), byte);
+      buf_pos = buf_append_printf(buf.get(), buf_size, buf_pos, "%02x ", byte);
     }
     ESP_LOGD(TAG, "WHOLE FRAME %s  size: %d", buf.get(), data.size());
   }
   if (!valid_daikin_frame) {
-    char sbuf[16 * 10 + 1];
-    sbuf[0] = '\0';
+    char sbuf[16 * 10 + 1] = {0};
+    size_t sbuf_pos = 0;
     for (size_t j = 0; j < static_cast<size_t>(data.size()); j++) {
       if ((j - 2) % 16 == 0) {
         if (j > 0) {
           ESP_LOGD(TAG, "DATA %04x: %s", (j - 16 > 0xffff ? 0 : j - 16), sbuf);
         }
         sbuf[0] = '\0';
+        sbuf_pos = 0;
       }
       char type_ch = ' ';
       // debug_tolerance = 25%
@@ -401,9 +404,10 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
         type_ch = '0';
 
       if (abs(data[j]) > 100000) {
-        sprintf(sbuf, "%s%-5d[%c] ", sbuf, data[j] > 0 ? 99999 : -99999, type_ch);
+        sbuf_pos = buf_append_printf(sbuf, sizeof(sbuf), sbuf_pos, "%-5d[%c] ", data[j] > 0 ? 99999 : -99999, type_ch);
       } else {
-        sprintf(sbuf, "%s%-5d[%c] ", sbuf, (int) (round(data[j] / 10.) * 10), type_ch);
+        sbuf_pos =
+            buf_append_printf(sbuf, sizeof(sbuf), sbuf_pos, "%-5d[%c] ", (int) (round(data[j] / 10.) * 10), type_ch);
       }
       if (j + 1 == static_cast<size_t>(data.size())) {
         ESP_LOGD(TAG, "DATA %04x: %s", (j - 8 > 0xffff ? 0 : j - 8), sbuf);


### PR DESCRIPTION
# What does this implement/fix?

Fix undefined behavior in daikin_arc where `sprintf` reads and writes the same buffer simultaneously.

The original code used patterns like:
```cpp
sprintf(buf, "%s%02x ", buf, frame[i]);  // UB: buf is both dest and %s source
```

This is undefined behavior per the C standard because the same buffer is passed as both the destination and as an argument to `%s`. The result is unpredictable and could cause memory corruption or incorrect output.

Replaced all 4 occurrences with `buf_append_printf()` which uses proper offset tracking:
```cpp
pos = buf_append_printf(buf, sizeof(buf), pos, "%02x ", frame[i]);
```

**Locations fixed:**
- `parse_state_frame_()`: hex dump of received state frame
- `on_receive()`: hex dump of whole frame during parsing
- `on_receive()`: debug data output (2 locations for value clamping)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (undefined behavior fix discovered during code review)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal fix only
climate:
  - platform: daikin_arc
    name: "Daikin AC"
    transmitter_id: ir_transmitter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
