### PR TITLE
[esp8266] Use SmallBufferWithHeapFallback in preferences

### DIFF
--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -12,7 +12,6 @@ extern "C" {
 #include "preferences.h"
 
 #include <cstring>
-#include <memory>
 
 namespace esphome::esp8266 {
 
@@ -143,16 +142,8 @@ class ESP8266PreferenceBackend : public ESPPreferenceBackend {
       return false;
 
     const size_t buffer_size = static_cast<size_t>(this->length_words) + 1;
-    uint32_t stack_buffer[PREF_BUFFER_WORDS];
-    std::unique_ptr<uint32_t[]> heap_buffer;
-    uint32_t *buffer;
-
-    if (buffer_size <= PREF_BUFFER_WORDS) {
-      buffer = stack_buffer;
-    } else {
-      heap_buffer = make_unique<uint32_t[]>(buffer_size);
-      buffer = heap_buffer.get();
-    }
+    SmallBufferWithHeapFallback<PREF_BUFFER_WORDS, uint32_t> buffer_alloc(buffer_size);
+    uint32_t *buffer = buffer_alloc.get();
     memset(buffer, 0, buffer_size * sizeof(uint32_t));
 
     memcpy(buffer, data, len);
@@ -167,16 +158,8 @@ class ESP8266PreferenceBackend : public ESPPreferenceBackend {
       return false;
 
     const size_t buffer_size = static_cast<size_t>(this->length_words) + 1;
-    uint32_t stack_buffer[PREF_BUFFER_WORDS];
-    std::unique_ptr<uint32_t[]> heap_buffer;
-    uint32_t *buffer;
-
-    if (buffer_size <= PREF_BUFFER_WORDS) {
-      buffer = stack_buffer;
-    } else {
-      heap_buffer = make_unique<uint32_t[]>(buffer_size);
-      buffer = heap_buffer.get();
-    }
+    SmallBufferWithHeapFallback<PREF_BUFFER_WORDS, uint32_t> buffer_alloc(buffer_size);
+    uint32_t *buffer = buffer_alloc.get();
 
     bool ret = this->in_flash ? load_from_flash(this->offset, buffer, buffer_size)
                               : load_from_rtc(this->offset, buffer, buffer_size);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -371,13 +371,15 @@ template<typename T> class FixedVector {
 /// @brief Helper class for efficient buffer allocation - uses stack for small sizes, heap for large
 /// This is useful when most operations need a small buffer but occasionally need larger ones.
 /// The stack buffer avoids heap allocation in the common case, while heap fallback handles edge cases.
-template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
+/// @tparam STACK_SIZE Number of elements in the stack buffer
+/// @tparam T Element type (default: uint8_t)
+template<size_t STACK_SIZE, typename T = uint8_t> class SmallBufferWithHeapFallback {
  public:
   explicit SmallBufferWithHeapFallback(size_t size) {
     if (size <= STACK_SIZE) {
       this->buffer_ = this->stack_buffer_;
     } else {
-      this->heap_buffer_ = new uint8_t[size];
+      this->heap_buffer_ = new T[size];
       this->buffer_ = this->heap_buffer_;
     }
   }
@@ -389,12 +391,12 @@ template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
   SmallBufferWithHeapFallback(SmallBufferWithHeapFallback &&) = delete;
   SmallBufferWithHeapFallback &operator=(SmallBufferWithHeapFallback &&) = delete;
 
-  uint8_t *get() { return this->buffer_; }
+  T *get() { return this->buffer_; }
 
  private:
-  uint8_t stack_buffer_[STACK_SIZE];
-  uint8_t *heap_buffer_{nullptr};
-  uint8_t *buffer_;
+  T stack_buffer_[STACK_SIZE];
+  T *heap_buffer_{nullptr};
+  T *buffer_;
 };
 
 ///@}


### PR DESCRIPTION
# What does this implement/fix?

Simplifies ESP8266 preferences by using the `SmallBufferWithHeapFallback` helper instead of manual stack/heap buffer management.

**Changes:**

1. **`esphome/core/helpers.h`**: Added template parameter `T` (default `uint8_t`) to `SmallBufferWithHeapFallback` to support `uint32_t` buffers while maintaining backwards compatibility with existing usages.

2. **`esphome/components/esp8266/preferences.cpp`**: Replaced manual stack/heap buffer management with the helper:

```cpp
// Before (in both save() and load() methods)
uint32_t stack_buffer[PREF_BUFFER_WORDS];
std::unique_ptr<uint32_t[]> heap_buffer;
uint32_t *buffer;
if (buffer_size <= PREF_BUFFER_WORDS) {
  buffer = stack_buffer;
} else {
  heap_buffer = make_unique<uint32_t[]>(buffer_size);
  buffer = heap_buffer.get();
}

// After
SmallBufferWithHeapFallback<PREF_BUFFER_WORDS, uint32_t> buffer_alloc(buffer_size);
uint32_t *buffer = buffer_alloc.get();
```

This removes ~20 lines of duplicated code and the `<memory>` include.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
