### PR TITLE
[tuya] Replace unsafe sprintf with snprintf in light color formatting

### DIFF
--- a/esphome/components/tuya/light/tuya_light.cpp
+++ b/esphome/components/tuya/light/tuya_light.cpp
@@ -191,7 +191,7 @@ void TuyaLight::write_state(light::LightState *state) {
       case TuyaColorType::RGB: {
         char buffer[7];
         const char *format_str = this->color_type_lowercase_ ? "%02x%02x%02x" : "%02X%02X%02X";
-        sprintf(buffer, format_str, int(red * 255), int(green * 255), int(blue * 255));
+        snprintf(buffer, sizeof(buffer), format_str, int(red * 255), int(green * 255), int(blue * 255));
         color_value = buffer;
         break;
       }
@@ -201,7 +201,7 @@ void TuyaLight::write_state(light::LightState *state) {
         rgb_to_hsv(red, green, blue, hue, saturation, value);
         char buffer[13];
         const char *format_str = this->color_type_lowercase_ ? "%04x%04x%04x" : "%04X%04X%04X";
-        sprintf(buffer, format_str, hue, int(saturation * 1000), int(value * 1000));
+        snprintf(buffer, sizeof(buffer), format_str, hue, int(saturation * 1000), int(value * 1000));
         color_value = buffer;
         break;
       }
@@ -211,8 +211,8 @@ void TuyaLight::write_state(light::LightState *state) {
         rgb_to_hsv(red, green, blue, hue, saturation, value);
         char buffer[15];
         const char *format_str = this->color_type_lowercase_ ? "%02x%02x%02x%04x%02x%02x" : "%02X%02X%02X%04X%02X%02X";
-        sprintf(buffer, format_str, int(red * 255), int(green * 255), int(blue * 255), hue, int(saturation * 255),
-                int(value * 255));
+        snprintf(buffer, sizeof(buffer), format_str, int(red * 255), int(green * 255), int(blue * 255), hue,
+                 int(saturation * 255), int(value * 255));
         color_value = buffer;
         break;
       }


### PR DESCRIPTION
# What does this implement/fix?

Replace unsafe `sprintf` with `snprintf` in Tuya light color formatting.

`sprintf` is unsafe because it has no buffer bounds checking and can cause buffer overflows. This PR eliminates all 3 `sprintf` calls in the tuya light component.

**Changes:**
- RGB format: `sprintf` → `snprintf(buffer, sizeof(buffer), ...)` (7-byte buffer)
- HSV format: `sprintf` → `snprintf(buffer, sizeof(buffer), ...)` (13-byte buffer)
- RGBHSV format: `sprintf` → `snprintf(buffer, sizeof(buffer), ...)` (15-byte buffer)

**Note:** These use runtime format string selection (lowercase/uppercase hex), so `buf_append_printf` with PSTR() optimization isn't applicable. `snprintf` provides the buffer safety.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
