### PR TITLE
[esp32] Default to CMN certificate bundle, saving ~51KB flash

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1108,21 +1108,19 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PSK_MODES", True)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
 
-        # Use CMN (common CAs) bundle by default to save ~35KB flash
-        # CMN covers CAs with >1% market share (~99% of websites)
-        # Components needing uncommon CAs can call require_full_certificate_bundle()
-        use_full_bundle = conf[CONF_ADVANCED].get(
-            CONF_USE_FULL_CERTIFICATE_BUNDLE, False
-        ) or CORE.data[KEY_ESP32].get(KEY_FULL_CERT_BUNDLE, False)
-        add_idf_sdkconfig_option(
-            "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
-        )
-        if not use_full_bundle:
-            add_idf_sdkconfig_option(
-                "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True
-            )
-
     cg.add_build_flag("-Wno-nonnull-compare")
+
+    # Use CMN (common CAs) bundle by default to save ~35KB flash
+    # CMN covers CAs with >1% market share (~99% of websites)
+    # Components needing uncommon CAs can call require_full_certificate_bundle()
+    use_full_bundle = conf[CONF_ADVANCED].get(
+        CONF_USE_FULL_CERTIFICATE_BUNDLE, False
+    ) or CORE.data[KEY_ESP32].get(KEY_FULL_CERT_BUNDLE, False)
+    add_idf_sdkconfig_option(
+        "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
+    )
+    if not use_full_bundle:
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True)
 
     add_idf_sdkconfig_option(f"CONFIG_IDF_TARGET_{variant}", True)
     add_idf_sdkconfig_option(

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -55,6 +55,7 @@ from .const import (  # noqa
     KEY_ESP32,
     KEY_EXTRA_BUILD_FILES,
     KEY_FLASH_SIZE,
+    KEY_FULL_CERT_BUNDLE,
     KEY_PATH,
     KEY_REF,
     KEY_REPO,
@@ -670,6 +671,7 @@ CONF_FREERTOS_IN_IRAM = "freertos_in_iram"
 CONF_RINGBUF_IN_IRAM = "ringbuf_in_iram"
 CONF_HEAP_IN_IRAM = "heap_in_iram"
 CONF_LOOP_TASK_STACK_SIZE = "loop_task_stack_size"
+CONF_USE_FULL_CERTIFICATE_BUNDLE = "use_full_certificate_bundle"
 
 # VFS requirement tracking
 # Components that need VFS features can call require_vfs_select() or require_vfs_dir()
@@ -693,6 +695,18 @@ def require_vfs_dir() -> None:
     This prevents CONFIG_VFS_SUPPORT_DIR from being disabled.
     """
     CORE.data[KEY_VFS_DIR_REQUIRED] = True
+
+
+def require_full_certificate_bundle() -> None:
+    """Request the full certificate bundle instead of the common-CAs-only bundle.
+
+    By default, ESPHome uses CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN which
+    includes only CAs with >1% market share (~35 KB smaller than full bundle).
+    This covers ~99% of websites including Let's Encrypt, DigiCert, Google, Amazon.
+
+    Call this from components that need to connect to services using uncommon CAs.
+    """
+    CORE.data[KEY_ESP32][KEY_FULL_CERT_BUNDLE] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -776,6 +790,9 @@ FRAMEWORK_SCHEMA = cv.Schema(
                     min=8192, max=32768
                 ),
                 cv.Optional(CONF_ENABLE_OTA_ROLLBACK, default=True): cv.boolean,
+                cv.Optional(
+                    CONF_USE_FULL_CERTIFICATE_BUNDLE, default=False
+                ): cv.boolean,
             }
         ),
         cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
@@ -1090,6 +1107,20 @@ async def to_code(config):
 
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PSK_MODES", True)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+
+        # Use CMN (common CAs) bundle by default to save ~35KB flash
+        # CMN covers CAs with >1% market share (~99% of websites)
+        # Components needing uncommon CAs can call require_full_certificate_bundle()
+        use_full_bundle = conf[CONF_ADVANCED].get(
+            CONF_USE_FULL_CERTIFICATE_BUNDLE, False
+        ) or CORE.data[KEY_ESP32].get(KEY_FULL_CERT_BUNDLE, False)
+        add_idf_sdkconfig_option(
+            "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL", use_full_bundle
+        )
+        if not use_full_bundle:
+            add_idf_sdkconfig_option(
+                "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN", True
+            )
 
     cg.add_build_flag("-Wno-nonnull-compare")
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1110,7 +1110,7 @@ async def to_code(config):
 
     cg.add_build_flag("-Wno-nonnull-compare")
 
-    # Use CMN (common CAs) bundle by default to save ~35KB flash
+    # Use CMN (common CAs) bundle by default to save ~51KB flash
     # CMN covers CAs with >1% market share (~99% of websites)
     # Components needing uncommon CAs can call require_full_certificate_bundle()
     use_full_bundle = conf[CONF_ADVANCED].get(

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -701,7 +701,7 @@ def require_full_certificate_bundle() -> None:
     """Request the full certificate bundle instead of the common-CAs-only bundle.
 
     By default, ESPHome uses CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN which
-    includes only CAs with >1% market share (~35 KB smaller than full bundle).
+    includes only CAs with >1% market share (~51 KB smaller than full bundle).
     This covers ~99% of websites including Let's Encrypt, DigiCert, Google, Amazon.
 
     Call this from components that need to connect to services using uncommon CAs.

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -12,6 +12,7 @@ KEY_REFRESH = "refresh"
 KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
+KEY_FULL_CERT_BUNDLE = "full_cert_bundle"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32C2 = "ESP32C2"

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -165,6 +165,16 @@ async def to_code(config):
                     ca_cert_content = f.read()
                 cg.add(var.set_ca_certificate(ca_cert_content))
             else:
+                # Uses the certificate bundle configured in esp32 component.
+                # By default, ESPHome uses the CMN (common CAs) bundle which covers
+                # ~99% of websites including GitHub, Let's Encrypt, DigiCert, etc.
+                # If connecting to services with uncommon CAs, components can call:
+                #   esp32.require_full_certificate_bundle()
+                # Or users can set in their config:
+                #   esp32:
+                #     framework:
+                #       advanced:
+                #         use_full_certificate_bundle: true
                 esp32.add_idf_sdkconfig_option(
                     "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True
                 )

--- a/tests/components/esp32/test.esp32-idf.yaml
+++ b/tests/components/esp32/test.esp32-idf.yaml
@@ -7,6 +7,7 @@ esp32:
       enable_lwip_mdns_queries: true
       enable_lwip_bridge_interface: true
       disable_libc_locks_in_iram: false  # Test explicit opt-out of RAM optimization
+      use_full_certificate_bundle: false  # Test CMN bundle (default)
 
 wifi:
   ssid: MySSID


### PR DESCRIPTION
## What does this implement/fix?

This PR changes the default certificate bundle from FULL (~69KB) to CMN (Common CAs, ~34KB) for ESP32 devices. This saves approximately **51KB of flash (-5.75%)** for configurations that use HTTPS (e.g., `http_request` component with `verify_ssl: true`).

The CMN bundle includes Certificate Authorities with >1% market share, covering approximately 99% of websites:
- Let's Encrypt (most common)
- DigiCert (GitHub, many enterprise sites)
- Google Trust Services
- Amazon Trust Services
- GlobalSign, Sectigo, and other major CAs

This is sufficient for the vast majority of ESPHome use cases, including:
- GitHub URLs for OTA updates (the most common `http_request` use case)
- Home Assistant Cloud
- Most HTTPS APIs and services

### Breaking Change

Connections to HTTPS services using uncommon Certificate Authorities will fail with certificate verification errors.

**Migration path:**

1. **User escape hatch** - Add to configuration:
   ```yaml
   esp32:
     framework:
       type: esp-idf
       advanced:
         use_full_certificate_bundle: true
   ```

2. **Component escape hatch** - Components can call:
   ```python
   from esphome.components.esp32 import require_full_certificate_bundle
   require_full_certificate_bundle()
   ```

### Changes

- Added `KEY_FULL_CERT_BUNDLE` to `esp32/const.py`
- Added `require_full_certificate_bundle()` helper function for components
- Added `use_full_certificate_bundle` config option (default: `false`)
- Modified certificate bundle logic to use `CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_CMN` by default
- Added documentation comment in `http_request` component

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (flash size optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5989

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default behavior - uses CMN bundle (~34KB, covers 99% of sites)
esp32:
  framework:
    type: esp-idf

http_request:
  verify_ssl: true
```

```yaml
# Escape hatch for uncommon CAs - uses full bundle (~69KB)
esp32:
  framework:
    type: esp-idf
    advanced:
      use_full_certificate_bundle: true

http_request:
  verify_ssl: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
