### PR TITLE
[ccs811] Use buf_append_printf for buffer safety and ESP8266 flash optimization

### DIFF
--- a/esphome/components/ccs811/ccs811.cpp
+++ b/esphome/components/ccs811/ccs811.cpp
@@ -81,8 +81,8 @@ void CCS811Component::setup() {
            bootloader_version, application_version);
   if (this->version_ != nullptr) {
     char version[20];  // "15.15.15 (0xffff)" is 17 chars, plus NUL, plus wiggle room
-    sprintf(version, "%d.%d.%d (0x%02x)", (application_version >> 12 & 15), (application_version >> 8 & 15),
-            (application_version >> 4 & 15), application_version);
+    buf_append_printf(version, sizeof(version), 0, "%d.%d.%d (0x%02x)", (application_version >> 12 & 15),
+                      (application_version >> 8 & 15), (application_version >> 4 & 15), application_version);
     ESP_LOGD(TAG, "publishing version state: %s", version);
     this->version_->publish_state(version);
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace `sprintf` with `buf_append_printf` for buffer safety and ESP8266 flash optimization.

**Before:**
```cpp
sprintf(version, "%d.%d.%d (0x%02x)", (application_version >> 12 & 15), (application_version >> 8 & 15),
        (application_version >> 4 & 15), application_version);
```

**After:**
```cpp
buf_append_printf(version, sizeof(version), 0, "%d.%d.%d (0x%02x)", (application_version >> 12 & 15),
                  (application_version >> 8 & 15), (application_version >> 4 & 15), application_version);
```

**Benefits:**
- **Buffer safety:** Prevents potential buffer overflow with explicit size parameter
- **ESP8266 optimization:** Format string stored in flash (PROGMEM) instead of RAM

Buffer is already properly sized (20 bytes for max "15.15.15 (0xffff)" = 17 chars + null).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
