### PR TITLE
[lvgl] Fix setting empty text

### DIFF
--- a/esphome/components/lvgl/widgets/label.py
+++ b/esphome/components/lvgl/widgets/label.py
@@ -32,7 +32,7 @@ class LabelType(WidgetType):
 
     async def to_code(self, w: Widget, config):
         """For a text object, create and set text"""
-        if value := config.get(CONF_TEXT):
+        if (value := config.get(CONF_TEXT)) is not None:
             await w.set_property(CONF_TEXT, await lv_text.process(value))
         await w.set_property(CONF_LONG_MODE, config)
         await w.set_property(CONF_RECOLOR, config)

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -197,6 +197,9 @@ lvgl:
         - lvgl.label.update:
             id: msgbox_label
             text: Unloaded
+        - lvgl.label.update:
+            id: msgbox_label
+            text: "" # Empty text
       on_all_events:
         logger.log:
           format: "Event %s"


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Using the `lvgl.label.update` action with an empty text string has no effect - this has been a bug present since the initial implementation!!


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
