### PR TITLE
[http_request] Use stack allocation for MD5 buffer in OTA

### DIFF
--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -82,7 +82,7 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
   uint32_t last_progress = 0;
   uint32_t update_start_time = millis();
   md5::MD5Digest md5_receive;
-  std::unique_ptr<char[]> md5_receive_str(new char[33]);
+  char md5_receive_str[33];
 
   if (this->md5_expected_.empty() && !this->http_get_md5_()) {
     return OTA_MD5_INVALID;
@@ -176,14 +176,14 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
 
   // verify MD5 is as expected and act accordingly
   md5_receive.calculate();
-  md5_receive.get_hex(md5_receive_str.get());
-  this->md5_computed_ = md5_receive_str.get();
+  md5_receive.get_hex(md5_receive_str);
+  this->md5_computed_ = md5_receive_str;
   if (strncmp(this->md5_computed_.c_str(), this->md5_expected_.c_str(), MD5_SIZE) != 0) {
     ESP_LOGE(TAG, "MD5 computed: %s - Aborting due to MD5 mismatch", this->md5_computed_.c_str());
     this->cleanup_(std::move(backend), container);
     return ota::OTA_RESPONSE_ERROR_MD5_MISMATCH;
   } else {
-    backend->set_update_md5(md5_receive_str.get());
+    backend->set_update_md5(md5_receive_str);
   }
 
   container->end();


### PR DESCRIPTION
# What does this implement/fix?

Uses stack allocation instead of heap allocation for the MD5 hex string buffer in HTTP OTA updates.

## Changes

- **Before:** `std::unique_ptr<char[]> md5_receive_str(new char[33])` - heap allocation
- **After:** `char md5_receive_str[33]` - stack allocation

The buffer is a fixed 33 bytes (32 hex chars + null terminator) that only lives within the `do_ota_()` function. There's no reason for it to be heap allocated.

## Why was this heap allocated?

No good reason - likely copy-paste or cargo-cult "modern C++" thinking that `unique_ptr` is always better. For a fixed-size buffer that doesn't outlive the function, stack allocation is clearly correct.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - Ongoing heap allocation reduction effort

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - Internal implementation detail, no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using HTTP OTA benefits automatically

ota:
  - platform: http_request

http_request:

button:
  - platform: template
    name: "Update Firmware"
    on_press:
      - ota.http_request.flash:
          url: http://example.com/firmware.bin
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
