### PR TITLE
[wifi] Fix stale error_from_callback_ causing immediate connection failures

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -565,7 +565,6 @@ void WiFiComponent::start() {
 void WiFiComponent::restart_adapter() {
   ESP_LOGW(TAG, "Restarting adapter");
   this->wifi_mode_(false, {});
-  this->error_from_callback_ = false;
 }
 
 void WiFiComponent::loop() {
@@ -618,8 +617,6 @@ void WiFiComponent::loop() {
         if (!this->is_connected()) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
-          // Clear error flag before reconnecting so first attempt is not seen as immediate failure
-          this->error_from_callback_ = false;
           this->retry_connect();
         } else {
           this->status_clear_warning();
@@ -963,6 +960,9 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
   ESP_LOGV(TAG, "  Hidden: %s", YESNO(ap.get_hidden()));
 #endif
 
+  // Clear any stale error from previous connection attempt
+  this->error_from_callback_ = false;
+
   if (!this->wifi_sta_connect_(ap)) {
     ESP_LOGE(TAG, "wifi_sta_connect_ failed");
     // Enter cooldown to allow WiFi hardware to stabilize
@@ -1068,7 +1068,6 @@ void WiFiComponent::enable() {
     return;
 
   ESP_LOGD(TAG, "Enabling");
-  this->error_from_callback_ = false;
   this->state_ = WIFI_COMPONENT_STATE_OFF;
   this->start();
 }
@@ -1329,11 +1328,6 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     // Reset to initial phase on successful connection (don't log transition, just reset state)
     this->retry_phase_ = WiFiRetryPhase::INITIAL_CONNECT;
     this->num_retried_ = 0;
-    // Ensure next connection attempt does not inherit error state
-    // so when WiFi disconnects later we start fresh and don't see
-    // the first connection as a failure.
-    this->error_from_callback_ = false;
-
     if (this->has_ap()) {
 #ifdef USE_CAPTIVE_PORTAL
       if (this->is_captive_portal_active_()) {
@@ -1844,8 +1838,6 @@ void WiFiComponent::retry_connect() {
     this->advance_to_next_target_or_increment_retry_();
   }
 
-  this->error_from_callback_ = false;
-
   yield();
   // Check if we have a valid target before building params
   // After exhausting all networks in a phase, selected_sta_index_ may be -1
@@ -2171,7 +2163,6 @@ void WiFiComponent::process_roaming_scan_() {
   this->roaming_state_ = RoamingState::CONNECTING;
 
   // Connect directly - wifi_sta_connect_ handles disconnect internally
-  this->error_from_callback_ = false;
   this->start_connecting(roam_params);
 }
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -565,6 +565,12 @@ void WiFiComponent::start() {
 void WiFiComponent::restart_adapter() {
   ESP_LOGW(TAG, "Restarting adapter");
   this->wifi_mode_(false, {});
+  // Clear error flag here because restart_adapter() enters COOLDOWN state,
+  // and check_connecting_finished() is called after cooldown without going
+  // through start_connecting() first. Without this clear, stale errors would
+  // trigger spurious "failed (callback)" logs. The canonical clear location
+  // is in start_connecting(); this is the only exception to that pattern.
+  this->error_from_callback_ = false;
 }
 
 void WiFiComponent::loop() {
@@ -960,7 +966,10 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
   ESP_LOGV(TAG, "  Hidden: %s", YESNO(ap.get_hidden()));
 #endif
 
-  // Clear any stale error from previous connection attempt
+  // Clear any stale error from previous connection attempt.
+  // This is the canonical location for clearing the flag since all connection
+  // attempts go through start_connecting(). The only other clear is in
+  // restart_adapter() which enters COOLDOWN without calling start_connecting().
   this->error_from_callback_ = false;
 
   if (!this->wifi_sta_connect_(ap)) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes WiFi connection failures caused by stale `error_from_callback_` state affecting new connection attempts.

## Problem

When a WiFi disconnect event occurs, `error_from_callback_` is set to `true`. This flag was supposed to be cleared before each new connection attempt. The original design (2020) cleared it only in `retry_connect()`, which worked when that was the only path to starting a connection.

Over time, as new entry points were added (enable, restart_adapter, roaming, direct calls from loop), each new path needed its own clear. This resulted in **symptom chasing** across multiple PRs:

| PR | Date | Location Added | Symptom Being Fixed | Status |
|----|------|----------------|---------------------|--------|
| #504 | 2020 | `retry_connect()` | Original implementation | Removed |
| #4810 | Nov 2022 | `enable()` | WiFi disable/enable feature | Removed |
| #11851 | Nov 2025 | `restart_adapter()` | Scan failures after adapter restart | **Kept** (needed) |
| #11873 | Nov 2025 | `loop()` + `check_connecting_finished()` | Slow reconnection after connection loss | Removed |
| #12809 | Dec 2025 | `process_roaming_scan_()` | Roaming support | Removed |

Each fix addressed symptoms rather than the root cause: **the clear should have been in `start_connecting()` from the beginning**, since that's where connections actually begin. The `restart_adapter()` clear is kept because it enters COOLDOWN without going through `start_connecting()`.

The bug in #13443 is yet another symptom: `retry_connect()` returns early when `transition_to_phase_()` starts a scan, skipping the `error_from_callback_ = false`. This caused stale errors from previous connection attempts to immediately fail new connections (6ms failure in logs - physically impossible for real WiFi auth failure).

**Note:** This is not a regression introduced in 2026.1.0. The bug has existed since the original design - timing changes in 2026.1.0 simply made it more likely to manifest. The issue could occur in any version when the right sequence of events happened.

## Evidence from Logs

**Example 1 (from #13443):** Connection fails in 6ms - physically impossible for real WiFi auth:
```
[16:05:35.850] Connecting to ... (attempt 1/2 in phase SCAN_CONNECTING)...
[16:05:35.856] Connecting to network failed (callback)   ← 6ms later, stale flag
```

**Example 2:** Genuine handshake failure followed by stale flag failure:
```
[20:45:09] Connecting to ... (attempt 1/1 in phase INITIAL_CONNECT)...
[20:45:26] Disconnected ... reason='Handshake Failed'     ← REAL failure after 17s, sets error_from_callback_=true
[20:45:26] Connecting to network failed (callback)
[20:45:26] Starting scan                                  ← transition_to_phase_() returns early, flag NOT cleared
[20:45:35] Found networks:
[20:45:35] Connecting to ... (attempt 1/2 in phase SCAN_CONNECTING)...
[20:45:35] Connecting to network failed (callback)        ← INSTANT failure (0 seconds!) from stale flag
```

In Example 2, the first failure was genuine (router handshake issue after 17 seconds). But the retry after scan fails **instantly** (same second) because the stale `error_from_callback_` wasn't cleared when the scan started.

## What This Fix Does and Does Not Do

**This fix addresses:**
- Stale `error_from_callback_` causing instant false failures after scans
- Retry attempts being wasted on stale state instead of actually attempting connection
- The specific pattern where connections fail in milliseconds (impossible for real WiFi)

**User-visible improvement:** WiFi connects faster because attempt 1 after a scan actually attempts to connect instead of instantly failing from a stale flag. Previously, the first real connection attempt was often attempt 2.

**This fix does NOT address:**
- Genuine WiFi authentication failures (Handshake Failed, Auth Leave, etc.)
- Router compatibility issues
- Signal strength problems

Users experiencing genuine auth failures (like the 17-second failure in Example 2) may still have connection issues, but at least the retry logic will now actually attempt to reconnect instead of instantly failing from stale state.

## How to Tell the Difference

| Failure Type | Time After Connect | Cause | This PR Fixes? |
|--------------|-------------------|-------|----------------|
| Instant (0-6ms) | < 100ms | Stale `error_from_callback_` flag | **Yes** |
| Real auth failure | 10+ seconds | Genuine WiFi/router issue | No |

## For Users with Genuine Auth Failures

If you see failures after 10+ seconds with reasons like "Handshake Failed", "Auth Leave", or "Authentication Failed", this PR will help ensure retries actually attempt to connect, but you may also need to:

1. **Reboot your WiFi AP** - Routers can have stale connection state for devices that were previously connected
2. **Check router firmware** - Some routers have known issues with ESP32 devices
3. **Try ESP-IDF 5.5.1** - Testing shows ESP-IDF 5.5.2 may have a separate WiFi driver issue where "there is no waiting time at all for connection to be established". Users can try:
   ```yaml
   esp32:
     framework:
       type: esp-idf
       version: 5.5.1
   ```

**Note:** This PR fixes the stale `error_from_callback_` bug, but ESP-IDF 5.5.2 appears to have additional WiFi timing issues that this PR cannot address. If you still have problems after this PR, try downgrading to ESP-IDF 5.5.1.

## Solution

Move `error_from_callback_ = false` to two well-documented locations:

1. **`start_connecting()`** - The canonical location. All connection attempts go through this function, so clearing here covers all normal code paths.

2. **`restart_adapter()`** - Exception to the pattern. This function enters COOLDOWN state directly without attempting a connection:
   ```
   disconnect event → error_from_callback_=true → restart_adapter() → COOLDOWN
       → cooldown expires → check_connecting_finished() → sees stale flag → spurious "failed" log
   ```
   Since `check_connecting_finished()` is called after cooldown without going through `start_connecting()` first, we must clear the flag in `restart_adapter()` to prevent spurious "Connecting to network failed (callback)" logs.

This consolidation:
1. Fixes the stale flag bug identified in #13443 (but does not resolve the ESP-IDF 5.5.2 compatibility issue)
2. Removes 5 redundant clears from other locations
3. Prevents future bugs from new code paths that call `start_connecting()`
4. Makes the code easier to reason about with clear documentation of the two clear locations

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13443

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a bugfix for existing behavior
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  fast_connect: true  # Configuration from issue reporter
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

