### PR TITLE
[mhz19] Refactor detection range logging to use LogString

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -3,8 +3,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace mhz19 {
+namespace esphome::mhz19 {
 
 static const char *const TAG = "mhz19";
 static const uint8_t MHZ19_REQUEST_LENGTH = 8;
@@ -156,5 +155,4 @@ void MHZ19Component::dump_config() {
   ESP_LOGCONFIG(TAG, "  Detection range: %s", LOG_STR_ARG(detection_range_to_log_string(this->detection_range_)));
 }
 
-}  // namespace mhz19
-}  // namespace esphome
+}  // namespace esphome::mhz19

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -17,6 +17,19 @@ static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM[] = {0xFF, 0x01, 0x
 static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x13, 0x88};
 static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x27, 0x10};
 
+static const LogString *detection_range_to_log_string(MHZ19DetectionRange range) {
+  switch (range) {
+    case MHZ19_DETECTION_RANGE_0_2000PPM:
+      return LOG_STR("0-2000 ppm");
+    case MHZ19_DETECTION_RANGE_0_5000PPM:
+      return LOG_STR("0-5000 ppm");
+    case MHZ19_DETECTION_RANGE_0_10000PPM:
+      return LOG_STR("0-10000 ppm");
+    default:
+      return LOG_STR("default");
+  }
+}
+
 uint8_t mhz19_checksum(const uint8_t *command) {
   uint8_t sum = 0;
   for (uint8_t i = 1; i < MHZ19_REQUEST_LENGTH; i++) {
@@ -91,24 +104,24 @@ void MHZ19Component::abc_disable() {
   this->mhz19_write_command_(MHZ19_COMMAND_ABC_DISABLE, nullptr);
 }
 
-void MHZ19Component::range_set(MHZ19DetectionRange detection_ppm) {
-  switch (detection_ppm) {
-    case MHZ19_DETECTION_RANGE_DEFAULT:
-      ESP_LOGV(TAG, "Using previously set detection range (no change)");
-      break;
+void MHZ19Component::range_set(MHZ19DetectionRange detection_range) {
+  const uint8_t *command;
+  switch (detection_range) {
     case MHZ19_DETECTION_RANGE_0_2000PPM:
-      ESP_LOGD(TAG, "Setting detection range to 0 to 2000ppm");
-      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM, nullptr);
+      command = MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM;
       break;
     case MHZ19_DETECTION_RANGE_0_5000PPM:
-      ESP_LOGD(TAG, "Setting detection range to 0 to 5000ppm");
-      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM, nullptr);
+      command = MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM;
       break;
     case MHZ19_DETECTION_RANGE_0_10000PPM:
-      ESP_LOGD(TAG, "Setting detection range to 0 to 10000ppm");
-      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM, nullptr);
+      command = MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM;
       break;
+    default:
+      ESP_LOGV(TAG, "Using previously set detection range (no change)");
+      return;
   }
+  ESP_LOGD(TAG, "Setting detection range to %s", LOG_STR_ARG(detection_range_to_log_string(detection_range)));
+  this->mhz19_write_command_(command, nullptr);
 }
 
 bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *response) {
@@ -140,26 +153,7 @@ void MHZ19Component::dump_config() {
   }
 
   ESP_LOGCONFIG(TAG, "  Warmup time: %" PRIu32 " s", this->warmup_seconds_);
-
-  const char *range_str;
-  switch (this->detection_range_) {
-    case MHZ19_DETECTION_RANGE_DEFAULT:
-      range_str = "default";
-      break;
-    case MHZ19_DETECTION_RANGE_0_2000PPM:
-      range_str = "0 to 2000ppm";
-      break;
-    case MHZ19_DETECTION_RANGE_0_5000PPM:
-      range_str = "0 to 5000ppm";
-      break;
-    case MHZ19_DETECTION_RANGE_0_10000PPM:
-      range_str = "0 to 10000ppm";
-      break;
-    default:
-      range_str = "default";
-      break;
-  }
-  ESP_LOGCONFIG(TAG, "  Detection range: %s", range_str);
+  ESP_LOGCONFIG(TAG, "  Detection range: %s", LOG_STR_ARG(detection_range_to_log_string(this->detection_range_)));
 }
 
 }  // namespace mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace mhz19 {
+namespace esphome::mhz19 {
 
 enum MHZ19ABCLogic {
   MHZ19_ABC_NONE = 0,
@@ -74,5 +73,4 @@ template<typename... Ts> class MHZ19DetectionRangeSetAction : public Action<Ts..
   void play(const Ts &...x) override { this->parent_->range_set(this->detection_range_.value(x...)); }
 };
 
-}  // namespace mhz19
-}  // namespace esphome
+}  // namespace esphome::mhz19

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -32,7 +32,7 @@ class MHZ19Component : public PollingComponent, public uart::UARTDevice {
   void calibrate_zero();
   void abc_enable();
   void abc_disable();
-  void range_set(MHZ19DetectionRange detection_ppm);
+  void range_set(MHZ19DetectionRange detection_range);
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_co2_sensor(sensor::Sensor *co2_sensor) { co2_sensor_ = co2_sensor; }


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #13526. Refactors the detection range string handling to follow ESPHome logging best practices:

1. **Adds `detection_range_to_log_string()` helper** - Returns `const LogString *` for flash storage on ESP8266
2. **Simplifies `dump_config()`** - Removes 17-line switch statement, replaced with single line using the helper
3. **Refactors `range_set()`** - Consolidates duplicate logging, uses early return for default case

**Note:** Log format changed from `"0 to 2000ppm"` to `"0-2000 ppm"` for consistency with the more compact style.

### Before (range_set):
```cpp
void MHZ19Component::range_set(MHZ19DetectionRange detection_ppm) {
  switch (detection_ppm) {
    case MHZ19_DETECTION_RANGE_DEFAULT:
      ESP_LOGV(TAG, "Using previously set detection range (no change)");
      break;
    case MHZ19_DETECTION_RANGE_0_2000PPM:
      ESP_LOGD(TAG, "Setting detection range to 0 to 2000ppm");
      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM, nullptr);
      break;
    case MHZ19_DETECTION_RANGE_0_5000PPM:
      ESP_LOGD(TAG, "Setting detection range to 0 to 5000ppm");
      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM, nullptr);
      break;
    case MHZ19_DETECTION_RANGE_0_10000PPM:
      ESP_LOGD(TAG, "Setting detection range to 0 to 10000ppm");
      this->mhz19_write_command_(MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM, nullptr);
      break;
  }
}
```

### After (range_set):
```cpp
void MHZ19Component::range_set(MHZ19DetectionRange detection_range) {
  const uint8_t *command;
  switch (detection_range) {
    case MHZ19_DETECTION_RANGE_0_2000PPM:
      command = MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM;
      break;
    case MHZ19_DETECTION_RANGE_0_5000PPM:
      command = MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM;
      break;
    case MHZ19_DETECTION_RANGE_0_10000PPM:
      command = MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM;
      break;
    default:
      ESP_LOGV(TAG, "Using previously set detection range (no change)");
      return;
  }
  ESP_LOGD(TAG, "Setting detection range to %s", LOG_STR_ARG(detection_range_to_log_string(detection_range)));
  this->mhz19_write_command_(command, nullptr);
}
```

### Benefits:
- Strings stored in flash on ESP8266 (saves RAM)
- Single source of truth for detection range strings
- Cleaner, more maintainable code
- Follows patterns used in `fan`, `wifi`, and other components

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13526

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
sensor:
  - platform: mhz19
    co2:
      name: "CO2"
    temperature:
      name: "Temperature"
    detection_range: 5000ppm
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).