### PR TITLE
[rc522_spi] Replace unsafe sprintf with buf_append_printf

### DIFF
--- a/esphome/components/rc522_spi/rc522_spi.cpp
+++ b/esphome/components/rc522_spi/rc522_spi.cpp
@@ -1,4 +1,5 @@
 #include "rc522_spi.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 // Based on:
@@ -70,7 +71,7 @@ void RC522Spi::pcd_read_register(PcdRegister reg,  ///< The register to read fro
     index++;
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-    sprintf(cstrb, " %x", values[0]);
+    buf_append_printf(cstrb, sizeof(cstrb), 0, " %x", values[0]);
     buf.append(cstrb);
 #endif
   }
@@ -78,7 +79,7 @@ void RC522Spi::pcd_read_register(PcdRegister reg,  ///< The register to read fro
     values[index] = transfer_byte(address);  // Read value and tell that we want to read the same address again.
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-    sprintf(cstrb, " %x", values[index]);
+    buf_append_printf(cstrb, sizeof(cstrb), 0, " %x", values[index]);
     buf.append(cstrb);
 #endif
 
@@ -88,7 +89,7 @@ void RC522Spi::pcd_read_register(PcdRegister reg,  ///< The register to read fro
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
   buf = buf + " ";
-  sprintf(cstrb, "%x", values[index]);
+  buf_append_printf(cstrb, sizeof(cstrb), 0, "%x", values[index]);
   buf.append(cstrb);
 
   ESP_LOGVV(TAG, "read_register_array_(%x, %d, , %d) -> %s", reg, count, rx_align, buf.c_str());
@@ -127,7 +128,7 @@ void RC522Spi::pcd_write_register(PcdRegister reg,  ///< The register to write t
     transfer_byte(values[index]);
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
-    sprintf(cstrb, " %x", values[index]);
+    buf_append_printf(cstrb, sizeof(cstrb), 0, " %x", values[index]);
     buf.append(cstrb);
 #endif
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace unsafe `sprintf` with `buf_append_printf` in RC522 SPI debug logging.

`sprintf` is unsafe because it has no buffer bounds checking and can cause buffer overflows. This PR eliminates all 4 `sprintf` calls in the rc522_spi component.

**Changes:**
- Add `#include "esphome/core/helpers.h"`
- Convert 4 `sprintf` calls to `buf_append_printf` with proper buffer size

All calls are in `#ifdef ESPHOME_LOG_HAS_VERY_VERBOSE` debug blocks for register read/write tracing.

**Benefits:**
- **Safety**: `buf_append_printf` takes buffer size and prevents overflow
- **ESP8266 flash optimization**: Automatically wraps format strings in `PSTR()` on ESP8266, moving them from RAM to flash
- **Consistency**: Part of codebase-wide effort to eliminate unsafe `sprintf`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
