### PR TITLE
[gpio] Use buf_append_printf in dump_summary for ESP8266 flash optimization

### DIFF
--- a/esphome/components/ch422g/ch422g.cpp
+++ b/esphome/components/ch422g/ch422g.cpp
@@ -133,7 +133,7 @@ bool CH422GGPIOPin::digital_read() { return this->parent_->digital_read(this->pi
 
 void CH422GGPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value ^ this->inverted_); }
 size_t CH422GGPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "EXIO%u via CH422G", this->pin_);
+  return buf_append_printf(buffer, len, 0, "EXIO%u via CH422G", this->pin_);
 }
 void CH422GGPIOPin::set_flags(gpio::Flags flags) {
   flags_ = flags;

--- a/esphome/components/esp8266/gpio.cpp
+++ b/esphome/components/esp8266/gpio.cpp
@@ -99,7 +99,7 @@ void ESP8266GPIOPin::pin_mode(gpio::Flags flags) {
 }
 
 size_t ESP8266GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "GPIO%u", this->pin_);
+  return buf_append_printf(buffer, len, 0, "GPIO%u", this->pin_);
 }
 
 bool ESP8266GPIOPin::digital_read() {

--- a/esphome/components/max6956/max6956.cpp
+++ b/esphome/components/max6956/max6956.cpp
@@ -162,7 +162,7 @@ void MAX6956GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this-
 bool MAX6956GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void MAX6956GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t MAX6956GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via Max6956", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via Max6956", this->pin_);
 }
 
 }  // namespace max6956

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -100,7 +100,7 @@ void MCP23016GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this
 bool MCP23016GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void MCP23016GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t MCP23016GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via MCP23016", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via MCP23016", this->pin_);
 }
 
 }  // namespace mcp23016

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.cpp
@@ -17,7 +17,7 @@ template<uint8_t N> void MCP23XXXGPIOPin<N>::digital_write(bool value) {
   this->parent_->digital_write(this->pin_, value != this->inverted_);
 }
 template<uint8_t N> size_t MCP23XXXGPIOPin<N>::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via MCP23XXX", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via MCP23XXX", this->pin_);
 }
 
 template class MCP23XXXGPIOPin<8>;

--- a/esphome/components/mpr121/mpr121.cpp
+++ b/esphome/components/mpr121/mpr121.cpp
@@ -154,7 +154,7 @@ void MPR121GPIOPin::digital_write(bool value) {
 }
 
 size_t MPR121GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "ELE%u on MPR121", this->pin_);
+  return buf_append_printf(buffer, len, 0, "ELE%u on MPR121", this->pin_);
 }
 
 }  // namespace mpr121

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -181,7 +181,7 @@ void PCA6416AGPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this
 bool PCA6416AGPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void PCA6416AGPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t PCA6416AGPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via PCA6416A", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via PCA6416A", this->pin_);
 }
 
 }  // namespace pca6416a

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -130,7 +130,7 @@ void PCA9554GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this-
 bool PCA9554GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void PCA9554GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t PCA9554GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via PCA9554", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via PCA9554", this->pin_);
 }
 
 }  // namespace pca9554

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -107,7 +107,7 @@ void PCF8574GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this-
 bool PCF8574GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void PCF8574GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t PCF8574GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via PCF8574", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via PCF8574", this->pin_);
 }
 
 }  // namespace pcf8574

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -165,7 +165,7 @@ void PI4IOE5V6408GPIOPin::digital_write(bool value) {
   this->parent_->digital_write(this->pin_, value != this->inverted_);
 }
 size_t PI4IOE5V6408GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via PI4IOE5V6408", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via PI4IOE5V6408", this->pin_);
 }
 
 }  // namespace pi4ioe5v6408

--- a/esphome/components/sn74hc165/sn74hc165.cpp
+++ b/esphome/components/sn74hc165/sn74hc165.cpp
@@ -65,7 +65,7 @@ float SN74HC165Component::get_setup_priority() const { return setup_priority::IO
 bool SN74HC165GPIOPin::digital_read() { return this->parent_->digital_read_(this->pin_) != this->inverted_; }
 
 size_t SN74HC165GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via SN74HC165", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via SN74HC165", this->pin_);
 }
 
 }  // namespace sn74hc165

--- a/esphome/components/sn74hc595/sn74hc595.cpp
+++ b/esphome/components/sn74hc595/sn74hc595.cpp
@@ -94,7 +94,7 @@ void SN74HC595GPIOPin::digital_write(bool value) {
   this->parent_->digital_write_(this->pin_, value != this->inverted_);
 }
 size_t SN74HC595GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via SN74HC595", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via SN74HC595", this->pin_);
 }
 
 }  // namespace sn74hc595

--- a/esphome/components/sx1509/sx1509_gpio_pin.cpp
+++ b/esphome/components/sx1509/sx1509_gpio_pin.cpp
@@ -13,7 +13,7 @@ void SX1509GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->
 bool SX1509GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void SX1509GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t SX1509GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via sx1509", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via sx1509", this->pin_);
 }
 
 }  // namespace sx1509

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -139,7 +139,7 @@ void TCA9555GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this-
 bool TCA9555GPIOPin::digital_read() { return this->parent_->digital_read(this->pin_) != this->inverted_; }
 void TCA9555GPIOPin::digital_write(bool value) { this->parent_->digital_write(this->pin_, value != this->inverted_); }
 size_t TCA9555GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via TCA9555", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via TCA9555", this->pin_);
 }
 
 }  // namespace tca9555

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -246,7 +246,7 @@ void WeikaiGPIOPin::setup() {
 }
 
 size_t WeikaiGPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via WeiKai %s", this->pin_, this->parent_->get_name());
+  return buf_append_printf(buffer, len, 0, "%u via WeiKai %s", this->pin_, this->parent_->get_name());
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/esphome/components/xl9535/xl9535.cpp
+++ b/esphome/components/xl9535/xl9535.cpp
@@ -111,7 +111,7 @@ void XL9535Component::pin_mode(uint8_t pin, gpio::Flags mode) {
 void XL9535GPIOPin::setup() { this->pin_mode(this->flags_); }
 
 size_t XL9535GPIOPin::dump_summary(char *buffer, size_t len) const {
-  return snprintf(buffer, len, "%u via XL9535", this->pin_);
+  return buf_append_printf(buffer, len, 0, "%u via XL9535", this->pin_);
 }
 
 void XL9535GPIOPin::pin_mode(gpio::Flags flags) { this->parent_->pin_mode(this->pin_, flags); }


### PR DESCRIPTION
# What does this implement/fix?

Use `buf_append_printf` in `dump_summary` functions across ESP8266 GPIO and all GPIO expanders to move format strings to flash on ESP8266.

The `buf_append_printf` helper automatically wraps format strings in `PSTR()` on ESP8266, moving them from RAM to flash. This saves a small amount of RAM per component for devices using GPIO expanders.

**Components updated:**
- esp8266
- ch422g
- max6956
- mcp23016
- mcp23xxx_base
- mpr121
- pca6416a
- pca9554
- pcf8574
- pi4ioe5v6408
- sn74hc165
- sn74hc595
- sx1509
- tca9555
- weikai
- xl9535

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
