### PR TITLE
[api] Use subtraction for protobuf bounds checking

### DIFF
--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -48,7 +48,7 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
         }
         uint32_t field_length = res->as_uint32();
         ptr += consumed;
-        if (field_length > end - ptr) {
+        if (field_length > static_cast<size_t>(end - ptr)) {
           return count;  // Out of bounds
         }
         ptr += field_length;
@@ -110,7 +110,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
         }
         uint32_t field_length = res->as_uint32();
         ptr += consumed;
-        if (field_length > end - ptr) {
+        if (field_length > static_cast<size_t>(end - ptr)) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -48,14 +48,14 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
         }
         uint32_t field_length = res->as_uint32();
         ptr += consumed;
-        if (ptr + field_length > end) {
+        if (field_length > end - ptr) {
           return count;  // Out of bounds
         }
         ptr += field_length;
         break;
       }
       case WIRE_TYPE_FIXED32: {  // 32-bit - skip 4 bytes
-        if (ptr + 4 > end) {
+        if (end - ptr < 4) {
           return count;
         }
         ptr += 4;
@@ -110,7 +110,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
         }
         uint32_t field_length = res->as_uint32();
         ptr += consumed;
-        if (ptr + field_length > end) {
+        if (field_length > end - ptr) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
@@ -121,7 +121,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
         break;
       }
       case WIRE_TYPE_FIXED32: {  // 32-bit
-        if (ptr + 4 > end) {
+        if (end - ptr < 4) {
           ESP_LOGV(TAG, "Out-of-bounds Fixed32-bit at offset %ld", (long) (ptr - buffer));
           return;
         }


### PR DESCRIPTION
# What does this implement/fix?

Refactor bounds checking in the protobuf decoder to use subtraction instead of addition. This is a defensive coding improvement that avoids potential arithmetic issues on 32-bit platforms.

Changes `ptr + field_length > end` to `field_length > end - ptr` which compares against remaining buffer size directly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
