### PR TITLE
[uln2003] Refactor step mode logging to use LogString

### DIFF
--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -1,8 +1,7 @@
 #include "uln2003.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace uln2003 {
+namespace esphome::uln2003 {
 
 static const char *const TAG = "uln2003.stepper";
 
@@ -88,5 +87,4 @@ void ULN2003::write_step_(int32_t step) {
   this->pin_d_->digital_write((res >> 3) & 1);
 }
 
-}  // namespace uln2003
-}  // namespace esphome
+}  // namespace esphome::uln2003

--- a/esphome/components/uln2003/uln2003.cpp
+++ b/esphome/components/uln2003/uln2003.cpp
@@ -6,6 +6,19 @@ namespace uln2003 {
 
 static const char *const TAG = "uln2003.stepper";
 
+static const LogString *step_mode_to_log_string(ULN2003StepMode mode) {
+  switch (mode) {
+    case ULN2003_STEP_MODE_FULL_STEP:
+      return LOG_STR("FULL STEP");
+    case ULN2003_STEP_MODE_HALF_STEP:
+      return LOG_STR("HALF STEP");
+    case ULN2003_STEP_MODE_WAVE_DRIVE:
+      return LOG_STR("WAVE DRIVE");
+    default:
+      return LOG_STR("UNKNOWN");
+  }
+}
+
 void ULN2003::setup() {
   this->pin_a_->setup();
   this->pin_b_->setup();
@@ -42,22 +55,7 @@ void ULN2003::dump_config() {
   LOG_PIN("  Pin B: ", this->pin_b_);
   LOG_PIN("  Pin C: ", this->pin_c_);
   LOG_PIN("  Pin D: ", this->pin_d_);
-  const char *step_mode_s;
-  switch (this->step_mode_) {
-    case ULN2003_STEP_MODE_FULL_STEP:
-      step_mode_s = "FULL STEP";
-      break;
-    case ULN2003_STEP_MODE_HALF_STEP:
-      step_mode_s = "HALF STEP";
-      break;
-    case ULN2003_STEP_MODE_WAVE_DRIVE:
-      step_mode_s = "WAVE DRIVE";
-      break;
-    default:
-      step_mode_s = "UNKNOWN";
-      break;
-  }
-  ESP_LOGCONFIG(TAG, "  Step Mode: %s", step_mode_s);
+  ESP_LOGCONFIG(TAG, "  Step Mode: %s", LOG_STR_ARG(step_mode_to_log_string(this->step_mode_)));
 }
 void ULN2003::write_step_(int32_t step) {
   int32_t n = this->step_mode_ == ULN2003_STEP_MODE_HALF_STEP ? 8 : 4;

--- a/esphome/components/uln2003/uln2003.h
+++ b/esphome/components/uln2003/uln2003.h
@@ -4,8 +4,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/stepper/stepper.h"
 
-namespace esphome {
-namespace uln2003 {
+namespace esphome::uln2003 {
 
 enum ULN2003StepMode {
   ULN2003_STEP_MODE_FULL_STEP,
@@ -40,5 +39,4 @@ class ULN2003 : public stepper::Stepper, public Component {
   int32_t current_uln_pos_{0};
 };
 
-}  // namespace uln2003
-}  // namespace esphome
+}  // namespace esphome::uln2003


### PR DESCRIPTION
# What does this implement/fix?

Refactors the step mode string handling in `dump_config()` to follow ESPHome logging best practices:

1. **Adds `step_mode_to_log_string()` helper** - Returns `const LogString *` for flash storage on ESP8266
2. **Simplifies `dump_config()`** - Removes 14-line switch statement, replaced with single line using the helper

### Before:
```cpp
const char *step_mode_s;
switch (this->step_mode_) {
  case ULN2003_STEP_MODE_FULL_STEP:
    step_mode_s = "FULL STEP";
    break;
  case ULN2003_STEP_MODE_HALF_STEP:
    step_mode_s = "HALF STEP";
    break;
  case ULN2003_STEP_MODE_WAVE_DRIVE:
    step_mode_s = "WAVE DRIVE";
    break;
  default:
    step_mode_s = "UNKNOWN";
    break;
}
ESP_LOGCONFIG(TAG, "  Step Mode: %s", step_mode_s);
```

### After:
```cpp
ESP_LOGCONFIG(TAG, "  Step Mode: %s", LOG_STR_ARG(step_mode_to_log_string(this->step_mode_)));
```

### Benefits:
- Strings stored in flash on ESP8266 (saves RAM)
- Cleaner, more maintainable code
- Follows patterns used in `fan`, `wifi`, and other components

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactoring only
stepper:
  - platform: uln2003
    id: my_stepper
    pin_a: GPIO12
    pin_b: GPIO13
    pin_c: GPIO14
    pin_d: GPIO15
    step_mode: HALF_STEP
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
