### PR TITLE
[shtcx] Use LogString for type to_string to save RAM on ESP8266

### DIFF
--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -13,14 +13,14 @@ static const uint16_t SHTCX_COMMAND_READ_ID_REGISTER = 0xEFC8;
 static const uint16_t SHTCX_COMMAND_SOFT_RESET = 0x805D;
 static const uint16_t SHTCX_COMMAND_POLLING_H = 0x7866;
 
-inline const char *to_string(SHTCXType type) {
+static const LogString *shtcx_type_to_string(SHTCXType type) {
   switch (type) {
     case SHTCX_TYPE_SHTC3:
-      return "SHTC3";
+      return LOG_STR("SHTC3");
     case SHTCX_TYPE_SHTC1:
-      return "SHTC1";
+      return LOG_STR("SHTC1");
     default:
-      return "UNKNOWN";
+      return LOG_STR("UNKNOWN");
   }
 }
 
@@ -52,7 +52,7 @@ void SHTCXComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "SHTCx:\n"
                 "  Model: %s (%04x)",
-                to_string(this->type_), this->sensor_id_);
+                LOG_STR_ARG(shtcx_type_to_string(this->type_)), this->sensor_id_);
   LOG_I2C_DEVICE(this);
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);


### PR DESCRIPTION
# What does this implement/fix?

Rename `to_string()` to `shtcx_type_to_string()` and convert to `LogString` pattern.

**Changes:**
- Rename function to follow codebase `*_to_string()` convention
- Convert to `LogString` to store strings in flash on ESP8266, saving RAM
- Use `LOG_STR()` for return values and `LOG_STR_ARG()` at call site

This avoids confusion with `std::to_string()` (which is available via `using std::to_string;` in the esphome namespace) and saves ~18 bytes of RAM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing heap/RAM optimization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
