### PR TITLE
[wifi] Fix bk72xx manual_ip preventing API connection

### DIFF
--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -460,13 +460,15 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
         listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
       }
 #endif
-      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
-#if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
+      // For static IP configurations, GOT_IP event may not fire, so set connected state here
+#ifdef USE_WIFI_MANUAL_IP
       if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
         s_sta_state = LTWiFiSTAState::CONNECTED;
+#ifdef USE_WIFI_IP_STATE_LISTENERS
         for (auto *listener : this->ip_state_listeners_) {
           listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
         }
+#endif
       }
 #endif
       break;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression where LibreTiny devices bk72xx with `manual_ip` configured would fail to connect to the Home Assistant API. The device would accept connections but immediately disconnect with "Network down" errors:

```
[D][api:139]: Accept 192.168.1.xxx
[W][api.connection:2236]: 192.168.1.xxx: Network down; disconnect
[W][wifi:1394]: Connecting to network failed (callback)
```

## Root Cause

In PR #13197, the WiFi listener system was refactored to use per-type compile-time defines. This accidentally moved the `s_sta_state = LTWiFiSTAState::CONNECTED` state transition inside a `USE_WIFI_IP_STATE_LISTENERS` guard.

For static IP configurations on LibreTiny, the `GOT_IP` event may not fire, so the connected state must be set when `STA_CONNECTED` is received. However, `USE_WIFI_IP_STATE_LISTENERS` is only defined when IP state listeners (like `wifi_info` IP sensors) are configured. Without such listeners, the state was never set to `CONNECTED`, causing `is_connected()` to return `false` even when WiFi was connected.

## Fix

Move `s_sta_state = LTWiFiSTAState::CONNECTED` outside the `USE_WIFI_IP_STATE_LISTENERS` guard, keeping it under only `USE_WIFI_MANUAL_IP`. The IP listener notification remains guarded by `USE_WIFI_IP_STATE_LISTENERS`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13419
- fixes https://github.com/esphome/esphome/issues/13420

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  fast_connect: on
  manual_ip:
    static_ip: 192.168.1.100
    subnet: 255.255.255.0
    gateway: 192.168.1.1
    dns1: 192.168.1.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
