### PR TITLE
[i2c] Increase ESP-IDF I2C transaction timeout from 20ms to 100ms

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -185,7 +185,7 @@ ErrorCode IDFI2CBus::write_readv(uint8_t address, const uint8_t *write_buffer, s
   }
   jobs[num_jobs++].command = I2C_MASTER_CMD_STOP;
   ESP_LOGV(TAG, "Sending %zu jobs", num_jobs);
-  esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 1000);
+  esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 100);
   if (err == ESP_ERR_INVALID_STATE) {
     ESP_LOGV(TAG, "TX to %02X failed: not acked", address);
     return ERROR_NOT_ACKNOWLEDGED;

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -185,7 +185,7 @@ ErrorCode IDFI2CBus::write_readv(uint8_t address, const uint8_t *write_buffer, s
   }
   jobs[num_jobs++].command = I2C_MASTER_CMD_STOP;
   ESP_LOGV(TAG, "Sending %zu jobs", num_jobs);
-  esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 20);
+  esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 1000);
   if (err == ESP_ERR_INVALID_STATE) {
     ESP_LOGV(TAG, "TX to %02X failed: not acked", address);
     return ERROR_NOT_ACKNOWLEDGED;


### PR DESCRIPTION
## What does this implement/fix?

Fixes a regression where I2C transactions timeout on slow buses or with large transfers.

## Root Cause

PR #12076 switched ESP32 Arduino builds to use the ESP-IDF I2C driver. The driver has a hardcoded 20ms software timeout for transactions:

```cpp
esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 20);
```

This timeout is the FreeRTOS semaphore wait time - how long to wait for the transaction to complete. It's separate from the hardware `scl_wait_us` timeout which handles clock stretching.

## The Problem

At slow I2C speeds, large transfers exceed 20ms:

| Speed | 48-byte read time | 20ms timeout |
|-------|-------------------|--------------|
| 100kHz | ~4.3ms | ✓ OK |
| 50kHz | ~8.6ms | ✓ OK |
| 10kHz | ~43ms | ✗ TIMEOUT |

The SEN5X sensor reads a 48-byte product name during initialization. Users with 10kHz I2C (valid but slow) see:
- Serial number read (9 bytes, ~8ms) succeeds
- Product name read (48 bytes, ~43ms) times out

## Solution

Increase the software timeout from 20ms to 100ms. This provides headroom for:
- Slow bus speeds (down to ~1kHz theoretical)
- Large transfers
- Clock stretching delays

The hardware `scl_wait_us` timeout still handles actual bus errors.

## Test plan

- [ ] Test SEN5X sensor at 10kHz I2C speed
- [ ] Test normal I2C operation at default 50kHz
- [ ] Verify stuck transactions still timeout (within 1s)

Fixes #13477

🤖 Generated with [Claude Code](https://claude.ai/code)