### PR TITLE
[light] Skip redundant publishes and adopt >> log format

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -79,6 +79,12 @@ void LightCall::perform() {
   LightColorValues v = this->validate_();
   const bool publish = this->get_publish_();
 
+  // Skip if values unchanged and not changing effect/flash
+  // Flash is allowed to repeat, effects may need to restart
+  if (v == this->parent_->remote_values && !this->has_flash_() && !this->has_effect_()) {
+    return;
+  }
+
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
   // Build combined log message in a single buffer to reduce API packet overhead
   // Buffer sized for: name(64) + state(10) + brightness(20) + color_brightness(25) +

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -2,6 +2,7 @@
 
 #include "light_call.h"
 #include "light_state.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
 
@@ -73,82 +74,100 @@ static const LogString *color_mode_to_human(ColorMode color_mode) {
   return LOG_STR("Unknown");
 }
 
-// Helper to log percentage values
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
-static void log_percent(const LogString *param, float value) {
-  ESP_LOGD(TAG, "  %s: %.0f%%", LOG_STR_ARG(param), value * 100.0f);
-}
-#else
-#define log_percent(param, value)
-#endif
-
 void LightCall::perform() {
   const char *name = this->parent_->get_name().c_str();
   LightColorValues v = this->validate_();
   const bool publish = this->get_publish_();
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+  // Build combined log message in a single buffer to reduce API packet overhead
+  // Buffer sized for: name(64) + state(10) + brightness(20) + color_brightness(25) +
+  // rgb(40) + white(15) + color_temp(35) + cw_ww(40) + transition/flash/effect(40) + margin
+  constexpr size_t LOG_BUF_SIZE = 320;
+  char log_buf[LOG_BUF_SIZE];
+  size_t log_pos = 0;
+
   if (publish) {
-    ESP_LOGD(TAG, "'%s' Setting:", name);
+    log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, "'%s' >>", name);
 
     // Only print color mode when it's being changed
     ColorMode current_color_mode = this->parent_->remote_values.get_color_mode();
     ColorMode target_color_mode = this->has_color_mode() ? this->color_mode_ : current_color_mode;
     if (target_color_mode != current_color_mode) {
-      ESP_LOGD(TAG, "  Color mode: %s", LOG_STR_ARG(color_mode_to_human(v.get_color_mode())));
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Color mode: %s",
+                                  LOG_STR_ARG(color_mode_to_human(v.get_color_mode())));
     }
 
     // Only print state when it's being changed
     bool current_state = this->parent_->remote_values.is_on();
     bool target_state = this->has_state() ? this->state_ : current_state;
     if (target_state != current_state) {
-      ESP_LOGD(TAG, "  State: %s", ONOFF(v.is_on()));
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " State: %s", ONOFF(v.is_on()));
     }
 
     if (this->has_brightness()) {
-      log_percent(LOG_STR("Brightness"), v.get_brightness());
+      log_pos =
+          buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Brightness: %.0f%%", v.get_brightness() * 100.0f);
     }
 
     if (this->has_color_brightness()) {
-      log_percent(LOG_STR("Color brightness"), v.get_color_brightness());
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Color brightness: %.0f%%",
+                                  v.get_color_brightness() * 100.0f);
     }
     if (this->has_red() || this->has_green() || this->has_blue()) {
-      ESP_LOGD(TAG, "  Red: %.0f%%, Green: %.0f%%, Blue: %.0f%%", v.get_red() * 100.0f, v.get_green() * 100.0f,
-               v.get_blue() * 100.0f);
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Red: %.0f%% Green: %.0f%% Blue: %.0f%%",
+                                  v.get_red() * 100.0f, v.get_green() * 100.0f, v.get_blue() * 100.0f);
     }
 
     if (this->has_white()) {
-      log_percent(LOG_STR("White"), v.get_white());
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " White: %.0f%%", v.get_white() * 100.0f);
     }
     if (this->has_color_temperature()) {
-      ESP_LOGD(TAG, "  Color temperature: %.1f mireds", v.get_color_temperature());
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Color temperature: %.1f mireds",
+                                  v.get_color_temperature());
     }
 
     if (this->has_cold_white() || this->has_warm_white()) {
-      ESP_LOGD(TAG, "  Cold white: %.0f%%, warm white: %.0f%%", v.get_cold_white() * 100.0f,
-               v.get_warm_white() * 100.0f);
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Cold white: %.0f%%, warm white: %.0f%%",
+                                  v.get_cold_white() * 100.0f, v.get_warm_white() * 100.0f);
     }
   }
+#endif
 
   if (this->has_flash_()) {
     // FLASH
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
     if (publish) {
-      ESP_LOGD(TAG, "  Flash length: %.1fs", this->flash_length_ / 1e3f);
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Flash: %.1fs", this->flash_length_ / 1e3f);
+      ESP_LOGD(TAG, "%s", log_buf);
     }
+#endif
 
     this->parent_->start_flash_(v, this->flash_length_, publish);
   } else if (this->has_transition_()) {
     // TRANSITION
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
     if (publish) {
-      ESP_LOGD(TAG, "  Transition length: %.1fs", this->transition_length_ / 1e3f);
+      log_pos =
+          buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Transition: %.1fs", this->transition_length_ / 1e3f);
     }
+#endif
 
     // Special case: Transition and effect can be set when turning off
     if (this->has_effect_()) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
       if (publish) {
-        ESP_LOGD(TAG, "  Effect: 'None'");
+        log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Effect: 'None'");
       }
+#endif
       this->parent_->stop_effect_();
     }
+
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+    if (publish) {
+      ESP_LOGD(TAG, "%s", log_buf);
+    }
+#endif
 
     this->parent_->start_transition_(v, this->transition_length_, publish);
 
@@ -161,9 +180,13 @@ void LightCall::perform() {
       effect_s = this->parent_->effects_[this->effect_ - 1]->get_name();
     }
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
     if (publish) {
-      ESP_LOGD(TAG, "  Effect: '%.*s'", (int) effect_s.size(), effect_s.c_str());
+      log_pos = buf_append_printf(log_buf, sizeof(log_buf), log_pos, " Effect: '%.*s'", (int) effect_s.size(),
+                                  effect_s.c_str());
+      ESP_LOGD(TAG, "%s", log_buf);
     }
+#endif
 
     this->parent_->start_effect_(this->effect_);
 
@@ -172,6 +195,11 @@ void LightCall::perform() {
     this->parent_->set_immediately_(v, true);
   } else {
     // INSTANT CHANGE
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+    if (publish && log_pos > 0) {
+      ESP_LOGD(TAG, "%s", log_buf);
+    }
+#endif
     this->parent_->set_immediately_(v, publish);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Two improvements to light state logging and publishing:

## 1. Combine log messages and adopt >> format

Combines multiple separate light state log messages into a single line and adopts the `>>` format used by other entity components.

**Before (4-5 separate log lines = 4-5 API packets):**
```
[D][light:091]: 'Light' Setting:
[D][light:079]:   Brightness: 50%
[D][light:115]:   Red: 0%, Green: 100%, Blue: 0%
[D][light:142]:   Transition length: 1.0s
```

**After (single log line = 1 API packet):**
```
[D][light:091]: 'Light' >> Brightness: 50% Red: 0% Green: 100% Blue: 0% Transition: 1.0s
```

This was missed in #13236 which normalized other entity state publishing logs to use the `>>` format. Light is special because it logs from `LightCall::perform()` rather than a simple `publish_state()` method.

## 2. Skip redundant state publishes

Adds an early return in `LightCall::perform()` when the target values match the current `remote_values` and no effect/flash change is requested. This prevents redundant logging and state publishing when automations or templates repeatedly call the light with the same values.

**Before:** Every call to set light state would log and publish, even if nothing changed.

**After:** Calls with unchanged values return immediately (unless it's a flash or effect change).

**Benefits:**
- Reduces API packet overhead (each log line is sent as a separate API message)
- Matches the `>>` format convention used by sensors, switches, and other entities
- Only logs values that are actually changing (state, color mode) rather than all values
- Eliminates redundant state publishes from automations/templates that set the same values repeatedly
- Uses `buf_append_printf` for safe buffer building

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13236

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal logging change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: rgb
    name: "Test Light"
    red: output_red
    green: output_green
    blue: output_blue
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
