### PR TITLE
[x9c] Fix potentiometer unable to decrement

### DIFF
--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -6,7 +6,7 @@ namespace x9c {
 
 static const char *const TAG = "x9c.output";
 
-void X9cOutput::trim_value(int change_amount) {
+void X9cOutput::trim_value(int32_t change_amount) {
   if (change_amount == 0) {
     return;
   }
@@ -47,17 +47,17 @@ void X9cOutput::setup() {
 
   if (this->initial_value_ <= 0.50) {
     this->trim_value(-101);  // Set min value (beyond 0)
-    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100)));
+    this->trim_value(static_cast<int32_t>(roundf(this->initial_value_ * 100)));
   } else {
     this->trim_value(101);  // Set max value (beyond 100)
-    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100) - 100));
+    this->trim_value(static_cast<int32_t>(roundf(this->initial_value_ * 100) - 100));
   }
   this->pot_value_ = this->initial_value_;
   this->write_state(this->initial_value_);
 }
 
 void X9cOutput::write_state(float state) {
-  this->trim_value(static_cast<uint32_t>(roundf((state - this->pot_value_) * 100)));
+  this->trim_value(static_cast<int32_t>(roundf((state - this->pot_value_) * 100)));
   this->pot_value_ = state;
 }
 

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -47,17 +47,17 @@ void X9cOutput::setup() {
 
   if (this->initial_value_ <= 0.50) {
     this->trim_value(-101);  // Set min value (beyond 0)
-    this->trim_value(static_cast<int32_t>(roundf(this->initial_value_ * 100)));
+    this->trim_value(lroundf(this->initial_value_ * 100));
   } else {
     this->trim_value(101);  // Set max value (beyond 100)
-    this->trim_value(static_cast<int32_t>(roundf(this->initial_value_ * 100) - 100));
+    this->trim_value(lroundf(this->initial_value_ * 100) - 100);
   }
   this->pot_value_ = this->initial_value_;
   this->write_state(this->initial_value_);
 }
 
 void X9cOutput::write_state(float state) {
-  this->trim_value(static_cast<int32_t>(roundf((state - this->pot_value_) * 100)));
+  this->trim_value(lroundf((state - this->pot_value_) * 100));
   this->pot_value_ = state;
 }
 

--- a/esphome/components/x9c/x9c.h
+++ b/esphome/components/x9c/x9c.h
@@ -18,7 +18,7 @@ class X9cOutput : public output::FloatOutput, public Component {
   void setup() override;
   void dump_config() override;
 
-  void trim_value(int change_amount);
+  void trim_value(int32_t change_amount);
 
  protected:
   void write_state(float state) override;


### PR DESCRIPTION
## What does this implement/fix?

Fixes a bug where the X9C potentiometer component cannot decrement values. The `trim_value()` function takes a signed int for the change amount, but callers were casting to `uint32_t`. When the change amount is negative (decrementing), casting a negative float to `uint32_t` is undefined behavior. On most platforms this produces 0, causing `trim_value()` to return early without making any change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported by user unable to decrement X9C potentiometer values

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Existing X9C configuration - no changes needed
output:
  - platform: x9c
    id: x9c_pot
    cs_pin: GPIO5
    inc_pin: GPIO18
    ud_pin: GPIO19
    initial_value: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

## Technical Details

The bug occurs in three places in `x9c.cpp`:

1. `setup()` line 50: `static_cast<uint32_t>(roundf(this->initial_value_ * 100))`
2. `setup()` line 53: `static_cast<uint32_t>(roundf(this->initial_value_ * 100) - 100)` - can be negative
3. `write_state()` line 60: `static_cast<uint32_t>(roundf((state - this->pot_value_) * 100))` - negative when decrementing

When `state < pot_value_` (decrementing), the expression `(state - pot_value_) * 100` is negative. Casting a negative float to `uint32_t` is undefined behavior per C++ standard. On x86 with SSE, this typically produces 0, causing `trim_value(0)` to return immediately without any action.

The fix changes `uint32_t` casts to `int32_t`, allowing negative values to be passed correctly to `trim_value()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)