### PR TITLE
[lock] Extract set_state_ helper to reduce code duplication

### DIFF
--- a/esphome/components/lock/lock.cpp
+++ b/esphome/components/lock/lock.cpp
@@ -28,16 +28,14 @@ const LogString *lock_state_to_string(LockState state) {
 Lock::Lock() : state(LOCK_STATE_NONE) {}
 LockCall Lock::make_call() { return LockCall(this); }
 
-void Lock::lock() {
+void Lock::set_state_(LockState state) {
   auto call = this->make_call();
-  call.set_state(LOCK_STATE_LOCKED);
+  call.set_state(state);
   this->control(call);
 }
-void Lock::unlock() {
-  auto call = this->make_call();
-  call.set_state(LOCK_STATE_UNLOCKED);
-  this->control(call);
-}
+
+void Lock::lock() { this->set_state_(LOCK_STATE_LOCKED); }
+void Lock::unlock() { this->set_state_(LOCK_STATE_UNLOCKED); }
 void Lock::open() {
   if (traits.get_supports_open()) {
     ESP_LOGD(TAG, "'%s' Opening.", this->get_name().c_str());

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -156,6 +156,9 @@ class Lock : public EntityBase {
  protected:
   friend LockCall;
 
+  /// Helper for lock/unlock convenience methods
+  void set_state_(LockState state);
+
   /** Perform the open latch action with hardware. This method is optional to implement
    * when creating a new lock.
    *


### PR DESCRIPTION
# What does this implement/fix?

Extract common pattern from `lock()` and `unlock()` methods into a `set_state_()` helper to reduce code duplication.

Before:
```cpp
void Lock::lock() {
  auto call = this->make_call();
  call.set_state(LOCK_STATE_LOCKED);
  this->control(call);
}
void Lock::unlock() {
  auto call = this->make_call();
  call.set_state(LOCK_STATE_UNLOCKED);
  this->control(call);
}
```

After:
```cpp
void Lock::set_state_(LockState state) {
  auto call = this->make_call();
  call.set_state(state);
  this->control(call);
}

void Lock::lock() { this->set_state_(LOCK_STATE_LOCKED); }
void Lock::unlock() { this->set_state_(LOCK_STATE_UNLOCKED); }
```

Saves ~20-30 bytes of flash by eliminating duplicate inline code.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
