### PR TITLE
[aqi] Remove unit_of_measurement to fix Home Assistant warning

### DIFF
--- a/esphome/components/aqi/sensor.py
+++ b/esphome/components/aqi/sensor.py
@@ -13,14 +13,11 @@ from . import AQI_CALCULATION_TYPE, CONF_CALCULATION_TYPE, aqi_ns
 CODEOWNERS = ["@jasstrong"]
 DEPENDENCIES = ["sensor"]
 
-UNIT_INDEX = "index"
-
 AQISensor = aqi_ns.class_("AQISensor", sensor.Sensor, cg.Component)
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
         AQISensor,
-        unit_of_measurement=UNIT_INDEX,
         accuracy_decimals=0,
         device_class=DEVICE_CLASS_AQI,
         state_class=STATE_CLASS_MEASUREMENT,


### PR DESCRIPTION
## What does this implement/fix?

Fixes Home Assistant warning when using the AQI sensor component:

```
Entity sensor.air_quality_air_quality_index is using native unit of measurement 'index' 
which is not a valid unit for the device class ('aqi') it is using; expected one of 
['no unit of measurement']
```

The `aqi` device class in Home Assistant expects no unit of measurement. Other ESPHome components using `DEVICE_CLASS_AQI` (ens160, sen5x, sgp4x, hm3301) correctly leave the unit empty.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13432

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing documentation changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - existing configs work unchanged
sensor:
  - platform: aqi
    name: "Air Quality Index"
    pm_2_5: pm25
    pm_10_0: pm10
    calculation_type: AQI
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)