### PR TITLE
[hub75] Add Huidu HD-WF1 board configuration

### DIFF
--- a/esphome/components/hub75/boards/huidu.py
+++ b/esphome/components/hub75/boards/huidu.py
@@ -2,6 +2,25 @@
 
 from . import BoardConfig
 
+# Huidu HD-WF1
+BoardConfig(
+    "huidu-hd-wf1",
+    r1_pin=2,
+    g1_pin=6,
+    b1_pin=3,
+    r2_pin=4,
+    g2_pin=8,
+    b2_pin=5,
+    a_pin=39,
+    b_pin=38,
+    c_pin=37,
+    d_pin=36,
+    e_pin=12,
+    lat_pin=33,
+    oe_pin=35,
+    clk_pin=34,
+)
+
 # Huidu HD-WF2
 BoardConfig(
     "huidu-hd-wf2",


### PR DESCRIPTION
# What does this implement/fix?

Added pin configuration for `WF1` version of the Huidu board.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related 7421f31160142f9bfd726ad75dcf1ba3c9c199d3

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5942

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: hub75
    id: matrix_display
    board: huidu-hd-wf1
    panel_width: 64
    panel_height: 32
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs)
