### PR TITLE
[pipsolar] Store command strings in flash

### DIFF
--- a/esphome/components/pipsolar/output/pipsolar_output.cpp
+++ b/esphome/components/pipsolar/output/pipsolar_output.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "pipsolar.output";
 
 void PipsolarOutput::write_state(float state) {
   char tmp[10];
-  sprintf(tmp, this->set_command_.c_str(), state);
+  snprintf(tmp, sizeof(tmp), this->set_command_, state);
 
   if (std::find(this->possible_values_.begin(), this->possible_values_.end(), state) != this->possible_values_.end()) {
     ESP_LOGD(TAG, "Will write: %s out of value %f / %02.0f", tmp, state, state);

--- a/esphome/components/pipsolar/output/pipsolar_output.h
+++ b/esphome/components/pipsolar/output/pipsolar_output.h
@@ -15,13 +15,15 @@ class PipsolarOutput : public output::FloatOutput {
  public:
   PipsolarOutput() {}
   void set_parent(Pipsolar *parent) { this->parent_ = parent; }
-  void set_set_command(const std::string &command) { this->set_command_ = command; };
+  void set_set_command(const char *command) { this->set_command_ = command; }
+  /// Prevent accidental use of std::string which would dangle
+  void set_set_command(const std::string &command) = delete;
   void set_possible_values(std::vector<float> possible_values) { this->possible_values_ = std::move(possible_values); }
-  void set_value(float value) { this->write_state(value); };
+  void set_value(float value) { this->write_state(value); }
 
  protected:
   void write_state(float state) override;
-  std::string set_command_;
+  const char *set_command_{nullptr};
   Pipsolar *parent_;
   std::vector<float> possible_values_;
 };

--- a/esphome/components/pipsolar/switch/pipsolar_switch.cpp
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.cpp
@@ -9,14 +9,9 @@ static const char *const TAG = "pipsolar.switch";
 
 void PipsolarSwitch::dump_config() { LOG_SWITCH("", "Pipsolar Switch", this); }
 void PipsolarSwitch::write_state(bool state) {
-  if (state) {
-    if (this->on_command_ != nullptr) {
-      this->parent_->queue_command(this->on_command_);
-    }
-  } else {
-    if (this->off_command_ != nullptr) {
-      this->parent_->queue_command(this->off_command_);
-    }
+  const char *command = state ? this->on_command_ : this->off_command_;
+  if (command != nullptr) {
+    this->parent_->queue_command(command);
   }
 }
 

--- a/esphome/components/pipsolar/switch/pipsolar_switch.cpp
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.cpp
@@ -10,11 +10,11 @@ static const char *const TAG = "pipsolar.switch";
 void PipsolarSwitch::dump_config() { LOG_SWITCH("", "Pipsolar Switch", this); }
 void PipsolarSwitch::write_state(bool state) {
   if (state) {
-    if (!this->on_command_.empty()) {
+    if (this->on_command_ != nullptr) {
       this->parent_->queue_command(this->on_command_);
     }
   } else {
-    if (!this->off_command_.empty()) {
+    if (this->off_command_ != nullptr) {
       this->parent_->queue_command(this->off_command_);
     }
   }

--- a/esphome/components/pipsolar/switch/pipsolar_switch.h
+++ b/esphome/components/pipsolar/switch/pipsolar_switch.h
@@ -9,15 +9,18 @@ namespace pipsolar {
 class Pipsolar;
 class PipsolarSwitch : public switch_::Switch, public Component {
  public:
-  void set_parent(Pipsolar *parent) { this->parent_ = parent; };
-  void set_on_command(const std::string &command) { this->on_command_ = command; };
-  void set_off_command(const std::string &command) { this->off_command_ = command; };
+  void set_parent(Pipsolar *parent) { this->parent_ = parent; }
+  void set_on_command(const char *command) { this->on_command_ = command; }
+  void set_off_command(const char *command) { this->off_command_ = command; }
+  /// Prevent accidental use of std::string which would dangle
+  void set_on_command(const std::string &command) = delete;
+  void set_off_command(const std::string &command) = delete;
   void dump_config() override;
 
  protected:
   void write_state(bool state) override;
-  std::string on_command_;
-  std::string off_command_;
+  const char *on_command_{nullptr};
+  const char *off_command_{nullptr};
   Pipsolar *parent_;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Stores command strings in flash instead of heap-allocating `std::string` objects. These command strings come from YAML configuration and are never modified at runtime.

## Changes

### pipsolar_switch.h/cpp
- Change `std::string on_command_` and `std::string off_command_` to `const char*`
- Update setters to take `const char*`
- Add deleted `std::string` overloads to catch accidental misuse at compile time
- Update `.empty()` checks to nullptr checks

### pipsolar_output.h/cpp
- Change `std::string set_command_` to `const char*`
- Update setter to take `const char*`
- Add deleted `std::string` overload
- Remove unnecessary `.c_str()` call (format string passed directly to snprintf)

## Memory Savings

~72 bytes per pipsolar device:
- ~48 bytes for switch (two std::string members)
- ~24 bytes for output (one std::string member)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Proactive memory optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP32-S2 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing configs continue to work unchanged

pipsolar:
  id: inverter0

switch:
  - platform: pipsolar
    pipsolar_id: inverter0
    output_source_priority_utility:
      name: "Output Source Priority Utility"

output:
  - platform: pipsolar
    pipsolar_id: inverter0
    battery_recharge_voltage:
      id: battery_recharge_voltage_out
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
