### PR TITLE
[spi] Fix display init failure by marking displays as write-only for half-duplex mode

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -190,8 +190,7 @@ async def to_code(config):
     # Rotation is handled by setting the transform
     display_config = {k: v for k, v in config.items() if k != CONF_ROTATION}
     await display.register_display(var, display_config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -191,6 +191,7 @@ async def to_code(config):
     display_config = {k: v for k, v in config.items() if k != CONF_ROTATION}
     await display.register_display(var, display_config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -224,6 +224,7 @@ async def to_code(config):
 
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))
     if init_sequences := config.get(CONF_INIT_SEQUENCE):

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -223,8 +223,7 @@ async def to_code(config):
     var = cg.Pvariable(config[CONF_ID], rhs)
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))
     if init_sequences := config.get(CONF_INIT_SEQUENCE):

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -29,8 +29,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -30,6 +30,7 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -87,6 +87,7 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -86,8 +86,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -260,8 +260,7 @@ async def to_code(config):
         cg.add(var.set_enable_pins(enable))
 
     if CONF_SPI_ID in config:
-        await spi.register_spi_device(var, config)
-        cg.add(var.set_write_only(True))
+        await spi.register_spi_device(var, config, write_only=True)
         sequence, madctl = model.get_sequence(config)
         cg.add(var.set_init_sequence(sequence))
         cg.add(var.set_madctl(madctl))

--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -261,6 +261,7 @@ async def to_code(config):
 
     if CONF_SPI_ID in config:
         await spi.register_spi_device(var, config)
+        cg.add(var.set_write_only(True))
         sequence, madctl = model.get_sequence(config)
         cg.add(var.set_init_sequence(sequence))
         cg.add(var.set_madctl(madctl))

--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -443,6 +443,4 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    # Displays are write-only, set the SPI device to write-only as well
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -45,6 +45,7 @@ async def to_code(config):
 
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -44,8 +44,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/qspi_dbi/display.py
+++ b/esphome/components/qspi_dbi/display.py
@@ -161,8 +161,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     chip = DriverChip.chips[config[CONF_MODEL]]
     if chip.initsequence:

--- a/esphome/components/qspi_dbi/display.py
+++ b/esphome/components/qspi_dbi/display.py
@@ -162,6 +162,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     chip = DriverChip.chips[config[CONF_MODEL]]
     if chip.initsequence:

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -39,6 +39,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core", "@clydebarrow"]
 spi_ns = cg.esphome_ns.namespace("spi")
@@ -448,9 +449,13 @@ def spi_device_schema(
     )
 
 
-async def register_spi_device(var, config):
+async def register_spi_device(
+    var: cg.Pvariable, config: ConfigType, write_only: bool = False
+) -> None:
     parent = await cg.get_variable(config[CONF_SPI_ID])
     cg.add(var.set_spi_parent(parent))
+    if write_only:
+        cg.add(var.set_write_only(True))
     if cs_pin := config.get(CONF_CS_PIN):
         pin = await cg.gpio_pin_expression(cs_pin)
         cg.add(var.set_cs_pin(pin))

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -1,5 +1,8 @@
 #include "spi.h"
 #include <vector>
+#ifdef USE_ESP32
+#include <esp_clk_tree.h>
+#endif
 
 namespace esphome::spi {
 
@@ -184,9 +187,14 @@ class SPIDelegateHw : public SPIDelegate {
   void read_array(uint8_t *ptr, size_t length) override { this->transfer(nullptr, ptr, length); }
 
  protected:
-  // Maximum SPI clock speed for full-duplex mode on GPIO matrix pins
-  // ESP-IDF limit is "less than APB_CLK/3" (26.67MHz), so we use 26MHz to be safe
-  static constexpr uint32_t MAX_FULL_DUPLEX_SPEED = 26000000;
+  // Get maximum SPI clock speed for full-duplex mode on GPIO matrix pins.
+  // ESP-IDF limit is "less than APB_CLK/3". We subtract 1 to ensure we're strictly less than.
+  // This varies by chip: ESP32/S2/S3/C3=26.67MHz, C5/C6=13.33MHz, H2=10.67MHz, etc.
+  static uint32_t get_max_full_duplex_speed_() {
+    uint32_t apb_freq = 0;
+    esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_EXACT, &apb_freq);
+    return (apb_freq / 3) - 1;
+  }
 
   bool add_device_() {
     spi_device_interface_config_t config = {};
@@ -203,15 +211,18 @@ class SPIDelegateHw : public SPIDelegate {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
       ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
                Utility::get_pin_no(this->cs_pin_));
-    } else if (this->data_rate_ > MAX_FULL_DUPLEX_SPEED) {
-      // Full-duplex mode has a lower speed limit due to GPIO matrix timing constraints.
-      // Cap the speed and warn instead of failing.
-      int cs_pin = Utility::get_pin_no(this->cs_pin_);
-      ESP_LOGW(TAG,
-               "SPI device with CS pin %d requested %u Hz, but full-duplex is limited to %u Hz. "
-               "Capping speed. To fix: ensure the component sets write-only mode, or lower data_rate.",
-               cs_pin, this->data_rate_, MAX_FULL_DUPLEX_SPEED);
-      config.clock_speed_hz = MAX_FULL_DUPLEX_SPEED;
+    } else {
+      uint32_t max_speed = get_max_full_duplex_speed_();
+      if (this->data_rate_ > max_speed) {
+        // Full-duplex mode has a lower speed limit due to GPIO matrix timing constraints.
+        // Cap the speed and warn instead of failing.
+        int cs_pin = Utility::get_pin_no(this->cs_pin_);
+        ESP_LOGW(TAG,
+                 "SPI device with CS pin %d requested %u Hz, but full-duplex is limited to %u Hz. "
+                 "Capping speed. To fix: ensure the component sets write-only mode, or lower data_rate.",
+                 cs_pin, this->data_rate_, max_speed);
+        config.clock_speed_hz = static_cast<int>(max_speed);
+      }
     }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -188,12 +188,11 @@ class SPIDelegateHw : public SPIDelegate {
 
  protected:
   // Get maximum SPI clock speed for full-duplex mode on GPIO matrix pins.
-  // ESP-IDF limit is "less than APB_CLK/3". We subtract 1 to ensure we're strictly less than.
-  // This varies by chip: ESP32/S2/S3/C3=26.67MHz, C5/C6=13.33MHz, H2=10.67MHz, etc.
+  // ESP-IDF limit is APB_CLK/3. Varies by chip: ESP32/S2/S3/C3=26.67MHz, C5/C6=13.33MHz, H2=10.67MHz, P4=30MHz.
   static uint32_t get_max_full_duplex_speed_() {
     uint32_t apb_freq = 0;
     esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_EXACT, &apb_freq);
-    return (apb_freq / 3) - 1;
+    return apb_freq / 3;
   }
 
   bool add_device_() {

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -201,6 +201,8 @@ class SPIDelegateHw : public SPIDelegate {
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
     if (this->write_only_) {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
+      ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
+               Utility::get_pin_no(this->cs_pin_));
     } else if (this->data_rate_ > MAX_FULL_DUPLEX_SPEED) {
       // Full-duplex mode has a lower speed limit due to GPIO matrix timing constraints.
       // Cap the speed and warn instead of failing.

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -184,6 +184,10 @@ class SPIDelegateHw : public SPIDelegate {
   void read_array(uint8_t *ptr, size_t length) override { this->transfer(nullptr, ptr, length); }
 
  protected:
+  // Maximum SPI clock speed for full-duplex mode on GPIO matrix pins
+  // ESP-IDF limit is "less than APB_CLK/3" (26.67MHz), so we use 26MHz to be safe
+  static constexpr uint32_t MAX_FULL_DUPLEX_SPEED = 26000000;
+
   bool add_device_() {
     spi_device_interface_config_t config = {};
     config.mode = static_cast<uint8_t>(this->mode_);
@@ -195,8 +199,18 @@ class SPIDelegateHw : public SPIDelegate {
     config.post_cb = nullptr;
     if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
-    if (this->write_only_)
+    if (this->write_only_) {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
+    } else if (this->data_rate_ > MAX_FULL_DUPLEX_SPEED) {
+      // Full-duplex mode has a lower speed limit due to GPIO matrix timing constraints.
+      // Cap the speed and warn instead of failing.
+      int cs_pin = Utility::get_pin_no(this->cs_pin_);
+      ESP_LOGW(TAG,
+               "SPI device with CS pin %d requested %u Hz, but full-duplex is limited to %u Hz. "
+               "Capping speed. To fix: ensure the component sets write-only mode, or lower data_rate.",
+               cs_pin, this->data_rate_, MAX_FULL_DUPLEX_SPEED);
+      config.clock_speed_hz = MAX_FULL_DUPLEX_SPEED;
+    }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Add device failed - err %X", err);

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -1,8 +1,5 @@
 #include "spi.h"
 #include <vector>
-#ifdef USE_ESP32
-#include <esp_clk_tree.h>
-#endif
 
 namespace esphome::spi {
 
@@ -187,14 +184,6 @@ class SPIDelegateHw : public SPIDelegate {
   void read_array(uint8_t *ptr, size_t length) override { this->transfer(nullptr, ptr, length); }
 
  protected:
-  // Get maximum SPI clock speed for full-duplex mode on GPIO matrix pins.
-  // ESP-IDF limit is APB_CLK/3. Varies by chip: ESP32/S2/S3/C3=26.67MHz, C5/C6=13.33MHz, H2=10.67MHz, P4=30MHz.
-  static uint32_t get_max_full_duplex_speed_() {
-    uint32_t apb_freq = 0;
-    esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_EXACT, &apb_freq);
-    return apb_freq / 3;
-  }
-
   bool add_device_() {
     spi_device_interface_config_t config = {};
     config.mode = static_cast<uint8_t>(this->mode_);
@@ -210,18 +199,6 @@ class SPIDelegateHw : public SPIDelegate {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
       ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
                Utility::get_pin_no(this->cs_pin_));
-    } else {
-      uint32_t max_speed = get_max_full_duplex_speed_();
-      if (this->data_rate_ > max_speed) {
-        // Full-duplex mode has a lower speed limit due to GPIO matrix timing constraints.
-        // Cap the speed and warn instead of failing.
-        int cs_pin = Utility::get_pin_no(this->cs_pin_);
-        ESP_LOGW(TAG,
-                 "SPI device with CS pin %d requested %u Hz, but full-duplex is limited to %u Hz. "
-                 "Capping speed. To fix: ensure the component sets write-only mode, or lower data_rate.",
-                 cs_pin, this->data_rate_, max_speed);
-        config.clock_speed_hz = static_cast<int>(max_speed);
-      }
     }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {

--- a/esphome/components/ssd1306_spi/display.py
+++ b/esphome/components/ssd1306_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1306_base.setup_ssd1306(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1306_spi/display.py
+++ b/esphome/components/ssd1306_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1306_base.setup_ssd1306(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1322_spi/display.py
+++ b/esphome/components/ssd1322_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1322_base.setup_ssd1322(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1322_spi/display.py
+++ b/esphome/components/ssd1322_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1322_base.setup_ssd1322(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1325_base.setup_ssd1325(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1325_base.setup_ssd1325(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1327_spi/display.py
+++ b/esphome/components/ssd1327_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1327_base.setup_ssd1327(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1327_spi/display.py
+++ b/esphome/components/ssd1327_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1327_base.setup_ssd1327(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1331_spi/display.py
+++ b/esphome/components/ssd1331_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1331_base.setup_ssd1331(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1331_spi/display.py
+++ b/esphome/components/ssd1331_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1331_base.setup_ssd1331(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1351_spi/display.py
+++ b/esphome/components/ssd1351_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1351_base.setup_ssd1351(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1351_spi/display.py
+++ b/esphome/components/ssd1351_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1351_base.setup_ssd1351(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7567_spi/display.py
+++ b/esphome/components/st7567_spi/display.py
@@ -32,8 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await st7567_base.setup_st7567(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7567_spi/display.py
+++ b/esphome/components/st7567_spi/display.py
@@ -33,6 +33,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await st7567_base.setup_st7567(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7701s/display.py
+++ b/esphome/components/st7701s/display.py
@@ -173,8 +173,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     sequence = []
     for seq in config[CONF_INIT_SEQUENCE]:

--- a/esphome/components/st7701s/display.py
+++ b/esphome/components/st7701s/display.py
@@ -174,6 +174,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     sequence = []
     for seq in config[CONF_INIT_SEQUENCE]:

--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -100,6 +100,7 @@ async def to_code(config):
     )
     await setup_st7735(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -99,8 +99,7 @@ async def to_code(config):
         config[CONF_INVERT_COLORS],
     )
     await setup_st7735(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -178,6 +178,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     cg.add(var.set_model_str(config[CONF_MODEL]))
 

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -177,8 +177,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     cg.add(var.set_model_str(config[CONF_MODEL]))
 

--- a/esphome/components/st7920/display.py
+++ b/esphome/components/st7920/display.py
@@ -28,8 +28,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/st7920/display.py
+++ b/esphome/components/st7920/display.py
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -239,8 +239,7 @@ async def to_code(config):
         raise NotImplementedError()
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -240,6 +240,7 @@ async def to_code(config):
 
     await display.register_display(var, config)
     await spi.register_spi_device(var, config)
+    cg.add(var.set_write_only(True))
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))


### PR DESCRIPTION
# What does this implement/fix?

Fixes SPI display initialization failures when the SPI bus has a MISO pin configured. This became a widespread issue after #12420 unified ESP32 Arduino to use the ESP-IDF SPI driver, but was actually a long-standing issue for ESP-IDF framework users.

## Background

The ESP-IDF SPI driver has a speed limit for full-duplex mode on GPIO matrix pins (ESP32 original only). When a MISO pin is present on the SPI bus, full-duplex mode is used. Most display components (like ili9xxx) default to 40 MHz, which exceeds the ~26.67 MHz limit.

**Timeline:**
- **ESP-IDF framework**: This issue always existed but affected fewer users
- **Arduino framework (pre-#12420)**: Arduino SPI library silently capped speeds to achievable rates, so 40 MHz requests worked
- **Arduino framework (post-#12420)**: Now uses ESP-IDF driver, exposing the same issue to a much larger user base

When the speed limit is exceeded, `spi_bus_add_device()` fails with:
```
E (43) spi_hal: The clock_speed_hz should less than 26666666
```

The device never gets registered, causing all subsequent SPI transactions to fail. Users see a white screen and the device fails to boot.

## Solution

**Mark all SPI display components as write-only**: Displays don't read data over SPI (busy status is read via separate GPIO pins). Setting `write_only=True` enables half-duplex mode (`SPI_DEVICE_HALFDUPLEX`), which has no speed limit.

## Future Work

This PR originally included fallback speed capping in the SPI driver for devices that don't set write-only mode. This was removed as too risky for a patch release since the speed limit calculation is complex (varies by chip variant, pin configuration, and whether GPIO matrix vs IOMUX is used). A future PR should address this to prevent the issue for external components or other SPI devices that may hit this limit.

## Implementation

Added a `write_only` parameter to `register_spi_device()` in the SPI component to centralize the write-only configuration. Display components now pass `write_only=True` when registering:

```python
await spi.register_spi_device(var, config, write_only=True)
```

Updated 20 display components:
- ili9xxx, epaper_spi, waveshare_epaper
- max7219, max7219digit
- mipi_rgb, mipi_spi, qspi_dbi, st7701s
- pcd8544, st7735, st7789v, st7920
- ssd1306_spi, ssd1322_spi, ssd1325_spi, ssd1327_spi, ssd1331_spi, ssd1351_spi
- st7567_spi

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13418

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes existing configs that broke after 2026.1.0
# Example config that was failing:
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19  # This caused full-duplex mode, triggering the 26MHz limit
  interface: hardware

display:
  - platform: ili9xxx
    model: ili9341
    cs_pin: GPIO5
    dc_pin: GPIO4
    # data_rate defaults to 40MHz, which now works because display uses half-duplex
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)