### PR TITLE
[nextion] Replace to_string with stack buffer and fix unsafe sprintf

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1,6 +1,7 @@
 #include "nextion.h"
 #include <cinttypes>
 #include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
@@ -1283,8 +1284,9 @@ void Nextion::check_pending_waveform_() {
   size_t buffer_to_send = component->get_wave_buffer_size() < 255 ? component->get_wave_buffer_size()
                                                                   : 255;  // ADDT command can only send 255
 
-  std::string command = "addt " + to_string(component->get_component_id()) + "," +
-                        to_string(component->get_wave_channel_id()) + "," + to_string(buffer_to_send);
+  char command[24];  // "addt " + uint8 + "," + uint8 + "," + uint8 + null = max 17 chars
+  buf_append_printf(command, sizeof(command), 0, "addt %u,%u,%zu", component->get_component_id(),
+                    component->get_wave_channel_id(), buffer_to_send);
   if (!this->send_command_(command)) {
     delete nb;  // NOLINT(cppcoreguidelines-owning-memory)
     this->waveform_queue_.pop_front();

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -34,7 +34,7 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
   }
 
   char range_header[32];
-  sprintf(range_header, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
+  buf_append_printf(range_header, sizeof(range_header), 0, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
   ESP_LOGV(TAG, "Range: %s", range_header);
   http_client.addHeader("Range", range_header);
   int code = http_client.GET();

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -36,7 +36,7 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
   }
 
   char range_header[32];
-  sprintf(range_header, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
+  buf_append_printf(range_header, sizeof(range_header), 0, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
   ESP_LOGV(TAG, "Range: %s", range_header);
   esp_http_client_set_header(http_client, "Range", range_header);
   ESP_LOGV(TAG, "Open HTTP");


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `to_string()` and unsafe `sprintf` with stack buffers in Nextion component.

## Changes

### nextion.cpp - `to_string()` removal

The original code used 3 `to_string()` calls + multiple string concatenations to build the "addt" command:
```cpp
std::string command = "addt " + to_string(component->get_component_id()) + "," +
                      to_string(component->get_wave_channel_id()) + "," + to_string(buffer_to_send);
```

**Changes:**
- Add `#include "esphome/core/helpers.h"`
- Replace with single `buf_append_printf` call into 24-byte stack buffer

**Buffer size calculation:**
- "addt " = 5 chars
- component_id (uint8_t, max 255) = 3 chars
- "," = 1 char
- wave_channel_id (uint8_t, max 255) = 3 chars
- "," = 1 char
- buffer_to_send (max 255) = 3 chars
- null = 1 char
- Total: 17 chars, using 24 for safety margin

### nextion_upload_esp32.cpp & nextion_upload_arduino.cpp - `sprintf` removal

Replaced unsafe `sprintf` with `buf_append_printf`:
```cpp
// Before
sprintf(range_header, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);

// After
buf_append_printf(range_header, sizeof(range_header), 0, "bytes=%" PRIu32 "-%" PRIu32, range_start, range_end);
```

## Benefits

- **No heap allocation**: Eliminates 3 `to_string()` heap allocations + string concatenations
- **Safety**: `buf_append_printf` takes buffer size and prevents overflow (unlike `sprintf`)
- **ESP8266 flash optimization**: `buf_append_printf` automatically uses PROGMEM for format strings
- **Simpler code**: Single format string vs multiple concatenations

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
