### PR TITLE
[hmac_sha256] Replace unsafe sprintf with format_hex_to

### DIFF
--- a/esphome/components/hmac_sha256/hmac_sha256.cpp
+++ b/esphome/components/hmac_sha256/hmac_sha256.cpp
@@ -24,7 +24,9 @@ void HmacSHA256::calculate() { mbedtls_md_hmac_finish(&this->ctx_, this->digest_
 
 void HmacSHA256::get_bytes(uint8_t *output) { memcpy(output, this->digest_, SHA256_DIGEST_SIZE); }
 
-void HmacSHA256::get_hex(char *output) { format_hex_to(output, this->digest_, SHA256_DIGEST_SIZE); }
+void HmacSHA256::get_hex(char *output) {
+  format_hex_to(output, SHA256_DIGEST_SIZE * 2 + 1, this->digest_, SHA256_DIGEST_SIZE);
+}
 
 bool HmacSHA256::equals_bytes(const uint8_t *expected) {
   return memcmp(this->digest_, expected, SHA256_DIGEST_SIZE) == 0;

--- a/esphome/components/hmac_sha256/hmac_sha256.cpp
+++ b/esphome/components/hmac_sha256/hmac_sha256.cpp
@@ -1,4 +1,3 @@
-#include <cstdio>
 #include <cstring>
 #include "hmac_sha256.h"
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_HOST)
@@ -25,11 +24,7 @@ void HmacSHA256::calculate() { mbedtls_md_hmac_finish(&this->ctx_, this->digest_
 
 void HmacSHA256::get_bytes(uint8_t *output) { memcpy(output, this->digest_, SHA256_DIGEST_SIZE); }
 
-void HmacSHA256::get_hex(char *output) {
-  for (size_t i = 0; i < SHA256_DIGEST_SIZE; i++) {
-    sprintf(output + (i * 2), "%02x", this->digest_[i]);
-  }
-}
+void HmacSHA256::get_hex(char *output) { format_hex_to(output, this->digest_, SHA256_DIGEST_SIZE); }
 
 bool HmacSHA256::equals_bytes(const uint8_t *expected) {
   return memcmp(this->digest_, expected, SHA256_DIGEST_SIZE) == 0;


### PR DESCRIPTION
# What does this implement/fix?

Replace unsafe `sprintf` with `format_hex_to` in HMAC-SHA256 component.

This was missed during code review of the new hmac_sha256 component. The original code used `sprintf` in a loop to format each digest byte as hex:

```cpp
// Before: 32 sprintf calls, unsafe
for (size_t i = 0; i < SHA256_DIGEST_SIZE; i++) {
  sprintf(output + (i * 2), "%02x", this->digest_[i]);
}

// After: single call to existing helper
format_hex_to(output, SHA256_DIGEST_SIZE * 2 + 1, this->digest_, SHA256_DIGEST_SIZE);
```

**Changes:**
- Replace sprintf loop with single `format_hex_to` call
- Remove unused `#include <cstdio>`

**Benefits:**
- **Safety**: Eliminates unsafe `sprintf` (no buffer bounds checking)
- **Efficiency**: 1 function call instead of 32
- **Code reuse**: Uses existing `format_hex_to` helper from `esphome/core/helpers.h`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
