### PR TITLE
[core] Encapsulate entity preference creation to prepare for hash migration

### DIFF
--- a/esphome/components/bl0940/number/calibration_number.cpp
+++ b/esphome/components/bl0940/number/calibration_number.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "bl0940.number";
 void CalibrationNumber::setup() {
   float value = 0.0f;
   if (this->restore_value_) {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     if (!this->pref_.load(&value)) {
       value = 0.0f;
     }

--- a/esphome/components/climate/climate.cpp
+++ b/esphome/components/climate/climate.cpp
@@ -360,8 +360,7 @@ void Climate::add_on_control_callback(std::function<void(ClimateCall &)> &&callb
 static const uint32_t RESTORE_STATE_VERSION = 0x848EA6ADUL;
 
 optional<ClimateDeviceRestoreState> Climate::restore_state_() {
-  this->rtc_ = global_preferences->make_preference<ClimateDeviceRestoreState>(this->get_preference_hash() ^
-                                                                              RESTORE_STATE_VERSION);
+  this->rtc_ = this->make_entity_preference<ClimateDeviceRestoreState>(RESTORE_STATE_VERSION);
   ClimateDeviceRestoreState recovered{};
   if (!this->rtc_.load(&recovered))
     return {};

--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -187,7 +187,7 @@ void Cover::publish_state(bool save) {
   }
 }
 optional<CoverRestoreState> Cover::restore_state_() {
-  this->rtc_ = global_preferences->make_preference<CoverRestoreState>(this->get_preference_hash());
+  this->rtc_ = this->make_entity_preference<CoverRestoreState>();
   CoverRestoreState recovered{};
   if (!this->rtc_.load(&recovered))
     return {};

--- a/esphome/components/duty_time/duty_time_sensor.cpp
+++ b/esphome/components/duty_time/duty_time_sensor.cpp
@@ -41,7 +41,7 @@ void DutyTimeSensor::setup() {
   uint32_t seconds = 0;
 
   if (this->restore_) {
-    this->pref_ = global_preferences->make_preference<uint32_t>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<uint32_t>();
     this->pref_.load(&seconds);
   }
 

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -227,8 +227,7 @@ void Fan::publish_state() {
 constexpr uint32_t RESTORE_STATE_VERSION = 0x71700ABA;
 optional<FanRestoreState> Fan::restore_state_() {
   FanRestoreState recovered{};
-  this->rtc_ =
-      global_preferences->make_preference<FanRestoreState>(this->get_preference_hash() ^ RESTORE_STATE_VERSION);
+  this->rtc_ = this->make_entity_preference<FanRestoreState>(RESTORE_STATE_VERSION);
   bool restored = this->rtc_.load(&recovered);
 
   switch (this->restore_mode_) {

--- a/esphome/components/haier/haier_base.cpp
+++ b/esphome/components/haier/haier_base.cpp
@@ -350,8 +350,7 @@ ClimateTraits HaierClimateBase::traits() { return traits_; }
 
 void HaierClimateBase::initialization() {
   constexpr uint32_t restore_settings_version = 0xA77D21EF;
-  this->base_rtc_ =
-      global_preferences->make_preference<HaierBaseSettings>(this->get_preference_hash() ^ restore_settings_version);
+  this->base_rtc_ = this->make_entity_preference<HaierBaseSettings>(restore_settings_version);
   HaierBaseSettings recovered;
   if (!this->base_rtc_.load(&recovered)) {
     recovered = {false, true};

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -515,8 +515,7 @@ haier_protocol::HaierMessage HonClimate::get_power_message(bool state) {
 void HonClimate::initialization() {
   HaierClimateBase::initialization();
   constexpr uint32_t restore_settings_version = 0x57EB59DDUL;
-  this->hon_rtc_ =
-      global_preferences->make_preference<HonSettings>(this->get_preference_hash() ^ restore_settings_version);
+  this->hon_rtc_ = this->make_entity_preference<HonSettings>(restore_settings_version);
   HonSettings recovered;
   if (this->hon_rtc_.load(&recovered)) {
     this->settings_ = recovered;

--- a/esphome/components/integration/integration_sensor.cpp
+++ b/esphome/components/integration/integration_sensor.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "integration";
 
 void IntegrationSensor::setup() {
   if (this->restore_) {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     float preference_value = 0;
     this->pref_.load(&preference_value);
     this->result_ = preference_value;

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -184,7 +184,7 @@ static inline bool validate_header_footer(const uint8_t *header_footer, const ui
 void LD2450Component::setup() {
 #ifdef USE_NUMBER
   if (this->presence_timeout_number_ != nullptr) {
-    this->pref_ = global_preferences->make_preference<float>(this->presence_timeout_number_->get_preference_hash());
+    this->pref_ = this->presence_timeout_number_->make_entity_preference<float>();
     this->set_presence_timeout();
   }
 #endif

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -44,7 +44,7 @@ void LightState::setup() {
     case LIGHT_RESTORE_DEFAULT_ON:
     case LIGHT_RESTORE_INVERTED_DEFAULT_OFF:
     case LIGHT_RESTORE_INVERTED_DEFAULT_ON:
-      this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_preference_hash());
+      this->rtc_ = this->make_entity_preference<LightStateRTCState>();
       // Attempt to load from preferences, else fall back to default values
       if (!this->rtc_.load(&recovered)) {
         recovered.state = (this->restore_mode_ == LIGHT_RESTORE_DEFAULT_ON ||
@@ -57,7 +57,7 @@ void LightState::setup() {
       break;
     case LIGHT_RESTORE_AND_OFF:
     case LIGHT_RESTORE_AND_ON:
-      this->rtc_ = global_preferences->make_preference<LightStateRTCState>(this->get_preference_hash());
+      this->rtc_ = this->make_entity_preference<LightStateRTCState>();
       this->rtc_.load(&recovered);
       recovered.state = (this->restore_mode_ == LIGHT_RESTORE_AND_ON);
       break;

--- a/esphome/components/lvgl/number/lvgl_number.h
+++ b/esphome/components/lvgl/number/lvgl_number.h
@@ -21,7 +21,7 @@ class LVGLNumber : public number::Number, public Component {
   void setup() override {
     float value = this->value_lambda_();
     if (this->restore_) {
-      this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+      this->pref_ = this->make_entity_preference<float>();
       if (this->pref_.load(&value)) {
         this->control_lambda_(value);
       }

--- a/esphome/components/lvgl/select/lvgl_select.h
+++ b/esphome/components/lvgl/select/lvgl_select.h
@@ -20,7 +20,7 @@ class LVGLSelect : public select::Select, public Component {
     this->set_options_();
     if (this->restore_) {
       size_t index;
-      this->pref_ = global_preferences->make_preference<size_t>(this->get_preference_hash());
+      this->pref_ = this->make_entity_preference<size_t>();
       if (this->pref_.load(&index))
         this->widget_->set_selected_index(index, LV_ANIM_OFF);
     }

--- a/esphome/components/number/automation.cpp
+++ b/esphome/components/number/automation.cpp
@@ -14,8 +14,7 @@ void ValueRangeTrigger::setup() {
   float local_min = this->min_.value(0.0);
   float local_max = this->max_.value(0.0);
   convert hash = {.from = (local_max - local_min)};
-  uint32_t myhash = hash.to ^ this->parent_->get_preference_hash();
-  this->rtc_ = global_preferences->make_preference<bool>(myhash);
+  this->rtc_ = this->parent_->make_entity_preference<bool>(hash.to);
   bool initial_state;
   if (this->rtc_.load(&initial_state)) {
     this->previous_in_range_ = initial_state;

--- a/esphome/components/opentherm/number/opentherm_number.cpp
+++ b/esphome/components/opentherm/number/opentherm_number.cpp
@@ -17,7 +17,7 @@ void OpenthermNumber::setup() {
   if (!this->restore_value_) {
     value = this->initial_value_;
   } else {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     if (!this->pref_.load(&value)) {
       if (!std::isnan(this->initial_value_)) {
         value = this->initial_value_;

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -132,7 +132,7 @@ void RotaryEncoderSensor::setup() {
   int32_t initial_value = 0;
   switch (this->restore_mode_) {
     case ROTARY_ENCODER_RESTORE_DEFAULT_ZERO:
-      this->rtc_ = global_preferences->make_preference<int32_t>(this->get_preference_hash());
+      this->rtc_ = this->make_entity_preference<int32_t>();
       if (!this->rtc_.load(&initial_value)) {
         initial_value = 0;
       }

--- a/esphome/components/sensor/automation.h
+++ b/esphome/components/sensor/automation.h
@@ -39,7 +39,7 @@ class ValueRangeTrigger : public Trigger<float>, public Component {
   template<typename V> void set_max(V max) { this->max_ = max; }
 
   void setup() override {
-    this->rtc_ = global_preferences->make_preference<bool>(this->parent_->get_preference_hash());
+    this->rtc_ = this->parent_->make_entity_preference<bool>();
     bool initial_state;
     if (this->rtc_.load(&initial_state)) {
       this->previous_in_range_ = initial_state;

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -55,7 +55,7 @@ void SpeakerMediaPlayer::setup() {
 
   this->media_control_command_queue_ = xQueueCreate(MEDIA_CONTROLS_QUEUE_LENGTH, sizeof(MediaCallCommand));
 
-  this->pref_ = global_preferences->make_preference<VolumeRestoreState>(this->get_preference_hash());
+  this->pref_ = this->make_entity_preference<VolumeRestoreState>();
 
   VolumeRestoreState volume_restore_state;
   if (this->pref_.load(&volume_restore_state)) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -16,7 +16,7 @@ void SprinklerControllerNumber::setup() {
   if (!this->restore_value_) {
     value = this->initial_value_;
   } else {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     if (!this->pref_.load(&value)) {
       if (!std::isnan(this->initial_value_)) {
         value = this->initial_value_;

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -34,7 +34,7 @@ optional<bool> Switch::get_initial_state() {
   if (!(restore_mode & RESTORE_MODE_PERSISTENT_MASK))
     return {};
 
-  this->rtc_ = global_preferences->make_preference<bool>(this->get_preference_hash());
+  this->rtc_ = this->make_entity_preference<bool>();
   bool initial_state;
   if (!this->rtc_.load(&initial_state))
     return {};

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -82,7 +82,7 @@ void TemplateAlarmControlPanel::setup() {
   this->current_state_ = ACP_STATE_DISARMED;
   if (this->restore_mode_ == ALARM_CONTROL_PANEL_RESTORE_DEFAULT_DISARMED) {
     uint8_t value;
-    this->pref_ = global_preferences->make_preference<uint8_t>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<uint8_t>();
     if (this->pref_.load(&value)) {
       this->current_state_ = static_cast<alarm_control_panel::AlarmControlPanelState>(value);
     }

--- a/esphome/components/template/datetime/template_date.cpp
+++ b/esphome/components/template/datetime/template_date.cpp
@@ -18,8 +18,7 @@ void TemplateDate::setup() {
     state = this->initial_value_;
   } else {
     datetime::DateEntityRestoreState temp;
-    this->pref_ =
-        global_preferences->make_preference<datetime::DateEntityRestoreState>(194434030U ^ this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<datetime::DateEntityRestoreState>(194434030U);
     if (this->pref_.load(&temp)) {
       temp.apply(this);
       return;

--- a/esphome/components/template/datetime/template_datetime.cpp
+++ b/esphome/components/template/datetime/template_datetime.cpp
@@ -18,8 +18,7 @@ void TemplateDateTime::setup() {
     state = this->initial_value_;
   } else {
     datetime::DateTimeEntityRestoreState temp;
-    this->pref_ = global_preferences->make_preference<datetime::DateTimeEntityRestoreState>(
-        194434090U ^ this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<datetime::DateTimeEntityRestoreState>(194434090U);
     if (this->pref_.load(&temp)) {
       temp.apply(this);
       return;

--- a/esphome/components/template/datetime/template_time.cpp
+++ b/esphome/components/template/datetime/template_time.cpp
@@ -18,8 +18,7 @@ void TemplateTime::setup() {
     state = this->initial_value_;
   } else {
     datetime::TimeEntityRestoreState temp;
-    this->pref_ =
-        global_preferences->make_preference<datetime::TimeEntityRestoreState>(194434060U ^ this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<datetime::TimeEntityRestoreState>(194434060U);
     if (this->pref_.load(&temp)) {
       temp.apply(this);
       return;

--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -13,7 +13,7 @@ void TemplateNumber::setup() {
   if (!this->restore_value_) {
     value = this->initial_value_;
   } else {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     if (!this->pref_.load(&value)) {
       if (!std::isnan(this->initial_value_)) {
         value = this->initial_value_;

--- a/esphome/components/template/select/template_select.cpp
+++ b/esphome/components/template/select/template_select.cpp
@@ -11,7 +11,7 @@ void TemplateSelect::setup() {
 
   size_t index = this->initial_option_index_;
   if (this->restore_value_) {
-    this->pref_ = global_preferences->make_preference<size_t>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<size_t>();
     size_t restored_index;
     if (this->pref_.load(&restored_index) && this->has_index(restored_index)) {
       index = restored_index;

--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -20,6 +20,10 @@ void TemplateText::setup() {
 
   // Need std::string for pref_->setup() to fill from flash
   std::string value{this->initial_value_ != nullptr ? this->initial_value_ : ""};
+  // For future hash migration: use migrate_entity_preference_() with:
+  //   old_key = get_preference_hash() + extra
+  //   new_key = get_preference_hash_v2() + extra
+  // See: https://github.com/esphome/backlog/issues/85
   uint32_t key = this->get_preference_hash();
   key += this->traits.get_min_length() << 2;
   key += this->traits.get_max_length() << 4;

--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -24,7 +24,10 @@ void TemplateText::setup() {
   //   old_key = get_preference_hash() + extra
   //   new_key = get_preference_hash_v2() + extra
   // See: https://github.com/esphome/backlog/issues/85
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   uint32_t key = this->get_preference_hash();
+#pragma GCC diagnostic pop
   key += this->traits.get_min_length() << 2;
   key += this->traits.get_max_length() << 4;
   key += fnv1_hash(this->traits.get_pattern_c_str()) << 6;

--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -10,7 +10,7 @@ void TotalDailyEnergy::setup() {
   float initial_value = 0;
 
   if (this->restore_) {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
     this->pref_.load(&initial_value);
   }
   this->publish_state_and_save(initial_value);

--- a/esphome/components/tuya/number/tuya_number.cpp
+++ b/esphome/components/tuya/number/tuya_number.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "tuya.number";
 
 void TuyaNumber::setup() {
   if (this->restore_value_) {
-    this->pref_ = global_preferences->make_preference<float>(this->get_preference_hash());
+    this->pref_ = this->make_entity_preference<float>();
   }
 
   this->parent_->register_listener(this->number_id_, [this](const TuyaDatapoint &datapoint) {

--- a/esphome/components/valve/valve.cpp
+++ b/esphome/components/valve/valve.cpp
@@ -161,7 +161,7 @@ void Valve::publish_state(bool save) {
   }
 }
 optional<ValveRestoreState> Valve::restore_state_() {
-  this->rtc_ = global_preferences->make_preference<ValveRestoreState>(this->get_preference_hash());
+  this->rtc_ = this->make_entity_preference<ValveRestoreState>();
   ValveRestoreState recovered{};
   if (!this->rtc_.load(&recovered))
     return {};

--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -146,9 +146,7 @@ void WaterHeaterCall::validate_() {
   }
 }
 
-void WaterHeater::setup() {
-  this->pref_ = global_preferences->make_preference<SavedWaterHeaterState>(this->get_preference_hash());
-}
+void WaterHeater::setup() { this->pref_ = this->make_entity_preference<SavedWaterHeaterState>(); }
 
 void WaterHeater::publish_state() {
   auto traits = this->get_traits();

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -127,7 +127,10 @@ ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t ve
   //   this->migrate_entity_preference_(size, old_key, new_key);
   //   return global_preferences->make_preference(size, new_key);
   //
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   uint32_t key = this->get_preference_hash() ^ version;
+#pragma GCC diagnostic pop
   return global_preferences->make_preference(size, key);
 }
 

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -92,6 +92,23 @@ StringRef EntityBase::get_object_id_to(std::span<char, OBJECT_ID_MAX_LEN> buf) c
 
 uint32_t EntityBase::get_object_id_hash() { return this->object_id_hash_; }
 
+// Migrate preference data from old_key to new_key if they differ.
+// This helper is exposed so callers with custom key computation (like TextPrefs)
+// can use it for manual migration. See: https://github.com/esphome/backlog/issues/85
+//
+// FUTURE IMPLEMENTATION:
+// This will require raw load/save methods on ESPPreferenceObject that take uint8_t* and size.
+//   void EntityBase::migrate_entity_preference_(size_t size, uint32_t old_key, uint32_t new_key) {
+//     if (old_key == new_key)
+//       return;
+//     auto old_pref = global_preferences->make_preference(size, old_key);
+//     auto new_pref = global_preferences->make_preference(size, new_key);
+//     SmallBufferWithHeapFallback<64> buffer(size);
+//     if (old_pref.load(buffer.data(), size)) {
+//       new_pref.save(buffer.data(), size);
+//     }
+//   }
+
 ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t version) {
   // This helper centralizes preference creation to enable fixing hash collisions.
   // See: https://github.com/esphome/backlog/issues/85
@@ -103,21 +120,12 @@ ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t ve
   // This causes entities to overwrite each other's stored preferences.
   //
   // FUTURE MIGRATION: When implementing get_preference_hash_v2() that hashes
-  // the original entity name (not sanitized object_id), migration logic goes here:
+  // the original entity name (not sanitized object_id):
   //
   //   uint32_t old_key = this->get_preference_hash() ^ version;
   //   uint32_t new_key = this->get_preference_hash_v2() ^ version;
-  //   if (old_key != new_key) {
-  //     auto old_pref = global_preferences->make_preference(size, old_key);
-  //     auto new_pref = global_preferences->make_preference(size, new_key);
-  //     SmallBufferWithHeapFallback<64> buffer(size);
-  //     if (old_pref.load(buffer.data(), size)) {
-  //       new_pref.save(buffer.data(), size);
-  //     }
-  //   }
+  //   this->migrate_entity_preference_(size, old_key, new_key);
   //   return global_preferences->make_preference(size, new_key);
-  //
-  // This will require raw load/save methods on ESPPreferenceObject (uint8_t*, size).
   //
   uint32_t key = this->get_preference_hash() ^ version;
   return global_preferences->make_preference(size, key);

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -92,6 +92,33 @@ StringRef EntityBase::get_object_id_to(std::span<char, OBJECT_ID_MAX_LEN> buf) c
 
 uint32_t EntityBase::get_object_id_hash() { return this->object_id_hash_; }
 
+ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t version) {
+  // This helper exists to centralize preference creation so we can fix hash collisions.
+  //
+  // PROBLEM: get_preference_hash() uses fnv1_hash on the sanitized object_id, which can
+  // collide when different entity names sanitize to the same string (e.g., "Living Room"
+  // and "living_room" both become "living_room"). This causes entities to overwrite
+  // each other's stored preferences.
+  //
+  // FUTURE MIGRATION (when implementing get_preference_hash_v2):
+  //   uint32_t old_key = this->get_preference_hash() ^ version;
+  //   uint32_t new_key = this->get_preference_hash_v2() ^ version;
+  //   if (old_key != new_key) {
+  //     auto old_pref = global_preferences->make_preference(size, old_key);
+  //     auto new_pref = global_preferences->make_preference(size, new_key);
+  //     SmallBufferWithHeapFallback<64> buffer(size);
+  //     if (old_pref.load(buffer.data(), size)) {
+  //       new_pref.save(buffer.data(), size);
+  //     }
+  //   }
+  //   return global_preferences->make_preference(size, new_key);
+  //
+  // NOTE: Will need raw load/save methods on ESPPreferenceObject that take uint8_t* and size.
+  //
+  uint32_t key = this->get_preference_hash() ^ version;
+  return global_preferences->make_preference(size, key);
+}
+
 std::string EntityBase_DeviceClass::get_device_class() {
   if (this->device_class_ == nullptr) {
     return "";

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -93,14 +93,18 @@ StringRef EntityBase::get_object_id_to(std::span<char, OBJECT_ID_MAX_LEN> buf) c
 uint32_t EntityBase::get_object_id_hash() { return this->object_id_hash_; }
 
 ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t version) {
-  // This helper exists to centralize preference creation so we can fix hash collisions.
+  // This helper centralizes preference creation to enable fixing hash collisions.
+  // See: https://github.com/esphome/backlog/issues/85
   //
-  // PROBLEM: get_preference_hash() uses fnv1_hash on the sanitized object_id, which can
-  // collide when different entity names sanitize to the same string (e.g., "Living Room"
-  // and "living_room" both become "living_room"). This causes entities to overwrite
-  // each other's stored preferences.
+  // COLLISION PROBLEM: get_preference_hash() uses fnv1_hash on sanitized object_id.
+  // Multiple entity names can sanitize to the same object_id:
+  //   - "Living Room" and "living_room" both become "living_room"
+  //   - UTF-8 names like "温度" and "湿度" both become "__" (underscores)
+  // This causes entities to overwrite each other's stored preferences.
   //
-  // FUTURE MIGRATION (when implementing get_preference_hash_v2):
+  // FUTURE MIGRATION: When implementing get_preference_hash_v2() that hashes
+  // the original entity name (not sanitized object_id), migration logic goes here:
+  //
   //   uint32_t old_key = this->get_preference_hash() ^ version;
   //   uint32_t new_key = this->get_preference_hash_v2() ^ version;
   //   if (old_key != new_key) {
@@ -113,7 +117,7 @@ ESPPreferenceObject EntityBase::make_entity_preference_(size_t size, uint32_t ve
   //   }
   //   return global_preferences->make_preference(size, new_key);
   //
-  // NOTE: Will need raw load/save methods on ESPPreferenceObject that take uint8_t* and size.
+  // This will require raw load/save methods on ESPPreferenceObject (uint8_t*, size).
   //
   uint32_t key = this->get_preference_hash() ^ version;
   return global_preferences->make_preference(size, key);

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -156,6 +156,7 @@ class EntityBase {
   /// @tparam T The type of data to store (must be trivially copyable)
   /// @param version Optional version hash XORed with preference key (change when struct layout changes)
   template<typename T> ESPPreferenceObject make_entity_preference(uint32_t version = 0) {
+    static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
     return this->make_entity_preference_(sizeof(T), version);
   }
 

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -6,6 +6,7 @@
 #include "string_ref.h"
 #include "helpers.h"
 #include "log.h"
+#include "preferences.h"
 
 #ifdef USE_DEVICES
 #include "device.h"
@@ -151,7 +152,18 @@ class EntityBase {
 #endif
   }
 
+  /// Create a preference object for storing this entity's state/settings.
+  /// @tparam T The type of data to store (must be trivially copyable)
+  /// @param version Optional version hash XORed with preference key (change when struct layout changes)
+  template<typename T> ESPPreferenceObject make_entity_preference(uint32_t version = 0) {
+    return this->make_entity_preference_(sizeof(T), version);
+  }
+
  protected:
+  /// Non-template helper for make_entity_preference() to avoid code bloat.
+  /// When preference hash algorithm changes, migration logic goes here.
+  ESPPreferenceObject make_entity_preference_(size_t size, uint32_t version);
+
   void calc_object_id_();
 
   StringRef name_;

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -139,9 +139,12 @@ class EntityBase {
    * from previous versions, so existing single-device configurations will continue to work.
    *
    * @return uint32_t The unique hash for preferences, including device_id if available.
-   * @deprecated Use make_entity_preference<T>() instead for automatic migration support.
+   * @deprecated Use make_entity_preference<T>() instead, or preferences won't be migrated.
+   * See https://github.com/esphome/backlog/issues/85
    */
-  ESPDEPRECATED("Use make_entity_preference<T>() instead. Will be removed in 2027.1.0.", "2026.7.0")
+  ESPDEPRECATED("Use make_entity_preference<T>() instead, or preferences won't be migrated. "
+                "See https://github.com/esphome/backlog/issues/85. Will be removed in 2027.1.0.",
+                "2026.7.0")
   uint32_t get_preference_hash() {
 #ifdef USE_DEVICES
     // Combine object_id_hash with device_id to ensure uniqueness across devices

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -139,7 +139,9 @@ class EntityBase {
    * from previous versions, so existing single-device configurations will continue to work.
    *
    * @return uint32_t The unique hash for preferences, including device_id if available.
+   * @deprecated Use make_entity_preference<T>() instead for automatic migration support.
    */
+  ESPDEPRECATED("Use make_entity_preference<T>() instead. Will be removed in 2027.1.0.", "2026.7.0")
   uint32_t get_preference_hash() {
 #ifdef USE_DEVICES
     // Combine object_id_hash with device_id to ensure uniqueness across devices


### PR DESCRIPTION
# What does this implement/fix?

Encapsulates entity preference creation into `EntityBase::make_entity_preference<T>()` to prepare for fixing preference hash collisions.

## Problem

`get_preference_hash()` uses `fnv1_hash` on the sanitized object_id, which can collide when different entity names sanitize to the same string:
- "Living Room" and "living_room" both become "living_room"
- UTF-8 names like "温度" and "湿度" both become "__" (underscores)

This causes entities to overwrite each other's stored preferences.

See: https://github.com/esphome/backlog/issues/85

## Solution

Add a helper method in `EntityBase` that centralizes preference creation:

```cpp
// Simple usage
this->pref_ = this->make_entity_preference<float>();

// With version (for struct layout changes)
this->rtc_ = this->make_entity_preference<FanRestoreState>(RESTORE_STATE_VERSION);

// Cross-entity (uses other entity's preference)
this->pref_ = this->presence_timeout_number_->make_entity_preference<float>();
```

This encapsulation means when we fix the hash algorithm later (implementing `get_preference_hash_v2()` that hashes the original name instead of sanitized object_id), migration logic goes in one place (`make_entity_preference_()`) instead of 28+ call sites.

## Implementation

- **Template method** `make_entity_preference<T>(version)` - thin wrapper with `static_assert` for trivially copyable types, passes `sizeof(T)` to helper
- **Non-template helper** `make_entity_preference_(size, version)` - avoids code bloat, future migration logic goes here
- **Future migration helper** `migrate_entity_preference_(size, old_key, new_key)` - documented in comments for when `get_preference_hash_v2()` is implemented (requires raw load/save methods on ESPPreferenceObject)
- **Deprecation** `get_preference_hash()` is now deprecated (will be removed in 2027.1.0)

The non-template helper ensures complex migration code is compiled once, not duplicated per template instantiation.

### Special case: template_text.cpp

This file uses `get_preference_hash()` with a composite key (ADD instead of XOR) and a different preference API (TextPrefs). It has been documented with a migration comment and uses `#pragma GCC diagnostic` to suppress the deprecation warning.

## Why external components must migrate

When we implement `get_preference_hash_v2()` to fix the collision problem, the migration logic (copying preferences from old key to new key) will be inside `make_entity_preference_()`.

**External components that continue using `get_preference_hash()` directly will NOT have their preferences automatically migrated.** This means users will lose saved state (calibration values, restore states, etc.) for entities in those components.

## Migration Guide for External Components

**Simple case** - storing entity state:

```cpp
// Before:
this->pref_ = global_preferences->make_preference<MyState>(this->get_preference_hash());

// After:
this->pref_ = this->make_entity_preference<MyState>();
```

**Using get_object_id_hash()** - same collision problem, migrate to helper:

Note: `get_object_id_hash()` is not deprecated yet but will be in a future release. Migrate now to avoid issues.

```cpp
// Before:
this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());

// After:
this->pref_ = this->make_entity_preference<float>();
```

**With version constant** - invalidating old data when struct layout changes:

```cpp
// Before:
this->pref_ = global_preferences->make_preference<MyState>(VERSION ^ this->get_preference_hash());

// After:
this->pref_ = this->make_entity_preference<MyState>(VERSION);
```

**Cross-entity** - using another entity's preference hash:

```cpp
// Before:
this->pref_ = global_preferences->make_preference<float>(this->some_number_->get_preference_hash());

// After:
this->pref_ = this->some_number_->make_entity_preference<float>();
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Preparation for https://github.com/esphome/backlog/issues/85 (Fix Home Assistant object id collisions)
- Related to https://github.com/esphome/backlog/issues/76 (object_id collision details)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (deprecation warning provides migration guidance)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes, internal refactoring only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
