### PR TITLE
[sensor] Clamp filter handles non-finite values better

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -445,22 +445,18 @@ optional<float> CalibratePolynomialFilter::new_value(float value) {
 ClampFilter::ClampFilter(float min, float max, bool ignore_out_of_range)
     : min_(min), max_(max), ignore_out_of_range_(ignore_out_of_range) {}
 optional<float> ClampFilter::new_value(float value) {
-  if (std::isfinite(value)) {
-    if (std::isfinite(this->min_) && value < this->min_) {
-      if (this->ignore_out_of_range_) {
-        return {};
-      } else {
-        return this->min_;
-      }
+  if (std::isfinite(this->min_) && !(value >= this->min_)) {
+    if (this->ignore_out_of_range_) {
+      return {};
     }
+    return this->min_;
+  }
 
-    if (std::isfinite(this->max_) && value > this->max_) {
-      if (this->ignore_out_of_range_) {
-        return {};
-      } else {
-        return this->max_;
-      }
+  if (std::isfinite(this->max_) && !(value <= this->max_)) {
+    if (this->ignore_out_of_range_) {
+      return {};
     }
+    return this->max_;
   }
   return value;
 }

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -117,7 +117,7 @@ sensor:
             - 10.0 -> 12.1
             - 13.0 -> 14.0
       - clamp:
-          # Infinity will be clamped to 10.0
+          # Infinity and NaN will be clamped (NaN -> min_value, +Infinity -> max_value, -Infinity -> min_value)
           max_value: 10.0
           min_value: -10.0
       - debounce: 0.1s

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -117,6 +117,7 @@ sensor:
             - 10.0 -> 12.1
             - 13.0 -> 14.0
       - clamp:
+          # Infinity will be clamped to 10.0
           max_value: 10.0
           min_value: -10.0
       - debounce: 0.1s


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The `clamp` sensor filter currently passes through non-finite values unchanged. This is clearly wrong for positive and negative infinity which should be clamped.

Also now clamp NaN to the lower bound if present, otherwise the upper bound.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5966
## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  platform: template
  id: sensor_id
  filters:
    - clamp:
        min_value: 0
        max_value: 10
  on_value:
    logger.log:
      format: "value %f"
      args: [x]

interval:
  - interval: 5s
    then:
      - lambda: id(sensor_id).publish_state(1.0);
      - delay: 2s
      - lambda: id(sensor_id).publish_state(NAN);
      - delay: 2s
      - lambda: id(sensor_id).publish_state(INFINITY);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
