### PR TITLE
[cs5460a] Remove unnecessary empty loop override

### DIFF
--- a/esphome/components/cs5460a/cs5460a.h
+++ b/esphome/components/cs5460a/cs5460a.h
@@ -76,7 +76,6 @@ class CS5460AComponent : public Component,
   void restart() { restart_(); }
 
   void setup() override;
-  void loop() override {}
   void dump_config() override;
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Removes unnecessary empty `loop() override {}` from `CS5460AComponent`.

The empty override caused `has_overridden_loop()` to return true, which added this component to `looping_components_` even though it does nothing every loop iteration.

Without the override, `has_overridden_loop()` returns false and the component is not added to the looping list, saving a small amount of CPU overhead per loop iteration.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
