### PR TITLE
[sensirion_common] Use SmallBufferWithHeapFallback helper

### DIFF
--- a/esphome/components/sensirion_common/i2c_sensirion.cpp
+++ b/esphome/components/sensirion_common/i2c_sensirion.cpp
@@ -39,18 +39,9 @@ bool SensirionI2CDevice::read_data(uint16_t *data, const uint8_t len) {
  */
 bool SensirionI2CDevice::write_command_(uint16_t command, CommandLen command_len, const uint16_t *data,
                                         const uint8_t data_len) {
-  uint8_t temp_stack[BUFFER_STACK_SIZE];
-  std::unique_ptr<uint8_t[]> temp_heap;
-  uint8_t *temp;
   size_t required_buffer_len = data_len * 3 + 2;
-
-  // Is a dynamic allocation required ?
-  if (required_buffer_len >= BUFFER_STACK_SIZE) {
-    temp_heap = std::unique_ptr<uint8_t[]>(new uint8_t[required_buffer_len]);
-    temp = temp_heap.get();
-  } else {
-    temp = temp_stack;
-  }
+  SmallBufferWithHeapFallback<BUFFER_STACK_SIZE> buffer(required_buffer_len);
+  uint8_t *temp = buffer.get();
   // First byte or word is the command
   uint8_t raw_idx = 0;
   if (command_len == 1) {


### PR DESCRIPTION
# What does this implement/fix?

Replace the manual stack-with-heap-fallback implementation in `write_command_` with the `SmallBufferWithHeapFallback` helper from `helpers.h`.

Before:
```cpp
uint8_t temp_stack[BUFFER_STACK_SIZE];
std::unique_ptr<uint8_t[]> temp_heap;
uint8_t *temp;
size_t required_buffer_len = data_len * 3 + 2;

// Is a dynamic allocation required ?
if (required_buffer_len >= BUFFER_STACK_SIZE) {
  temp_heap = std::unique_ptr<uint8_t[]>(new uint8_t[required_buffer_len]);
  temp = temp_heap.get();
} else {
  temp = temp_stack;
}
```

After:
```cpp
size_t required_buffer_len = data_len * 3 + 2;
SmallBufferWithHeapFallback<BUFFER_STACK_SIZE> buffer(required_buffer_len);
uint8_t *temp = buffer.get();
```

This reduces code duplication by using the existing helper that encapsulates the same pattern.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable - internal refactoring only.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
