### PR TITLE
[template] Store alarm control panel codes in flash instead of heap

### DIFF
--- a/esphome/components/template/alarm_control_panel/__init__.py
+++ b/esphome/components/template/alarm_control_panel/__init__.py
@@ -118,8 +118,7 @@ async def to_code(config):
     var = await alarm_control_panel.new_alarm_control_panel(config)
     await cg.register_component(var, config)
     if CONF_CODES in config:
-        for acode in config[CONF_CODES]:
-            cg.add(var.add_code(acode))
+        cg.add(var.set_codes(config[CONF_CODES]))
         if CONF_REQUIRES_CODE_TO_ARM in config:
             cg.add(var.set_requires_code_to_arm(config[CONF_REQUIRES_CODE_TO_ARM]))
 

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -206,7 +206,13 @@ bool TemplateAlarmControlPanel::is_code_valid_(optional<std::string> code) {
   if (!this->codes_.empty()) {
     if (code.has_value()) {
       ESP_LOGVV(TAG, "Checking code: %s", code.value().c_str());
-      return (std::count(this->codes_.begin(), this->codes_.end(), code.value()) == 1);
+      // Use strcmp for const char* comparison
+      const char *code_cstr = code.value().c_str();
+      for (const char *stored_code : this->codes_) {
+        if (strcmp(stored_code, code_cstr) == 0)
+          return true;
+      }
+      return false;
     }
     ESP_LOGD(TAG, "No code provided");
     return false;

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cinttypes>
+#include <cstring>
 #include <vector>
 
 #include "esphome/core/automation.h"
@@ -86,11 +87,14 @@ class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControl
                   AlarmSensorType type = ALARM_SENSOR_TYPE_DELAYED);
 #endif
 
-  /** add a code
+  /** Set the codes (from initializer list).
    *
-   * @param code The code
+   * @param codes The list of valid codes
    */
-  void add_code(const std::string &code) { this->codes_.push_back(code); }
+  void set_codes(std::initializer_list<const char *> codes) { this->codes_ = codes; }
+
+  // Deleted overload to catch incorrect std::string usage at compile time
+  void set_codes(std::initializer_list<std::string> codes) = delete;
 
   /** set requires a code to arm
    *
@@ -155,8 +159,8 @@ class TemplateAlarmControlPanel final : public alarm_control_panel::AlarmControl
   uint32_t pending_time_;
   // the time in trigger
   uint32_t trigger_time_;
-  // a list of codes
-  std::vector<std::string> codes_;
+  // a list of codes (const char* pointers to string literals in flash)
+  FixedVector<const char *> codes_;
   // requires a code to arm
   bool requires_code_to_arm_ = false;
   bool supports_arm_home_ = false;

--- a/tests/components/alarm_control_panel/common.yaml
+++ b/tests/components/alarm_control_panel/common.yaml
@@ -9,6 +9,8 @@ alarm_control_panel:
     name: Alarm Panel
     codes:
       - "1234"
+      - "5678"
+      - "0000"
     requires_code_to_arm: true
     arming_home_time: 1s
     arming_night_time: 1s
@@ -29,6 +31,7 @@ alarm_control_panel:
     name: Alarm Panel 2
     codes:
       - "1234"
+      - "9999"
     requires_code_to_arm: true
     arming_home_time: 1s
     arming_night_time: 1s


### PR DESCRIPTION
# What does this implement/fix?

Optimizes memory usage in `template` alarm control panel by storing codes as `const char*` pointers to flash instead of heap-allocated `std::string` objects.

**Changes:**

1. Changed `std::vector<std::string> codes_` to `FixedVector<const char *> codes_`
2. Replaced `add_code()` loop with `set_codes(std::initializer_list<const char *>)`
3. Updated `is_code_valid_()` to use `strcmp` for string comparison
4. Added deleted overload `set_codes(std::initializer_list<std::string>)` to catch incorrect usage at compile time

**Why this is safe:**

Codes come from YAML configuration and are passed as string literals from codegen (e.g., `var->set_codes({"1234", "5678"})`). String literals are stored in the `.rodata` section (flash) and remain valid for the program lifetime.

**Memory savings:**

- ~24 bytes per code (std::string overhead) + string content
- For typical configs (2-4 codes): 48-192 bytes saved

**Pattern consistency:**

This follows the same pattern already used in:
- `FanTraits::preset_modes_`
- `ClimateTraits::supported_custom_fan_modes_`
- `ClimateTraits::supported_custom_presets_`
- `Event::types_`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
# Existing configs continue to work unchanged

alarm_control_panel:
  - platform: template
    name: "Alarm Panel"
    codes:
      - "1234"
      - "5678"
    requires_code_to_arm: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Updated `tests/components/alarm_control_panel/common.yaml` to test multiple codes

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
