### PR TITLE
2026.1.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.1.0
+PROJECT_NUMBER         = 2026.1.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1844,23 +1844,8 @@ bool APIConnection::send_buffer(ProtoWriteBuffer buffer, uint8_t message_type) {
     return false;
   }
 
-  // Toggle Nagle's algorithm based on message type to prevent log messages from
-  // filling the TCP send buffer and crowding out important state updates.
-  //
-  // This honors the `no_delay` proto option - SubscribeLogsResponse is the only
-  // message with `option (no_delay) = false;` in api.proto, indicating it should
-  // allow Nagle coalescing. This option existed since 2019 but was never implemented.
-  //
-  // - Log messages: Enable Nagle (NODELAY=false) so small log packets coalesce
-  //   into fewer, larger packets. They flush naturally via TCP delayed ACK timer
-  //   (~200ms), buffer filling, or when a state update triggers a flush.
-  //
-  // - All other messages (state updates, responses): Disable Nagle (NODELAY=true)
-  //   for immediate delivery. These are time-sensitive and should not be delayed.
-  //
-  // This must be done proactively BEFORE the buffer fills up - checking buffer
-  // state here would be too late since we'd already be in a degraded state.
-  this->helper_->set_nodelay(!is_log_message);
+  // Set TCP_NODELAY based on message type - see set_nodelay_for_message() for details
+  this->helper_->set_nodelay_for_message(is_log_message);
 
   APIError err = this->helper_->write_protobuf_packet(message_type, buffer);
   if (err == APIError::WOULD_BLOCK)

--- a/esphome/components/aqi/sensor.py
+++ b/esphome/components/aqi/sensor.py
@@ -13,14 +13,11 @@ from . import AQI_CALCULATION_TYPE, CONF_CALCULATION_TYPE, aqi_ns
 CODEOWNERS = ["@jasstrong"]
 DEPENDENCIES = ["sensor"]
 
-UNIT_INDEX = "index"
-
 AQISensor = aqi_ns.class_("AQISensor", sensor.Sensor, cg.Component)
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
         AQISensor,
-        unit_of_measurement=UNIT_INDEX,
         accuracy_decimals=0,
         device_class=DEVICE_CLASS_AQI,
         state_class=STATE_CLASS_MEASUREMENT,

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -89,10 +89,8 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     delayMicroseconds(500);
   } else if (this->model_ == DHT_MODEL_DHT22_TYPE2) {
     delayMicroseconds(2000);
-  } else if (this->model_ == DHT_MODEL_AM2120 || this->model_ == DHT_MODEL_AM2302) {
-    delayMicroseconds(1000);
   } else {
-    delayMicroseconds(800);
+    delayMicroseconds(1000);
   }
 
 #ifdef USE_ESP32

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -190,7 +190,7 @@ async def to_code(config):
     # Rotation is handled by setting the transform
     display_config = {k: v for k, v in config.items() if k != CONF_ROTATION}
     await display.register_display(var, display_config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -180,6 +180,12 @@ def set_core_data(config):
             path=[CONF_CPU_FREQUENCY],
         )
 
+    if variant == VARIANT_ESP32P4 and cpu_frequency == "400MHZ":
+        _LOGGER.warning(
+            "400MHz on ESP32-P4 is experimental and may not boot. "
+            "Consider using 360MHz instead. See https://github.com/esphome/esphome/issues/13425"
+        )
+
     CORE.data[KEY_ESP32] = {}
     CORE.data[KEY_CORE][KEY_TARGET_PLATFORM] = PLATFORM_ESP32
     conf = config[CONF_FRAMEWORK]

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -1,4 +1,5 @@
 #include "fingerprint_grow.h"
+#include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 #include <cinttypes>
 
@@ -532,14 +533,21 @@ void FingerprintGrowComponent::sensor_sleep_() {
 }
 
 void FingerprintGrowComponent::dump_config() {
+  char sensing_pin_buf[GPIO_SUMMARY_MAX_LEN];
+  char power_pin_buf[GPIO_SUMMARY_MAX_LEN];
+  if (this->has_sensing_pin_) {
+    this->sensing_pin_->dump_summary(sensing_pin_buf, sizeof(sensing_pin_buf));
+  }
+  if (this->has_power_pin_) {
+    this->sensor_power_pin_->dump_summary(power_pin_buf, sizeof(power_pin_buf));
+  }
   ESP_LOGCONFIG(TAG,
                 "GROW_FINGERPRINT_READER:\n"
                 "  System Identifier Code: 0x%.4X\n"
                 "  Touch Sensing Pin: %s\n"
                 "  Sensor Power Pin: %s",
-                this->system_identifier_code_,
-                this->has_sensing_pin_ ? this->sensing_pin_->dump_summary().c_str() : "None",
-                this->has_power_pin_ ? this->sensor_power_pin_->dump_summary().c_str() : "None");
+                this->system_identifier_code_, this->has_sensing_pin_ ? sensing_pin_buf : "None",
+                this->has_power_pin_ ? power_pin_buf : "None");
   if (this->idle_period_to_sleep_ms_ < UINT32_MAX) {
     ESP_LOGCONFIG(TAG, "  Idle Period to Sleep: %" PRIu32 " ms", this->idle_period_to_sleep_ms_);
   } else {

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -157,6 +157,7 @@ async def to_code(config):
     if CORE.is_esp32:
         cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
         cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
+        cg.add(var.set_verify_ssl(config[CONF_VERIFY_SSL]))
 
         if config.get(CONF_VERIFY_SSL):
             esp32.add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   config.max_redirection_count = this->redirect_limit_;
   config.auth_type = HTTP_AUTH_TYPE_BASIC;
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
-  if (secure) {
+  if (secure && this->verify_ssl_) {
     config.crt_bundle_attach = esp_crt_bundle_attach;
   }
 #endif

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -34,6 +34,7 @@ class HttpRequestIDF : public HttpRequestComponent {
 
   void set_buffer_size_rx(uint16_t buffer_size_rx) { this->buffer_size_rx_ = buffer_size_rx; }
   void set_buffer_size_tx(uint16_t buffer_size_tx) { this->buffer_size_tx_ = buffer_size_tx; }
+  void set_verify_ssl(bool verify_ssl) { this->verify_ssl_ = verify_ssl; }
 
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
@@ -42,6 +43,7 @@ class HttpRequestIDF : public HttpRequestComponent {
   // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
   uint16_t buffer_size_rx_{};
   uint16_t buffer_size_tx_{};
+  bool verify_ssl_{true};
 
   /// @brief Monitors the http client events to gather response headers
   static esp_err_t http_event_handler(esp_http_client_event_t *evt);

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -223,7 +223,7 @@ async def to_code(config):
     var = cg.Pvariable(config[CONF_ID], rhs)
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))
     if init_sequences := config.get(CONF_INIT_SEQUENCE):

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -86,7 +86,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
     cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))

--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -260,7 +260,7 @@ async def to_code(config):
         cg.add(var.set_enable_pins(enable))
 
     if CONF_SPI_ID in config:
-        await spi.register_spi_device(var, config)
+        await spi.register_spi_device(var, config, write_only=True)
         sequence, madctl = model.get_sequence(config)
         cg.add(var.set_init_sequence(sequence))
         cg.add(var.set_madctl(madctl))

--- a/esphome/components/mipi_spi/display.py
+++ b/esphome/components/mipi_spi/display.py
@@ -443,6 +443,4 @@ async def to_code(config):
         )
         cg.add(var.set_writer(lambda_))
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
-    # Displays are write-only, set the SPI device to write-only as well
-    cg.add(var.set_write_only(True))
+    await spi.register_spi_device(var, config, write_only=True)

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -44,7 +44,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/qspi_dbi/display.py
+++ b/esphome/components/qspi_dbi/display.py
@@ -161,7 +161,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     chip = DriverChip.chips[config[CONF_MODEL]]
     if chip.initsequence:

--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -39,6 +39,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core", "@clydebarrow"]
 spi_ns = cg.esphome_ns.namespace("spi")
@@ -448,9 +449,13 @@ def spi_device_schema(
     )
 
 
-async def register_spi_device(var, config):
+async def register_spi_device(
+    var: cg.Pvariable, config: ConfigType, write_only: bool = False
+) -> None:
     parent = await cg.get_variable(config[CONF_SPI_ID])
     cg.add(var.set_spi_parent(parent))
+    if write_only:
+        cg.add(var.set_write_only(True))
     if cs_pin := config.get(CONF_CS_PIN):
         pin = await cg.gpio_pin_expression(cs_pin)
         cg.add(var.set_cs_pin(pin))

--- a/esphome/components/spi/spi_esp_idf.cpp
+++ b/esphome/components/spi/spi_esp_idf.cpp
@@ -195,8 +195,11 @@ class SPIDelegateHw : public SPIDelegate {
     config.post_cb = nullptr;
     if (this->bit_order_ == BIT_ORDER_LSB_FIRST)
       config.flags |= SPI_DEVICE_BIT_LSBFIRST;
-    if (this->write_only_)
+    if (this->write_only_) {
       config.flags |= SPI_DEVICE_HALFDUPLEX | SPI_DEVICE_NO_DUMMY;
+      ESP_LOGD(TAG, "SPI device with CS pin %d using half-duplex mode (write-only)",
+               Utility::get_pin_no(this->cs_pin_));
+    }
     esp_err_t const err = spi_bus_add_device(this->channel_, &config, &this->handle_);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Add device failed - err %X", err);

--- a/esphome/components/ssd1306_spi/display.py
+++ b/esphome/components/ssd1306_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1306_base.setup_ssd1306(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1322_spi/display.py
+++ b/esphome/components/ssd1322_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1322_base.setup_ssd1322(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1325_spi/display.py
+++ b/esphome/components/ssd1325_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1325_base.setup_ssd1325(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1327_spi/display.py
+++ b/esphome/components/ssd1327_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1327_base.setup_ssd1327(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1331_spi/display.py
+++ b/esphome/components/ssd1331_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1331_base.setup_ssd1331(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/ssd1351_spi/display.py
+++ b/esphome/components/ssd1351_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await ssd1351_base.setup_ssd1351(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7567_spi/display.py
+++ b/esphome/components/st7567_spi/display.py
@@ -32,7 +32,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await st7567_base.setup_st7567(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7701s/display.py
+++ b/esphome/components/st7701s/display.py
@@ -173,7 +173,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     sequence = []
     for seq in config[CONF_INIT_SEQUENCE]:

--- a/esphome/components/st7735/display.py
+++ b/esphome/components/st7735/display.py
@@ -99,7 +99,7 @@ async def to_code(config):
         config[CONF_INVERT_COLORS],
     )
     await setup_st7735(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -177,7 +177,7 @@ FINAL_VALIDATE_SCHEMA = spi.final_validate_device_schema(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     cg.add(var.set_model_str(config[CONF_MODEL]))
 

--- a/esphome/components/st7920/display.py
+++ b/esphome/components/st7920/display.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     if CONF_LAMBDA in config:
         lambda_ = await cg.process_lambda(

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -40,6 +40,9 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
     // Unsigned subtraction handles wraparound correctly, then cast to signed
     int32_t diff = static_cast<int32_t>(epoch - static_cast<uint32_t>(current_time));
     if (diff >= -1 && diff <= 1) {
+      // Time is already synchronized, but still call callbacks so components
+      // waiting for time sync (e.g., uptime timestamp sensor) can initialize
+      this->time_sync_callback_.call();
       return;
     }
   }

--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -239,7 +239,7 @@ async def to_code(config):
         raise NotImplementedError()
 
     await display.register_display(var, config)
-    await spi.register_spi_device(var, config)
+    await spi.register_spi_device(var, config, write_only=True)
 
     dc = await cg.gpio_pin_expression(config[CONF_DC_PIN])
     cg.add(var.set_dc_pin(dc))

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -460,13 +460,15 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
         listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
       }
 #endif
-      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
-#if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
+      // For static IP configurations, GOT_IP event may not fire, so set connected state here
+#ifdef USE_WIFI_MANUAL_IP
       if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
         s_sta_state = LTWiFiSTAState::CONNECTED;
+#ifdef USE_WIFI_IP_STATE_LISTENERS
         for (auto *listener : this->ip_state_listeners_) {
           listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
         }
+#endif
       }
 #endif
       break;

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.1.0"
+__version__ = "2026.1.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [wifi] Process scan results one at a time to avoid heap allocation [esphome#13400](https://github.com/esphome/esphome/pull/13400)
- [lvgl] Validate LVGL dropdown symbols require Unicode codepoint ≥ 0x100 [esphome#13394](https://github.com/esphome/esphome/pull/13394)
- [http_request] Fix verify_ssl: false not working on ESP32 [esphome#13422](https://github.com/esphome/esphome/pull/13422)
- [esp32] Add warning for experimental 400MHz on ESP32-P4 [esphome#13433](https://github.com/esphome/esphome/pull/13433)
- [wifi] Fix bk72xx manual_ip preventing API connection [esphome#13426](https://github.com/esphome/esphome/pull/13426)
- [spi] Fix display init failure by marking displays as write-only for half-duplex mode [esphome#13431](https://github.com/esphome/esphome/pull/13431)
- [http_request] Fix OTA failures on ESP8266/Arduino by making read semantics consistent [esphome#13435](https://github.com/esphome/esphome/pull/13435)
- [dht] Increase delay for DHT22 and RHT03 [esphome#13446](https://github.com/esphome/esphome/pull/13446)
- [api] Limit Nagle batching for log messages to reduce LWIP buffer pressure [esphome#13439](https://github.com/esphome/esphome/pull/13439)
- [wifi] Fix stale error_from_callback_ causing immediate connection failures [esphome#13450](https://github.com/esphome/esphome/pull/13450)
- [fingerprint_grow] Use buffer-based dump_summary to fix deprecation warnings [esphome#13447](https://github.com/esphome/esphome/pull/13447)
- [aqi] Remove unit_of_measurement to fix Home Assistant warning [esphome#13448](https://github.com/esphome/esphome/pull/13448)
- [time] Always call time sync callbacks even when time unchanged [esphome#13456](https://github.com/esphome/esphome/pull/13456)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
