### PR TITLE
[tm1638] Use member array instead of heap allocation for display buffer

### DIFF
--- a/esphome/components/tm1638/tm1638.cpp
+++ b/esphome/components/tm1638/tm1638.cpp
@@ -35,9 +35,6 @@ void TM1638Component::setup() {
   this->set_intensity(intensity_);
 
   this->reset_();  // all LEDs off
-
-  for (uint8_t i = 0; i < 8; i++)  // zero fill print buffer
-    this->buffer_[i] = 0;
 }
 
 void TM1638Component::dump_config() {

--- a/esphome/components/tm1638/tm1638.h
+++ b/esphome/components/tm1638/tm1638.h
@@ -70,7 +70,7 @@ class TM1638Component : public PollingComponent {
   GPIOPin *clk_pin_;
   GPIOPin *stb_pin_;
   GPIOPin *dio_pin_;
-  uint8_t *buffer_ = new uint8_t[8];
+  uint8_t buffer_[8]{};
   tm1638_writer_t writer_{};
   std::vector<KeyListener *> listeners_{};
 };


### PR DESCRIPTION
# What does this implement/fix?

Replace unnecessary heap allocation with a fixed-size member array in `TM1638Component`.

The class was allocating a fixed 8-byte buffer on the heap:
```cpp
uint8_t *buffer_ = new uint8_t[8];
```

Since the size is always exactly 8 bytes and known at compile time, this should simply be a member array. There's no reason to add heap fragmentation for a fixed-size buffer.

**Before:**
```cpp
uint8_t *buffer_ = new uint8_t[8];
```

**After:**
```cpp
uint8_t buffer_[8]{};
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A - Removes unnecessary heap allocation

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal fix
# Affects any configuration using TM1638 display
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
