### PR TITLE
[esp32] Add warning for experimental 400MHz on ESP32-P4

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -182,6 +182,12 @@ def set_core_data(config):
             path=[CONF_CPU_FREQUENCY],
         )
 
+    if variant == VARIANT_ESP32P4 and cpu_frequency == "400MHZ":
+        _LOGGER.warning(
+            "400MHz on ESP32-P4 is experimental and may not boot. "
+            "Consider using 360MHz instead. See https://github.com/esphome/esphome/issues/13425"
+        )
+
     CORE.data[KEY_ESP32] = {}
     CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_ESP32
     conf = config[CONF_FRAMEWORK]


### PR DESCRIPTION
# What does this implement/fix?

Adds a warning when users configure `cpu_frequency: 400MHz` on ESP32-P4 devices, as this setting is experimental and may cause bootloops with certain ESP-IDF versions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13425

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-p4-function-ev-board
  variant: ESP32P4
  cpu_frequency: 400MHz  # Will show warning
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.ai/code)