### PR TITLE
[core] Simplify LazyCallbackManager memory management

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1343,16 +1343,23 @@ template<typename... X> class LazyCallbackManager;
  *
  * Memory overhead comparison (32-bit systems):
  * - CallbackManager: 12 bytes (empty std::vector)
- * - LazyCallbackManager: 4 bytes (nullptr unique_ptr)
+ * - LazyCallbackManager: 4 bytes (nullptr pointer)
+ *
+ * Note: Uses plain pointer instead of unique_ptr since callbacks are never freed
+ * (entities live for device lifetime). This avoids destructor template overhead.
  *
  * @tparam Ts The arguments for the callbacks, wrapped in void().
  */
 template<typename... Ts> class LazyCallbackManager<void(Ts...)> {
  public:
+  /// Destructor - clean up allocated CallbackManager if any.
+  /// In practice this never runs (entities live for device lifetime) but included for correctness.
+  ~LazyCallbackManager() { delete this->callbacks_; }
+
   /// Add a callback to the list. Allocates the underlying CallbackManager on first use.
   void add(std::function<void(Ts...)> &&callback) {
     if (!this->callbacks_) {
-      this->callbacks_ = make_unique<CallbackManager<void(Ts...)>>();
+      this->callbacks_ = new CallbackManager<void(Ts...)>();
     }
     this->callbacks_->add(std::move(callback));
   }
@@ -1374,7 +1381,7 @@ template<typename... Ts> class LazyCallbackManager<void(Ts...)> {
   void operator()(Ts... args) { this->call(args...); }
 
  protected:
-  std::unique_ptr<CallbackManager<void(Ts...)>> callbacks_;
+  CallbackManager<void(Ts...)> *callbacks_{nullptr};
 };
 
 /// Helper class to deduplicate items in a series of values.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1345,16 +1345,23 @@ template<typename... X> class LazyCallbackManager;
  * - CallbackManager: 12 bytes (empty std::vector)
  * - LazyCallbackManager: 4 bytes (nullptr pointer)
  *
- * Note: Uses plain pointer instead of unique_ptr since callbacks are never freed
- * (entities live for device lifetime). This avoids destructor template overhead.
+ * Uses plain pointer instead of unique_ptr to avoid template instantiation overhead.
+ * The class is explicitly non-copyable/non-movable for Rule of Five compliance.
  *
  * @tparam Ts The arguments for the callbacks, wrapped in void().
  */
 template<typename... Ts> class LazyCallbackManager<void(Ts...)> {
  public:
+  LazyCallbackManager() = default;
   /// Destructor - clean up allocated CallbackManager if any.
   /// In practice this never runs (entities live for device lifetime) but included for correctness.
   ~LazyCallbackManager() { delete this->callbacks_; }
+
+  // Non-copyable and non-movable (entities are never copied or moved)
+  LazyCallbackManager(const LazyCallbackManager &) = delete;
+  LazyCallbackManager &operator=(const LazyCallbackManager &) = delete;
+  LazyCallbackManager(LazyCallbackManager &&) = delete;
+  LazyCallbackManager &operator=(LazyCallbackManager &&) = delete;
 
   /// Add a callback to the list. Allocates the underlying CallbackManager on first use.
   void add(std::function<void(Ts...)> &&callback) {


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::unique_ptr` with direct pointer management in `LazyCallbackManager`.

The original `unique_ptr` usage was reflexive rather than intentional. For self-contained class members with simple lifetime semantics, `unique_ptr` adds template overhead without benefit:
- The owning object manages the pointer's entire lifetime
- Allocation and deallocation happen in obvious, controlled places
- There's no ownership transfer

`LazyCallbackManager` fits all these criteria - it allocates on first `add()` and the pointer lives until the owning entity is destroyed (which in practice is never, since entities live for device lifetime).

**Savings: 272 bytes flash**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - internal change only

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
