### PR TITLE
[datetime] Add const char * overloads for string parsing to avoid heap allocation

### DIFF
--- a/esphome/components/datetime/date_entity.cpp
+++ b/esphome/components/datetime/date_entity.cpp
@@ -106,9 +106,9 @@ DateCall &DateCall::set_date(uint16_t year, uint8_t month, uint8_t day) {
 
 DateCall &DateCall::set_date(ESPTime time) { return this->set_date(time.year, time.month, time.day_of_month); };
 
-DateCall &DateCall::set_date(const char *date) {
+DateCall &DateCall::set_date(const char *date, size_t len) {
   ESPTime val{};
-  if (!ESPTime::strptime(date, val)) {
+  if (!ESPTime::strptime(date, len, val)) {
     ESP_LOGE(TAG, "Could not convert the date string to an ESPTime object");
     return *this;
   }

--- a/esphome/components/datetime/date_entity.cpp
+++ b/esphome/components/datetime/date_entity.cpp
@@ -106,7 +106,7 @@ DateCall &DateCall::set_date(uint16_t year, uint8_t month, uint8_t day) {
 
 DateCall &DateCall::set_date(ESPTime time) { return this->set_date(time.year, time.month, time.day_of_month); };
 
-DateCall &DateCall::set_date(const std::string &date) {
+DateCall &DateCall::set_date(const char *date) {
   ESPTime val{};
   if (!ESPTime::strptime(date, val)) {
     ESP_LOGE(TAG, "Could not convert the date string to an ESPTime object");

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -67,8 +67,9 @@ class DateCall {
   void perform();
   DateCall &set_date(uint16_t year, uint8_t month, uint8_t day);
   DateCall &set_date(ESPTime time);
-  DateCall &set_date(const char *date);
-  DateCall &set_date(const std::string &date) { return this->set_date(date.c_str()); }
+  DateCall &set_date(const char *date, size_t len);
+  DateCall &set_date(const char *date) { return this->set_date(date, strlen(date)); }
+  DateCall &set_date(const std::string &date) { return this->set_date(date.c_str(), date.size()); }
 
   DateCall &set_year(uint16_t year) {
     this->year_ = year;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -67,7 +67,8 @@ class DateCall {
   void perform();
   DateCall &set_date(uint16_t year, uint8_t month, uint8_t day);
   DateCall &set_date(ESPTime time);
-  DateCall &set_date(const std::string &date);
+  DateCall &set_date(const char *date);
+  DateCall &set_date(const std::string &date) { return this->set_date(date.c_str()); }
 
   DateCall &set_year(uint16_t year) {
     this->year_ = year;

--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -163,9 +163,9 @@ DateTimeCall &DateTimeCall::set_datetime(ESPTime datetime) {
                             datetime.second);
 };
 
-DateTimeCall &DateTimeCall::set_datetime(const char *datetime) {
+DateTimeCall &DateTimeCall::set_datetime(const char *datetime, size_t len) {
   ESPTime val{};
-  if (!ESPTime::strptime(datetime, val)) {
+  if (!ESPTime::strptime(datetime, len, val)) {
     ESP_LOGE(TAG, "Could not convert the time string to an ESPTime object");
     return *this;
   }

--- a/esphome/components/datetime/datetime_entity.cpp
+++ b/esphome/components/datetime/datetime_entity.cpp
@@ -163,7 +163,7 @@ DateTimeCall &DateTimeCall::set_datetime(ESPTime datetime) {
                             datetime.second);
 };
 
-DateTimeCall &DateTimeCall::set_datetime(const std::string &datetime) {
+DateTimeCall &DateTimeCall::set_datetime(const char *datetime) {
   ESPTime val{};
   if (!ESPTime::strptime(datetime, val)) {
     ESP_LOGE(TAG, "Could not convert the time string to an ESPTime object");

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -71,7 +71,8 @@ class DateTimeCall {
   void perform();
   DateTimeCall &set_datetime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
   DateTimeCall &set_datetime(ESPTime datetime);
-  DateTimeCall &set_datetime(const std::string &datetime);
+  DateTimeCall &set_datetime(const char *datetime);
+  DateTimeCall &set_datetime(const std::string &datetime) { return this->set_datetime(datetime.c_str()); }
   DateTimeCall &set_datetime(time_t epoch_seconds);
 
   DateTimeCall &set_year(uint16_t year) {

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -71,8 +71,11 @@ class DateTimeCall {
   void perform();
   DateTimeCall &set_datetime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
   DateTimeCall &set_datetime(ESPTime datetime);
-  DateTimeCall &set_datetime(const char *datetime);
-  DateTimeCall &set_datetime(const std::string &datetime) { return this->set_datetime(datetime.c_str()); }
+  DateTimeCall &set_datetime(const char *datetime, size_t len);
+  DateTimeCall &set_datetime(const char *datetime) { return this->set_datetime(datetime, strlen(datetime)); }
+  DateTimeCall &set_datetime(const std::string &datetime) {
+    return this->set_datetime(datetime.c_str(), datetime.size());
+  }
   DateTimeCall &set_datetime(time_t epoch_seconds);
 
   DateTimeCall &set_year(uint16_t year) {

--- a/esphome/components/datetime/time_entity.cpp
+++ b/esphome/components/datetime/time_entity.cpp
@@ -74,9 +74,9 @@ TimeCall &TimeCall::set_time(uint8_t hour, uint8_t minute, uint8_t second) {
 
 TimeCall &TimeCall::set_time(ESPTime time) { return this->set_time(time.hour, time.minute, time.second); };
 
-TimeCall &TimeCall::set_time(const char *time) {
+TimeCall &TimeCall::set_time(const char *time, size_t len) {
   ESPTime val{};
-  if (!ESPTime::strptime(time, val)) {
+  if (!ESPTime::strptime(time, len, val)) {
     ESP_LOGE(TAG, "Could not convert the time string to an ESPTime object");
     return *this;
   }

--- a/esphome/components/datetime/time_entity.cpp
+++ b/esphome/components/datetime/time_entity.cpp
@@ -74,7 +74,7 @@ TimeCall &TimeCall::set_time(uint8_t hour, uint8_t minute, uint8_t second) {
 
 TimeCall &TimeCall::set_time(ESPTime time) { return this->set_time(time.hour, time.minute, time.second); };
 
-TimeCall &TimeCall::set_time(const std::string &time) {
+TimeCall &TimeCall::set_time(const char *time) {
   ESPTime val{};
   if (!ESPTime::strptime(time, val)) {
     ESP_LOGE(TAG, "Could not convert the time string to an ESPTime object");

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -69,8 +69,9 @@ class TimeCall {
   void perform();
   TimeCall &set_time(uint8_t hour, uint8_t minute, uint8_t second);
   TimeCall &set_time(ESPTime time);
-  TimeCall &set_time(const char *time);
-  TimeCall &set_time(const std::string &time) { return this->set_time(time.c_str()); }
+  TimeCall &set_time(const char *time, size_t len);
+  TimeCall &set_time(const char *time) { return this->set_time(time, strlen(time)); }
+  TimeCall &set_time(const std::string &time) { return this->set_time(time.c_str(), time.size()); }
 
   TimeCall &set_hour(uint8_t hour) {
     this->hour_ = hour;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -69,7 +69,8 @@ class TimeCall {
   void perform();
   TimeCall &set_time(uint8_t hour, uint8_t minute, uint8_t second);
   TimeCall &set_time(ESPTime time);
-  TimeCall &set_time(const std::string &time);
+  TimeCall &set_time(const char *time);
+  TimeCall &set_time(const std::string &time) { return this->set_time(time.c_str()); }
 
   TimeCall &set_hour(uint8_t hour) {
     this->hour_ = hour;

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -67,7 +67,7 @@ std::string ESPTime::strftime(const char *format) {
 
 std::string ESPTime::strftime(const std::string &format) { return this->strftime(format.c_str()); }
 
-bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
+bool ESPTime::strptime(const char *time_to_parse, size_t len, ESPTime &esp_time) {
   uint16_t year;
   uint8_t month;
   uint8_t day;
@@ -75,40 +75,41 @@ bool ESPTime::strptime(const std::string &time_to_parse, ESPTime &esp_time) {
   uint8_t minute;
   uint8_t second;
   int num;
+  const int ilen = static_cast<int>(len);
 
-  if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
-             &hour,                                                                                      // NOLINT
-             &minute,                                                                                    // NOLINT
-             &second, &num) == 6 &&                                                                      // NOLINT
-      num == static_cast<int>(time_to_parse.size())) {
+  if (sscanf(time_to_parse, "%04hu-%02hhu-%02hhu %02hhu:%02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
+             &hour,                                                                              // NOLINT
+             &minute,                                                                            // NOLINT
+             &second, &num) == 6 &&                                                              // NOLINT
+      num == ilen) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
-                    &hour,                                                                               // NOLINT
-                    &minute, &num) == 5 &&                                                               // NOLINT
-             num == static_cast<int>(time_to_parse.size())) {
+  } else if (sscanf(time_to_parse, "%04hu-%02hhu-%02hhu %02hhu:%02hhu %n", &year, &month, &day,  // NOLINT
+                    &hour,                                                                       // NOLINT
+                    &minute, &num) == 5 &&                                                       // NOLINT
+             num == ilen) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
-  } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu:%02hhu %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
-             num == static_cast<int>(time_to_parse.size())) {
+  } else if (sscanf(time_to_parse, "%02hhu:%02hhu:%02hhu %n", &hour, &minute, &second, &num) == 3 &&  // NOLINT
+             num == ilen) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = second;
-  } else if (sscanf(time_to_parse.c_str(), "%02hhu:%02hhu %n", &hour, &minute, &num) == 2 &&  // NOLINT
-             num == static_cast<int>(time_to_parse.size())) {
+  } else if (sscanf(time_to_parse, "%02hhu:%02hhu %n", &hour, &minute, &num) == 2 &&  // NOLINT
+             num == ilen) {
     esp_time.hour = hour;
     esp_time.minute = minute;
     esp_time.second = 0;
-  } else if (sscanf(time_to_parse.c_str(), "%04hu-%02hhu-%02hhu %n", &year, &month, &day, &num) == 3 &&  // NOLINT
-             num == static_cast<int>(time_to_parse.size())) {
+  } else if (sscanf(time_to_parse, "%04hu-%02hhu-%02hhu %n", &year, &month, &day, &num) == 3 &&  // NOLINT
+             num == ilen) {
     esp_time.year = year;
     esp_time.month = month;
     esp_time.day_of_month = day;

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <span>
 #include <string>

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -80,11 +80,20 @@ struct ESPTime {
   }
 
   /** Convert a string to ESPTime struct as specified by the format argument.
-   * @param time_to_parse null-terminated c string formatet like this: 2020-08-25 05:30:00.
+   * @param time_to_parse c string formatted like this: 2020-08-25 05:30:00.
+   * @param len length of the string (not including null terminator if present)
    * @param esp_time an instance of a ESPTime struct
-   * @return the success sate of the parsing
+   * @return the success state of the parsing
    */
-  static bool strptime(const std::string &time_to_parse, ESPTime &esp_time);
+  static bool strptime(const char *time_to_parse, size_t len, ESPTime &esp_time);
+  /// @copydoc strptime(const char *, size_t, ESPTime &)
+  static bool strptime(const char *time_to_parse, ESPTime &esp_time) {
+    return strptime(time_to_parse, strlen(time_to_parse), esp_time);
+  }
+  /// @copydoc strptime(const char *, size_t, ESPTime &)
+  static bool strptime(const std::string &time_to_parse, ESPTime &esp_time) {
+    return strptime(time_to_parse.c_str(), time_to_parse.size(), esp_time);
+  }
 
   /// Convert a C tm struct instance with a C unix epoch timestamp to an ESPTime instance.
   static ESPTime from_c_tm(struct tm *c_tm, time_t c_time);


### PR DESCRIPTION
# What does this implement/fix?

Add `const char *` overloads with length parameter for datetime string parsing methods to avoid unnecessary `std::string` heap allocation and redundant `strlen()` calls.

Changes:
- `ESPTime::strptime` now has a length-aware primary implementation `strptime(const char *, size_t len, ESPTime &)`
- `DateCall::set_date`, `TimeCall::set_time`, and `DateTimeCall::set_datetime` now have length-aware `const char *` overloads as the primary string implementation
- Convenience overloads handle common cases:
  - `set_xxx(const char *)` - calls length-aware version with `strlen()`
  - `set_xxx(const std::string &)` - calls length-aware version with `.size()` (no redundant `strlen()`)

This allows user lambdas like:
```cpp
call.set_date("2024-02-25");
call.set_time("12:34:56");
call.set_datetime("2024-12-31 12:34:56");
```
to avoid heap allocation from implicit `std::string` construction.

When called with `std::string`, the known length is passed directly to avoid a redundant `strlen()` call.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed - API remains compatible)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this optimizes existing lambda functionality
datetime:
  - platform: template
    id: my_date
    name: "My Date"
    type: date
    optimistic: true
    on_value:
      - lambda: |-
          // String literal now avoids heap allocation
          auto call = id(my_date).make_call();
          call.set_date("2024-02-25");
          call.perform();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
