### PR TITLE
Add experimental Fendt Caravan BLE component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -176,6 +176,7 @@ esphome/components/ezo_pmp/* @carlos-sarmiento
 esphome/components/factory_reset/* @anatoly-savchenkov
 esphome/components/fastled_base/* @OttoWinter
 esphome/components/feedback/* @ianchi
+esphome/components/fendt_caravan/* @rawsludge
 esphome/components/fingerprint_grow/* @alexborro @loongyh @OnFreund
 esphome/components/font/* @clydebarrow @esphome/core
 esphome/components/fs3000/* @kahrendt

--- a/esphome/components/fendt_caravan/__init__.py
+++ b/esphome/components/fendt_caravan/__init__.py
@@ -1,0 +1,45 @@
+import esphome.codegen as cg
+from esphome.components import ble_client, esp32_ble_tracker
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@rawsludge"]
+DEPENDENCIES = ["ble_client", "esp32_ble_tracker"]
+AUTO_LOAD = ["text_sensor", "switch", "number", "select", "light"]
+
+MULTI_CONF = True
+
+fendt_caravan_ns = cg.esphome_ns.namespace("fendt_caravan")
+FendtCaravan = fendt_caravan_ns.class_(
+    "FendtCaravan", ble_client.BLEClientNode, cg.Component
+)
+
+FendtTextSensor = fendt_caravan_ns.class_("FendtTextSensor", cg.Component)
+FendtSwitch = fendt_caravan_ns.class_("FendtSwitch", cg.Component)
+FendtNumber = fendt_caravan_ns.class_("FendtNumber", cg.Component)
+FendtSelect = fendt_caravan_ns.class_("FendtSelect", cg.Component)
+FendtSensor = fendt_caravan_ns.class_("FendtSensor", cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(FendtCaravan),
+            cv.Required(ble_client.CONF_BLE_CLIENT_ID): cv.use_id(ble_client.BLEClient),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)
+)
+
+CONF_FENDT_CARAVAN_ID = "fendt_caravan_id"
+CONFIG_FENDT_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_FENDT_CARAVAN_ID): cv.use_id(FendtCaravan),
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await ble_client.register_ble_node(var, config)

--- a/esphome/components/fendt_caravan/__init__.py
+++ b/esphome/components/fendt_caravan/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID
 CODEOWNERS = ["@rawsludge"]
 DEPENDENCIES = ["ble_client", "esp32_ble_tracker"]
 AUTO_LOAD = ["text_sensor", "switch", "number", "select", "light"]
+PLATFORMS = ["esp32"]
 
 MULTI_CONF = True
 

--- a/esphome/components/fendt_caravan/fendt_caravan.cpp
+++ b/esphome/components/fendt_caravan/fendt_caravan.cpp
@@ -1,0 +1,168 @@
+#include "fendt_caravan.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace fendt_caravan {
+
+namespace espbt = esphome::esp32_ble_tracker;
+
+using namespace std;
+const uint8_t WIAT_COMMAND = 200;
+
+void FendtCaravan::dump_config() { ESP_LOGCONFIG(TAG, "Fend Caravan Log"); }
+
+void FendtCaravan::setup() { ESP_LOGD(TAG, "Setup called"); }
+
+void FendtCaravan::loop() {
+  if (!command_enabled)
+    return;
+
+  if (this->parent()->state() != espbt::ClientState::ESTABLISHED)
+    return;
+
+  uint32_t time_stamp = millis();
+  if (this->commands_.size() > 0 && (time_stamp - this->last_command_time_) >= WIAT_COMMAND && !this->_wait_buffer) {
+    std::string cmd = this->commands_.at(0);
+
+    uint8_t buffer[cmd.length() + 1];
+    memset(buffer, 0, sizeof(buffer));
+    memcpy(buffer, cmd.c_str(), cmd.length());
+    auto status =
+        esp_ble_gattc_write_char(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), this->char_handle_,
+                                 cmd.length(), buffer, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+    if (status) {
+      ESP_LOGE(TAG, "Error writing command to device, error = %d", status);
+    }
+
+    ESP_LOGD(TAG, "Command sent: %s, %d", buffer, cmd.length());
+    this->last_command_time_ = time_stamp;
+    this->commands_.erase(std::remove(this->commands_.begin(), this->commands_.end(), cmd), this->commands_.end());
+  }
+}
+
+void FendtCaravan::update() {}
+
+void FendtCaravan::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                                       esp_ble_gattc_cb_param_t *param) {
+  switch (event) {
+    case ESP_GATTC_OPEN_EVT:
+      ESP_LOGV(TAG, "BLE connected (OPEN_EVT)");
+      break;
+    case ESP_GATTC_DIS_SRVC_CMPL_EVT:
+      ESP_LOGV(TAG, "BLE ESP_GATTC_DIS_SRVC_CMPL_EVT called");
+      break;
+    case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
+      ESP_LOGV(TAG, "BLE ESP_GATTC_REG_FOR_NOTIFY_EVT called");
+      break;
+    }
+    case ESP_GATTC_SEARCH_CMPL_EVT: {
+      ESP_LOGV(TAG, "Service discovery complete");
+
+      auto service = this->parent()->get_service(espbt::ESPBTUUID::from_raw(SERVICE_UUID));
+      if (service == nullptr) {
+        ESP_LOGW(TAG, "control service not found at device, not a Fendt Caravan..?");
+        break;
+      }
+      auto chr = service->get_characteristic(CHARACTERISTIC_UUID);
+      if (chr == nullptr) {
+        ESP_LOGW(TAG, "control characteristic not found at device, not a Fendt Caravan..?");
+        break;
+      }
+      this->char_handle_ = chr->handle;
+      auto status = esp_ble_gattc_register_for_notify(this->parent()->get_gattc_if(), this->parent()->get_remote_bda(),
+                                                      chr->handle);
+      if (status) {
+        ESP_LOGW(TAG, "esp_ble_gattc_register_for_notify failed, status=%d", status);
+      }
+      auto *descr = chr->get_descriptor(0x2902);
+      if (descr == nullptr) {
+        ESP_LOGW(TAG, "No CCC descriptor found at service");
+        break;
+      }
+      uint8_t cccd_value[2] = {1, 0};
+      status =
+          esp_ble_gattc_write_char_descr(this->parent()->get_gattc_if(), this->parent()->get_conn_id(), descr->handle,
+                                         2, cccd_value, ESP_GATT_WRITE_TYPE_RSP, ESP_GATT_AUTH_REQ_NONE);
+      if (status) {
+        ESP_LOGW(TAG, "Error sending CCC descriptor write request, status=%d", status);
+        break;
+        ;
+      }
+
+      this->add_command("net-BT_ID-c0:ee:fb:90:b0:a7");
+      this->add_command("net-BT_VARS");
+      this->command_enabled = true;
+      break;
+    }
+    case ESP_GATTC_NOTIFY_EVT:
+      if (param->notify.handle == this->char_handle_) {
+        this->_wait_buffer = true;
+        char buffer[param->notify.value_len + 1] = {0};
+        memcpy(buffer, param->notify.value, param->notify.value_len);
+        std::string result = std::string(buffer);
+        if (!this->last_response_.empty()) {
+          result = this->last_response_ + result;
+          this->last_response_.clear();
+        }
+        if (strchr(buffer, '@') != nullptr) {
+          this->last_response_.append(buffer, param->notify.value_len - 1);
+          break;
+        }
+        this->_wait_buffer = false;
+        ESP_LOGD(TAG, "Notified value: %s", result.c_str());
+        on_data_received(result);
+      }
+      break;
+    case ESP_GATTC_DISCONNECT_EVT:
+      ESP_LOGW(TAG, "BLE disconnected");
+      break;
+  }
+}
+void FendtCaravan::add_command(const std::string &cmd) {
+  int8_t start_index = 0;
+  int8_t end_index = 17;
+  int8_t last_index = cmd.length();
+  bool last_chunk = false;
+  while (!last_chunk) {
+    std::string chunk = "";
+    if (end_index < last_index) {
+      chunk = cmd.substr(0, 17);
+      chunk += "@";
+    } else {
+      chunk = cmd.substr(start_index, last_index);
+      last_chunk = true;
+    }
+    this->commands_.push_back(chunk);
+    start_index = end_index;
+    end_index = start_index + 17;
+    if (end_index > last_index)
+      end_index = last_index;
+  }
+}
+
+void FendtCaravan::on_data_received(const std::string &data) {
+  std::string key, value;
+
+  size_t start = 0;
+  size_t end = data.find(':');
+  key = data.substr(start, end);
+  value = data.substr(end + 1);
+  if (this->control_unit_device_)
+    this->control_unit_device_->decode(key, value);
+  if (this->alde_device_)
+    this->alde_device_->decode(key, value);
+  if (this->fridge_device_)
+    this->fridge_device_->decode(key, value);
+  if (this->lighting_device_)
+    this->lighting_device_->decode(key, value);
+}
+
+void FendtCaravan::on_command_send(const std::string &command) {
+  ESP_LOGD(TAG, "on_command_send called. Command: %s", command.c_str());
+  this->add_command(command);
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/fendt_caravan.cpp
+++ b/esphome/components/fendt_caravan/fendt_caravan.cpp
@@ -15,14 +15,14 @@ void FendtCaravan::dump_config() { ESP_LOGCONFIG(TAG, "Fend Caravan Log"); }
 void FendtCaravan::setup() { ESP_LOGD(TAG, "Setup called"); }
 
 void FendtCaravan::loop() {
-  if (!command_enabled)
+  if (!command_enabled_)
     return;
 
   if (this->parent()->state() != espbt::ClientState::ESTABLISHED)
     return;
 
   uint32_t time_stamp = millis();
-  if (this->commands_.size() > 0 && (time_stamp - this->last_command_time_) >= WIAT_COMMAND && !this->_wait_buffer) {
+  if (this->commands_.size() > 0 && (time_stamp - this->last_command_time_) >= WIAT_COMMAND && !this->wait_buffer_) {
     std::string cmd = this->commands_.at(0);
 
     uint8_t buffer[cmd.length() + 1];
@@ -59,12 +59,12 @@ void FendtCaravan::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
     case ESP_GATTC_SEARCH_CMPL_EVT: {
       ESP_LOGV(TAG, "Service discovery complete");
 
-      auto service = this->parent()->get_service(espbt::ESPBTUUID::from_raw(SERVICE_UUID));
+      auto service = this->parent()->get_service(espbt::ESPBTUUID::from_raw(service_uuid_));
       if (service == nullptr) {
         ESP_LOGW(TAG, "control service not found at device, not a Fendt Caravan..?");
         break;
       }
-      auto chr = service->get_characteristic(CHARACTERISTIC_UUID);
+      auto chr = service->get_characteristic(characteristic_uuid_);
       if (chr == nullptr) {
         ESP_LOGW(TAG, "control characteristic not found at device, not a Fendt Caravan..?");
         break;
@@ -90,14 +90,14 @@ void FendtCaravan::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
         ;
       }
 
-      this->add_command("net-BT_ID-c0:ee:fb:90:b0:a7");
-      this->add_command("net-BT_VARS");
-      this->command_enabled = true;
+      this->add_command_("net-BT_ID-c0:ee:fb:90:b0:a7");
+      this->add_command_("net-BT_VARS");
+      this->command_enabled_ = true;
       break;
     }
     case ESP_GATTC_NOTIFY_EVT:
       if (param->notify.handle == this->char_handle_) {
-        this->_wait_buffer = true;
+        this->wait_buffer_ = true;
         char buffer[param->notify.value_len + 1] = {0};
         memcpy(buffer, param->notify.value, param->notify.value_len);
         std::string result = std::string(buffer);
@@ -109,9 +109,9 @@ void FendtCaravan::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
           this->last_response_.append(buffer, param->notify.value_len - 1);
           break;
         }
-        this->_wait_buffer = false;
+        this->wait_buffer_ = false;
         ESP_LOGD(TAG, "Notified value: %s", result.c_str());
-        on_data_received(result);
+        on_data_received_(result);
       }
       break;
     case ESP_GATTC_DISCONNECT_EVT:
@@ -119,7 +119,7 @@ void FendtCaravan::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t
       break;
   }
 }
-void FendtCaravan::add_command(const std::string &cmd) {
+void FendtCaravan::add_command_(const std::string &cmd) {
   int8_t start_index = 0;
   int8_t end_index = 17;
   int8_t last_index = cmd.length();
@@ -141,7 +141,7 @@ void FendtCaravan::add_command(const std::string &cmd) {
   }
 }
 
-void FendtCaravan::on_data_received(const std::string &data) {
+void FendtCaravan::on_data_received_(const std::string &data) {
   std::string key, value;
 
   size_t start = 0;
@@ -160,7 +160,7 @@ void FendtCaravan::on_data_received(const std::string &data) {
 
 void FendtCaravan::on_command_send(const std::string &command) {
   ESP_LOGD(TAG, "on_command_send called. Command: %s", command.c_str());
-  this->add_command(command);
+  this->add_command_(command);
 }
 
 }  // namespace fendt_caravan

--- a/esphome/components/fendt_caravan/fendt_caravan.h
+++ b/esphome/components/fendt_caravan/fendt_caravan.h
@@ -48,17 +48,17 @@ class FendtCaravan : public PollingComponent, public ble_client::BLEClientNode {
 
   void dump_config() override;
   void on_command_send(const std::string &command);
+  const char *TAG = "FC";
 
  protected:
-  void add_command(const std::string &cmd);
-  void on_data_received(const std::string &data);
+  void add_command_(const std::string &cmd);
+  void on_data_received_(const std::string &data);
 
  private:
-  const char *TAG = "FC";
-  const char *SERVICE_UUID = "C7841029-FE7C-4894-8532-F97908EF1AE4";  // değiştirilmesi gerekebilir
-  const uint16_t CHARACTERISTIC_UUID = 0x0001;
-  bool command_enabled = false;
-  volatile bool _wait_buffer = false;
+  const char *service_uuid_ = "C7841029-FE7C-4894-8532-F97908EF1AE4";  // değiştirilmesi gerekebilir
+  const uint16_t characteristic_uuid_ = 0x0001;
+  bool command_enabled_ = false;
+  volatile bool wait_buffer_ = false;
   uint16_t char_handle_;
   std::vector<std::string> commands_{};
   uint32_t last_command_time_ = 0;

--- a/esphome/components/fendt_caravan/fendt_caravan.h
+++ b/esphome/components/fendt_caravan/fendt_caravan.h
@@ -1,0 +1,73 @@
+
+#pragma once
+
+#include <numbers>
+#include "sensor/caravan_device.h"
+#include "esphome/core/log.h"
+#include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/components/ble_client/ble_client.h"
+#include "esphome/components/esp32_ble_client/ble_characteristic.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace fendt_caravan {
+
+using namespace std;
+
+class FendtCaravan : public PollingComponent, public ble_client::BLEClientNode {
+ public:
+  void setup() override;
+  void loop() override;
+  void update() override;
+
+  void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
+                           esp_ble_gattc_cb_param_t *param) override;
+
+  void set_address(uint64_t address) { address_ = address; };
+
+  void set_control_unit(CaravanDevice *control_unit_device) {
+    this->control_unit_device_ = control_unit_device;
+    this->control_unit_device_->set_command_send_callback(
+        [this](const std::string &cmd) { this->on_command_send(cmd); });
+  }
+  void set_alde_device(CaravanDevice *device) {
+    this->alde_device_ = device;
+    this->alde_device_->set_command_send_callback([this](const std::string &cmd) { this->on_command_send(cmd); });
+  }
+  void set_fridge_device(CaravanDevice *device) {
+    this->fridge_device_ = device;
+    this->fridge_device_->set_command_send_callback([this](const std::string &cmd) { this->on_command_send(cmd); });
+  }
+
+  void set_lighting_device(CaravanDevice *device) {
+    this->lighting_device_ = device;
+    this->lighting_device_->set_command_send_callback([this](const std::string &cmd) { this->on_command_send(cmd); });
+  }
+
+  void dump_config() override;
+  void on_command_send(const std::string &command);
+
+ protected:
+  void add_command(const std::string &cmd);
+  void on_data_received(const std::string &data);
+
+ private:
+  const char *TAG = "FC";
+  const char *SERVICE_UUID = "C7841029-FE7C-4894-8532-F97908EF1AE4";  // değiştirilmesi gerekebilir
+  const uint16_t CHARACTERISTIC_UUID = 0x0001;
+  bool command_enabled = false;
+  volatile bool _wait_buffer = false;
+  uint16_t char_handle_;
+  std::vector<std::string> commands_{};
+  uint32_t last_command_time_ = 0;
+  std::string last_response_ = {};
+  CaravanDevice *control_unit_device_{nullptr};
+  CaravanDevice *alde_device_{nullptr};
+  CaravanDevice *fridge_device_{nullptr};
+  CaravanDevice *lighting_device_{nullptr};
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/__init__.py
+++ b/esphome/components/fendt_caravan/sensor/__init__.py
@@ -26,14 +26,14 @@ from .control_unit_sensor import (
     CONTROL_UNITS,
 )
 from .fridge_sensor import CONF_FRIDGE_DEVICE, CONFIG_FRIDGE_SCHEMA, FRIDGES
-from .lighting_sensor import CONF_LIGHTONG_DEVICE, CONFIG_LIGHTING_SCHEMA, LIGHTINGS
+from .lighting_sensor import CONF_LIGHTING_DEVICE, CONFIG_LIGHTING_SCHEMA, LIGHTINGS
 
 CONFIG_SCHEMA = CONFIG_FENDT_SCHEMA.extend(
     {
         cv.Required(CONF_CONTROL_UNIT_DEVICE): CONFIG_CONTROL_UNIT_SCHEMA,
         cv.Optional(CONF_FRIDGE_DEVICE): CONFIG_FRIDGE_SCHEMA,
         cv.Optional(CONF_ALDE_DEVICE): CONFIG_ALDE_SCHEMA,
-        cv.Optional(CONF_LIGHTONG_DEVICE): CONFIG_LIGHTING_SCHEMA,
+        cv.Optional(CONF_LIGHTING_DEVICE): CONFIG_LIGHTING_SCHEMA,
     }
 )
 
@@ -91,7 +91,7 @@ async def to_code(config):
         cg.add(parent.set_fridge_device(var))
         await device_to_code(var, FRIDGES, conf_fridge)
 
-    if conf_lighting := config.get(CONF_LIGHTONG_DEVICE):
+    if conf_lighting := config.get(CONF_LIGHTING_DEVICE):
         var = cg.new_Pvariable(conf_lighting[CONF_ID])
         await cg.register_component(var, conf_lighting)
         cg.add(parent.set_lighting_device(var))

--- a/esphome/components/fendt_caravan/sensor/__init__.py
+++ b/esphome/components/fendt_caravan/sensor/__init__.py
@@ -1,0 +1,98 @@
+import esphome.codegen as cg
+from esphome.components import light, number, select, sensor, switch, text_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_OPTIONS,
+    CONF_OUTPUT_ID,
+    CONF_STEP,
+)
+
+from .. import (
+    CONF_FENDT_CARAVAN_ID,
+    CONFIG_FENDT_SCHEMA,
+    FendtNumber,
+    FendtSelect,
+    FendtSensor,
+    FendtSwitch,
+    FendtTextSensor,
+)
+from .alde_sensor import ALDES, CONF_ALDE_DEVICE, CONFIG_ALDE_SCHEMA
+from .control_unit_sensor import (
+    CONF_CONTROL_UNIT_DEVICE,
+    CONFIG_CONTROL_UNIT_SCHEMA,
+    CONTROL_UNITS,
+)
+from .fridge_sensor import CONF_FRIDGE_DEVICE, CONFIG_FRIDGE_SCHEMA, FRIDGES
+from .lighting_sensor import CONF_LIGHTONG_DEVICE, CONFIG_LIGHTING_SCHEMA, LIGHTINGS
+
+CONFIG_SCHEMA = CONFIG_FENDT_SCHEMA.extend(
+    {
+        cv.Required(CONF_CONTROL_UNIT_DEVICE): CONFIG_CONTROL_UNIT_SCHEMA,
+        cv.Optional(CONF_FRIDGE_DEVICE): CONFIG_FRIDGE_SCHEMA,
+        cv.Optional(CONF_ALDE_DEVICE): CONFIG_ALDE_SCHEMA,
+        cv.Optional(CONF_LIGHTONG_DEVICE): CONFIG_LIGHTING_SCHEMA,
+    }
+)
+
+
+async def device_to_code(parent, types, config):
+    for conf in types:
+        if conf in config:
+            conf_item = config[conf]
+            if conf_item[CONF_ID].type is FendtTextSensor:
+                var = await text_sensor.new_text_sensor(conf_item)
+                cg.add(getattr(parent, f"set_{conf}_text_sensor")(var))
+            if conf_item[CONF_ID].type is FendtSwitch:
+                var = await switch.new_switch(conf_item)
+                cg.add(getattr(parent, f"set_{conf}_switch")(var))
+            if conf_item[CONF_ID].type is FendtSelect:
+                var = await select.new_select(
+                    conf_item, options=conf_item[CONF_OPTIONS]
+                )
+                cg.add(getattr(parent, f"set_{conf}_select")(var))
+            if conf_item[CONF_ID].type is FendtNumber:
+                var = await number.new_number(
+                    conf_item,
+                    min_value=conf_item[CONF_MIN_VALUE],
+                    max_value=conf_item[CONF_MAX_VALUE],
+                    step=conf_item[CONF_STEP],
+                )
+                cg.add(getattr(parent, f"set_{conf}_number")(var))
+            if conf_item[CONF_ID].type is FendtSensor:
+                var = await sensor.new_sensor(conf_item)
+                cg.add(getattr(parent, f"set_{conf}_sensor")(var))
+            if conf_item[CONF_ID].type is light.LightState:
+                var = cg.new_Pvariable(conf_item[CONF_OUTPUT_ID])
+                await light.register_light(var, conf_item)
+                cg.add(getattr(parent, f"set_{conf}_light_output")(var))
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_FENDT_CARAVAN_ID])
+
+    conf_unit = config[CONF_CONTROL_UNIT_DEVICE]
+    unit = cg.new_Pvariable(conf_unit[CONF_ID])
+    await cg.register_component(unit, conf_unit)
+    cg.add(parent.set_control_unit(unit))
+    await device_to_code(unit, CONTROL_UNITS, conf_unit)
+
+    if conf_alde := config.get(CONF_ALDE_DEVICE):
+        var = cg.new_Pvariable(conf_alde[CONF_ID])
+        await cg.register_component(var, conf_alde)
+        cg.add(parent.set_alde_device(var))
+        await device_to_code(var, ALDES, conf_alde)
+
+    if conf_fridge := config.get(CONF_FRIDGE_DEVICE):
+        var = cg.new_Pvariable(conf_fridge[CONF_ID])
+        await cg.register_component(var, conf_fridge)
+        cg.add(parent.set_fridge_device(var))
+        await device_to_code(var, FRIDGES, conf_fridge)
+
+    if conf_lighting := config.get(CONF_LIGHTONG_DEVICE):
+        var = cg.new_Pvariable(conf_lighting[CONF_ID])
+        await cg.register_component(var, conf_lighting)
+        cg.add(parent.set_lighting_device(var))
+        await device_to_code(var, LIGHTINGS, conf_lighting)

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
@@ -55,22 +55,22 @@ void AldeDeviceSensor::setup() {
 
   if (this->alde_heater_status_switch_)
     this->alde_heater_status_switch_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_water_switch_)
     this->alde_heater_water_switch_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_water_temperature_switch_)
     this->alde_heater_water_temperature_switch_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_temperature_number_)
     this->alde_heater_temperature_number_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_number_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_number_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_electric_select_)
     this->alde_heater_electric_select_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_select_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_select_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_gas_switch_)
     this->alde_heater_gas_switch_->set_state_change_callback(
-        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&AldeDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void AldeDeviceSensor::dump_config() {
@@ -84,7 +84,7 @@ void AldeDeviceSensor::dump_config() {
   LOG_SWITCH(TAG, "  Heater Gas", this->alde_heater_gas_switch_);
 }
 
-void AldeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+void AldeDeviceSensor::on_switch_state_change_(FendtSwitch *sw, bool state) {
   if (!sw->get_variable())
     return;
   std::string command = sw->get_variable()->get_command();
@@ -94,7 +94,7 @@ void AldeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
   }
 }
 
-void AldeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
+void AldeDeviceSensor::on_number_state_change_(FendtNumber *num, float state) {
   if (!num->get_variable())
     return;
   std::string command = num->get_variable()->get_command();
@@ -103,7 +103,7 @@ void AldeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
     this->command_callback_.call(command);
   }
 }
-void AldeDeviceSensor::on_select_state_change(FendtSelect *sel, std::string state) {
+void AldeDeviceSensor::on_select_state_change_(FendtSelect *sel, std::string state) {
   if (!sel->get_variable())
     return;
   std::string command = sel->get_variable()->get_command();

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
@@ -11,50 +11,50 @@ void AldeDeviceSensor::setup() {
     auto alde_available =
         this->alde_available_text_sensor_->create_variable("HEATER_AVAILABLE", [](const std::string &value) {
           const char *tmp[] = {"Available", "Not available"};
-          return Coders::decode_bool_str(value, tmp);
+          return DeviceDecoders::decode_bool_str(value, tmp);
         });
     this->add_variable(alde_available);
   }
 
-  if (this->alde_heater_satus_switch_) {
-    auto heater_status = this->alde_heater_satus_switch_->create_variable("HEATER_ONOFF", Coders::decode_bool,
-                                                                          Commands::update_toggle<bool>);
+  if (this->alde_heater_status_switch_) {
+    auto heater_status = this->alde_heater_status_switch_->create_variable("HEATER_ONOFF", DeviceDecoders::decode_bool,
+                                                                           Commands::update_toggle<bool>);
     this->add_variable(heater_status);
   }
 
   if (this->alde_heater_temperature_number_) {
-    auto heater_temp = this->alde_heater_temperature_number_->create_variable("HEATER_TEMP", Coders::decode_temperature,
-                                                                              Commands::update_temp_10);
+    auto heater_temp = this->alde_heater_temperature_number_->create_variable(
+        "HEATER_TEMP", DeviceDecoders::decode_temperature, Commands::update_temp_10);
     this->add_variable(heater_temp);
   }
 
   if (this->alde_heater_water_switch_) {
-    auto heater_water = this->alde_heater_water_switch_->create_variable("HEATER_WATER", Coders::decode_bool,
+    auto heater_water = this->alde_heater_water_switch_->create_variable("HEATER_WATER", DeviceDecoders::decode_bool,
                                                                          Commands::update_toggle<bool>);
     this->add_variable(heater_water);
   }
 
   if (this->alde_heater_water_temperature_switch_) {
     auto heater_water_temp = this->alde_heater_water_temperature_switch_->create_variable(
-        "HEATER_WATER_TEMP", [](const std::string &data) { return Coders::decode_temperature(data) == 65.0f; },
+        "HEATER_WATER_TEMP", [](const std::string &data) { return DeviceDecoders::decode_temperature(data) == 65.0f; },
         Commands::update_toggle<bool>);
     this->add_variable(heater_water_temp);
   }
 
   if (this->alde_heater_electric_select_) {
-    auto heater_el = this->alde_heater_electric_select_->create_variable("HEATER_EL", Coders::decode_heater_el,
+    auto heater_el = this->alde_heater_electric_select_->create_variable("HEATER_EL", DeviceDecoders::decode_heater_el,
                                                                          Commands::update_heater_el);
     this->add_variable(heater_el);
   }
 
   if (this->alde_heater_gas_switch_) {
-    auto heater_gas = this->alde_heater_gas_switch_->create_variable("HEATER_GAS", Coders::decode_bool,
+    auto heater_gas = this->alde_heater_gas_switch_->create_variable("HEATER_GAS", DeviceDecoders::decode_bool,
                                                                      Commands::update_toggle<bool>);
     this->add_variable(heater_gas);
   }
 
-  if (this->alde_heater_satus_switch_)
-    this->alde_heater_satus_switch_->set_state_change_callback(
+  if (this->alde_heater_status_switch_)
+    this->alde_heater_status_switch_->set_state_change_callback(
         std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
   if (this->alde_heater_water_switch_)
     this->alde_heater_water_switch_->set_state_change_callback(
@@ -76,7 +76,7 @@ void AldeDeviceSensor::setup() {
 void AldeDeviceSensor::dump_config() {
   ESP_LOGCONFIG(TAG, " -Fendt Alde Device-");
   LOG_TEXT_SENSOR(TAG, "  Alde Sensor", this->alde_available_text_sensor_);
-  LOG_SWITCH(TAG, "  Alde Status Switch", this->alde_heater_satus_switch_);
+  LOG_SWITCH(TAG, "  Alde Status Switch", this->alde_heater_status_switch_);
   LOG_NUMBER(TAG, "  Heater Temperature", this->alde_heater_temperature_number_);
   LOG_SWITCH(TAG, "  Heater Water", this->alde_heater_water_switch_);
   LOG_SWITCH(TAG, "  Water Temperature", this->alde_heater_water_temperature_switch_);

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.cpp
@@ -1,0 +1,117 @@
+#include "alde_device_sensor.h"
+
+#ifdef USE_ESP32
+namespace esphome {
+namespace fendt_caravan {
+
+void AldeDeviceSensor::setup() {
+  ESP_LOGI(TAG, "Setup called");
+
+  if (this->alde_available_text_sensor_) {
+    auto alde_available =
+        this->alde_available_text_sensor_->create_variable("HEATER_AVAILABLE", [](const std::string &value) {
+          const char *tmp[] = {"Available", "Not available"};
+          return Coders::decode_bool_str(value, tmp);
+        });
+    this->add_variable(alde_available);
+  }
+
+  if (this->alde_heater_satus_switch_) {
+    auto heater_status = this->alde_heater_satus_switch_->create_variable("HEATER_ONOFF", Coders::decode_bool,
+                                                                          Commands::update_toggle<bool>);
+    this->add_variable(heater_status);
+  }
+
+  if (this->alde_heater_temperature_number_) {
+    auto heater_temp = this->alde_heater_temperature_number_->create_variable("HEATER_TEMP", Coders::decode_temperature,
+                                                                              Commands::update_temp_10);
+    this->add_variable(heater_temp);
+  }
+
+  if (this->alde_heater_water_switch_) {
+    auto heater_water = this->alde_heater_water_switch_->create_variable("HEATER_WATER", Coders::decode_bool,
+                                                                         Commands::update_toggle<bool>);
+    this->add_variable(heater_water);
+  }
+
+  if (this->alde_heater_water_temperature_switch_) {
+    auto heater_water_temp = this->alde_heater_water_temperature_switch_->create_variable(
+        "HEATER_WATER_TEMP", [](const std::string &data) { return Coders::decode_temperature(data) == 65.0f; },
+        Commands::update_toggle<bool>);
+    this->add_variable(heater_water_temp);
+  }
+
+  if (this->alde_heater_electric_select_) {
+    auto heater_el = this->alde_heater_electric_select_->create_variable("HEATER_EL", Coders::decode_heater_el,
+                                                                         Commands::update_heater_el);
+    this->add_variable(heater_el);
+  }
+
+  if (this->alde_heater_gas_switch_) {
+    auto heater_gas = this->alde_heater_gas_switch_->create_variable("HEATER_GAS", Coders::decode_bool,
+                                                                     Commands::update_toggle<bool>);
+    this->add_variable(heater_gas);
+  }
+
+  if (this->alde_heater_satus_switch_)
+    this->alde_heater_satus_switch_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  if (this->alde_heater_water_switch_)
+    this->alde_heater_water_switch_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  if (this->alde_heater_water_temperature_switch_)
+    this->alde_heater_water_temperature_switch_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  if (this->alde_heater_temperature_number_)
+    this->alde_heater_temperature_number_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_number_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  if (this->alde_heater_electric_select_)
+    this->alde_heater_electric_select_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_select_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  if (this->alde_heater_gas_switch_)
+    this->alde_heater_gas_switch_->set_state_change_callback(
+        std::bind(&AldeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+void AldeDeviceSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, " -Fendt Alde Device-");
+  LOG_TEXT_SENSOR(TAG, "  Alde Sensor", this->alde_available_text_sensor_);
+  LOG_SWITCH(TAG, "  Alde Status Switch", this->alde_heater_satus_switch_);
+  LOG_NUMBER(TAG, "  Heater Temperature", this->alde_heater_temperature_number_);
+  LOG_SWITCH(TAG, "  Heater Water", this->alde_heater_water_switch_);
+  LOG_SWITCH(TAG, "  Water Temperature", this->alde_heater_water_temperature_switch_);
+  LOG_SELECT(TAG, "  Heater Electric", this->alde_heater_electric_select_);
+  LOG_SWITCH(TAG, "  Heater Gas", this->alde_heater_gas_switch_);
+}
+
+void AldeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+  if (!sw->get_variable())
+    return;
+  std::string command = sw->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGD(TAG, "Switch state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+
+void AldeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
+  if (!num->get_variable())
+    return;
+  std::string command = num->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGD(TAG, "Number state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+void AldeDeviceSensor::on_select_state_change(FendtSelect *sel, std::string state) {
+  if (!sel->get_variable())
+    return;
+  std::string command = sel->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGD(TAG, "Select state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+}  // namespace fendt_caravan
+}  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -24,7 +24,7 @@ class AldeDeviceSensor : public CaravanDevice {
   void dump_config() override;
 
   FENDT_TEXT_SENSOR(alde_available);
-  FENDT_SWITCH(alde_heater_satus);
+  FENDT_SWITCH(alde_heater_status);
   FENDT_NUMBER(alde_heater_temperature);
   FENDT_SWITCH(alde_heater_water);
   FENDT_SWITCH(alde_heater_water_temperature);

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "esphome/core/application.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "fendt_text_sensor.h"
+#include "fendt_number.h"
+#include "fendt_switch.h"
+#include "fendt_sensor.h"
+#include "fendt_select.h"
+#include "variable.h"
+#include "caravan_device.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace fendt_caravan {
+
+using namespace std;
+
+class AldeDeviceSensor : public CaravanDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  FENDT_TEXT_SENSOR(alde_available);
+  FENDT_SWITCH(alde_heater_satus);
+  FENDT_NUMBER(alde_heater_temperature);
+  FENDT_SWITCH(alde_heater_water);
+  FENDT_SWITCH(alde_heater_water_temperature);
+  FENDT_SELECT(alde_heater_electric);
+  FENDT_SWITCH(alde_heater_gas);
+
+ protected:
+  const char *get_tag() override { return this->TAG; }
+
+ private:
+  const char *const TAG = "ALD";
+  void on_switch_state_change(FendtSwitch *sw, bool state);
+  void on_number_state_change(FendtNumber *num, float state);
+  void on_select_state_change(FendtSelect *sel, std::string state);
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -32,7 +32,7 @@ class AldeDeviceSensor : public CaravanDevice {
   FENDT_SWITCH(alde_heater_gas);
 
  protected:
-  const char *get_tag() override { return this->TAG; }
+  const char *get_tag_() override { return this->TAG; }
 
  private:
   const char *const TAG = "ALD";

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifdef USE_ESP32
 #include "esphome/core/application.h"
 #include "esphome/core/string_ref.h"
 #include "esphome/core/component.h"
@@ -10,8 +12,6 @@
 #include "fendt_select.h"
 #include "variable.h"
 #include "caravan_device.h"
-
-#ifdef USE_ESP32
 
 namespace esphome {
 namespace fendt_caravan {

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -30,15 +30,15 @@ class AldeDeviceSensor : public CaravanDevice {
   FENDT_SWITCH(alde_heater_water_temperature);
   FENDT_SELECT(alde_heater_electric);
   FENDT_SWITCH(alde_heater_gas);
+  const char *const TAG = "ALD";
 
  protected:
   const char *get_tag_() override { return this->TAG; }
 
  private:
-  const char *const TAG = "ALD";
-  void on_switch_state_change(FendtSwitch *sw, bool state);
-  void on_number_state_change(FendtNumber *num, float state);
-  void on_select_state_change(FendtSelect *sel, std::string state);
+  void on_switch_state_change_(FendtSwitch *sw, bool state);
+  void on_number_state_change_(FendtNumber *num, float state);
+  void on_select_state_change_(FendtSelect *sel, std::string state);
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/alde_device_sensor.h
@@ -33,7 +33,7 @@ class AldeDeviceSensor : public CaravanDevice {
   const char *const TAG = "ALD";
 
  protected:
-  const char *get_tag_() override { return this->TAG; }
+  const char *get_tag() override { return this->TAG; }
 
  private:
   void on_switch_state_change_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/alde_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/alde_sensor.py
@@ -18,19 +18,19 @@ AldeDeviceSensor = fendt_caravan_ns.class_("AldeDeviceSensor", cg.PollingCompone
 
 CONF_ALDE_DEVICE = "alde_device"
 CONF_ALDE_AVAILABLE = "alde_available"
-CONF_ALDE_HEATER_STATUS = "alde_heater_satus"
-CONF_ALDE_HEATER_TEMP = "alde_heater_temperature"
+CONF_ALDE_HEATER_STATUS = "alde_heater_status"
+CONF_ALDE_HEATER_TEMPERATURE = "alde_heater_temperature"
 CONF_ALDE_HEATER_WATER = "alde_heater_water"
-CONF_ALDE_HEATER_WATER_TEMP = "alde_heater_water_temperature"
+CONF_ALDE_HEATER_WATER_TEMPERATURE = "alde_heater_water_temperature"
 CONF_ALDE_HEATER_ELECTRIC = "alde_heater_electric"
 CONF_ALDE_HEATER_GAS = "alde_heater_gas"
 
 ALDES = {
     CONF_ALDE_AVAILABLE,
     CONF_ALDE_HEATER_STATUS,
-    CONF_ALDE_HEATER_TEMP,
+    CONF_ALDE_HEATER_TEMPERATURE,
     CONF_ALDE_HEATER_WATER,
-    CONF_ALDE_HEATER_WATER_TEMP,
+    CONF_ALDE_HEATER_WATER_TEMPERATURE,
     CONF_ALDE_HEATER_ELECTRIC,
     CONF_ALDE_HEATER_GAS,
 }
@@ -43,7 +43,7 @@ ALDE_TYPES = {
     CONF_ALDE_HEATER_STATUS: switch.switch_schema(
         FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:heat-wave"
     ),
-    CONF_ALDE_HEATER_TEMP: number.number_schema(
+    CONF_ALDE_HEATER_TEMPERATURE: number.number_schema(
         FendtNumber,
         device_class=DEVICE_CLASS_TEMPERATURE,
         unit_of_measurement=UNIT_CELSIUS,
@@ -57,7 +57,7 @@ ALDE_TYPES = {
     CONF_ALDE_HEATER_WATER: switch.switch_schema(
         FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:water-boiler"
     ),
-    CONF_ALDE_HEATER_WATER_TEMP: switch.switch_schema(
+    CONF_ALDE_HEATER_WATER_TEMPERATURE: switch.switch_schema(
         FendtSwitch,
         default_restore_mode="RESTORE_DEFAULT_OFF",
         icon="mdi:thermometer-alert",

--- a/esphome/components/fendt_caravan/sensor/alde_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/alde_sensor.py
@@ -1,0 +1,84 @@
+import esphome.codegen as cg
+from esphome.components import number, select, switch, text_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_OPTIONS,
+    CONF_STEP,
+    DEVICE_CLASS_TEMPERATURE,
+    ENTITY_CATEGORY_CONFIG,
+    UNIT_CELSIUS,
+)
+
+from .. import FendtNumber, FendtSelect, FendtSwitch, FendtTextSensor, fendt_caravan_ns
+
+AldeDeviceSensor = fendt_caravan_ns.class_("AldeDeviceSensor", cg.PollingComponent)
+
+CONF_ALDE_DEVICE = "alde_device"
+CONF_ALDE_AVAILABLE = "alde_available"
+CONF_ALDE_HEATER_STATUS = "alde_heater_satus"
+CONF_ALDE_HEATER_TEMP = "alde_heater_temperature"
+CONF_ALDE_HEATER_WATER = "alde_heater_water"
+CONF_ALDE_HEATER_WATER_TEMP = "alde_heater_water_temperature"
+CONF_ALDE_HEATER_ELECTRIC = "alde_heater_electric"
+CONF_ALDE_HEATER_GAS = "alde_heater_gas"
+
+ALDES = {
+    CONF_ALDE_AVAILABLE,
+    CONF_ALDE_HEATER_STATUS,
+    CONF_ALDE_HEATER_TEMP,
+    CONF_ALDE_HEATER_WATER,
+    CONF_ALDE_HEATER_WATER_TEMP,
+    CONF_ALDE_HEATER_ELECTRIC,
+    CONF_ALDE_HEATER_GAS,
+}
+
+
+ALDE_TYPES = {
+    CONF_ALDE_AVAILABLE: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:air-filter"
+    ),
+    CONF_ALDE_HEATER_STATUS: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:heat-wave"
+    ),
+    CONF_ALDE_HEATER_TEMP: number.number_schema(
+        FendtNumber,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        unit_of_measurement=UNIT_CELSIUS,
+    ).extend(
+        {
+            cv.Optional(CONF_MIN_VALUE, default=5): cv.float_,
+            cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
+            cv.Optional(CONF_STEP, default=0.5): cv.float_,
+        }
+    ),
+    CONF_ALDE_HEATER_WATER: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:water-boiler"
+    ),
+    CONF_ALDE_HEATER_WATER_TEMP: switch.switch_schema(
+        FendtSwitch,
+        default_restore_mode="RESTORE_DEFAULT_OFF",
+        icon="mdi:thermometer-alert",
+    ),
+    CONF_ALDE_HEATER_ELECTRIC: select.select_schema(
+        FendtSelect, entity_category=ENTITY_CATEGORY_CONFIG, icon="mdi:power-settings"
+    ).extend(
+        {
+            cv.Optional(
+                CONF_OPTIONS, default=["Off", "1 kW", "2 kW", "3 kW"]
+            ): cv.ensure_list(cv.string_strict)
+        }
+    ),
+    CONF_ALDE_HEATER_GAS: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:water-boiler"
+    ),
+}
+
+CONFIG_ALDE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(AldeDeviceSensor),
+        **{cv.Optional(type): schema for type, schema in ALDE_TYPES.items()},
+    }
+).extend(cv.polling_component_schema("60s"))

--- a/esphome/components/fendt_caravan/sensor/caravan_device.cpp
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.cpp
@@ -1,0 +1,28 @@
+#include "caravan_device.h"
+
+#ifdef USE_ESP32
+namespace esphome {
+namespace fendt_caravan {
+
+void CaravanDevice::decode(const std::string &name, const std::string &value) {
+  auto *variable = this->get_variable(name);
+  if (variable)
+    variable->decode(value);
+};
+void CaravanDevice::update() {
+  ESP_LOGD(this->get_tag(), "Update called");
+  if (!this->log_variables_)
+    return;
+  ESP_LOGI(this->get_tag(), "Variable Count :%d", this->variables_.size());
+  for (auto *var : this->variables_) {
+    if (var->is_active()) {
+      ESP_LOGI(this->get_tag(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
+    }
+  }
+  this->log_variables_ = false;
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/fendt_caravan/sensor/caravan_device.cpp
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.cpp
@@ -10,13 +10,13 @@ void CaravanDevice::decode(const std::string &name, const std::string &value) {
     variable->decode(value);
 };
 void CaravanDevice::update() {
-  ESP_LOGD(this->get_tag_(), "Update called");
+  ESP_LOGD(this->get_tag(), "Update called");
   if (!this->log_variables_)
     return;
-  ESP_LOGI(this->get_tag_(), "Variable Count :%d", this->variables_.size());
+  ESP_LOGI(this->get_tag(), "Variable Count :%d", this->variables_.size());
   for (auto *var : this->variables_) {
     if (var->is_active()) {
-      ESP_LOGI(this->get_tag_(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
+      ESP_LOGI(this->get_tag(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
     }
   }
   this->log_variables_ = false;

--- a/esphome/components/fendt_caravan/sensor/caravan_device.cpp
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.cpp
@@ -10,13 +10,13 @@ void CaravanDevice::decode(const std::string &name, const std::string &value) {
     variable->decode(value);
 };
 void CaravanDevice::update() {
-  ESP_LOGD(this->get_tag(), "Update called");
+  ESP_LOGD(this->get_tag_(), "Update called");
   if (!this->log_variables_)
     return;
-  ESP_LOGI(this->get_tag(), "Variable Count :%d", this->variables_.size());
+  ESP_LOGI(this->get_tag_(), "Variable Count :%d", this->variables_.size());
   for (auto *var : this->variables_) {
     if (var->is_active()) {
-      ESP_LOGI(this->get_tag(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
+      ESP_LOGI(this->get_tag_(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
     }
   }
   this->log_variables_ = false;

--- a/esphome/components/fendt_caravan/sensor/caravan_device.cpp
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.cpp
@@ -5,7 +5,7 @@ namespace esphome {
 namespace fendt_caravan {
 
 void CaravanDevice::decode(const std::string &name, const std::string &value) {
-  auto *variable = this->get_variable(name);
+  auto *variable = this->get_variable_(name);
   if (variable)
     variable->decode(value);
 };

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -11,29 +11,14 @@ using namespace std;
 
 class CaravanDevice : public PollingComponent {
  public:
-  virtual void decode(const std::string &name, const std::string &value) {
-    auto variable = this->get_variable(name);
-    if (variable)
-      variable->decode(value);
-  };
+  virtual void decode(const std::string &name, const std::string &value);
   void add_variable(IVariable *variable) { this->variables_.push_back(variable); }
   void set_command_send_callback(std::function<void(const std::string &)> &&callback) {
     this->command_callback_.add(std::move(callback));
   }
   void setup() override{};
   void loop() override{};
-  void update() override {
-    ESP_LOGD(this->get_tag(), "Update called");
-    if (!this->log_variables_)
-      return;
-    ESP_LOGI(this->get_tag(), "Variable Count :%d", this->variables_.size());
-    for (auto var : this->variables_) {
-      if (var->is_active()) {
-        ESP_LOGI(this->get_tag(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
-      }
-    }
-    this->log_variables_ = false;
-  };
+  virtual void update();
   void dump_config() override = 0;
 
  protected:
@@ -41,7 +26,7 @@ class CaravanDevice : public PollingComponent {
   CallbackManager<void(const std::string &)> command_callback_{};
   std::vector<IVariable *> get_variables() { return this->variables_; }
   IVariable *get_variable(const std::string &name) {
-    for (auto variable : this->variables_) {
+    for (auto *variable : this->variables_) {
       if (variable->get_name() == name)
         return variable;
     }

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -18,14 +18,14 @@ class CaravanDevice : public PollingComponent {
   }
   void setup() override{};
   void loop() override{};
-  virtual void update();
+  void update() override;
   void dump_config() override = 0;
 
  protected:
   std::vector<IVariable *> variables_{};
   CallbackManager<void(const std::string &)> command_callback_{};
-  std::vector<IVariable *> get_variables() { return this->variables_; }
-  IVariable *get_variable(const std::string &name) {
+  std::vector<IVariable *> get_variables_() { return this->variables_; }
+  IVariable *get_variable_(const std::string &name) {
     for (auto *variable : this->variables_) {
       if (variable->get_name() == name)
         return variable;

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -34,7 +34,7 @@ class CaravanDevice : public PollingComponent {
     }
     return nullptr;
   }
-  virtual const char *get_tag_() = 0;
+  virtual const char *get_tag() = 0;
 
  private:
   bool log_variables_ = false;

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -34,7 +34,7 @@ class CaravanDevice : public PollingComponent {
     }
     return nullptr;
   }
-  virtual const char *get_tag() = 0;
+  virtual const char *get_tag_() = 0;
 
  private:
   bool log_variables_ = false;

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
+#include "variable.h"
+#include "device_commands.h"
+#include "device_decoders.h"
+
+namespace esphome {
+namespace fendt_caravan {
+using namespace std;
+
+class CaravanDevice : public PollingComponent {
+ public:
+  virtual void decode(const std::string &name, const std::string &value) {
+    auto variable = this->get_variable(name);
+    if (variable)
+      variable->decode(value);
+  };
+  void add_variable(IVariable *variable) { this->variables_.push_back(variable); }
+  void set_command_send_callback(std::function<void(const std::string &)> &&callback) {
+    this->command_callback_.add(std::move(callback));
+  }
+  void setup() override{};
+  void loop() override{};
+  void update() override {
+    ESP_LOGD(this->get_tag(), "Update called");
+    if (!this->log_variables_)
+      return;
+    ESP_LOGI(this->get_tag(), "Variable Count :%d", this->variables_.size());
+    for (auto var : this->variables_) {
+      if (var->is_active()) {
+        ESP_LOGI(this->get_tag(), "Variable: %s, raw value: %s", var->get_name().c_str(), var->get_raw_value().c_str());
+      }
+    }
+    this->log_variables_ = false;
+  };
+  void dump_config() override = 0;
+
+ protected:
+  std::vector<IVariable *> variables_{};
+  CallbackManager<void(const std::string &)> command_callback_{};
+  std::vector<IVariable *> get_variables() { return this->variables_; }
+  IVariable *get_variable(const std::string &name) {
+    for (auto variable : this->variables_) {
+      if (variable->get_name() == name)
+        return variable;
+    }
+    return nullptr;
+  }
+  virtual const char *get_tag() = 0;
+
+ private:
+  bool log_variables_ = false;
+};
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/caravan_device.h
+++ b/esphome/components/fendt_caravan/sensor/caravan_device.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifdef USE_ESP32
 #include "esphome/core/component.h"
 #include "esphome/core/string_ref.h"
 #include "variable.h"
@@ -37,6 +39,6 @@ class CaravanDevice : public PollingComponent {
  private:
   bool log_variables_ = false;
 };
-
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
@@ -4,7 +4,7 @@
 namespace esphome {
 namespace fendt_caravan {
 
-#define GET_VARIABLE(T, name) static_cast<Variable<T> *>(this->get_variable(name))
+#define GET_VARIABLE(T, name) static_cast<Variable<T> *>(this->get_variable_(name))
 
 void ControlUnitDeviceSensor::setup() {
   ESP_LOGI(TAG, "Setup called");
@@ -126,7 +126,7 @@ void ControlUnitDeviceSensor::dump_config() {
 
 void ControlUnitDeviceSensor::decode(const std::string &name, const std::string &value) {
   CaravanDevice::decode(name, value);
-  auto variable = this->get_variable(name);
+  auto variable = this->get_variable_(name);
   if (this->main_switch_switch_ && name == "HS_KEY_STATE") {
     auto hs_key_state = static_cast<Variable<int> *>(variable);
     if (hs_key_state->is_active()) {

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
@@ -12,12 +12,12 @@ void ControlUnitDeviceSensor::setup() {
   if (this->power_status_text_sensor_) {
     auto network = this->power_status_text_sensor_->create_variable("LINE_EN", [](const std::string &value) {
       const char *tmp[] = {"Connected", "Disconnected"};
-      return Coders::decode_bool_str(value, tmp);
+      return DeviceDecoders::decode_bool_str(value, tmp);
     });
     this->add_variable(network);
   }
 
-  auto main_switch = new Variable<bool>("HS_EN", Coders::decode_bool, Commands::update_toggle<bool>);
+  auto main_switch = new Variable<bool>("HS_EN", DeviceDecoders::decode_bool, Commands::update_toggle<bool>);
   this->add_variable(main_switch);
 
   auto hs_key = new Variable<bool>("HS_KEY", nullptr, Commands::update_run);
@@ -26,83 +26,83 @@ void ControlUnitDeviceSensor::setup() {
   auto hs_key_long = new Variable<bool>("HS_KEY_LONG", nullptr, Commands::update_run);
   this->add_variable(hs_key_long);
 
-  auto d_plus = new Variable<bool>("D_PLUS", Coders::decode_bool);
+  auto d_plus = new Variable<bool>("D_PLUS", DeviceDecoders::decode_bool);
   this->add_variable(d_plus);
 
-  auto battery_loading_status = new Variable<int>("IBAT_BAL", Coders::decode_int);
+  auto battery_loading_status = new Variable<int>("IBAT_BAL", DeviceDecoders::decode_int);
   this->add_variable(battery_loading_status);
 
   auto ac_active = new Variable<std::string>("AC_EN", [](const std::string &value) {
     const char *tmp[] = {"Enable", "Disable"};
-    return Coders::decode_bool_str(value, tmp);
+    return DeviceDecoders::decode_bool_str(value, tmp);
   });
   this->add_variable(ac_active);
 
-  auto alarm_clock_active = new Variable<bool>("WAKE_EN", Coders::decode_bool);
+  auto alarm_clock_active = new Variable<bool>("WAKE_EN", DeviceDecoders::decode_bool);
   this->add_variable(alarm_clock_active);
 
   if (this->temperature_in_sensor_) {
-    auto temp_in = this->temperature_in_sensor_->create_variable("TEMP_IN", Coders::decode_temperature);
+    auto temp_in = this->temperature_in_sensor_->create_variable("TEMP_IN", DeviceDecoders::decode_temperature);
     this->add_variable(temp_in);
   }
 
   if (this->temperature_out_sensor_) {
-    auto temp_out = this->temperature_out_sensor_->create_variable("TEMP_OUT", Coders::decode_temperature);
+    auto temp_out = this->temperature_out_sensor_->create_variable("TEMP_OUT", DeviceDecoders::decode_temperature);
     this->add_variable(temp_out);
   }
 
-  auto battery_voltage = new Variable<float>("UBAT", Coders::decode_voltage);
+  auto battery_voltage = new Variable<float>("UBAT", DeviceDecoders::decode_voltage);
   this->add_variable(battery_voltage);
 
-  auto battery_voltage2 = new Variable<float>("UBATM", Coders::decode_voltage);
+  auto battery_voltage2 = new Variable<float>("UBATM", DeviceDecoders::decode_voltage);
   this->add_variable(battery_voltage2);
 
-  auto date = new Variable<time_t>("DATE", Coders::decode_date);
+  auto date = new Variable<time_t>("DATE", DeviceDecoders::decode_date);
   this->add_variable(date);
 
-  auto time = new Variable<time_t>("TIME", Coders::decode_time);
+  auto time = new Variable<time_t>("TIME", DeviceDecoders::decode_time);
   this->add_variable(time);
 
   if (this->floor_heater_switch_) {
-    auto *sw = this->floor_heater_switch_->create_variable("FLOOR_HEATER_ON", Coders::decode_bool,
+    auto *sw = this->floor_heater_switch_->create_variable("FLOOR_HEATER_ON", DeviceDecoders::decode_bool,
                                                            Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->floor_heater_switch_->set_state_change_callback(std::bind(
         &ControlUnitDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
   }
 
-  auto temp_in_offset = new Variable<int>("TEMP_IN_OFFSET", Coders::decode_int);
+  auto temp_in_offset = new Variable<int>("TEMP_IN_OFFSET", DeviceDecoders::decode_int);
   this->add_variable(temp_in_offset);
 
-  auto temp_out_offset = new Variable<int>("TEMP_OUT_OFFSET", Coders::decode_int);
+  auto temp_out_offset = new Variable<int>("TEMP_OUT_OFFSET", DeviceDecoders::decode_int);
   this->add_variable(temp_out_offset);
 
   if (this->software_version_text_sensor_) {
     auto software_version =
-        this->software_version_text_sensor_->create_variable("SOFTWARE_VERSION", Coders::decode_str);
+        this->software_version_text_sensor_->create_variable("SOFTWARE_VERSION", DeviceDecoders::decode_str);
     this->add_variable(software_version);
   }
 
-  auto hs_key_state = new Variable<int>("HS_KEY_STATE", Coders::decode_int);
+  auto hs_key_state = new Variable<int>("HS_KEY_STATE", DeviceDecoders::decode_int);
   this->add_variable(hs_key_state);
 
-  auto th_error = new Variable<int>("TH_ERROR", Coders::decode_int);
+  auto th_error = new Variable<int>("TH_ERROR", DeviceDecoders::decode_int);
   this->add_variable(th_error);
 
-  auto trade_show = new Variable<int>("TRADE_SHOW", Coders::decode_int);
+  auto trade_show = new Variable<int>("TRADE_SHOW", DeviceDecoders::decode_int);
   this->add_variable(trade_show);
 
-  auto therme_config = new Variable<int>("THERME_CONFIG", Coders::decode_int);
+  auto therme_config = new Variable<int>("THERME_CONFIG", DeviceDecoders::decode_int);
   this->add_variable(therme_config);
 
   auto floor_heater_config =
-      new Variable<bool>("FLOOR_HEATER_CONFIG", Coders::decode_bool, Commands::update_toggle<bool>);
+      new Variable<bool>("FLOOR_HEATER_CONFIG", DeviceDecoders::decode_bool, Commands::update_toggle<bool>);
   this->add_variable(floor_heater_config);
 
-  auto waste_water_heater_config = new Variable<int>("WASTE_WATER_HEATER_CONFIG", Coders::decode_int);
+  auto waste_water_heater_config = new Variable<int>("WASTE_WATER_HEATER_CONFIG", DeviceDecoders::decode_int);
   this->add_variable(waste_water_heater_config);
 
-  auto radio_config = new Variable<bool>("RADIO_CONFIG", Coders::decode_bool);
+  auto radio_config = new Variable<bool>("RADIO_CONFIG", DeviceDecoders::decode_bool);
   this->add_variable(radio_config);
 
   if (this->main_switch_switch_)

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
@@ -68,7 +68,7 @@ void ControlUnitDeviceSensor::setup() {
                                                            Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->floor_heater_switch_->set_state_change_callback(std::bind(
-        &ControlUnitDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        &ControlUnitDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   }
 
   auto temp_in_offset = new Variable<int>("TEMP_IN_OFFSET", DeviceDecoders::decode_int);
@@ -106,11 +106,11 @@ void ControlUnitDeviceSensor::setup() {
   this->add_variable(radio_config);
 
   if (this->main_switch_switch_)
-    this->main_switch_switch_->set_state_change_callback(std::bind(&ControlUnitDeviceSensor::on_switch_state_change,
+    this->main_switch_switch_->set_state_change_callback(std::bind(&ControlUnitDeviceSensor::on_switch_state_change_,
                                                                    this, std::placeholders::_1, std::placeholders::_2));
   if (this->light_status_switch_)
     this->light_status_switch_->set_state_change_callback(std::bind(
-        &ControlUnitDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        &ControlUnitDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void ControlUnitDeviceSensor::dump_config() {
@@ -138,9 +138,9 @@ void ControlUnitDeviceSensor::decode(const std::string &name, const std::string 
   }
 }
 
-void ControlUnitDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+void ControlUnitDeviceSensor::on_switch_state_change_(FendtSwitch *sw, bool state) {
   std::string command = "";
-  ESP_LOGV(TAG, "on_switch_state_change called");
+  ESP_LOGV(TAG, "on_switch_state_change_ called");
   if (sw == this->main_switch_switch_) {
     auto hs_key_long = GET_VARIABLE(bool, "HS_KEY_LONG");
     auto hs_key_state = GET_VARIABLE(int, "HS_KEY_STATE");

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.cpp
@@ -1,0 +1,189 @@
+#include "control_unit_device_sensor.h"
+
+#ifdef USE_ESP32
+namespace esphome {
+namespace fendt_caravan {
+
+#define GET_VARIABLE(T, name) static_cast<Variable<T> *>(this->get_variable(name))
+
+void ControlUnitDeviceSensor::setup() {
+  ESP_LOGI(TAG, "Setup called");
+
+  if (this->power_status_text_sensor_) {
+    auto network = this->power_status_text_sensor_->create_variable("LINE_EN", [](const std::string &value) {
+      const char *tmp[] = {"Connected", "Disconnected"};
+      return Coders::decode_bool_str(value, tmp);
+    });
+    this->add_variable(network);
+  }
+
+  auto main_switch = new Variable<bool>("HS_EN", Coders::decode_bool, Commands::update_toggle<bool>);
+  this->add_variable(main_switch);
+
+  auto hs_key = new Variable<bool>("HS_KEY", nullptr, Commands::update_run);
+  this->add_variable(hs_key);
+
+  auto hs_key_long = new Variable<bool>("HS_KEY_LONG", nullptr, Commands::update_run);
+  this->add_variable(hs_key_long);
+
+  auto d_plus = new Variable<bool>("D_PLUS", Coders::decode_bool);
+  this->add_variable(d_plus);
+
+  auto battery_loading_status = new Variable<int>("IBAT_BAL", Coders::decode_int);
+  this->add_variable(battery_loading_status);
+
+  auto ac_active = new Variable<std::string>("AC_EN", [](const std::string &value) {
+    const char *tmp[] = {"Enable", "Disable"};
+    return Coders::decode_bool_str(value, tmp);
+  });
+  this->add_variable(ac_active);
+
+  auto alarm_clock_active = new Variable<bool>("WAKE_EN", Coders::decode_bool);
+  this->add_variable(alarm_clock_active);
+
+  if (this->temperature_in_sensor_) {
+    auto temp_in = this->temperature_in_sensor_->create_variable("TEMP_IN", Coders::decode_temperature);
+    this->add_variable(temp_in);
+  }
+
+  if (this->temperature_out_sensor_) {
+    auto temp_out = this->temperature_out_sensor_->create_variable("TEMP_OUT", Coders::decode_temperature);
+    this->add_variable(temp_out);
+  }
+
+  auto battery_voltage = new Variable<float>("UBAT", Coders::decode_voltage);
+  this->add_variable(battery_voltage);
+
+  auto battery_voltage2 = new Variable<float>("UBATM", Coders::decode_voltage);
+  this->add_variable(battery_voltage2);
+
+  auto date = new Variable<time_t>("DATE", Coders::decode_date);
+  this->add_variable(date);
+
+  auto time = new Variable<time_t>("TIME", Coders::decode_time);
+  this->add_variable(time);
+
+  if (this->floor_heater_switch_) {
+    auto *sw = this->floor_heater_switch_->create_variable("FLOOR_HEATER_ON", Coders::decode_bool,
+                                                           Commands::update_toggle<bool>);
+    this->add_variable(sw);
+    this->floor_heater_switch_->set_state_change_callback(std::bind(
+        &ControlUnitDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  }
+
+  auto temp_in_offset = new Variable<int>("TEMP_IN_OFFSET", Coders::decode_int);
+  this->add_variable(temp_in_offset);
+
+  auto temp_out_offset = new Variable<int>("TEMP_OUT_OFFSET", Coders::decode_int);
+  this->add_variable(temp_out_offset);
+
+  if (this->software_version_text_sensor_) {
+    auto software_version =
+        this->software_version_text_sensor_->create_variable("SOFTWARE_VERSION", Coders::decode_str);
+    this->add_variable(software_version);
+  }
+
+  auto hs_key_state = new Variable<int>("HS_KEY_STATE", Coders::decode_int);
+  this->add_variable(hs_key_state);
+
+  auto th_error = new Variable<int>("TH_ERROR", Coders::decode_int);
+  this->add_variable(th_error);
+
+  auto trade_show = new Variable<int>("TRADE_SHOW", Coders::decode_int);
+  this->add_variable(trade_show);
+
+  auto therme_config = new Variable<int>("THERME_CONFIG", Coders::decode_int);
+  this->add_variable(therme_config);
+
+  auto floor_heater_config =
+      new Variable<bool>("FLOOR_HEATER_CONFIG", Coders::decode_bool, Commands::update_toggle<bool>);
+  this->add_variable(floor_heater_config);
+
+  auto waste_water_heater_config = new Variable<int>("WASTE_WATER_HEATER_CONFIG", Coders::decode_int);
+  this->add_variable(waste_water_heater_config);
+
+  auto radio_config = new Variable<bool>("RADIO_CONFIG", Coders::decode_bool);
+  this->add_variable(radio_config);
+
+  if (this->main_switch_switch_)
+    this->main_switch_switch_->set_state_change_callback(std::bind(&ControlUnitDeviceSensor::on_switch_state_change,
+                                                                   this, std::placeholders::_1, std::placeholders::_2));
+  if (this->light_status_switch_)
+    this->light_status_switch_->set_state_change_callback(std::bind(
+        &ControlUnitDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+}
+
+void ControlUnitDeviceSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, " -Fendt Control Unit-");
+  LOG_SWITCH(TAG, "  Main Switch", this->main_switch_switch_);
+  LOG_SWITCH(TAG, "  Lights Status", this->light_status_switch_);
+  LOG_SENSOR(TAG, "  Temp In", this->temperature_in_sensor_);
+  LOG_SENSOR(TAG, "  Temp Out", this->temperature_out_sensor_);
+  LOG_TEXT_SENSOR(TAG, "  Power Status", this->power_status_text_sensor_);
+  LOG_TEXT_SENSOR(TAG, "  Software Version", this->software_version_text_sensor_);
+  LOG_SWITCH(TAG, "  Floor Heater", this->floor_heater_switch_);
+}
+
+void ControlUnitDeviceSensor::decode(const std::string &name, const std::string &value) {
+  CaravanDevice::decode(name, value);
+  auto variable = this->get_variable(name);
+  if (this->main_switch_switch_ && name == "HS_KEY_STATE") {
+    auto hs_key_state = static_cast<Variable<int> *>(variable);
+    if (hs_key_state->is_active()) {
+      if (this->main_switch_switch_)
+        this->main_switch_switch_->publish_state(hs_key_state->get_value() > 0);
+      if (this->light_status_switch_)
+        this->light_status_switch_->publish_state(hs_key_state->get_value() == 2);
+    }
+  }
+}
+
+void ControlUnitDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+  std::string command = "";
+  ESP_LOGV(TAG, "on_switch_state_change called");
+  if (sw == this->main_switch_switch_) {
+    auto hs_key_long = GET_VARIABLE(bool, "HS_KEY_LONG");
+    auto hs_key_state = GET_VARIABLE(int, "HS_KEY_STATE");
+    bool current_state = hs_key_state->get_value() > 0;
+
+    ESP_LOGV(TAG, "Main switch state changed. cs: %d, state:%d", current_state, state);
+    if (!(hs_key_long && hs_key_state))
+      return;
+    if (state == current_state)
+      return;
+
+    std::string command = "";
+    if (current_state) {
+      hs_key_long->set_value(true);
+      command = hs_key_long->get_command();
+    } else {
+      auto hs_key = GET_VARIABLE(bool, "HS_KEY");
+      hs_key->set_value(true);
+      command = hs_key->get_command();
+    }
+  } else if (sw == this->light_status_switch_) {
+    auto hs_key = GET_VARIABLE(bool, "HS_KEY");
+    auto hs_key_state = GET_VARIABLE(int, "HS_KEY_STATE");
+    bool current_state = hs_key_state->get_value() == 2;
+    ESP_LOGD(TAG, "Light switch state changed. cs: %d, state:%d", current_state, state);
+    if (hs_key && hs_key_state) {
+      if (current_state == state)
+        return;
+      command = hs_key->get_command();
+    }
+  } else if (sw == this->floor_heater_switch_) {
+    ESP_LOGV(TAG, "Floor switch state changed. cs: %d, state:%d", this->floor_heater_switch_->state, state);
+    if (state == this->floor_heater_switch_->state)
+      return;
+    command = this->floor_heater_switch_->get_variable()->get_command();
+  }
+  if (!command.empty()) {
+    ESP_LOGD(TAG, "Switch state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef USE_ESP32
+#include <functional>
+#include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/application.h"
+#include "esphome/core/log.h"
+#include "fendt_text_sensor.h"
+#include "caravan_device.h"
+#include "fendt_sensor.h"
+#include "fendt_switch.h"
+#include "variable.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+using namespace std;
+
+// using command_callback = std::function<void(const std::string &)>;
+
+class ControlUnitDeviceSensor : public CaravanDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void decode(const std::string &variable, const std::string &value) override;
+
+  FENDT_SWITCH(main_switch);
+  FENDT_SENSOR(temperature_in);
+  FENDT_SENSOR(temperature_out);
+  FENDT_TEXT_SENSOR(power_status);
+  FENDT_SWITCH(light_status);
+  FENDT_TEXT_SENSOR(software_version);
+  FENDT_SWITCH(floor_heater);
+
+ protected:
+  const char *get_tag() override { return this->TAG; }
+
+ private:
+  const char *TAG = "MCU";
+  void on_switch_state_change(FendtSwitch *sw, bool state);
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
@@ -35,7 +35,7 @@ class ControlUnitDeviceSensor : public CaravanDevice {
   const char *TAG = "MCU";
 
  protected:
-  const char *get_tag_() override { return this->TAG; }
+  const char *get_tag() override { return this->TAG; }
 
  private:
   void on_switch_state_change_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
@@ -34,7 +34,7 @@ class ControlUnitDeviceSensor : public CaravanDevice {
   FENDT_SWITCH(floor_heater);
 
  protected:
-  const char *get_tag() override { return this->TAG; }
+  const char *get_tag_() override { return this->TAG; }
 
  private:
   const char *TAG = "MCU";

--- a/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/control_unit_device_sensor.h
@@ -32,13 +32,13 @@ class ControlUnitDeviceSensor : public CaravanDevice {
   FENDT_SWITCH(light_status);
   FENDT_TEXT_SENSOR(software_version);
   FENDT_SWITCH(floor_heater);
+  const char *TAG = "MCU";
 
  protected:
   const char *get_tag_() override { return this->TAG; }
 
  private:
-  const char *TAG = "MCU";
-  void on_switch_state_change(FendtSwitch *sw, bool state);
+  void on_switch_state_change_(FendtSwitch *sw, bool state);
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/control_unit_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/control_unit_sensor.py
@@ -14,50 +14,50 @@ ControlUnitDeviceSensor = fendt_caravan_ns.class_(
     "ControlUnitDeviceSensor", cg.PollingComponent
 )
 
-CONF_CONTROL_UNIT_DEVICE = "control_unit"
-CONF_UNIT_MAIN_SWITCH = "main_switch"
-CONF_UNIT_TEMP_IN = "temperature_in"
-CONF_UNIT_TEMP_OUT = "temperature_out"
-CONF_UNIT_POWER_STATUS = "power_status"
-CONF_UNIT_LIGHT_STATUS = "light_status"
-CONF_UNIT_SOFTWARE_VERSION = "software_version"
+CONF_CONTROL_UNIT_DEVICE = "control_unit_device"
+CONF_MAIN_SWITCH = "main_switch"
+CONF_TEMPERATURE_IN = "temperature_in"
+CONF_TEMPERATURE_OUT = "temperature_out"
+CONF_POWER_STATUS = "power_status"
+CONF_LIGHT_STATUS = "light_status"
+CONF_SOFTWARE_VERSION = "software_version"
 CONF_FLOOR_HEATER = "floor_heater"
 
 CONTROL_UNITS = {
-    CONF_UNIT_MAIN_SWITCH,
-    CONF_UNIT_TEMP_IN,
-    CONF_UNIT_TEMP_OUT,
-    CONF_UNIT_POWER_STATUS,
-    CONF_UNIT_LIGHT_STATUS,
-    CONF_UNIT_SOFTWARE_VERSION,
+    CONF_MAIN_SWITCH,
+    CONF_TEMPERATURE_IN,
+    CONF_TEMPERATURE_OUT,
+    CONF_POWER_STATUS,
+    CONF_LIGHT_STATUS,
+    CONF_SOFTWARE_VERSION,
     CONF_FLOOR_HEATER,
 }
 
 UNIT_TYPES = {
-    CONF_UNIT_MAIN_SWITCH: switch.switch_schema(
+    CONF_MAIN_SWITCH: switch.switch_schema(
         FendtSwitch, default_restore_mode="ALWAYS_OFF", icon="mdi:switch"
     ),
-    CONF_UNIT_TEMP_IN: sensor.sensor_schema(
+    CONF_TEMPERATURE_IN: sensor.sensor_schema(
         FendtSensor,
         unit_of_measurement=UNIT_CELSIUS,
         accuracy_decimals=1,
         state_class=STATE_CLASS_MEASUREMENT,
         device_class=DEVICE_CLASS_TEMPERATURE,
     ),
-    CONF_UNIT_TEMP_OUT: sensor.sensor_schema(
+    CONF_TEMPERATURE_OUT: sensor.sensor_schema(
         FendtSensor,
         unit_of_measurement=UNIT_CELSIUS,
         accuracy_decimals=1,
         state_class=STATE_CLASS_MEASUREMENT,
         device_class=DEVICE_CLASS_TEMPERATURE,
     ),
-    CONF_UNIT_POWER_STATUS: text_sensor.text_sensor_schema(
+    CONF_POWER_STATUS: text_sensor.text_sensor_schema(
         FendtTextSensor, icon="mdi:power-plug"
     ),
-    CONF_UNIT_LIGHT_STATUS: switch.switch_schema(
+    CONF_LIGHT_STATUS: switch.switch_schema(
         FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
     ),
-    CONF_UNIT_SOFTWARE_VERSION: text_sensor.text_sensor_schema(
+    CONF_SOFTWARE_VERSION: text_sensor.text_sensor_schema(
         FendtTextSensor, icon="mdi:application-braces-outline"
     ),
     CONF_FLOOR_HEATER: switch.switch_schema(

--- a/esphome/components/fendt_caravan/sensor/control_unit_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/control_unit_sensor.py
@@ -1,0 +1,73 @@
+import esphome.codegen as cg
+from esphome.components import sensor, switch, text_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+)
+
+from .. import FendtSensor, FendtSwitch, FendtTextSensor, fendt_caravan_ns
+
+ControlUnitDeviceSensor = fendt_caravan_ns.class_(
+    "ControlUnitDeviceSensor", cg.PollingComponent
+)
+
+CONF_CONTROL_UNIT_DEVICE = "control_unit"
+CONF_UNIT_MAIN_SWITCH = "main_switch"
+CONF_UNIT_TEMP_IN = "temperature_in"
+CONF_UNIT_TEMP_OUT = "temperature_out"
+CONF_UNIT_POWER_STATUS = "power_status"
+CONF_UNIT_LIGHT_STATUS = "light_status"
+CONF_UNIT_SOFTWARE_VERSION = "software_version"
+CONF_FLOOR_HEATER = "floor_heater"
+
+CONTROL_UNITS = {
+    CONF_UNIT_MAIN_SWITCH,
+    CONF_UNIT_TEMP_IN,
+    CONF_UNIT_TEMP_OUT,
+    CONF_UNIT_POWER_STATUS,
+    CONF_UNIT_LIGHT_STATUS,
+    CONF_UNIT_SOFTWARE_VERSION,
+    CONF_FLOOR_HEATER,
+}
+
+UNIT_TYPES = {
+    CONF_UNIT_MAIN_SWITCH: switch.switch_schema(
+        FendtSwitch, default_restore_mode="ALWAYS_OFF", icon="mdi:switch"
+    ),
+    CONF_UNIT_TEMP_IN: sensor.sensor_schema(
+        FendtSensor,
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    CONF_UNIT_TEMP_OUT: sensor.sensor_schema(
+        FendtSensor,
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        state_class=STATE_CLASS_MEASUREMENT,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+    ),
+    CONF_UNIT_POWER_STATUS: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:power-plug"
+    ),
+    CONF_UNIT_LIGHT_STATUS: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
+    ),
+    CONF_UNIT_SOFTWARE_VERSION: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:application-braces-outline"
+    ),
+    CONF_FLOOR_HEATER: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:heat-wave"
+    ),
+}
+
+CONFIG_CONTROL_UNIT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(ControlUnitDeviceSensor),
+        **{cv.Optional(type): schema for type, schema in UNIT_TYPES.items()},
+    }
+).extend(cv.polling_component_schema("60s"))

--- a/esphome/components/fendt_caravan/sensor/device_commands.h
+++ b/esphome/components/fendt_caravan/sensor/device_commands.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifdef USE_ESP32
 #include "esphome/core/string_ref.h"
 #include "esphome/core/log.h"
 
@@ -47,3 +49,4 @@ class Commands {
 
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/device_commands.h
+++ b/esphome/components/fendt_caravan/sensor/device_commands.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace fendt_caravan {
@@ -13,12 +14,13 @@ class Commands {
   }
   static std::string update_run(const std::string &name, bool value) {
     std::string ret_value = "";
-    if (name == "HS_KEY")
+    if (name == "HS_KEY") {
       ret_value = "net-HS_KEY";
-    else if (name == "HS_KEY_LONG")
+    } else if (name == "HS_KEY_LONG") {
       ret_value = "net-HS_KEY_LONG";
-    else
+    } else {
       ret_value = std::string("cmd-run:") + name;
+    }
     return ret_value;
   }
 
@@ -27,14 +29,15 @@ class Commands {
     return "net-" + name + "-" + std::to_string(val);
   }
 
-  static std::string update_heater_el(const std::string &name, std::string el) {
+  static std::string update_heater_el(const std::string &name, const std::string &el) {
     std::string value = "0";
-    if (el == "1 kW")
+    if (el == "1 kW") {
       value = "1";
-    else if (el == "2 kW")
+    } else if (el == "2 kW") {
       value = "2";
-    else if (el == "3 kW")
+    } else if (el == "3 kW") {
       value = "3";
+    }
     return "net-" + name + "-" + value;
   }
   static std::string update_int(const std::string &name, int value) {

--- a/esphome/components/fendt_caravan/sensor/device_commands.h
+++ b/esphome/components/fendt_caravan/sensor/device_commands.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "esphome/core/string_ref.h"
+
+namespace esphome {
+namespace fendt_caravan {
+using namespace std;
+
+class Commands {
+ public:
+  template<class T> static std::string update_toggle(const std::string &name, T value) {
+    std::string command = "cmd-tgl:" + name;
+    return command;
+  }
+  static std::string update_run(const std::string &name, bool value) {
+    std::string ret_value = "";
+    if (name == "HS_KEY")
+      ret_value = "net-HS_KEY";
+    else if (name == "HS_KEY_LONG")
+      ret_value = "net-HS_KEY_LONG";
+    else
+      ret_value = std::string("cmd-run:") + name;
+    return ret_value;
+  }
+
+  static std::string update_temp_10(const std::string &name, float temp) {
+    int val = (int) (temp * 10.0);
+    return "net-" + name + "-" + std::to_string(val);
+  }
+
+  static std::string update_heater_el(const std::string &name, std::string el) {
+    std::string value = "0";
+    if (el == "1 kW")
+      value = "1";
+    else if (el == "2 kW")
+      value = "2";
+    else if (el == "3 kW")
+      value = "3";
+    return "net-" + name + "-" + value;
+  }
+  static std::string update_int(const std::string &name, int value) {
+    return "cmd-set:" + name + "=" + std::to_string(value);
+  }
+};
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/device_decoders.cpp
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.cpp
@@ -1,5 +1,6 @@
 #include "device_decoders.h"
 
+#ifdef USE_ESP32
 namespace esphome {
 namespace fendt_caravan {
 
@@ -25,6 +26,6 @@ time_t DeviceDecoders::decode_time(const std::string &data) {
   time_t ret = mktime(&tm);
   return ret;
 }
-
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/device_decoders.cpp
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.cpp
@@ -1,0 +1,30 @@
+#include "device_decoders.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+time_t DeviceDecoders::decode_date(const std::string &data) {
+  std::istringstream date(data);
+  tm tm = {};
+  date >> get_time(&tm, "%d.%m.%y");
+  if (date.fail()) {
+    ESP_LOGE("CODERS", "Date Parsing failed");
+    return 0;
+  }
+  time_t ret = mktime(&tm);
+  return ret;
+}
+time_t DeviceDecoders::decode_time(const std::string &data) {
+  std::istringstream date(data);
+  tm tm = {};
+  date >> get_time(&tm, "%H:%M:%S");
+  if (date.fail()) {
+    ESP_LOGE("CODERS", "Date Parsing failed");
+    return 0;
+  }
+  time_t ret = mktime(&tm);
+  return ret;
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/device_decoders.h
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.h
@@ -3,20 +3,18 @@
 #include <iostream>
 #include <iomanip>
 #include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace fendt_caravan {
 using namespace std;
 
-class Coders {
+class DeviceDecoders {
  public:
   static bool decode_bool(const std::string &value) {
     std::string decode = value;
     std::transform(decode.begin(), decode.end(), decode.begin(), [](unsigned char c) { return std::tolower(c); });
-    if ((decode == "01") || (decode == "true") || (decode == "1") || (decode == "on"))
-      return true;
-    else
-      return false;
+    return (decode == "01") || (decode == "true") || (decode == "1") || (decode == "on");
   }
   static std::string decode_str(const std::string &value) { return value; }
   static std::string decode_bool_str(const std::string &value, const char **text) {
@@ -27,7 +25,7 @@ class Coders {
     size_t start = value.find("^C");
     if (start != std::string::npos)
       value.replace(start, 2, "");
-    start = value.find(",");
+    start = value.find(',');
     if (start != std::string::npos)
       value.replace(start, 1, ".");
     return std::stof(value);
@@ -37,34 +35,14 @@ class Coders {
     size_t start = value.find("V");
     if (start != std::string::npos)
       value.replace(start, 1, "");
-    start = value.find(",");
+    start = value.find(',');
     if (start != std::string::npos)
       value.replace(start, 1, ".");
     return std::stof(value);
   }
   static int decode_int(const std::string &data) { return std::stoi(data); }
-  static time_t decode_date(const std::string &data) {
-    std::istringstream date(data);
-    tm tm = {};
-    date >> get_time(&tm, "%d.%m.%y");
-    if (date.fail()) {
-      ESP_LOGE("CODERS", "Date Parsing failed");
-      return 0;
-    }
-    time_t ret = mktime(&tm);
-    return ret;
-  }
-  static time_t decode_time(const std::string &data) {
-    std::istringstream date(data);
-    tm tm = {};
-    date >> get_time(&tm, "%H:%M:%S");
-    if (date.fail()) {
-      ESP_LOGE("CODERS", "Date Parsing failed");
-      return 0;
-    }
-    time_t ret = mktime(&tm);
-    return ret;
-  }
+  static time_t decode_date(const std::string &data);
+  static time_t decode_time(const std::string &data);
 
   static std::string decode_heater_el(const std::string &data) {
     std::string ret_val = data;

--- a/esphome/components/fendt_caravan/sensor/device_decoders.h
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.h
@@ -2,6 +2,11 @@
 #include <ctime>
 #include <iostream>
 #include <iomanip>
+#include <vector>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cctype>
 #include "esphome/core/string_ref.h"
 #include "esphome/core/log.h"
 

--- a/esphome/components/fendt_caravan/sensor/device_decoders.h
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.h
@@ -1,0 +1,87 @@
+#pragma once
+#include <ctime>
+#include <iostream>
+#include <iomanip>
+#include "esphome/core/string_ref.h"
+
+namespace esphome {
+namespace fendt_caravan {
+using namespace std;
+
+class Coders {
+ public:
+  static bool decode_bool(const std::string &value) {
+    std::string decode = value;
+    std::transform(decode.begin(), decode.end(), decode.begin(), [](unsigned char c) { return std::tolower(c); });
+    if ((decode == "01") || (decode == "true") || (decode == "1") || (decode == "on"))
+      return true;
+    else
+      return false;
+  }
+  static std::string decode_str(const std::string &value) { return value; }
+  static std::string decode_bool_str(const std::string &value, const char **text) {
+    return decode_bool(value) ? std::string(text[0]) : std::string(text[1]);
+  }
+  static float decode_temperature(const std::string &data) {
+    std::string value = data;
+    size_t start = value.find("^C");
+    if (start != std::string::npos)
+      value.replace(start, 2, "");
+    start = value.find(",");
+    if (start != std::string::npos)
+      value.replace(start, 1, ".");
+    return std::stof(value);
+  }
+  static float decode_voltage(const std::string &data) {
+    std::string value = data;
+    size_t start = value.find("V");
+    if (start != std::string::npos)
+      value.replace(start, 1, "");
+    start = value.find(",");
+    if (start != std::string::npos)
+      value.replace(start, 1, ".");
+    return std::stof(value);
+  }
+  static int decode_int(const std::string &data) { return std::stoi(data); }
+  static time_t decode_date(const std::string &data) {
+    std::istringstream date(data);
+    tm tm = {};
+    date >> get_time(&tm, "%d.%m.%y");
+    if (date.fail()) {
+      ESP_LOGE("CODERS", "Date Parsing failed");
+      return 0;
+    }
+    time_t ret = mktime(&tm);
+    return ret;
+  }
+  static time_t decode_time(const std::string &data) {
+    std::istringstream date(data);
+    tm tm = {};
+    date >> get_time(&tm, "%H:%M:%S");
+    if (date.fail()) {
+      ESP_LOGE("CODERS", "Date Parsing failed");
+      return 0;
+    }
+    time_t ret = mktime(&tm);
+    return ret;
+  }
+
+  static std::string decode_heater_el(const std::string &data) {
+    std::string ret_val = data;
+
+    /*     if( data == "Off" ) ret_val = "0";
+        if( data == "1 kW") ret_val = "1";
+        if( data == "2 kW") ret_val = "2";
+        if( data == "3 kW") ret_val = "3"; */
+    return ret_val;
+  }
+  static std::string decode_int_str(const std::string &data, const std::vector<std::string> &list) {
+    int val = std::stoi(data);
+    return list.at(val);
+  }
+
+ private:
+};
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/device_decoders.h
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifdef USE_ESP32
 #include "esphome/core/log.h"
 #include "esphome/core/string_ref.h"
 #include <algorithm>
@@ -67,3 +69,4 @@ class DeviceDecoders {
 
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/device_decoders.h
+++ b/esphome/components/fendt_caravan/sensor/device_decoders.h
@@ -1,14 +1,13 @@
 #pragma once
-#include <ctime>
-#include <iostream>
-#include <iomanip>
-#include <vector>
-#include <string>
-#include <vector>
+#include "esphome/core/log.h"
+#include "esphome/core/string_ref.h"
 #include <algorithm>
 #include <cctype>
-#include "esphome/core/string_ref.h"
-#include "esphome/core/log.h"
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace esphome {
 namespace fendt_caravan {
@@ -37,7 +36,7 @@ class DeviceDecoders {
   }
   static float decode_voltage(const std::string &data) {
     std::string value = data;
-    size_t start = value.find("V");
+    size_t start = value.find('V');
     if (start != std::string::npos)
       value.replace(start, 1, "");
     start = value.find(',');

--- a/esphome/components/fendt_caravan/sensor/fendt_component.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_component.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "variable.h"
 #include "esphome/core/component.h"
 
@@ -31,3 +32,4 @@ template<typename T> class FendtComponent : public Component {
 };
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_component.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_component.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "variable.h"
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+template<typename T> class FendtComponent : public Component {
+ public:
+  void set_variable(Variable<T> *variable) {
+    this->variable_ = variable;
+    this->variable_->set_on_decode_callback(std::bind(&FendtComponent::on_decoded, this, std::placeholders::_1));
+  }
+  Variable<T> *get_variable() { return this->variable_; }
+
+  Variable<T> *create_variable(
+      const std::string &name, std::function<T(const std::string &)> decode_funct,
+      std::function<std::string(const std::string &name, T value)> command_funct = nullptr,
+      std::function<std::string(const std::string &name, T value)> alt_command_funct = nullptr) {
+    auto variable = new Variable<T>(name, decode_funct, command_funct, alt_command_funct);
+    this->set_variable(variable);
+    return variable;
+  }
+
+ protected:
+  virtual void on_decoded(const T value) {}
+  Variable<T> *variable_{nullptr};
+
+ private:
+};
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.cpp
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.cpp
@@ -1,0 +1,21 @@
+#include "fendt_light_output.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+void FendtLightOutput::write_state(light::LightState *state) {
+  LampStateT ls(state->current_values.is_on(), state->current_values.get_brightness());
+  ESP_LOGD(tag_, "Current state: %d, %f", state->current_values.is_on(), state->current_values.get_brightness());
+  ESP_LOGD(tag_, "Remote state: %d, %f", state->remote_values.is_on(), state->remote_values.get_brightness());
+  this->on_state_change_.call(this, ls);
+}
+
+void FendtLightOutput::on_decoded(const LampStateT state) {
+  ESP_LOGD(tag_, "on_decoded called. Sate: %d, brightness: %f", state.status, state.state);
+  this->light_state_->remote_values.set_state(state.status);
+  this->light_state_->remote_values.set_brightness(state.state);
+  this->light_state_->publish_state();
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.cpp
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.cpp
@@ -1,5 +1,6 @@
 #include "fendt_light_output.h"
 
+#ifdef USE_ESP32
 namespace esphome {
 namespace fendt_caravan {
 
@@ -19,3 +20,4 @@ void FendtLightOutput::on_decoded(const LampStateT state) {
 
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.h
@@ -13,41 +13,31 @@ namespace fendt_caravan {
  public: \
   void set_##name##_light_output(FendtLightOutput *light_output) { this->name##_light_output_ = light_output; }
 
-struct lamp_state_t {
+struct LampStateT {
   bool status;
   float state;
 };
 
-class FendtLightOutput : public FendtComponent<lamp_state_t>, public light::LightOutput {
+class FendtLightOutput : public FendtComponent<LampStateT>, public light::LightOutput {
  public:
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
     traits.set_supported_color_modes({light::ColorMode::BRIGHTNESS});
     return traits;
   }
-  void set_state_change_callback(std::function<void(FendtLightOutput *, lamp_state_t state)> &&callback) {
+  void set_state_change_callback(std::function<void(FendtLightOutput *, LampStateT state)> &&callback) {
     this->on_state_change_.add(std::move(callback));
   }
 
-  void write_state(light::LightState *state) override {
-    lamp_state_t ls(state->current_values.is_on(), state->current_values.get_brightness());
-    ESP_LOGD(TAG, "Current state: %d, %f", state->current_values.is_on(), state->current_values.get_brightness());
-    ESP_LOGD(TAG, "Remote state: %d, %f", state->remote_values.is_on(), state->remote_values.get_brightness());
-    this->on_state_change_.call(this, ls);
-  }
+  void write_state(light::LightState *state) override;
   void setup_state(light::LightState *state) override { this->light_state_ = state; }
 
  protected:
-  void on_decoded(const lamp_state_t state) override {
-    ESP_LOGD(TAG, "on_decoded called. Sate: %d, brightness: %f", state.status, state.state);
-    this->light_state_->remote_values.set_state(state.status);
-    this->light_state_->remote_values.set_brightness(state.state);
-    this->light_state_->publish_state();
-  }
+  void on_decoded(const LampStateT state) override;
 
  private:
-  CallbackManager<void(FendtLightOutput *, lamp_state_t state)> on_state_change_{};
-  const char *TAG = "FLO";
+  CallbackManager<void(FendtLightOutput *, LampStateT state)> on_state_change_{};
+  const char *tag_ = "FLO";
   light::LightState *light_state_{nullptr};
 };
 }  // namespace fendt_caravan

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "esphome/components/light/light_output.h"
+#include "fendt_component.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+#define FENDT_LIGHT_OUTPUT(name) \
+ protected: \
+  FendtLightOutput *name##_light_output_{nullptr}; \
+\
+ public: \
+  void set_##name##_light_output(FendtLightOutput *light_output) { this->name##_light_output_ = light_output; }
+
+struct lamp_state_t {
+  bool status;
+  float state;
+};
+
+class FendtLightOutput : public FendtComponent<lamp_state_t>, public light::LightOutput {
+ public:
+  light::LightTraits get_traits() override {
+    auto traits = light::LightTraits();
+    traits.set_supported_color_modes({light::ColorMode::BRIGHTNESS});
+    return traits;
+  }
+  void set_state_change_callback(std::function<void(FendtLightOutput *, lamp_state_t state)> &&callback) {
+    this->on_state_change_.add(std::move(callback));
+  }
+
+  void write_state(light::LightState *state) override {
+    lamp_state_t ls(state->current_values.is_on(), state->current_values.get_brightness());
+    ESP_LOGD(TAG, "Current state: %d, %f", state->current_values.is_on(), state->current_values.get_brightness());
+    ESP_LOGD(TAG, "Remote state: %d, %f", state->remote_values.is_on(), state->remote_values.get_brightness());
+    this->on_state_change_.call(this, ls);
+  }
+  void setup_state(light::LightState *state) override { this->light_state_ = state; }
+
+ protected:
+  void on_decoded(const lamp_state_t state) override {
+    ESP_LOGD(TAG, "on_decoded called. Sate: %d, brightness: %f", state.status, state.state);
+    this->light_state_->remote_values.set_state(state.status);
+    this->light_state_->remote_values.set_brightness(state.state);
+    this->light_state_->publish_state();
+  }
+
+ private:
+  CallbackManager<void(FendtLightOutput *, lamp_state_t state)> on_state_change_{};
+  const char *TAG = "FLO";
+  light::LightState *light_state_{nullptr};
+};
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "esphome/components/light/light_output.h"
 #include "fendt_component.h"
 
@@ -42,3 +43,4 @@ class FendtLightOutput : public FendtComponent<LampStateT>, public light::LightO
 };
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_light_output.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_light_output.h
@@ -33,7 +33,7 @@ class FendtLightOutput : public FendtComponent<LampStateT>, public light::LightO
   void setup_state(light::LightState *state) override { this->light_state_ = state; }
 
  protected:
-  void on_decoded(const LampStateT state) override;
+  void on_decoded(LampStateT state) override;
 
  private:
   CallbackManager<void(FendtLightOutput *, LampStateT state)> on_state_change_{};

--- a/esphome/components/fendt_caravan/sensor/fendt_number.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_number.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "esphome/components/number/number.h"
 #include "esphome/core/string_ref.h"
 #include "esphome/core/log.h"
 #include "fendt_component.h"
 #include "variable.h"
 
-#ifdef USE_ESP32
 namespace esphome {
 namespace fendt_caravan {
 

--- a/esphome/components/fendt_caravan/sensor/fendt_number.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_number.h
@@ -33,7 +33,7 @@ class FendtNumber : public FendtComponent<float>, public number::Number {
 
  private:
   CallbackManager<void(FendtNumber *, float state)> on_state_change_{};
-  const char *const TAG = "FNB";
+  const char *const tag_ = "FNB";
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_number.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_number.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
+#include "fendt_component.h"
+#include "variable.h"
+
+#ifdef USE_ESP32
+namespace esphome {
+namespace fendt_caravan {
+
+#define FENDT_NUMBER(name) \
+ protected: \
+  FendtNumber *name##_number_{nullptr}; \
+\
+ public: \
+  void set_##name##_number(FendtNumber *number) { this->name##_number_ = number; }
+
+class FendtNumber : public FendtComponent<float>, public number::Number {
+ public:
+  void set_state_change_callback(std::function<void(FendtNumber *, float state)> &&callback) {
+    this->on_state_change_.add(std::move(callback));
+  }
+
+ protected:
+  void control(float value) override {
+    if (this->variable_)
+      this->variable_->set_value(value);
+    this->on_state_change_.call(this, value);
+  }
+  void on_decoded(const float value) override { this->publish_state(value); }
+
+ private:
+  CallbackManager<void(FendtNumber *, float state)> on_state_change_{};
+  const char *const TAG = "FNB";
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_select.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_select.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#ifdef USE_ESP32
+#include "esphome/components/select/select.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
+#include "fendt_component.h"
+#include "variable.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+#define FENDT_SELECT(name) \
+ protected: \
+  FendtSelect *name##_select_{nullptr}; \
+\
+ public: \
+  void set_##name##_select(FendtSelect *select) { this->name##_select_ = select; }
+
+class FendtSelect : public FendtComponent<std::string>, public select::Select {
+ public:
+  void set_state_change_callback(std::function<void(FendtSelect *, std::string state)> &&callback) {
+    this->on_state_change_.add(std::move(callback));
+  }
+
+ protected:
+  void control(const std::string &value) override {
+    if (this->variable_)
+      this->variable_->set_value(value);
+    this->on_state_change_.call(this, value);
+  }
+  void on_decoded(std::string value) override { this->publish_state(value); }
+
+ private:
+  CallbackManager<void(FendtSelect *, std::string state)> on_state_change_{};
+  const char *const TAG = "FST";
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_select.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_select.h
@@ -33,7 +33,7 @@ class FendtSelect : public FendtComponent<std::string>, public select::Select {
 
  private:
   CallbackManager<void(FendtSelect *, std::string state)> on_state_change_{};
-  const char *const TAG = "FST";
+  const char *const tag_ = "FST";
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_sensor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/log.h"
+#include "fendt_component.h"
+#include "variable.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+#define FENDT_SENSOR(name) \
+ protected: \
+  FendtSensor *name##_sensor_{nullptr}; \
+\
+ public: \
+  void set_##name##_sensor(FendtSensor *sensor) { this->name##_sensor_ = sensor; }
+
+class FendtSensor : public FendtComponent<float>, public sensor::Sensor {
+ public:
+ protected:
+  void on_decoded(const float value) override { this->publish_state(value); }
+
+ private:
+  const char *const TAG = "FS";
+};
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_sensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/log.h"
 #include "fendt_component.h"
@@ -25,3 +26,4 @@ class FendtSensor : public FendtComponent<float>, public sensor::Sensor {
 };
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_sensor.h
@@ -21,7 +21,7 @@ class FendtSensor : public FendtComponent<float>, public sensor::Sensor {
   void on_decoded(const float value) override { this->publish_state(value); }
 
  private:
-  const char *const TAG = "FS";
+  const char *const tag_ = "FS";
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_switch.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_switch.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
+#include "fendt_component.h"
+#include "variable.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+#define FENDT_SWITCH(name) \
+ protected: \
+  FendtSwitch *name##_switch_{nullptr}; \
+\
+ public: \
+  void set_##name##_switch(FendtSwitch *s) { this->name##_switch_ = s; }
+
+class FendtSwitch : public FendtComponent<bool>, public switch_::Switch {
+ public:
+  void set_state_change_callback(std::function<void(FendtSwitch *, bool state)> &&callback) {
+    this->on_state_change_.add(std::move(callback));
+  }
+
+ protected:
+  void write_state(bool state) override {
+    if (this->variable_)
+      this->variable_->set_value(state);
+    this->on_state_change_.call(this, state);
+  }
+  void on_decoded(const bool value) override { this->publish_state(value); }
+  CallbackManager<void(FendtSwitch *, bool state)> on_state_change_{};
+
+ private:
+  const char *const TAG = "FSW";
+};
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_switch.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_switch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/string_ref.h"
 #include "esphome/core/log.h"
@@ -37,3 +38,4 @@ class FendtSwitch : public FendtComponent<bool>, public switch_::Switch {
 
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_switch.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_switch.h
@@ -32,7 +32,7 @@ class FendtSwitch : public FendtComponent<bool>, public switch_::Switch {
   CallbackManager<void(FendtSwitch *, bool state)> on_state_change_{};
 
  private:
-  const char *const TAG = "FSW";
+  const char *const tag_ = "FSW";
 };
 
 }  // namespace fendt_caravan

--- a/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
+#include "fendt_component.h"
+#include "variable.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+using namespace std;
+
+#define FENDT_TEXT_SENSOR(name) \
+ protected: \
+  FendtTextSensor *name##_text_sensor_{nullptr}; \
+\
+ public: \
+  void set_##name##_text_sensor(FendtTextSensor *sensor) { this->name##_text_sensor_ = sensor; }
+
+class FendtTextSensor : public FendtComponent<std::string>, public text_sensor::TextSensor {
+ public:
+ protected:
+  void on_decoded(const std::string value) override { this->publish_state(value); }
+
+ private:
+  const char *const TAG = "FTS";
+};
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#ifdef USE_ESP32
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/string_ref.h"
 #include "esphome/core/log.h"
@@ -28,3 +29,4 @@ class FendtTextSensor : public FendtComponent<std::string>, public text_sensor::
 };
 }  // namespace fendt_caravan
 }  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fendt_text_sensor.h
@@ -24,7 +24,7 @@ class FendtTextSensor : public FendtComponent<std::string>, public text_sensor::
   void on_decoded(const std::string value) override { this->publish_state(value); }
 
  private:
-  const char *const TAG = "FTS";
+  const char *const tag_ = "FTS";
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
@@ -13,12 +13,12 @@ void FridgeDeviceSensor::setup() {
     auto available =
         this->fridge_available_text_sensor_->create_variable("FRIDGE_AVAILABLE", [](const std::string &value) {
           const char *tmp[] = {"Available", "Not available"};
-          return Coders::decode_bool_str(value, tmp);
+          return DeviceDecoders::decode_bool_str(value, tmp);
         });
     this->add_variable(available);
   }
   if (this->fridge_status_switch_) {
-    auto status = this->fridge_status_switch_->create_variable("FRIDGE_ON_OFF", Coders::decode_bool,
+    auto status = this->fridge_status_switch_->create_variable("FRIDGE_ON_OFF", DeviceDecoders::decode_bool,
                                                                Commands::update_toggle<bool>);
     this->add_variable(status);
     this->fridge_status_switch_->set_state_change_callback(
@@ -27,7 +27,7 @@ void FridgeDeviceSensor::setup() {
   if (this->fridge_mode_select_) {
     std::vector<std::string> list = {"Performance", "", "Quite", "Boost"};
     auto mode = this->fridge_mode_select_->create_variable(
-        "FRIDGE_MODE", [list](const std::string &value) { return Coders::decode_int_str(value, list); },
+        "FRIDGE_MODE", [list](const std::string &value) { return DeviceDecoders::decode_int_str(value, list); },
         [list](const std::string &name, std::string value) {
           auto it = std::find(list.begin(), list.end(), value);
           if (it != list.end()) {
@@ -43,19 +43,19 @@ void FridgeDeviceSensor::setup() {
   if (this->fridge_source_text_sensor_) {
     std::vector<std::string> list = {"Automatic", "Gas", "DirectCurrent", "AlternatingCurrent"};
     auto source = this->fridge_source_text_sensor_->create_variable(
-        "FRIDGE_SOURCE", [list](const std::string &value) { return Coders::decode_int_str(value, list); });
+        "FRIDGE_SOURCE", [list](const std::string &value) { return DeviceDecoders::decode_int_str(value, list); });
     this->add_variable(source);
   }
   if (this->fridge_type_text_sensor_) {
     std::vector<std::string> list = {"None", "DometicAbsorberFridge", "HobbyCompressorRMVOC90",
                                      "DOMETICRC104Compressor", "DOMETIC_RUC"};
     auto ftype = this->fridge_type_text_sensor_->create_variable(
-        "FRIDGE_TYPE", [list](const std::string &value) { return Coders::decode_int_str(value, list); });
+        "FRIDGE_TYPE", [list](const std::string &value) { return DeviceDecoders::decode_int_str(value, list); });
     this->add_variable(ftype);
   }
   if (this->fridge_temperature_number_) {
-    auto temp =
-        this->fridge_temperature_number_->create_variable("FRIDGE_TEMP", Coders::decode_int, Commands::update_int);
+    auto temp = this->fridge_temperature_number_->create_variable("FRIDGE_TEMP", DeviceDecoders::decode_int,
+                                                                  Commands::update_int);
     this->add_variable(temp);
     this->fridge_temperature_number_->set_state_change_callback(
         std::bind(&FridgeDeviceSensor::on_number_state_change, this, std::placeholders::_1, std::placeholders::_2));

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
@@ -1,0 +1,101 @@
+#ifdef USE_ESP32
+#include "fridge_device_sensor.h"
+#include <array>
+#include <vector>
+
+namespace esphome {
+namespace fendt_caravan {
+
+void FridgeDeviceSensor::setup() {
+  ESP_LOGV(TAG, "Fridge Setup Called");
+
+  if (this->fridge_available_text_sensor_) {
+    auto available =
+        this->fridge_available_text_sensor_->create_variable("FRIDGE_AVAILABLE", [](const std::string &value) {
+          const char *tmp[] = {"Available", "Not available"};
+          return Coders::decode_bool_str(value, tmp);
+        });
+    this->add_variable(available);
+  }
+  if (this->fridge_status_switch_) {
+    auto status = this->fridge_status_switch_->create_variable("FRIDGE_ON_OFF", Coders::decode_bool,
+                                                               Commands::update_toggle<bool>);
+    this->add_variable(status);
+    this->fridge_status_switch_->set_state_change_callback(
+        std::bind(&FridgeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->fridge_mode_select_) {
+    std::vector<std::string> list = {"Performance", "", "Quite", "Boost"};
+    auto mode = this->fridge_mode_select_->create_variable(
+        "FRIDGE_MODE", [list](const std::string &value) { return Coders::decode_int_str(value, list); },
+        [list](const std::string &name, std::string value) {
+          auto it = std::find(list.begin(), list.end(), value);
+          if (it != list.end()) {
+            size_t index = std::distance(list.begin(), it);
+            return Commands::update_int(name, index);
+          }
+          return std::string("");
+        });
+    this->add_variable(mode);
+    this->fridge_mode_select_->set_state_change_callback(
+        std::bind(&FridgeDeviceSensor::on_select_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->fridge_source_text_sensor_) {
+    std::vector<std::string> list = {"Automatic", "Gas", "DirectCurrent", "AlternatingCurrent"};
+    auto source = this->fridge_source_text_sensor_->create_variable(
+        "FRIDGE_SOURCE", [list](const std::string &value) { return Coders::decode_int_str(value, list); });
+    this->add_variable(source);
+  }
+  if (this->fridge_type_text_sensor_) {
+    std::vector<std::string> list = {"None", "DometicAbsorberFridge", "HobbyCompressorRMVOC90",
+                                     "DOMETICRC104Compressor", "DOMETIC_RUC"};
+    auto ftype = this->fridge_type_text_sensor_->create_variable(
+        "FRIDGE_TYPE", [list](const std::string &value) { return Coders::decode_int_str(value, list); });
+    this->add_variable(ftype);
+  }
+  if (this->fridge_temperature_number_) {
+    auto temp =
+        this->fridge_temperature_number_->create_variable("FRIDGE_TEMP", Coders::decode_int, Commands::update_int);
+    this->add_variable(temp);
+    this->fridge_temperature_number_->set_state_change_callback(
+        std::bind(&FridgeDeviceSensor::on_number_state_change, this, std::placeholders::_1, std::placeholders::_2));
+  }
+}
+
+void FridgeDeviceSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, " -Fendt Fridge Device-");
+  LOG_TEXT_SENSOR(TAG, "  Fridge Available", this->fridge_available_text_sensor_);
+  LOG_SWITCH(TAG, "  Fridge Status", this->fridge_status_switch_);
+  LOG_SELECT(TAG, "  Fridge Mode", this->fridge_mode_select_);
+  LOG_TEXT_SENSOR(TAG, "  Fridge Source", this->fridge_source_text_sensor_);
+  LOG_TEXT_SENSOR(TAG, "  Fridge Type", this->fridge_type_text_sensor_);
+  LOG_NUMBER(TAG, "  Fridge Temperature", this->fridge_temperature_number_);
+}
+
+void FridgeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+  std::string command = sw->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGV(TAG, "Switch state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+
+void FridgeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
+  std::string command = num->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGV(TAG, "Number state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+
+void FridgeDeviceSensor::on_select_state_change(FendtSelect *sel, std::string state) {
+  std::string command = sel->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGV(TAG, "Select state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+
+}  // namespace fendt_caravan
+}  // namespace esphome
+#endif

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.cpp
@@ -22,7 +22,7 @@ void FridgeDeviceSensor::setup() {
                                                                Commands::update_toggle<bool>);
     this->add_variable(status);
     this->fridge_status_switch_->set_state_change_callback(
-        std::bind(&FridgeDeviceSensor::on_switch_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&FridgeDeviceSensor::on_switch_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->fridge_mode_select_) {
     std::vector<std::string> list = {"Performance", "", "Quite", "Boost"};
@@ -38,7 +38,7 @@ void FridgeDeviceSensor::setup() {
         });
     this->add_variable(mode);
     this->fridge_mode_select_->set_state_change_callback(
-        std::bind(&FridgeDeviceSensor::on_select_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&FridgeDeviceSensor::on_select_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->fridge_source_text_sensor_) {
     std::vector<std::string> list = {"Automatic", "Gas", "DirectCurrent", "AlternatingCurrent"};
@@ -58,7 +58,7 @@ void FridgeDeviceSensor::setup() {
                                                                   Commands::update_int);
     this->add_variable(temp);
     this->fridge_temperature_number_->set_state_change_callback(
-        std::bind(&FridgeDeviceSensor::on_number_state_change, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&FridgeDeviceSensor::on_number_state_change_, this, std::placeholders::_1, std::placeholders::_2));
   }
 }
 
@@ -72,7 +72,7 @@ void FridgeDeviceSensor::dump_config() {
   LOG_NUMBER(TAG, "  Fridge Temperature", this->fridge_temperature_number_);
 }
 
-void FridgeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
+void FridgeDeviceSensor::on_switch_state_change_(FendtSwitch *sw, bool state) {
   std::string command = sw->get_variable()->get_command();
   if (!command.empty()) {
     ESP_LOGV(TAG, "Switch state changed command:%s", command.c_str());
@@ -80,7 +80,7 @@ void FridgeDeviceSensor::on_switch_state_change(FendtSwitch *sw, bool state) {
   }
 }
 
-void FridgeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
+void FridgeDeviceSensor::on_number_state_change_(FendtNumber *num, float state) {
   std::string command = num->get_variable()->get_command();
   if (!command.empty()) {
     ESP_LOGV(TAG, "Number state changed command:%s", command.c_str());
@@ -88,7 +88,7 @@ void FridgeDeviceSensor::on_number_state_change(FendtNumber *num, float state) {
   }
 }
 
-void FridgeDeviceSensor::on_select_state_change(FendtSelect *sel, std::string state) {
+void FridgeDeviceSensor::on_select_state_change_(FendtSelect *sel, std::string state) {
   std::string command = sel->get_variable()->get_command();
   if (!command.empty()) {
     ESP_LOGV(TAG, "Select state changed command:%s", command.c_str());

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
@@ -25,7 +25,7 @@ class FridgeDeviceSensor : public CaravanDevice {
   FENDT_NUMBER(fridge_temperature);
 
  protected:
-  const char *get_tag() override { return this->TAG; }
+  const char *get_tag_() override { return this->TAG; }
 
  private:
   const char *TAG = "FRG";

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
@@ -26,7 +26,7 @@ class FridgeDeviceSensor : public CaravanDevice {
   const char *TAG = "FRG";
 
  protected:
-  const char *get_tag_() override { return this->TAG; }
+  const char *get_tag() override { return this->TAG; }
 
  private:
   void on_switch_state_change_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
@@ -1,0 +1,39 @@
+#pragma once
+#ifdef USE_ESP32
+#include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
+#include "esphome/core/log.h"
+#include "variable.h"
+#include "caravan_device.h"
+#include "fendt_text_sensor.h"
+#include "fendt_number.h"
+#include "fendt_switch.h"
+#include "fendt_select.h"
+
+namespace esphome {
+namespace fendt_caravan {
+class FridgeDeviceSensor : public CaravanDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  FENDT_TEXT_SENSOR(fridge_available);
+  FENDT_SWITCH(fridge_status);
+  FENDT_SELECT(fridge_mode);
+  FENDT_TEXT_SENSOR(fridge_source);
+  FENDT_TEXT_SENSOR(fridge_type);
+  FENDT_NUMBER(fridge_temperature);
+
+ protected:
+  const char *get_tag() override { return this->TAG; }
+
+ private:
+  const char *TAG = "FRG";
+  void on_switch_state_change(FendtSwitch *sw, bool state);
+  void on_number_state_change(FendtNumber *num, float state);
+  void on_select_state_change(FendtSelect *sel, std::string state);
+};
+}  // namespace fendt_caravan
+}  // namespace esphome
+
+#endif

--- a/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/fridge_device_sensor.h
@@ -23,15 +23,15 @@ class FridgeDeviceSensor : public CaravanDevice {
   FENDT_TEXT_SENSOR(fridge_source);
   FENDT_TEXT_SENSOR(fridge_type);
   FENDT_NUMBER(fridge_temperature);
+  const char *TAG = "FRG";
 
  protected:
   const char *get_tag_() override { return this->TAG; }
 
  private:
-  const char *TAG = "FRG";
-  void on_switch_state_change(FendtSwitch *sw, bool state);
-  void on_number_state_change(FendtNumber *num, float state);
-  void on_select_state_change(FendtSelect *sel, std::string state);
+  void on_switch_state_change_(FendtSwitch *sw, bool state);
+  void on_number_state_change_(FendtNumber *num, float state);
+  void on_select_state_change_(FendtSelect *sel, std::string state);
 };
 }  // namespace fendt_caravan
 }  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/fridge_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/fridge_sensor.py
@@ -19,7 +19,7 @@ CONF_FRIDGE_STATUS = "fridge_status"
 CONF_FRIDGE_MODE = "fridge_mode"
 CONF_FRIDGE_SOURCE = "fridge_source"
 CONF_FRIDGE_TYPE = "fridge_type"
-CONF_FRIDGE_TEMP = "fridge_temperature"
+CONF_FRIDGE_TEMPERATURE = "fridge_temperature"
 
 FRIDGES = {
     CONF_FRIDGE_AVAILABLE,
@@ -27,7 +27,7 @@ FRIDGES = {
     CONF_FRIDGE_MODE,
     CONF_FRIDGE_SOURCE,
     CONF_FRIDGE_TYPE,
-    CONF_FRIDGE_TEMP,
+    CONF_FRIDGE_TEMPERATURE,
 }
 
 FRIDGE_TYPES = {
@@ -48,7 +48,9 @@ FRIDGE_TYPES = {
     CONF_FRIDGE_TYPE: text_sensor.text_sensor_schema(
         FendtTextSensor, icon="mdi:power-settings"
     ),
-    CONF_FRIDGE_TEMP: number.number_schema(FendtNumber, icon="mdi:gauge-empty").extend(
+    CONF_FRIDGE_TEMPERATURE: number.number_schema(
+        FendtNumber, icon="mdi:gauge-empty"
+    ).extend(
         {
             cv.Optional(CONF_MIN_VALUE, default=1): cv.int_,
             cv.Optional(CONF_MAX_VALUE, default=5): cv.int_,

--- a/esphome/components/fendt_caravan/sensor/fridge_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/fridge_sensor.py
@@ -1,0 +1,65 @@
+import esphome.codegen as cg
+from esphome.components import number, select, switch, text_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_OPTIONS,
+    CONF_STEP,
+)
+
+from .. import FendtNumber, FendtSelect, FendtSwitch, FendtTextSensor, fendt_caravan_ns
+
+FridgeDeviceSensor = fendt_caravan_ns.class_("FridgeDeviceSensor", cg.PollingComponent)
+
+CONF_FRIDGE_DEVICE = "fridge_device"
+CONF_FRIDGE_AVAILABLE = "fridge_available"
+CONF_FRIDGE_STATUS = "fridge_status"
+CONF_FRIDGE_MODE = "fridge_mode"
+CONF_FRIDGE_SOURCE = "fridge_source"
+CONF_FRIDGE_TYPE = "fridge_type"
+CONF_FRIDGE_TEMP = "fridge_temperature"
+
+FRIDGES = {
+    CONF_FRIDGE_AVAILABLE,
+    CONF_FRIDGE_STATUS,
+    CONF_FRIDGE_MODE,
+    CONF_FRIDGE_SOURCE,
+    CONF_FRIDGE_TYPE,
+    CONF_FRIDGE_TEMP,
+}
+
+FRIDGE_TYPES = {
+    CONF_FRIDGE_AVAILABLE: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:power-settings"
+    ),
+    CONF_FRIDGE_STATUS: switch.switch_schema(FendtSwitch, icon="mdi:fridge"),
+    CONF_FRIDGE_MODE: select.select_schema(FendtSelect, icon="mdi:gauge").extend(
+        {
+            cv.Optional(
+                CONF_OPTIONS, default=["Performance", "Quite", "Boost"]
+            ): cv.ensure_list(cv.string_strict)
+        }
+    ),
+    CONF_FRIDGE_SOURCE: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:power-settings"
+    ),
+    CONF_FRIDGE_TYPE: text_sensor.text_sensor_schema(
+        FendtTextSensor, icon="mdi:power-settings"
+    ),
+    CONF_FRIDGE_TEMP: number.number_schema(FendtNumber, icon="mdi:gauge-empty").extend(
+        {
+            cv.Optional(CONF_MIN_VALUE, default=1): cv.int_,
+            cv.Optional(CONF_MAX_VALUE, default=5): cv.int_,
+            cv.Optional(CONF_STEP, default=1): cv.int_,
+        }
+    ),
+}
+
+CONFIG_FRIDGE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(FridgeDeviceSensor),
+        **{cv.Optional(type): schema for type, schema in FRIDGE_TYPES.items()},
+    }
+).extend(cv.polling_component_schema("60s"))

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
@@ -1,0 +1,96 @@
+#include "lighting_device_sensor.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+void LightingDeviceSensor::setup() {
+  if (this->light_sw0_switch_) {
+    auto *sw = this->light_sw0_switch_->create_variable("LIGHT_SW0", Coders::decode_int, Commands::update_toggle<bool>);
+    this->add_variable(sw);
+    this->light_sw0_switch_->set_state_change_callback(
+        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_sw1_switch_) {
+    auto *sw = this->light_sw1_switch_->create_variable("LIGHT_SW1", Coders::decode_int, Commands::update_toggle<bool>);
+    this->add_variable(sw);
+    this->light_sw1_switch_->set_state_change_callback(
+        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_sw2_switch_) {
+    auto *sw = this->light_sw2_switch_->create_variable("LIGHT_SW2", Coders::decode_int, Commands::update_toggle<bool>);
+    this->add_variable(sw);
+    this->light_sw2_switch_->set_state_change_callback(
+        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_sw3_switch_) {
+    auto *sw = this->light_sw3_switch_->create_variable("LIGHT_SW3", Coders::decode_int, Commands::update_toggle<bool>);
+    this->add_variable(sw);
+    this->light_sw3_switch_->set_state_change_callback(
+        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+
+  if (this->light_dimsw0_light_output_) {
+    auto *dimsw = this->create_variable("LIGHT_DIM0", this->light_dimsw0_light_output_);
+    this->add_variable(dimsw);
+    this->light_dimsw0_light_output_->set_state_change_callback(std::bind(
+        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+
+  if (this->light_dimsw1_light_output_) {
+    auto *dimsw = this->create_variable("LIGHT_DIM1", this->light_dimsw1_light_output_);
+    this->add_variable(dimsw);
+    this->light_dimsw1_light_output_->set_state_change_callback(std::bind(
+        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_dimsw2_light_output_) {
+    auto *dimsw = this->create_variable("LIGHT_DIM2", this->light_dimsw2_light_output_);
+    this->add_variable(dimsw);
+    this->light_dimsw2_light_output_->set_state_change_callback(std::bind(
+        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_dimsw3_light_output_) {
+    auto *dimsw = this->create_variable("LIGHT_DIM3", this->light_dimsw3_light_output_);
+    this->add_variable(dimsw);
+    this->light_dimsw3_light_output_->set_state_change_callback(std::bind(
+        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+  if (this->light_dimsw4_light_output_) {
+    auto *dimsw = this->create_variable("LIGHT_DIM4", this->light_dimsw4_light_output_);
+    this->add_variable(dimsw);
+    this->light_dimsw4_light_output_->set_state_change_callback(std::bind(
+        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+  }
+}
+
+void LightingDeviceSensor::dump_config() {}
+
+void LightingDeviceSensor::on_switch_state_changed(FendtSwitch *sw, bool state) {
+  if (!sw->get_variable())
+    return;
+
+  std::string command = "";
+  command = sw->get_variable()->get_command();
+  if (!command.empty()) {
+    ESP_LOGD(TAG, "Select state changed command:%s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+void LightingDeviceSensor::on_light_output_state_changed(FendtLightOutput *lo, lamp_state_t state) {
+  if (!lo->get_variable())
+    return;
+  std::string command = "";
+  auto *variable = lo->get_variable();
+  if (variable->get_value().status != state.status) {
+    variable->set_value(state);
+    command = variable->get_command();
+  } else if (variable->get_value().state != state.state) {
+    variable->set_value(state);
+    command = variable->get_alt_command();
+  }
+  if (!command.empty()) {
+    ESP_LOGV(TAG, "Lamp state changed. Command: %s", command.c_str());
+    this->command_callback_.call(command);
+  }
+}
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
@@ -5,77 +5,81 @@ namespace fendt_caravan {
 
 void LightingDeviceSensor::setup() {
   if (this->light_sw0_switch_) {
-    auto *sw = this->light_sw0_switch_->create_variable("LIGHT_SW0", Coders::decode_int, Commands::update_toggle<bool>);
+    auto *sw = this->light_sw0_switch_->create_variable("LIGHT_SW0", DeviceDecoders::decode_int,
+                                                        Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->light_sw0_switch_->set_state_change_callback(
-        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&LightingDeviceSensor::on_switch_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_sw1_switch_) {
-    auto *sw = this->light_sw1_switch_->create_variable("LIGHT_SW1", Coders::decode_int, Commands::update_toggle<bool>);
+    auto *sw = this->light_sw1_switch_->create_variable("LIGHT_SW1", DeviceDecoders::decode_int,
+                                                        Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->light_sw1_switch_->set_state_change_callback(
-        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&LightingDeviceSensor::on_switch_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_sw2_switch_) {
-    auto *sw = this->light_sw2_switch_->create_variable("LIGHT_SW2", Coders::decode_int, Commands::update_toggle<bool>);
+    auto *sw = this->light_sw2_switch_->create_variable("LIGHT_SW2", DeviceDecoders::decode_int,
+                                                        Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->light_sw2_switch_->set_state_change_callback(
-        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&LightingDeviceSensor::on_switch_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_sw3_switch_) {
-    auto *sw = this->light_sw3_switch_->create_variable("LIGHT_SW3", Coders::decode_int, Commands::update_toggle<bool>);
+    auto *sw = this->light_sw3_switch_->create_variable("LIGHT_SW3", DeviceDecoders::decode_int,
+                                                        Commands::update_toggle<bool>);
     this->add_variable(sw);
     this->light_sw3_switch_->set_state_change_callback(
-        std::bind(&LightingDeviceSensor::on_switch_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        std::bind(&LightingDeviceSensor::on_switch_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
 
   if (this->light_dimsw0_light_output_) {
-    auto *dimsw = this->create_variable("LIGHT_DIM0", this->light_dimsw0_light_output_);
+    auto *dimsw = this->create_variable_("LIGHT_DIM0", this->light_dimsw0_light_output_);
     this->add_variable(dimsw);
     this->light_dimsw0_light_output_->set_state_change_callback(std::bind(
-        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        &LightingDeviceSensor::on_light_output_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
 
   if (this->light_dimsw1_light_output_) {
-    auto *dimsw = this->create_variable("LIGHT_DIM1", this->light_dimsw1_light_output_);
+    auto *dimsw = this->create_variable_("LIGHT_DIM1", this->light_dimsw1_light_output_);
     this->add_variable(dimsw);
     this->light_dimsw1_light_output_->set_state_change_callback(std::bind(
-        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        &LightingDeviceSensor::on_light_output_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_dimsw2_light_output_) {
-    auto *dimsw = this->create_variable("LIGHT_DIM2", this->light_dimsw2_light_output_);
+    auto *dimsw = this->create_variable_("LIGHT_DIM2", this->light_dimsw2_light_output_);
     this->add_variable(dimsw);
     this->light_dimsw2_light_output_->set_state_change_callback(std::bind(
-        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        &LightingDeviceSensor::on_light_output_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_dimsw3_light_output_) {
-    auto *dimsw = this->create_variable("LIGHT_DIM3", this->light_dimsw3_light_output_);
+    auto *dimsw = this->create_variable_("LIGHT_DIM3", this->light_dimsw3_light_output_);
     this->add_variable(dimsw);
     this->light_dimsw3_light_output_->set_state_change_callback(std::bind(
-        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        &LightingDeviceSensor::on_light_output_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
   if (this->light_dimsw4_light_output_) {
-    auto *dimsw = this->create_variable("LIGHT_DIM4", this->light_dimsw4_light_output_);
+    auto *dimsw = this->create_variable_("LIGHT_DIM4", this->light_dimsw4_light_output_);
     this->add_variable(dimsw);
     this->light_dimsw4_light_output_->set_state_change_callback(std::bind(
-        &LightingDeviceSensor::on_light_output_state_changed, this, std::placeholders::_1, std::placeholders::_2));
+        &LightingDeviceSensor::on_light_output_state_changed_, this, std::placeholders::_1, std::placeholders::_2));
   }
 }
 
 void LightingDeviceSensor::dump_config() {}
 
-void LightingDeviceSensor::on_switch_state_changed(FendtSwitch *sw, bool state) {
+void LightingDeviceSensor::on_switch_state_changed_(FendtSwitch *sw, bool state) {
   if (!sw->get_variable())
     return;
 
   std::string command = "";
   command = sw->get_variable()->get_command();
   if (!command.empty()) {
-    ESP_LOGD(TAG, "Select state changed command:%s", command.c_str());
+    ESP_LOGD(this->tag_, "Select state changed command:%s", command.c_str());
     this->command_callback_.call(command);
   }
 }
-void LightingDeviceSensor::on_light_output_state_changed(FendtLightOutput *lo, lamp_state_t state) {
+void LightingDeviceSensor::on_light_output_state_changed_(FendtLightOutput *lo, LampStateT state) {
   if (!lo->get_variable())
     return;
   std::string command = "";
@@ -88,7 +92,7 @@ void LightingDeviceSensor::on_light_output_state_changed(FendtLightOutput *lo, l
     command = variable->get_alt_command();
   }
   if (!command.empty()) {
-    ESP_LOGV(TAG, "Lamp state changed. Command: %s", command.c_str());
+    ESP_LOGV(this->tag_, "Lamp state changed. Command: %s", command.c_str());
     this->command_callback_.call(command);
   }
 }

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.cpp
@@ -66,7 +66,13 @@ void LightingDeviceSensor::setup() {
   }
 }
 
-void LightingDeviceSensor::dump_config() {}
+void LightingDeviceSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, " - Fendt Lighting Device -");
+  LOG_SWITCH(TAG, "  Light SW0", this->light_sw0_switch_);
+  LOG_SWITCH(TAG, "  Light SW1", this->light_sw1_switch_);
+  LOG_SWITCH(TAG, "  Light SW2", this->light_sw2_switch_);
+  LOG_SWITCH(TAG, "  Light SW3", this->light_sw3_switch_);
+}
 
 void LightingDeviceSensor::on_switch_state_changed_(FendtSwitch *sw, bool state) {
   if (!sw->get_variable())
@@ -75,7 +81,7 @@ void LightingDeviceSensor::on_switch_state_changed_(FendtSwitch *sw, bool state)
   std::string command = "";
   command = sw->get_variable()->get_command();
   if (!command.empty()) {
-    ESP_LOGD(this->tag_, "Select state changed command:%s", command.c_str());
+    ESP_LOGD(TAG, "Select state changed command:%s", command.c_str());
     this->command_callback_.call(command);
   }
 }
@@ -92,7 +98,7 @@ void LightingDeviceSensor::on_light_output_state_changed_(FendtLightOutput *lo, 
     command = variable->get_alt_command();
   }
   if (!command.empty()) {
-    ESP_LOGV(this->tag_, "Lamp state changed. Command: %s", command.c_str());
+    ESP_LOGV(TAG, "Lamp state changed. Command: %s", command.c_str());
     this->command_callback_.call(command);
   }
 }

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -27,7 +27,7 @@ class LightingDeviceSensor : public CaravanDevice {
   const char *TAG = "LDS";
 
  protected:
-  const char *get_tag_() { return this->TAG; }
+  const char *get_tag() { return this->TAG; }
 
  private:
   void on_switch_state_changed_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -27,7 +27,7 @@ class LightingDeviceSensor : public CaravanDevice {
   const char *TAG = "LDS";
 
  protected:
-  const char *get_tag() { return this->TAG; }
+  const char *get_tag() override { return this->TAG; }
 
  private:
   void on_switch_state_changed_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "caravan_device.h"
+#include "fendt_switch.h"
+#include "fendt_light_output.h"
+
+namespace esphome {
+namespace fendt_caravan {
+
+class LightingDeviceSensor : public CaravanDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  FENDT_SWITCH(light_sw0);
+  FENDT_SWITCH(light_sw1);
+  FENDT_SWITCH(light_sw2);
+  FENDT_SWITCH(light_sw3);
+  FENDT_LIGHT_OUTPUT(light_dimsw0);
+  FENDT_LIGHT_OUTPUT(light_dimsw1);
+  FENDT_LIGHT_OUTPUT(light_dimsw2);
+  FENDT_LIGHT_OUTPUT(light_dimsw3);
+  FENDT_LIGHT_OUTPUT(light_dimsw4);
+  const char *get_tag() override { return this->TAG; }
+
+ private:
+  const char *TAG = "LDS";
+  void on_switch_state_changed(FendtSwitch *sw, bool state);
+  void on_light_output_state_changed(FendtLightOutput *lo, lamp_state_t state);
+  Variable<lamp_state_t> *create_variable(const std::string &name, FendtLightOutput *lo) {
+    auto *dimsw = lo->create_variable(
+        name,
+        [](const std::string &data) {
+          int value = Coders::decode_int(data);
+          lamp_state_t ls = {.status = value != 0, .state = (float) value / 15.0f};
+          return ls;
+        },
+        Commands::update_toggle<lamp_state_t>,
+        [](const std::string &name, lamp_state_t state) { return Commands::update_int(name, state.state * 15.f); });
+    return dimsw;
+  }
+};
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -14,7 +14,6 @@ class LightingDeviceSensor : public CaravanDevice {
   void setup() override;
   void dump_config() override;
 
- protected:
   FENDT_SWITCH(light_sw0);
   FENDT_SWITCH(light_sw1);
   FENDT_SWITCH(light_sw2);
@@ -24,10 +23,12 @@ class LightingDeviceSensor : public CaravanDevice {
   FENDT_LIGHT_OUTPUT(light_dimsw2);
   FENDT_LIGHT_OUTPUT(light_dimsw3);
   FENDT_LIGHT_OUTPUT(light_dimsw4);
-  const char *get_tag() override { return this->tag_; }
+
+ protected:
+  const char *get_tag_() override { return this->TAG; }
 
  private:
-  const char *tag_ = "LDS";
+  const char *TAG = "LDS";
   void on_switch_state_changed_(FendtSwitch *sw, bool state);
   void on_light_output_state_changed_(FendtLightOutput *lo, LampStateT state);
   Variable<LampStateT> *create_variable_(const std::string &name, FendtLightOutput *lo) {

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -27,7 +27,7 @@ class LightingDeviceSensor : public CaravanDevice {
   const char *TAG = "LDS";
 
  protected:
-  const char *get_tag() override { return this->TAG; }
+  const char *get_tag() { return this->TAG; }
 
  private:
   void on_switch_state_changed_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -24,22 +24,22 @@ class LightingDeviceSensor : public CaravanDevice {
   FENDT_LIGHT_OUTPUT(light_dimsw2);
   FENDT_LIGHT_OUTPUT(light_dimsw3);
   FENDT_LIGHT_OUTPUT(light_dimsw4);
-  const char *get_tag() override { return this->TAG; }
+  const char *get_tag() override { return this->tag_; }
 
  private:
-  const char *TAG = "LDS";
-  void on_switch_state_changed(FendtSwitch *sw, bool state);
-  void on_light_output_state_changed(FendtLightOutput *lo, lamp_state_t state);
-  Variable<lamp_state_t> *create_variable(const std::string &name, FendtLightOutput *lo) {
+  const char *tag_ = "LDS";
+  void on_switch_state_changed_(FendtSwitch *sw, bool state);
+  void on_light_output_state_changed_(FendtLightOutput *lo, LampStateT state);
+  Variable<LampStateT> *create_variable_(const std::string &name, FendtLightOutput *lo) {
     auto *dimsw = lo->create_variable(
         name,
         [](const std::string &data) {
-          int value = Coders::decode_int(data);
-          lamp_state_t ls = {.status = value != 0, .state = (float) value / 15.0f};
+          int value = DeviceDecoders::decode_int(data);
+          LampStateT ls = {.status = value != 0, .state = (float) value / 15.0f};
           return ls;
         },
-        Commands::update_toggle<lamp_state_t>,
-        [](const std::string &name, lamp_state_t state) { return Commands::update_int(name, state.state * 15.f); });
+        Commands::update_toggle<LampStateT>,
+        [](const std::string &name, LampStateT state) { return Commands::update_int(name, state.state * 15.f); });
     return dimsw;
   }
 };

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -11,8 +11,8 @@ namespace fendt_caravan {
 
 class LightingDeviceSensor : public CaravanDevice {
  public:
-  void setup() override;
-  void dump_config() override;
+  void setup();
+  void dump_config();
 
   FENDT_SWITCH(light_sw0);
   FENDT_SWITCH(light_sw1);
@@ -27,7 +27,7 @@ class LightingDeviceSensor : public CaravanDevice {
   const char *TAG = "LDS";
 
  protected:
-  const char *get_tag_() override { return this->TAG; }
+  const char *get_tag_() { return this->TAG; }
 
  private:
   void on_switch_state_changed_(FendtSwitch *sw, bool state);

--- a/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
+++ b/esphome/components/fendt_caravan/sensor/lighting_device_sensor.h
@@ -24,11 +24,12 @@ class LightingDeviceSensor : public CaravanDevice {
   FENDT_LIGHT_OUTPUT(light_dimsw3);
   FENDT_LIGHT_OUTPUT(light_dimsw4);
 
+  const char *TAG = "LDS";
+
  protected:
   const char *get_tag_() override { return this->TAG; }
 
  private:
-  const char *TAG = "LDS";
   void on_switch_state_changed_(FendtSwitch *sw, bool state);
   void on_light_output_state_changed_(FendtLightOutput *lo, LampStateT state);
   Variable<LampStateT> *create_variable_(const std::string &name, FendtLightOutput *lo) {

--- a/esphome/components/fendt_caravan/sensor/lighting_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/lighting_sensor.py
@@ -10,7 +10,7 @@ LightingDeviceSensor = fendt_caravan_ns.class_(
 )
 FendtLightOutput = fendt_caravan_ns.class_("FendtLightOutput", light.LightOutput)
 
-CONF_LIGHTONG_DEVICE = "lighting_device"
+CONF_LIGHTING_DEVICE = "lighting_device"
 
 CONF_LIGHT_SW0 = "light_sw0"
 CONF_LIGHT_SW1 = "light_sw1"

--- a/esphome/components/fendt_caravan/sensor/lighting_sensor.py
+++ b/esphome/components/fendt_caravan/sensor/lighting_sensor.py
@@ -1,0 +1,71 @@
+import esphome.codegen as cg
+from esphome.components import light, switch
+import esphome.config_validation as cv
+from esphome.const import CONF_DEFAULT_TRANSITION_LENGTH, CONF_ID, CONF_OUTPUT_ID
+
+from .. import FendtSwitch, fendt_caravan_ns
+
+LightingDeviceSensor = fendt_caravan_ns.class_(
+    "LightingDeviceSensor", cg.PollingComponent
+)
+FendtLightOutput = fendt_caravan_ns.class_("FendtLightOutput", light.LightOutput)
+
+CONF_LIGHTONG_DEVICE = "lighting_device"
+
+CONF_LIGHT_SW0 = "light_sw0"
+CONF_LIGHT_SW1 = "light_sw1"
+CONF_LIGHT_SW2 = "light_sw2"
+CONF_LIGHT_SW3 = "light_sw3"
+CONF_LIGHT_DIMSW0 = "light_dimsw0"
+CONF_LIGHT_DIMSW1 = "light_dimsw1"
+CONF_LIGHT_DIMSW2 = "light_dimsw2"
+CONF_LIGHT_DIMSW3 = "light_dimsw3"
+CONF_LIGHT_DIMSW4 = "light_dimsw4"
+
+LIGHTINGS = {
+    CONF_LIGHT_SW0,
+    CONF_LIGHT_SW1,
+    CONF_LIGHT_SW2,
+    CONF_LIGHT_SW3,
+    CONF_LIGHT_DIMSW0,
+    CONF_LIGHT_DIMSW1,
+    CONF_LIGHT_DIMSW2,
+    CONF_LIGHT_DIMSW3,
+    CONF_LIGHT_DIMSW4,
+}
+
+CONF_LIGHT_DIM_SCHEMA = light.BRIGHTNESS_ONLY_LIGHT_SCHEMA.extend(
+    {
+        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(FendtLightOutput),
+        cv.Optional(
+            CONF_DEFAULT_TRANSITION_LENGTH, default="0s"
+        ): cv.positive_time_period_milliseconds,
+    }
+)
+
+LIGHTING_TYPES = {
+    CONF_LIGHT_SW0: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
+    ),
+    CONF_LIGHT_SW1: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
+    ),
+    CONF_LIGHT_SW2: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
+    ),
+    CONF_LIGHT_SW3: switch.switch_schema(
+        FendtSwitch, default_restore_mode="RESTORE_DEFAULT_OFF", icon="mdi:lamp"
+    ),
+    CONF_LIGHT_DIMSW0: CONF_LIGHT_DIM_SCHEMA,
+    CONF_LIGHT_DIMSW1: CONF_LIGHT_DIM_SCHEMA,
+    CONF_LIGHT_DIMSW2: CONF_LIGHT_DIM_SCHEMA,
+    CONF_LIGHT_DIMSW3: CONF_LIGHT_DIM_SCHEMA,
+    CONF_LIGHT_DIMSW4: CONF_LIGHT_DIM_SCHEMA,
+}
+
+CONFIG_LIGHTING_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ID): cv.declare_id(LightingDeviceSensor),
+        **{cv.Optional(type): schema for type, schema in LIGHTING_TYPES.items()},
+    }
+).extend(cv.polling_component_schema("60s"))

--- a/esphome/components/fendt_caravan/sensor/variable.h
+++ b/esphome/components/fendt_caravan/sensor/variable.h
@@ -1,10 +1,11 @@
 #pragma once
 #include "esphome/core/component.h"
 #include "esphome/core/string_ref.h"
-#include <string>
-#include <functional>
-#include <vector>
 #include <any>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace esphome {
 namespace fendt_caravan {
@@ -14,7 +15,7 @@ using namespace std;
 class IVariable {
  public:
   std::string get_name() { return this->name_; }
-  void set_name(std::string name) { this->name_ = name; }
+  void set_name(std::string name) { this->name_ = std::move(name); }
   std::string get_raw_value() { return this->raw_value_; }
 
   bool is_active() { return this->is_active_; }
@@ -34,7 +35,7 @@ template<class T> class Variable : public IVariable {
   Variable(const std::string name, std::function<T(const std::string &)> decode_funct = nullptr,
            std::function<std::string(const std::string &, T value)> command_funct = nullptr,
            std::function<std::string(const std::string &, T value)> alt_command_funct = nullptr)
-      : decode_funct_(decode_funct), command_funct_(command_funct), alt_command_funct_(alt_command_funct) {
+      : decode_funct_(std::move(decode_funct)), command_funct_(command_funct), alt_command_funct_(alt_command_funct) {
     name_ = name;
     is_active_ = false;
   }
@@ -63,7 +64,7 @@ template<class T> class Variable : public IVariable {
     this->on_decode_.add(std::move(callback));
   }
 
-  void decode(const std::string &value) {
+  void decode(const std::string &value) override {
     raw_value_ = value;
     this->value_ = this->decode_funct_(value);
     this->is_active_ = true;

--- a/esphome/components/fendt_caravan/sensor/variable.h
+++ b/esphome/components/fendt_caravan/sensor/variable.h
@@ -1,0 +1,82 @@
+#pragma once
+#include "esphome/core/component.h"
+#include "esphome/core/string_ref.h"
+#include <string>
+#include <functional>
+#include <vector>
+#include <any>
+
+namespace esphome {
+namespace fendt_caravan {
+
+using namespace std;
+
+class IVariable {
+ public:
+  std::string get_name() { return this->name_; }
+  void set_name(std::string name) { this->name_ = name; }
+  std::string get_raw_value() { return this->raw_value_; }
+
+  bool is_active() { return this->is_active_; }
+  void is_active(bool active) { this->is_active_ = active; }
+  virtual void decode(const std::string &value) = 0;
+
+ protected:
+  bool is_active_;
+  std::string name_;
+  std::string raw_value_;
+};
+
+// using command_callback = std::function<void(const std::string &)>;
+
+template<class T> class Variable : public IVariable {
+ public:
+  Variable(const std::string name, std::function<T(const std::string &)> decode_funct = nullptr,
+           std::function<std::string(const std::string &, T value)> command_funct = nullptr,
+           std::function<std::string(const std::string &, T value)> alt_command_funct = nullptr)
+      : decode_funct_(decode_funct), command_funct_(command_funct), alt_command_funct_(alt_command_funct) {
+    name_ = name;
+    is_active_ = false;
+  }
+  void send_value(T value) {
+    if (this->command_funct_) {
+      std::string command = this->command_funct_(this->name_, value);
+    }
+  }
+  void set_value(T value) { this->value_ = value; }
+
+  T get_value() { return this->value_; }
+
+  std::string get_command() {
+    if (this->command_funct_) {
+      return this->command_funct_(this->name_, this->value_);
+    }
+    return "";
+  }
+  std::string get_alt_command() {
+    if (this->alt_command_funct_) {
+      return this->alt_command_funct_(this->name_, this->value_);
+    }
+    return "";
+  }
+  void set_on_decode_callback(std::function<void(const T &value)> &&callback) {
+    this->on_decode_.add(std::move(callback));
+  }
+
+  void decode(const std::string &value) {
+    raw_value_ = value;
+    this->value_ = this->decode_funct_(value);
+    this->is_active_ = true;
+    this->on_decode_.call(this->value_);
+  }
+
+ protected:
+  std::function<T(const std::string &)> decode_funct_;
+  std::function<const std::string(const std::string &, T val)> command_funct_;
+  std::function<const std::string(const std::string &, T val)> alt_command_funct_;
+  CallbackManager<void(const T &value)> on_decode_{};
+  T value_;
+};
+
+}  // namespace fendt_caravan
+}  // namespace esphome

--- a/esphome/components/fendt_caravan/sensor/variable.h
+++ b/esphome/components/fendt_caravan/sensor/variable.h
@@ -15,7 +15,7 @@ using namespace std;
 class IVariable {
  public:
   std::string get_name() { return this->name_; }
-  void set_name(std::string name) { this->name_ = std::move(name); }
+  void set_name(const std::string &name) { this->name_ = std::move(name); }
   std::string get_raw_value() { return this->raw_value_; }
 
   bool is_active() { return this->is_active_; }

--- a/tests/components/fendt_caravan/common.yaml
+++ b/tests/components/fendt_caravan/common.yaml
@@ -1,0 +1,84 @@
+esp32_ble_tracker:
+
+ble_client:
+  - mac_address: DE:00:40:10:62:39
+    id: my_ble_client
+    auto_connect: true
+
+fendt_caravan:
+  id: my_caravan
+  ble_client_id: my_ble_client
+
+sensor:
+  - platform: fendt_caravan
+    fendt_caravan_id: my_caravan
+    control_unit:
+      id: control_unit
+      main_switch:
+        name: "Main Switch"
+      temperature_in:
+        name: "In Temperature"
+        filters:
+          - median:
+              window_size: 5
+      temperature_out:
+        name: "Out Temperature"
+        filters:
+          - median:
+              window_size: 5
+      power_status:
+        name: "AC Status"
+      light_status:
+        name: "Main Light"
+      software_version:
+        name: "Software Version"
+      floor_heater:
+        name: "Floot Heater"
+    fridge_device:
+      fridge_available:
+        name: "Fridge Available"
+      fridge_status:
+        name: "Fridge Status"
+      fridge_mode:
+        name: "Fridge Mode"
+      fridge_source:
+        name: "Fridge Source"
+      fridge_type:
+        name: "Fridge Type"
+      fridge_temperature:
+        name: "Fridge Temperature"
+    alde_device:
+      alde_available:
+        name: "Alde Available"
+      alde_heater_satus:
+        name: "Heater Status"
+      alde_heater_temperature:
+        name: "Heater Temperature"
+      alde_heater_water:
+        name: "Water Heater"
+      alde_heater_water_temperature:
+        name: "Boost Water Temperature"
+      alde_heater_electric:
+        name: "Heater Electricity"
+      alde_heater_gas:
+        name: "Heater Gas Status"
+    lighting_device:
+      id: light_devices
+      light_sw0:
+        name: "Light 1"
+      light_sw1:
+        name: "Light 2"
+      light_sw2:
+        name: "Light 3"
+      light_sw3:
+        name: "Light 4"
+      light_dimsw0:
+        name: "Light Dim 1"
+      light_dimsw1:
+        name: "Light Dim 2"
+      light_dimsw2:
+        name: "Light Dim 3"
+      light_dimsw3:
+        name: "Light Dim 4"
+      light_dimsw4:
+        name: "Light Dim 5"

--- a/tests/components/fendt_caravan/common.yaml
+++ b/tests/components/fendt_caravan/common.yaml
@@ -12,7 +12,7 @@ fendt_caravan:
 sensor:
   - platform: fendt_caravan
     fendt_caravan_id: my_caravan
-    control_unit:
+    control_unit_device:
       id: control_unit
       main_switch:
         name: "Main Switch"
@@ -50,7 +50,7 @@ sensor:
     alde_device:
       alde_available:
         name: "Alde Available"
-      alde_heater_satus:
+      alde_heater_status:
         name: "Heater Status"
       alde_heater_temperature:
         name: "Heater Temperature"

--- a/tests/components/fendt_caravan/test.esp32-c3-idf.yaml
+++ b/tests/components/fendt_caravan/test.esp32-c3-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

This PR introduces a new **experimental `fendt_caravan` component** for ESPHome.

The component allows ESP32 devices to connect directly to the Bluetooth Low Energy (BLE) interface of **Fendt** and **Hobby** caravans and exposes the same data and control capabilities available in the official *Fendt Connect* mobile application to Home Assistant.

All communication is fully local and does not rely on any cloud services.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

---

## Features

- Native BLE communication with caravan control unit
- Mirrors the structure and behavior of the Fendt Connect mobile app
- Exposes multiple subsystems as Home Assistant entities:
  - Control unit (power status, temperatures, software version)
  - Fridge (availability, mode, source, temperature)
  - Alde heating system (gas, electric, water heating)
  - Interior lighting (on/off and dimming channels)
- Fully local operation

---

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32_ble_tracker:

ble_client:
  - mac_address: DE:00:40:10:62:39
    id: my_ble_client
    auto_connect: true

fendt_caravan:
  id: my_caravan
  ble_client_id: my_ble_client

sensor:
  - platform: fendt_caravan
    fendt_caravan_id: my_caravan
    control_unit:
      id: control_unit
      main_switch:
        name: "Main Switch"
      temperature_in:
        name: "In Temperature"
        filters:
          - median:
              window_size: 5
      temperature_out:
        name: "Out Temperature"
        filters:
          - median:
              window_size: 5
      power_status:
        name: "AC Status"
      light_status:
        name: "Main Light"
      software_version:
        name: "Software Version"
      floor_heater:
        name: "Floot Heater"
    fridge_device:
      fridge_available:
        name: "Fridge Available"
      fridge_status:
        name: "Fridge Status"
      fridge_mode:
        name: "Fridge Mode"
      fridge_source:
        name: "Fridge Source"
      fridge_type:
        name: "Fridge Type"
      fridge_temperature:
        name: "Fridge Temperature"
    alde_device:
      alde_available:
        name: "Alde Available"
      alde_heater_satus:
        name: "Heater Status"
      alde_heater_temperature:
        name: "Heater Temperature"
      alde_heater_water:
        name: "Water Heater"
      alde_heater_water_temperature:
        name: "Boost Water Temperature"
      alde_heater_electric:
        name: "Heater Electricity"
      alde_heater_gas:
        name: "Heater Gas Status"
    lighting_device:
      id: light_devices
      light_sw0:
        name: "Light 1"
      light_sw1:
        name: "Light 2"
      light_sw2:
        name: "Light 3"
      light_sw3:
        name: "Light 4"
      light_dimsw0:
        name: "Light Dim 1"
      light_dimsw1:
        name: "Light Dim 2"
      light_dimsw2:
        name: "Light Dim 3"
      light_dimsw3:
        name: "Light Dim 4"
      light_dimsw4:
        name: "Light Dim 5"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
  - Doc PR requires esphome PR number. I am going to push component docs in couple of minutes.