### PR TITLE
[http_request] Fix verify_ssl: false not working on ESP32

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -157,6 +157,7 @@ async def to_code(config):
     if CORE.is_esp32:
         cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
         cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
+        cg.add(var.set_verify_ssl(config[CONF_VERIFY_SSL]))
 
         if config.get(CONF_VERIFY_SSL):
             esp32.add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   config.max_redirection_count = this->redirect_limit_;
   config.auth_type = HTTP_AUTH_TYPE_BASIC;
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
-  if (secure) {
+  if (secure && this->verify_ssl_) {
     config.crt_bundle_attach = esp_crt_bundle_attach;
   }
 #endif

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -34,6 +34,7 @@ class HttpRequestIDF : public HttpRequestComponent {
 
   void set_buffer_size_rx(uint16_t buffer_size_rx) { this->buffer_size_rx_ = buffer_size_rx; }
   void set_buffer_size_tx(uint16_t buffer_size_tx) { this->buffer_size_tx_ = buffer_size_tx; }
+  void set_verify_ssl(bool verify_ssl) { this->verify_ssl_ = verify_ssl; }
 
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
@@ -42,6 +43,7 @@ class HttpRequestIDF : public HttpRequestComponent {
   // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
   uint16_t buffer_size_rx_{};
   uint16_t buffer_size_tx_{};
+  bool verify_ssl_{true};
 
   /// @brief Monitors the http client events to gather response headers
   static esp_err_t http_event_handler(esp_http_client_event_t *evt);


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced in #12428 where `verify_ssl: false` stopped working on ESP32. Users with self-signed certificates were getting SSL handshake failures despite setting `verify_ssl: false`.

The root cause was that the C++ code unconditionally attached the certificate bundle for HTTPS connections when it was compiled in, ignoring the `verify_ssl` setting. The compile-time flags (`CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY`) weren't sufficient because `crt_bundle_attach` was always set.

## Solution

This PR adds **runtime control** of SSL verification:
- Added `verify_ssl_` member and `set_verify_ssl()` method to `HttpRequestIDF`
- The cert bundle is now only attached when **both** the connection is secure **and** `verify_ssl_` is true

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13413

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  verify_ssl: false

# Used with online_image or other components that fetch from HTTPS URLs
# with self-signed certificates
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)