### PR TITLE
[sml] Use constexpr std::array for START_SEQ constant

### DIFF
--- a/esphome/components/sml/constants.h
+++ b/esphome/components/sml/constants.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 namespace esphome {
@@ -21,7 +22,7 @@ enum SmlMessageType : uint16_t { SML_PUBLIC_OPEN_RES = 0x0101, SML_GET_LIST_RES 
 const uint16_t START_MASK = 0x55aa;  // 0x1b 1b 1b 1b 01 01 01 01
 const uint16_t END_MASK = 0x0157;    // 0x1b 1b 1b 1b 1a
 
-const std::vector<uint8_t> START_SEQ = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
+constexpr std::array<uint8_t, 8> START_SEQ = {0x1b, 0x1b, 0x1b, 0x1b, 0x01, 0x01, 0x01, 0x01};
 
 }  // namespace sml
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Replace `const std::vector<uint8_t>` with `constexpr std::array<uint8_t, 8>` for the `START_SEQ` constant in SML component.

This moves the 8-byte constant from heap to flash and eliminates a heap allocation at startup. The `std::array` provides the same iterator interface (`begin()`, `end()`, `size()`) used by the existing code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - No user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - existing SML configurations work unchanged
uart:
  rx_pin: GPIO16
  baud_rate: 9600

sml:
  id: my_sml
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
