### PR TITLE
Add support for the Waveshare 2.66inch (B) e-paper display

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -31,6 +31,9 @@ WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
 WaveshareEpaper1P54INBV2 = waveshare_epaper_ns.class_(
     "WaveshareEPaper1P54InBV2", WaveshareEPaperBWR
 )
+WaveshareEPaper2P66InB = waveshare_epaper_ns.class_(
+    "WaveshareEPaper2P66InB", WaveshareEPaperBWR
+)
 WaveshareEPaper2P7In = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P7In", WaveshareEPaper
 )
@@ -140,6 +143,7 @@ MODELS = {
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
     "gdew029t5": ("c", GDEW029T5),
+    "2.66in-b": ("b", WaveshareEPaper2P66InB),
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.70in-b": ("b", WaveshareEPaper2P7InB),
     "2.70in-bv2": ("b", WaveshareEPaper2P7InBV2),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -1060,6 +1060,83 @@ void WaveshareEPaper1P54InBV2::dump_config() {
 }
 
 // ========================================================
+//                          2.66inch_e-paper_b
+// ========================================================
+// Datasheet:
+//  - https://files.waveshare.com/upload/e/ec/2.66inch-e-paper-b-specification.pdf
+//  - https://github.com/waveshareteam/e-Paper/blob/master/RaspberryPi_JetsonNano/c/lib/e-Paper/EPD_2in66b.c
+
+void WaveshareEPaper2P66InB::initialize() {
+  this->reset_();
+  this->wait_until_idle_();
+
+  this->command(0x12);  // Soft reset
+  this->wait_until_idle_();
+
+  this->command(0x11);  // Data entry mode
+  this->data(0x03);
+
+  // Set display window
+  const uint32_t xend = this->get_width_internal() - 1;
+  const uint32_t yend = this->get_height_internal() - 1;
+
+  this->command(0x44);
+  this->data(0x00);
+  this->data((xend >> 3) & 0x1F);
+
+  this->command(0x45);
+  this->data(0x00);
+  this->data(0x00);
+  this->data(yend & 0xFF);
+  this->data((yend >> 8) & 0x01);
+
+  this->command(0x21);  // Display update control
+  this->data(0x00);
+  this->data(0x80);
+
+  // Set cursor
+  this->command(0x4E);
+  this->data(0x00);
+  this->command(0x4F);
+  this->data(0x00);
+  this->data(0x00);
+
+  this->wait_until_idle_();
+}
+
+void HOT WaveshareEPaper2P66InB::display() {
+  const uint32_t buf_len = this->get_buffer_length_();
+  const uint32_t buf_half_len = buf_len / 2u;
+
+  // Black
+  this->command(0x24);
+  for (uint32_t i = 0; i < buf_half_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  // Red
+  this->command(0x26);
+  for (uint32_t i = buf_half_len; i < buf_len; i++) {
+    this->data(this->buffer_[i]);
+  }
+
+  // Display frame
+  this->command(0x20);
+}
+
+void WaveshareEPaper2P66InB::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 2.66in B");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+int WaveshareEPaper2P66InB::get_width_internal() { return 152; }
+int WaveshareEPaper2P66InB::get_height_internal() { return 296; }
+
+// ========================================================
 //                          2.7inch_e-paper_b
 // ========================================================
 // Datasheet:

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -202,6 +202,24 @@ class WaveshareEPaper1P54InBV2 : public WaveshareEPaperBWR {
   int get_height_internal() override;
 };
 
+class WaveshareEPaper2P66InB : public WaveshareEPaperBWR {
+ public:
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+};
+
 class WaveshareEPaper2P7In : public WaveshareEPaper {
  public:
   void initialize() override;

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -227,6 +227,25 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
+  # 2.66 inch displays
+  - platform: waveshare_epaper
+    id: epd_2_66b
+    model: 2.66in-b
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
   # 2.7 inch displays
   - platform: waveshare_epaper
     id: epd_2_70


### PR DESCRIPTION
# What does this implement/fix?

Add support for the Waveshare 2.66inch (B) e-paper display, information about the display can be found [here](https://www.waveshare.com/wiki/2.66inch_e-Paper_Module_(B)_Manual).

<img width="885" height="997" alt="image" src="https://github.com/user-attachments/assets/b419a87a-4915-4b25-8b36-cdc8b7e62bf8" />

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5939

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: waveshare_epaper
    model: 2.66in-b
    id: e_ink_display
    cs_pin: GPIO15
    dc_pin: GPIO9
    reset_pin: GPIO11
    busy_pin: GPIO10
    update_interval: never
    pages:
      - id: main_page
        lambda: |-
          const auto BLACK   = Color(0,   0,   0,   0);
          const auto WHITE   = Color(255, 255, 255, 0);
          const auto RED     = Color(255, 0,   0,   0);

          it.fill(WHITE);

          it.print(it.get_width() / 2, 0, id(ChareInk_Body), BLACK, TextAlign::TOP_CENTER, "Hello World!");
          it.print(it.get_width() / 2, 20, id(ChareInk_Body), RED, TextAlign::TOP_CENTER, "From ESPHome!");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
