### PR TITLE
[mqtt] Eliminate per-entity loop overhead and heap churn 

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -396,6 +396,12 @@ void MQTTClientComponent::loop() {
 
         this->last_connected_ = now;
         this->resubscribe_subscriptions_();
+
+        // Process pending resends for all MQTT components centrally
+        // This is more efficient than each component polling in its own loop
+        for (MQTTComponent *component : this->children_) {
+          component->process_resend();
+        }
       }
       break;
   }

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -307,15 +307,11 @@ void MQTTComponent::call_setup() {
   }
 }
 
-void MQTTComponent::call_loop() {
-  if (this->is_internal())
+void MQTTComponent::process_resend() {
+  // Called by MQTTClientComponent when connected to process pending resends
+  // Note: is_internal() check not needed - internal components are never registered
+  if (!this->resend_state_)
     return;
-
-  this->loop();
-
-  if (!this->resend_state_ || !this->is_connected_()) {
-    return;
-  }
 
   this->resend_state_ = false;
   if (this->is_discovery_enabled()) {

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -81,8 +81,6 @@ class MQTTComponent : public Component {
   /// Override setup_ so that we can call send_discovery() when needed.
   void call_setup() override;
 
-  void call_loop() override;
-
   void call_dump_config() override;
 
   /// Send discovery info the Home Assistant, override this.
@@ -132,6 +130,9 @@ class MQTTComponent : public Component {
 
   /// Internal method for the MQTT client base to schedule a resend of the state on reconnect.
   void schedule_resend_state();
+
+  /// Process pending resend if needed (called by MQTTClientComponent)
+  void process_resend();
 
   /** Send a MQTT message.
    *


### PR DESCRIPTION
# What does this implement/fix?

Eliminates per-component loop overhead for MQTT entities by centralizing resend processing in `MQTTClientComponent`.

Previously, each MQTT entity (sensor, switch, binary_sensor, etc.) was registered as a looping component and had its `call_loop()` called every main loop iteration. The loop did almost nothing most of the time - just checking `resend_state_` and `is_connected_()` flags.

**Worse, `call_loop()` called `is_internal()` which in turn calls `get_state_topic_()`, `get_command_topic_()`, or `get_default_topic_for_()` - all of which return `std::string` and allocate heap memory. This caused massive heap churn: ~7000 allocations/deallocations per minute *per entity*.**

With 15+ MQTT entities, this added ~4500ms of CPU time per minute and significant heap fragmentation.

## Changes

1. **Removed `call_loop()` override from `MQTTComponent`** - Since no MQTT entities override `loop()`, this was just overhead
2. **Added `process_resend()` method** - Handles the resend logic that was previously in `call_loop()`
3. **Centralized resend processing in `MQTTClientComponent::loop()`** - When connected, iterates over all children and calls `process_resend()`

Since `MQTTComponent` no longer overrides `loop()` or `call_loop()`, `has_overridden_loop()` returns false and MQTT entities are never added to the looping components list.

All non-internal MQTT components are still registered via `register_mqtt_component()` in `call_setup()` - internal components return early before registration, so the `is_internal()` check is not needed in `process_resend()`.

This aligns MQTT with how the API component works: `APIServer` has a single `loop()` that directly calls `client->loop()` on its connections - the clients are not registered as separate looping components.

## Behavioral Verification

| Check | Old Behavior | New Behavior | Status |
|-------|--------------|--------------|--------|
| Reconnect trigger | `schedule_resend_state()` on all children | Same - called in `start_connect_()` | ✓ Equivalent |
| When resend runs | `is_connected_() && resend_state_` | `CONNECTED state + backend.connected() + resend_state_` | ✓ Equivalent |
| Async resend_state_ | All calls from main loop context | Same - no ISR/task calls | ✓ Equivalent |
| Internal entities | Early return in `call_setup()` before register | Same - never in `children_` | ✓ Equivalent |
| Failed send retry | `schedule_resend_state()` sets flag for next loop | Same - called in `process_resend()` | ✓ Equivalent |

**Note:** One subtle difference is that old code processed components interleaved with other components, while new code processes all MQTT children in a batch within `MQTTClientComponent::loop()`. This has no functional impact.

**Tested:** Forced device to reconnect to WiFi - all entities resent discovery/state correctly.

## Runtime Stats

**Before (15+ MQTT entities):**
```
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.06ms, max=3ms, total=422ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.05ms, max=3ms, total=379ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.05ms, max=4ms, total=329ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.05ms, max=3ms, total=328ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=6ms, total=293ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=2ms, total=293ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6907, avg=0.04ms, max=106ms, total=292ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=5ms, total=291ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=3ms, total=290ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=4ms, total=287ms
[17:41:32.204][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=2ms, total=285ms
[17:41:32.207][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=4ms, total=277ms
[17:41:32.207][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=3ms, total=272ms
[17:41:32.207][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=3ms, total=263ms
[17:41:32.207][I][runtime_stats:052]:   mqtt: count=6906, avg=0.04ms, max=3ms, total=255ms
Total MQTT overhead: ~4500ms per 60 seconds
```

**After (single MQTTClientComponent):**
```
[17:50:40.144][I][runtime_stats:052]:   mqtt: count=7190, avg=0.08ms, max=106ms, total=606ms
```

**Savings:**
- CPU: ~3900ms/min (~6.5% reduction)
- RAM: ~900 bytes (smaller `looping_components_` vector, no vtable overhead for removed override)

Note: This test was with a modest 15 MQTT entities. Savings scale linearly with entity count - a device with 45+ entities would save ~12,000ms/min (~20% CPU) and proportionally more RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal optimization
mqtt:
  broker: !secret mqtt_broker
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
