### PR TITLE
[media_player] Use const char* for format strings

### DIFF
--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -67,7 +67,7 @@ enum class MediaPlayerFormatPurpose : uint8_t {
 };
 
 struct MediaPlayerSupportedFormat {
-  std::string format;
+  const char *format;
   uint32_t sample_rate;
   uint32_t num_channels;
   MediaPlayerFormatPurpose purpose;


### PR DESCRIPTION
# What does this implement/fix?

Change `MediaPlayerSupportedFormat::format` from `std::string` to `const char*` to eliminate unnecessary heap allocation.

The format field only ever contains one of three string literals set by codegen: "flac", "mp3", or "wav". Using `std::string` copies these literals from flash to heap, wasting RAM and contributing to heap fragmentation.

With `const char*`, the pointer references the flash string directly - zero heap allocation, zero copy.

The API path is also zero-copy since the protobuf struct already uses `StringRef` for this field, which accepts `const char*` directly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (memory optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is an internal optimization
# Existing speaker media_player configs continue to work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
