### PR TITLE
[sun] Store text sensor format string in flash

### DIFF
--- a/esphome/components/sun/text_sensor/sun_text_sensor.h
+++ b/esphome/components/sun/text_sensor/sun_text_sensor.h
@@ -14,7 +14,9 @@ class SunTextSensor : public text_sensor::TextSensor, public PollingComponent {
   void set_parent(Sun *parent) { parent_ = parent; }
   void set_elevation(double elevation) { elevation_ = elevation; }
   void set_sunrise(bool sunrise) { sunrise_ = sunrise; }
-  void set_format(const std::string &format) { format_ = format; }
+  void set_format(const char *format) { this->format_ = format; }
+  /// Prevent accidental use of std::string which would dangle
+  void set_format(const std::string &format) = delete;
 
   void update() override {
     optional<ESPTime> res;
@@ -29,14 +31,14 @@ class SunTextSensor : public text_sensor::TextSensor, public PollingComponent {
     }
 
     char buf[ESPTime::STRFTIME_BUFFER_SIZE];
-    size_t len = res->strftime_to(buf, this->format_.c_str());
+    size_t len = res->strftime_to(buf, this->format_);
     this->publish_state(buf, len);
   }
 
   void dump_config() override;
 
  protected:
-  std::string format_{};
+  const char *format_{nullptr};
   Sun *parent_;
   double elevation_;
   bool sunrise_;


### PR DESCRIPTION
# What does this implement/fix?

Stores the `format_` member in flash instead of heap-allocating a `std::string`. The format string comes from YAML configuration and is never modified at runtime.

## Changes

- Change `std::string format_` to `const char *format_{nullptr}`
- Update setter to take `const char*`
- Add deleted `std::string` overload to catch accidental misuse at compile time
- Remove unnecessary `.c_str()` call

## Memory Savings

~24 bytes per sun text sensor instance (std::string SSO buffer overhead eliminated).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Proactive memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing configs continue to work unchanged

sun:
  latitude: 48.8584
  longitude: 2.2945

text_sensor:
  - platform: sun
    name: "Next Sunrise"
    type: sunrise
    format: "%X"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
