### PR TITLE
[modbus_controller] Fix YAML serialization error with custom_command

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -279,7 +279,7 @@ def modbus_calc_properties(config):
             if isinstance(value, str):
                 value = value.encode()
             config[CONF_ADDRESS] = binascii.crc_hqx(value, 0)
-        config[CONF_REGISTER_TYPE] = ModbusRegisterType.CUSTOM
+        config[CONF_REGISTER_TYPE] = cv.enum(MODBUS_REGISTER_TYPE)("custom")
         config[CONF_FORCE_NEW_RANGE] = True
     return byte_offset, reg_count
 


### PR DESCRIPTION
## What does this implement/fix?

Fixes a regression introduced in ESPHome 2026.1.0 where Modbus RTU configurations using `custom_command` fail to compile with the error:

```
yaml.representer.RepresenterError: ('cannot represent an object', MockObj<modbus_controller::ModbusRegisterType::CUSTOM>)
```

## Root Cause

In `modbus_calc_properties()`, the register type was being set directly to a `MockObj`:

```python
config[CONF_REGISTER_TYPE] = ModbusRegisterType.CUSTOM
```

This worked previously because the config dictionary was never serialized to YAML. However, PR #12425 (Add Build Info to Image) introduced config hash calculation which serializes the config to YAML, exposing this latent bug.

## Solution

Use `cv.enum()` to create a proper `EnumValue` object:

```python
config[CONF_REGISTER_TYPE] = cv.enum(MODBUS_REGISTER_TYPE)("custom")
```

This creates an object that:
- Serializes as the string `"custom"` for YAML (fixing the config hash)
- Provides the `MockObj` via `.enum_value` attribute for code generation

## Test plan

- [ ] Compile a Modbus RTU configuration using `custom_command`
- [ ] Verify the config hash is computed without errors
- [ ] Verify the generated C++ code is correct

Fixes #13478

🤖 Generated with [Claude Code](https://claude.ai/code)