### PR TITLE
[api] Use stack buffers for noise handshake messages

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -3,6 +3,7 @@
 #ifdef USE_API_NOISE
 #include "api_connection.h"  // For ClientInfo struct
 #include "esphome/core/application.h"
+#include "esphome/core/entity_base.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -267,17 +268,19 @@ APIError APINoiseFrameHelper::state_action_() {
     size_t mac_offset = name_offset + name_len;
     size_t total_size = 1 + name_len + mac_len;
 
-    auto msg = std::make_unique<uint8_t[]>(total_size);
+    // 1 (proto) + name + null + mac + null
+    constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + mac_len;
+    uint8_t msg[max_msg_size];
 
     // chosen proto
     msg[0] = 0x01;
 
     // node name, terminated by null byte
-    std::memcpy(msg.get() + name_offset, name.c_str(), name_len);
+    std::memcpy(msg + name_offset, name.c_str(), name_len);
     // node mac, terminated by null byte
-    std::memcpy(msg.get() + mac_offset, mac, mac_len);
+    std::memcpy(msg + mac_offset, mac, mac_len);
 
-    aerr = write_frame_(msg.get(), total_size);
+    aerr = write_frame_(msg, total_size);
     if (aerr != APIError::OK)
       return aerr;
 
@@ -353,35 +356,31 @@ APIError APINoiseFrameHelper::state_action_() {
   return APIError::OK;
 }
 void APINoiseFrameHelper::send_explicit_handshake_reject_(const LogString *reason) {
+  // Max reject message: "Bad handshake packet len" (24) + 1 (failure byte) = 25 bytes
+  uint8_t data[32];
+  data[0] = 0x01;  // failure
+
 #ifdef USE_STORE_LOG_STR_IN_FLASH
   // On ESP8266 with flash strings, we need to use PROGMEM-aware functions
   size_t reason_len = strlen_P(reinterpret_cast<PGM_P>(reason));
-  size_t data_size = reason_len + 1;
-  auto data = std::make_unique<uint8_t[]>(data_size);
-  data[0] = 0x01;  // failure
-
-  // Copy error message from PROGMEM
   if (reason_len > 0) {
-    memcpy_P(data.get() + 1, reinterpret_cast<PGM_P>(reason), reason_len);
+    memcpy_P(data + 1, reinterpret_cast<PGM_P>(reason), reason_len);
   }
 #else
   // Normal memory access
   const char *reason_str = LOG_STR_ARG(reason);
   size_t reason_len = strlen(reason_str);
-  size_t data_size = reason_len + 1;
-  auto data = std::make_unique<uint8_t[]>(data_size);
-  data[0] = 0x01;  // failure
-
-  // Copy error message in bulk
   if (reason_len > 0) {
-    std::memcpy(data.get() + 1, reason_str, reason_len);
+    std::memcpy(data + 1, reason_str, reason_len);
   }
 #endif
+
+  size_t data_size = reason_len + 1;
 
   // temporarily remove failed state
   auto orig_state = state_;
   state_ = State::EXPLICIT_REJECT;
-  write_frame_(data.get(), data_size);
+  write_frame_(data, data_size);
   state_ = orig_state;
 }
 APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -257,19 +257,18 @@ APIError APINoiseFrameHelper::state_action_() {
   }
   if (state_ == State::SERVER_HELLO) {
     // send server hello
-    constexpr size_t mac_len = 13;  // 12 hex chars + null terminator
     const std::string &name = App.get_name();
-    char mac[mac_len];
+    char mac[MAC_ADDRESS_BUFFER_SIZE];
     get_mac_address_into_buffer(mac);
 
     // Calculate positions and sizes
     size_t name_len = name.size() + 1;  // including null terminator
     size_t name_offset = 1;
     size_t mac_offset = name_offset + name_len;
-    size_t total_size = 1 + name_len + mac_len;
+    size_t total_size = 1 + name_len + MAC_ADDRESS_BUFFER_SIZE;
 
     // 1 (proto) + name + null + mac + null
-    constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + mac_len;
+    constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + MAC_ADDRESS_BUFFER_SIZE;
     uint8_t msg[max_msg_size];
 
     // chosen proto

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -267,7 +267,8 @@ APIError APINoiseFrameHelper::state_action_() {
     size_t mac_offset = name_offset + name_len;
     size_t total_size = 1 + name_len + MAC_ADDRESS_BUFFER_SIZE;
 
-    // 1 (proto) + name + null + mac + null
+    // 1 (proto) + name (max ESPHOME_DEVICE_NAME_MAX_LEN) + 1 (name null)
+    // + mac (MAC_ADDRESS_BUFFER_SIZE - 1) + 1 (mac null)
     constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + MAC_ADDRESS_BUFFER_SIZE;
     uint8_t msg[max_msg_size];
 

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -371,6 +371,7 @@ void APINoiseFrameHelper::send_explicit_handshake_reject_(const LogString *reaso
   const char *reason_str = LOG_STR_ARG(reason);
   size_t reason_len = strlen(reason_str);
   if (reason_len > 0) {
+    // NOLINTNEXTLINE(bugprone-not-null-terminated-result) - binary protocol, not a C string
     std::memcpy(data + 1, reason_str, reason_len);
   }
 #endif

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -277,7 +277,7 @@ APIError APINoiseFrameHelper::state_action_() {
     // node name, terminated by null byte
     std::memcpy(msg + name_offset, name.c_str(), name_len);
     // node mac, terminated by null byte
-    std::memcpy(msg + mac_offset, mac, mac_len);
+    std::memcpy(msg + mac_offset, mac, MAC_ADDRESS_BUFFER_SIZE);
 
     aerr = write_frame_(msg, total_size);
     if (aerr != APIError::OK)


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocation during API noise protocol handshake by using fixed-size stack buffers instead of `std::make_unique<uint8_t[]>`.

**Changes:**

1. **Server hello message** — Max size is bounded by `ESPHOME_DEVICE_NAME_MAX_LEN` (31) + mac (13) + proto (1) = 45 bytes:
```cpp
// Before
auto msg = std::make_unique<uint8_t[]>(total_size);

// After
constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + mac_len;
uint8_t msg[max_msg_size];
```

2. **Handshake reject message** — Max size is longest error string (24 chars) + failure byte = 25 bytes:
```cpp
// Before
auto data = std::make_unique<uint8_t[]>(data_size);

// After
uint8_t data[32];
```

**Lifetime safety:** `write_frame_()` either sends data synchronously via socket or copies it to a heap buffer before returning. The stack buffer pointer is never stored.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
