### PR TITLE
[core] Add fnv1_hash_extend() string overloads, use in atm90e32

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -158,12 +158,14 @@ void ATM90E32Component::setup() {
 
   if (this->enable_offset_calibration_) {
     // Initialize flash storage for offset calibrations
-    uint32_t o_hash = fnv1_hash(std::string("_offset_calibration_") + this->cs_summary_);
+    uint32_t o_hash = fnv1_hash("_offset_calibration_");
+    o_hash = fnv1_hash_extend(o_hash, this->cs_summary_);
     this->offset_pref_ = global_preferences->make_preference<OffsetCalibration[3]>(o_hash, true);
     this->restore_offset_calibrations_();
 
     // Initialize flash storage for power offset calibrations
-    uint32_t po_hash = fnv1_hash(std::string("_power_offset_calibration_") + this->cs_summary_);
+    uint32_t po_hash = fnv1_hash("_power_offset_calibration_");
+    po_hash = fnv1_hash_extend(po_hash, this->cs_summary_);
     this->power_offset_pref_ = global_preferences->make_preference<PowerOffsetCalibration[3]>(po_hash, true);
     this->restore_power_offset_calibrations_();
   } else {
@@ -183,7 +185,8 @@ void ATM90E32Component::setup() {
 
   if (this->enable_gain_calibration_) {
     // Initialize flash storage for gain calibration
-    uint32_t g_hash = fnv1_hash(std::string("_gain_calibration_") + this->cs_summary_);
+    uint32_t g_hash = fnv1_hash("_gain_calibration_");
+    g_hash = fnv1_hash_extend(g_hash, this->cs_summary_);
     this->gain_calibration_pref_ = global_preferences->make_preference<GainCalibration[3]>(g_hash, true);
     this->restore_gain_calibrations_();
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -397,9 +397,11 @@ constexpr uint32_t FNV1_PRIME = 16777619UL;
 
 /// Extend a FNV-1 hash with an integer (hashes each byte).
 template<std::integral T> constexpr uint32_t fnv1_hash_extend(uint32_t hash, T value) {
+  using UnsignedT = std::make_unsigned_t<T>;
+  UnsignedT uvalue = static_cast<UnsignedT>(value);
   for (size_t i = 0; i < sizeof(T); i++) {
     hash *= FNV1_PRIME;
-    hash ^= (value >> (i * 8)) & 0xFF;
+    hash ^= (uvalue >> (i * 8)) & 0xFF;
   }
   return hash;
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -395,6 +395,26 @@ constexpr uint32_t FNV1_OFFSET_BASIS = 2166136261UL;
 /// FNV-1 32-bit prime
 constexpr uint32_t FNV1_PRIME = 16777619UL;
 
+/// Extend a FNV-1 hash with an integer (hashes each byte).
+template<std::integral T> constexpr uint32_t fnv1_hash_extend(uint32_t hash, T value) {
+  for (size_t i = 0; i < sizeof(T); i++) {
+    hash *= FNV1_PRIME;
+    hash ^= (value >> (i * 8)) & 0xFF;
+  }
+  return hash;
+}
+/// Extend a FNV-1 hash with additional string data.
+constexpr uint32_t fnv1_hash_extend(uint32_t hash, const char *str) {
+  if (str) {
+    while (*str) {
+      hash *= FNV1_PRIME;
+      hash ^= *str++;
+    }
+  }
+  return hash;
+}
+inline uint32_t fnv1_hash_extend(uint32_t hash, const std::string &str) { return fnv1_hash_extend(hash, str.c_str()); }
+
 /// Extend a FNV-1a hash with additional string data.
 constexpr uint32_t fnv1a_hash_extend(uint32_t hash, const char *str) {
   if (str) {


### PR DESCRIPTION
# What does this implement/fix?

Adds `fnv1_hash_extend()` overloads for `const char*` and `std::string`, enabling hash computation without heap allocation from string concatenation.

This mirrors the existing `fnv1a_hash_extend()` string overloads but for the FNV-1 algorithm (multiply-then-XOR vs XOR-then-multiply). The FNV-1 variant is needed for backward compatibility with existing code that uses `fnv1_hash()`.

Updated atm90e32 component to use the new helper, eliminating 3 heap allocations during setup:

```cpp
// Before - allocates temporary std::string
uint32_t hash = fnv1_hash(std::string("_offset_calibration_") + this->cs_summary_);

// After - zero heap allocation, same hash value
uint32_t hash = fnv1_hash("_offset_calibration_");
hash = fnv1_hash_extend(hash, this->cs_summary_);
```

Hash values are identical to the concatenation approach, so stored preferences remain valid.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
sensor:
  - platform: atm90e32
    # ... existing config
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)

