### PR TITLE
2026.1.0b4

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.1.0b3
+PROJECT_NUMBER         = 2026.1.0b4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1,5 +1,6 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
+from collections.abc import Callable
 from datetime import datetime
 import functools
 import getpass
@@ -931,11 +932,21 @@ def command_dashboard(args: ArgsProtocol) -> int | None:
     return dashboard.start_dashboard(args)
 
 
-def command_update_all(args: ArgsProtocol) -> int | None:
+def run_multiple_configs(
+    files: list, command_builder: Callable[[str], list[str]]
+) -> int:
+    """Run a command for each configuration file in a subprocess.
+
+    Args:
+        files: List of configuration files to process.
+        command_builder: Callable that takes a file path and returns a command list.
+
+    Returns:
+        Number of failed files.
+    """
     import click
 
     success = {}
-    files = list_yaml_files(args.configuration)
     twidth = 60
 
     def print_bar(middle_text):
@@ -945,17 +956,19 @@ def command_update_all(args: ArgsProtocol) -> int | None:
         safe_print(f"{half_line}{middle_text}{half_line}")
 
     for f in files:
-        safe_print(f"Updating {color(AnsiFore.CYAN, str(f))}")
+        f_path = Path(f) if not isinstance(f, Path) else f
+
+        if any(f_path.name == x for x in SECRETS_FILES):
+            _LOGGER.warning("Skipping secrets file %s", f_path)
+            continue
+
+        safe_print(f"Processing {color(AnsiFore.CYAN, str(f))}")
         safe_print("-" * twidth)
         safe_print()
-        if CORE.dashboard:
-            rc = run_external_process(
-                "esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"
-            )
-        else:
-            rc = run_external_process(
-                "esphome", "run", f, "--no-logs", "--device", "OTA"
-            )
+
+        cmd = command_builder(f)
+        rc = run_external_process(*cmd)
+
         if rc == 0:
             print_bar(f"[{color(AnsiFore.BOLD_GREEN, 'SUCCESS')}] {str(f)}")
             success[f] = True
@@ -970,12 +983,25 @@ def command_update_all(args: ArgsProtocol) -> int | None:
     print_bar(f"[{color(AnsiFore.BOLD_WHITE, 'SUMMARY')}]")
     failed = 0
     for f in files:
+        if f not in success:
+            continue  # Skipped file
         if success[f]:
             safe_print(f"  - {str(f)}: {color(AnsiFore.GREEN, 'SUCCESS')}")
         else:
             safe_print(f"  - {str(f)}: {color(AnsiFore.BOLD_RED, 'FAILED')}")
             failed += 1
     return failed
+
+
+def command_update_all(args: ArgsProtocol) -> int | None:
+    files = list_yaml_files(args.configuration)
+
+    def build_command(f):
+        if CORE.dashboard:
+            return ["esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"]
+        return ["esphome", "run", f, "--no-logs", "--device", "OTA"]
+
+    return run_multiple_configs(files, build_command)
 
 
 def command_idedata(args: ArgsProtocol, config: ConfigType) -> int:
@@ -1528,38 +1554,48 @@ def run_esphome(argv):
 
     _LOGGER.info("ESPHome %s", const.__version__)
 
-    for conf_path in args.configuration:
-        conf_path = Path(conf_path)
-        if any(conf_path.name == x for x in SECRETS_FILES):
-            _LOGGER.warning("Skipping secrets file %s", conf_path)
-            continue
+    # Multiple configurations: use subprocesses to avoid state leakage
+    # between compilations (e.g., LVGL touchscreen state in module globals)
+    if len(args.configuration) > 1:
+        # Build command by reusing argv, replacing all configs with single file
+        # argv[0] is the program path, skip it since we prefix with "esphome"
+        def build_command(f):
+            return (
+                ["esphome"]
+                + [arg for arg in argv[1:] if arg not in args.configuration]
+                + [str(f)]
+            )
 
-        CORE.config_path = conf_path
-        CORE.dashboard = args.dashboard
+        return run_multiple_configs(args.configuration, build_command)
 
-        # For logs command, skip updating external components
-        skip_external = args.command == "logs"
-        config = read_config(
-            dict(args.substitution) if args.substitution else {},
-            skip_external_update=skip_external,
-        )
-        if config is None:
-            return 2
-        CORE.config = config
+    # Single configuration
+    conf_path = Path(args.configuration[0])
+    if any(conf_path.name == x for x in SECRETS_FILES):
+        _LOGGER.warning("Skipping secrets file %s", conf_path)
+        return 0
 
-        if args.command not in POST_CONFIG_ACTIONS:
-            safe_print(f"Unknown command {args.command}")
+    CORE.config_path = conf_path
+    CORE.dashboard = args.dashboard
 
-        try:
-            rc = POST_CONFIG_ACTIONS[args.command](args, config)
-        except EsphomeError as e:
-            _LOGGER.error(e, exc_info=args.verbose)
-            return 1
-        if rc != 0:
-            return rc
+    # For logs command, skip updating external components
+    skip_external = args.command == "logs"
+    config = read_config(
+        dict(args.substitution) if args.substitution else {},
+        skip_external_update=skip_external,
+    )
+    if config is None:
+        return 2
+    CORE.config = config
 
-        CORE.reset()
-    return 0
+    if args.command not in POST_CONFIG_ACTIONS:
+        safe_print(f"Unknown command {args.command}")
+        return 1
+
+    try:
+        return POST_CONFIG_ACTIONS[args.command](args, config)
+    except EsphomeError as e:
+        _LOGGER.error(e, exc_info=args.verbose)
+        return 1
 
 
 def main():

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -42,8 +42,8 @@ ErrorCode I2CDevice::read_register16(uint16_t a_register, uint8_t *data, size_t 
 }
 
 ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, size_t len) const {
-  SmallBufferWithHeapFallback<17> buffer_alloc;  // Most I2C writes are <= 16 bytes
-  uint8_t *buffer = buffer_alloc.get(len + 1);
+  SmallBufferWithHeapFallback<17> buffer_alloc(len + 1);  // Most I2C writes are <= 16 bytes
+  uint8_t *buffer = buffer_alloc.get();
 
   buffer[0] = a_register;
   std::copy(data, data + len, buffer + 1);
@@ -51,8 +51,8 @@ ErrorCode I2CDevice::write_register(uint8_t a_register, const uint8_t *data, siz
 }
 
 ErrorCode I2CDevice::write_register16(uint16_t a_register, const uint8_t *data, size_t len) const {
-  SmallBufferWithHeapFallback<18> buffer_alloc;  // Most I2C writes are <= 16 bytes + 2 for register
-  uint8_t *buffer = buffer_alloc.get(len + 2);
+  SmallBufferWithHeapFallback<18> buffer_alloc(len + 2);  // Most I2C writes are <= 16 bytes + 2 for register
+  uint8_t *buffer = buffer_alloc.get();
 
   buffer[0] = a_register >> 8;
   buffer[1] = a_register;

--- a/esphome/components/wifi_info/text_sensor.py
+++ b/esphome/components/wifi_info/text_sensor.py
@@ -79,13 +79,17 @@ async def setup_conf(config, key):
 
 async def to_code(config):
     # Request specific WiFi listeners based on which sensors are configured
+    # Each sensor needs its own listener slot - call request for EACH sensor
+
     # SSID and BSSID use WiFiConnectStateListener
-    if CONF_SSID in config or CONF_BSSID in config:
-        wifi.request_wifi_connect_state_listener()
+    for key in (CONF_SSID, CONF_BSSID):
+        if key in config:
+            wifi.request_wifi_connect_state_listener()
 
     # IP address and DNS use WiFiIPStateListener
-    if CONF_IP_ADDRESS in config or CONF_DNS_ADDRESS in config:
-        wifi.request_wifi_ip_state_listener()
+    for key in (CONF_IP_ADDRESS, CONF_DNS_ADDRESS):
+        if key in config:
+            wifi.request_wifi_ip_state_listener()
 
     # Scan results use WiFiScanResultsListener
     if CONF_SCAN_RESULTS in config:

--- a/esphome/components/x9c/x9c.cpp
+++ b/esphome/components/x9c/x9c.cpp
@@ -6,7 +6,7 @@ namespace x9c {
 
 static const char *const TAG = "x9c.output";
 
-void X9cOutput::trim_value(int change_amount) {
+void X9cOutput::trim_value(int32_t change_amount) {
   if (change_amount == 0) {
     return;
   }
@@ -47,17 +47,17 @@ void X9cOutput::setup() {
 
   if (this->initial_value_ <= 0.50) {
     this->trim_value(-101);  // Set min value (beyond 0)
-    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100)));
+    this->trim_value(lroundf(this->initial_value_ * 100));
   } else {
     this->trim_value(101);  // Set max value (beyond 100)
-    this->trim_value(static_cast<uint32_t>(roundf(this->initial_value_ * 100) - 100));
+    this->trim_value(lroundf(this->initial_value_ * 100) - 100);
   }
   this->pot_value_ = this->initial_value_;
   this->write_state(this->initial_value_);
 }
 
 void X9cOutput::write_state(float state) {
-  this->trim_value(static_cast<uint32_t>(roundf((state - this->pot_value_) * 100)));
+  this->trim_value(lroundf((state - this->pot_value_) * 100));
   this->pot_value_ = state;
 }
 

--- a/esphome/components/x9c/x9c.h
+++ b/esphome/components/x9c/x9c.h
@@ -18,7 +18,7 @@ class X9cOutput : public output::FloatOutput, public Component {
   void setup() override;
   void dump_config() override;
 
-  void trim_value(int change_amount);
+  void trim_value(int32_t change_amount);
 
  protected:
   void write_state(float state) override;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.1.0b3"
+__version__ = "2026.1.0b4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/integration/fixtures/api_homeassistant.yaml
+++ b/tests/integration/fixtures/api_homeassistant.yaml
@@ -108,6 +108,25 @@ text_sensor:
             format: "HA Empty state updated: %s"
             args: ['x.c_str()']
 
+  # Test long attribute handling (>255 characters)
+  # HA states are limited to 255 chars, but attributes are not
+  - platform: homeassistant
+    name: "HA Long Attribute"
+    entity_id: sensor.long_data
+    attribute: long_value
+    id: ha_long_attribute
+    on_value:
+      then:
+        - logger.log:
+            format: "HA Long attribute received, length: %d"
+            args: ['x.size()']
+        # Log the first 50 and last 50 chars to verify no truncation
+        - lambda: |-
+            if (x.size() >= 100) {
+              ESP_LOGI("test", "Long attribute first 50 chars: %.50s", x.c_str());
+              ESP_LOGI("test", "Long attribute last 50 chars: %s", x.c_str() + x.size() - 50);
+            }
+
 # Number component for testing HA number control
 number:
   - platform: template

--- a/tests/integration/test_api_homeassistant.py
+++ b/tests/integration/test_api_homeassistant.py
@@ -40,6 +40,7 @@ async def test_api_homeassistant(
     humidity_update_future = loop.create_future()
     motion_update_future = loop.create_future()
     weather_update_future = loop.create_future()
+    long_attr_future = loop.create_future()
 
     # Number future
     ha_number_future = loop.create_future()
@@ -58,6 +59,7 @@ async def test_api_homeassistant(
     humidity_update_pattern = re.compile(r"HA Humidity state updated: ([\d.]+)")
     motion_update_pattern = re.compile(r"HA Motion state changed: (ON|OFF)")
     weather_update_pattern = re.compile(r"HA Weather condition updated: (\w+)")
+    long_attr_pattern = re.compile(r"HA Long attribute received, length: (\d+)")
 
     # Number pattern
     ha_number_pattern = re.compile(r"Setting HA number to: ([\d.]+)")
@@ -143,8 +145,14 @@ async def test_api_homeassistant(
         elif not weather_update_future.done() and weather_update_pattern.search(line):
             weather_update_future.set_result(line)
 
-        # Check number pattern
-        elif not ha_number_future.done() and ha_number_pattern.search(line):
+        # Check long attribute pattern - separate if since it can come at different times
+        if not long_attr_future.done():
+            match = long_attr_pattern.search(line)
+            if match:
+                long_attr_future.set_result(int(match.group(1)))
+
+        # Check number pattern - separate if since it can come at different times
+        if not ha_number_future.done():
             match = ha_number_pattern.search(line)
             if match:
                 ha_number_future.set_result(match.group(1))
@@ -178,6 +186,14 @@ async def test_api_homeassistant(
         client.send_home_assistant_state("sensor.external_humidity", "", "65.0")
         client.send_home_assistant_state("binary_sensor.external_motion", "", "ON")
         client.send_home_assistant_state("weather.home", "condition", "sunny")
+
+        # Send a long attribute (300 characters) to test that attributes aren't truncated
+        # HA states are limited to 255 chars, but attributes are NOT limited
+        # This tests the fix for the 256-byte buffer truncation bug
+        long_attr_value = "X" * 300  # 300 chars - enough to expose truncation bug
+        client.send_home_assistant_state(
+            "sensor.long_data", "long_value", long_attr_value
+        )
 
         # Test edge cases for zero-copy implementation safety
         # Empty entity_id should be silently ignored (no crash)
@@ -224,6 +240,13 @@ async def test_api_homeassistant(
             # Number test
             number_value = await asyncio.wait_for(ha_number_future, timeout=5.0)
             assert number_value == "42.5", f"Unexpected number value: {number_value}"
+
+            # Long attribute test - verify 300 chars weren't truncated to 255
+            long_attr_len = await asyncio.wait_for(long_attr_future, timeout=5.0)
+            assert long_attr_len == 300, (
+                f"Long attribute was truncated! Expected 300 chars, got {long_attr_len}. "
+                "This indicates the 256-byte truncation bug."
+            )
 
             # Wait for completion
             await asyncio.wait_for(tests_complete_future, timeout=5.0)


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [network] Fix IPAddress::str_to() to lowercase IPv6 hex digits [esphome#13325](https://github.com/esphome/esphome/pull/13325)
- [api] Fix truncation of Home Assistant attributes longer than 255 characters [esphome#13348](https://github.com/esphome/esphome/pull/13348)
- [core] Fix state leakage and module caching when processing multiple configurations [esphome#13368](https://github.com/esphome/esphome/pull/13368)
- [x9c] Fix potentiometer unable to decrement [esphome#13382](https://github.com/esphome/esphome/pull/13382)
- [wifi_info] Fix missing state when both IP+DNS or SSID+BSSID configure [esphome#13385](https://github.com/esphome/esphome/pull/13385)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
