### PR TITLE
[libretiny] Disable unused LWIP statistics to save RAM and flash

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -382,4 +382,11 @@ async def component_to_code(config):
             "custom_options.sys_config#h", _BK7231N_SYS_CONFIG_OPTIONS
         )
 
+    # Disable LWIP statistics to save RAM - not needed in production
+    # Must explicitly disable all sub-stats to avoid redefinition warnings
+    cg.add_platformio_option(
+        "custom_options.lwip",
+        ["LWIP_STATS=0", "MEM_STATS=0", "MEMP_STATS=0"],
+    )
+
     await cg.register_component(var, config)


### PR DESCRIPTION
# What does this implement/fix?

Disables LWIP statistics collection on LibreTiny platforms to save RAM and flash. These statistics are useful for debugging but not needed in production firmware.

The change adds `LWIP_STATS=0`, `MEM_STATS=0`, and `MEMP_STATS=0` to the lwip configuration for all LibreTiny builds.

**Measured savings:**

| Platform | RAM | Flash |
|----------|-----|-------|
| BK7231N | -504 bytes | -1,752 bytes |
| RTL8720CF | 0 | -72 bytes |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration needed - automatically applied to all LibreTiny builds
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
