### PR TITLE
[uptime] Use buf_append_printf for ESP8266 flash optimization

### DIFF
--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -9,17 +9,12 @@ namespace uptime {
 
 static const char *const TAG = "uptime.sensor";
 
-// Clamp position to valid buffer range when snprintf indicates truncation
-static size_t clamp_buffer_pos(size_t pos, size_t buf_size) { return pos < buf_size ? pos : buf_size - 1; }
-
 static void append_unit(char *buf, size_t buf_size, size_t &pos, const char *separator, unsigned value,
                         const char *label) {
   if (pos > 0) {
-    pos += snprintf(buf + pos, buf_size - pos, "%s", separator);
-    pos = clamp_buffer_pos(pos, buf_size);
+    pos = buf_append_printf(buf, buf_size, pos, "%s", separator);
   }
-  pos += snprintf(buf + pos, buf_size - pos, "%u%s", value, label);
-  pos = clamp_buffer_pos(pos, buf_size);
+  pos = buf_append_printf(buf, buf_size, pos, "%u%s", value, label);
 }
 
 void UptimeTextSensor::setup() {


### PR DESCRIPTION
# What does this implement/fix?

Simplify `append_unit` in uptime text sensor by using `buf_append_printf` instead of manual `snprintf` + position clamping.

Benefits:
- **ESP8266 RAM savings**: Format strings (`"%s"`, `"%u%s"`) are moved to flash via automatic `PSTR()` wrapping
- **Code simplification**: Removes `clamp_buffer_pos` helper since `buf_append_printf` already returns the clamped position
- **5 fewer lines of code**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
