### PR TITLE
[light] Fix cwww state restore

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -391,7 +391,10 @@ void LightCall::transform_parameters_() {
       min_mireds > 0.0f && max_mireds > 0.0f) {
     ESP_LOGD(TAG, "'%s': setting cold/warm white channels using white/color temperature values",
              this->parent_->get_name().c_str());
-    if (this->has_color_temperature()) {
+    // Only compute cold_white/warm_white from color_temperature if they're not already explicitly set.
+    // This is important for state restoration, where both color_temperature and cold_white/warm_white
+    // are restored from flash - we want to preserve the saved cold_white/warm_white values.
+    if (this->has_color_temperature() && !this->has_cold_white() && !this->has_warm_white()) {
       const float color_temp = clamp(this->color_temperature_, min_mireds, max_mireds);
       const float range = max_mireds - min_mireds;
       const float ww_fraction = (color_temp - min_mireds) / range;


### PR DESCRIPTION
# What does this implement/fix?

## Problem

The `cold_white` (and `warm_white`) values were not being restored correctly at boot for lights using `COLD_WARM_WHITE` color mode.

**Root Cause**: In `light_call.cpp`, the `transform_parameters_()` function is designed to convert `color_temperature` to `cold_white`/`warm_white` values for CWWW lights. However, during state restoration at boot:

1. All saved values are restored: `color_temperature`, `cold_white`, and `warm_white`
2. The `transform_parameters_()` function sees that `color_temperature` is set
3. It unconditionally **overwrites** the explicitly restored `cold_white` and `warm_white` values with new values computed from `color_temperature`

This is problematic because:
- The saved `cold_white`/`warm_white` values represent the actual state the user wanted
- The saved `color_temperature` might be stale or derived, not reflecting the true cold/warm white balance
- The transformation destroys the correct saved values

## Fix

Added a condition to skip the `color_temperature` → `cold_white`/`warm_white` transformation when `cold_white` and `warm_white` are already explicitly set:

```cpp
// Before:
if (this->has_color_temperature()) {

// After:  
if (this->has_color_temperature() && !this->has_cold_white() && !this->has_warm_white()) {
```

This ensures:
1. **During restore**: The saved `cold_white`/`warm_white` values are preserved (since they're explicitly set before validation)
2. **Normal API calls**: When Home Assistant sends only `color_temperature` (without explicit `cold_white`/`warm_white`), the transformation still works as expected


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
