### PR TITLE
[ac_dimmer] Use a shared ESP32 GPTimer for multiple dimmers

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -203,6 +203,7 @@ void AcDimmer::setup() {
     dimmer_timer = timer_begin(TIMER_FREQUENCY_HZ);
     if (dimmer_timer == nullptr) {
       ESP_LOGE(TAG, "Failed to create GPTimer for AC dimmer");
+      this->mark_failed();
       return;
     }
     timer_attach_interrupt(dimmer_timer, &AcDimmerDataStore::s_timer_intr);

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -199,12 +199,18 @@ void AcDimmer::setup() {
   setTimer1Callback(&timer_interrupt);
 #endif
 #ifdef USE_ESP32
-  dimmer_timer = timer_begin(TIMER_FREQUENCY_HZ);
-  timer_attach_interrupt(dimmer_timer, &AcDimmerDataStore::s_timer_intr);
-  // For ESP32, we can't use dynamic interval calculation because the timerX functions
-  // are not callable from ISR (placed in flash storage).
-  // Here we just use an interrupt firing every 50 µs.
-  timer_alarm(dimmer_timer, TIMER_INTERVAL_US, true, 0);
+  if (dimmer_timer == nullptr) {
+    dimmer_timer = timer_begin(TIMER_FREQUENCY_HZ);
+    if (dimmer_timer == nullptr) {
+      ESP_LOGE(TAG, "Failed to create GPTimer for AC dimmer");
+      return;
+    }
+    timer_attach_interrupt(dimmer_timer, &AcDimmerDataStore::s_timer_intr);
+    // For ESP32, we can't use dynamic interval calculation because the timerX functions
+    // are not callable from ISR (placed in flash storage).
+    // Here we just use an interrupt firing every 50 µs.
+    timer_alarm(dimmer_timer, TIMER_INTERVAL_US, true, 0);
+  }
 #endif
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Prevent GPTimer exhaustion and watchdog resets when multiple AC dimmers are configured on ESP32 by using a single shared GPTimer. The timer is initialized once and reused; if creation fails, the code logs an error and avoids NULL-handle calls. This removes repeated GPTimer creation failures seen on boards with many dimmers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under tests/ folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in esphome-docs.
