### PR TITLE
Add scaling factor for power usage as some midea AC units report just…

### DIFF
--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -50,7 +50,8 @@ void AirConditioner::on_status_change() {
   if (need_publish)
     this->publish_state();
   set_sensor(this->outdoor_sensor_, this->base_.getOutdoorTemp());
-  set_sensor(this->power_sensor_, this->base_.getPowerUsage());
+  set_sensor(this->power_sensor_, this->base_.getPowerUsage() * this->power_multiplier_);
+
   set_sensor(this->humidity_sensor_, this->base_.getIndoorHum());
 }
 

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -29,6 +29,7 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   void set_outdoor_temperature_sensor(Sensor *sensor) { this->outdoor_sensor_ = sensor; }
   void set_humidity_setpoint_sensor(Sensor *sensor) { this->humidity_sensor_ = sensor; }
   void set_power_sensor(Sensor *sensor) { this->power_sensor_ = sensor; }
+  void set_power_multiplier(float multiplier) { this->power_multiplier_ = multiplier; }
   void on_status_change() override;
 
   /* ############### */
@@ -60,6 +61,8 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   Sensor *outdoor_sensor_{nullptr};
   Sensor *humidity_sensor_{nullptr};
   Sensor *power_sensor_{nullptr};
+  float power_multiplier_{1.0f};
+
 };
 
 }  // namespace ac

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -62,7 +62,6 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   Sensor *humidity_sensor_{nullptr};
   Sensor *power_sensor_{nullptr};
   float power_multiplier_{1.0f};
-
 };
 
 }  // namespace ac

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -36,6 +36,7 @@ CODEOWNERS = ["@dudanov"]
 DEPENDENCIES = ["climate", "uart"]
 AUTO_LOAD = ["sensor"]
 CONF_POWER_USAGE = "power_usage"
+CONF_POWER_MULTIPLIER = "power_multiplier"
 CONF_HUMIDITY_SETPOINT = "humidity_setpoint"
 midea_ac_ns = cg.esphome_ns.namespace("midea").namespace("ac")
 AirConditioner = midea_ac_ns.class_("AirConditioner", climate.Climate, cg.Component)
@@ -137,7 +138,12 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_POWER,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Optional(CONF_POWER_MULTIPLIER, default=1.0): cv.float_,
+                }
             ),
+
             cv.Optional(CONF_HUMIDITY_SETPOINT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 icon=ICON_WATER_PERCENT,
@@ -285,8 +291,11 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_OUTDOOR_TEMPERATURE])
         cg.add(var.set_outdoor_temperature_sensor(sens))
     if CONF_POWER_USAGE in config:
-        sens = await sensor.new_sensor(config[CONF_POWER_USAGE])
+        sens_config = config[CONF_POWER_USAGE]
+        sens = await sensor.new_sensor(sens_config)
         cg.add(var.set_power_sensor(sens))
+        if CONF_POWER_MULTIPLIER in sens_config:
+            cg.add(var.set_power_multiplier(sens_config[CONF_POWER_MULTIPLIER]))
     if CONF_HUMIDITY_SETPOINT in config:
         sens = await sensor.new_sensor(config[CONF_HUMIDITY_SETPOINT])
         cg.add(var.set_humidity_setpoint_sensor(sens))

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -143,7 +143,6 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_POWER_MULTIPLIER, default=1.0): cv.float_,
                 }
             ),
-
             cv.Optional(CONF_HUMIDITY_SETPOINT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 icon=ICON_WATER_PERCENT,

--- a/tests/components/midea/common.yaml
+++ b/tests/components/midea/common.yaml
@@ -64,5 +64,6 @@ climate:
       name: Temp
     power_usage:
       name: Power
+      power_multiplier: 3
     humidity_setpoint:
       name: Humidity


### PR DESCRIPTION
… 1/3 or 1/10th of their actual power usage.

# What does this implement/fix?

A simple facotr that allows the reported power usage to be scaled.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


## Test Environment

- [x ] ESP32
- [ x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: midea
    name: Midea Climate         # Use a unique name.
    period: 1s                  # Optional
    timeout: 2s                 # Optional
    num_attempts: 3             # Optional
    autoconf: true              # Autoconfigure most options.
    beeper: true                # Beep on commands.
    visual:                     # Optional. Example of visual settings override.
      min_temperature: 17 °C    # min: 17
      max_temperature: 30 °C    # max: 30
      temperature_step: 0.5 °C  # min: 0.5
    supported_modes:            # Optional. All capabilities in this section may be detected by autoconf.
      - FAN_ONLY
      - HEAT_COOL
      - COOL
      - HEAT
      - DRY
    custom_fan_modes:           # Optional
      - SILENT
      - TURBO
    supported_presets:          # Optional. All capabilities in this section may be detected by autoconf.
      - ECO
      - BOOST
      - SLEEP
    custom_presets:             # Optional. All capabilities in this section may be detected by autoconf.
      - FREEZE_PROTECTION
    supported_swing_modes:      # Optional
      - VERTICAL
      - HORIZONTAL
      - BOTH
    outdoor_temperature:        # Optional. Outdoor temperature sensor (may display incorrect values after long inactivity).
      name: Temp
    power_usage:                # Optional. Power usage sensor (only for devices that support this feature).
      name: Power
      power_multiplier: 3
    humidity_setpoint:          # Optional. Indoor humidity sensor (only for devices that support this feature).
      name: Humidity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
