### PR TITLE
[sprinkler] Eliminate std::string heap allocations

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -327,7 +327,7 @@ SprinklerValveOperator *SprinklerValveRunRequest::valve_operator() { return this
 
 SprinklerValveRunRequestOrigin SprinklerValveRunRequest::request_is_from() { return this->origin_; }
 
-Sprinkler::Sprinkler() {}
+Sprinkler::Sprinkler() : Sprinkler("") {}
 Sprinkler::Sprinkler(const char *name) : name_(name) {
   // The `name` is stored for dump_config logging
   this->timer_.init(2);

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -328,13 +328,12 @@ SprinklerValveOperator *SprinklerValveRunRequest::valve_operator() { return this
 SprinklerValveRunRequestOrigin SprinklerValveRunRequest::request_is_from() { return this->origin_; }
 
 Sprinkler::Sprinkler() {}
-Sprinkler::Sprinkler(const std::string &name) {
-  // The `name` is needed to set timers up, hence non-default constructor
-  // replaces `set_name()` method previously existed
-  this->name_ = name;
+Sprinkler::Sprinkler(const char *name) : name_(name) {
+  // The `name` is stored for dump_config logging
   this->timer_.init(2);
-  this->timer_.push_back({this->name_ + "sm", false, 0, 0, std::bind(&Sprinkler::sm_timer_callback_, this)});
-  this->timer_.push_back({this->name_ + "vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
+  // Timer names only need to be unique within this component instance
+  this->timer_.push_back({"sm", false, 0, 0, std::bind(&Sprinkler::sm_timer_callback_, this)});
+  this->timer_.push_back({"vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
 }
 
 void Sprinkler::setup() { this->all_valves_off_(true); }
@@ -1575,8 +1574,7 @@ const LogString *Sprinkler::state_as_str_(SprinklerState state) {
 
 void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
   if (this->timer_duration_(timer_index) > 0) {
-    // FixedVector ensures timer_ can't be resized, so .c_str() pointers remain valid
-    this->set_timeout(this->timer_[timer_index].name.c_str(), this->timer_duration_(timer_index),
+    this->set_timeout(this->timer_[timer_index].name, this->timer_duration_(timer_index),
                       this->timer_cbf_(timer_index));
     this->timer_[timer_index].start_time = millis();
     this->timer_[timer_index].active = true;
@@ -1587,7 +1585,7 @@ void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {
 
 bool Sprinkler::cancel_timer_(const SprinklerTimerIndex timer_index) {
   this->timer_[timer_index].active = false;
-  return this->cancel_timeout(this->timer_[timer_index].name.c_str());
+  return this->cancel_timeout(this->timer_[timer_index].name);
 }
 
 bool Sprinkler::timer_active_(const SprinklerTimerIndex timer_index) { return this->timer_[timer_index].active; }
@@ -1618,7 +1616,7 @@ void Sprinkler::sm_timer_callback_() {
 }
 
 void Sprinkler::dump_config() {
-  ESP_LOGCONFIG(TAG, "Sprinkler Controller -- %s", this->name_.c_str());
+  ESP_LOGCONFIG(TAG, "Sprinkler Controller -- %s", this->name_);
   if (this->manual_selection_delay_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Manual Selection Delay: %" PRIu32 " seconds", this->manual_selection_delay_.value_or(0));
   }

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -504,7 +504,7 @@ class Sprinkler : public Component {
   uint32_t start_delay_{0};
   uint32_t stop_delay_{0};
 
-  const char *name_;
+  const char *name_{""};
 
   /// Sprinkler controller state
   SprinklerState state_{IDLE};

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -11,7 +11,7 @@
 
 namespace esphome::sprinkler {
 
-const std::string MIN_STR = "min";
+inline constexpr const char *MIN_STR = "min";
 
 enum SprinklerState : uint8_t {
   // NOTE: these states are used by both SprinklerValveOperator and Sprinkler (the controller)!
@@ -49,7 +49,7 @@ struct SprinklerQueueItem {
 };
 
 struct SprinklerTimer {
-  const std::string name;
+  const char *name;
   bool active;
   uint32_t time;
   uint32_t start_time;
@@ -176,7 +176,7 @@ class SprinklerValveRunRequest {
 class Sprinkler : public Component {
  public:
   Sprinkler();
-  Sprinkler(const std::string &name);
+  Sprinkler(const char *name);
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -504,7 +504,7 @@ class Sprinkler : public Component {
   uint32_t start_delay_{0};
   uint32_t stop_delay_{0};
 
-  std::string name_;
+  const char *name_;
 
   /// Sprinkler controller state
   SprinklerState state_{IDLE};


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #13251 - eliminates remaining `std::string` usage in the sprinkler component to avoid heap allocations.

## Changes

1. **`MIN_STR`**: Changed from `const std::string` to `inline constexpr const char *` - eliminates global `std::string` construction at startup

2. **`SprinklerTimer::name`**: Changed from `const std::string` to `const char *` - no more per-timer heap allocation

3. **`Sprinkler::name_`**: Changed from `std::string` to `const char *` - the name comes from Python codegen as a string literal stored in flash

4. **Constructor**: Changed from `const std::string &name` to `const char *name`

5. **Timer names simplified**: The scheduler stores `SchedulerItem` entries keyed by both the component pointer AND the timer name. This means timer names only need to be unique within a single component instance, not globally unique across all components. Changed from `name_ + "sm"` and `name_ + "vs"` (heap allocation for string concatenation) to just `"sm"` and `"vs"` (static strings in flash). Two different `Sprinkler` instances can both use timer name `"sm"` without conflict because the scheduler distinguishes them by component pointer.

6. **Removed `.c_str()` calls**: No longer needed since `name` is already `const char *`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13251

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing sprinkler configurations work without changes
switch:
  - platform: template
    id: pump_switch
    optimistic: true
  - platform: template
    id: valve_switch
    optimistic: true

sprinkler:
  - id: test_sprinkler
    main_switch: Test Sprinklers
    auto_advance_switch: Auto Advance
    valves:
      - valve_switch: Valve 1
        pump_switch_id: pump_switch
        run_duration: 10s
        valve_switch_id: valve_switch
      - valve_switch: Valve 2
        pump_switch_id: pump_switch
        run_duration: 10s
        valve_switch_id: valve_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
