### PR TITLE
[st7701s] Fix dump_summary deprecation warning

### DIFF
--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_ESP32_VARIANT_ESP32S3
 #include "st7701s.h"
+#include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 
 namespace esphome {
@@ -183,8 +184,11 @@ void ST7701S::dump_config() {
   LOG_PIN("  DE Pin: ", this->de_pin_);
   LOG_PIN("  Reset Pin: ", this->reset_pin_);
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
-  for (size_t i = 0; i != data_pin_count; i++)
-    ESP_LOGCONFIG(TAG, "  Data pin %d: %s", i, (this->data_pins_[i])->dump_summary().c_str());
+  char pin_summary[GPIO_SUMMARY_MAX_LEN];
+  for (size_t i = 0; i != data_pin_count; i++) {
+    this->data_pins_[i]->dump_summary(pin_summary, sizeof(pin_summary));
+    ESP_LOGCONFIG(TAG, "  Data pin %d: %s", i, pin_summary);
+  }
   ESP_LOGCONFIG(TAG, "  SPI Data rate: %dMHz", (unsigned) (this->data_rate_ / 1000000));
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes deprecation warnings when compiling the st7701s component:

```
warning: 'virtual std::string esphome::GPIOPin::dump_summary() const' is deprecated:
Override dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.
```

Migrates from the deprecated `std::string dump_summary()` method to the buffer-based `dump_summary(char*, size_t)` API using a stack buffer in `dump_config()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/13445 (similar deprecation warning fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - existing configs work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
