### PR TITLE
[wifi] Avoid heap allocation when building AP SSID

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -748,28 +748,28 @@ void WiFiComponent::setup_ap_config_() {
   if (this->ap_.get_ssid().empty()) {
     // Build AP SSID from app name without heap allocation
     // WiFi SSID max is 32 bytes, with MAC suffix we keep first 25 + last 7
-    static constexpr size_t MAX_SSID_LEN = 32;
-    static constexpr size_t PREFIX_LEN = 25;
-    static constexpr size_t SUFFIX_LEN = 7;
+    static constexpr size_t AP_SSID_MAX_LEN = 32;
+    static constexpr size_t AP_SSID_PREFIX_LEN = 25;
+    static constexpr size_t AP_SSID_SUFFIX_LEN = 7;
 
     const std::string &app_name = App.get_name();
     const char *name_ptr = app_name.c_str();
     size_t name_len = app_name.length();
 
-    if (name_len <= MAX_SSID_LEN) {
+    if (name_len <= AP_SSID_MAX_LEN) {
       // Name fits, use directly
       this->ap_.set_ssid(name_ptr);
     } else {
       // Name too long, need to truncate into stack buffer
-      char ssid_buf[MAX_SSID_LEN + 1];
+      char ssid_buf[AP_SSID_MAX_LEN + 1];
       if (App.is_name_add_mac_suffix_enabled()) {
         // Keep first 25 chars and last 7 chars (MAC suffix), remove middle
-        memcpy(ssid_buf, name_ptr, PREFIX_LEN);
-        memcpy(ssid_buf + PREFIX_LEN, name_ptr + name_len - SUFFIX_LEN, SUFFIX_LEN);
+        memcpy(ssid_buf, name_ptr, AP_SSID_PREFIX_LEN);
+        memcpy(ssid_buf + AP_SSID_PREFIX_LEN, name_ptr + name_len - AP_SSID_SUFFIX_LEN, AP_SSID_SUFFIX_LEN);
       } else {
-        memcpy(ssid_buf, name_ptr, MAX_SSID_LEN);
+        memcpy(ssid_buf, name_ptr, AP_SSID_MAX_LEN);
       }
-      ssid_buf[MAX_SSID_LEN] = '\0';
+      ssid_buf[AP_SSID_MAX_LEN] = '\0';
       this->ap_.set_ssid(ssid_buf);
     }
   }

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -746,16 +746,32 @@ void WiFiComponent::setup_ap_config_() {
     return;
 
   if (this->ap_.get_ssid().empty()) {
-    std::string name = App.get_name();
-    if (name.length() > 32) {
+    // Build AP SSID from app name without heap allocation
+    // WiFi SSID max is 32 bytes, with MAC suffix we keep first 25 + last 7
+    static constexpr size_t max_ssid_len = 32;
+    static constexpr size_t prefix_len = 25;
+    static constexpr size_t suffix_len = 7;
+
+    const std::string &app_name = App.get_name();
+    const char *name_ptr = app_name.c_str();
+    size_t name_len = app_name.length();
+
+    if (name_len <= max_ssid_len) {
+      // Name fits, use directly
+      this->ap_.set_ssid(name_ptr);
+    } else {
+      // Name too long, need to truncate into stack buffer
+      char ssid_buf[max_ssid_len + 1];
       if (App.is_name_add_mac_suffix_enabled()) {
         // Keep first 25 chars and last 7 chars (MAC suffix), remove middle
-        name.erase(25, name.length() - 32);
+        memcpy(ssid_buf, name_ptr, prefix_len);
+        memcpy(ssid_buf + prefix_len, name_ptr + name_len - suffix_len, suffix_len);
       } else {
-        name.resize(32);
+        memcpy(ssid_buf, name_ptr, max_ssid_len);
       }
+      ssid_buf[max_ssid_len] = '\0';
+      this->ap_.set_ssid(ssid_buf);
     }
-    this->ap_.set_ssid(name);
   }
   this->ap_setup_ = this->wifi_start_ap_(this->ap_);
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -748,28 +748,28 @@ void WiFiComponent::setup_ap_config_() {
   if (this->ap_.get_ssid().empty()) {
     // Build AP SSID from app name without heap allocation
     // WiFi SSID max is 32 bytes, with MAC suffix we keep first 25 + last 7
-    static constexpr size_t max_ssid_len = 32;
-    static constexpr size_t prefix_len = 25;
-    static constexpr size_t suffix_len = 7;
+    static constexpr size_t MAX_SSID_LEN = 32;
+    static constexpr size_t PREFIX_LEN = 25;
+    static constexpr size_t SUFFIX_LEN = 7;
 
     const std::string &app_name = App.get_name();
     const char *name_ptr = app_name.c_str();
     size_t name_len = app_name.length();
 
-    if (name_len <= max_ssid_len) {
+    if (name_len <= MAX_SSID_LEN) {
       // Name fits, use directly
       this->ap_.set_ssid(name_ptr);
     } else {
       // Name too long, need to truncate into stack buffer
-      char ssid_buf[max_ssid_len + 1];
+      char ssid_buf[MAX_SSID_LEN + 1];
       if (App.is_name_add_mac_suffix_enabled()) {
         // Keep first 25 chars and last 7 chars (MAC suffix), remove middle
-        memcpy(ssid_buf, name_ptr, prefix_len);
-        memcpy(ssid_buf + prefix_len, name_ptr + name_len - suffix_len, suffix_len);
+        memcpy(ssid_buf, name_ptr, PREFIX_LEN);
+        memcpy(ssid_buf + PREFIX_LEN, name_ptr + name_len - SUFFIX_LEN, SUFFIX_LEN);
       } else {
-        memcpy(ssid_buf, name_ptr, max_ssid_len);
+        memcpy(ssid_buf, name_ptr, MAX_SSID_LEN);
       }
-      ssid_buf[max_ssid_len] = '\0';
+      ssid_buf[MAX_SSID_LEN] = '\0';
       this->ap_.set_ssid(ssid_buf);
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap allocation when building the WiFi AP SSID from the app name in `setup_ap_config_()`.

Previously, the code copied `App.get_name()` into a new `std::string`, then used `erase()` or `resize()` to truncate it. This caused unnecessary heap allocation during AP fallback mode setup.

The new implementation:
- Uses the existing `const std::string &` reference from `App.get_name()` directly
- Only creates a stack buffer when truncation is actually needed (name > 32 chars)
- Uses `memcpy` to build the truncated SSID without heap allocation

**Before:**
```cpp
std::string name = App.get_name();  // heap allocation
if (name.length() > 32) {
  if (App.is_name_add_mac_suffix_enabled()) {
    name.erase(25, name.length() - 32);  // potential reallocation
  } else {
    name.resize(32);  // potential reallocation
  }
}
this->ap_.set_ssid(name);
```

**After:**
```cpp
static constexpr size_t MAX_SSID_LEN = 32;
static constexpr size_t PREFIX_LEN = 25;
static constexpr size_t SUFFIX_LEN = 7;

const std::string &app_name = App.get_name();  // no copy
const char *name_ptr = app_name.c_str();
size_t name_len = app_name.length();

if (name_len <= MAX_SSID_LEN) {
  this->ap_.set_ssid(name_ptr);  // use directly
} else {
  char ssid_buf[MAX_SSID_LEN + 1];  // stack buffer
  // ... memcpy truncation logic ...
  this->ap_.set_ssid(ssid_buf);
}
```

**Savings (ESP8266):**
- RAM: 36 bytes
- Flash: 412 bytes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal optimization
# The AP SSID truncation behavior is unchanged

wifi:
  ap:
    # AP SSID defaults to device name, truncated to 32 chars if needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
