### PR TITLE
[slow_pwm] Fix dump_summary deprecation warning

### DIFF
--- a/esphome/components/slow_pwm/slow_pwm_output.cpp
+++ b/esphome/components/slow_pwm/slow_pwm_output.cpp
@@ -1,6 +1,7 @@
 #include "slow_pwm_output.h"
-#include "esphome/core/log.h"
 #include "esphome/core/application.h"
+#include "esphome/core/gpio.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace slow_pwm {
@@ -20,7 +21,9 @@ void SlowPWMOutput::set_output_state_(bool new_state) {
   }
   if (new_state != current_state_) {
     if (this->pin_) {
-      ESP_LOGV(TAG, "Switching output pin %s to %s", this->pin_->dump_summary().c_str(), ONOFF(new_state));
+      char pin_summary[GPIO_SUMMARY_MAX_LEN];
+      this->pin_->dump_summary(pin_summary, sizeof(pin_summary));
+      ESP_LOGV(TAG, "Switching output pin %s to %s", pin_summary, ONOFF(new_state));
     } else {
       ESP_LOGV(TAG, "Switching to %s", ONOFF(new_state));
     }


### PR DESCRIPTION
# What does this implement/fix?

Fixes deprecation warnings when compiling the slow_pwm component:

```
warning: 'virtual std::string esphome::GPIOPin::dump_summary() const' is deprecated:
Override dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.
```

Migrates from the deprecated `std::string dump_summary()` method to the buffer-based `dump_summary(char*, size_t)` API using a stack buffer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/13445 (similar deprecation warning fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - existing configs work unchanged
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
