### PR TITLE
[light] Use member array instead of heap allocation in AddressableLightWrapper

### DIFF
--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -116,7 +116,7 @@ class AddressableLightWrapper : public light::AddressableLight {
   }
 
   light::LightState *light_state_;
-  uint8_t wrapper_state_[5]{};
+  mutable uint8_t wrapper_state_[5]{};
   ColorMode color_mode_{ColorMode::UNKNOWN};
 };
 

--- a/esphome/components/light/addressable_light_wrapper.h
+++ b/esphome/components/light/addressable_light_wrapper.h
@@ -7,9 +7,7 @@ namespace esphome::light {
 
 class AddressableLightWrapper : public light::AddressableLight {
  public:
-  explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {
-    this->wrapper_state_ = new uint8_t[5];  // NOLINT(cppcoreguidelines-owning-memory)
-  }
+  explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {}
 
   int32_t size() const override { return 1; }
 
@@ -118,7 +116,7 @@ class AddressableLightWrapper : public light::AddressableLight {
   }
 
   light::LightState *light_state_;
-  uint8_t *wrapper_state_;
+  uint8_t wrapper_state_[5]{};
   ColorMode color_mode_{ColorMode::UNKNOWN};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Replace unnecessary heap allocation with a fixed-size member array in `AddressableLightWrapper`.

The class was allocating a fixed 5-byte buffer on the heap in the constructor:
```cpp
this->wrapper_state_ = new uint8_t[5];
```

Since the size is always exactly 5 bytes and known at compile time, this should simply be a member array. There's no reason to add heap fragmentation for a fixed-size buffer.

The array is marked `mutable` because `get_view_internal()` is a `const` method (required by the base class interface) but returns an `ESPColorView` that allows writing to the color components. With the original pointer member, the pointer was const but what it pointed to wasn't. With a member array, `mutable` is needed to preserve that behavior.

**Before:**
```cpp
explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {
  this->wrapper_state_ = new uint8_t[5];  // NOLINT
}
// ...
uint8_t *wrapper_state_;
```

**After:**
```cpp
explicit AddressableLightWrapper(light::LightState *light_state) : light_state_(light_state) {}
// ...
mutable uint8_t wrapper_state_[5]{};
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Removes unnecessary heap allocation

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
# Affects any configuration using light partitions with non-addressable lights
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
