### PR TITLE
[mhz19] Fix Uninitialized var warning message

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -155,6 +155,9 @@ void MHZ19Component::dump_config() {
     case MHZ19_DETECTION_RANGE_0_10000PPM:
       range_str = "0 to 10000ppm";
       break;
+    default:
+      range_str = "default";
+      break;
   }
   ESP_LOGCONFIG(TAG, "  Detection range: %s", range_str);
 }


### PR DESCRIPTION
# What does this implement/fix?

When new settings ``detection_range`` is not set in YAML file there is the following warning during compilation.
```
Compiling .pioenvs/mhz19/src/esphome/components/sensor/automation.cpp.o
In file included from src/esphome/core/component.h:9,
                 from src/esphome/components/mhz19/mhz19.h:3,
                 from src/esphome/components/mhz19/mhz19.cpp:1:
src/esphome/core/log.h: In member function 'virtual void esphome::mhz19::MHZ19Component::dump_config()':
src/esphome/core/log.h:98:29: warning: 'range_str' may be used uninitialized in this function [-Wmaybe-uninitialized]
   98 |   ::esphome::esp_log_printf_(ESPHOME_LOG_LEVEL_CONFIG, tag, __LINE__, ESPHOME_LOG_FORMAT(format), ##__VA_ARGS__)
      |                             ^
src/esphome/components/mhz19/mhz19.cpp:144:15: note: 'range_str' was declared here
  144 |   const char *range_str;
      |               ^~~~~~~~~
```

With this fix, warning does not occur any more

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: mhz19
  friendly_name: mhz19

esp8266:
  board: d1_mini

# Enable logging
logger:

# Enable Home Assistant API
api:
  encryption:
    key: "ya8XZh2iqIBGDi/AZPeU="

ota:
  - platform: esphome
    password: "23b15c167415ba8"

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Mhz19 Fallback Hotspot"
    password: "5UwZxonXGJQI"

captive_portal:

uart:
  
- id: uart_b
  rx_pin: D1
  tx_pin: D3
  baud_rate: 9600

   
sensor:
  - platform: mhz19
    uart_id: uart_b
    co2:
      name: "CO2 Value"
    update_interval: 60s
    automatic_baseline_calibration: false
    id: mhz19_sensor

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
