### PR TITLE
[time] Always call time sync callbacks even when time unchanged

### DIFF
--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -40,6 +40,9 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
     // Unsigned subtraction handles wraparound correctly, then cast to signed
     int32_t diff = static_cast<int32_t>(epoch - static_cast<uint32_t>(current_time));
     if (diff >= -1 && diff <= 1) {
+      // Time is already synchronized, but still call callbacks so components
+      // waiting for time sync (e.g., uptime timestamp sensor) can initialize
+      this->time_sync_callback_.call();
       return;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced in #13253 where the uptime timestamp sensor reports unavailable (NA) after upgrading to 2026.1.0.

## Root Cause

In #13253, an optimization was added to `RealTimeClock::synchronize_epoch_()` to skip redundant time updates when the incoming epoch is within 1 second of the current system time. This prevents unnecessary writes and log spam.

However, when this early return is taken, the `time_sync_callback_.call()` was being skipped entirely. Components like the uptime timestamp sensor register a callback via `add_on_time_sync_callback()` to know when time has been synchronized, so they can publish their initial state:

```cpp
// uptime_timestamp_sensor.cpp
void UptimeTimestampSensor::setup() {
  this->time_->add_on_time_sync_callback([this]() {
    if (this->has_state())
      return;  // No need to update the timestamp if it's already set
    // ... calculate and publish timestamp
  });
}
```

When the system already has valid time (e.g., from RTC memory, previous SNTP sync, or another time source), and `synchronize_epoch_()` is called with a time within 1 second of the current time, the function returned early without calling the callbacks. This left the uptime timestamp sensor in an uninitialized state, showing "unavailable" in Home Assistant and the web server.

## Why This Was Missed

The original testing for #13253 was done via serial flash with the device unplugged between tests. Each boot started with invalid time, so the early return path was never taken and callbacks were always called.

With OTA updates (the common upgrade path for users), the device maintains power and retains its system time. When the time source (e.g., Home Assistant) sends a time sync after OTA, the time difference is within 1 second, triggering the early return and skipping the callbacks.

## Fix

Call `time_sync_callback_.call()` before the early return. The callbacks should be invoked whenever time synchronization is confirmed, regardless of whether the actual system time was updated. This is semantically correct because:

1. Time IS synchronized (confirmed to be accurate)
2. Components waiting for "time is ready" need to be notified
3. The callbacks already guard against duplicate processing (e.g., `if (this->has_state()) return;`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13444

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: homeassistant
    id: ha_time

sensor:
  - platform: uptime
    type: timestamp
    name: Uptime
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
