### PR TITLE
[cc1101] Add on_packet listener callback code (packet_transport)

### DIFF
--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -11,6 +11,11 @@ namespace esphome::cc1101 {
 
 enum class CC1101Error { NONE = 0, TIMEOUT, PARAMS, CRC_ERROR, FIFO_OVERFLOW, PLL_LOCK };
 
+class CC1101Listener {
+ public:
+  virtual void on_packet(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) = 0;
+};
+
 class CC1101Component : public Component,
                         public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                               spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
@@ -73,6 +78,7 @@ class CC1101Component : public Component,
 
   // Packet mode operations
   CC1101Error transmit_packet(const std::vector<uint8_t> &packet);
+  void register_listener(CC1101Listener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float, uint8_t> *get_packet_trigger() const { return this->packet_trigger_; }
 
  protected:
@@ -89,9 +95,11 @@ class CC1101Component : public Component,
   InternalGPIOPin *gdo0_pin_{nullptr};
 
   // Packet handling
+  void call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi);
   Trigger<std::vector<uint8_t>, float, float, uint8_t> *packet_trigger_{
       new Trigger<std::vector<uint8_t>, float, float, uint8_t>()};
   std::vector<uint8_t> packet_;
+  std::vector<CC1101Listener *> listeners_;
 
   // Low-level Helpers
   uint8_t strobe_(Command cmd);


### PR DESCRIPTION
# What does this implement/fix?

An on_packet callback listener is a prerequisite for packet_transport support on cc1101.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

Same implementation as sx127x component.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

n/a

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
