### PR TITLE
[esp32] [libretiny] Use stack buffer for preference comparison

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -181,7 +181,8 @@ class ESP32Preferences : public ESPPreferences {
     if (actual_len != to_save.len) {
       return true;
     }
-    auto stored_data = std::make_unique<uint8_t[]>(actual_len);
+    // Most preferences are small, use stack buffer with heap fallback for large ones
+    SmallBufferWithHeapFallback<256> stored_data(actual_len);
     err = nvs_get_blob(nvs_handle, key_str, stored_data.get(), &actual_len);
     if (err != 0) {
       ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", key_str, esp_err_to_name(err));

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -166,8 +166,8 @@ class LibreTinyPreferences : public ESPPreferences {
       return true;
     }
 
-    // Allocate buffer on heap to avoid stack allocation for large data
-    auto stored_data = std::make_unique<uint8_t[]>(kv.value_len);
+    // Most preferences are small, use stack buffer with heap fallback for large ones
+    SmallBufferWithHeapFallback<256> stored_data(kv.value_len);
     fdb_blob_make(&this->blob, stored_data.get(), kv.value_len);
     size_t actual_len = fdb_kv_get_blob(db, key_str, &this->blob);
     if (actual_len != kv.value_len) {


### PR DESCRIPTION
# What does this implement/fix?

Reduces heap allocation in ESP32 and LibreTiny preferences by using `SmallBufferWithHeapFallback<256>` instead of `std::make_unique<uint8_t[]>` in the `is_changed_()` methods.

Most preferences are small (< 256 bytes), so this avoids heap allocation in the common case while still supporting larger preferences via heap fallback.

**Changes:**

```cpp
// Before
auto stored_data = std::make_unique<uint8_t[]>(actual_len);

// After
SmallBufferWithHeapFallback<256> stored_data(actual_len);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
