### PR TITLE
[esp8266] Use direct SDK calls instead of Arduino ESP class wrappers

### DIFF
--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -6,7 +6,11 @@
 #include "esphome/core/helpers.h"
 #include "preferences.h"
 #include <Arduino.h>
-#include <Esp.h>
+#include <core_esp8266_features.h>
+
+extern "C" {
+#include <user_interface.h>
+}
 
 namespace esphome {
 
@@ -16,23 +20,19 @@ void IRAM_ATTR HOT delay(uint32_t ms) { ::delay(ms); }
 uint32_t IRAM_ATTR HOT micros() { return ::micros(); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { delay_microseconds_safe(us); }
 void arch_restart() {
-  ESP.restart();  // NOLINT(readability-static-accessed-through-instance)
+  system_restart();
   // restart() doesn't always end execution
   while (true) {  // NOLINT(clang-diagnostic-unreachable-code)
     yield();
   }
 }
 void arch_init() {}
-void IRAM_ATTR HOT arch_feed_wdt() {
-  ESP.wdtFeed();  // NOLINT(readability-static-accessed-through-instance)
-}
+void IRAM_ATTR HOT arch_feed_wdt() { system_soft_wdt_feed(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) {
   return pgm_read_byte(addr);  // NOLINT
 }
-uint32_t IRAM_ATTR HOT arch_get_cpu_cycle_count() {
-  return ESP.getCycleCount();  // NOLINT(readability-static-accessed-through-instance)
-}
+uint32_t IRAM_ATTR HOT arch_get_cpu_cycle_count() { return esp_get_cycle_count(); }
 uint32_t arch_get_cpu_freq_hz() { return F_CPU; }
 
 void force_link_symbols() {


### PR DESCRIPTION
# What does this implement/fix?

Replaces Arduino ESP class wrapper calls with direct SDK functions in the ESP8266 core component to reduce Arduino dependency and prepare for potential future Arduino-free support.

**Changes:**
- Replace `ESP.restart()` with `system_restart()`
- Replace `ESP.wdtFeed()` with `system_soft_wdt_feed()`
- Replace `ESP.getCycleCount()` with `esp_get_cycle_count()`
- Remove `<Esp.h>` include (no longer needed)
- Add `<user_interface.h>` and `<core_esp8266_features.h>` includes for SDK functions

This is a no-op change functionally - the Arduino wrappers just call these SDK functions directly. Benefits:
- Fewer Arduino dependencies in core code
- Reduces coupling to Arduino framework
- One less place to update if ESP8266 ever supports non-Arduino builds

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce Arduino wrapper usage on ESP8266

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal refactoring
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
