### PR TITLE
[core] Add str_endswith_ignore_case to avoid heap allocation in audio file type detection

### DIFF
--- a/esphome/components/audio/audio_reader.cpp
+++ b/esphome/components/audio/audio_reader.cpp
@@ -185,18 +185,16 @@ esp_err_t AudioReader::start(const std::string &uri, AudioFileType &file_type) {
       return err;
     }
 
-    std::string url_string = str_lower_case(url);
-
-    if (str_endswith(url_string, ".wav")) {
+    if (str_endswith_ignore_case(url, ".wav")) {
       file_type = AudioFileType::WAV;
     }
 #ifdef USE_AUDIO_MP3_SUPPORT
-    else if (str_endswith(url_string, ".mp3")) {
+    else if (str_endswith_ignore_case(url, ".mp3")) {
       file_type = AudioFileType::MP3;
     }
 #endif
 #ifdef USE_AUDIO_FLAC_SUPPORT
-    else if (str_endswith(url_string, ".flac")) {
+    else if (str_endswith_ignore_case(url, ".flac")) {
       file_type = AudioFileType::FLAC;
     }
 #endif

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -174,6 +174,13 @@ bool str_endswith(const std::string &str, const std::string &end) {
   return str.rfind(end) == (str.size() - end.size());
 }
 #endif
+
+bool str_endswith_ignore_case(const char *str, size_t str_len, const char *suffix, size_t suffix_len) {
+  if (suffix_len > str_len)
+    return false;
+  return strncasecmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
+}
+
 std::string str_truncate(const std::string &str, size_t length) {
   return str.length() > length ? str.substr(0, length) : str;
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -523,6 +523,15 @@ bool str_startswith(const std::string &str, const std::string &start);
 /// Check whether a string ends with a value.
 bool str_endswith(const std::string &str, const std::string &end);
 
+/// Case-insensitive check if string ends with suffix (no heap allocation).
+bool str_endswith_ignore_case(const char *str, size_t str_len, const char *suffix, size_t suffix_len);
+inline bool str_endswith_ignore_case(const char *str, const char *suffix) {
+  return str_endswith_ignore_case(str, strlen(str), suffix, strlen(suffix));
+}
+inline bool str_endswith_ignore_case(const std::string &str, const char *suffix) {
+  return str_endswith_ignore_case(str.c_str(), str.size(), suffix, strlen(suffix));
+}
+
 /// Truncate a string to a specific length.
 /// @warning Allocates heap memory. Avoid in new code - causes heap fragmentation on long-running devices.
 std::string str_truncate(const std::string &str, size_t length);


### PR DESCRIPTION
# What does this implement/fix?

Add `str_endswith_ignore_case()` helper for case-insensitive suffix matching without heap allocation.

**Before (audio_reader.cpp):**
```cpp
std::string url_string = str_lower_case(url);  // Allocates ~500 bytes
if (str_endswith(url_string, ".wav")) { ... }
```

**After:**
```cpp
if (str_endswith_ignore_case(url, ".wav")) { ... }  // Zero allocation
```

The new helper uses `strncasecmp()` which is optimized on most platforms. This eliminates a heap allocation every time the audio reader needs to determine file type from URL.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce heap allocations in hot paths

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal optimization, no configuration changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A)
