### PR TITLE
[web_server] Add legacy_id to SSE events for third-party integration compatibility

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -533,6 +533,17 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const char *prefix, J
 
   root[ESPHOME_F("id")] = id_buf;
 
+  // Add legacy_id for backward compatibility with third-party integrations
+  // Old format: {prefix}-{object_id} (e.g., "cover-garage_door")
+  // Remove before 2026.7.0 when object_id support is fully removed
+  char legacy_buf[ESPHOME_DOMAIN_MAX_LEN + 1 + OBJECT_ID_MAX_LEN];
+  char *lp = legacy_buf;
+  memcpy(lp, prefix, prefix_len);
+  lp += prefix_len;
+  *lp++ = '-';
+  obj->write_object_id_to(lp, sizeof(legacy_buf) - (lp - legacy_buf));
+  root[ESPHOME_F("legacy_id")] = legacy_buf;
+
   if (start_config == DETAIL_ALL) {
     root[ESPHOME_F("domain")] = prefix;
     root[ESPHOME_F("name")] = name;


### PR DESCRIPTION
# What does this implement/fix?

Adds a `legacy_id` field to all SSE (Server-Sent Events) JSON payloads for backward compatibility with third-party integrations that rely on the old entity ID format.

## Background

PR #12627 changed the entity ID format in SSE payloads from the old `{domain}-{object_id}` format to the new `{domain}/{name}` format:

| Field | Old Format (2025.12) | New Format (2026.1) |
|-------|---------------------|---------------------|
| `id` | `cover-garage_door` | `cover/Garage Door` |

While the REST API URLs have backward compatibility (old object_id URLs still work with deprecation warning until 2026.7.0), the SSE event `id` field changed immediately, breaking third-party integrations that parse these events.

**Note:** Since 2026.1.0 has already shipped, reverting the `id` field format would break devices that have already updated. The web server frontend is cloud-served and cannot serve version-specific builds to different ESPHome versions. Adding `legacy_id` alongside the existing `id` provides a migration path for affected third-party integrations without disrupting users on the new format.

This affects integrations like:
- Control4 drivers (via Chowmain)
- Other third-party REST/SSE integrations

## Solution

Add a `legacy_id` field containing the old format alongside the new `id` field in all SSE JSON payloads:

```json
{
  "id": "cover/Garage Door",
  "legacy_id": "cover-garage_door",
  "state": "OPEN",
  ...
}
```

Third-party integrations can use `legacy_id` during the migration period, then switch to the new `id` format before 2026.7.0 when object_id support is fully removed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses third-party integration breakage reported after #12627
- Related to https://github.com/esphome/backlog/issues/76

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal compatibility field, will be removed in 2026.7.0)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - legacy_id is automatically included in SSE payloads

web_server:
  port: 80

cover:
  - platform: template
    name: "Garage Door"
    # SSE payload will include:
    # "id": "cover/Garage Door"
    # "legacy_id": "cover-garage_door"
```

## SSE Payload Example

**Before this PR:**
```json
{"id":"cover/Garage Door","state":"OPEN","current_operation":"IDLE","position":100}
```

**After this PR:**
```json
{"id":"cover/Garage Door","legacy_id":"cover-garage_door","state":"OPEN","current_operation":"IDLE","position":100}
```

## Migration Path for Third-Party Integrations

1. **Immediate**: Use `legacy_id` field if present, fall back to `id`
2. **Before 2026.7.0**: Migrate to using the new `id` format (`{domain}/{name}`)
3. **2026.7.0**: `legacy_id` field will be removed along with all object_id support

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
