### PR TITLE
[mqtt] Reduce heap allocations in publish path

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -538,6 +538,7 @@ bool MQTTClientComponent::publish(const char *topic, const char *payload, size_t
   if (!logging_topic) {
     if (ret) {
       ESP_LOGV(TAG, "Publish(topic='%s' retain=%d qos=%d)", topic, retain, qos);
+      ESP_LOGVV(TAG, "Publish payload (len=%u): '%.*s'", payload_length, static_cast<int>(payload_length), payload);
     } else {
       ESP_LOGV(TAG, "Publish failed for topic='%s' (len=%u). Will retry", topic, payload_length);
       this->status_momentary_warning("publish", 1000);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
+#include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
@@ -66,10 +67,13 @@ void MQTTClientComponent::setup() {
         "esphome/discover", [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); },
         2);
 
-    std::string topic = "esphome/ping/";
-    topic.append(App.get_name());
+    // Format topic on stack - subscribe() copies it
+    // "esphome/ping/" (13) + name (31) + null (1) = 45
+    constexpr size_t ping_topic_buffer_size = 13 + ESPHOME_DEVICE_NAME_MAX_LEN + 1;
+    char ping_topic[ping_topic_buffer_size];
+    buf_append_printf(ping_topic, sizeof(ping_topic), 0, "esphome/ping/%s", App.get_name().c_str());
     this->subscribe(
-        topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
+        ping_topic, [this](const std::string &topic, const std::string &payload) { this->send_device_info_(); }, 2);
   }
 
   if (this->enable_on_boot_) {
@@ -81,8 +85,11 @@ void MQTTClientComponent::send_device_info_() {
   if (!this->is_connected() or !this->is_discovery_ip_enabled()) {
     return;
   }
-  std::string topic = "esphome/discover/";
-  topic.append(App.get_name());
+  // Format topic on stack to avoid heap allocation
+  // "esphome/discover/" (17) + name (31) + null (1) = 49
+  constexpr size_t topic_buffer_size = 17 + ESPHOME_DEVICE_NAME_MAX_LEN + 1;
+  char topic[topic_buffer_size];
+  buf_append_printf(topic, sizeof(topic), 0, "esphome/discover/%s", App.get_name().c_str());
 
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   this->publish_json(
@@ -500,39 +507,48 @@ bool MQTTClientComponent::publish(const std::string &topic, const std::string &p
 
 bool MQTTClientComponent::publish(const std::string &topic, const char *payload, size_t payload_length, uint8_t qos,
                                   bool retain) {
-  return publish({.topic = topic, .payload = std::string(payload, payload_length), .qos = qos, .retain = retain});
+  return this->publish(topic.c_str(), payload, payload_length, qos, retain);
 }
 
 bool MQTTClientComponent::publish(const MQTTMessage &message) {
+  return this->publish(message.topic.c_str(), message.payload.c_str(), message.payload.length(), message.qos,
+                       message.retain);
+}
+bool MQTTClientComponent::publish_json(const std::string &topic, const json::json_build_t &f, uint8_t qos,
+                                       bool retain) {
+  return this->publish_json(topic.c_str(), f, qos, retain);
+}
+
+bool MQTTClientComponent::publish(const char *topic, const char *payload, size_t payload_length, uint8_t qos,
+                                  bool retain) {
   if (!this->is_connected()) {
-    // critical components will re-transmit their messages
     return false;
   }
-  bool logging_topic = this->log_message_.topic == message.topic;
-  bool ret = this->mqtt_backend_.publish(message);
+  size_t topic_len = strlen(topic);
+  bool logging_topic = (topic_len == this->log_message_.topic.size()) &&
+                       (memcmp(this->log_message_.topic.c_str(), topic, topic_len) == 0);
+  bool ret = this->mqtt_backend_.publish(topic, payload, payload_length, qos, retain);
   delay(0);
   if (!ret && !logging_topic && this->is_connected()) {
     delay(0);
-    ret = this->mqtt_backend_.publish(message);
+    ret = this->mqtt_backend_.publish(topic, payload, payload_length, qos, retain);
     delay(0);
   }
 
   if (!logging_topic) {
     if (ret) {
-      ESP_LOGV(TAG, "Publish(topic='%s' payload='%s' retain=%d qos=%d)", message.topic.c_str(), message.payload.c_str(),
-               message.retain, message.qos);
+      ESP_LOGV(TAG, "Publish(topic='%s' retain=%d qos=%d)", topic, retain, qos);
     } else {
-      ESP_LOGV(TAG, "Publish failed for topic='%s' (len=%u). Will retry", message.topic.c_str(),
-               message.payload.length());
+      ESP_LOGV(TAG, "Publish failed for topic='%s' (len=%u). Will retry", topic, payload_length);
       this->status_momentary_warning("publish", 1000);
     }
   }
   return ret != 0;
 }
-bool MQTTClientComponent::publish_json(const std::string &topic, const json::json_build_t &f, uint8_t qos,
-                                       bool retain) {
+
+bool MQTTClientComponent::publish_json(const char *topic, const json::json_build_t &f, uint8_t qos, bool retain) {
   std::string message = json::build_json(f);
-  return this->publish(topic, message, qos, retain);
+  return this->publish(topic, message.c_str(), message.length(), qos, retain);
 }
 
 void MQTTClientComponent::enable() {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -68,7 +68,7 @@ void MQTTClientComponent::setup() {
         2);
 
     // Format topic on stack - subscribe() copies it
-    // "esphome/ping/" (13) + name (31) + null (1) = 45
+    // "esphome/ping/" (13) + name (ESPHOME_DEVICE_NAME_MAX_LEN) + null (1)
     constexpr size_t ping_topic_buffer_size = 13 + ESPHOME_DEVICE_NAME_MAX_LEN + 1;
     char ping_topic[ping_topic_buffer_size];
     buf_append_printf(ping_topic, sizeof(ping_topic), 0, "esphome/ping/%s", App.get_name().c_str());
@@ -86,7 +86,7 @@ void MQTTClientComponent::send_device_info_() {
     return;
   }
   // Format topic on stack to avoid heap allocation
-  // "esphome/discover/" (17) + name (31) + null (1) = 49
+  // "esphome/discover/" (17) + name (ESPHOME_DEVICE_NAME_MAX_LEN) + null (1)
   constexpr size_t topic_buffer_size = 17 + ESPHOME_DEVICE_NAME_MAX_LEN + 1;
   char topic[topic_buffer_size];
   buf_append_printf(topic, sizeof(topic), 0, "esphome/discover/%s", App.get_name().c_str());

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -229,6 +229,9 @@ class MQTTClientComponent : public Component
   bool publish(const std::string &topic, const char *payload, size_t payload_length, uint8_t qos = 0,
                bool retain = false);
 
+  /// Publish directly without creating MQTTMessage (avoids heap allocation for topic)
+  bool publish(const char *topic, const char *payload, size_t payload_length, uint8_t qos = 0, bool retain = false);
+
   /** Construct and send a JSON MQTT message.
    *
    * @param topic The topic.
@@ -236,6 +239,9 @@ class MQTTClientComponent : public Component
    * @param retain Whether to retain the message.
    */
   bool publish_json(const std::string &topic, const json::json_build_t &f, uint8_t qos = 0, bool retain = false);
+
+  /// Publish JSON directly without heap allocation for topic
+  bool publish_json(const char *topic, const json::json_build_t &f, uint8_t qos = 0, bool retain = false);
 
   /// Setup the MQTT client, registering a bunch of callbacks and attempting to connect.
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocations in the MQTT publish path by:

1. **Adding `const char*` overloads for `publish()` and `publish_json()`** - These bypass `MQTTMessage` creation entirely, allowing callers to pass stack-allocated topic buffers directly to the backend.

2. **Using stack buffers for discovery topics** - `send_device_info_()` and setup's ping topic subscription now format topics on the stack instead of creating `std::string` objects.

3. **Consolidating publish logic** - All publish paths now funnel through a single `publish(const char*, ...)` implementation, reducing code duplication. The `publish(MQTTMessage)` method is now a thin wrapper.

### Changes

- `send_device_info_()`: Formats `"esphome/discover/<name>"` on stack (was allocating `std::string` on every call)
- `setup()`: Formats `"esphome/ping/<name>"` on stack (was allocating `std::string`)
- New `publish(const char *topic, const char *payload, size_t len, ...)` method
- New `publish_json(const char *topic, ...)` method
- `publish(std::string, ...)` and `publish(MQTTMessage)` now wrap the `const char*` version

### Future work

This is a first step toward reducing MQTT heap allocations including:
- `get_state_topic_()` allocates on every sensor publish (infrastructure exists via `get_state_topic_to_()`, needs wiring)
- `on_message()` creates temporary `std::string` from `const char*` topic
- ESP8266 `defer()` copies topic and payload strings

Small steps to avoid heap fragmentation on long-running devices.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce heap fragmentation on memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
mqtt:
  broker: mqtt.example.com
  discovery_ip: true  # This path is optimized
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
