### PR TITLE
[esp32_ble_tracker] Optimize loop with state change tracking for ~85% CPU reduction

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -135,8 +135,8 @@ void BluetoothConnection::loop() {
   // - For V3_WITH_CACHE: Services are never sent, disable after INIT state
   // - For V3_WITHOUT_CACHE: Disable only after service discovery is complete
   //   (send_service_ == DONE_SENDING_SERVICES, which is only set after services are sent)
-  if (this->state_ != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
-                                                   this->send_service_ == DONE_SENDING_SERVICES)) {
+  if (this->state() != espbt::ClientState::INIT && (this->connection_type_ == espbt::ConnectionType::V3_WITH_CACHE ||
+                                                    this->send_service_ == DONE_SENDING_SERVICES)) {
     this->disable_loop();
   }
 }

--- a/esphome/components/esp32_ble_client/ble_client_base.h
+++ b/esphome/components/esp32_ble_client/ble_client_base.h
@@ -44,7 +44,7 @@ class BLEClientBase : public espbt::ESPBTClient, public Component {
   void unconditional_disconnect();
   void release_services();
 
-  bool connected() { return this->state_ == espbt::ClientState::ESTABLISHED; }
+  bool connected() { return this->state() == espbt::ClientState::ESTABLISHED; }
 
   void set_auto_connect(bool auto_connect) { this->auto_connect_ = auto_connect; }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -250,6 +250,9 @@ void ESP32BLETracker::start_scan_(bool first) {
 void ESP32BLETracker::register_client(ESPBTClient *client) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   client->app_id = ++this->app_id_;
+  // Give client a pointer to our state_version_ so it can notify us of state changes.
+  // This enables loop() fast-path optimization - we skip expensive work when no state changed.
+  // Safe because ESP32BLETracker (singleton) outlives all registered clients.
   client->set_tracker_state_version(&this->state_version_);
   this->clients_.push_back(client);
   this->recalculate_advertisement_parser_types();

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -135,8 +135,11 @@ void ESP32BLETracker::loop() {
   // if no state has changed since last loop iteration.
   //
   // How state changes ensure we reach the code below:
-  // - handle_scanner_failure_(): scanner_state_ set via set_scanner_state_() increments version
-  // - start_scan_()/update_coex_preference_(): scanner_state_ becomes IDLE via set_scanner_state_()
+  // - handle_scanner_failure_(): scanner_state_ becomes FAILED via set_scanner_state_(), or
+  //   scan_set_param_failed_ requires scanner_state_==RUNNING which can only be reached via
+  //   set_scanner_state_(RUNNING) in gap_scan_start_complete_() (scan params are set during
+  //   STARTING, not RUNNING, so version is always incremented before this condition is true)
+  // - start_scan_(): scanner_state_ becomes IDLE via set_scanner_state_() in cleanup_scan_state_()
   // - try_promote_discovered_clients_(): client enters DISCOVERED via set_state(), or
   //   connecting client finishes (state change), or scanner reaches RUNNING/IDLE
   //

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -106,21 +106,23 @@ void ESP32BLETracker::loop() {
 
   // Check for scan timeout - moved here from scheduler to avoid false reboots
   // when the loop is blocked. This must run every iteration for safety.
-  if (this->scanner_state_ == ScannerState::RUNNING && this->scan_timeout_state_ == ScanTimeoutState::MONITORING) {
-    // Robust time comparison that handles rollover correctly
-    // This works because unsigned arithmetic wraps around predictably
-    if ((App.get_loop_component_start_time() - this->scan_start_time_) > this->scan_timeout_ms_) {
-      // First time we've seen the timeout exceeded - wait one more loop iteration
-      // This ensures all components have had a chance to process pending events
-      // This is because esp32_ble may not have run yet and called
-      // gap_scan_event_handler yet when the loop unblocks
-      ESP_LOGW(TAG, "Scan timeout exceeded");
-      this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
+  if (this->scanner_state_ == ScannerState::RUNNING) {
+    if (this->scan_timeout_state_ == ScanTimeoutState::MONITORING) {
+      // Robust time comparison that handles rollover correctly
+      // This works because unsigned arithmetic wraps around predictably
+      if ((App.get_loop_component_start_time() - this->scan_start_time_) > this->scan_timeout_ms_) {
+        // First time we've seen the timeout exceeded - wait one more loop iteration
+        // This ensures all components have had a chance to process pending events
+        // This is because esp32_ble may not have run yet and called
+        // gap_scan_event_handler yet when the loop unblocks
+        ESP_LOGW(TAG, "Scan timeout exceeded");
+        this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
+      }
+    } else if (this->scan_timeout_state_ == ScanTimeoutState::EXCEEDED_WAIT) {
+      // We've waited at least one full loop iteration, and scan is still running
+      ESP_LOGE(TAG, "Scan never terminated, rebooting");
+      App.reboot();
     }
-  } else if (this->scan_timeout_state_ == ScanTimeoutState::EXCEEDED_WAIT) {
-    // We've waited at least one full loop iteration, and scan is still running
-    ESP_LOGE(TAG, "Scan never terminated, rebooting");
-    App.reboot();
   }
 
   // Fast path: skip expensive client state counting and processing

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -107,21 +107,27 @@ void ESP32BLETracker::loop() {
   // Check for scan timeout - moved here from scheduler to avoid false reboots
   // when the loop is blocked. This must run every iteration for safety.
   if (this->scanner_state_ == ScannerState::RUNNING) {
-    if (this->scan_timeout_state_ == ScanTimeoutState::MONITORING) {
-      // Robust time comparison that handles rollover correctly
-      // This works because unsigned arithmetic wraps around predictably
-      if ((App.get_loop_component_start_time() - this->scan_start_time_) > this->scan_timeout_ms_) {
-        // First time we've seen the timeout exceeded - wait one more loop iteration
-        // This ensures all components have had a chance to process pending events
-        // This is because esp32_ble may not have run yet and called
-        // gap_scan_event_handler yet when the loop unblocks
-        ESP_LOGW(TAG, "Scan timeout exceeded");
-        this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
+    switch (this->scan_timeout_state_) {
+      case ScanTimeoutState::MONITORING: {
+        // Robust time comparison that handles rollover correctly
+        // This works because unsigned arithmetic wraps around predictably
+        if ((App.get_loop_component_start_time() - this->scan_start_time_) > this->scan_timeout_ms_) {
+          // First time we've seen the timeout exceeded - wait one more loop iteration
+          // This ensures all components have had a chance to process pending events
+          // This is because esp32_ble may not have run yet and called
+          // gap_scan_event_handler yet when the loop unblocks
+          ESP_LOGW(TAG, "Scan timeout exceeded");
+          this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
+        }
+        break;
       }
-    } else if (this->scan_timeout_state_ == ScanTimeoutState::EXCEEDED_WAIT) {
-      // We've waited at least one full loop iteration, and scan is still running
-      ESP_LOGE(TAG, "Scan never terminated, rebooting");
-      App.reboot();
+      case ScanTimeoutState::EXCEEDED_WAIT:
+        // We've waited at least one full loop iteration, and scan is still running
+        ESP_LOGE(TAG, "Scan never terminated, rebooting");
+        App.reboot();
+        break;
+      case ScanTimeoutState::INACTIVE:
+        break;
     }
   }
 

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -126,7 +126,16 @@ void ESP32BLETracker::loop() {
   }
 
   // Fast path: skip expensive client state counting and processing
-  // if no state has changed since last loop iteration
+  // if no state has changed since last loop iteration.
+  //
+  // How state changes ensure we reach the code below:
+  // - handle_scanner_failure_(): scanner_state_ set via set_scanner_state_() increments version
+  // - start_scan_()/update_coex_preference_(): scanner_state_ becomes IDLE via set_scanner_state_()
+  // - try_promote_discovered_clients_(): client enters DISCOVERED via set_state(), or
+  //   connecting client finishes (state change), or scanner reaches RUNNING/IDLE
+  //
+  // All conditions that affect the logic below are tied to state changes that increment
+  // state_version_, so the fast path is safe.
   if (this->state_version_ == this->last_processed_version_) {
     return;
   }
@@ -140,6 +149,7 @@ void ESP32BLETracker::loop() {
              this->client_state_counts_.discovered, this->client_state_counts_.disconnecting);
   }
 
+  // Scanner failure: reached when set_scanner_state_(FAILED) or scan_set_param_failed_ set
   if (this->scanner_state_ == ScannerState::FAILED ||
       (this->scan_set_param_failed_ && this->scanner_state_ == ScannerState::RUNNING)) {
     this->handle_scanner_failure_();
@@ -158,6 +168,8 @@ void ESP32BLETracker::loop() {
 
   */
 
+  // Start scan: reached when scanner_state_ becomes IDLE (via set_scanner_state_()) and
+  // all clients are idle (their state changes increment version when they finish)
   if (this->scanner_state_ == ScannerState::IDLE && !counts.connecting && !counts.disconnecting && !counts.discovered) {
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
     this->update_coex_preference_(false);
@@ -166,8 +178,9 @@ void ESP32BLETracker::loop() {
       this->start_scan_(false);  // first = false
     }
   }
-  // If there is a discovered client and no connecting
-  // clients, then promote the discovered client to ready to connect.
+  // Promote discovered clients: reached when a client's state becomes DISCOVERED (via set_state()),
+  // or when a blocking condition clears (connecting client finishes, scanner reaches RUNNING/IDLE).
+  // All these trigger state_version_ increment, so we'll process and check promotion eligibility.
   // We check both RUNNING and IDLE states because:
   // - RUNNING: gap_scan_event_handler initiates stop_scan_() but promotion can happen immediately
   // - IDLE: Scanner has already stopped (naturally or by gap_scan_event_handler)

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -105,36 +105,32 @@ void ESP32BLETracker::loop() {
   }
 
   // Check for scan timeout - moved here from scheduler to avoid false reboots
-  // when the loop is blocked
-  if (this->scanner_state_ == ScannerState::RUNNING) {
-    switch (this->scan_timeout_state_) {
-      case ScanTimeoutState::MONITORING: {
-        uint32_t now = App.get_loop_component_start_time();
-        uint32_t timeout_ms = this->scan_duration_ * 2000;
-        // Robust time comparison that handles rollover correctly
-        // This works because unsigned arithmetic wraps around predictably
-        if ((now - this->scan_start_time_) > timeout_ms) {
-          // First time we've seen the timeout exceeded - wait one more loop iteration
-          // This ensures all components have had a chance to process pending events
-          // This is because esp32_ble may not have run yet and called
-          // gap_scan_event_handler yet when the loop unblocks
-          ESP_LOGW(TAG, "Scan timeout exceeded");
-          this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
-        }
-        break;
-      }
-      case ScanTimeoutState::EXCEEDED_WAIT:
-        // We've waited at least one full loop iteration, and scan is still running
-        ESP_LOGE(TAG, "Scan never terminated, rebooting");
-        App.reboot();
-        break;
-
-      case ScanTimeoutState::INACTIVE:
-        // This case should be unreachable - scanner and timeout states are always synchronized
-        break;
+  // when the loop is blocked. This must run every iteration for safety.
+  if (this->scanner_state_ == ScannerState::RUNNING && this->scan_timeout_state_ == ScanTimeoutState::MONITORING) {
+    // Robust time comparison that handles rollover correctly
+    // This works because unsigned arithmetic wraps around predictably
+    if ((App.get_loop_component_start_time() - this->scan_start_time_) > this->scan_timeout_ms_) {
+      // First time we've seen the timeout exceeded - wait one more loop iteration
+      // This ensures all components have had a chance to process pending events
+      // This is because esp32_ble may not have run yet and called
+      // gap_scan_event_handler yet when the loop unblocks
+      ESP_LOGW(TAG, "Scan timeout exceeded");
+      this->scan_timeout_state_ = ScanTimeoutState::EXCEEDED_WAIT;
     }
+  } else if (this->scan_timeout_state_ == ScanTimeoutState::EXCEEDED_WAIT) {
+    // We've waited at least one full loop iteration, and scan is still running
+    ESP_LOGE(TAG, "Scan never terminated, rebooting");
+    App.reboot();
   }
 
+  // Fast path: skip expensive client state counting and processing
+  // if no state has changed since last loop iteration
+  if (this->state_version_ == this->last_processed_version_) {
+    return;
+  }
+  this->last_processed_version_ = this->state_version_;
+
+  // State changed - do full processing
   ClientStateCounts counts = this->count_client_states_();
   if (counts != this->client_state_counts_) {
     this->client_state_counts_ = counts;
@@ -236,6 +232,7 @@ void ESP32BLETracker::start_scan_(bool first) {
   // Start timeout monitoring in loop() instead of using scheduler
   // This prevents false reboots when the loop is blocked
   this->scan_start_time_ = App.get_loop_component_start_time();
+  this->scan_timeout_ms_ = this->scan_duration_ * 2000;
   this->scan_timeout_state_ = ScanTimeoutState::MONITORING;
 
   esp_err_t err = esp_ble_gap_set_scan_params(&this->scan_params_);
@@ -253,6 +250,7 @@ void ESP32BLETracker::start_scan_(bool first) {
 void ESP32BLETracker::register_client(ESPBTClient *client) {
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
   client->app_id = ++this->app_id_;
+  client->set_tracker_state_version(&this->state_version_);
   this->clients_.push_back(client);
   this->recalculate_advertisement_parser_types();
 #endif
@@ -382,6 +380,7 @@ void ESP32BLETracker::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_i
 
 void ESP32BLETracker::set_scanner_state_(ScannerState state) {
   this->scanner_state_ = state;
+  this->state_version_++;
   for (auto *listener : this->scanner_state_listeners_) {
     listener->on_scanner_state(state);
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -216,6 +216,19 @@ enum class ConnectionType : uint8_t {
   V3_WITHOUT_CACHE
 };
 
+/// Base class for BLE GATT clients that connect to remote devices.
+///
+/// State Change Tracking Design:
+/// -----------------------------
+/// ESP32BLETracker::loop() needs to know when client states change to avoid
+/// expensive polling. Rather than checking all clients every iteration (~7000/min),
+/// we use a version counter owned by ESP32BLETracker that clients increment on
+/// state changes. The tracker compares versions to skip work when nothing changed.
+///
+/// Ownership: ESP32BLETracker owns state_version_. Clients hold a non-owning
+/// pointer (tracker_state_version_) set during register_client(). Clients
+/// increment the counter through this pointer when their state changes.
+/// The pointer may be null if the client is not registered with a tracker.
 class ESPBTClient : public ESPBTDeviceListener {
  public:
   virtual bool gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
@@ -225,6 +238,9 @@ class ESPBTClient : public ESPBTDeviceListener {
   virtual void disconnect() = 0;
   bool disconnect_pending() const { return this->want_disconnect_; }
   void cancel_pending_disconnect() { this->want_disconnect_ = false; }
+
+  /// Set the client state with IDLE handling (clears want_disconnect_).
+  /// Notifies the tracker of state change for loop optimization.
   virtual void set_state(ClientState st) {
     this->set_state_internal_(st);
     if (st == ClientState::IDLE) {
@@ -233,16 +249,21 @@ class ESPBTClient : public ESPBTDeviceListener {
   }
   ClientState state() const { return this->state_; }
 
-  /// Set the tracker's state version pointer for change notification
+  /// Called by ESP32BLETracker::register_client() to enable state change notifications.
+  /// The pointer must remain valid for the lifetime of the client (guaranteed since
+  /// ESP32BLETracker is a singleton that outlives all clients).
   void set_tracker_state_version(uint8_t *version) { this->tracker_state_version_ = version; }
 
   // Memory optimized layout
   uint8_t app_id;  // App IDs are small integers assigned sequentially
 
  protected:
-  /// Set state without IDLE handling - use for direct state transitions
+  /// Set state without IDLE handling - use for direct state transitions.
+  /// Increments the tracker's state version counter to signal that loop()
+  /// should do full processing on the next iteration.
   void set_state_internal_(ClientState st) {
     this->state_ = st;
+    // Notify tracker that state changed (tracker_state_version_ is owned by ESP32BLETracker)
     if (this->tracker_state_version_ != nullptr) {
       (*this->tracker_state_version_)++;
     }
@@ -256,8 +277,9 @@ class ESPBTClient : public ESPBTDeviceListener {
 
  private:
   ClientState state_{ClientState::INIT};
-  /// Pointer to tracker's state_version_ counter, incremented on state changes
-  /// to enable fast-path loop optimization. Set by ESP32BLETracker::register_client().
+  /// Non-owning pointer to ESP32BLETracker::state_version_. When this client's
+  /// state changes, we increment the tracker's counter to signal that loop()
+  /// should perform full processing. Null if client not registered with tracker.
   uint8_t *tracker_state_version_{nullptr};
 };
 
@@ -394,10 +416,15 @@ class ESP32BLETracker : public Component,
   // Group 4: 1-byte types (enums, uint8_t, bool)
   uint8_t app_id_{0};
   uint8_t scan_start_fail_count_{0};
-  /// Version counter incremented on any state change (scanner or client)
-  /// Used for fast-path optimization in loop() to skip work when nothing changed.
+  /// Version counter for loop() fast-path optimization. Incremented when:
+  /// - Scanner state changes (via set_scanner_state_())
+  /// - Any registered client's state changes (clients hold pointer to this counter)
+  /// Owned by this class; clients receive non-owning pointer via register_client().
+  /// When loop() sees state_version_ == last_processed_version_, it skips expensive
+  /// client state counting and takes the fast path (just timeout check + return).
   uint8_t state_version_{0};
-  /// Last state version that was fully processed in loop()
+  /// Last state_version_ value when loop() did full processing. Compared against
+  /// state_version_ to detect if any state changed since last iteration.
   uint8_t last_processed_version_{0};
   ScannerState scanner_state_{ScannerState::IDLE};
   bool scan_continuous_;

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -226,25 +226,39 @@ class ESPBTClient : public ESPBTDeviceListener {
   bool disconnect_pending() const { return this->want_disconnect_; }
   void cancel_pending_disconnect() { this->want_disconnect_ = false; }
   virtual void set_state(ClientState st) {
-    this->state_ = st;
+    this->set_state_internal_(st);
     if (st == ClientState::IDLE) {
       this->want_disconnect_ = false;
     }
   }
-  ClientState state() const { return state_; }
+  ClientState state() const { return this->state_; }
+
+  /// Set the tracker's state version pointer for change notification
+  void set_tracker_state_version(uint8_t *version) { this->tracker_state_version_ = version; }
 
   // Memory optimized layout
   uint8_t app_id;  // App IDs are small integers assigned sequentially
 
  protected:
-  // Group 1: 1-byte types
-  ClientState state_{ClientState::INIT};
+  /// Set state without IDLE handling - use for direct state transitions
+  void set_state_internal_(ClientState st) {
+    this->state_ = st;
+    if (this->tracker_state_version_ != nullptr) {
+      (*this->tracker_state_version_)++;
+    }
+  }
+
   // want_disconnect_ is set to true when a disconnect is requested
   // while the client is connecting. This is used to disconnect the
   // client as soon as we get the connection id (conn_id_) from the
   // ESP_GATTC_OPEN_EVT event.
   bool want_disconnect_{false};
-  // 2 bytes used, 2 bytes padding
+
+ private:
+  ClientState state_{ClientState::INIT};
+  /// Pointer to tracker's state_version_ counter, incremented on state changes
+  /// to enable fast-path loop optimization. Set by ESP32BLETracker::register_client().
+  uint8_t *tracker_state_version_{nullptr};
 };
 
 class ESP32BLETracker : public Component,
@@ -380,6 +394,11 @@ class ESP32BLETracker : public Component,
   // Group 4: 1-byte types (enums, uint8_t, bool)
   uint8_t app_id_{0};
   uint8_t scan_start_fail_count_{0};
+  /// Version counter incremented on any state change (scanner or client)
+  /// Used for fast-path optimization in loop() to skip work when nothing changed.
+  uint8_t state_version_{0};
+  /// Last state version that was fully processed in loop()
+  uint8_t last_processed_version_{0};
   ScannerState scanner_state_{ScannerState::IDLE};
   bool scan_continuous_;
   bool scan_active_;
@@ -396,6 +415,8 @@ class ESP32BLETracker : public Component,
     EXCEEDED_WAIT,  // Timeout exceeded, waiting one loop before reboot
   };
   uint32_t scan_start_time_{0};
+  /// Precomputed timeout value: scan_duration_ * 2000
+  uint32_t scan_timeout_ms_{0};
   ScanTimeoutState scan_timeout_state_{ScanTimeoutState::INACTIVE};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `esp32_ble_tracker` loop to avoid unnecessary work when state hasn't changed.

Previously, the loop would count client states and check various conditions ~7000 times per minute, even though state changes only occur a few times per scan cycle. This PR adds a version counter that tracks state changes, allowing the loop to take a fast path when nothing has changed.

## Changes

**ESP32BLETracker:**
- Added `state_version_` counter incremented on any state change
- Added `last_processed_version_` to track last processed version
- Added `scan_timeout_ms_` to precompute timeout value (avoids multiplication every loop)
- `loop()` now takes fast path when version unchanged: only does timeout check and returns
- `set_scanner_state_()` increments version counter
- `register_client()` sets up version pointer on clients

**ESPBTClient:**
- Made `state_` private to enforce state change tracking
- Added `set_state_internal_()` for state transitions that increments tracker's version
- Added `tracker_state_version_` non-owning pointer set during client registration
- Changed direct `state_` reads to use `state()` getter
- Added comprehensive design documentation explaining ownership model

## Performance Results

**Before optimization:**
```
esp32_ble_tracker: count=6967, avg=0.02ms, max=1ms, total=131-162ms per 60s
```

**After optimization:**
```
esp32_ble_tracker: count=6646, avg=0.00ms, max=1ms, total=11-18ms per 60s
```

**~85-90% reduction in CPU time** for esp32_ble_tracker loop.

## Memory Cost

- ESP32BLETracker: +6 bytes (`state_version_`, `last_processed_version_`, `scan_timeout_ms_`)
- ESPBTClient: +4 bytes per client (pointer to tracker's version counter)
- Total: ~10-22 bytes for typical 1-4 client configurations

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Breaking change note:** `ESPBTClient::state_` is now private. External components that directly accessed `state_` must use `state()` getter for reads and `set_state()` or `set_state_internal_()` for writes.

## Developer Breaking Change

`ESPBTClient::state_` changed from `protected` to `private`. This is unlikely to affect external components since all direct accesses were internal to `ble_client_base.cpp` and `bluetooth_connection.cpp`.

If affected: use `state()` for reads, `set_state()` or `set_state_internal_()` for writes.

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - optimization is automatic
esp32_ble_tracker:

bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
