### PR TITLE
[syslog] Use buf_append_printf for ESP8266 flash optimization

### DIFF
--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -58,10 +58,8 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
   size_t ts_written = now.is_valid() ? now.strftime(packet + offset, remaining, "%b %e %H:%M:%S") : 0;
   if (ts_written > 0) {
     offset += ts_written;
-    remaining -= ts_written;
   } else if (remaining > 0) {
     packet[offset++] = '-';
-    remaining--;
   }
 
   // Write hostname, tag, and message

--- a/esphome/components/syslog/esphome_syslog.cpp
+++ b/esphome/components/syslog/esphome_syslog.cpp
@@ -47,12 +47,11 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
   size_t remaining = sizeof(packet);
 
   // Write PRI - abort if this fails as packet would be malformed
-  int ret = snprintf(packet, remaining, "<%d>", pri);
-  if (ret <= 0 || static_cast<size_t>(ret) >= remaining) {
-    return;
+  offset = buf_append_printf(packet, sizeof(packet), 0, "<%d>", pri);
+  if (offset == 0) {
+    return;  // PRI always produces at least "<0>" (3 chars), so 0 means error
   }
-  offset = ret;
-  remaining -= ret;
+  remaining -= offset;
 
   // Write timestamp directly into packet (RFC 5424: use "-" if time not valid or strftime fails)
   auto now = this->time_->now();
@@ -66,10 +65,11 @@ void Syslog::log_(const int level, const char *tag, const char *message, size_t 
   }
 
   // Write hostname, tag, and message
-  ret = snprintf(packet + offset, remaining, " %s %s: %.*s", App.get_name().c_str(), tag, (int) len, message);
-  if (ret > 0) {
-    // snprintf returns chars that would be written; clamp to actual buffer space
-    offset += std::min(static_cast<size_t>(ret), remaining > 0 ? remaining - 1 : 0);
+  offset = buf_append_printf(packet, sizeof(packet), offset, " %s %s: %.*s", App.get_name().c_str(), tag, (int) len,
+                             message);
+  // Clamp to exclude null terminator position if buffer was filled
+  if (offset >= sizeof(packet)) {
+    offset = sizeof(packet) - 1;
   }
 
   if (offset > 0) {


### PR DESCRIPTION
# What does this implement/fix?

Use `buf_append_printf` instead of `snprintf` in the syslog component to move format strings to flash on ESP8266.

**Changes:**

1. **PRI formatting** - Simplified error check:
   ```cpp
   // Before
   int ret = snprintf(packet, remaining, "<%d>", pri);
   if (ret <= 0 || static_cast<size_t>(ret) >= remaining) {
     return;
   }
   offset = ret;

   // After
   offset = buf_append_printf(packet, sizeof(packet), 0, "<%d>", pri);
   if (offset == 0) {
     return;  // PRI always produces at least "<0>" (3 chars), so 0 means error
   }
   ```

2. **Hostname/tag/message formatting** - Removed manual clamping logic:
   ```cpp
   // Before (4 lines)
   ret = snprintf(packet + offset, remaining, " %s %s: %.*s", ...);
   if (ret > 0) {
     offset += std::min(static_cast<size_t>(ret), remaining > 0 ? remaining - 1 : 0);
   }

   // After (2 lines)
   offset = buf_append_printf(packet, sizeof(packet), offset, " %s %s: %.*s", ...);
   if (offset >= sizeof(packet)) {
     offset = sizeof(packet) - 1;  // Exclude null terminator from send length
   }
   ```

The truncation clamp ensures the send length excludes the null terminator position, matching the original behavior exactly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
