### PR TITLE
[socket] ESP8266: call delay(0) instead of esp_delay(0, cb) for zero timeout

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -30,11 +30,11 @@ void socket_delay(uint32_t ms) {
   // This allows the delay to exit early when socket_wake() is called by
   // lwip recv_fn/accept_fn callbacks, reducing socket latency.
   //
-  // When ms is 0, we must explicitly yield() because esp_delay(0, callback)
+  // When ms is 0, we must use delay(0) because esp_delay(0, callback)
   // exits immediately without yielding, which can cause watchdog timeouts
   // when the main loop runs in high-frequency mode (e.g., during light effects).
   if (ms == 0) {
-    yield();
+    delay(0);
     return;
   }
   s_socket_woke = false;

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -29,6 +29,14 @@ void socket_delay(uint32_t ms) {
   // Use esp_delay with a callback that checks if socket data arrived.
   // This allows the delay to exit early when socket_wake() is called by
   // lwip recv_fn/accept_fn callbacks, reducing socket latency.
+  //
+  // When ms is 0, we must explicitly yield() because esp_delay(0, callback)
+  // exits immediately without yielding, which can cause watchdog timeouts
+  // when the main loop runs in high-frequency mode (e.g., during light effects).
+  if (ms == 0) {
+    yield();
+    return;
+  }
   s_socket_woke = false;
   esp_delay(ms, []() { return !s_socket_woke; });
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression where `socket_delay(0)` doesn't yield on ESP8266, unlike the original `delay(0)` behavior.

**Background:**

In 2025.11.0, the ESP8266 path in `yield_with_select_()` used `delay(delay_ms)`. When `delay_ms == 0`, `delay(0)` yields to feed the watchdog and let system tasks run.

When `socket_delay` was introduced for ESP8266, the ESP8266 path changed to use `socket_delay(delay_ms)`. However, `socket_delay(0)` calls `esp_delay(0, callback)`, which exits immediately without yielding because the timeout condition (`elapsed >= timeout`, i.e., `0 >= 0`) is satisfied before the internal `delay()` call.

This means `yield_with_select_(0)` (called when the loop overruns its 16ms interval) no longer yields on ESP8266, which can cause watchdog timeouts during high-frequency operations like continuous light effects.

**Why this likely didn't present until 2026.1.0:**

The regression was introduced in 2025.12.x but likely didn't cause visible issues because other sources of overhead in the loop (primarily heap churn and fragmentation) provided enough incidental delays to prevent watchdog timeouts. In 2026.1.0, we reduced much of this heap overhead, which may have tightened loop execution enough that the missing yield now causes WDT resets during high-frequency operations.

Note: This theory is based on a single user report (#13527) and has not been independently reproduced. However, the fix addresses a clear correctness issue regardless of whether it fully resolves that specific report.

**The fix:**

Call `delay(0)` when `ms == 0` in `socket_delay()`, restoring the original behavior from 2025.11.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13527

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Config that may trigger the issue - continuous PWM pulse effect on ESP8266
esphome:
  name: test-esp8266

esp8266:
  board: nodemcuv2

output:
  - platform: esp8266_pwm
    pin: D7
    id: pwm_output

light:
  - platform: monochromatic
    output: pwm_output
    effects:
      - pulse:
          transition_length: 0.5s
          update_interval: 1s
    name: "Test Light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
