### PR TITLE
2026.1.0b3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.1.0b2
+PROJECT_NUMBER         = 2026.1.0b3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -558,8 +558,10 @@ bool APIServer::clear_noise_psk(bool make_active) {
 #ifdef USE_HOMEASSISTANT_TIME
 void APIServer::request_time() {
   for (auto &client : this->clients_) {
-    if (!client->flags_.remove && client->is_authenticated())
+    if (!client->flags_.remove && client->is_authenticated()) {
       client->send_time_request();
+      return;  // Only request from one client to avoid clock conflicts
+    }
   }
 }
 #endif

--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -44,7 +44,7 @@ void DallasTemperatureSensor::update() {
 
   this->send_command_(DALLAS_COMMAND_START_CONVERSION);
 
-  this->set_timeout(this->get_address_name(), this->millis_to_wait_for_conversion_(), [this] {
+  this->set_timeout(this->get_address_name().c_str(), this->millis_to_wait_for_conversion_(), [this] {
     if (!this->read_scratch_pad_() || !this->check_scratch_pad_()) {
       this->publish_state(NAN);
       return;

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -193,8 +193,16 @@ void BLEClientBase::log_event_(const char *name) {
   ESP_LOGD(TAG, "[%d] [%s] %s", this->connection_index_, this->address_str_, name);
 }
 
-void BLEClientBase::log_gattc_event_(const char *name) {
+void BLEClientBase::log_gattc_lifecycle_event_(const char *name) {
   ESP_LOGD(TAG, "[%d] [%s] ESP_GATTC_%s_EVT", this->connection_index_, this->address_str_, name);
+}
+
+void BLEClientBase::log_gattc_data_event_(const char *name) {
+  // Data transfer events are logged at VERBOSE level because logging to UART creates
+  // delays that cause timing issues during time-sensitive BLE operations. This is
+  // especially problematic during pairing or firmware updates which require rapid
+  // writes to many characteristics - the log spam can cause these operations to fail.
+  ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_%s_EVT", this->connection_index_, this->address_str_, name);
 }
 
 void BLEClientBase::log_gattc_warning_(const char *operation, esp_gatt_status_t status) {
@@ -280,7 +288,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_OPEN_EVT: {
       if (!this->check_addr(param->open.remote_bda))
         return false;
-      this->log_gattc_event_("OPEN");
+      this->log_gattc_lifecycle_event_("OPEN");
       // conn_id was already set in ESP_GATTC_CONNECT_EVT
       this->service_count_ = 0;
 
@@ -331,7 +339,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CONNECT_EVT: {
       if (!this->check_addr(param->connect.remote_bda))
         return false;
-      this->log_gattc_event_("CONNECT");
+      this->log_gattc_lifecycle_event_("CONNECT");
       this->conn_id_ = param->connect.conn_id;
       // Start MTU negotiation immediately as recommended by ESP-IDF examples
       // (gatt_client, ble_throughput) which call esp_ble_gattc_send_mtu_req in
@@ -376,7 +384,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_CLOSE_EVT: {
       if (this->conn_id_ != param->close.conn_id)
         return false;
-      this->log_gattc_event_("CLOSE");
+      this->log_gattc_lifecycle_event_("CLOSE");
       this->release_services();
       this->set_state(espbt::ClientState::IDLE);
       this->conn_id_ = UNSET_CONN_ID;
@@ -404,7 +412,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       if (this->conn_id_ != param->search_cmpl.conn_id)
         return false;
-      this->log_gattc_event_("SEARCH_CMPL");
+      this->log_gattc_lifecycle_event_("SEARCH_CMPL");
       // For V3_WITHOUT_CACHE, switch back to medium connection parameters after service discovery
       // This balances performance with bandwidth usage after the critical discovery phase
       if (this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
@@ -431,35 +439,35 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_READ_DESCR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("READ_DESCR");
+      this->log_gattc_data_event_("READ_DESCR");
       break;
     }
     case ESP_GATTC_WRITE_DESCR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("WRITE_DESCR");
+      this->log_gattc_data_event_("WRITE_DESCR");
       break;
     }
     case ESP_GATTC_WRITE_CHAR_EVT: {
       if (this->conn_id_ != param->write.conn_id)
         return false;
-      this->log_gattc_event_("WRITE_CHAR");
+      this->log_gattc_data_event_("WRITE_CHAR");
       break;
     }
     case ESP_GATTC_READ_CHAR_EVT: {
       if (this->conn_id_ != param->read.conn_id)
         return false;
-      this->log_gattc_event_("READ_CHAR");
+      this->log_gattc_data_event_("READ_CHAR");
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
       if (this->conn_id_ != param->notify.conn_id)
         return false;
-      this->log_gattc_event_("NOTIFY");
+      this->log_gattc_data_event_("NOTIFY");
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
-      this->log_gattc_event_("REG_FOR_NOTIFY");
+      this->log_gattc_data_event_("REG_FOR_NOTIFY");
       if (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
           this->connection_type_ == espbt::ConnectionType::V3_WITHOUT_CACHE) {
         // Client is responsible for flipping the descriptor value
@@ -491,7 +499,7 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
       esp_err_t status =
           esp_ble_gattc_write_char_descr(this->gattc_if_, this->conn_id_, desc_result.handle, sizeof(notify_en),
                                          (uint8_t *) &notify_en, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
-      ESP_LOGD(TAG, "Wrote notify descriptor %d, properties=%d", notify_en, char_result.properties);
+      ESP_LOGV(TAG, "Wrote notify descriptor %d, properties=%d", notify_en, char_result.properties);
       if (status) {
         this->log_gattc_warning_("esp_ble_gattc_write_char_descr", status);
       }
@@ -499,13 +507,13 @@ bool BLEClientBase::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     }
 
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
-      this->log_gattc_event_("UNREG_FOR_NOTIFY");
+      this->log_gattc_data_event_("UNREG_FOR_NOTIFY");
       break;
     }
 
     default:
-      // ideally would check all other events for matching conn_id
-      ESP_LOGD(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_, event);
+      // Unknown events logged at VERBOSE to avoid UART delays during time-sensitive operations
+      ESP_LOGV(TAG, "[%d] [%s] Event %d", this->connection_index_, this->address_str_, event);
       break;
   }
   return true;

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -127,7 +127,8 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   // 6 bytes used, 2 bytes padding
 
   void log_event_(const char *name);
-  void log_gattc_event_(const char *name);
+  void log_gattc_lifecycle_event_(const char *name);
+  void log_gattc_data_event_(const char *name);
   void update_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,
                            const char *param_type);
   void set_conn_params_(uint16_t min_interval, uint16_t max_interval, uint16_t latency, uint16_t timeout,

--- a/esphome/components/hmac_sha256/hmac_sha256.cpp
+++ b/esphome/components/hmac_sha256/hmac_sha256.cpp
@@ -1,4 +1,3 @@
-#include <cstdio>
 #include <cstring>
 #include "hmac_sha256.h"
 #if defined(USE_ESP32) || defined(USE_ESP8266) || defined(USE_RP2040) || defined(USE_LIBRETINY) || defined(USE_HOST)
@@ -26,9 +25,7 @@ void HmacSHA256::calculate() { mbedtls_md_hmac_finish(&this->ctx_, this->digest_
 void HmacSHA256::get_bytes(uint8_t *output) { memcpy(output, this->digest_, SHA256_DIGEST_SIZE); }
 
 void HmacSHA256::get_hex(char *output) {
-  for (size_t i = 0; i < SHA256_DIGEST_SIZE; i++) {
-    sprintf(output + (i * 2), "%02x", this->digest_[i]);
-  }
+  format_hex_to(output, SHA256_DIGEST_SIZE * 2 + 1, this->digest_, SHA256_DIGEST_SIZE);
 }
 
 bool HmacSHA256::equals_bytes(const uint8_t *expected) {

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -242,9 +242,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       return;
     }
 
-    size_t content_length = container->content_length;
-    size_t max_length = std::min(content_length, this->max_response_buffer_size_);
-
+    size_t max_length = this->max_response_buffer_size_;
 #ifdef USE_HTTP_REQUEST_RESPONSE
     if (this->capture_response_.value(x...)) {
       std::string response_body;

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -213,18 +213,12 @@ int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
   const uint32_t start = millis();
   watchdog::WatchdogManager wdm(this->parent_->get_watchdog_timeout());
 
-  int bufsize = std::min(max_len, this->content_length - this->bytes_read_);
-
-  if (bufsize == 0) {
-    this->duration_ms += (millis() - start);
-    return 0;
+  this->feed_wdt();
+  int read_len = esp_http_client_read(this->client_, (char *) buf, max_len);
+  this->feed_wdt();
+  if (read_len > 0) {
+    this->bytes_read_ += read_len;
   }
-
-  this->feed_wdt();
-  int read_len = esp_http_client_read(this->client_, (char *) buf, bufsize);
-  this->feed_wdt();
-  this->bytes_read_ += read_len;
-
   this->duration_ms += (millis() - start);
 
   return read_len;

--- a/esphome/components/ntc/ntc.cpp
+++ b/esphome/components/ntc/ntc.cpp
@@ -23,7 +23,7 @@ void NTC::process_(float value) {
   double v = this->a_ + this->b_ * lr + this->c_ * lr * lr * lr;
   auto temp = float(1.0 / v - 273.15);
 
-  ESP_LOGD(TAG, "'%s' - Temperature: %.1f°C", this->name_.c_str(), temp);
+  ESP_LOGV(TAG, "'%s' - Temperature: %.1f°C", this->name_.c_str(), temp);
   this->publish_state(temp);
 }
 

--- a/esphome/components/resistance/resistance_sensor.cpp
+++ b/esphome/components/resistance/resistance_sensor.cpp
@@ -39,7 +39,7 @@ void ResistanceSensor::process_(float value) {
   }
 
   res *= this->resistor_;
-  ESP_LOGD(TAG, "'%s' - Resistance %.1fΩ", this->name_.c_str(), res);
+  ESP_LOGV(TAG, "'%s' - Resistance %.1fΩ", this->name_.c_str(), res);
   this->publish_state(res);
 }
 

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -332,6 +332,7 @@ Sprinkler::Sprinkler(const std::string &name) {
   // The `name` is needed to set timers up, hence non-default constructor
   // replaces `set_name()` method previously existed
   this->name_ = name;
+  this->timer_.init(2);
   this->timer_.push_back({this->name_ + "sm", false, 0, 0, std::bind(&Sprinkler::sm_timer_callback_, this)});
   this->timer_.push_back({this->name_ + "vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
 }
@@ -1574,7 +1575,8 @@ const LogString *Sprinkler::state_as_str_(SprinklerState state) {
 
 void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
   if (this->timer_duration_(timer_index) > 0) {
-    this->set_timeout(this->timer_[timer_index].name, this->timer_duration_(timer_index),
+    // FixedVector ensures timer_ can't be resized, so .c_str() pointers remain valid
+    this->set_timeout(this->timer_[timer_index].name.c_str(), this->timer_duration_(timer_index),
                       this->timer_cbf_(timer_index));
     this->timer_[timer_index].start_time = millis();
     this->timer_[timer_index].active = true;
@@ -1585,7 +1587,7 @@ void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
 
 bool Sprinkler::cancel_timer_(const SprinklerTimerIndex timer_index) {
   this->timer_[timer_index].active = false;
-  return this->cancel_timeout(this->timer_[timer_index].name);
+  return this->cancel_timeout(this->timer_[timer_index].name.c_str());
 }
 
 bool Sprinkler::timer_active_(const SprinklerTimerIndex timer_index) { return this->timer_[timer_index].active; }

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -3,6 +3,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/switch/switch.h"
 
@@ -553,8 +554,8 @@ class Sprinkler : public Component {
   /// Sprinkler valve operator objects
   std::vector<SprinklerValveOperator> valve_op_{2};
 
-  /// Valve control timers
-  std::vector<SprinklerTimer> timer_{};
+  /// Valve control timers - FixedVector enforces that this can never grow beyond init() size
+  FixedVector<SprinklerTimer> timer_;
 
   /// Other Sprinkler instances we should be aware of (used to check if pumps are in use)
   std::vector<Sprinkler *> other_controllers_;

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -31,6 +31,18 @@ void RealTimeClock::dump_config() {
 
 void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   ESP_LOGVV(TAG, "Got epoch %" PRIu32, epoch);
+  // Skip if time is already synchronized to avoid unnecessary writes, log spam,
+  // and prevent clock jumping backwards due to network latency
+  constexpr time_t min_valid_epoch = 1546300800;  // January 1, 2019
+  time_t current_time = this->timestamp_now();
+  // Check if time is valid (year >= 2019) before comparing
+  if (current_time >= min_valid_epoch) {
+    // Unsigned subtraction handles wraparound correctly, then cast to signed
+    int32_t diff = static_cast<int32_t>(epoch - static_cast<uint32_t>(current_time));
+    if (diff >= -1 && diff <= 1) {
+      return;
+    }
+  }
   // Update UTC epoch time.
 #ifdef USE_ZEPHYR
   struct timespec ts;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.1.0b2"
+__version__ = "2026.1.0b3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -28,8 +28,8 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.2.2
+    version: 0.3.0
     rules:
-      - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"
+      - if: "target in [esp32, esp32s2, esp32s3, esp32c6, esp32p4]"
   esp32async/asynctcp:
     version: 3.4.91


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [i2s_audio] Bugfix: Buffer overflow in software volume control [esphome#13190](https://github.com/esphome/esphome/pull/13190)
- [sprinkler] Fix scheduler deprecation warnings and heap churn with FixedVector [esphome#13251](https://github.com/esphome/esphome/pull/13251)
- [dallas_temp] Use const char* for set_timeout to fix deprecation warning and heap churn [esphome#13250](https://github.com/esphome/esphome/pull/13250)
- [api] Fix clock conflicts when multiple clients connected to homeassistant time [esphome#13253](https://github.com/esphome/esphome/pull/13253)
- [esp32_ble_client] Reduce GATT data event logging to prevent firmware update failures [esphome#13252](https://github.com/esphome/esphome/pull/13252)
- [ntc, resistance] change log level to verbose [esphome#13268](https://github.com/esphome/esphome/pull/13268)
- [api] Use subtraction for protobuf bounds checking [esphome#13306](https://github.com/esphome/esphome/pull/13306)
- [hmac_sha256] Replace unsafe sprintf with format_hex_to [esphome#13290](https://github.com/esphome/esphome/pull/13290)
- [hub75] Bump esp-hub75 version to 0.3.0 [esphome#13243](https://github.com/esphome/esphome/pull/13243) (breaking-change)
- [http_request] Unable to handle chunked responses [esphome#7884](https://github.com/esphome/esphome/pull/7884)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
