### PR TITLE
[wifi] Fix scan flag race condition causing reconnect failure on ESP8266/LibreTiny

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -698,6 +698,10 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   if (!this->wifi_mode_(true, {}))
     return false;
 
+  // Reset scan_done_ before starting new scan to prevent stale flag from previous scan
+  // (e.g., roaming scan completed just before unexpected disconnect)
+  this->scan_done_ = false;
+
   struct scan_config config {};
   memset(&config, 0, sizeof(config));
   config.ssid = nullptr;

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -649,6 +649,10 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   if (!this->wifi_mode_(true, {}))
     return false;
 
+  // Reset scan_done_ before starting new scan to prevent stale flag from previous scan
+  // (e.g., roaming scan completed just before unexpected disconnect)
+  this->scan_done_ = false;
+
   // need to use WiFi because of WiFiScanClass allocations :(
   int16_t err = WiFi.scanNetworks(true, true, passive, 200);
   if (err != WIFI_SCAN_RUNNING) {


### PR DESCRIPTION
# What does this implement/fix?

Fix WiFi reconnection failure after unexpected disconnect on ESP8266 and LibreTiny platforms.

After an unexpected disconnect (e.g., AP deauth, beacon timeout), the device would incorrectly report "No networks found" within milliseconds of starting a scan, then proceed to blind hidden network retry mode instead of waiting for actual scan results. The real scan results would arrive seconds later - too late to be used.

**Root cause:** The `scan_done_` flag was not being reset to `false` when starting a new scan. If a previous scan (e.g., roaming scan) had completed and set `scan_done_ = true`, but was not yet consumed by the main loop before an unexpected disconnect occurred, the stale flag would cause the new reconnection scan to be immediately considered "done" with empty/stale results.

**Fix:** Reset `scan_done_ = false` at the start of `wifi_scan_start_()` on ESP8266 and LibreTiny, matching the existing behavior on ESP-IDF and Pico W.

**Before fix:**
```
16:31:04.048 - Starting scan
16:31:04.095 - "No networks found" (47ms later - stale flag!)
16:31:08.790 - Scan done arrives 4.7 seconds too late
```

**After fix:**
```
16:38:01.646 - Starting scan
16:38:03.216 - Scan done (1.6 seconds later - proper timing)
16:38:03.326 - Found networks: 3 stored
16:38:06.075 - Connected!
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while testing https://github.com/libretiny-eu/libretiny/pull/346 with forced AP reboots and disconnects

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required - this is an internal bug fix
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
