### PR TITLE
[dht] Increase delay for DHT22 and RHT03

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -89,10 +89,8 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(500);
   } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
     delayMicroseconds(2000);
-  } else if (this->model_ == DHT_MODEL_AM2120 || this->model_ == DHT_MODEL_AM2302) {
-    delayMicroseconds(1000);
   } else {
-    delayMicroseconds(800);
+    delayMicroseconds(1000);
   }
 
 #ifdef USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
After #9225 some users have problems with DHT22 sensors no longer reading correctly with `DHT_MODEL_AUTO_DETECT` or `DHT_MODEL_DHT22`.
When the model is switched to `DHT_MODEL_DHT22_TYPE2`or `DHT_MODEL_AM2302`, the sensors start working again.
The datasheet specifies a minimum initial delay of 800µs and a typical delay of 1ms.
Since the PR made the timings more accurate, now some sensors have problems with the minimum delay of 800µs used for DHT22.

```
  if (this->model_ == DHT_MODEL_DHT11) {
    delayMicroseconds(18000);
  } else if (this->model_ == DHT_MODEL_SI7021) {
    delayMicroseconds(500);
  } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
    delayMicroseconds(2000);
  } else if (this->model_ == DHT_MODEL_AM2120 || this->model_ == DHT_MODEL_AM2302) {
    delayMicroseconds(1000);
  } else {
    delayMicroseconds(800);
  }
```

After some research, it turns out DHT22, AM2302 and RHT03 are the same device, so they all should use the recommended 1ms delay.

![](https://www.waveshare.net/w/upload/c/c9/DHT22-Temperature-Humidity-Sensor-User-Manual-4.png)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13421

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: dht
    pin: GPIO4
    temperature:
      name: "T1"
    humidity:
      name: "H1"
    update_interval: 10s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
