### PR TITLE
[uart] Replace unsafe sprintf with buf_append_printf in debugger

### DIFF
--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -166,11 +166,13 @@ void UARTDebug::log_int(UARTDirection direction, std::vector<uint8_t> bytes, uin
   } else {
     res += ">>> ";
   }
+  char buf[4];  // max 3 digits for uint8_t (255) + null
   for (size_t i = 0; i < len; i++) {
     if (i > 0) {
       res += separator;
     }
-    res += to_string(bytes[i]);
+    buf_append_printf(buf, sizeof(buf), 0, "%u", bytes[i]);
+    res += buf;
   }
   ESP_LOGD(TAG, "%s", res.c_str());
   delay(10);

--- a/esphome/components/uart/uart_debugger.cpp
+++ b/esphome/components/uart/uart_debugger.cpp
@@ -107,7 +107,7 @@ void UARTDebug::log_hex(UARTDirection direction, std::vector<uint8_t> bytes, uin
     if (i > 0) {
       res += separator;
     }
-    sprintf(buf, "%02X", bytes[i]);
+    buf_append_printf(buf, sizeof(buf), 0, "%02X", bytes[i]);
     res += buf;
   }
   ESP_LOGD(TAG, "%s", res.c_str());
@@ -147,7 +147,7 @@ void UARTDebug::log_string(UARTDirection direction, std::vector<uint8_t> bytes) 
     } else if (bytes[i] == 92) {
       res += "\\\\";
     } else if (bytes[i] < 32 || bytes[i] > 127) {
-      sprintf(buf, "\\x%02X", bytes[i]);
+      buf_append_printf(buf, sizeof(buf), 0, "\\x%02X", bytes[i]);
       res += buf;
     } else {
       res += bytes[i];
@@ -189,7 +189,7 @@ void UARTDebug::log_binary(UARTDirection direction, std::vector<uint8_t> bytes, 
     if (i > 0) {
       res += separator;
     }
-    sprintf(buf, "0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", BYTE_TO_BINARY(bytes[i]), bytes[i]);
+    buf_append_printf(buf, sizeof(buf), 0, "0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", BYTE_TO_BINARY(bytes[i]), bytes[i]);
     res += buf;
   }
   ESP_LOGD(TAG, "%s", res.c_str());


### PR DESCRIPTION
# What does this implement/fix?

Replace unsafe `sprintf` and heap-allocating `to_string()` with `buf_append_printf` in UART debugger logging functions.

- `sprintf` is unsafe - no buffer bounds checking, can cause buffer overflows
- `to_string()` allocates heap memory - causes fragmentation on long-running devices

**Changes:**

1. `log_hex()`: Convert `sprintf(buf, "%02X", ...)` to `buf_append_printf`
2. `log_string()`: Convert `sprintf(buf, "\\x%02X", ...)` to `buf_append_printf`
3. `log_binary()`: Convert `sprintf(buf, "0b" BYTE_TO_BINARY_PATTERN " (0x%02X)", ...)` to `buf_append_printf`
4. `log_int()`: Replace `to_string(bytes[i])` with `buf_append_printf` and 4-byte stack buffer (max 3 digits for uint8_t)

**Benefits:**
- **Safety**: `buf_append_printf` takes buffer size and prevents overflow
- **No heap allocation**: Stack buffers eliminate heap fragmentation from `to_string()`
- **ESP8266 flash optimization**: Automatically wraps format strings in `PSTR()` on ESP8266, moving them from RAM to flash
- **Consistency**: Part of codebase-wide effort to eliminate unsafe `sprintf` and heap-allocating `to_string()`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 9600
  debug:
    direction: BOTH
    dummy_receiver: true
    after:
      delimiter: "\n"
    sequence:
      - lambda: UARTDebug::log_hex(direction, bytes, ' ');
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
