### PR TITLE
[ota] Improve error message when device closes connection without responding

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -154,6 +154,12 @@ def check_error(data: list[int] | bytes, expect: int | list[int] | None) -> None
     """
     if not expect:
         return
+    if not data:
+        raise OTAError(
+            "Error: Device closed connection without responding. "
+            "This may indicate the device ran out of memory, "
+            "a network issue, or the connection was interrupted."
+        )
     dat = data[0]
     if dat == RESPONSE_ERROR_MAGIC:
         raise OTAError("Error: Invalid magic byte")

--- a/tests/unit_tests/test_espota2.py
+++ b/tests/unit_tests/test_espota2.py
@@ -192,6 +192,20 @@ def test_check_error_unexpected_response() -> None:
         espota2.check_error([0x7F], [espota2.RESPONSE_OK, espota2.RESPONSE_AUTH_OK])
 
 
+def test_check_error_empty_data() -> None:
+    """Test check_error raises error when device closes connection without responding."""
+    with pytest.raises(
+        espota2.OTAError, match="Device closed connection without responding"
+    ):
+        espota2.check_error([], [espota2.RESPONSE_OK])
+
+    # Also test with empty bytes
+    with pytest.raises(
+        espota2.OTAError, match="Device closed connection without responding"
+    ):
+        espota2.check_error(b"", [espota2.RESPONSE_OK])
+
+
 def test_send_check_with_various_data_types(mock_socket: Mock) -> None:
     """Test send_check handles different data types."""
 


### PR DESCRIPTION
# What does this implement/fix?

Improves error handling when the device closes the OTA connection without sending a response. Previously, this resulted in a cryptic `IndexError: list index out of range` traceback. Now it shows a helpful error message:

```
Error: Device closed connection without responding. This may indicate the device ran out of memory, a network issue, or the connection was interrupted.
```

This commonly occurs when:
- The device runs out of memory during OTA
- Network connectivity issues cause the connection to drop
- The connection is interrupted mid-transfer

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing documentation needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(This is Python-side error handling, applies to all platforms)

## Example entry for `config.yaml`:

```yaml
# N/A - no configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A)
