### PR TITLE
[esp32_ble] Deprecate ESPBTUUID::to_string() in favor of heap-free to_str()

### DIFF
--- a/esphome/components/esp32_ble/ble_uuid.h
+++ b/esphome/components/esp32_ble/ble_uuid.h
@@ -46,6 +46,8 @@ class ESPBTUUID {
 
   esp_bt_uuid_t get_uuid() const;
 
+  // Remove before 2026.8.0
+  ESPDEPRECATED("Use to_str() instead. Removed in 2026.8.0", "2026.2.0")
   std::string to_string() const;
   const char *to_str(std::span<char, UUID_STR_LEN> output) const;
 


### PR DESCRIPTION
# What does this implement/fix?

Deprecates `ESPBTUUID::to_string()` in favor of the heap-free `to_str()` method.

The `to_string()` method allocates a `std::string` on every call, contributing to heap fragmentation on long-running devices. The `to_str()` method was added as a zero-allocation alternative that writes to a caller-provided buffer.

All internal ESPHome components have already been migrated to use `to_str()`. This deprecation warning will notify external component authors and users with custom lambdas (unlikely) to migrate before removal in 2026.8.0.

**Migration example:**
```cpp
// Before (heap allocation)
ESP_LOGD(TAG, "UUID: %s", uuid.to_string().c_str());

// After (stack buffer, no heap allocation)
char uuid_buf[esp32_ble::UUID_STR_LEN];
ESP_LOGD(TAG, "UUID: %s", uuid.to_str(uuid_buf));
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

n/a - internal API change only

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
