### PR TITLE
[logger] Optimize ESP8266 UART write path with direct FIFO register access

### DIFF
--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -3,11 +3,11 @@
 #include "esphome/core/log.h"
 
 // Direct UART register access for optimized write path
-// Arduino's Serial.write() has significant overhead:
-// - pgm_read_byte() for every character (unnecessary for RAM buffers)
-// - optimistic_yield() after every character (massive scheduler overhead)
-// - Per-character FIFO checks (could batch)
-// Direct register writes with batching are 10-50x faster for CPU-side work.
+// Arduino's Serial.write() (uart.cpp lines 545-548) has significant overhead:
+// - PROGMEM read for every character (unnecessary for RAM buffers)
+// - optimistic_yield(10000) after every character (scheduler overhead)
+// - Per-character FIFO checks via uart_do_write_char() (line 513)
+// Direct register writes with batching eliminate ~300 function calls per 100-byte message.
 #include <esp8266_peri.h>  // USF, USS, USTXC register macros
 
 namespace esphome::logger {

--- a/esphome/components/logger/logger_esp8266.cpp
+++ b/esphome/components/logger/logger_esp8266.cpp
@@ -2,9 +2,30 @@
 #include "logger.h"
 #include "esphome/core/log.h"
 
+// Direct UART register access for optimized write path
+// Arduino's Serial.write() has significant overhead:
+// - pgm_read_byte() for every character (unnecessary for RAM buffers)
+// - optimistic_yield() after every character (massive scheduler overhead)
+// - Per-character FIFO checks (could batch)
+// Direct register writes with batching are 10-50x faster for CPU-side work.
+#include <esp8266_peri.h>  // USF, USS, USTXC register macros
+
 namespace esphome::logger {
 
 static const char *const TAG = "logger";
+
+// UART TX FIFO size is 128 bytes, use 0x7F as threshold
+static constexpr uint8_t UART_TX_FIFO_THRESHOLD = 0x7F;
+
+// Yield timeout in microseconds - matches Arduino's uart_write behavior
+static constexpr uint32_t YIELD_TIMEOUT_US = 10000UL;
+
+// Determine UART number at compile time
+#if defined(USE_ESP8266_LOGGER_SERIAL)
+static const uint8_t LOGGER_UART_NUM = 0;
+#elif defined(USE_ESP8266_LOGGER_SERIAL1)
+static const uint8_t LOGGER_UART_NUM = 1;
+#endif
 
 void Logger::pre_setup() {
 #if defined(USE_ESP8266_LOGGER_SERIAL)
@@ -29,8 +50,30 @@ void Logger::pre_setup() {
 }
 
 void HOT Logger::write_msg_(const char *msg, size_t len) {
-  // Single write with newline already in buffer (added by caller)
-  this->hw_serial_->write(msg, len);
+#if defined(USE_ESP8266_LOGGER_SERIAL) || defined(USE_ESP8266_LOGGER_SERIAL1)
+  // Direct FIFO writes with batching - much faster than Arduino's per-character approach
+  // Arduino's uart_write() calls optimistic_yield() after EVERY character,
+  // but we can burst up to 127 bytes at once and only yield when FIFO is actually full.
+  while (len > 0) {
+    // Check current FIFO level (USTXC field at bits 16-23)
+    uint8_t fifo_cnt = (USS(LOGGER_UART_NUM) >> USTXC) & 0xFF;
+
+    if (fifo_cnt >= UART_TX_FIFO_THRESHOLD) {
+      // FIFO full - yield once and retry
+      optimistic_yield(YIELD_TIMEOUT_US);
+      continue;
+    }
+
+    // Burst write to FIFO - no function calls, no PROGMEM overhead
+    size_t fifo_free = UART_TX_FIFO_THRESHOLD - fifo_cnt;
+    size_t to_write = len < fifo_free ? len : fifo_free;
+    len -= to_write;
+
+    while (to_write--) {
+      USF(LOGGER_UART_NUM) = *msg++;
+    }
+  }
+#endif
 }
 
 const LogString *Logger::get_uart_selection_() {


### PR DESCRIPTION
# What does this implement/fix?

Optimizes ESP8266 logger performance by replacing Arduino's `Serial.write()` with direct UART FIFO register writes in the hot `write_msg_()` path.

Arduino's `uart_write()` implementation has significant overhead:
- Calls `pgm_read_byte()` for every character (unnecessary for RAM buffers)
- Calls `optimistic_yield()` after every character (massive scheduler overhead)
- Performs per-character FIFO full checks (could batch)

This change uses direct register access (`USF()`, `USS()` macros from `esp8266_peri.h`) to burst-write up to 127 bytes at once, only yielding when the FIFO is actually full. This eliminates ~100 function calls per 100-byte message (pgm_read_byte, optimistic_yield, FIFO checks), significantly reducing CPU overhead.

The `pre_setup()` initialization remains unchanged, keeping Arduino's `Serial.begin()` for compatibility with `improv_serial` and other components that check `hw_serial_`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (performance optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - optimization is automatic
# Standard logger configuration works as before:

logger:
  level: DEBUG
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
