### PR TITLE
[logger] Use raw pointer for task log buffer to match tx_buffer pattern

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -1,8 +1,5 @@
 #include "logger.h"
 #include <cinttypes>
-#ifdef USE_ESPHOME_TASK_LOG_BUFFER
-#include <memory>  // For unique_ptr
-#endif
 
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
@@ -199,7 +196,8 @@ inline uint8_t Logger::level_for(const char *tag) {
 
 Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size) : baud_rate_(baud_rate), tx_buffer_size_(tx_buffer_size) {
   // add 1 to buffer size for null terminator
-  this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];  // NOLINT
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
+  this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
   this->main_task_ = xTaskGetCurrentTaskHandle();
 #elif defined(USE_ZEPHYR)
@@ -212,11 +210,14 @@ Logger::Logger(uint32_t baud_rate, size_t tx_buffer_size) : baud_rate_(baud_rate
 void Logger::init_log_buffer(size_t total_buffer_size) {
 #ifdef USE_HOST
   // Host uses slot count instead of byte size
-  this->log_buffer_ = esphome::make_unique<logger::TaskLogBufferHost>(total_buffer_size);
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
+  this->log_buffer_ = new logger::TaskLogBufferHost(total_buffer_size);
 #elif defined(USE_ESP32)
-  this->log_buffer_ = esphome::make_unique<logger::TaskLogBuffer>(total_buffer_size);
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
+  this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);
 #elif defined(USE_LIBRETINY)
-  this->log_buffer_ = esphome::make_unique<logger::TaskLogBufferLibreTiny>(total_buffer_size);
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
+  this->log_buffer_ = new logger::TaskLogBufferLibreTiny(total_buffer_size);
 #endif
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -412,11 +412,11 @@ class Logger : public Component {
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
 #ifdef USE_HOST
-  std::unique_ptr<logger::TaskLogBufferHost> log_buffer_;  // Will be initialized with init_log_buffer
+  logger::TaskLogBufferHost *log_buffer_{nullptr};  // Allocated once, never freed
 #elif defined(USE_ESP32)
-  std::unique_ptr<logger::TaskLogBuffer> log_buffer_;  // Will be initialized with init_log_buffer
+  logger::TaskLogBuffer *log_buffer_{nullptr};  // Allocated once, never freed
 #elif defined(USE_LIBRETINY)
-  std::unique_ptr<logger::TaskLogBufferLibreTiny> log_buffer_;  // Will be initialized with init_log_buffer
+  logger::TaskLogBufferLibreTiny *log_buffer_{nullptr};  // Allocated once, never freed
 #endif
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Changes the task log buffer from `std::unique_ptr` to a raw pointer, matching the existing pattern used for `tx_buffer_`. Both buffers are allocated once at startup and never freed (the device runs forever), so the `unique_ptr` destructor code is pure waste - it will never execute.

```cpp
// Before - unique_ptr with destructor code that never runs
std::unique_ptr<logger::TaskLogBuffer> log_buffer_;
this->log_buffer_ = esphome::make_unique<logger::TaskLogBuffer>(total_buffer_size);

// After - raw pointer matching tx_buffer_ pattern
logger::TaskLogBuffer *log_buffer_{nullptr};
this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);
```

This is consistent with `tx_buffer_` which already uses raw `new`:
```cpp
this->tx_buffer_ = new char[this->tx_buffer_size_ + 1];
```

Also updates NOLINT comments to use the specific `cppcoreguidelines-owning-memory` rule.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
