### PR TITLE
[rd03d] Fix speed and resolution field order

### DIFF
--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -133,14 +133,17 @@ void RD03DComponent::process_frame_() {
     uint8_t offset = FRAME_HEADER_SIZE + (i * TARGET_DATA_SIZE);
 
     // Extract raw bytes for this target
+    // Note: Despite datasheet Table 5-2 showing order as X, Y, Speed, Resolution,
+    // actual radar output has Resolution before Speed (verified empirically -
+    // stationary targets were showing non-zero speed with original field order)
     uint8_t x_low = this->buffer_[offset + 0];
     uint8_t x_high = this->buffer_[offset + 1];
     uint8_t y_low = this->buffer_[offset + 2];
     uint8_t y_high = this->buffer_[offset + 3];
-    uint8_t speed_low = this->buffer_[offset + 4];
-    uint8_t speed_high = this->buffer_[offset + 5];
-    uint8_t res_low = this->buffer_[offset + 6];
-    uint8_t res_high = this->buffer_[offset + 7];
+    uint8_t res_low = this->buffer_[offset + 4];
+    uint8_t res_high = this->buffer_[offset + 5];
+    uint8_t speed_low = this->buffer_[offset + 6];
+    uint8_t speed_high = this->buffer_[offset + 7];
 
     // Decode values per RD-03D format
     int16_t x = decode_value(x_low, x_high);


### PR DESCRIPTION
  # What does this implement/fix?

  Fixes rd03d radar showing incorrect speed and target detection since 2026.1.1 release.

  The RD-03D datasheet (Table 5-2) documents the per-target field order as: X, Y, Speed, Resolution. However, empirical testing shows the actual radar output has Resolution before Speed.

  With the original field order, stationary targets were incorrectly reporting constant high speed values (~2500 mm/s) while moving targets showed ~0 speed - the exact opposite of expected FMCW radar behavior.

  ## Types of changes

  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Developer breaking change (an API change that could break external components)
  - [ ] Code quality improvements to existing code or addition of tests
  - [ ] Other

  **Related issue or feature (if applicable):**

  - fixes https://github.com/esphome/esphome/issues/13484

  **Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

  - N/A

  ## Test Environment

  - [ ] ESP32
  - [ ] ESP32 IDF
  - [x] ESP8266
  - [ ] RP2040
  - [ ] BK72xx
  - [ ] RTL87xx
  - [ ] LN882x
  - [ ] nRF52840

  ## Example entry for `config.yaml`:

  ```yaml
  # Example config.yaml - no changes needed, existing rd03d configs work
```

  Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under tests/ folder).

  If user exposed functionality or configuration variables are added/changed:
  (n/a) Documentation added/updated in https://github.com/esphome/esphome-docs.

  Then click "Create pull request".