### PR TITLE
[cc1101] Add packet transport support

### DIFF
--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -19,6 +19,7 @@ MULTI_CONF = True
 
 ns = cg.esphome_ns.namespace("cc1101")
 CC1101Component = ns.class_("CC1101Component", cg.Component, spi.SPIDevice)
+CC1101Listener = ns.class_("CC1101Listener")
 
 # Config keys
 CONF_OUTPUT_POWER = "output_power"

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -391,6 +391,13 @@ CC1101Error CC1101Component::transmit_packet(const std::vector<uint8_t> &packet)
   return CC1101Error::NONE;
 }
 
+size_t CC1101Component::get_max_packet_size() {
+  if (this->state_.LENGTH_CONFIG == static_cast<uint8_t>(LengthConfig::LENGTH_CONFIG_FIXED)) {
+    return this->state_.PKTLEN;
+  }
+  return 64 - 1;  // FIFO size - length indicator
+}
+
 // Setters
 void CC1101Component::set_output_power(float value) {
   this->output_power_requested_ = value;

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -80,6 +80,7 @@ class CC1101Component : public Component,
   CC1101Error transmit_packet(const std::vector<uint8_t> &packet);
   void register_listener(CC1101Listener *listener) { this->listeners_.push_back(listener); }
   Trigger<std::vector<uint8_t>, float, float, uint8_t> *get_packet_trigger() const { return this->packet_trigger_; }
+  size_t get_max_packet_size();
 
  protected:
   uint16_t chip_id_{0};

--- a/esphome/components/cc1101/packet_transport/__init__.py
+++ b/esphome/components/cc1101/packet_transport/__init__.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components.packet_transport import (
+    PacketTransport,
+    new_packet_transport,
+    transport_schema,
+)
+import esphome.config_validation as cv
+from esphome.cpp_types import PollingComponent
+
+from .. import CC1101Component, CC1101Listener, ns as cc1101_ns
+
+CONF_CC1101_ID = "cc1101_id"
+
+CC1101Transport = cc1101_ns.class_(
+    "CC1101Transport", PacketTransport, PollingComponent, CC1101Listener
+)
+
+CONFIG_SCHEMA = transport_schema(CC1101Transport).extend(
+    {
+        cv.GenerateID(CONF_CC1101_ID): cv.use_id(CC1101Component),
+    }
+)
+
+
+async def to_code(config):
+    var, _ = await new_packet_transport(config)
+    await cg.register_parented(var, config[CONF_CC1101_ID])

--- a/esphome/components/cc1101/packet_transport/cc1101_transport.cpp
+++ b/esphome/components/cc1101/packet_transport/cc1101_transport.cpp
@@ -1,0 +1,22 @@
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+#include "cc1101_transport.h"
+
+namespace esphome {
+namespace cc1101 {
+
+static const char *const TAG = "cc1101_transport";
+
+void CC1101Transport::setup() {
+  PacketTransport::setup();
+  this->parent_->register_listener(this);
+}
+
+void CC1101Transport::send_packet(const std::vector<uint8_t> &buf) const { this->parent_->transmit_packet(buf); }
+
+void CC1101Transport::on_packet(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) {
+  this->process_(packet);
+}
+
+}  // namespace cc1101
+}  // namespace esphome

--- a/esphome/components/cc1101/packet_transport/cc1101_transport.h
+++ b/esphome/components/cc1101/packet_transport/cc1101_transport.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/cc1101/cc1101.h"
+#include "esphome/components/packet_transport/packet_transport.h"
+#include <vector>
+
+namespace esphome {
+namespace cc1101 {
+
+class CC1101Transport : public packet_transport::PacketTransport,
+                        public Parented<CC1101Component>,
+                        public CC1101Listener {
+ public:
+  void setup() override;
+  void on_packet(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+ protected:
+  void send_packet(const std::vector<uint8_t> &buf) const override;
+  bool should_send() override { return true; }
+  size_t get_max_packet_size() override { return this->parent_->get_max_packet_size(); }
+};
+
+}  // namespace cc1101
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Packet transport support for CC1101

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
    name: cc1011-pt

esp32:
  variant: esp32
  framework:
    type: esp-idf
    advanced:
      minimum_chip_revision: '3.1'

spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23
  miso_pin: GPIO19

cc1101:
  id: rf_1
  cs_pin: GPIO5
  gdo0_pin: GPIO2
  packet_mode: yes
  packet_length: 64
  frequency: 868.3MHz
  modulation_type: 2-FSK
  fsk_deviation: 50.781250kHz
  manchester: no
  carrier_sense_above_threshold: yes
  channel: 0
  channel_spacing: 200kHz
  symbol_rate: 38400
  sync_mode: '16/16'
  sync0: 0xFE
  sync1: 0xAB

packet_transport:
  platform: cc1101
  sensors:
    - uptime_1

sensor:
  - platform: uptime
    name: Uptime
    id: uptime_1
    update_interval: 10s


```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
