### PR TITLE
[web_server_idf] Use direct member for ListEntitiesIterator instead of unique_ptr

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -487,7 +487,7 @@ void AsyncEventSource::deferrable_send_state(void *source, const char *event_typ
 AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *request,
                                                    esphome::web_server_idf::AsyncEventSource *server,
                                                    esphome::web_server::WebServer *ws)
-    : server_(server), web_server_(ws), entities_iterator_(new esphome::web_server::ListEntitiesIterator(ws, server)) {
+    : server_(server), web_server_(ws), entities_iterator_(ws, server) {
   httpd_req_t *req = *request;
 
   httpd_resp_set_status(req, HTTPD_200);
@@ -531,12 +531,12 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
   }
 #endif
 
-  this->entities_iterator_->begin(ws->include_internal_);
+  this->entities_iterator_.begin(ws->include_internal_);
 
   // just dump them all up-front and take advantage of the deferred queue
   //     on second thought that takes too long, but leaving the commented code here for debug purposes
-  // while(!this->entities_iterator_->completed()) {
-  //  this->entities_iterator_->advance();
+  // while(!this->entities_iterator_.completed()) {
+  //  this->entities_iterator_.advance();
   //}
 }
 
@@ -634,8 +634,8 @@ void AsyncEventSourceResponse::process_buffer_() {
 void AsyncEventSourceResponse::loop() {
   process_buffer_();
   process_deferred_queue_();
-  if (!this->entities_iterator_->completed())
-    this->entities_iterator_->advance();
+  if (!this->entities_iterator_.completed())
+    this->entities_iterator_.advance();
 }
 
 bool AsyncEventSourceResponse::try_send_nodefer(const char *message, const char *event, uint32_t id,
@@ -781,7 +781,7 @@ void AsyncEventSourceResponse::deferrable_send_state(void *source, const char *e
                                                      message_generator_t *message_generator) {
   // allow all json "details_all" to go through before publishing bare state events, this avoids unnamed entries showing
   // up in the web GUI and reduces event load during initial connect
-  if (!entities_iterator_->completed() && 0 != strcmp(event_type, "state_detail_all"))
+  if (!this->entities_iterator_.completed() && 0 != strcmp(event_type, "state_detail_all"))
     return;
 
   if (source == nullptr)

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -13,11 +13,14 @@
 #include <utility>
 #include <vector>
 
+#ifdef USE_WEBSERVER
+#include "esphome/components/web_server/list_entities.h"
+#endif
+
 namespace esphome {
 #ifdef USE_WEBSERVER
 namespace web_server {
 class WebServer;
-class ListEntitiesIterator;
 };  // namespace web_server
 #endif
 namespace web_server_idf {
@@ -284,7 +287,7 @@ class AsyncEventSourceResponse {
   std::atomic<int> fd_{};
   std::vector<DeferredEvent> deferred_queue_;
   esphome::web_server::WebServer *web_server_;
-  std::unique_ptr<esphome::web_server::ListEntitiesIterator> entities_iterator_;
+  esphome::web_server::ListEntitiesIterator entities_iterator_;
   std::string event_buffer_{""};
   size_t event_bytes_sent_;
   uint16_t consecutive_send_failures_{0};


### PR DESCRIPTION
# What does this implement/fix?

Convert `ListEntitiesIterator` from heap-allocated `std::unique_ptr` to a direct member in `AsyncEventSourceResponse`.

The iterator is a small object (~20 bytes) that was previously heap-allocated via `std::unique_ptr` to avoid working out include ordering. Since `list_entities.h` only forward-declares `AsyncEventSource` and uses it as a pointer, we can safely include it before `AsyncEventSource` is defined, eliminating the need for the pointer indirection.

**Changes:**
- Add `#include "esphome/components/web_server/list_entities.h"` to `web_server_idf.h`
- Remove forward declaration of `ListEntitiesIterator`
- Change `std::unique_ptr<ListEntitiesIterator>` to direct member `ListEntitiesIterator`
- Update constructor and all usages from `->` to `.`

**Benefits:**
- Eliminates one heap allocation per SSE client connection
- Removes pointer indirection on every iterator access
- Better cache locality (iterator data inline with response object)
- Reduces heap fragmentation from repeated SSE connect/disconnect cycles

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
