### PR TITLE
[network] Deprecate IPAddress::str() in favor of heap-free str_to()

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -60,6 +60,8 @@ struct IPAddress {
   }
   IPAddress(const std::string &in_address) { inet_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
+  // Remove before 2026.8.0
+  ESPDEPRECATED("Use str_to() instead. Removed in 2026.8.0", "2026.2.0")
   std::string str() const {
     char buf[IP_ADDRESS_BUFFER_SIZE];
     this->str_to(buf);
@@ -147,6 +149,8 @@ struct IPAddress {
   bool is_ip4() const { return IP_IS_V4(&ip_addr_); }
   bool is_ip6() const { return IP_IS_V6(&ip_addr_); }
   bool is_multicast() const { return ip_addr_ismulticast(&ip_addr_); }
+  // Remove before 2026.8.0
+  ESPDEPRECATED("Use str_to() instead. Removed in 2026.8.0", "2026.2.0")
   std::string str() const {
     char buf[IP_ADDRESS_BUFFER_SIZE];
     this->str_to(buf);


### PR DESCRIPTION
# What does this implement/fix?

Deprecates `IPAddress::str()` in favor of the heap-free `str_to()` method.

The `str()` method allocates a `std::string` on every call, contributing to heap fragmentation on long-running devices. The `str_to()` method writes to a caller-provided buffer with no heap allocation.

**Migration example:**
```cpp
// Before (heap allocation)
ESP_LOGD(TAG, "IP: %s", ip.str().c_str());

// After (stack buffer, no heap allocation)
char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
ESP_LOGD(TAG, "IP: %s", ip.str_to(ip_buf));
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266
- [x] Host

## Example entry for `config.yaml`:

n/a - internal API change only

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
