### PR TITLE
[mapping] Use stack buffers for numeric key error logging

### DIFF
--- a/esphome/components/mapping/mapping.h
+++ b/esphome/components/mapping/mapping.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 #include <map>
 #include <string>
 
@@ -43,7 +44,20 @@ template<typename K, typename V> class Mapping {
       esph_log_e(TAG, "Key '%p' not found in mapping", key);
     } else if constexpr (std::is_same_v<K, std::string>) {
       esph_log_e(TAG, "Key '%s' not found in mapping", key.c_str());
+    } else if constexpr (std::is_integral_v<K>) {
+      char buf[24];  // enough for int64_t
+      buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
+      esph_log_e(TAG, "Key '%s' not found in mapping", buf);
+    } else if constexpr (std::is_floating_point_v<K>) {
+      char buf[24];
+      buf_append_printf(buf, sizeof(buf), 0, "%g", static_cast<double>(key));
+      esph_log_e(TAG, "Key '%s' not found in mapping", buf);
+    } else if constexpr (std::is_enum_v<K>) {
+      char buf[24];  // enough for underlying integral type
+      buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
+      esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else {
+      // Fallback for custom types - likely unreachable but kept for compatibility
       esph_log_e(TAG, "Key '%s' not found in mapping", to_string(key).c_str());
     }
     return {};

--- a/esphome/components/mapping/mapping.h
+++ b/esphome/components/mapping/mapping.h
@@ -52,10 +52,6 @@ template<typename K, typename V> class Mapping {
         buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
       }
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
-    } else if constexpr (std::is_floating_point_v<K>) {
-      char buf[32];  // enough for %g with doubles
-      buf_append_printf(buf, sizeof(buf), 0, "%g", static_cast<double>(key));
-      esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else {
       // All supported key types are handled above - this should never be reached
       static_assert(sizeof(K) == 0, "Unsupported key type for Mapping error logging");

--- a/esphome/components/mapping/mapping.h
+++ b/esphome/components/mapping/mapping.h
@@ -66,8 +66,8 @@ template<typename K, typename V> class Mapping {
       }
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else {
-      // Fallback for custom types - likely unreachable but kept for compatibility
-      esph_log_e(TAG, "Key '%s' not found in mapping", to_string(key).c_str());
+      // All supported key types are handled above - this should never be reached
+      static_assert(sizeof(K) == 0, "Unsupported key type for Mapping error logging");
     }
     return {};
   }

--- a/esphome/components/mapping/mapping.h
+++ b/esphome/components/mapping/mapping.h
@@ -45,16 +45,25 @@ template<typename K, typename V> class Mapping {
     } else if constexpr (std::is_same_v<K, std::string>) {
       esph_log_e(TAG, "Key '%s' not found in mapping", key.c_str());
     } else if constexpr (std::is_integral_v<K>) {
-      char buf[24];  // enough for int64_t
-      buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
+      char buf[24];  // enough for 64-bit integer
+      if constexpr (std::is_unsigned_v<K>) {
+        buf_append_printf(buf, sizeof(buf), 0, "%" PRIu64, static_cast<uint64_t>(key));
+      } else {
+        buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
+      }
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else if constexpr (std::is_floating_point_v<K>) {
-      char buf[24];
+      char buf[32];  // enough for %g with doubles
       buf_append_printf(buf, sizeof(buf), 0, "%g", static_cast<double>(key));
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else if constexpr (std::is_enum_v<K>) {
+      using underlying_t = std::underlying_type_t<K>;
       char buf[24];  // enough for underlying integral type
-      buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
+      if constexpr (std::is_unsigned_v<underlying_t>) {
+        buf_append_printf(buf, sizeof(buf), 0, "%" PRIu64, static_cast<uint64_t>(static_cast<underlying_t>(key)));
+      } else {
+        buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(static_cast<underlying_t>(key)));
+      }
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else {
       // Fallback for custom types - likely unreachable but kept for compatibility

--- a/esphome/components/mapping/mapping.h
+++ b/esphome/components/mapping/mapping.h
@@ -56,15 +56,6 @@ template<typename K, typename V> class Mapping {
       char buf[32];  // enough for %g with doubles
       buf_append_printf(buf, sizeof(buf), 0, "%g", static_cast<double>(key));
       esph_log_e(TAG, "Key '%s' not found in mapping", buf);
-    } else if constexpr (std::is_enum_v<K>) {
-      using underlying_t = std::underlying_type_t<K>;
-      char buf[24];  // enough for underlying integral type
-      if constexpr (std::is_unsigned_v<underlying_t>) {
-        buf_append_printf(buf, sizeof(buf), 0, "%" PRIu64, static_cast<uint64_t>(static_cast<underlying_t>(key)));
-      } else {
-        buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(static_cast<underlying_t>(key)));
-      }
-      esph_log_e(TAG, "Key '%s' not found in mapping", buf);
     } else {
       // All supported key types are handled above - this should never be reached
       static_assert(sizeof(K) == 0, "Unsupported key type for Mapping error logging");


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocating `to_string()` with stack buffers for numeric key types in mapping component error logging.

**Before:**
```cpp
} else {
  esph_log_e(TAG, "Key '%s' not found in mapping", to_string(key).c_str());
}
```

**After:**
```cpp
} else if constexpr (std::is_integral_v<K>) {
  char buf[24];  // enough for 64-bit integer
  if constexpr (std::is_unsigned_v<K>) {
    buf_append_printf(buf, sizeof(buf), 0, "%" PRIu64, static_cast<uint64_t>(key));
  } else {
    buf_append_printf(buf, sizeof(buf), 0, "%" PRId64, static_cast<int64_t>(key));
  }
  esph_log_e(TAG, "Key '%s' not found in mapping", buf);
} else {
  // All supported key types are handled above
  static_assert(sizeof(K) == 0, "Unsupported key type for Mapping error logging");
}
```

**Changes:**
- Added `if constexpr` branch for integral types with signed/unsigned handling (`PRId64`/`PRIu64`)
- Uses `buf_append_printf()` for ESP8266 PROGMEM optimization
- Replaced `to_string()` fallback with `static_assert` to ensure unsupported types fail at compile time
- Added `#include <cinttypes>` for `PRId64`/`PRIu64` macros

**Buffer size:**
- 24 bytes for integral types (enough for int64_t/uint64_t: 20 digits + sign + null)

Note: The mapping component only supports `int` and `std::string` key types, so only the integral and string branches are instantiated.

**Benefits:**
- **No heap allocation** for common numeric key types (int, float, etc.)
- **Compile-time dispatch** via `if constexpr` - no runtime overhead
- **ESP8266 optimized** - format strings in flash via `buf_append_printf`

Note: This is an error path (key not found), so performance isn't critical, but avoiding heap allocation prevents fragmentation on long-running devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
