### PR TITLE
Improve support for updating lvgl arcs (rotation, start_angle, end_angle)

### DIFF
--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -43,6 +43,9 @@ ARC_SCHEMA = cv.Schema(
 ARC_MODIFY_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_VALUE): lv_float,
+        cv.Optional(CONF_ROTATION): lv_angle_degrees,
+        cv.Optional(CONF_START_ANGLE): lv_angle_degrees,
+        cv.Optional(CONF_END_ANGLE): lv_angle_degrees,
     }
 )
 
@@ -62,13 +65,22 @@ class ArcType(NumberType):
             max_value = await lv_int.process(config[CONF_MAX_VALUE])
             min_value = await lv_int.process(config[CONF_MIN_VALUE])
             lv.arc_set_range(w.obj, min_value, max_value)
-            start = await lv_angle_degrees.process(config[CONF_START_ANGLE])
-            end = await lv_angle_degrees.process(config[CONF_END_ANGLE])
-            rotation = await lv_angle_degrees.process(config[CONF_ROTATION])
-            lv.arc_set_bg_angles(w.obj, start, end)
-            lv.arc_set_rotation(w.obj, rotation)
             lv.arc_set_mode(w.obj, literal(config[CONF_MODE]))
             lv.arc_set_change_rate(w.obj, config[CONF_CHANGE_RATE])
+
+        start_angle = CONF_START_ANGLE in config
+        end_angle = CONF_END_ANGLE in config
+
+        if start_angle or end_angle:
+            if not start_angle or not end_angle:
+                raise cv.Invalid("start_angle and end_angle must be specified together for update")
+            start = await lv_angle_degrees.process(config[CONF_START_ANGLE])
+            end = await lv_angle_degrees.process(config[CONF_END_ANGLE])
+            lv.arc_set_bg_angles(w.obj, start, end)
+
+        if CONF_ROTATION in config:
+            rotation = await lv_angle_degrees.process(config[CONF_ROTATION])
+            lv.arc_set_rotation(w.obj, rotation)
 
         if CONF_ADJUSTABLE in config:
             if not config[CONF_ADJUSTABLE]:


### PR DESCRIPTION
# What does this implement/fix?

Allows the use of `rotation`, `start_angle` and `end_angle` properties in `lvgl.arc.update` actions. This was discussed [here](https://community.home-assistant.io/t/esphome-lvgl-widget-arc-update-problem/845590)

Previously these were only supported when defining arc widgets.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
            - lvgl.arc.update:
                id: hvac_temp_knob
                start_angle: 180
                end_angle: 0
                rotation: 90
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

The documentation already seems to imply that these properties are supported in `lvgl.arc.update`.