### PR TITLE
[toshiba] Replace to_string with stack buffer in debug logging

### DIFF
--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -1,5 +1,6 @@
 #include "toshiba.h"
 #include "esphome/components/remote_base/toshiba_ac_protocol.h"
+#include "esphome/core/helpers.h"
 
 #include <vector>
 
@@ -428,8 +429,13 @@ void ToshibaClimate::setup() {
   if (std::isnan(this->target_temperature))
     this->target_temperature = 24;
   // Log final state for debugging HA errors
-  ESP_LOGV(TAG, "Setup complete - Mode: %d, Fan: %s, Swing: %d, Temp: %.1f", static_cast<int>(this->mode),
-           this->fan_mode.has_value() ? std::to_string(static_cast<int>(this->fan_mode.value())).c_str() : "NONE",
+  const char *fan_mode_str = "NONE";
+  char fan_mode_buf[4];  // max 3 digits for fan mode enum + null
+  if (this->fan_mode.has_value()) {
+    buf_append_printf(fan_mode_buf, sizeof(fan_mode_buf), 0, "%d", static_cast<int>(this->fan_mode.value()));
+    fan_mode_str = fan_mode_buf;
+  }
+  ESP_LOGV(TAG, "Setup complete - Mode: %d, Fan: %s, Swing: %d, Temp: %.1f", static_cast<int>(this->mode), fan_mode_str,
            static_cast<int>(this->swing_mode), this->target_temperature);
 }
 

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -428,6 +428,7 @@ void ToshibaClimate::setup() {
   // Never send nan to HA
   if (std::isnan(this->target_temperature))
     this->target_temperature = 24;
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   // Log final state for debugging HA errors
   const char *fan_mode_str = "NONE";
   char fan_mode_buf[4];  // max 3 digits for fan mode enum + null
@@ -437,6 +438,7 @@ void ToshibaClimate::setup() {
   }
   ESP_LOGV(TAG, "Setup complete - Mode: %d, Fan: %s, Swing: %d, Temp: %.1f", static_cast<int>(this->mode), fan_mode_str,
            static_cast<int>(this->swing_mode), this->target_temperature);
+#endif
 }
 
 void ToshibaClimate::transmit_state() {


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `std::to_string()` with stack buffer in Toshiba climate debug logging.

**Before:**
```cpp
ESP_LOGV(TAG, "Setup complete - Mode: %d, Fan: %s, Swing: %d, Temp: %.1f", static_cast<int>(this->mode),
         this->fan_mode.has_value() ? std::to_string(static_cast<int>(this->fan_mode.value())).c_str() : "NONE",
         static_cast<int>(this->swing_mode), this->target_temperature);
```

**After:**
```cpp
const char *fan_mode_str = "NONE";
char fan_mode_buf[4];  // max 3 digits for fan mode enum + null
if (this->fan_mode.has_value()) {
  buf_append_printf(fan_mode_buf, sizeof(fan_mode_buf), 0, "%d", static_cast<int>(this->fan_mode.value()));
  fan_mode_str = fan_mode_buf;
}
ESP_LOGV(TAG, "Setup complete - Mode: %d, Fan: %s, Swing: %d, Temp: %.1f", static_cast<int>(this->mode),
         fan_mode_str, static_cast<int>(this->swing_mode), this->target_temperature);
```

**Benefits:**
- **No heap allocation**: Eliminates `std::to_string()` heap allocation
- **ESP8266 flash optimization**: `buf_append_printf` automatically uses PROGMEM for format strings on ESP8266
- **Buffer size**: 4 bytes (fan mode enum is small int, max 3 digits + null)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
