### PR TITLE
[dsmr] Avoid std::string allocation for decryption key

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -25,29 +25,13 @@ dsmr_ns = cg.esphome_ns.namespace("esphome::dsmr")
 Dsmr = dsmr_ns.class_("Dsmr", cg.Component, uart.UARTDevice)
 
 
-def _validate_key(value):
-    value = cv.string_strict(value)
-    parts = [value[i : i + 2] for i in range(0, len(value), 2)]
-    if len(parts) != 16:
-        raise cv.Invalid("Decryption key must consist of 16 hexadecimal numbers")
-    parts_int = []
-    if any(len(part) != 2 for part in parts):
-        raise cv.Invalid("Decryption key must be format XX")
-    for part in parts:
-        try:
-            parts_int.append(int(part, 16))
-        except ValueError:
-            # pylint: disable=raise-missing-from
-            raise cv.Invalid("Decryption key must be hex values from 00 to FF")
-
-    return "".join(f"{part:02X}" for part in parts_int)
-
-
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Dsmr),
-            cv.Optional(CONF_DECRYPTION_KEY): _validate_key,
+            cv.Optional(CONF_DECRYPTION_KEY): lambda value: cv.bind_key(
+                value, name="Decryption key"
+            ),
             cv.Optional(CONF_CRC_CHECK, default=True): cv.boolean,
             cv.Optional(CONF_GAS_MBUS_ID, default=1): cv.int_,
             cv.Optional(CONF_WATER_MBUS_ID, default=2): cv.int_,

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -1,4 +1,5 @@
 #include "dsmr.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 #include <AES.h>
@@ -294,8 +295,8 @@ void Dsmr::dump_config() {
   DSMR_TEXT_SENSOR_LIST(DSMR_LOG_TEXT_SENSOR, )
 }
 
-void Dsmr::set_decryption_key(const std::string &decryption_key) {
-  if (decryption_key.empty()) {
+void Dsmr::set_decryption_key(const char *decryption_key) {
+  if (decryption_key == nullptr || decryption_key[0] == '\0') {
     ESP_LOGI(TAG, "Disabling decryption");
     this->decryption_key_.clear();
     if (this->crypt_telegram_ != nullptr) {
@@ -305,21 +306,14 @@ void Dsmr::set_decryption_key(const std::string &decryption_key) {
     return;
   }
 
-  if (decryption_key.length() != 32) {
-    ESP_LOGE(TAG, "Error, decryption key must be 32 character long");
+  if (!parse_hex(decryption_key, this->decryption_key_, 16)) {
+    ESP_LOGE(TAG, "Error, decryption key must be 32 hex characters");
     return;
   }
-  this->decryption_key_.clear();
 
   ESP_LOGI(TAG, "Decryption key is set");
   // Verbose level prints decryption key
-  ESP_LOGV(TAG, "Using decryption key: %s", decryption_key.c_str());
-
-  char temp[3] = {0};
-  for (int i = 0; i < 16; i++) {
-    strncpy(temp, &(decryption_key.c_str()[i * 2]), 2);
-    this->decryption_key_.push_back(std::strtoul(temp, nullptr, 16));
-  }
+  ESP_LOGV(TAG, "Using decryption key: %s", decryption_key);
 
   if (this->crypt_telegram_ == nullptr) {
     this->crypt_telegram_ = new uint8_t[this->max_telegram_len_];  // NOLINT

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -308,6 +308,7 @@ void Dsmr::set_decryption_key(const char *decryption_key) {
 
   if (!parse_hex(decryption_key, this->decryption_key_, 16)) {
     ESP_LOGE(TAG, "Error, decryption key must be 32 hex characters");
+    this->decryption_key_.clear();
     return;
   }
 

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -63,7 +63,7 @@ class Dsmr : public Component, public uart::UARTDevice {
 
   void dump_config() override;
 
-  void set_decryption_key(const std::string &decryption_key);
+  void set_decryption_key(const char *decryption_key);
   void set_max_telegram_length(size_t length) { this->max_telegram_len_ = length; }
   void set_request_pin(GPIOPin *request_pin) { this->request_pin_ = request_pin; }
   void set_request_interval(uint32_t interval) { this->request_interval_ = interval; }

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1046,20 +1046,20 @@ def mac_address(value):
     return core.MACAddress(*parts_int)
 
 
-def bind_key(value):
+def bind_key(value, *, name="Bind key"):
     value = string_strict(value)
     parts = [value[i : i + 2] for i in range(0, len(value), 2)]
     if len(parts) != 16:
-        raise Invalid("Bind key must consist of 16 hexadecimal numbers")
+        raise Invalid(f"{name} must consist of 16 hexadecimal numbers")
     parts_int = []
     if any(len(part) != 2 for part in parts):
-        raise Invalid("Bind key must be format XX")
+        raise Invalid(f"{name} must be format XX")
     for part in parts:
         try:
             parts_int.append(int(part, 16))
         except ValueError:
             # pylint: disable=raise-missing-from
-            raise Invalid("Bind key must be hex values from 00 to FF")
+            raise Invalid(f"{name} must be hex values from 00 to FF")
 
     return "".join(f"{part:02X}" for part in parts_int)
 


### PR DESCRIPTION
# What does this implement/fix?

Avoids a temporary `std::string` heap allocation when setting the DSMR decryption key at setup time.

Changes:
- `set_decryption_key` now takes `const char *` instead of `const std::string &`
- Replaced manual `strncpy`/`strtoul` hex parsing loop with the existing `parse_hex()` helper
- Clear `decryption_key_` on parse failure to maintain correct empty state
- Python: Use `cv.bind_key` validator instead of duplicate `_validate_key` function
- Added `name` parameter to `cv.bind_key()` for customizable error messages (defaults to "Bind key")

Since the key is only set at setup time from codegen (string literal in rodata), there's no need to construct a `std::string` temporary. This eliminates a heap allocation and reduces code size by removing the string construction overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing config unchanged
uart:
  rx_pin: GPIO16
  baud_rate: 115200

dsmr:
  decryption_key: "AABBCCDDEEFF00112233445566778899"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
