### PR TITLE
[mqtt] Remove unnecessary defer in ESP8266 on_message callback

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -610,18 +610,10 @@ static bool topic_match(const char *message, const char *subscription) {
 }
 
 void MQTTClientComponent::on_message(const std::string &topic, const std::string &payload) {
-#ifdef USE_ESP8266
-  // on ESP8266, this is called in lwIP/AsyncTCP task; some components do not like running
-  // from a different task.
-  this->defer([this, topic, payload]() {
-#endif
-    for (auto &subscription : this->subscriptions_) {
-      if (topic_match(topic.c_str(), subscription.topic.c_str()))
-        subscription.callback(topic, payload);
-    }
-#ifdef USE_ESP8266
-  });
-#endif
+  for (auto &subscription : this->subscriptions_) {
+    if (topic_match(topic.c_str(), subscription.topic.c_str()))
+      subscription.callback(topic, payload);
+  }
 }
 
 // Setters


### PR DESCRIPTION
# What does this implement/fix?

Removes the unnecessary `defer()` wrapper around MQTT message handling on ESP8266.

The defer was added in 2019 with comments suggesting it was needed because "LWiP callbacks run from a different task" and "called from an ISR". These comments were factually incorrect - ESP8266 is single-threaded with cooperative multitasking. There are no real threads or ISRs involved in the AsyncMqttClient callback path.

The defer caused two unnecessary heap allocations per received MQTT message (one for topic string, one for payload string copy into the lambda capture). Removing it:
- Eliminates 2 heap allocations per MQTT message received
- Reduces heap fragmentation on long-running devices
- Simplifies the code path to match all other Arduino platforms

ESP8266 and LibreTiny platforms use AsyncMqttClient. ESP32 uses ESP-IDF's `esp_mqtt_client` which has its own task and event queue built into the backend. LibreTiny uses AsyncMqttClient but has never had a defer wrapper.

### Reentrancy analysis

One might think the defer provided protection against reentrancy races, but it did not:

**Without defer:** If a subscription callback yields (logging, network I/O), another message could arrive and `on_message()` could be called again, interleaving message processing.

**With defer:** Messages are captured and queued, but when the deferred lambda runs, if a callback yields, other deferred callbacks can execute. The same interleaving occurs - just at the defer queue level instead of the callback loop.

The defer moved where interleaving could happen without preventing it. The `subscriptions_` vector is populated during `setup()` and never modified at runtime, so concurrent iteration is safe. Callback-level state safety is an application concern that exists regardless of defer.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of ongoing effort to reduce heap fragmentation on memory-constrained devices

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
mqtt:
  broker: mqtt.example.com
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
