### PR TITLE
[esp32] Eliminate dead exception class code via linker wraps

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1049,16 +1049,18 @@ async def to_code(config):
         if use_platformio:
             cg.add_platformio_option("framework", "espidf")
 
-        # Wrap std::__throw_* functions to abort immediately, eliminating ~1KB of
+        # Wrap std::__throw_* functions to abort immediately, eliminating ~3KB of
         # exception class overhead. See throw_stubs.cpp for implementation.
-        # ESP-IDF wraps __cxa_throw but not these higher-level functions.
-        # Mangled names: _ZSt = std::, number = identifier length, PKc = char const*
-        cg.add_build_flag("-Wl,--wrap=_ZSt20__throw_length_errorPKc")
-        cg.add_build_flag("-Wl,--wrap=_ZSt19__throw_logic_errorPKc")
-        cg.add_build_flag("-Wl,--wrap=_ZSt20__throw_out_of_rangePKc")
-        cg.add_build_flag("-Wl,--wrap=_ZSt24__throw_out_of_range_fmtPKcz")
-        cg.add_build_flag("-Wl,--wrap=_ZSt17__throw_bad_allocv")
-        cg.add_build_flag("-Wl,--wrap=_ZSt25__throw_bad_function_callv")
+        # ESP-IDF already compiles with -fno-exceptions, so this code was dead anyway.
+        for mangled in [
+            "_ZSt20__throw_length_errorPKc",
+            "_ZSt19__throw_logic_errorPKc",
+            "_ZSt20__throw_out_of_rangePKc",
+            "_ZSt24__throw_out_of_range_fmtPKcz",
+            "_ZSt17__throw_bad_allocv",
+            "_ZSt25__throw_bad_function_callv",
+        ]:
+            cg.add_build_flag(f"-Wl,--wrap={mangled}")
     else:
         cg.add_build_flag("-DUSE_ARDUINO")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1048,6 +1048,17 @@ async def to_code(config):
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")
         if use_platformio:
             cg.add_platformio_option("framework", "espidf")
+
+        # Wrap std::__throw_* functions to abort immediately, eliminating ~1KB of
+        # exception class overhead. See throw_stubs.cpp for implementation.
+        # ESP-IDF wraps __cxa_throw but not these higher-level functions.
+        # Mangled names: _ZSt = std::, number = identifier length, PKc = char const*
+        cg.add_build_flag("-Wl,--wrap=_ZSt20__throw_length_errorPKc")
+        cg.add_build_flag("-Wl,--wrap=_ZSt19__throw_logic_errorPKc")
+        cg.add_build_flag("-Wl,--wrap=_ZSt20__throw_out_of_rangePKc")
+        cg.add_build_flag("-Wl,--wrap=_ZSt24__throw_out_of_range_fmtPKcz")
+        cg.add_build_flag("-Wl,--wrap=_ZSt17__throw_bad_allocv")
+        cg.add_build_flag("-Wl,--wrap=_ZSt25__throw_bad_function_callv")
     else:
         cg.add_build_flag("-DUSE_ARDUINO")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")

--- a/esphome/components/esp32/throw_stubs.cpp
+++ b/esphome/components/esp32/throw_stubs.cpp
@@ -23,31 +23,33 @@
 #ifdef USE_ESP_IDF
 #include "esp_system.h"
 
+namespace esphome::esp32 {}
+
+// Linker wraps for std::__throw_* - must be extern "C" at global scope.
+// Names must be __wrap_ + mangled name for the linker's --wrap option.
+
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 extern "C" {
 
-// std::__throw_length_error(char const*)
-// Called when container size exceeds max_size()
+// std::__throw_length_error(char const*) - called when container size exceeds max_size()
 void __wrap__ZSt20__throw_length_errorPKc(const char *) { esp_system_abort("std::length_error"); }
 
-// std::__throw_logic_error(char const*)
-// Called for logic errors (e.g., promise already satisfied)
+// std::__throw_logic_error(char const*) - called for logic errors (e.g., promise already satisfied)
 void __wrap__ZSt19__throw_logic_errorPKc(const char *) { esp_system_abort("std::logic_error"); }
 
-// std::__throw_out_of_range(char const*)
-// Called by at() when index is out of bounds
+// std::__throw_out_of_range(char const*) - called by at() when index is out of bounds
 void __wrap__ZSt20__throw_out_of_rangePKc(const char *) { esp_system_abort("std::out_of_range"); }
 
-// std::__throw_out_of_range_fmt(char const*, ...)
-// Called by bitset::to_ulong when value doesn't fit
+// std::__throw_out_of_range_fmt(char const*, ...) - called by bitset::to_ulong when value doesn't fit
 void __wrap__ZSt24__throw_out_of_range_fmtPKcz(const char *, ...) { esp_system_abort("std::out_of_range"); }
 
-// std::__throw_bad_alloc()
-// Called when operator new fails
+// std::__throw_bad_alloc() - called when operator new fails
 void __wrap__ZSt17__throw_bad_allocv() { esp_system_abort("std::bad_alloc"); }
 
-// std::__throw_bad_function_call()
-// Called when invoking empty std::function
+// std::__throw_bad_function_call() - called when invoking empty std::function
 void __wrap__ZSt25__throw_bad_function_callv() { esp_system_abort("std::bad_function_call"); }
 
 }  // extern "C"
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+
 #endif  // USE_ESP_IDF

--- a/esphome/components/esp32/throw_stubs.cpp
+++ b/esphome/components/esp32/throw_stubs.cpp
@@ -1,0 +1,53 @@
+/*
+ * Linker wrap stubs for std::__throw_* functions.
+ *
+ * ESP-IDF disables C++ exceptions but doesn't wrap the std::__throw_*
+ * functions that construct exception objects before calling __cxa_throw.
+ * This wastes ~1KB on exception class code that can never execute.
+ *
+ * These stubs abort immediately with a descriptive message, allowing
+ * the linker to dead-code eliminate the exception class infrastructure.
+ *
+ * The ESP8266 Arduino toolchain solves this by rebuilding libstdc++ with
+ * similar stubs. We achieve the same result using linker --wrap.
+ *
+ * Wrapped functions and their callers:
+ * - std::__throw_length_error: std::string::reserve, std::vector::reserve
+ * - std::__throw_logic_error: std::promise, std::packaged_task
+ * - std::__throw_out_of_range: std::string::at, std::vector::at
+ * - std::__throw_out_of_range_fmt: std::bitset::to_ulong
+ * - std::__throw_bad_alloc: operator new
+ * - std::__throw_bad_function_call: std::function::operator()
+ */
+
+#ifdef USE_ESP_IDF
+#include "esp_system.h"
+
+extern "C" {
+
+// std::__throw_length_error(char const*)
+// Called when container size exceeds max_size()
+void __wrap__ZSt20__throw_length_errorPKc(const char *) { esp_system_abort("std::length_error"); }
+
+// std::__throw_logic_error(char const*)
+// Called for logic errors (e.g., promise already satisfied)
+void __wrap__ZSt19__throw_logic_errorPKc(const char *) { esp_system_abort("std::logic_error"); }
+
+// std::__throw_out_of_range(char const*)
+// Called by at() when index is out of bounds
+void __wrap__ZSt20__throw_out_of_rangePKc(const char *) { esp_system_abort("std::out_of_range"); }
+
+// std::__throw_out_of_range_fmt(char const*, ...)
+// Called by bitset::to_ulong when value doesn't fit
+void __wrap__ZSt24__throw_out_of_range_fmtPKcz(const char *, ...) { esp_system_abort("std::out_of_range"); }
+
+// std::__throw_bad_alloc()
+// Called when operator new fails
+void __wrap__ZSt17__throw_bad_allocv() { esp_system_abort("std::bad_alloc"); }
+
+// std::__throw_bad_function_call()
+// Called when invoking empty std::function
+void __wrap__ZSt25__throw_bad_function_callv() { esp_system_abort("std::bad_function_call"); }
+
+}  // extern "C"
+#endif  // USE_ESP_IDF

--- a/esphome/components/esp32/throw_stubs.cpp
+++ b/esphome/components/esp32/throw_stubs.cpp
@@ -1,15 +1,17 @@
 /*
  * Linker wrap stubs for std::__throw_* functions.
  *
- * ESP-IDF disables C++ exceptions but doesn't wrap the std::__throw_*
- * functions that construct exception objects before calling __cxa_throw.
- * This wastes ~1KB on exception class code that can never execute.
+ * ESP-IDF compiles with -fno-exceptions, so C++ exceptions always abort.
+ * However, ESP-IDF only wraps low-level functions (__cxa_throw, etc.),
+ * not the std::__throw_* functions that construct exception objects first.
+ * This pulls in ~3KB of dead exception class code that can never run.
+ *
+ * ESP8266 Arduino already solved this: their toolchain rebuilds libstdc++
+ * with throw functions that just call abort(). We achieve the same result
+ * using linker --wrap without requiring toolchain changes.
  *
  * These stubs abort immediately with a descriptive message, allowing
  * the linker to dead-code eliminate the exception class infrastructure.
- *
- * The ESP8266 Arduino toolchain solves this by rebuilding libstdc++ with
- * similar stubs. We achieve the same result using linker --wrap.
  *
  * Wrapped functions and their callers:
  * - std::__throw_length_error: std::string::reserve, std::vector::reserve


### PR DESCRIPTION
# What does this implement/fix?

Wrap `std::__throw_*` functions with stubs that abort immediately, eliminating ~3KB of dead exception class infrastructure from ESP-IDF firmware.

**ESP8266 already does this:** The ESP8266 Arduino toolchain rebuilds `libstdc++` with throw functions that just call `abort()`. This PR brings the same optimization to ESP32 using linker `--wrap` (no toolchain changes needed).

**Background:** ESP-IDF compiles with `-fno-exceptions`, so C++ exceptions can never be caught - they always abort. ESP-IDF wraps low-level exception machinery (`__cxa_throw`, `__cxa_allocate_exception`) to abort immediately. However, the higher-level `std::__throw_*` functions from libstdc++ still construct exception objects before hitting the abort, pulling in dead code that can never execute:

```
std::vector::at(5)  // out of bounds
  → std::__throw_out_of_range(msg)
    → constructs std::out_of_range object (pulls in vtable, typeinfo, old ABI strings)
    → calls __cxa_allocate_exception (wrapped → abort)
```

This PR adds linker `--wrap` for these functions to abort immediately with a descriptive message, allowing the linker to dead-code eliminate the exception class infrastructure.

**Measured savings:** 3,074 bytes on athom-co2-sensor (ESP32-C3)

Eliminated:
- `std::logic_error`, `std::length_error`, `std::out_of_range`, `std::bad_function_call` classes
- Their vtables, typeinfo, typeinfo names
- Constructors, destructors, `what()` methods
- Old ABI string code (`_Rep::_S_create`, `_Rep::_M_dispose`)

Only `std::bad_alloc` (~100 bytes) remains because it's used by `operator new(std::nothrow_t)`.

**Bonus:** Crash messages are now more informative.

Before (no context about what went wrong):
```
abort() was called at PC 0x4013acc6 on core 1
Backtrace: 0x40087c8d:0x3ffbfad0 0x40087c55:0x3ffbfaf0 0x4008bc12:0x3ffbfb10 0x4013acc6:0x3ffbfb80 ...
Decoded: panic_abort at panic.c:477
Decoded: esp_system_abort at esp_system_chip.c:87
Decoded: abort at abort.c:38
Decoded: __wrap___cxa_allocate_exception at cxx_exception_stubs.cpp:184
Decoded: std::__throw_bad_function_call() at functional.cc:34
Decoded: std::function<void ()>::operator()() const at std_function.h:590
```

After (exception type clearly shown at top):
```
std::bad_function_call
Backtrace: 0x40087c8d:0x3ffbfc30 0x40087c55:0x3ffbfc50 0x400d4e0e:0x3ffbfc70 0x400daad7:0x3ffbfc90 ...
Decoded: panic_abort at panic.c:477
Decoded: esp_system_abort at esp_system_chip.c:87
Decoded: __wrap__ZSt25__throw_bad_function_callv at throw_stubs.cpp:52
Decoded: std::function<void ()>::operator()() const at std_function.h:590
```

**Why this is safe:** Since ESP-IDF compiles with `-fno-exceptions`, exceptions were never catchable - they always resulted in abort. This change just moves the abort earlier (before constructing the exception object) and eliminates the dead construction code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration needed - optimization is automatic for ESP-IDF builds
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Test config to verify behavior:

```yaml
# Test config for throw_stubs - triggers various std::__throw_* functions
# Flash to device and press buttons to verify abort messages + backtraces

esphome:
  name: atomu
  friendly_name: "Throw Stubs Test"

esp32:
  board: esp32dev
  framework:
    type: esp-idf

logger:
  level: DEBUG

api:

ota:
  platform: esphome

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

button:
  - platform: template
    name: "Test out_of_range (vector::at)"
    on_press:
      - lambda: |-
          std::vector<int> v;
          v.at(0);  // Should abort with "std::out_of_range"

  - platform: template
    name: "Test length_error (string::reserve)"
    on_press:
      - lambda: |-
          std::string s;
          s.reserve(s.max_size() + 1);  // Should abort with "std::length_error"

  - platform: template
    name: "Test bad_function_call"
    on_press:
      - lambda: |-
          std::function<void()> f;
          f();  // Should abort with "std::bad_function_call"

  - platform: template
    name: "Test bad_alloc"
    on_press:
      - lambda: |-
          // Try to allocate way more than available
          auto p = new char[1024 * 1024 * 1024];  // 1GB - should abort with "std::bad_alloc"
          (void)p;

  - platform: restart
    name: "Restart"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
