### PR TITLE
[mqtt] Add subscribe() overloads to avoid temporary string allocation

### DIFF
--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -15,8 +15,9 @@ using namespace esphome::alarm_control_panel;
 MQTTAlarmControlPanelComponent::MQTTAlarmControlPanelComponent(AlarmControlPanel *alarm_control_panel)
     : alarm_control_panel_(alarm_control_panel) {}
 void MQTTAlarmControlPanelComponent::setup() {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
   this->alarm_control_panel_->add_on_state_callback([this]() { this->publish_state(); });
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     auto call = this->alarm_control_panel_->make_call();
     if (strcasecmp(payload.c_str(), "ARM_AWAY") == 0) {
       call.arm_away();

--- a/esphome/components/mqtt/mqtt_button.cpp
+++ b/esphome/components/mqtt/mqtt_button.cpp
@@ -15,7 +15,8 @@ using namespace esphome::button;
 MQTTButtonComponent::MQTTButtonComponent(button::Button *button) : button_(button) {}
 
 void MQTTButtonComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     if (payload == "PRESS") {
       this->button_->press();
     } else {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -466,6 +466,10 @@ void MQTTClientComponent::resubscribe_subscriptions_() {
 }
 
 void MQTTClientComponent::subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos) {
+  this->subscribe(topic.c_str(), std::move(callback), qos);
+}
+
+void MQTTClientComponent::subscribe(const char *topic, mqtt_callback_t callback, uint8_t qos) {
   MQTTSubscription subscription{
       .topic = topic,
       .qos = qos,
@@ -474,10 +478,14 @@ void MQTTClientComponent::subscribe(const std::string &topic, mqtt_callback_t ca
       .resubscribe_timeout = 0,
   };
   this->resubscribe_subscription_(&subscription);
-  this->subscriptions_.push_back(subscription);
+  this->subscriptions_.push_back(std::move(subscription));
 }
 
 void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos) {
+  this->subscribe_json(topic.c_str(), callback, qos);
+}
+
+void MQTTClientComponent::subscribe_json(const char *topic, const mqtt_json_callback_t &callback, uint8_t qos) {
   auto f = [callback](const std::string &topic, const std::string &payload) {
     json::parse_json(payload, [topic, callback](JsonObject root) -> bool {
       callback(topic, root);
@@ -492,7 +500,7 @@ void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_js
       .resubscribe_timeout = 0,
   };
   this->resubscribe_subscription_(&subscription);
-  this->subscriptions_.push_back(subscription);
+  this->subscriptions_.push_back(std::move(subscription));
 }
 
 void MQTTClientComponent::unsubscribe(const std::string &topic) {

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -478,7 +478,7 @@ void MQTTClientComponent::subscribe(const char *topic, mqtt_callback_t callback,
       .resubscribe_timeout = 0,
   };
   this->resubscribe_subscription_(&subscription);
-  this->subscriptions_.push_back(std::move(subscription));
+  this->subscriptions_.push_back(subscription);
 }
 
 void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos) {
@@ -500,7 +500,7 @@ void MQTTClientComponent::subscribe_json(const char *topic, const mqtt_json_call
       .resubscribe_timeout = 0,
   };
   this->resubscribe_subscription_(&subscription);
-  this->subscriptions_.push_back(std::move(subscription));
+  this->subscriptions_.push_back(subscription);
 }
 
 void MQTTClientComponent::unsubscribe(const std::string &topic) {

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -192,6 +192,9 @@ class MQTTClientComponent : public Component
    */
   void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
 
+  /// Subscribe with const char* topic (avoids temporary std::string allocation)
+  void subscribe(const char *topic, mqtt_callback_t callback, uint8_t qos = 0);
+
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *
    * If an invalid JSON payload is received, the callback will not be called.
@@ -202,6 +205,9 @@ class MQTTClientComponent : public Component
    * @param qos The QoS of this subscription.
    */
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos = 0);
+
+  /// Subscribe JSON with const char* topic (avoids temporary std::string allocation)
+  void subscribe_json(const char *topic, const mqtt_json_callback_t &callback, uint8_t qos = 0);
 
   /** Unsubscribe from an MQTT topic.
    *

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -331,7 +331,15 @@ void MQTTComponent::subscribe(const std::string &topic, mqtt_callback_t callback
   global_mqtt_client->subscribe(topic, std::move(callback), qos);
 }
 
+void MQTTComponent::subscribe(const char *topic, mqtt_callback_t callback, uint8_t qos) {
+  global_mqtt_client->subscribe(topic, std::move(callback), qos);
+}
+
 void MQTTComponent::subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos) {
+  global_mqtt_client->subscribe_json(topic, callback, qos);
+}
+
+void MQTTComponent::subscribe_json(const char *topic, const mqtt_json_callback_t &callback, uint8_t qos) {
   global_mqtt_client->subscribe_json(topic, callback, qos);
 }
 

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -218,6 +218,14 @@ class MQTTComponent : public Component {
    */
   void subscribe(const std::string &topic, mqtt_callback_t callback, uint8_t qos = 0);
 
+  /// Subscribe with const char* topic (avoids temporary std::string allocation)
+  void subscribe(const char *topic, mqtt_callback_t callback, uint8_t qos = 0);
+
+  /// Subscribe with StringRef topic (for use with get_command_topic_to_())
+  void subscribe(StringRef topic, mqtt_callback_t callback, uint8_t qos = 0) {
+    this->subscribe(topic.c_str(), std::move(callback), qos);
+  }
+
   /** Subscribe to a MQTT topic and automatically parse JSON payload.
    *
    * If an invalid JSON payload is received, the callback will not be called.
@@ -228,6 +236,14 @@ class MQTTComponent : public Component {
    * @param qos The MQTT quality of service. Defaults to 0.
    */
   void subscribe_json(const std::string &topic, const mqtt_json_callback_t &callback, uint8_t qos = 0);
+
+  /// Subscribe JSON with const char* topic (avoids temporary std::string allocation)
+  void subscribe_json(const char *topic, const mqtt_json_callback_t &callback, uint8_t qos = 0);
+
+  /// Subscribe JSON with StringRef topic (for use with get_command_topic_to_())
+  void subscribe_json(StringRef topic, const mqtt_json_callback_t &callback, uint8_t qos = 0) {
+    this->subscribe_json(topic.c_str(), callback, qos);
+  }
 
  protected:
   /// Helper method to get the discovery topic for this component.

--- a/esphome/components/mqtt/mqtt_cover.cpp
+++ b/esphome/components/mqtt/mqtt_cover.cpp
@@ -14,9 +14,10 @@ using namespace esphome::cover;
 
 MQTTCoverComponent::MQTTCoverComponent(Cover *cover) : cover_(cover) {}
 void MQTTCoverComponent::setup() {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
   auto traits = this->cover_->get_traits();
   this->cover_->add_on_state_callback([this]() { this->publish_state(); });
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     auto call = this->cover_->make_call();
     call.set_command(payload.c_str());
     call.perform();

--- a/esphome/components/mqtt/mqtt_date.cpp
+++ b/esphome/components/mqtt/mqtt_date.cpp
@@ -17,7 +17,8 @@ using namespace esphome::datetime;
 MQTTDateComponent::MQTTDateComponent(DateEntity *date) : date_(date) {}
 
 void MQTTDateComponent::setup() {
-  this->subscribe_json(this->get_command_topic_(), [this](const std::string &topic, JsonObject root) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe_json(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, JsonObject root) {
     auto call = this->date_->make_call();
     if (root[ESPHOME_F("year")].is<uint16_t>()) {
       call.set_year(root[ESPHOME_F("year")]);

--- a/esphome/components/mqtt/mqtt_datetime.cpp
+++ b/esphome/components/mqtt/mqtt_datetime.cpp
@@ -17,7 +17,8 @@ using namespace esphome::datetime;
 MQTTDateTimeComponent::MQTTDateTimeComponent(DateTimeEntity *datetime) : datetime_(datetime) {}
 
 void MQTTDateTimeComponent::setup() {
-  this->subscribe_json(this->get_command_topic_(), [this](const std::string &topic, JsonObject root) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe_json(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, JsonObject root) {
     auto call = this->datetime_->make_call();
     if (root[ESPHOME_F("year")].is<uint16_t>()) {
       call.set_year(root[ESPHOME_F("year")]);

--- a/esphome/components/mqtt/mqtt_fan.cpp
+++ b/esphome/components/mqtt/mqtt_fan.cpp
@@ -19,7 +19,8 @@ MQTT_COMPONENT_TYPE(MQTTFanComponent, "fan")
 const EntityBase *MQTTFanComponent::get_entity() const { return this->state_; }
 
 void MQTTFanComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     auto val = parse_on_off(payload.c_str());
     switch (val) {
       case PARSE_ON:

--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -18,7 +18,8 @@ MQTT_COMPONENT_TYPE(MQTTJSONLightComponent, "light")
 const EntityBase *MQTTJSONLightComponent::get_entity() const { return this->state_; }
 
 void MQTTJSONLightComponent::setup() {
-  this->subscribe_json(this->get_command_topic_(), [this](const std::string &topic, JsonObject root) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe_json(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, JsonObject root) {
     LightCall call = this->state_->make_call();
     LightJSONSchema::parse_json(*this->state_, call, root);
     call.perform();

--- a/esphome/components/mqtt/mqtt_lock.cpp
+++ b/esphome/components/mqtt/mqtt_lock.cpp
@@ -15,7 +15,8 @@ using namespace esphome::lock;
 MQTTLockComponent::MQTTLockComponent(lock::Lock *a_lock) : lock_(a_lock) {}
 
 void MQTTLockComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     if (strcasecmp(payload.c_str(), "LOCK") == 0) {
       this->lock_->lock();
     } else if (strcasecmp(payload.c_str(), "UNLOCK") == 0) {

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -15,7 +15,8 @@ using namespace esphome::number;
 MQTTNumberComponent::MQTTNumberComponent(Number *number) : number_(number) {}
 
 void MQTTNumberComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &state) {
     auto val = parse_number<float>(state);
     if (!val.has_value()) {
       ESP_LOGW(TAG, "Can't convert '%s' to number!", state.c_str());

--- a/esphome/components/mqtt/mqtt_select.cpp
+++ b/esphome/components/mqtt/mqtt_select.cpp
@@ -15,7 +15,8 @@ using namespace esphome::select;
 MQTTSelectComponent::MQTTSelectComponent(Select *select) : select_(select) {}
 
 void MQTTSelectComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &state) {
     auto call = this->select_->make_call();
     call.set_option(state);
     call.perform();

--- a/esphome/components/mqtt/mqtt_switch.cpp
+++ b/esphome/components/mqtt/mqtt_switch.cpp
@@ -15,7 +15,8 @@ using namespace esphome::switch_;
 MQTTSwitchComponent::MQTTSwitchComponent(switch_::Switch *a_switch) : switch_(a_switch) {}
 
 void MQTTSwitchComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     switch (parse_on_off(payload.c_str())) {
       case PARSE_ON:
         this->switch_->turn_on();

--- a/esphome/components/mqtt/mqtt_text.cpp
+++ b/esphome/components/mqtt/mqtt_text.cpp
@@ -15,7 +15,8 @@ using namespace esphome::text;
 MQTTTextComponent::MQTTTextComponent(Text *text) : text_(text) {}
 
 void MQTTTextComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &state) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &state) {
     auto call = this->text_->make_call();
     call.set_value(state);
     call.perform();

--- a/esphome/components/mqtt/mqtt_time.cpp
+++ b/esphome/components/mqtt/mqtt_time.cpp
@@ -17,7 +17,8 @@ using namespace esphome::datetime;
 MQTTTimeComponent::MQTTTimeComponent(TimeEntity *time) : time_(time) {}
 
 void MQTTTimeComponent::setup() {
-  this->subscribe_json(this->get_command_topic_(), [this](const std::string &topic, JsonObject root) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe_json(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, JsonObject root) {
     auto call = this->time_->make_call();
     if (root[ESPHOME_F("hour")].is<uint8_t>()) {
       call.set_hour(root[ESPHOME_F("hour")]);

--- a/esphome/components/mqtt/mqtt_update.cpp
+++ b/esphome/components/mqtt/mqtt_update.cpp
@@ -15,7 +15,8 @@ using namespace esphome::update;
 MQTTUpdateComponent::MQTTUpdateComponent(UpdateEntity *update) : update_(update) {}
 
 void MQTTUpdateComponent::setup() {
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     if (payload == "INSTALL") {
       this->update_->perform();
     } else {

--- a/esphome/components/mqtt/mqtt_valve.cpp
+++ b/esphome/components/mqtt/mqtt_valve.cpp
@@ -14,9 +14,10 @@ using namespace esphome::valve;
 
 MQTTValveComponent::MQTTValveComponent(Valve *valve) : valve_(valve) {}
 void MQTTValveComponent::setup() {
+  char topic_buf[MQTT_DEFAULT_TOPIC_MAX_LEN];
   auto traits = this->valve_->get_traits();
   this->valve_->add_on_state_callback([this]() { this->publish_state(); });
-  this->subscribe(this->get_command_topic_(), [this](const std::string &topic, const std::string &payload) {
+  this->subscribe(this->get_command_topic_to_(topic_buf), [this](const std::string &topic, const std::string &payload) {
     auto call = this->valve_->make_call();
     call.set_command(payload.c_str());
     call.perform();


### PR DESCRIPTION
# What does this implement/fix?

**Depends on #13434**

Add `const char*` and `StringRef` overloads for `subscribe()` and `subscribe_json()` methods, and update all MQTT components to use `get_command_topic_to_()` with stack buffers instead of `get_command_topic_()` which allocates a temporary `std::string`.

This eliminates one heap allocation per MQTT subscription during `setup()`. While subscriptions only happen once at startup (not in hot paths), this reduces heap fragmentation on memory-constrained devices by avoiding unnecessary temporary string allocations.

**Before (per subscription):**
1. `get_command_topic_()` creates temporary `std::string` (heap alloc step 1)
2. `subscribe(const std::string&)` copies to `MQTTSubscription::topic` (heap alloc step 2)
3. Temporary destroyed

**After (per subscription):**
1. `get_command_topic_to_(buf)` formats into stack buffer (no heap alloc)
2. `subscribe(const char*)` copies to `MQTTSubscription::topic` (heap alloc - 1)

Saves one heap allocation per MQTT entity subscription.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Built on top of #13434

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
