### PR TITLE
Add Adafruit soil sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@ esphome/components/a01nyub/* @MrSuicideParrot
 esphome/components/a02yyuw/* @TH-Braemer
 esphome/components/absolute_humidity/* @DAVe3283
 esphome/components/ac_dimmer/* @glmnet
+esphome/components/adafruit_soil_sensor/* @thegreatco
 esphome/components/adc/* @esphome/core
 esphome/components/adc128s102/* @DeerMaximum
 esphome/components/addressable_light/* @justfalter

--- a/esphome/components/adafruit_soil_sensor/__init__.py
+++ b/esphome/components/adafruit_soil_sensor/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@thegreatco"]

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -77,7 +77,9 @@ void AdafruitSoilSensor::update() {
 
 bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
   uint8_t buf[4];
-  if (!this->read(buf, 4)) {
+  i2c::ErrorCode res = this->read(buf, 4);
+  if (res != i2c::ErrorCode::ERROR_OK) {
+    ESP_LOGW(TAG, "Failed to read from bus %v", res);
     return false;
   }
   int32_t ret = ((uint32_t) buf[0] << 24) | ((uint32_t) buf[1] << 16) | ((uint32_t) buf[2] << 8) | (uint32_t) buf[3];
@@ -87,11 +89,13 @@ bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
 
 bool AdafruitSoilSensor::read_capacitance_(uint16_t &touch_value) {
   uint8_t buf[2];
-  if (this->read(buf, 2)) {
-    touch_value = ((uint16_t) buf[0] << 8) | buf[1];
-    return true;
+  i2c::ErrorCode res = this->read(buf, 2);
+  if (res != i2c::ErrorCode::ERROR_OK) {
+    ESP_LOGW(TAG, "Failed to read from bus %v", res);
+    return false;
   }
-  return false;
+  touch_value = ((uint16_t) buf[0] << 8) | buf[1];
+  return true;
 }
 
 bool AdafruitSoilSensor::set_seesaw_port_(uint8_t base_address, uint8_t specific_address) {

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -23,34 +23,61 @@ void AdafruitSoilSensor::dump_config() {
     ESP_LOGCONFIG(TAG, "  Raw Moisture Sensor:");
     LOG_SENSOR("", "Raw Moisture", this->capacitance_raw_);
   }
+  ESP_LOGCONFIG(TAG, "Read Delay: %dms", this->read_delay_);
 }
 
 void AdafruitSoilSensor::update() {
-  ESP_LOGD(TAG, "Updating sensor");
+  ESP_LOGV(TAG, "Updating sensor");
   if (this->is_failed())
     return;
-
-  if (this->temperature_ != nullptr) {
-    float c;
-    if (this->read_temp_c_(c)) {
-      this->temperature_->publish_state(c);
-    } else {
-      ESP_LOGW(TAG, "Failed to read temperature");
-    }
+  if (this->busy_) {
+    ESP_LOGW(TAG, "Overlapping calls to update, ignoring");
+    return;
+  }
+  this->busy_ = true;
+  ESP_LOGV(TAG, "Setting port to capacitance...");
+  if (!this->set_seesaw_port_(BaseAddress::TOUCH, TouchAddress::CHAN_0)) {
+    ESP_LOGW(TAG, "Failed to set seesaw port to capacitance");
+    this->busy_ = false;
+    return;
   }
 
-  if (this->capacitance_raw_ != nullptr) {
-    uint16_t raw;
-    if (this->read_capacitance_(raw)) {
-      float raw_f = static_cast<float>(raw);
-      this->capacitance_raw_->publish_state(raw_f);
+  ESP_LOGV(TAG, "Set seesaw port");
+  set_timeout("capacitance", this->read_delay_, [this]() {
+    if (this->capacitance_raw_ != nullptr) {
+      ESP_LOGV(TAG, "reading capacitance...");
+      uint16_t raw;
+      if (this->read_capacitance_(raw)) {
+        float raw_f = static_cast<float>(raw);
+        this->capacitance_raw_->publish_state(raw_f);
+      }
     }
-  }
+
+    ESP_LOGV(TAG, "Setting port to temperature...");
+    if (!this->set_seesaw_port_(BaseAddress::STATUS, StatusAddress::TEMPERATURE)) {
+      ESP_LOGW(TAG, "Failed to set seesaw port to temperature");
+      this->busy_ = false;
+      return;
+    }
+    set_timeout("temperature", this->read_delay_, [this]() {
+      if (this->temperature_ != nullptr) {
+        ESP_LOGV(TAG, "reading temperature...");
+        float c;
+        if (this->read_temp_c_(c)) {
+          this->temperature_->publish_state(c);
+        } else {
+          ESP_LOGW(TAG, "Failed to read temperature");
+        }
+      }
+      this->busy_ = false;
+      return;
+    });
+  });
 }
 
 bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
   uint8_t buf[4];
-  if (!this->read_(BaseAddress::STATUS, StatusAddress::TEMPERATURE, buf, 4)) {
+  if (!this->read(buf, 4)) {
     return false;
   }
   int32_t ret = ((uint32_t) buf[0] << 24) | ((uint32_t) buf[1] << 16) | ((uint32_t) buf[2] << 8) | (uint32_t) buf[3];
@@ -60,26 +87,18 @@ bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
 
 bool AdafruitSoilSensor::read_capacitance_(uint16_t &touch_value) {
   uint8_t buf[2];
-  uint8_t p = 0;  // only one channel
-  for (uint8_t retry = 0; retry < 5; retry++) {
-    if (this->read_(BaseAddress::TOUCH, TouchAddress::CHAN_0 + p, buf, 2)) {
-      touch_value = ((uint16_t) buf[0] << 8) | buf[1];
-      return true;
-    }
+  if (this->read(buf, 2)) {
+    touch_value = ((uint16_t) buf[0] << 8) | buf[1];
+    return true;
   }
   return false;
 }
 
-bool AdafruitSoilSensor::read_(uint8_t reg_high, uint8_t reg_low, uint8_t *buf, uint16_t len) {
-  uint8_t cmd[2] = {reg_high, reg_low};
+bool AdafruitSoilSensor::set_seesaw_port_(uint8_t base_address, uint8_t specific_address) {
+  uint8_t cmd[2] = {base_address, specific_address};
   i2c::ErrorCode res = this->write(cmd, 2);
   if (res != i2c::ErrorCode::ERROR_OK) {
     ESP_LOGW(TAG, "Error starting i2c txn");
-    return false;
-  }
-  res = this->read(buf, len);
-  if (res != i2c::ErrorCode::ERROR_OK) {
-    ESP_LOGW(TAG, "Got error %d from read", res);
     return false;
   }
   return true;

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -1,0 +1,111 @@
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include "adafruit_soil_sensor.h"
+
+namespace esphome {
+namespace adafruit_soil_sensor {
+
+static const char *const TAG = "adafruit_soil_sensor";
+
+void AdafruitSoilSensor::setup() { ESP_LOGCONFIG(TAG, "Setting up Adafruit seesaw soil sensor..."); }
+
+void AdafruitSoilSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "Adafruit seesaw soil sensor:");
+  LOG_I2C_DEVICE(this);
+  if (this->temperature_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Temperature Sensor:");
+    LOG_SENSOR("", "Temperature", this->temperature_);
+  }
+  if (this->moisture_raw_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Raw Moisture Sensor:");
+    LOG_SENSOR("", "Raw Moisture", this->moisture_raw_);
+  }
+  if (this->moisture_raw_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Calibrated Moisture Sensor:");
+    LOG_SENSOR("", "Calibrated Moisture", this->moisture_calibrated_);
+  }
+}
+
+void AdafruitSoilSensor::update() {
+  ESP_LOGW(TAG, "Updating sensor");
+  if (this->is_failed())
+    return;
+
+  if (this->temperature_ != nullptr) {
+    float c;
+    if (this->read_temp_c_(c)) {
+      this->temperature_->publish_state(c);
+    } else {
+      ESP_LOGW(TAG, "Failed to read temperature");
+    }
+  }
+
+  if (this->moisture_raw_ != nullptr) {
+    uint16_t raw;
+    if (this->read_touch_(raw)) {
+      float raw_f = static_cast<float>(raw);
+      this->moisture_raw_->publish_state(raw_f);
+      if (this->moisture_calibrated_ != nullptr) {
+        if (dry_ == wet_) {
+          ESP_LOGE(TAG, "Dry and wet calibration values are equal");
+        }
+        if (dry_ != 0 && wet_ != 0) {
+          float moisture_percent = ((raw_f - dry_) / (wet_ - dry_)) * 100;
+          if (moisture_percent > 100) {
+            ESP_LOGD(TAG, "Calibrated value %f greater than 100%, clamping.", moisture_percent);
+            moisture_percent = 100;
+          }
+          this->moisture_calibrated_->publish_state(moisture_percent);
+        } else {
+          ESP_LOGW(TAG, "Calibration sensor is configured but both values are 0");
+        }
+      }
+    }
+  }
+}
+
+bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
+  uint8_t buf[4];
+  if (!this->read_(BaseAddress::STATUS, StatusAddress::TEMPERATURE, buf, 4, 100)) {
+    return false;
+  }
+  int32_t ret = ((uint32_t) buf[0] << 24) | ((uint32_t) buf[1] << 16) | ((uint32_t) buf[2] << 8) | (uint32_t) buf[3];
+  temp_c = (1.0 / (1UL << 16)) * ret;
+  return true;
+}
+
+bool AdafruitSoilSensor::read_touch_(uint16_t &touch_value) {
+  uint8_t buf[2];
+  uint8_t p = 0;  // only one channel
+  for (uint8_t retry = 0; retry < 5; retry++) {
+    if (this->read_(BaseAddress::TOUCH, TouchAddress::CHAN_0 + p, buf, 2, 300 + retry * 100)) {
+      touch_value = ((uint16_t) buf[0] << 8) | buf[1];
+      return true;
+    }
+  }
+  return false;
+}
+
+bool AdafruitSoilSensor::read_(uint8_t reg_high, uint8_t reg_low, uint8_t *buf, uint16_t len, uint16_t delay_ms) {
+  uint8_t cmd[2] = {reg_high, reg_low};
+  i2c::ErrorCode res = this->write(cmd, 2);
+  if (res != i2c::ErrorCode::ERROR_OK) {
+    ESP_LOGW(TAG, "Error starting i2c txn");
+    return false;
+  }
+  if (delay_ms > 0) {
+    delay(delay_ms);
+  }
+  res = this->read(buf, len);
+  if (res != i2c::ErrorCode::ERROR_OK) {
+    ESP_LOGW(TAG, "Got error %d from read", res);
+    return false;
+  }
+  return true;
+}
+
+}  // namespace adafruit_soil_sensor
+}  // namespace esphome

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -19,13 +19,9 @@ void AdafruitSoilSensor::dump_config() {
     ESP_LOGCONFIG(TAG, "  Temperature Sensor:");
     LOG_SENSOR("", "Temperature", this->temperature_);
   }
-  if (this->moisture_raw_ != nullptr) {
+  if (this->capacitance_raw_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Raw Moisture Sensor:");
-    LOG_SENSOR("", "Raw Moisture", this->moisture_raw_);
-  }
-  if (this->moisture_raw_ != nullptr) {
-    ESP_LOGCONFIG(TAG, "  Calibrated Moisture Sensor:");
-    LOG_SENSOR("", "Calibrated Moisture", this->moisture_calibrated_);
+    LOG_SENSOR("", "Raw Moisture", this->capacitance_raw_);
   }
 }
 
@@ -43,33 +39,18 @@ void AdafruitSoilSensor::update() {
     }
   }
 
-  if (this->moisture_raw_ != nullptr) {
+  if (this->capacitance_raw_ != nullptr) {
     uint16_t raw;
-    if (this->read_touch_(raw)) {
+    if (this->read_capacitance_(raw)) {
       float raw_f = static_cast<float>(raw);
-      this->moisture_raw_->publish_state(raw_f);
-      if (this->moisture_calibrated_ != nullptr) {
-        if (dry_ == wet_) {
-          ESP_LOGE(TAG, "Dry and wet calibration values are equal");
-        }
-        if (dry_ != 0 && wet_ != 0) {
-          float moisture_percent = ((raw_f - dry_) / (wet_ - dry_)) * 100;
-          if (moisture_percent > 100) {
-            ESP_LOGD(TAG, "Calibrated value %f greater than 100%, clamping.", moisture_percent);
-            moisture_percent = 100;
-          }
-          this->moisture_calibrated_->publish_state(moisture_percent);
-        } else {
-          ESP_LOGW(TAG, "Calibration sensor is configured but both values are 0");
-        }
-      }
+      this->capacitance_raw_->publish_state(raw_f);
     }
   }
 }
 
 bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
   uint8_t buf[4];
-  if (!this->read_(BaseAddress::STATUS, StatusAddress::TEMPERATURE, buf, 4, 100)) {
+  if (!this->read_(BaseAddress::STATUS, StatusAddress::TEMPERATURE, buf, 4)) {
     return false;
   }
   int32_t ret = ((uint32_t) buf[0] << 24) | ((uint32_t) buf[1] << 16) | ((uint32_t) buf[2] << 8) | (uint32_t) buf[3];
@@ -77,11 +58,11 @@ bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
   return true;
 }
 
-bool AdafruitSoilSensor::read_touch_(uint16_t &touch_value) {
+bool AdafruitSoilSensor::read_capacitance_(uint16_t &touch_value) {
   uint8_t buf[2];
   uint8_t p = 0;  // only one channel
   for (uint8_t retry = 0; retry < 5; retry++) {
-    if (this->read_(BaseAddress::TOUCH, TouchAddress::CHAN_0 + p, buf, 2, 300 + retry * 100)) {
+    if (this->read_(BaseAddress::TOUCH, TouchAddress::CHAN_0 + p, buf, 2)) {
       touch_value = ((uint16_t) buf[0] << 8) | buf[1];
       return true;
     }
@@ -89,15 +70,12 @@ bool AdafruitSoilSensor::read_touch_(uint16_t &touch_value) {
   return false;
 }
 
-bool AdafruitSoilSensor::read_(uint8_t reg_high, uint8_t reg_low, uint8_t *buf, uint16_t len, uint16_t delay_ms) {
+bool AdafruitSoilSensor::read_(uint8_t reg_high, uint8_t reg_low, uint8_t *buf, uint16_t len) {
   uint8_t cmd[2] = {reg_high, reg_low};
   i2c::ErrorCode res = this->write(cmd, 2);
   if (res != i2c::ErrorCode::ERROR_OK) {
     ESP_LOGW(TAG, "Error starting i2c txn");
     return false;
-  }
-  if (delay_ms > 0) {
-    delay(delay_ms);
   }
   res = this->read(buf, len);
   if (res != i2c::ErrorCode::ERROR_OK) {

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -79,7 +79,7 @@ bool AdafruitSoilSensor::read_temp_c_(float &temp_c) {
   uint8_t buf[4];
   i2c::ErrorCode res = this->read(buf, 4);
   if (res != i2c::ErrorCode::ERROR_OK) {
-    ESP_LOGW(TAG, "Failed to read from bus %v", res);
+    ESP_LOGW(TAG, "Failed to read from bus %d", res);
     return false;
   }
   int32_t ret = ((uint32_t) buf[0] << 24) | ((uint32_t) buf[1] << 16) | ((uint32_t) buf[2] << 8) | (uint32_t) buf[3];
@@ -91,7 +91,7 @@ bool AdafruitSoilSensor::read_capacitance_(uint16_t &touch_value) {
   uint8_t buf[2];
   i2c::ErrorCode res = this->read(buf, 2);
   if (res != i2c::ErrorCode::ERROR_OK) {
-    ESP_LOGW(TAG, "Failed to read from bus %v", res);
+    ESP_LOGW(TAG, "Failed to read from bus %d", res);
     return false;
   }
   touch_value = ((uint16_t) buf[0] << 8) | buf[1];

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.cpp
@@ -30,7 +30,7 @@ void AdafruitSoilSensor::dump_config() {
 }
 
 void AdafruitSoilSensor::update() {
-  ESP_LOGW(TAG, "Updating sensor");
+  ESP_LOGD(TAG, "Updating sensor");
   if (this->is_failed())
     return;
 

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
@@ -11,10 +11,7 @@ class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, publi
  public:
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
   void set_capacitance(sensor::Sensor *capacitance) { capacitance_raw_ = capacitance; }
-  void set_calibration(uint16_t dry, uint16_t wet) {
-    dry_ = dry;
-    wet_ = wet;
-  }
+  void set_read_delay(uint32_t delay) { read_delay_ = delay; }
 
   void setup() override;
   void update() override;
@@ -23,9 +20,7 @@ class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, publi
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *capacitance_raw_{nullptr};
-  uint16_t dry_;
-  uint16_t wet_;
-  bool read_(uint8_t reg_start, uint8_t reg_end, uint8_t *buf, uint16_t len);
+  uint32_t read_delay_;
   bool read_temp_c_(float &temp_c);
   bool read_capacitance_(uint16_t &touch_value);
 
@@ -33,6 +28,8 @@ class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, publi
   enum BaseAddress { STATUS = 0x00, TOUCH = 0x0F };
   enum TouchAddress { CHAN_0 = 0x10 };
   enum StatusAddress { HW_ID = 0x01, VERSION = 0x02, OPTIONS = 0x03, TEMPERATURE = 0x04, RESET = 0x7F };
+  bool set_seesaw_port_(uint8_t base_address, uint8_t specific_address);
+  bool busy_;
 };
 
 }  // namespace adafruit_soil_sensor

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
@@ -10,8 +10,7 @@ namespace adafruit_soil_sensor {
 class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
  public:
   void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
-  void set_moisture_calibrated(sensor::Sensor *moisture) { moisture_calibrated_ = moisture; }
-  void set_moisture_raw(sensor::Sensor *moisture) { moisture_raw_ = moisture; }
+  void set_capacitance(sensor::Sensor *capacitance) { capacitance_raw_ = capacitance; }
   void set_calibration(uint16_t dry, uint16_t wet) {
     dry_ = dry;
     wet_ = wet;
@@ -23,13 +22,12 @@ class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, publi
 
  protected:
   sensor::Sensor *temperature_{nullptr};
-  sensor::Sensor *moisture_raw_{nullptr};
-  sensor::Sensor *moisture_calibrated_{nullptr};
+  sensor::Sensor *capacitance_raw_{nullptr};
   uint16_t dry_;
   uint16_t wet_;
-  bool read_(uint8_t reg_start, uint8_t reg_end, uint8_t *buf, uint16_t len, uint16_t delay_ms);
+  bool read_(uint8_t reg_start, uint8_t reg_end, uint8_t *buf, uint16_t len);
   bool read_temp_c_(float &temp_c);
-  bool read_touch_(uint16_t &touch_value);
+  bool read_capacitance_(uint16_t &touch_value);
 
  private:
   enum BaseAddress { STATUS = 0x00, TOUCH = 0x0F };

--- a/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
+++ b/esphome/components/adafruit_soil_sensor/adafruit_soil_sensor.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/i2c/i2c.h"
+
+namespace esphome {
+namespace adafruit_soil_sensor {
+
+class AdafruitSoilSensor : public sensor::Sensor, public PollingComponent, public i2c::I2CDevice {
+ public:
+  void set_temperature(sensor::Sensor *temperature) { temperature_ = temperature; }
+  void set_moisture_calibrated(sensor::Sensor *moisture) { moisture_calibrated_ = moisture; }
+  void set_moisture_raw(sensor::Sensor *moisture) { moisture_raw_ = moisture; }
+  void set_calibration(uint16_t dry, uint16_t wet) {
+    dry_ = dry;
+    wet_ = wet;
+  }
+
+  void setup() override;
+  void update() override;
+  void dump_config() override;
+
+ protected:
+  sensor::Sensor *temperature_{nullptr};
+  sensor::Sensor *moisture_raw_{nullptr};
+  sensor::Sensor *moisture_calibrated_{nullptr};
+  uint16_t dry_;
+  uint16_t wet_;
+  bool read_(uint8_t reg_start, uint8_t reg_end, uint8_t *buf, uint16_t len, uint16_t delay_ms);
+  bool read_temp_c_(float &temp_c);
+  bool read_touch_(uint16_t &touch_value);
+
+ private:
+  enum BaseAddress { STATUS = 0x00, TOUCH = 0x0F };
+  enum TouchAddress { CHAN_0 = 0x10 };
+  enum StatusAddress { HW_ID = 0x01, VERSION = 0x02, OPTIONS = 0x03, TEMPERATURE = 0x04, RESET = 0x7F };
+};
+
+}  // namespace adafruit_soil_sensor
+}  // namespace esphome

--- a/esphome/components/adafruit_soil_sensor/sensor.py
+++ b/esphome/components/adafruit_soil_sensor/sensor.py
@@ -2,15 +2,13 @@ import esphome.codegen as cg
 from esphome.components import i2c, sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_CAPACITANCE,
     CONF_ID,
-    CONF_MOISTURE,
     CONF_TEMPERATURE,
-    DEVICE_CLASS_MOISTURE,
     DEVICE_CLASS_TEMPERATURE,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
     UNIT_EMPTY,
-    UNIT_PERCENT,
 )
 
 CODEOWNERS = ["@thegreatco"]
@@ -21,46 +19,6 @@ adafruit_soil_sensor_ns = cg.esphome_ns.namespace("adafruit_soil_sensor")
 AdafruitSoilSensor = adafruit_soil_sensor_ns.class_(
     "AdafruitSoilSensor", cg.PollingComponent, i2c.I2CDevice
 )
-CONF_MOISTURE_RAW = CONF_MOISTURE + "_raw"
-CONF_DRY_VALUE = "dry_value"
-CONF_WET_VALUE = "wet_value"
-
-CONF_MOISTURE_SCHEMA = sensor.sensor_schema(
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=0,
-    state_class=STATE_CLASS_MEASUREMENT,
-).extend(
-    {
-        cv.Required(CONF_DRY_VALUE): cv.int_range(min=0, max=65535),
-        cv.Required(CONF_WET_VALUE): cv.int_range(min=0, max=65535),
-    }
-)
-
-
-def _validate_percent_calibration(config):
-    # If the calibrated moisture sensor is configured, require dry/wet values.
-    if CONF_MOISTURE in config:
-        if CONF_MOISTURE_RAW not in config:
-            raise cv.Invalid(
-                f"When '{CONF_MOISTURE}:' is configured, you must also set '{CONF_MOISTURE_RAW}:' in the config."
-            )
-        if (
-            CONF_DRY_VALUE not in config[CONF_MOISTURE]
-            or CONF_WET_VALUE not in config[CONF_MOISTURE]
-        ):
-            raise cv.Invalid(
-                f"When '{CONF_MOISTURE}:' is configured, you must also set '{CONF_DRY_VALUE}:' and '{CONF_WET_VALUE}:' "
-                "to calibrate the sensor."
-            )
-        if (
-            config[CONF_MOISTURE][CONF_WET_VALUE]
-            <= config[CONF_MOISTURE][CONF_DRY_VALUE]
-        ):
-            raise cv.Invalid(
-                f"'{CONF_WET_VALUE}' must be greater than '{CONF_DRY_VALUE}'."
-            )
-    return config
-
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -72,27 +30,15 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_MOISTURE_RAW): sensor.sensor_schema(
+            cv.Optional(CONF_CAPACITANCE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_MOISTURE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                accuracy_decimals=0,
-                device_class=DEVICE_CLASS_MOISTURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(
-                {
-                    cv.Required(CONF_DRY_VALUE): cv.int_range(min=0, max=65535),
-                    cv.Required(CONF_WET_VALUE): cv.int_range(min=0, max=65535),
-                }
             ),
         }
     )
     .extend(cv.polling_component_schema("60s"))
     .extend(i2c.i2c_device_schema(0x36)),
-    _validate_percent_calibration,
 )
 
 
@@ -105,16 +51,6 @@ async def to_code(config):
         ct = await sensor.new_sensor(conf_temperature)
         cg.add(var.set_temperature(ct))
 
-    if (conf_moisture_raw := config.get(CONF_MOISTURE_RAW)) is not None:
-        cmr = await sensor.new_sensor(conf_moisture_raw)
-        cg.add(var.set_moisture_raw(cmr))
-
-    if (conf_moisture_calibrated := config.get(CONF_MOISTURE)) is not None:
-        cmc = await sensor.new_sensor(conf_moisture_calibrated)
-        cg.add(var.set_moisture_calibrated(cmc))
-        cg.add(
-            var.set_calibration(
-                conf_moisture_calibrated[CONF_DRY_VALUE],
-                conf_moisture_calibrated[CONF_WET_VALUE],
-            )
-        )
+    if (conf_capacitance := config.get(CONF_CAPACITANCE)) is not None:
+        cmr = await sensor.new_sensor(conf_capacitance)
+        cg.add(var.set_capacitance(cmr))

--- a/esphome/components/adafruit_soil_sensor/sensor.py
+++ b/esphome/components/adafruit_soil_sensor/sensor.py
@@ -1,0 +1,120 @@
+import esphome.codegen as cg
+from esphome.components import i2c, sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MOISTURE,
+    CONF_TEMPERATURE,
+    DEVICE_CLASS_MOISTURE,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_EMPTY,
+    UNIT_PERCENT,
+)
+
+CODEOWNERS = ["@thegreatco"]
+
+DEPENDENCIES = ["i2c"]
+
+adafruit_soil_sensor_ns = cg.esphome_ns.namespace("adafruit_soil_sensor")
+AdafruitSoilSensor = adafruit_soil_sensor_ns.class_(
+    "AdafruitSoilSensor", cg.PollingComponent, i2c.I2CDevice
+)
+CONF_MOISTURE_RAW = CONF_MOISTURE + "_raw"
+CONF_DRY_VALUE = "dry_value"
+CONF_WET_VALUE = "wet_value"
+
+CONF_MOISTURE_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement=UNIT_PERCENT,
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_MEASUREMENT,
+).extend(
+    {
+        cv.Required(CONF_DRY_VALUE): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_WET_VALUE): cv.int_range(min=0, max=65535),
+    }
+)
+
+
+def _validate_percent_calibration(config):
+    # If the calibrated moisture sensor is configured, require dry/wet values.
+    if CONF_MOISTURE in config:
+        if CONF_MOISTURE_RAW not in config:
+            raise cv.Invalid(
+                f"When '{CONF_MOISTURE}:' is configured, you must also set '{CONF_MOISTURE_RAW}:' in the config."
+            )
+        if (
+            CONF_DRY_VALUE not in config[CONF_MOISTURE]
+            or CONF_WET_VALUE not in config[CONF_MOISTURE]
+        ):
+            raise cv.Invalid(
+                f"When '{CONF_MOISTURE}:' is configured, you must also set '{CONF_DRY_VALUE}:' and '{CONF_WET_VALUE}:' "
+                "to calibrate the sensor."
+            )
+        if (
+            config[CONF_MOISTURE][CONF_WET_VALUE]
+            <= config[CONF_MOISTURE][CONF_DRY_VALUE]
+        ):
+            raise cv.Invalid(
+                f"'{CONF_WET_VALUE}' must be greater than '{CONF_DRY_VALUE}'."
+            )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(AdafruitSoilSensor),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_MOISTURE_RAW): sensor.sensor_schema(
+                unit_of_measurement=UNIT_EMPTY,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_MOISTURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_MOISTURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ).extend(
+                {
+                    cv.Required(CONF_DRY_VALUE): cv.int_range(min=0, max=65535),
+                    cv.Required(CONF_WET_VALUE): cv.int_range(min=0, max=65535),
+                }
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x36)),
+    _validate_percent_calibration,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    if (conf_temperature := config.get(CONF_TEMPERATURE)) is not None:
+        ct = await sensor.new_sensor(conf_temperature)
+        cg.add(var.set_temperature(ct))
+
+    if (conf_moisture_raw := config.get(CONF_MOISTURE_RAW)) is not None:
+        cmr = await sensor.new_sensor(conf_moisture_raw)
+        cg.add(var.set_moisture_raw(cmr))
+
+    if (conf_moisture_calibrated := config.get(CONF_MOISTURE)) is not None:
+        cmc = await sensor.new_sensor(conf_moisture_calibrated)
+        cg.add(var.set_moisture_calibrated(cmc))
+        cg.add(
+            var.set_calibration(
+                conf_moisture_calibrated[CONF_DRY_VALUE],
+                conf_moisture_calibrated[CONF_WET_VALUE],
+            )
+        )

--- a/esphome/components/adafruit_soil_sensor/sensor.py
+++ b/esphome/components/adafruit_soil_sensor/sensor.py
@@ -14,6 +14,7 @@ from esphome.const import (
 CODEOWNERS = ["@thegreatco"]
 
 DEPENDENCIES = ["i2c"]
+READ_DELAY = "read_delay"
 
 adafruit_soil_sensor_ns = cg.esphome_ns.namespace("adafruit_soil_sensor")
 AdafruitSoilSensor = adafruit_soil_sensor_ns.class_(
@@ -35,6 +36,7 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=0,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(READ_DELAY): cv.uint32_t,
         }
     )
     .extend(cv.polling_component_schema("60s"))
@@ -47,10 +49,13 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
+    read_delay = config.get(READ_DELAY, 10)
     if (conf_temperature := config.get(CONF_TEMPERATURE)) is not None:
         ct = await sensor.new_sensor(conf_temperature)
         cg.add(var.set_temperature(ct))
+        cg.add(var.set_read_delay(read_delay))
 
     if (conf_capacitance := config.get(CONF_CAPACITANCE)) is not None:
         cmr = await sensor.new_sensor(conf_capacitance)
         cg.add(var.set_capacitance(cmr))
+        cg.add(var.set_read_delay(read_delay))

--- a/tests/components/adafruit_soil_sensor/common.yaml
+++ b/tests/components/adafruit_soil_sensor/common.yaml
@@ -1,0 +1,8 @@
+sensor:
+  - platform: adafruit_soil_sensor
+    i2c_id: i2c_bus
+    temperature:
+      name: "Temperature"
+    capacitance:
+      name: "Raw Soil Moisture"
+    update_interval: 60s

--- a/tests/components/adafruit_soil_sensor/test.esp32-idf.yaml
+++ b/tests/components/adafruit_soil_sensor/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add support for the Adafruit i2c Capacitive soil sensor

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5987

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - id: moisture_sensor
    platform: adafruit_soil_sensor
    temperature:
      name: "Temperature"
    capacitance:
      name: "Raw Soil Moisture"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
