### PR TITLE
[wireguard] Store configuration strings in flash instead of heap

### DIFF
--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -30,6 +30,7 @@ _WG_KEY_REGEX = re.compile(r"^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw480]=$")
 
 wireguard_ns = cg.esphome_ns.namespace("wireguard")
 Wireguard = wireguard_ns.class_("Wireguard", cg.Component, cg.PollingComponent)
+AllowedIP = wireguard_ns.struct("AllowedIP")
 WireguardPeerOnlineCondition = wireguard_ns.class_(
     "WireguardPeerOnlineCondition", automation.Condition
 )
@@ -108,8 +109,18 @@ async def to_code(config):
         )
     )
 
-    for ip in allowed_ips:
-        cg.add(var.add_allowed_ip(str(ip.network_address), str(ip.netmask)))
+    cg.add(
+        var.set_allowed_ips(
+            [
+                cg.StructInitializer(
+                    AllowedIP,
+                    ("ip", str(ip.network_address)),
+                    ("netmask", str(ip.netmask)),
+                )
+                for ip in allowed_ips
+            ]
+        )
+    )
 
     cg.add(var.set_srctime(await cg.get_variable(config[CONF_TIME_ID])))
 


### PR DESCRIPTION
# What does this implement/fix?

Convert WireGuard configuration storage from heap-allocated `std::string` to `const char*` pointers for data that comes from YAML/codegen. This eliminates runtime heap allocation for string literals that are already stored in flash.

## Changes

### String Storage Optimization
- Convert 6 string members (`address_`, `netmask_`, `private_key_`, `peer_endpoint_`, `peer_public_key_`, `preshared_key_`) from `std::string` to `const char*`
- Add deleted `std::string` overloads to catch accidental misuse at compile time

### Allowed IPs Optimization
- Replace `std::vector<std::tuple<std::string, std::string>>` with `FixedVector<AllowedIP>` using new `AllowedIP` struct
- Use `std::initializer_list<AllowedIP>` pattern for codegen

### mask_key Function Optimization
- Replace heap-allocating `std::string mask_key()` with buffer-based `void mask_key_to()`
- Add `MASK_KEY_BUFFER_SIZE` constexpr for buffer sizing

### Code Style
- Update namespace to C++17 style (`namespace esphome::wireguard`)

## Memory Savings
- ~144 bytes from 6 string members (24 bytes std::string overhead each)
- ~40 bytes per allowed IP entry (from 48-byte tuple to 8-byte struct)
- Eliminates heap allocation/deallocation in dump_config

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Proactive memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (tested on real ESP32-S2 hardware) 
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing configs continue to work unchanged

wireguard:
  time_id: sntp_time
  address: 172.16.34.100
  netmask: 255.255.255.0
  private_key: wPBMxtNYH3mChicrbpsRpZIasIdPq3yZuthn23FbGG8=
  peer_public_key: Hs2JfikvYU03/Kv3YoAs1hrUIPPTEkpsZKSPUljE9yc=
  peer_preshared_key: 20fjM5GRnSolGPC5SRj9ljgIUyQfruv0B0bvLl3Yt60=
  peer_endpoint: wg.server.example
  peer_persistent_keepalive: 25s
  peer_allowed_ips:
    - 172.16.34.0/24
    - 192.168.4.0/24
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
