### PR TITLE
[template] Store text initial_value in flash and avoid heap allocation in setup

### DIFF
--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -8,16 +8,23 @@ static const char *const TAG = "template.text";
 void TemplateText::setup() {
   if (this->f_.has_value())
     return;
-  std::string value = this->initial_value_;
-  if (!this->pref_) {
-    ESP_LOGD(TAG, "State from initial: %s", value.c_str());
-  } else {
-    uint32_t key = this->get_preference_hash();
-    key += this->traits.get_min_length() << 2;
-    key += this->traits.get_max_length() << 4;
-    key += fnv1_hash(this->traits.get_pattern_c_str()) << 6;
-    this->pref_->setup(key, value);
+
+  if (this->pref_ == nullptr) {
+    // No restore - use const char* directly, no heap allocation needed
+    if (this->initial_value_ != nullptr && this->initial_value_[0] != '\0') {
+      ESP_LOGD(TAG, "State from initial: %s", this->initial_value_);
+      this->publish_state(this->initial_value_);
+    }
+    return;
   }
+
+  // Need std::string for pref_->setup() to fill from flash
+  std::string value{this->initial_value_ != nullptr ? this->initial_value_ : ""};
+  uint32_t key = this->get_preference_hash();
+  key += this->traits.get_min_length() << 2;
+  key += this->traits.get_max_length() << 4;
+  key += fnv1_hash(this->traits.get_pattern_c_str()) << 6;
+  this->pref_->setup(key, value);
   if (!value.empty())
     this->publish_state(value);
 }

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -70,13 +70,15 @@ class TemplateText final : public text::Text, public PollingComponent {
 
   Trigger<std::string> *get_set_trigger() const { return this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
-  void set_initial_value(const std::string &initial_value) { this->initial_value_ = initial_value; }
+  void set_initial_value(const char *initial_value) { this->initial_value_ = initial_value; }
+  /// Prevent accidental use of std::string which would dangle
+  void set_initial_value(const std::string &initial_value) = delete;
   void set_value_saver(TemplateTextSaverBase *restore_value_saver) { this->pref_ = restore_value_saver; }
 
  protected:
   void control(const std::string &value) override;
   bool optimistic_ = false;
-  std::string initial_value_;
+  const char *initial_value_{nullptr};
   Trigger<std::string> *set_trigger_ = new Trigger<std::string>();
   TemplateLambda<std::string> f_{};
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes template text component by storing `initial_value_` as `const char*` pointer to flash instead of heap-allocated `std::string`, and restructures `setup()` to avoid heap allocation entirely for the common case.

## Changes

### Member Storage
- Convert `std::string initial_value_` to `const char *initial_value_{nullptr}`
- Add deleted `std::string` overload to catch accidental misuse at compile time

### Setup Optimization
- When `restore_value: false` (the default), use `const char*` directly with `publish_state(const char*)` overload - **zero heap allocation**
- When `restore_value: true`, only then create local `std::string` for `pref_->setup()` to fill from flash
- Use early return for cleaner code structure

## Memory Savings
- ~24 bytes permanent member storage per template text instance
- Zero heap allocation in `setup()` for the common case (`restore_value: false`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Proactive memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing configs continue to work unchanged

text:
  - platform: template
    name: "My Text"
    optimistic: true
    initial_value: "Hello"
    min_length: 0
    max_length: 100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).  tests/integration/test_text_command.py covers this already

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
