### PR TITLE
[wifi] Process scan results one at a time to avoid heap allocation

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -827,16 +827,16 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     }
 
     uint16_t number = it.number;
-    auto records = std::make_unique<wifi_ap_record_t[]>(number);
-    err = esp_wifi_scan_get_ap_records(&number, records.get());
-    if (err != ESP_OK) {
-      ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
-      return;
-    }
-
     scan_result_.init(number);
-    for (int i = 0; i < number; i++) {
-      auto &record = records[i];
+
+    // Process one record at a time to avoid large buffer allocation
+    wifi_ap_record_t record;
+    for (uint16_t i = 0; i < number; i++) {
+      err = esp_wifi_scan_get_ap_record(&record);
+      if (err != ESP_OK) {
+        ESP_LOGW(TAG, "esp_wifi_scan_get_ap_record failed: %s", esp_err_to_name(err));
+        break;
+      }
       bssid_t bssid;
       std::copy(record.bssid, record.bssid + 6, bssid.begin());
       std::string ssid(reinterpret_cast<const char *>(record.ssid));

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -835,6 +835,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
       err = esp_wifi_scan_get_ap_record(&record);
       if (err != ESP_OK) {
         ESP_LOGW(TAG, "esp_wifi_scan_get_ap_record failed: %s", esp_err_to_name(err));
+        esp_wifi_clear_ap_list();  // Free remaining records not yet retrieved
         break;
       }
       bssid_t bssid;


### PR DESCRIPTION
# What does this implement/fix?

Eliminates unnecessary heap allocation when processing WiFi scan results on ESP32 by using `esp_wifi_scan_get_ap_record()` (singular) instead of `esp_wifi_scan_get_ap_records()` (plural).

**Before:**
1. ESP-IDF allocates internal heap buffer for scan results
2. ESPHome allocated another heap buffer (92 bytes × N APs = 3KB+ for 35 APs)
3. Copied to `scan_result_`

**After:**
1. ESP-IDF allocates internal heap buffer for scan results
2. ESPHome reads one record at a time into 92-byte stack buffer
3. Copies directly to `scan_result_`

This eliminates a 3KB+ heap allocation/deallocation cycle on every WiFi scan, reducing heap fragmentation that can cause crashes after weeks of uptime.

**Performance:** Same or better. The singular API `esp_wifi_scan_get_ap_record()` was added by Espressif specifically for memory-constrained use cases. Both APIs read from the same internal ESP-IDF cache, and eliminating the large heap allocation/deallocation likely improves performance by avoiding allocator overhead.

```cpp
// Before - heap allocation for all records
auto records = std::make_unique<wifi_ap_record_t[]>(number);
err = esp_wifi_scan_get_ap_records(&number, records.get());

// After - single stack buffer, process one at a time
wifi_ap_record_t record;
for (uint16_t i = 0; i < number; i++) {
  err = esp_wifi_scan_get_ap_record(&record);
  // process...
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
