### PR TITLE
[wifi] Fix watchdog timeout on P4 WiFi scan

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -12,6 +12,7 @@ from esphome.const import (
     KEY_FRAMEWORK_VERSION,
 )
 from esphome.core import CORE
+from esphome.cpp_generator import add_define
 
 CODEOWNERS = ["@swoboda1337"]
 
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    add_define("USE_ESP32_HOSTED")
     if config[CONF_ACTIVE_HIGH]:
         esp32.add_idf_sdkconfig_option(
             "CONFIG_ESP_HOSTED_SDIO_RESET_ACTIVE_HIGH",

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <memory>
 #include <utility>
 #ifdef USE_WIFI_WPA2_EAP
 #if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
@@ -834,6 +835,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     auto records = std::make_unique<wifi_ap_record_t[]>(number);
     err = esp_wifi_scan_get_ap_records(&number, records.get());
     if (err != ESP_OK) {
+      esp_wifi_clear_ap_list();
       ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
       return;
     }

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -828,16 +828,27 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
     uint16_t number = it.number;
     scan_result_.init(number);
-
-    // Process one record at a time to avoid large buffer allocation
-    wifi_ap_record_t record;
+#ifdef USE_ESP32_VARIANT_ESP32P4
+    // getting records one at a time fails on P4
+    auto records = std::make_unique<wifi_ap_record_t[]>(number);
+    err = esp_wifi_scan_get_ap_records(&number, records.get());
+    if (err != ESP_OK) {
+      ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
+      return;
+    }
     for (uint16_t i = 0; i < number; i++) {
+      wifi_ap_record_t &record = records[i];
+#else
+    // Process one record at a time to avoid large buffer allocation
+    for (uint16_t i = 0; i < number; i++) {
+      wifi_ap_record_t record;
       err = esp_wifi_scan_get_ap_record(&record);
       if (err != ESP_OK) {
         ESP_LOGW(TAG, "esp_wifi_scan_get_ap_record failed: %s", esp_err_to_name(err));
         esp_wifi_clear_ap_list();  // Free remaining records not yet retrieved
         break;
       }
+#endif  // USE_ESP32_VARIANT_ESP32P4
       bssid_t bssid;
       std::copy(record.bssid, record.bssid + 6, bssid.begin());
       std::string ssid(reinterpret_cast<const char *>(record.ssid));

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -828,8 +828,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 
     uint16_t number = it.number;
     scan_result_.init(number);
-#ifdef USE_ESP32_VARIANT_ESP32P4
-    // getting records one at a time fails on P4
+#ifdef USE_ESP32_HOSTED
+    // getting records one at a time fails on P4 with hosted esp32 WiFi coprocessor
+    // Presumably an upstream bug, work-around by getting all records at once
     auto records = std::make_unique<wifi_ap_record_t[]>(number);
     err = esp_wifi_scan_get_ap_records(&number, records.get());
     if (err != ESP_OK) {
@@ -848,7 +849,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
         esp_wifi_clear_ap_list();  // Free remaining records not yet retrieved
         break;
       }
-#endif  // USE_ESP32_VARIANT_ESP32P4
+#endif  // USE_ESP32_HOSTED
       bssid_t bssid;
       std::copy(record.bssid, record.bssid + 6, bssid.begin());
       std::string ssid(reinterpret_cast<const char *>(record.ssid));

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -42,6 +42,7 @@
 #define USE_DEVICES
 #define USE_DISPLAY
 #define USE_ENTITY_ICON
+#define USE_ESP32_HOSTED
 #define USE_ESP32_IMPROV_STATE_CALLBACK
 #define USE_EVENT
 #define USE_FAN


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent change to WiFi AP scanning causes watchdog timeout on P4

Workaround is to add `fast_connect: true` to WiFi config. Fix here reverts to old code for P4 only.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #13519 https://github.com/esphome/esphome/issues/13500

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
