### PR TITLE
[api] Limit Nagle batching for log messages to reduce LWIP buffer pressure

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1844,23 +1844,8 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
     return false;
   }
 
-  // Toggle Nagle's algorithm based on message type to prevent log messages from
-  // filling the TCP send buffer and crowding out important state updates.
-  //
-  // This honors the `no_delay` proto option - SubscribeLogsResponse is the only
-  // message with `option (no_delay) = false;` in api.proto, indicating it should
-  // allow Nagle coalescing. This option existed since 2019 but was never implemented.
-  //
-  // - Log messages: Enable Nagle (NODELAY=false) so small log packets coalesce
-  //   into fewer, larger packets. They flush naturally via TCP delayed ACK timer
-  //   (~200ms), buffer filling, or when a state update triggers a flush.
-  //
-  // - All other messages (state updates, responses): Disable Nagle (NODELAY=true)
-  //   for immediate delivery. These are time-sensitive and should not be delayed.
-  //
-  // This must be done proactively BEFORE the buffer fills up - checking buffer
-  // state here would be too late since we'd already be in a degraded state.
-  this->helper_->set_nodelay(!is_log_message);
+  // Set TCP_NODELAY based on message type - see set_nodelay_for_message() for details
+  this->helper_->set_nodelay_for_message(is_log_message);
 
   APIError err = this->helper_->write_protobuf_packet(message_type, buffer);
   if (err == APIError::WOULD_BLOCK)

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -143,7 +143,7 @@ class APIFrameHelper {
       return;
     }
 
-    // Log message: -1 -> 1 -> 2 -> -1 (flush)
+    // Log messages 1-3: state transitions -1 -> 1 -> 2 -> -1 (flush on 3rd)
     if (this->nodelay_state_ == NODELAY_ON) {
       this->set_nodelay_raw_(false);
       this->nodelay_state_ = 1;

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -147,7 +147,7 @@ class APIFrameHelper {
     if (this->nodelay_state_ == NODELAY_ON) {
       this->set_nodelay_raw_(false);
       this->nodelay_state_ = 1;
-    } else if (this->nodelay_state_ >= LOG_BATCH_MAX) {
+    } else if (this->nodelay_state_ >= LOG_NAGLE_COUNT) {
       this->set_nodelay_raw_(true);
       this->nodelay_state_ = NODELAY_ON;
     } else {
@@ -244,9 +244,9 @@ class APIFrameHelper {
   uint8_t tx_buf_count_{0};
   // Nagle batching state for log messages. NODELAY_ON (-1) means NODELAY is enabled
   // (immediate send). Values 1-2 count log messages in the current Nagle batch.
-  // After LOG_BATCH_MAX logs, we switch to NODELAY to flush and reset.
+  // After LOG_NAGLE_COUNT logs, we switch to NODELAY to flush and reset.
   static constexpr int8_t NODELAY_ON = -1;
-  static constexpr int8_t LOG_BATCH_MAX = 2;
+  static constexpr int8_t LOG_NAGLE_COUNT = 2;
   int8_t nodelay_state_{NODELAY_ON};
 
   // Internal helper to set TCP_NODELAY socket option

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -120,26 +120,39 @@ class APIFrameHelper {
     }
     return APIError::OK;
   }
-  /// Toggle TCP_NODELAY socket option to control Nagle's algorithm.
-  ///
-  /// This is used to allow log messages to coalesce (Nagle enabled) while keeping
-  /// state updates low-latency (NODELAY enabled). Without this, many small log
-  /// packets fill the TCP send buffer, crowding out important state updates.
-  ///
-  /// State is tracked to minimize setsockopt() overhead - on lwip_raw (ESP8266/RP2040)
-  /// this is just a boolean assignment; on other platforms it's a lightweight syscall.
-  ///
-  /// @param enable true to enable NODELAY (disable Nagle), false to enable Nagle
-  /// @return true if successful or already in desired state
-  bool set_nodelay(bool enable) {
-    if (this->nodelay_enabled_ == enable)
-      return true;
-    int val = enable ? 1 : 0;
-    int err = this->socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
-    if (err == 0) {
-      this->nodelay_enabled_ = enable;
+  // Manage TCP_NODELAY (Nagle's algorithm) based on message type.
+  //
+  // For non-log messages (sensor data, state updates): Always disable Nagle
+  // (NODELAY on) for immediate delivery - these are time-sensitive.
+  //
+  // For log messages: Use Nagle to coalesce multiple small log packets into
+  // fewer larger packets, reducing WiFi overhead. However, we limit batching
+  // to 3 messages to avoid excessive LWIP buffer pressure on memory-constrained
+  // devices like ESP8266. LWIP's TCP_OVERSIZE option coalesces the data into
+  // shared pbufs, but holding data too long waiting for Nagle's timer causes
+  // buffer exhaustion and dropped messages.
+  //
+  // Flow: Log 1 (Nagle on) -> Log 2 (Nagle on) -> Log 3 (NODELAY, flush all)
+  //
+  void set_nodelay_for_message(bool is_log_message) {
+    if (!is_log_message) {
+      if (this->nodelay_state_ != NODELAY_ON) {
+        this->set_nodelay_raw_(true);
+        this->nodelay_state_ = NODELAY_ON;
+      }
+      return;
     }
-    return err == 0;
+
+    // Log message: -1 -> 1 -> 2 -> -1 (flush)
+    if (this->nodelay_state_ == NODELAY_ON) {
+      this->set_nodelay_raw_(false);
+      this->nodelay_state_ = 1;
+    } else if (this->nodelay_state_ >= LOG_BATCH_MAX) {
+      this->set_nodelay_raw_(true);
+      this->nodelay_state_ = NODELAY_ON;
+    } else {
+      this->nodelay_state_++;
+    }
   }
   virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
   // Write multiple protobuf messages in a single operation
@@ -229,10 +242,18 @@ class APIFrameHelper {
   uint8_t tx_buf_head_{0};
   uint8_t tx_buf_tail_{0};
   uint8_t tx_buf_count_{0};
-  // Tracks TCP_NODELAY state to minimize setsockopt() calls. Initialized to true
-  // since init_common_() enables NODELAY. Used by set_nodelay() to allow log
-  // messages to coalesce while keeping state updates low-latency.
-  bool nodelay_enabled_{true};
+  // Nagle batching state for log messages. NODELAY_ON (-1) means NODELAY is enabled
+  // (immediate send). Values 1-2 count log messages in the current Nagle batch.
+  // After LOG_BATCH_MAX logs, we switch to NODELAY to flush and reset.
+  static constexpr int8_t NODELAY_ON = -1;
+  static constexpr int8_t LOG_BATCH_MAX = 2;
+  int8_t nodelay_state_{NODELAY_ON};
+
+  // Internal helper to set TCP_NODELAY socket option
+  void set_nodelay_raw_(bool enable) {
+    int val = enable ? 1 : 0;
+    this->socket_->setsockopt(IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
+  }
 
   // Common initialization for both plaintext and noise protocols
   APIError init_common_();


### PR DESCRIPTION
# What does this implement/fix?

Fixes log message drops on ESP8266 during dump_config by limiting Nagle batching to 3 messages.

This is a follow-up to #13026 which enabled Nagle's algorithm for log messages to coalesce them into fewer packets. That PR was very successful at reducing WiFi radio time and showed significant performance improvements (30% faster average, 43% lower worst-case latency, 28% less CPU time). With unlimited Nagle batching, we achieved ~10x reduction in packets during dump_config. However, this shifted the pressure to LWIP's buffer limits - a classic embedded systems problem where fixing one constraint reveals another.

Before #13026, we had log drops due to WiFi buffer limits - too many small packets saturating the radio. After #13026, we shifted the drops to LWIP buffer limits - data sitting in pbufs waiting for more data or ACKs. ESP8266 only has ~10 pbufs with a ~2920-byte send buffer (`TCP_SND_BUF = 2 * TCP_MSS`). With many log messages queuing up during dump_config, the buffers fill faster than they drain, causing writes to fail with `ERR_MEM` and logs to be dropped.

This PR limits log batching to 3 messages before forcing a flush:
- Log 1: Nagle on (coalesce)
- Log 2: Nagle on (coalesce)
- Log 3: NODELAY on (flush all 3)

This balances two competing goals:
1. **Free up WiFi radio time** by batching logs into fewer packets, leaving more bandwidth for state updates, bluetooth proxy, voice assistant, and camera images to get through
2. **Respect LWIP buffer limits** to reduce how often logs get dropped due to `ERR_MEM`

We still get the benefit from #13026 of preventing the fixed-size send queue (`API_MAX_SEND_QUEUE`, 5 buffers on ESP8266) from filling up and dropping the connection. The 3x packet reduction is enough to keep the queue from backing up under normal logging conditions.

When buffer space runs out, we intentionally drop logs first to avoid OOMing the device or forcing the connection to drop - the pressure has to give somewhere, and logs are the lowest priority. This change reduces how often we hit that limit by not holding data in LWIP buffers as long.

For logging, this PR achieves ~3x reduction in WiFi packets compared to ~10x with the previous unlimited Nagle batching. **This means we give back some of the CPU time and latency improvements from #13026, but the tradeoff is necessary to avoid excessive log drops on memory-constrained devices.**

Non-log messages (sensor data, state updates) always use NODELAY for immediate delivery.

Implementation repurposes the existing `bool nodelay_enabled_` as `int8_t nodelay_state_` to track both the socket state and log message count, so there's no additional memory cost.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13436
- follow-up to #13026

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal implementation detail)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
api:

logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
