### PR TITLE
[mdns] Use stack buffer for txt records on ESP32

### DIFF
--- a/esphome/components/mdns/mdns_esp32.cpp
+++ b/esphome/components/mdns/mdns_esp32.cpp
@@ -24,13 +24,14 @@ static void register_esp32(MDNSComponent *comp, StaticVector<MDNSService, MDNS_S
   mdns_instance_name_set(hostname);
 
   for (const auto &service : services) {
-    auto txt_records = std::make_unique<mdns_txt_item_t[]>(service.txt_records.size());
+    // Stack buffer for up to 16 txt records, heap fallback for more
+    SmallBufferWithHeapFallback<16, mdns_txt_item_t> txt_records(service.txt_records.size());
     for (size_t i = 0; i < service.txt_records.size(); i++) {
       const auto &record = service.txt_records[i];
       // key and value are either compile-time string literals in flash or pointers to dynamic_txt_values_
       // Both remain valid for the lifetime of this function, and ESP-IDF makes internal copies
-      txt_records[i].key = MDNS_STR_ARG(record.key);
-      txt_records[i].value = MDNS_STR_ARG(record.value);
+      txt_records.get()[i].key = MDNS_STR_ARG(record.key);
+      txt_records.get()[i].value = MDNS_STR_ARG(record.value);
     }
     uint16_t port = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
     err = mdns_service_add(nullptr, MDNS_STR_ARG(service.service_type), MDNS_STR_ARG(service.proto), port,

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -371,13 +371,15 @@ template<typename T> class FixedVector {
 /// @brief Helper class for efficient buffer allocation - uses stack for small sizes, heap for large
 /// This is useful when most operations need a small buffer but occasionally need larger ones.
 /// The stack buffer avoids heap allocation in the common case, while heap fallback handles edge cases.
-template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
+/// @tparam STACK_SIZE Number of elements in the stack buffer
+/// @tparam T Element type (default: uint8_t)
+template<size_t STACK_SIZE, typename T = uint8_t> class SmallBufferWithHeapFallback {
  public:
   explicit SmallBufferWithHeapFallback(size_t size) {
     if (size <= STACK_SIZE) {
       this->buffer_ = this->stack_buffer_;
     } else {
-      this->heap_buffer_ = new uint8_t[size];
+      this->heap_buffer_ = new T[size];
       this->buffer_ = this->heap_buffer_;
     }
   }
@@ -389,12 +391,12 @@ template<size_t STACK_SIZE> class SmallBufferWithHeapFallback {
   SmallBufferWithHeapFallback(SmallBufferWithHeapFallback &&) = delete;
   SmallBufferWithHeapFallback &operator=(SmallBufferWithHeapFallback &&) = delete;
 
-  uint8_t *get() { return this->buffer_; }
+  T *get() { return this->buffer_; }
 
  private:
-  uint8_t stack_buffer_[STACK_SIZE];
-  uint8_t *heap_buffer_{nullptr};
-  uint8_t *buffer_;
+  T stack_buffer_[STACK_SIZE];
+  T *heap_buffer_{nullptr};
+  T *buffer_;
 };
 
 ///@}


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocation when registering mDNS services by using `SmallBufferWithHeapFallback` for the txt records array.

```cpp
// Before - heap allocation
auto txt_records = std::make_unique<mdns_txt_item_t[]>(service.txt_records.size());

// After - stack buffer for up to 16 records, heap fallback for more
SmallBufferWithHeapFallback<16, mdns_txt_item_t> txt_records(service.txt_records.size());
```

`mdns_txt_item_t` is two pointers (~8 bytes on 32-bit), so 16 records = ~128 bytes on stack. This covers virtually all real-world mDNS configurations.

While this only runs once at setup, eliminating unnecessary heap allocations during startup reduces initial heap fragmentation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
