### PR TITLE
[web_server] Add name_id to SSE for entity ID format migration

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -531,7 +531,19 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const char *prefix, J
   memcpy(p, name.c_str(), name_len);
   p[name_len] = '\0';
 
-  root[ESPHOME_F("id")] = id_buf;
+  // name_id: new format {prefix}/{device?}/{name} - frontend should prefer this
+  // Remove in 2026.8.0 when id switches to new format permanently
+  root[ESPHOME_F("name_id")] = id_buf;
+
+  // id: old format {prefix}-{object_id} for backward compatibility
+  // Will switch to new format in 2026.8.0
+  char legacy_buf[ESPHOME_DOMAIN_MAX_LEN + 1 + OBJECT_ID_MAX_LEN];
+  char *lp = legacy_buf;
+  memcpy(lp, prefix, prefix_len);
+  lp += prefix_len;
+  *lp++ = '-';
+  obj->write_object_id_to(lp, sizeof(legacy_buf) - (lp - legacy_buf));
+  root[ESPHOME_F("id")] = legacy_buf;
 
   if (start_config == DETAIL_ALL) {
     root[ESPHOME_F("domain")] = prefix;


### PR DESCRIPTION
## IMPORTANT: we need to make sure we backport the webserver assets update PR that will automatically be generated after merging and releasing esphome-websever PRs as well as cherry-picking any PRs from previous updates. The esphome-webserver changes are designed to be backwards compatible so they can ship to the cloud service and work with 2025.12.x format, 2026.1.0-2, and 2026.1.3 forward.

# What does this implement/fix?

Follow-up to #12627. Adds a deprecation path for the SSE entity ID format change to help third-party integrations migrate.

- `name_id`: new format (`sensor/Temperature`) - integrations should migrate to this
- `id`: legacy format (`sensor-temperature`) - restored for backward compatibility

The `id` field will switch to the new format in ESPHome 2026.8.0, at which point `name_id` will be removed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #12627
- Frontend: https://github.com/esphome/esphome-webserver/pull/186

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/5979

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed

web_server:
  port: 80
```

## SSE Payload Example

```json
{
  "name_id": "sensor/Temperature",
  "id": "sensor-temperature",
  "state": "21.5 °C",
  "value": 21.5
}
```

## Timeline

- **2026.1.3**: `name_id` introduced, `id` reverts to legacy format
- **2026.8.0**: `name_id` removed, `id` becomes new format permanently

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
