### PR TITLE
[waveshare_epaper] Add support for WeAct 3-color e-paper displays

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -122,10 +122,14 @@ WaveshareEPaper2P13InV3 = waveshare_epaper_ns.class_(
 WaveshareEPaper13P3InK = waveshare_epaper_ns.class_(
     "WaveshareEPaper13P3InK", WaveshareEPaper
 )
+# WeAct 3C e-paper display driver
+WeActEPaper3C = waveshare_epaper_ns.class_("WeActEPaper3C", WaveshareEPaperBWR)
+
 GDEW0154M09 = waveshare_epaper_ns.class_("GDEW0154M09", WaveshareEPaper)
 
 WaveshareEPaperTypeAModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeAModel")
 WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel")
+WeActEPaper3CModel = waveshare_epaper_ns.enum("WeActEPaper3CModel")
 
 MODELS = {
     "1.54in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_1_54_IN),
@@ -137,8 +141,10 @@ MODELS = {
     "2.13in-ttgo-b1": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B1),
     "2.13in-ttgo-b73": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B73),
     "2.13in-ttgo-b74": ("a", WaveshareEPaperTypeAModel.TTGO_EPAPER_2_13_IN_B74),
+    "2.13in3c-weact": ("weact_3c", WeActEPaper3CModel.WEACT_EPAPER_2_13_IN_3C),
     "2.90in": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN),
     "2.90inv2": ("a", WaveshareEPaperTypeAModel.WAVESHARE_EPAPER_2_9_IN_V2),
+    "2.90in3c-weact": ("weact_3c", WeActEPaper3CModel.WEACT_EPAPER_2_90_IN_3C),
     "gdew029t5": ("c", GDEW029T5),
     "2.70in": ("b", WaveshareEPaper2P7In),
     "2.70in-b": ("b", WaveshareEPaper2P7InB),
@@ -154,6 +160,7 @@ MODELS = {
     "4.20in": ("b", WaveshareEPaper4P2In),
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),
     "4.20in-bv2-bwr": ("b", WaveshareEPaper4P2InBV2BWR),
+    "4.20in3c-weact": ("weact_3c", WeActEPaper3CModel.WEACT_EPAPER_4_20_IN_3C),
     "5.65in-f": ("b", WaveshareEPaper5P65InF),
     "5.83in": ("b", WaveshareEPaper5P8In),
     "5.83inv2": ("b", WaveshareEPaper5P8InV2),
@@ -232,6 +239,9 @@ async def to_code(config):
     if model_type == "a":
         rhs = WaveshareEPaperTypeA.new(model)
         var = cg.Pvariable(config[CONF_ID], rhs, WaveshareEPaperTypeA)
+    elif model_type == "weact_3c":
+        rhs = WeActEPaper3C.new(model)
+        var = cg.Pvariable(config[CONF_ID], rhs, WeActEPaper3C)
     elif model_type in ("b", "c"):
         rhs = model.new()
         var = cg.Pvariable(config[CONF_ID], rhs, model)

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -1099,5 +1099,40 @@ class WaveshareEPaper13P3InK : public WaveshareEPaper {
   uint32_t idle_timeout_() override;
 };
 
+// WeAct 3-Color e-paper display driver
+enum WeActEPaper3CModel {
+  WEACT_EPAPER_2_13_IN_3C,
+  WEACT_EPAPER_2_90_IN_3C,
+  WEACT_EPAPER_4_20_IN_3C,
+};
+
+class WeActEPaper3C : public WaveshareEPaperBWR {
+ public:
+  explicit WeActEPaper3C(WeActEPaper3CModel model);
+
+  void display() override;
+  void dump_config() override;
+  void deep_sleep() override;
+  void setup() override;
+  void loop() override;
+  void initialize() override;
+
+ protected:
+  int get_width_internal() override;
+  int get_height_internal() override;
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t idle_timeout_() override;
+
+ private:
+  void send_reset_();
+  void full_update_();
+  void set_window_(int t, int b);
+  void write_buffer_(int top, int bottom);
+
+  WeActEPaper3CModel model_;
+  bool is_busy_{false};
+  bool initialized_{false};
+};
+
 }  // namespace waveshare_epaper
 }  // namespace esphome

--- a/esphome/components/waveshare_epaper/weact_epaper_3c.cpp
+++ b/esphome/components/waveshare_epaper/weact_epaper_3c.cpp
@@ -1,0 +1,213 @@
+#include "waveshare_epaper.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+namespace esphome {
+namespace waveshare_epaper {
+
+static const char *const TAG = "weact_3c";
+
+// General Commands
+static const uint8_t SW_RESET = 0x12;
+static const uint8_t ACTIVATE = 0x20;
+static const uint8_t WRITE_BLACK = 0x24;
+static const uint8_t WRITE_COLOR = 0x26;
+static const uint8_t SLEEP[] = {0x10, 0x01};
+static const uint8_t UPDATE_FULL[] = {0x22, 0xF7};
+
+// Configuration commands
+static const uint8_t DATA_ENTRY[] = {0x11, 0x03};            // data entry mode
+static const uint8_t BORDER_FULL[] = {0x3C, 0x05};           // border waveform
+static const uint8_t TEMP_SENS[] = {0x18, 0x80};             // use internal temp sensor
+static const uint8_t DISPLAY_UPDATE[] = {0x21, 0x00, 0x80};  // display update control
+
+// For controlling which part of the image we want to write
+static const uint8_t RAM_X_POS[] = {0x4E, 0x00};  // Always start at 0
+static const uint8_t RAM_Y_POS = 0x4F;
+
+#define SEND(x) this->cmd_data(x, sizeof(x))
+
+WeActEPaper3C::WeActEPaper3C(WeActEPaper3CModel model) : model_(model) {}
+
+int WeActEPaper3C::get_width_internal() {
+  switch (this->model_) {
+    case WEACT_EPAPER_2_13_IN_3C:
+      return 122;
+    case WEACT_EPAPER_4_20_IN_3C:
+      return 400;
+    case WEACT_EPAPER_2_90_IN_3C:
+    default:
+      return 128;
+  }
+}
+
+int WeActEPaper3C::get_height_internal() {
+  switch (this->model_) {
+    case WEACT_EPAPER_2_13_IN_3C:
+      return 250;
+    case WEACT_EPAPER_4_20_IN_3C:
+      return 300;
+    case WEACT_EPAPER_2_90_IN_3C:
+    default:
+      return 296;
+  }
+}
+
+uint32_t WeActEPaper3C::idle_timeout_() { return 20000; }
+
+void WeActEPaper3C::dump_config() {
+  LOG_DISPLAY("", "WeAct E-Paper (3 Color)", this);
+  switch (this->model_) {
+    case WEACT_EPAPER_2_13_IN_3C:
+      ESP_LOGCONFIG(TAG, "  Model: 2.13in 3-Color");
+      break;
+    case WEACT_EPAPER_4_20_IN_3C:
+      ESP_LOGCONFIG(TAG, "  Model: 4.20in 3-Color");
+      break;
+    case WEACT_EPAPER_2_90_IN_3C:
+    default:
+      ESP_LOGCONFIG(TAG, "  Model: 2.90in 3-Color");
+      break;
+  }
+  LOG_PIN("  CS Pin: ", this->cs_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void WeActEPaper3C::setup() {
+  this->init_internal_(this->get_buffer_length_());
+  this->spi_setup();
+  setup_pins_();
+
+  if (this->buffer_ != nullptr) {
+    memset(this->buffer_, 0x00, this->get_buffer_length_());
+  }
+}
+
+void WeActEPaper3C::send_reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(2);
+    this->reset_pin_->digital_write(true);
+  }
+}
+
+void WeActEPaper3C::initialize() {}
+
+void WeActEPaper3C::deep_sleep() { SEND(SLEEP); }
+
+void WeActEPaper3C::set_window_(int t, int b) {
+  const uint8_t ram_x_range[] = {0x44, 0x00, (uint8_t) (this->get_width_internal() / 8u - 1)};
+  const uint8_t ram_y_range[] = {0x45, 0x00, 0x00, (uint8_t) (this->get_height_internal() - 1),
+                                 (uint8_t) ((this->get_height_internal() - 1) >> 8)};
+  this->cmd_data(ram_x_range, sizeof(ram_x_range));
+  this->cmd_data(ram_y_range, sizeof(ram_y_range));
+
+  SEND(RAM_X_POS);
+
+  uint8_t buffer[3];
+  buffer[0] = RAM_Y_POS;
+  buffer[1] = (uint8_t) t % 256;
+  buffer[2] = (uint8_t) (t / 256);
+  SEND(buffer);
+}
+
+void WeActEPaper3C::write_buffer_(int top, int bottom) {
+  auto width_bytes = this->get_width_internal() / 8u;
+  auto offset = top * width_bytes;
+  auto length = (bottom - top) * width_bytes;
+  auto red_offset = this->get_buffer_length_() / 2u;
+
+  this->wait_until_idle_();
+  this->set_window_(top, bottom);
+
+  // RED plane first
+  this->command(WRITE_COLOR);
+  this->start_data_();
+  this->write_array(this->buffer_ + offset + red_offset, length);
+  this->end_data_();
+
+  // BLACK plane second
+  this->command(WRITE_BLACK);
+  this->start_data_();
+  this->write_array(this->buffer_ + offset, length);
+  this->end_data_();
+}
+
+void HOT WeActEPaper3C::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x < 0 || y < 0 || x >= this->get_width_internal() || y >= this->get_height_internal())
+    return;
+
+  const uint32_t pos = (x + y * this->get_width_internal()) / 8u;
+  const uint8_t bit = 0x80 >> (x & 0x07);
+  const uint32_t red_offset = this->get_buffer_length_() / 2u;
+  bool is_red = ((color.red > 0) && (color.green == 0) && (color.blue == 0));
+
+  // BLACK PLANE: 0=Black, 1=White
+  // We want Black Ink if color is Active AND NOT Red.
+  if (color.is_on() && !is_red) {
+    this->buffer_[pos] &= ~bit;  // Black Ink
+  } else {
+    this->buffer_[pos] |= bit;  // White Paper
+  }
+
+  // RED PLANE: 1=Red, 0=None
+  if (is_red) {
+    this->buffer_[pos + red_offset] |= bit;
+  } else {
+    this->buffer_[pos + red_offset] &= ~bit;
+  }
+}
+
+void WeActEPaper3C::full_update_() {
+  ESP_LOGD(TAG, "Performing full e-paper update.");
+
+  this->wait_until_idle_();
+
+  this->write_buffer_(0, this->get_height_internal());
+  SEND(UPDATE_FULL);
+  this->command(ACTIVATE);
+  // Non-blocking: wait in loop()
+}
+
+void WeActEPaper3C::display() {
+  if (!this->initialized_) {
+    this->initialized_ = true;
+
+    this->send_reset_();
+    delay(10);
+
+    this->command(SW_RESET);
+    this->wait_until_idle_();
+
+    const uint8_t drv_out_ctl[] = {0x01, (uint8_t) ((this->get_height_internal() - 1) & 0xFF),
+                                   (uint8_t) (((this->get_height_internal() - 1) >> 8) & 0xFF), 0x00};
+    this->cmd_data(drv_out_ctl, sizeof(drv_out_ctl));
+
+    SEND(DATA_ENTRY);
+    SEND(BORDER_FULL);
+    SEND(TEMP_SENS);
+    SEND(DISPLAY_UPDATE);
+
+    return;  // first display call is just init
+  }
+
+  if (this->is_busy_ || (this->busy_pin_ != nullptr && this->busy_pin_->digital_read()))
+    return;
+
+  this->is_busy_ = true;
+  this->full_update_();
+}
+
+void WeActEPaper3C::loop() {
+  if (this->is_busy_) {
+    if (this->busy_pin_ == nullptr || !this->busy_pin_->digital_read()) {
+      this->is_busy_ = false;
+    }
+  }
+}
+
+}  // namespace waveshare_epaper
+}  // namespace esphome

--- a/tests/components/waveshare_epaper/common.yaml
+++ b/tests/components/waveshare_epaper/common.yaml
@@ -227,6 +227,61 @@ display:
     lambda: |-
       it.rectangle(0, 0, it.get_width(), it.get_height());
 
+  # WeAct 3-Color displays
+  - platform: waveshare_epaper
+    id: epd_2_13in3c_weact
+    model: 2.13in3c-weact
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
+  - platform: waveshare_epaper
+    id: epd_2_90in3c_weact
+    model: 2.90in3c-weact
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
+  - platform: waveshare_epaper
+    id: epd_4_20in3c_weact
+    model: 4.20in3c-weact
+    cs_pin:
+      allow_other_uses: true
+      number: ${cs_pin}
+    dc_pin:
+      allow_other_uses: true
+      number: ${dc_pin}
+    busy_pin:
+      allow_other_uses: true
+      number: ${busy_pin}
+    reset_pin:
+      allow_other_uses: true
+      number: ${reset_pin}
+    lambda: |-
+      it.rectangle(0, 0, it.get_width(), it.get_height());
+
   # 2.7 inch displays
   - platform: waveshare_epaper
     id: epd_2_70


### PR DESCRIPTION
## Summary
This pull request introduces support for a family of WeAct 3-color e-paper displays (2.13in, 2.90in, and 4.20in) into the existing `waveshare_epaper` component.

-   **Refactored Driver:** The individual drivers for the 2.90in and 4.20in 3-color displays have been consolidated into a single, universal `WeActEPaper3C` C++ class. This improves maintainability and extensibility, allowing for easier integration of future WeAct 3-color models.

-   **Added 2.13in Support:** The 2.13in (122x250) 3-color display model has been added to the universal `WeActEPaper3C` driver.

-   **Configuration Integration:** The `display.py` file has been updated to correctly map user-defined YAML models (`2.13in3c-weact`, `2.90in3c-weact`, `4.20in3c-weact`) to the new generic C++ implementation.
    This change aims to broaden the compatibility of the `waveshare_epaper` component with popular WeAct e-paper modules.

It was based on https://github.com/RaceNJason/WeAct-Studio_ePaper and reworked/adjusted to 2026.1.0 version.

I hope it can be merged into esphome now, as I found multiple outdated PRs (like 6226) doing the same, but each time esphome version is upgraded there is a risk those implementations will stop working, so after a few tries I was able to get to this point.
 ## Breaking Change?
    No.
 ## Codeowner
    @pgolawsk
## Test Cases
-   Testing performed with ESPHome `2026.1.1` locally with 2.9in display (I have no access to 2.13 and 4.20, assuming they would work)
-   Tested using `esphome compile <config_file.yaml>` with configurations for 2.90in and 2.13in displays.
    ## Changes
-   `esphome/components/waveshare_epaper/waveshare_epaper.h`: Added `WeActEPaper3CModel` enum and `WeActEPaper3C` class definition.
 -   `esphome/components/waveshare_epaper/weact_epaper_3c.cpp`: Implemented the universal `WeActEPaper3C` class with logic for 2.13in, 2.90in, and 4.20in models.
-   `esphome/components/waveshare_epaper/display.py`: Updated `MODELS` dictionary and `to_code` function to support the new `weact_3c` models.

Related documentation PR: esphome/esphome-docs#5977
