### PR TITLE
[atm90e32] Fix dump_summary deprecation warning and remove stored cs_summary_

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -108,10 +108,14 @@ void ATM90E32Component::update() {
 #endif
 }
 
+void ATM90E32Component::get_cs_summary_(std::span<char, GPIO_SUMMARY_MAX_LEN> buffer) {
+  this->cs_->dump_summary(buffer.data(), buffer.size());
+}
+
 void ATM90E32Component::setup() {
   this->spi_setup();
-  this->cs_summary_ = this->cs_->dump_summary();
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
 
   uint16_t mmode0 = 0x87;  // 3P4W 50Hz
   uint16_t high_thresh = 0;
@@ -159,13 +163,13 @@ void ATM90E32Component::setup() {
   if (this->enable_offset_calibration_) {
     // Initialize flash storage for offset calibrations
     uint32_t o_hash = fnv1_hash("_offset_calibration_");
-    o_hash = fnv1_hash_extend(o_hash, this->cs_summary_);
+    o_hash = fnv1_hash_extend(o_hash, cs);
     this->offset_pref_ = global_preferences->make_preference<OffsetCalibration[3]>(o_hash, true);
     this->restore_offset_calibrations_();
 
     // Initialize flash storage for power offset calibrations
     uint32_t po_hash = fnv1_hash("_power_offset_calibration_");
-    po_hash = fnv1_hash_extend(po_hash, this->cs_summary_);
+    po_hash = fnv1_hash_extend(po_hash, cs);
     this->power_offset_pref_ = global_preferences->make_preference<PowerOffsetCalibration[3]>(po_hash, true);
     this->restore_power_offset_calibrations_();
   } else {
@@ -186,7 +190,7 @@ void ATM90E32Component::setup() {
   if (this->enable_gain_calibration_) {
     // Initialize flash storage for gain calibration
     uint32_t g_hash = fnv1_hash("_gain_calibration_");
-    g_hash = fnv1_hash_extend(g_hash, this->cs_summary_);
+    g_hash = fnv1_hash_extend(g_hash, cs);
     this->gain_calibration_pref_ = global_preferences->make_preference<GainCalibration[3]>(g_hash, true);
     this->restore_gain_calibrations_();
 
@@ -217,7 +221,8 @@ void ATM90E32Component::setup() {
 }
 
 void ATM90E32Component::log_calibration_status_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
 
   bool offset_mismatch = false;
   bool power_mismatch = false;
@@ -568,7 +573,8 @@ float ATM90E32Component::get_chip_temperature_() {
 }
 
 void ATM90E32Component::run_gain_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->enable_gain_calibration_) {
     ESP_LOGW(TAG, "[CALIBRATION][%s] Gain calibration is disabled! Enable it first with enable_gain_calibration: true",
              cs);
@@ -668,7 +674,8 @@ void ATM90E32Component::run_gain_calibrations() {
 }
 
 void ATM90E32Component::save_gain_calibration_to_memory_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   bool success = this->gain_calibration_pref_.save(&this->gain_phase_);
   global_preferences->sync();
   if (success) {
@@ -681,7 +688,8 @@ void ATM90E32Component::save_gain_calibration_to_memory_() {
 }
 
 void ATM90E32Component::save_offset_calibration_to_memory_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   bool success = this->offset_pref_.save(&this->offset_phase_);
   global_preferences->sync();
   if (success) {
@@ -697,7 +705,8 @@ void ATM90E32Component::save_offset_calibration_to_memory_() {
 }
 
 void ATM90E32Component::save_power_offset_calibration_to_memory_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   bool success = this->power_offset_pref_.save(&this->power_offset_phase_);
   global_preferences->sync();
   if (success) {
@@ -713,7 +722,8 @@ void ATM90E32Component::save_power_offset_calibration_to_memory_() {
 }
 
 void ATM90E32Component::run_offset_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->enable_offset_calibration_) {
     ESP_LOGW(TAG,
              "[CALIBRATION][%s] Offset calibration is disabled! Enable it first with enable_offset_calibration: true",
@@ -743,7 +753,8 @@ void ATM90E32Component::run_offset_calibrations() {
 }
 
 void ATM90E32Component::run_power_offset_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->enable_offset_calibration_) {
     ESP_LOGW(
         TAG,
@@ -816,7 +827,8 @@ void ATM90E32Component::write_power_offsets_to_registers_(uint8_t phase, int16_t
 }
 
 void ATM90E32Component::restore_gain_calibrations_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   for (uint8_t i = 0; i < 3; ++i) {
     this->config_gain_phase_[i].voltage_gain = this->phase_[i].voltage_gain_;
     this->config_gain_phase_[i].current_gain = this->phase_[i].ct_gain_;
@@ -870,7 +882,8 @@ void ATM90E32Component::restore_gain_calibrations_() {
 }
 
 void ATM90E32Component::restore_offset_calibrations_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   for (uint8_t i = 0; i < 3; ++i)
     this->config_offset_phase_[i] = this->offset_phase_[i];
 
@@ -912,7 +925,8 @@ void ATM90E32Component::restore_offset_calibrations_() {
 }
 
 void ATM90E32Component::restore_power_offset_calibrations_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   for (uint8_t i = 0; i < 3; ++i)
     this->config_power_offset_phase_[i] = this->power_offset_phase_[i];
 
@@ -954,7 +968,8 @@ void ATM90E32Component::restore_power_offset_calibrations_() {
 }
 
 void ATM90E32Component::clear_gain_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->using_saved_calibrations_) {
     ESP_LOGI(TAG, "[CALIBRATION][%s] No stored gain calibrations to clear. Current values:", cs);
     ESP_LOGI(TAG, "[CALIBRATION][%s] ----------------------------------------------------------", cs);
@@ -1003,7 +1018,8 @@ void ATM90E32Component::clear_gain_calibrations() {
 }
 
 void ATM90E32Component::clear_offset_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->restored_offset_calibration_) {
     ESP_LOGI(TAG, "[CALIBRATION][%s] No stored offset calibrations to clear. Current values:", cs);
     ESP_LOGI(TAG, "[CALIBRATION][%s] --------------------------------------------------------------", cs);
@@ -1045,7 +1061,8 @@ void ATM90E32Component::clear_offset_calibrations() {
 }
 
 void ATM90E32Component::clear_power_offset_calibrations() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   if (!this->restored_power_offset_calibration_) {
     ESP_LOGI(TAG, "[CALIBRATION][%s] No stored power offsets to clear. Current values:", cs);
     ESP_LOGI(TAG, "[CALIBRATION][%s] ---------------------------------------------------------------------", cs);
@@ -1120,7 +1137,8 @@ int16_t ATM90E32Component::calibrate_power_offset(uint8_t phase, bool reactive) 
 }
 
 bool ATM90E32Component::verify_gain_writes_() {
-  const char *cs = this->cs_summary_.c_str();
+  char cs[GPIO_SUMMARY_MAX_LEN];
+  this->get_cs_summary_(cs);
   bool success = true;
   for (uint8_t phase = 0; phase < 3; phase++) {
     uint16_t read_voltage = this->read16_(voltage_gain_registers[phase]);

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <span>
 #include <unordered_map>
 #include "atm90e32_reg.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/spi/spi.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
+#include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
@@ -182,6 +184,7 @@ class ATM90E32Component : public PollingComponent,
   bool verify_gain_writes_();
   bool validate_spi_read_(uint16_t expected, const char *context = nullptr);
   void log_calibration_status_();
+  void get_cs_summary_(std::span<char, GPIO_SUMMARY_MAX_LEN> buffer);
 
   struct ATM90E32Phase {
     uint16_t voltage_gain_{0};
@@ -247,7 +250,6 @@ class ATM90E32Component : public PollingComponent,
   ESPPreferenceObject offset_pref_;
   ESPPreferenceObject power_offset_pref_;
   ESPPreferenceObject gain_calibration_pref_;
-  std::string cs_summary_;
 
   sensor::Sensor *freq_sensor_{nullptr};
 #ifdef USE_TEXT_SENSOR


### PR DESCRIPTION
# What does this implement/fix?

Fixes deprecation warnings when compiling the atm90e32 component:

```
warning: 'virtual std::string esphome::GPIOPin::dump_summary() const' is deprecated:
Override dump_summary(char*, size_t) instead. Will be removed in 2026.7.0.
```

## Changes

- Migrates from the deprecated `std::string dump_summary()` method to the buffer-based `dump_summary(char*, size_t)` API
- Removes the `std::string cs_summary_` member variable that was permanently storing the CS pin summary
- Adds a `get_cs_summary_()` helper method that generates the summary on demand into a stack buffer
- Each function that needs the CS summary now uses a local stack buffer

This saves RAM by not permanently storing the pin summary string, since it's only used for logging and one-time preference hashing.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/13445 (similar deprecation warning fix)

fixes #13668

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - existing configs work unchanged
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
