### PR TITLE
[anova] Replace sprintf with bounds-checked alternatives

### DIFF
--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -18,31 +18,31 @@ AnovaPacket *AnovaCodec::clean_packet_() {
 
 AnovaPacket *AnovaCodec::get_read_device_status_request() {
   this->current_query_ = READ_DEVICE_STATUS;
-  sprintf((char *) this->packet_.data, "%s", CMD_READ_DEVICE_STATUS);
+  strncpy((char *) this->packet_.data, CMD_READ_DEVICE_STATUS, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_target_temp_request() {
   this->current_query_ = READ_TARGET_TEMPERATURE;
-  sprintf((char *) this->packet_.data, "%s", CMD_READ_TARGET_TEMP);
+  strncpy((char *) this->packet_.data, CMD_READ_TARGET_TEMP, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_current_temp_request() {
   this->current_query_ = READ_CURRENT_TEMPERATURE;
-  sprintf((char *) this->packet_.data, "%s", CMD_READ_CURRENT_TEMP);
+  strncpy((char *) this->packet_.data, CMD_READ_CURRENT_TEMP, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_unit_request() {
   this->current_query_ = READ_UNIT;
-  sprintf((char *) this->packet_.data, "%s", CMD_READ_UNIT);
+  strncpy((char *) this->packet_.data, CMD_READ_UNIT, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_data_request() {
   this->current_query_ = READ_DATA;
-  sprintf((char *) this->packet_.data, "%s", CMD_READ_DATA);
+  strncpy((char *) this->packet_.data, CMD_READ_DATA, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
@@ -50,25 +50,25 @@ AnovaPacket *AnovaCodec::get_set_target_temp_request(float temperature) {
   this->current_query_ = SET_TARGET_TEMPERATURE;
   if (this->fahrenheit_)
     temperature = ctof(temperature);
-  sprintf((char *) this->packet_.data, CMD_SET_TARGET_TEMP, temperature);
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), CMD_SET_TARGET_TEMP, temperature);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_set_unit_request(char unit) {
   this->current_query_ = SET_UNIT;
-  sprintf((char *) this->packet_.data, CMD_SET_TEMP_UNIT, unit);
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), CMD_SET_TEMP_UNIT, unit);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_start_request() {
   this->current_query_ = START;
-  sprintf((char *) this->packet_.data, CMD_START);
+  strncpy((char *) this->packet_.data, CMD_START, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_stop_request() {
   this->current_query_ = STOP;
-  sprintf((char *) this->packet_.data, CMD_STOP);
+  strncpy((char *) this->packet_.data, CMD_STOP, sizeof(this->packet_.data));
   return this->clean_packet_();
 }
 

--- a/esphome/components/anova/anova_base.cpp
+++ b/esphome/components/anova/anova_base.cpp
@@ -18,31 +18,31 @@ AnovaPacket *AnovaCodec::clean_packet_() {
 
 AnovaPacket *AnovaCodec::get_read_device_status_request() {
   this->current_query_ = READ_DEVICE_STATUS;
-  strncpy((char *) this->packet_.data, CMD_READ_DEVICE_STATUS, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_DEVICE_STATUS);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_target_temp_request() {
   this->current_query_ = READ_TARGET_TEMPERATURE;
-  strncpy((char *) this->packet_.data, CMD_READ_TARGET_TEMP, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_TARGET_TEMP);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_current_temp_request() {
   this->current_query_ = READ_CURRENT_TEMPERATURE;
-  strncpy((char *) this->packet_.data, CMD_READ_CURRENT_TEMP, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_CURRENT_TEMP);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_unit_request() {
   this->current_query_ = READ_UNIT;
-  strncpy((char *) this->packet_.data, CMD_READ_UNIT, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_UNIT);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_read_data_request() {
   this->current_query_ = READ_DATA;
-  strncpy((char *) this->packet_.data, CMD_READ_DATA, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_DATA);
   return this->clean_packet_();
 }
 
@@ -62,13 +62,13 @@ AnovaPacket *AnovaCodec::get_set_unit_request(char unit) {
 
 AnovaPacket *AnovaCodec::get_start_request() {
   this->current_query_ = START;
-  strncpy((char *) this->packet_.data, CMD_START, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_START);
   return this->clean_packet_();
 }
 
 AnovaPacket *AnovaCodec::get_stop_request() {
   this->current_query_ = STOP;
-  strncpy((char *) this->packet_.data, CMD_STOP, sizeof(this->packet_.data));
+  snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_STOP);
   return this->clean_packet_();
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Replace `sprintf` calls with bounds-checked `snprintf` in the anova component as part of a codebase-wide effort to eliminate `sprintf`.

The existing code was likely safe (the 24-byte buffer is adequately sized for all commands), but `sprintf` is being removed from the codebase in favor of bounds-checked alternatives for consistency and to prevent future issues.

**Changes:**
- All `sprintf` calls → `snprintf` with explicit buffer size

```cpp
// Before - no bounds checking
sprintf((char *) this->packet_.data, "%s", CMD_READ_DEVICE_STATUS);
sprintf((char *) this->packet_.data, CMD_SET_TARGET_TEMP, temperature);

// After - explicit buffer size prevents overflow, always null-terminates
snprintf((char *) this->packet_.data, sizeof(this->packet_.data), "%s", CMD_READ_DEVICE_STATUS);
snprintf((char *) this->packet_.data, sizeof(this->packet_.data), CMD_SET_TARGET_TEMP, temperature);
```

**Benefits:**
- Buffer overflow protection with explicit size parameters
- Guaranteed null-termination (unlike `strncpy`)
- No functional changes - all commands still fit within the 24-byte packet buffer

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal safety improvement
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
