### PR TITLE
[thermostat] change comparison as the thermostat should disengage and…

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -1060,11 +1060,11 @@ bool ThermostatClimate::cooling_required_() {
   auto temperature = this->supports_two_points_ ? this->target_temperature_high : this->target_temperature;
 
   if (this->supports_cool_) {
-    if (this->current_temperature > temperature + this->cooling_deadband_) {
-      // if the current temperature exceeds the target + deadband, cooling is required
+    if (this->current_temperature >= temperature + this->cooling_deadband_) {
+      // if the current temperature reaches or exceeds the target + deadband, cooling is required
       return true;
-    } else if (this->current_temperature < temperature - this->cooling_overrun_) {
-      // if the current temperature is less than the target - overrun, cooling should stop
+    } else if (this->current_temperature <= temperature - this->cooling_overrun_) {
+      // if the current temperature is less than or equal to the target - overrun, cooling should stop
       return false;
     } else {
       // if we get here, the current temperature is between target + deadband and target - overrun,
@@ -1081,11 +1081,11 @@ bool ThermostatClimate::fanning_required_() {
 
   if (this->supports_fan_only_) {
     if (this->supports_fan_only_cooling_) {
-      if (this->current_temperature > temperature + this->cooling_deadband_) {
-        // if the current temperature exceeds the target + deadband, fanning is required
+      if (this->current_temperature >= temperature + this->cooling_deadband_) {
+        // if the current temperature reaches or exceeds the target + deadband, fanning is required
         return true;
-      } else if (this->current_temperature < temperature - this->cooling_overrun_) {
-        // if the current temperature is less than the target - overrun, fanning should stop
+      } else if (this->current_temperature <= temperature - this->cooling_overrun_) {
+        // if the current temperature is less than or equal to the target - overrun, fanning should stop
         return false;
       } else {
         // if we get here, the current temperature is between target + deadband and target - overrun,
@@ -1103,11 +1103,12 @@ bool ThermostatClimate::heating_required_() {
   auto temperature = this->supports_two_points_ ? this->target_temperature_low : this->target_temperature;
 
   if (this->supports_heat_) {
-    if (this->current_temperature < temperature - this->heating_deadband_) {
-      // if the current temperature is below the target - deadband, heating is required
+    if (this->current_temperature <= temperature - this->heating_deadband_) {
+      // if the current temperature is below or equal to the target - deadband, heating is required
       return true;
-    } else if (this->current_temperature > temperature + this->heating_overrun_) {
-      // if the current temperature is above the target + overrun, heating should stop
+    } else if (this->current_temperature >= temperature + this->heating_overrun_) {
+      // if the current temperature is above or equal to the target + overrun, heating should stop
+
       return false;
     } else {
       // if we get here, the current temperature is between target - deadband and target + overrun,


### PR DESCRIPTION
… engage immediately if the temperature is reached

# What does this implement/fix?

According to the thermostat documentation under https://esphome.io/components/climate/thermostat/#controller-behavior-and-hysteresis, the cool_deadband, cool_overrun, heat_deadband and heat_overrun shall be the minimum differential to trigger disengaging/engaging.
Currently, the it's triggered when the differential is exceeded. The PR changes this behaviour so that the disengaging/engaging is triggered if it's equal or higher/less.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
