### PR TITLE
[status] Convert to PollingComponent to reduce CPU usage

### DIFF
--- a/esphome/components/status/binary_sensor.py
+++ b/esphome/components/status/binary_sensor.py
@@ -7,14 +7,14 @@ DEPENDENCIES = ["network"]
 
 status_ns = cg.esphome_ns.namespace("status")
 StatusBinarySensor = status_ns.class_(
-    "StatusBinarySensor", binary_sensor.BinarySensor, cg.Component
+    "StatusBinarySensor", binary_sensor.BinarySensor, cg.PollingComponent
 )
 
 CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(
     StatusBinarySensor,
     device_class=DEVICE_CLASS_CONNECTIVITY,
     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-).extend(cv.COMPONENT_SCHEMA)
+).extend(cv.polling_component_schema("1s"))
 
 
 async def to_code(config):

--- a/esphome/components/status/status_binary_sensor.cpp
+++ b/esphome/components/status/status_binary_sensor.cpp
@@ -10,12 +10,11 @@
 #include "esphome/components/api/api_server.h"
 #endif
 
-namespace esphome {
-namespace status {
+namespace esphome::status {
 
 static const char *const TAG = "status";
 
-void StatusBinarySensor::loop() {
+void StatusBinarySensor::update() {
   bool status = network::is_connected();
 #ifdef USE_MQTT
   if (mqtt::global_mqtt_client != nullptr) {
@@ -33,5 +32,4 @@ void StatusBinarySensor::loop() {
 void StatusBinarySensor::setup() { this->publish_initial_state(false); }
 void StatusBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Status Binary Sensor", this); }
 
-}  // namespace status
-}  // namespace esphome
+}  // namespace esphome::status

--- a/esphome/components/status/status_binary_sensor.h
+++ b/esphome/components/status/status_binary_sensor.h
@@ -3,12 +3,11 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace status {
+namespace esphome::status {
 
-class StatusBinarySensor : public binary_sensor::BinarySensor, public Component {
+class StatusBinarySensor : public binary_sensor::BinarySensor, public PollingComponent {
  public:
-  void loop() override;
+  void update() override;
 
   void setup() override;
   void dump_config() override;
@@ -16,5 +15,4 @@ class StatusBinarySensor : public binary_sensor::BinarySensor, public Component 
   bool is_status_binary_sensor() const override { return true; }
 };
 
-}  // namespace status
-}  // namespace esphome
+}  // namespace esphome::status


### PR DESCRIPTION
# What does this implement/fix?

Convert the status binary sensor from `Component` to `PollingComponent` to reduce CPU usage.

Previously, the status binary sensor ran its `loop()` on every app loop iteration (~110 Hz), checking network/MQTT/API connection status and calling `publish_state()` each time. While `publish_state()` has internal deduplication, the repeated checks still consumed CPU.

Now it polls once per second (configurable via `update_interval`), reducing CPU usage significantly:

- **Before:** `status.binary_sensor: count=6715, avg=0.03ms, total=180ms`
- **After:** `status.binary_sensor: count=60, avg=0.48ms, total=29ms`

84% reduction in CPU time (180ms → 29ms per minute).

A 1-second polling interval is appropriate since:
1. Network/MQTT/API connection states don't change faster than that
2. Users can configure `update_interval` if needed

Also applies C++17 nested namespace syntax.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5943

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default 1 second polling (recommended)
binary_sensor:
  - platform: status
    name: Status

# Custom polling interval if needed
binary_sensor:
  - platform: status
    name: Status
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
