### PR TITLE
[alarm_control_panel] Reduce heap allocations in arm/disarm methods

### DIFF
--- a/esphome/components/alarm_control_panel/alarm_control_panel.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.cpp
@@ -67,52 +67,29 @@ void AlarmControlPanel::add_on_ready_callback(std::function<void()> &&callback) 
   this->ready_callback_.add(std::move(callback));
 }
 
-void AlarmControlPanel::arm_away(optional<std::string> code) {
+void AlarmControlPanel::arm_with_code_(AlarmControlPanelCall &(AlarmControlPanelCall::*arm_method)(),
+                                       const char *code) {
   auto call = this->make_call();
-  call.arm_away();
-  if (code.has_value())
-    call.set_code(code.value());
+  (call.*arm_method)();
+  if (code != nullptr)
+    call.set_code(code);
   call.perform();
 }
 
-void AlarmControlPanel::arm_home(optional<std::string> code) {
-  auto call = this->make_call();
-  call.arm_home();
-  if (code.has_value())
-    call.set_code(code.value());
-  call.perform();
+void AlarmControlPanel::arm_away(const char *code) { this->arm_with_code_(&AlarmControlPanelCall::arm_away, code); }
+
+void AlarmControlPanel::arm_home(const char *code) { this->arm_with_code_(&AlarmControlPanelCall::arm_home, code); }
+
+void AlarmControlPanel::arm_night(const char *code) { this->arm_with_code_(&AlarmControlPanelCall::arm_night, code); }
+
+void AlarmControlPanel::arm_vacation(const char *code) {
+  this->arm_with_code_(&AlarmControlPanelCall::arm_vacation, code);
 }
 
-void AlarmControlPanel::arm_night(optional<std::string> code) {
-  auto call = this->make_call();
-  call.arm_night();
-  if (code.has_value())
-    call.set_code(code.value());
-  call.perform();
+void AlarmControlPanel::arm_custom_bypass(const char *code) {
+  this->arm_with_code_(&AlarmControlPanelCall::arm_custom_bypass, code);
 }
 
-void AlarmControlPanel::arm_vacation(optional<std::string> code) {
-  auto call = this->make_call();
-  call.arm_vacation();
-  if (code.has_value())
-    call.set_code(code.value());
-  call.perform();
-}
-
-void AlarmControlPanel::arm_custom_bypass(optional<std::string> code) {
-  auto call = this->make_call();
-  call.arm_custom_bypass();
-  if (code.has_value())
-    call.set_code(code.value());
-  call.perform();
-}
-
-void AlarmControlPanel::disarm(optional<std::string> code) {
-  auto call = this->make_call();
-  call.disarm();
-  if (code.has_value())
-    call.set_code(code.value());
-  call.perform();
-}
+void AlarmControlPanel::disarm(const char *code) { this->arm_with_code_(&AlarmControlPanelCall::disarm, code); }
 
 }  // namespace esphome::alarm_control_panel

--- a/esphome/components/alarm_control_panel/alarm_control_panel.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel.h
@@ -76,37 +76,53 @@ class AlarmControlPanel : public EntityBase {
    *
    * @param code The code
    */
-  void arm_away(optional<std::string> code = nullopt);
+  void arm_away(const char *code = nullptr);
+  void arm_away(const optional<std::string> &code) {
+    this->arm_away(code.has_value() ? code.value().c_str() : nullptr);
+  }
 
   /** arm the alarm in home mode
    *
    * @param code The code
    */
-  void arm_home(optional<std::string> code = nullopt);
+  void arm_home(const char *code = nullptr);
+  void arm_home(const optional<std::string> &code) {
+    this->arm_home(code.has_value() ? code.value().c_str() : nullptr);
+  }
 
   /** arm the alarm in night mode
    *
    * @param code The code
    */
-  void arm_night(optional<std::string> code = nullopt);
+  void arm_night(const char *code = nullptr);
+  void arm_night(const optional<std::string> &code) {
+    this->arm_night(code.has_value() ? code.value().c_str() : nullptr);
+  }
 
   /** arm the alarm in vacation mode
    *
    * @param code The code
    */
-  void arm_vacation(optional<std::string> code = nullopt);
+  void arm_vacation(const char *code = nullptr);
+  void arm_vacation(const optional<std::string> &code) {
+    this->arm_vacation(code.has_value() ? code.value().c_str() : nullptr);
+  }
 
   /** arm the alarm in custom bypass mode
    *
    * @param code The code
    */
-  void arm_custom_bypass(optional<std::string> code = nullopt);
+  void arm_custom_bypass(const char *code = nullptr);
+  void arm_custom_bypass(const optional<std::string> &code) {
+    this->arm_custom_bypass(code.has_value() ? code.value().c_str() : nullptr);
+  }
 
   /** disarm the alarm
    *
    * @param code The code
    */
-  void disarm(optional<std::string> code = nullopt);
+  void disarm(const char *code = nullptr);
+  void disarm(const optional<std::string> &code) { this->disarm(code.has_value() ? code.value().c_str() : nullptr); }
 
   /** Get the state
    *
@@ -118,6 +134,8 @@ class AlarmControlPanel : public EntityBase {
 
  protected:
   friend AlarmControlPanelCall;
+  // Helper to reduce code duplication for arm/disarm methods
+  void arm_with_code_(AlarmControlPanelCall &(AlarmControlPanelCall::*arm_method)(), const char *code);
   // in order to store last panel state in flash
   ESPPreferenceObject pref_;
   // current state

--- a/esphome/components/alarm_control_panel/alarm_control_panel_call.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_call.cpp
@@ -10,8 +10,10 @@ static const char *const TAG = "alarm_control_panel";
 
 AlarmControlPanelCall::AlarmControlPanelCall(AlarmControlPanel *parent) : parent_(parent) {}
 
-AlarmControlPanelCall &AlarmControlPanelCall::set_code(const std::string &code) {
-  this->code_ = code;
+AlarmControlPanelCall &AlarmControlPanelCall::set_code(const char *code) {
+  if (code != nullptr) {
+    this->code_ = std::string(code);
+  }
   return *this;
 }
 

--- a/esphome/components/alarm_control_panel/alarm_control_panel_call.h
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_call.h
@@ -14,7 +14,8 @@ class AlarmControlPanelCall {
  public:
   AlarmControlPanelCall(AlarmControlPanel *parent);
 
-  AlarmControlPanelCall &set_code(const std::string &code);
+  AlarmControlPanelCall &set_code(const char *code);
+  AlarmControlPanelCall &set_code(const std::string &code) { return this->set_code(code.c_str()); }
   AlarmControlPanelCall &arm_away();
   AlarmControlPanelCall &arm_home();
   AlarmControlPanelCall &arm_night();

--- a/esphome/components/alarm_control_panel/automation.h
+++ b/esphome/components/alarm_control_panel/automation.h
@@ -66,15 +66,7 @@ template<typename... Ts> class ArmAwayAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(std::string, code)
 
-  void play(const Ts &...x) override {
-    auto call = this->alarm_control_panel_->make_call();
-    auto code = this->code_.optional_value(x...);
-    if (code.has_value()) {
-      call.set_code(code.value());
-    }
-    call.arm_away();
-    call.perform();
-  }
+  void play(const Ts &...x) override { this->alarm_control_panel_->arm_away(this->code_.optional_value(x...)); }
 
  protected:
   AlarmControlPanel *alarm_control_panel_;
@@ -86,15 +78,7 @@ template<typename... Ts> class ArmHomeAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(std::string, code)
 
-  void play(const Ts &...x) override {
-    auto call = this->alarm_control_panel_->make_call();
-    auto code = this->code_.optional_value(x...);
-    if (code.has_value()) {
-      call.set_code(code.value());
-    }
-    call.arm_home();
-    call.perform();
-  }
+  void play(const Ts &...x) override { this->alarm_control_panel_->arm_home(this->code_.optional_value(x...)); }
 
  protected:
   AlarmControlPanel *alarm_control_panel_;
@@ -106,15 +90,7 @@ template<typename... Ts> class ArmNightAction : public Action<Ts...> {
 
   TEMPLATABLE_VALUE(std::string, code)
 
-  void play(const Ts &...x) override {
-    auto call = this->alarm_control_panel_->make_call();
-    auto code = this->code_.optional_value(x...);
-    if (code.has_value()) {
-      call.set_code(code.value());
-    }
-    call.arm_night();
-    call.perform();
-  }
+  void play(const Ts &...x) override { this->alarm_control_panel_->arm_night(this->code_.optional_value(x...)); }
 
  protected:
   AlarmControlPanel *alarm_control_panel_;


### PR DESCRIPTION
# What does this implement/fix?

Reduce heap allocations in alarm control panel arm/disarm methods by using `const char *` as the primary implementation instead of `optional<std::string>`.

**Changes:**

- Add `const char *` overload for `AlarmControlPanelCall::set_code()` as primary implementation
- Change `arm_away`, `arm_home`, `arm_night`, `arm_vacation`, `arm_custom_bypass`, and `disarm` to use `const char *code = nullptr` as primary signature
- Add `optional<std::string>` overloads as thin wrappers for backward compatibility
- Extract common pattern into `arm_with_code_()` helper using member function pointer to reduce code duplication
- Simplify automation actions (`ArmAwayAction`, `ArmHomeAction`, `ArmNightAction`) to use the convenience methods directly

When a string literal is passed (e.g., `panel->disarm("1234")`), this avoids constructing an intermediate `optional<std::string>` wrapper. The string is copied once into the call's `code_` member.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- existing integration tests fully cover this already

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
