### PR TITLE
[wifi_info] Fix missing state when both IP+DNS or SSID+BSSID configure

### DIFF
--- a/esphome/components/wifi_info/text_sensor.py
+++ b/esphome/components/wifi_info/text_sensor.py
@@ -79,13 +79,17 @@ async def setup_conf(config, key):
 
 async def to_code(config):
     # Request specific WiFi listeners based on which sensors are configured
+    # Each sensor needs its own listener slot - call request for EACH sensor
+
     # SSID and BSSID use WiFiConnectStateListener
-    if CONF_SSID in config or CONF_BSSID in config:
-        wifi.request_wifi_connect_state_listener()
+    for key in (CONF_SSID, CONF_BSSID):
+        if key in config:
+            wifi.request_wifi_connect_state_listener()
 
     # IP address and DNS use WiFiIPStateListener
-    if CONF_IP_ADDRESS in config or CONF_DNS_ADDRESS in config:
-        wifi.request_wifi_ip_state_listener()
+    for key in (CONF_IP_ADDRESS, CONF_DNS_ADDRESS):
+        if key in config:
+            wifi.request_wifi_ip_state_listener()
 
     # Scan results use WiFiScanResultsListener
     if CONF_SCAN_RESULTS in config:


### PR DESCRIPTION
# What does this implement/fix?

Fixes wifi_info text sensors showing "Unknown" when multiple sensors of the same listener type are configured together (e.g., both `ip_address` and `dns_address`, or both `ssid` and `bssid`).

The bug was in `to_code()` which used an `or` condition to request listener slots:
```python
# Before (buggy):
if CONF_SSID in config or CONF_BSSID in config:
    wifi.request_wifi_connect_state_listener()  # Called once even if both configured!
```

This caused the `StaticVector` to be sized to 1 even when 2 listeners needed to register. The second listener was silently dropped, causing it to never receive callbacks.

The fix calls the request function for each configured sensor:
```python
# After (fixed):
for key in (CONF_SSID, CONF_BSSID):
    if key in config:
        wifi.request_wifi_connect_state_listener()  # Called for each sensor
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13318

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
text_sensor:
  - platform: wifi_info
    ip_address:
      name: "IP Address"
    dns_address:
      name: "DNS"
    ssid:
      name: "SSID"
    bssid:
      name: "BSSID"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
