### PR TITLE
[homeassistant] Use buf_append_printf for ESP8266 flash optimization

### DIFF
--- a/esphome/components/homeassistant/number/homeassistant_number.cpp
+++ b/esphome/components/homeassistant/number/homeassistant_number.cpp
@@ -97,7 +97,7 @@ void HomeassistantNumber::control(float value) {
   entity_value.key = VALUE_KEY;
   // Stack buffer - no heap allocation; %g produces shortest representation
   char value_buf[16];
-  snprintf(value_buf, sizeof(value_buf), "%g", value);
+  buf_append_printf(value_buf, sizeof(value_buf), 0, "%g", value);
   entity_value.value = StringRef(value_buf);
 
   api::global_api_server->send_homeassistant_action(resp);


### PR DESCRIPTION
# What does this implement/fix?

Use `buf_append_printf` instead of `snprintf` in HomeAssistant number component to move the format string to flash on ESP8266.

The `buf_append_printf` helper automatically wraps format strings in `PSTR()` on ESP8266, moving them from RAM to flash.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
