### PR TITLE
[sprinkler] Disable loops when idle to reduce CPU overhead

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -43,13 +43,11 @@ SprinklerControllerSwitch::SprinklerControllerSwitch()
     : turn_on_trigger_(new Trigger<>()), turn_off_trigger_(new Trigger<>()) {}
 
 void SprinklerControllerSwitch::loop() {
-  if (!this->f_.has_value())
-    return;
+  // Loop is only enabled when f_ has a value (see setup())
   auto s = (*this->f_)();
-  if (!s.has_value())
-    return;
-
-  this->publish_state(*s);
+  if (s.has_value()) {
+    this->publish_state(*s);
+  }
 }
 
 void SprinklerControllerSwitch::write_state(bool state) {
@@ -74,7 +72,13 @@ float SprinklerControllerSwitch::get_setup_priority() const { return setup_prior
 Trigger<> *SprinklerControllerSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
 Trigger<> *SprinklerControllerSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 
-void SprinklerControllerSwitch::setup() { this->state = this->get_initial_state_with_restore_mode().value_or(false); }
+void SprinklerControllerSwitch::setup() {
+  this->state = this->get_initial_state_with_restore_mode().value_or(false);
+  // Disable loop if no state lambda is set - nothing to poll
+  if (!this->f_.has_value()) {
+    this->disable_loop();
+  }
+}
 
 void SprinklerControllerSwitch::dump_config() { LOG_SWITCH("", "Sprinkler Switch", this); }
 
@@ -337,15 +341,23 @@ Sprinkler::Sprinkler(const std::string &name) {
   this->timer_.push_back({this->name_ + "vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
 }
 
-void Sprinkler::setup() { this->all_valves_off_(true); }
+void Sprinkler::setup() {
+  this->all_valves_off_(true);
+  // Start with loop disabled - nothing to do when idle
+  this->disable_loop();
+}
 
 void Sprinkler::loop() {
   for (auto &vo : this->valve_op_) {
     vo.loop();
   }
-  if (this->prev_req_.has_request() && this->prev_req_.has_valve_operator() &&
-      this->prev_req_.valve_operator()->state() == IDLE) {
-    this->prev_req_.reset();
+  if (this->prev_req_.has_request()) {
+    if (this->prev_req_.has_valve_operator() && this->prev_req_.valve_operator()->state() == IDLE) {
+      this->prev_req_.reset();
+    }
+  } else if (this->state_ == IDLE) {
+    // Nothing more to do - disable loop until next activation
+    this->disable_loop();
   }
 }
 
@@ -1333,6 +1345,8 @@ void Sprinkler::start_valve_(SprinklerValveRunRequest *req) {
   if (!this->is_a_valid_valve(req->valve())) {
     return;  // we can't do anything if the valve number isn't valid
   }
+  // Enable loop to monitor valve operator states
+  this->enable_loop();
   for (auto &vo : this->valve_op_) {  // find the first available SprinklerValveOperator, load it and start it up
     if (vo.state() == IDLE) {
       auto run_duration = req->run_duration() ? req->run_duration() : this->valve_run_duration_adjusted(req->valve());


### PR DESCRIPTION
# What does this implement/fix?

Reduces CPU overhead in the sprinkler component by disabling loops when idle.

## Changes

### SprinklerControllerSwitch (per-switch optimization)

Switches without state lambdas now disable their loop in `setup()`. Only switches that need to poll state (main_switch, valve switches) keep their loops enabled.

**Affected switches (loop disabled when no lambda):**
- `auto_advance_switch`
- `reverse_switch`
- `queue_enable_switch`
- `standby_switch`
- `enable_switch` (per valve)

**Switches with lambdas (loop stays enabled):**
- `main_switch` - polls valve states
- Valve switches - poll valve + pump state

### Main Sprinkler Controller (idle optimization)

The main controller now uses `enable_loop()` / `disable_loop()` to only run its loop during active valve operations:

1. **`setup()`** - disables loop (starts idle)
2. **`start_valve_()`** - enables loop when starting a valve
3. **`loop()`** - self-disables when state is IDLE and no pending work

**Measured results:**
- Main controller loop only ran **1,226 times** during a 60-second period where a valve ran for ~11 seconds
- Compared to **6,660 times** for always-on components
- Loop was active only **18% of the time** (matching actual valve runtime)

### Simplified loop() logic

Removed redundant `f_.has_value()` check in `SprinklerControllerSwitch::loop()` since the loop is now disabled when no lambda is set.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# All existing sprinkler configurations benefit automatically
switch:
  - platform: template
    id: pump_switch
    optimistic: true
  - platform: template
    id: valve1_switch
    optimistic: true
  - platform: template
    id: valve2_switch
    optimistic: true

sprinkler:
  - id: test_sprinkler
    main_switch: Test Sprinklers
    auto_advance_switch: Auto Advance
    reverse_switch: Reverse
    queue_enable_switch: Queue Enable
    standby_switch: Standby
    valves:
      - valve_switch: Valve 1
        enable_switch: Valve 1 Enable
        pump_switch_id: pump_switch
        run_duration: 10s
        valve_switch_id: valve1_switch
      - valve_switch: Valve 2
        enable_switch: Valve 2 Enable
        pump_switch_id: pump_switch
        run_duration: 10s
        valve_switch_id: valve2_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
