### PR TITLE
[core] Add PROGMEM string comparison helpers and use in cover/valve/helpers

### DIFF
--- a/esphome/components/cover/cover.cpp
+++ b/esphome/components/cover/cover.cpp
@@ -1,10 +1,10 @@
 #include "cover.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
+#include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 #include <strings.h>
-
-#include "esphome/core/log.h"
 
 namespace esphome::cover {
 
@@ -39,13 +39,13 @@ Cover::Cover() : position{COVER_OPEN} {}
 
 CoverCall::CoverCall(Cover *parent) : parent_(parent) {}
 CoverCall &CoverCall::set_command(const char *command) {
-  if (strcasecmp(command, "OPEN") == 0) {
+  if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("OPEN")) == 0) {
     this->set_command_open();
-  } else if (strcasecmp(command, "CLOSE") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("CLOSE")) == 0) {
     this->set_command_close();
-  } else if (strcasecmp(command, "STOP") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("STOP")) == 0) {
     this->set_command_stop();
-  } else if (strcasecmp(command, "TOGGLE") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TOGGLE")) == 0) {
     this->set_command_toggle();
   } else {
     ESP_LOGW(TAG, "'%s' - Unrecognized command %s", this->parent_->get_name().c_str(), command);

--- a/esphome/components/valve/valve.cpp
+++ b/esphome/components/valve/valve.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
+
 #include <strings.h>
 
 namespace esphome {
@@ -38,13 +40,13 @@ Valve::Valve() : position{VALVE_OPEN} {}
 
 ValveCall::ValveCall(Valve *parent) : parent_(parent) {}
 ValveCall &ValveCall::set_command(const char *command) {
-  if (strcasecmp(command, "OPEN") == 0) {
+  if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("OPEN")) == 0) {
     this->set_command_open();
-  } else if (strcasecmp(command, "CLOSE") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("CLOSE")) == 0) {
     this->set_command_close();
-  } else if (strcasecmp(command, "STOP") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("STOP")) == 0) {
     this->set_command_stop();
-  } else if (strcasecmp(command, "TOGGLE") == 0) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TOGGLE")) == 0) {
     this->set_command_toggle();
   } else {
     ESP_LOGW(TAG, "'%s' - Unrecognized command %s", this->parent_->get_name().c_str(), command);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -3,6 +3,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include "esphome/core/string_ref.h"
 
 #include <strings.h>
@@ -451,15 +452,15 @@ std::string format_bin(const uint8_t *data, size_t length) {
 }
 
 ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
-  if (on == nullptr && strcasecmp(str, "on") == 0)
+  if (on == nullptr && ESPHOME_strcasecmp_P(str, ESPHOME_PSTR("on")) == 0)
     return PARSE_ON;
   if (on != nullptr && strcasecmp(str, on) == 0)
     return PARSE_ON;
-  if (off == nullptr && strcasecmp(str, "off") == 0)
+  if (off == nullptr && ESPHOME_strcasecmp_P(str, ESPHOME_PSTR("off")) == 0)
     return PARSE_OFF;
   if (off != nullptr && strcasecmp(str, off) == 0)
     return PARSE_OFF;
-  if (strcasecmp(str, "toggle") == 0)
+  if (ESPHOME_strcasecmp_P(str, ESPHOME_PSTR("toggle")) == 0)
     return PARSE_TOGGLE;
 
   return PARSE_NONE;

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -12,6 +12,10 @@
 #define ESPHOME_strncpy_P strncpy_P
 #define ESPHOME_strncat_P strncat_P
 #define ESPHOME_snprintf_P snprintf_P
+#define ESPHOME_strcmp_P strcmp_P
+#define ESPHOME_strcasecmp_P strcasecmp_P
+#define ESPHOME_strncmp_P strncmp_P
+#define ESPHOME_strncasecmp_P strncasecmp_P
 // Type for pointers to PROGMEM strings (for use with ESPHOME_F return values)
 using ProgmemStr = const __FlashStringHelper *;
 #else
@@ -21,6 +25,10 @@ using ProgmemStr = const __FlashStringHelper *;
 #define ESPHOME_strncpy_P strncpy
 #define ESPHOME_strncat_P strncat
 #define ESPHOME_snprintf_P snprintf
+#define ESPHOME_strcmp_P strcmp
+#define ESPHOME_strcasecmp_P strcasecmp
+#define ESPHOME_strncmp_P strncmp
+#define ESPHOME_strncasecmp_P strncasecmp
 // Type for pointers to strings (no PROGMEM on non-ESP8266 platforms)
 using ProgmemStr = const char *;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Adds PROGMEM-aware string comparison helpers to `progmem.h` and uses them in core entity components to keep command string literals in flash on ESP8266, saving RAM.

## Changes

**New helpers in `esphome/core/progmem.h`:**
- `ESPHOME_strcmp_P` - case-sensitive comparison with PROGMEM string
- `ESPHOME_strcasecmp_P` - case-insensitive comparison with PROGMEM string
- `ESPHOME_strncmp_P` - bounded case-sensitive comparison
- `ESPHOME_strncasecmp_P` - bounded case-insensitive comparison

On ESP8266, these map to the Arduino `_P` suffix functions (`strcasecmp_P`, etc.) which compare a RAM string against a flash-stored string. On other platforms, they map to the standard functions.

**Updated components:**
- `cover.cpp` - OPEN, CLOSE, STOP, TOGGLE command strings now in flash
- `valve.cpp` - OPEN, CLOSE, STOP, TOGGLE command strings now in flash
- `helpers.cpp` - "on", "off", "toggle" literals in `parse_on_off()` now in flash

## ESP8266 RAM Savings

| File | Strings | Bytes Saved |
|------|---------|-------------|
| cover.cpp | OPEN, CLOSE, STOP, TOGGLE | ~22 bytes |
| valve.cpp | OPEN, CLOSE, STOP, TOGGLE | ~22 bytes |
| helpers.cpp | on, off, toggle | ~14 bytes |
| **Total** | | **~58 bytes** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Ongoing ESP8266 memory optimization effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation detail, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using cover or valve entities benefits automatically

cover:
  - platform: template
    name: "Test Cover"
    lambda: return COVER_OPEN;
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"

valve:
  - platform: template
    name: "Test Valve"
    lambda: return VALVE_OPEN;
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
