### PR TITLE
[core] Add LOG_ENTITY_ICON/DEVICE_CLASS/UNIT_OF_MEASUREMENT macros 

### DIFF
--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -14,7 +14,7 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
 }
 
 void BinarySensor::publish_state(bool new_state) {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -14,7 +14,7 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
 }
 
 void BinarySensor::publish_state(bool new_state) {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -14,10 +14,7 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-  }
+  log_entity_device_class(tag, prefix, *obj);
 }
 
 void BinarySensor::publish_state(bool new_state) {

--- a/esphome/components/binary_sensor/binary_sensor.cpp
+++ b/esphome/components/binary_sensor/binary_sensor.cpp
@@ -14,7 +14,7 @@ void log_binary_sensor(const char *tag, const char *prefix, const char *type, Bi
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_device_class(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
 }
 
 void BinarySensor::publish_state(bool new_state) {

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -12,7 +12,7 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_icon(tag, prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 }
 
 void Button::press() {

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -12,10 +12,7 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
+  log_entity_icon(tag, prefix, *obj);
 }
 
 void Button::press() {

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -12,7 +12,7 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_ICON(tag, prefix, *obj);
+  LOG_ENTITY_ICON(prefix, *obj);
 }
 
 void Button::press() {

--- a/esphome/components/button/button.cpp
+++ b/esphome/components/button/button.cpp
@@ -12,7 +12,7 @@ void log_button(const char *tag, const char *prefix, const char *type, Button *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_ICON(prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 }
 
 void Button::press() {

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,7 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,7 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_device_class(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,7 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Cover;

--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -20,9 +20,7 @@ const extern float COVER_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    log_entity_device_class(TAG, prefix, *(obj)); \
   }
 
 class Cover;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -15,9 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/date_entity.h
+++ b/esphome/components/datetime/date_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATE(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class DateCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -15,9 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/datetime_entity.h
+++ b/esphome/components/datetime/datetime_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_DATETIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class DateTimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -15,9 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/datetime/time_entity.h
+++ b/esphome/components/datetime/time_entity.h
@@ -15,7 +15,7 @@ namespace esphome::datetime {
 #define LOG_DATETIME_TIME(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 class TimeCall;

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -16,12 +16,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
+    log_entity_device_class(TAG, prefix, *(obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -16,8 +16,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
-    log_entity_device_class(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -16,8 +16,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
-    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/event/event.h
+++ b/esphome/components/event/event.h
@@ -16,8 +16,8 @@ namespace event {
 #define LOG_EVENT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
-    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Event : public EntityBase, public EntityBase_DeviceClass {

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -14,7 +14,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -14,7 +14,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -14,7 +14,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/lock/lock.h
+++ b/esphome/components/lock/lock.h
@@ -14,9 +14,7 @@ class Lock;
 #define LOG_LOCK(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
     if ((obj)->traits.get_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -14,9 +14,9 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_ICON(tag, prefix, *obj);
-  LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj->traits);
-  LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj->traits);
+  LOG_ENTITY_ICON(prefix, *obj);
+  LOG_ENTITY_UNIT_OF_MEASUREMENT(prefix, obj->traits);
+  LOG_ENTITY_DEVICE_CLASS(prefix, obj->traits);
 }
 
 void Number::publish_state(float state) {

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -14,9 +14,9 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_icon(tag, prefix, *obj);
-  log_entity_unit_of_measurement(tag, prefix, obj->traits);
-  log_entity_device_class(tag, prefix, obj->traits);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
+  LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj->traits);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj->traits);
 }
 
 void Number::publish_state(float state) {

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -14,9 +14,9 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_ICON(prefix, *obj);
-  LOG_ENTITY_UNIT_OF_MEASUREMENT(prefix, obj->traits);
-  LOG_ENTITY_DEVICE_CLASS(prefix, obj->traits);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
+  LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj->traits);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj->traits);
 }
 
 void Number::publish_state(float state) {

--- a/esphome/components/number/number.cpp
+++ b/esphome/components/number/number.cpp
@@ -14,18 +14,9 @@ void log_number(const char *tag, const char *prefix, const char *type, Number *o
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
-
-  if (!obj->traits.get_unit_of_measurement_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj->traits.get_unit_of_measurement_ref().c_str());
-  }
-
-  if (!obj->traits.get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->traits.get_device_class_ref().c_str());
-  }
+  log_entity_icon(tag, prefix, *obj);
+  log_entity_unit_of_measurement(tag, prefix, obj->traits);
+  log_entity_device_class(tag, prefix, obj->traits);
 }
 
 void Number::publish_state(float state) {

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,7 +12,7 @@ namespace esphome::select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,9 +12,7 @@ namespace esphome::select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,7 +12,7 @@ namespace esphome::select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/select/select.h
+++ b/esphome/components/select/select.h
@@ -12,7 +12,7 @@ namespace esphome::select {
 #define LOG_SELECT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 #define SUB_SELECT(name) \

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -22,8 +22,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                 obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
-  LOG_ENTITY_ICON(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
+  LOG_ENTITY_ICON(prefix, *obj);
 
   if (obj->get_force_update()) {
     ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -22,8 +22,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                 obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-  log_entity_device_class(tag, prefix, *obj);
-  log_entity_icon(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 
   if (obj->get_force_update()) {
     ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -22,13 +22,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                 obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-  }
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
+  log_entity_device_class(tag, prefix, *obj);
+  log_entity_icon(tag, prefix, *obj);
 
   if (obj->get_force_update()) {
     ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -22,8 +22,8 @@ void log_sensor(const char *tag, const char *prefix, const char *type, Sensor *o
                 LOG_STR_ARG(state_class_to_string(obj->get_state_class())), prefix,
                 obj->get_unit_of_measurement_ref().c_str(), prefix, obj->get_accuracy_decimals());
 
-  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
-  LOG_ENTITY_ICON(prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 
   if (obj->get_force_update()) {
     ESP_LOGV(tag, "%s  Force Update: YES", prefix);

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -96,14 +96,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    LOG_ENTITY_ICON(prefix, *obj);
+    LOG_ENTITY_ICON(tag, prefix, *obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
+    LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
   }
 }
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -96,14 +96,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    log_entity_icon(tag, prefix, *obj);
+    LOG_ENTITY_ICON(tag, prefix, *obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    log_entity_device_class(tag, prefix, *obj);
+    LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
   }
 }
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -96,14 +96,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    LOG_ENTITY_ICON(tag, prefix, *obj);
+    LOG_ENTITY_ICON(prefix, *obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+    LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
   }
 }
 

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -96,18 +96,14 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
                   LOG_STR_ARG(onoff));
 
     // Add optional fields separately
-    if (!obj->get_icon_ref().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-    }
+    log_entity_icon(tag, prefix, *obj);
     if (obj->assumed_state()) {
       ESP_LOGCONFIG(tag, "%s  Assumed State: YES", prefix);
     }
     if (obj->is_inverted()) {
       ESP_LOGCONFIG(tag, "%s  Inverted: YES", prefix);
     }
-    if (!obj->get_device_class_ref().empty()) {
-      ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-    }
+    log_entity_device_class(tag, prefix, *obj);
   }
 }
 

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,7 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(prefix, *(obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,9 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    if (!(obj)->get_icon_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Icon: '%s'", prefix, (obj)->get_icon_ref().c_str()); \
-    } \
+    log_entity_icon(TAG, prefix, *(obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,7 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    log_entity_icon(TAG, prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -12,7 +12,7 @@ namespace text {
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
     ESP_LOGCONFIG(TAG, "%s%s '%s'", prefix, LOG_STR_LITERAL(type), (obj)->get_name().c_str()); \
-    LOG_ENTITY_ICON(prefix, *(obj)); \
+    LOG_ENTITY_ICON(TAG, prefix, *(obj)); \
   }
 
 /** Base-class for all text inputs.

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -15,8 +15,8 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  log_entity_device_class(tag, prefix, *obj);
-  log_entity_icon(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 }
 
 void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -15,8 +15,8 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
-  LOG_ENTITY_ICON(tag, prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
+  LOG_ENTITY_ICON(prefix, *obj);
 }
 
 void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -15,14 +15,8 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-
-  if (!obj->get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
-  }
-
-  if (!obj->get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
-  }
+  log_entity_device_class(tag, prefix, *obj);
+  log_entity_icon(tag, prefix, *obj);
 }
 
 void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -15,8 +15,8 @@ void log_text_sensor(const char *tag, const char *prefix, const char *type, Text
   }
 
   ESP_LOGCONFIG(tag, "%s%s '%s'", prefix, type, obj->get_name().c_str());
-  LOG_ENTITY_DEVICE_CLASS(prefix, *obj);
-  LOG_ENTITY_ICON(prefix, *obj);
+  LOG_ENTITY_DEVICE_CLASS(tag, prefix, *obj);
+  LOG_ENTITY_ICON(tag, prefix, *obj);
 }
 
 void TextSensor::publish_state(const std::string &state) { this->publish_state(state.data(), state.size()); }

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -20,7 +20,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    log_entity_device_class(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -20,7 +20,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -20,7 +20,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    LOG_ENTITY_DEVICE_CLASS(TAG, prefix, *(obj)); \
+    LOG_ENTITY_DEVICE_CLASS(prefix, *(obj)); \
   }
 
 class Valve;

--- a/esphome/components/valve/valve.h
+++ b/esphome/components/valve/valve.h
@@ -20,9 +20,7 @@ const extern float VALVE_CLOSED;
     if (traits_.get_is_assumed_state()) { \
       ESP_LOGCONFIG(TAG, "%s  Assumed State: YES", prefix); \
     } \
-    if (!(obj)->get_device_class_ref().empty()) { \
-      ESP_LOGCONFIG(TAG, "%s  Device Class: '%s'", prefix, (obj)->get_device_class_ref().c_str()); \
-    } \
+    log_entity_device_class(TAG, prefix, *(obj)); \
   }
 
 class Valve;

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -152,4 +152,22 @@ void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_m
   this->unit_of_measurement_ = unit_of_measurement;
 }
 
+void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj) {
+  if (!obj.get_icon_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj.get_icon_ref().c_str());
+  }
+}
+
+void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj) {
+  if (!obj.get_device_class_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj.get_device_class_ref().c_str());
+  }
+}
+
+void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj) {
+  if (!obj.get_unit_of_measurement_ref().empty()) {
+    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj.get_unit_of_measurement_ref().c_str());
+  }
+}
+
 }  // namespace esphome

--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -152,22 +152,4 @@ void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_m
   this->unit_of_measurement_ = unit_of_measurement;
 }
 
-void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj) {
-  if (!obj.get_icon_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj.get_icon_ref().c_str());
-  }
-}
-
-void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj) {
-  if (!obj.get_device_class_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj.get_device_class_ref().c_str());
-  }
-}
-
-void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj) {
-  if (!obj.get_unit_of_measurement_ref().empty()) {
-    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, obj.get_unit_of_measurement_ref().c_str());
-  }
-}
-
 }  // namespace esphome

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -231,20 +231,14 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
 };
 
 /// Log entity icon if set (for use in dump_config)
-#define LOG_ENTITY_ICON(tag, prefix, obj) \
-  if (!(obj).get_icon_ref().empty()) { \
-    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, (obj).get_icon_ref().c_str()); \
-  }
+#define LOG_ENTITY_ICON(prefix, obj) log_entity_icon(TAG, prefix, obj)
+void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
 /// Log entity device class if set (for use in dump_config)
-#define LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj) \
-  if (!(obj).get_device_class_ref().empty()) { \
-    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, (obj).get_device_class_ref().c_str()); \
-  }
+#define LOG_ENTITY_DEVICE_CLASS(prefix, obj) log_entity_device_class(TAG, prefix, obj)
+void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj);
 /// Log entity unit of measurement if set (for use in dump_config)
-#define LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj) \
-  if (!(obj).get_unit_of_measurement_ref().empty()) { \
-    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, (obj).get_unit_of_measurement_ref().c_str()); \
-  }
+#define LOG_ENTITY_UNIT_OF_MEASUREMENT(prefix, obj) log_entity_unit_of_measurement(TAG, prefix, obj)
+void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj);
 
 /**
  * An entity that has a state.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -231,11 +231,20 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
 };
 
 /// Log entity icon if set (for use in dump_config)
-void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
+#define LOG_ENTITY_ICON(tag, prefix, obj) \
+  if (!(obj).get_icon_ref().empty()) { \
+    ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, (obj).get_icon_ref().c_str()); \
+  }
 /// Log entity device class if set (for use in dump_config)
-void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj);
+#define LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj) \
+  if (!(obj).get_device_class_ref().empty()) { \
+    ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, (obj).get_device_class_ref().c_str()); \
+  }
 /// Log entity unit of measurement if set (for use in dump_config)
-void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj);
+#define LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj) \
+  if (!(obj).get_unit_of_measurement_ref().empty()) { \
+    ESP_LOGCONFIG(tag, "%s  Unit of Measurement: '%s'", prefix, (obj).get_unit_of_measurement_ref().c_str()); \
+  }
 
 /**
  * An entity that has a state.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -230,6 +230,13 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
   const char *unit_of_measurement_{nullptr};  ///< Unit of measurement override
 };
 
+/// Log entity icon if set (for use in dump_config)
+void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
+/// Log entity device class if set (for use in dump_config)
+void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj);
+/// Log entity unit of measurement if set (for use in dump_config)
+void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj);
+
 /**
  * An entity that has a state.
  * @tparam T The type of the state

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -231,13 +231,13 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
 };
 
 /// Log entity icon if set (for use in dump_config)
-#define LOG_ENTITY_ICON(prefix, obj) log_entity_icon(TAG, prefix, obj)
+#define LOG_ENTITY_ICON(tag, prefix, obj) log_entity_icon(tag, prefix, obj)
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
 /// Log entity device class if set (for use in dump_config)
-#define LOG_ENTITY_DEVICE_CLASS(prefix, obj) log_entity_device_class(TAG, prefix, obj)
+#define LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj) log_entity_device_class(tag, prefix, obj)
 void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj);
 /// Log entity unit of measurement if set (for use in dump_config)
-#define LOG_ENTITY_UNIT_OF_MEASUREMENT(prefix, obj) log_entity_unit_of_measurement(TAG, prefix, obj)
+#define LOG_ENTITY_UNIT_OF_MEASUREMENT(tag, prefix, obj) log_entity_unit_of_measurement(tag, prefix, obj)
 void log_entity_unit_of_measurement(const char *tag, const char *prefix, const EntityBase_UnitOfMeasurement &obj);
 
 /**


### PR DESCRIPTION
# What does this implement/fix?

Consolidates duplicate `dump_config` logging code for entity icon, device_class, and unit_of_measurement into shared macros/functions in `entity_base.h`/`entity_base.cpp`.

Previously, the same logging patterns were duplicated across 15+ files:
```cpp
if (!obj->get_icon_ref().empty()) {
  ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj->get_icon_ref().c_str());
}
if (!obj->get_device_class_ref().empty()) {
  ESP_LOGCONFIG(tag, "%s  Device Class: '%s'", prefix, obj->get_device_class_ref().c_str());
}
```

Now consolidated into three macros following the same pattern as `LOG_SENSOR`, `LOG_PIN`, etc:
```cpp
LOG_ENTITY_ICON(TAG, prefix, obj);
LOG_ENTITY_DEVICE_CLASS(TAG, prefix, obj);
LOG_ENTITY_UNIT_OF_MEASUREMENT(TAG, prefix, obj);
```

The macros take `tag` as a parameter so callers can pass the correct tag (e.g., `TAG` in dump_config, or a passed `tag` parameter in log_* functions).

**Benefits:**
- Code duplication reduced across 15 files
- Single point of maintenance for logging format changes
- Consistent logging format across all entity types
- Follows existing ESPHome patterns (`LOG_SENSOR`, `LOG_PIN`, etc.)

**Note on line numbers:** All `LOG_*` macros in ESPHome (`LOG_PIN`, `LOG_SENSOR`, `LOG_BINARY_SENSOR`, etc.) use the macro + function pattern, which means log line numbers point to the function implementation rather than the call site. This tradeoff has already been accepted throughout the codebase.

**Files updated:**

Core:
- `esphome/core/entity_base.h` - added macro definitions and function declarations
- `esphome/core/entity_base.cpp` - added function implementations

Components (.cpp files):
- `button/button.cpp`
- `binary_sensor/binary_sensor.cpp`
- `text_sensor/text_sensor.cpp`
- `sensor/sensor.cpp`
- `switch/switch.cpp`
- `number/number.cpp`

Components (.h macro files):
- `datetime/date_entity.h`
- `datetime/datetime_entity.h`
- `datetime/time_entity.h`
- `event/event.h`
- `lock/lock.h`
- `select/select.h`
- `text/text.h`
- `cover/cover.h`
- `valve/valve.h`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A - code cleanup

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A - internal refactoring only

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
