### PR TITLE
[dfrobot_sen0395][pipsolar][sim800l][wl_134] Replace sprintf with snprintf/buf_append_printf

### DIFF
--- a/esphome/components/dfrobot_sen0395/commands.h
+++ b/esphome/components/dfrobot_sen0395/commands.h
@@ -75,8 +75,8 @@ class SetLatencyCommand : public Command {
 class SensorCfgStartCommand : public Command {
  public:
   SensorCfgStartCommand(bool startup_mode) : startup_mode_(startup_mode) {
-    char tmp_cmd[20] = {0};
-    sprintf(tmp_cmd, "sensorCfgStart %d", startup_mode);
+    char tmp_cmd[20];  // "sensorCfgStart " (15) + "0/1" (1) + null = 17
+    buf_append_printf(tmp_cmd, sizeof(tmp_cmd), 0, "sensorCfgStart %d", startup_mode);
     cmd_ = std::string(tmp_cmd);
   }
   uint8_t on_message(std::string &message) override;
@@ -142,8 +142,8 @@ class SensitivityCommand : public Command {
   SensitivityCommand(uint8_t sensitivity) : sensitivity_(sensitivity) {
     if (sensitivity > 9)
       sensitivity_ = sensitivity = 9;
-    char tmp_cmd[20] = {0};
-    sprintf(tmp_cmd, "setSensitivity %d", sensitivity);
+    char tmp_cmd[20];  // "setSensitivity " (15) + "0-9" (1) + null = 17
+    buf_append_printf(tmp_cmd, sizeof(tmp_cmd), 0, "setSensitivity %d", sensitivity);
     cmd_ = std::string(tmp_cmd);
   };
   uint8_t on_message(std::string &message) override;

--- a/esphome/components/pipsolar/output/pipsolar_output.cpp
+++ b/esphome/components/pipsolar/output/pipsolar_output.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "pipsolar.output";
 
 void PipsolarOutput::write_state(float state) {
   char tmp[10];
-  sprintf(tmp, this->set_command_.c_str(), state);
+  snprintf(tmp, sizeof(tmp), this->set_command_.c_str(), state);
 
   if (std::find(this->possible_values_.begin(), this->possible_values_.end(), state) != this->possible_values_.end()) {
     ESP_LOGD(TAG, "Will write: %s out of value %f / %02.0f", tmp, state, state);

--- a/esphome/components/pipsolar/output/pipsolar_output.cpp
+++ b/esphome/components/pipsolar/output/pipsolar_output.cpp
@@ -8,7 +8,7 @@ namespace pipsolar {
 static const char *const TAG = "pipsolar.output";
 
 void PipsolarOutput::write_state(float state) {
-  char tmp[10];
+  char tmp[16];
   snprintf(tmp, sizeof(tmp), this->set_command_.c_str(), state);
 
   if (std::find(this->possible_values_.begin(), this->possible_values_.end(), state) != this->possible_values_.end()) {

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -1,4 +1,5 @@
 #include "sim800l.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <cstring>
 
@@ -50,8 +51,8 @@ void Sim800LComponent::update() {
   } else if (state_ == STATE_RECEIVED_SMS) {
     // Serial Buffer should have flushed.
     // Send cmd to delete received sms
-    char delete_cmd[20];
-    sprintf(delete_cmd, "AT+CMGD=%d", this->parse_index_);
+    char delete_cmd[20];  // "AT+CMGD=" (8) + int (max 11) + null = 20
+    buf_append_printf(delete_cmd, sizeof(delete_cmd), 0, "AT+CMGD=%d", this->parse_index_);
     this->send_cmd_(delete_cmd);
     this->state_ = STATE_CHECK_SMS;
     this->expect_ack_ = true;

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -51,7 +51,7 @@ void Sim800LComponent::update() {
   } else if (state_ == STATE_RECEIVED_SMS) {
     // Serial Buffer should have flushed.
     // Send cmd to delete received sms
-    char delete_cmd[20];  // "AT+CMGD=" (8) + int (max 11) + null = 20
+    char delete_cmd[20];  // "AT+CMGD=" (8) + uint8_t (max 3) + null = 12 <= 20
     buf_append_printf(delete_cmd, sizeof(delete_cmd), 0, "AT+CMGD=%d", this->parse_index_);
     this->send_cmd_(delete_cmd);
     this->state_ = STATE_CHECK_SMS;

--- a/esphome/components/wl_134/wl_134.cpp
+++ b/esphome/components/wl_134/wl_134.cpp
@@ -1,4 +1,5 @@
 #include "wl_134.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #include <cinttypes>
@@ -78,8 +79,8 @@ Wl134Component::Rfid134Error Wl134Component::read_packet_() {
            reading.id, reading.country, reading.isData ? "true" : "false", reading.isAnimal ? "true" : "false",
            reading.reserved0, reading.reserved1);
 
-  char buf[20];
-  sprintf(buf, "%03d%012lld", reading.country, reading.id);
+  char buf[20];  // "%03d" (3) + "%012" PRId64 (12) + null = 16 max
+  buf_append_printf(buf, sizeof(buf), 0, "%03d%012" PRId64, reading.country, reading.id);
   this->publish_state(buf);
   if (this->do_reset_) {
     this->set_timeout(1000, [this]() { this->publish_state(""); });


### PR DESCRIPTION
# What does this implement/fix?

Replace unsafe `sprintf` with `snprintf`/`buf_append_printf` across multiple components for buffer safety and ESP8266 flash optimization.

**Components updated:**

| Component | Change | Benefit |
|-----------|--------|---------|
| dfrobot_sen0395 | `sprintf` → `buf_append_printf` (2 locations) | Buffer safety + ESP8266 PROGMEM |
| pipsolar | `sprintf` → `snprintf` | Buffer safety (runtime format string) |
| sim800l | `sprintf` → `buf_append_printf` | Buffer safety + ESP8266 PROGMEM |
| wl_134 | `sprintf` → `buf_append_printf`, `%lld` → `PRId64` | Buffer safety + ESP8266 PROGMEM + portability |

**Example change (sim800l):**
```cpp
// Before
sprintf(delete_cmd, "AT+CMGD=%d", this->parse_index_);

// After
buf_append_printf(delete_cmd, sizeof(delete_cmd), 0, "AT+CMGD=%d", this->parse_index_);
```

**Benefits:**
- **Buffer safety:** Explicit size parameter prevents potential buffer overflows
- **ESP8266 optimization:** `buf_append_printf` stores format strings in flash (PROGMEM) instead of RAM
- **Portability:** wl_134 now uses `PRId64` instead of `%lld` for 64-bit integers

**Note:** pipsolar uses `snprintf` instead of `buf_append_printf` because it has a runtime format string (`this->set_command_.c_str()`), which can't use the PSTR() optimization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
