### PR TITLE
[fingerprint_grow] Use buffer-based dump_summary to fix deprecation warnings

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -1,4 +1,5 @@
 #include "fingerprint_grow.h"
+#include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
 
@@ -532,14 +533,21 @@ void FingerprintGrowComponent::sensor_sleep_() {
 }
 
 void FingerprintGrowComponent::dump_config() {
+  char sensing_pin_buf[GPIO_SUMMARY_MAX_LEN];
+  char power_pin_buf[GPIO_SUMMARY_MAX_LEN];
+  if (this->has_sensing_pin_) {
+    this->sensing_pin_->dump_summary(sensing_pin_buf, sizeof(sensing_pin_buf));
+  }
+  if (this->has_power_pin_) {
+    this->sensor_power_pin_->dump_summary(power_pin_buf, sizeof(power_pin_buf));
+  }
   ESP_LOGCONFIG(TAG,
                 "GROW_FINGERPRINT_READER:\n"
                 "  System Identifier Code: 0x%.4X\n"
                 "  Touch Sensing Pin: %s\n"
                 "  Sensor Power Pin: %s",
-                this->system_identifier_code_,
-                this->has_sensing_pin_ ? this->sensing_pin_->dump_summary().c_str() : "None",
-                this->has_power_pin_ ? this->sensor_power_pin_->dump_summary().c_str() : "None");
+                this->system_identifier_code_, this->has_sensing_pin_ ? sensing_pin_buf : "None",
+                this->has_power_pin_ ? power_pin_buf : "None");
   if (this->idle_period_to_sleep_ms_ < UINT32_MAX) {
     ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: %" PRIu32 " ms", this->idle_period_to_sleep_ms_);
   } else {


### PR DESCRIPTION
## What does this implement/fix?

Fixes deprecation warnings when compiling the fingerprint_grow component:

```
warning: 'virtual std::string esphome::GPIOPin::dump_summary() const' is deprecated: 
Override dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.
```

## Changes

Migrates from the deprecated `std::string dump_summary()` method to the buffer-based `dump_summary(char*, size_t)` API in `dump_config()`. This:

- Eliminates the deprecation warnings
- Avoids heap allocations by using stack buffers with `GPIO_SUMMARY_MAX_LEN`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13445

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - existing configs work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)