### PR TITLE
[light] Store color mode JSON strings in flash on ESP8266

### DIFF
--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -48,7 +48,7 @@ void LightJSONSchema::dump_json(LightState &state, JsonObject root) {
   auto values = state.remote_values;
 
   const auto color_mode = values.get_color_mode();
-  auto mode_str = get_color_mode_json_str(color_mode);
+  const auto *mode_str = get_color_mode_json_str(color_mode);
   if (mode_str != nullptr) {
     root[ESPHOME_F("color_mode")] = mode_str;
   }

--- a/esphome/components/light/light_json_schema.cpp
+++ b/esphome/components/light/light_json_schema.cpp
@@ -1,4 +1,5 @@
 #include "light_json_schema.h"
+#include "color_mode.h"
 #include "light_output.h"
 #include "esphome/core/progmem.h"
 
@@ -8,29 +9,32 @@ namespace esphome::light {
 
 // See https://www.home-assistant.io/integrations/light.mqtt/#json-schema for documentation on the schema
 
-// Get JSON string for color mode using linear search (avoids large switch jump table)
-static const char *get_color_mode_json_str(ColorMode mode) {
-  // Parallel arrays: mode values and their corresponding strings
-  // Uses less RAM than a switch jump table on sparse enum values
-  static constexpr ColorMode MODES[] = {
-      ColorMode::ON_OFF,
-      ColorMode::BRIGHTNESS,
-      ColorMode::WHITE,
-      ColorMode::COLOR_TEMPERATURE,
-      ColorMode::COLD_WARM_WHITE,
-      ColorMode::RGB,
-      ColorMode::RGB_WHITE,
-      ColorMode::RGB_COLOR_TEMPERATURE,
-      ColorMode::RGB_COLD_WARM_WHITE,
-  };
-  static constexpr const char *STRINGS[] = {
-      "onoff", "brightness", "white", "color_temp", "cwww", "rgb", "rgbw", "rgbct", "rgbww",
-  };
-  for (size_t i = 0; i < sizeof(MODES) / sizeof(MODES[0]); i++) {
-    if (MODES[i] == mode)
-      return STRINGS[i];
+// Get JSON string for color mode.
+// ColorMode enum values are sparse bitmasks (0, 1, 3, 7, 11, 19, 35, 39, 47, 51) which would
+// generate a large jump table. Converting to bit index (0-9) allows a compact switch.
+static ProgmemStr get_color_mode_json_str(ColorMode mode) {
+  switch (ColorModeBitPolicy::to_bit(mode)) {
+    case 1:
+      return ESPHOME_F("onoff");
+    case 2:
+      return ESPHOME_F("brightness");
+    case 3:
+      return ESPHOME_F("white");
+    case 4:
+      return ESPHOME_F("color_temp");
+    case 5:
+      return ESPHOME_F("cwww");
+    case 6:
+      return ESPHOME_F("rgb");
+    case 7:
+      return ESPHOME_F("rgbw");
+    case 8:
+      return ESPHOME_F("rgbct");
+    case 9:
+      return ESPHOME_F("rgbww");
+    default:
+      return nullptr;
   }
-  return nullptr;
 }
 
 void LightJSONSchema::dump_json(LightState &state, JsonObject root) {
@@ -44,7 +48,7 @@ void LightJSONSchema::dump_json(LightState &state, JsonObject root) {
   auto values = state.remote_values;
 
   const auto color_mode = values.get_color_mode();
-  const char *mode_str = get_color_mode_json_str(color_mode);
+  auto mode_str = get_color_mode_json_str(color_mode);
   if (mode_str != nullptr) {
     root[ESPHOME_F("color_mode")] = mode_str;
   }

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -12,6 +12,8 @@
 #define ESPHOME_strncpy_P strncpy_P
 #define ESPHOME_strncat_P strncat_P
 #define ESPHOME_snprintf_P snprintf_P
+// Type for pointers to PROGMEM strings (for use with ESPHOME_F return values)
+using ProgmemStr = const __FlashStringHelper *;
 #else
 #define ESPHOME_F(string_literal) (string_literal)
 #define ESPHOME_PGM_P const char *
@@ -19,4 +21,6 @@
 #define ESPHOME_strncpy_P strncpy
 #define ESPHOME_strncat_P strncat
 #define ESPHOME_snprintf_P snprintf
+// Type for pointers to strings (no PROGMEM on non-ESP8266 platforms)
+using ProgmemStr = const char *;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Reduce ESP8266 RAM usage in light JSON schema by storing color mode strings in flash.

The previous implementation used parallel `static constexpr` arrays for ColorMode values and their JSON string representations. On ESP8266, `static constexpr` doesn't guarantee flash storage, so these arrays (~60 bytes) were stored in RAM.

This change:
- Replaces the parallel arrays with a switch statement using `ColorModeBitPolicy::to_bit()` to convert sparse ColorMode enum values (0, 1, 3, 7, 11, 19, 35, 39, 47, 51) to compact bit indices (0-9), avoiding a large jump table
- Uses `ESPHOME_F()` for each string to ensure flash storage on ESP8266
- Adds `ProgmemStr` type alias to `esphome/core/progmem.h` for reuse across the codebase

**Measurements on ESP8266:**
| | Before | After | Delta |
|---|---|---|---|
| RAM | 33,236 | 33,176 | **-60 bytes** |
| Flash | 499,377 | 499,409 | +32 bytes |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
light:
  - platform: rgb
    name: "Test Light"
    red: output_red
    green: output_green
    blue: output_blue
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
