### PR TITLE
[runtime_stats] Eliminate heap churn by using stack-allocated buffer for sorting

### DIFF
--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -44,7 +44,7 @@ void RuntimeStatsCollector::log_stats_() {
     return;
   }
 
-  // Stack buffer sized to actual active count (up to 256 = 1KB), heap fallback for larger
+  // Stack buffer sized to actual active count (up to 256 components), heap fallback for larger
   SmallBufferWithHeapFallback<256, Component *> buffer(count);
   Component **sorted = buffer.get();
 

--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -27,46 +27,61 @@ void RuntimeStatsCollector::record_component_time(Component *component, uint32_t
 }
 
 void RuntimeStatsCollector::log_stats_() {
+  // First pass: count active components
+  size_t count = 0;
+  for (const auto &it : this->component_stats_) {
+    if (it.second.get_period_count() > 0) {
+      count++;
+    }
+  }
+
   ESP_LOGI(TAG,
            "Component Runtime Statistics\n"
-           " Period stats (last %" PRIu32 "ms):",
-           this->log_interval_);
+           " Period stats (last %" PRIu32 "ms): %zu active components",
+           this->log_interval_, count);
 
-  // First collect stats we want to display
-  std::vector<ComponentStatPair> stats_to_display;
+  if (count == 0) {
+    return;
+  }
 
+  // Stack buffer sized to actual active count (up to 256 = 1KB), heap fallback for larger
+  SmallBufferWithHeapFallback<256, Component *> buffer(count);
+  Component **sorted = buffer.get();
+
+  // Second pass: fill buffer with active components
+  size_t idx = 0;
   for (const auto &it : this->component_stats_) {
-    Component *component = it.first;
-    const ComponentRuntimeStats &stats = it.second;
-    if (stats.get_period_count() > 0) {
-      ComponentStatPair pair = {component, &stats};
-      stats_to_display.push_back(pair);
+    if (it.second.get_period_count() > 0) {
+      sorted[idx++] = it.first;
     }
   }
 
   // Sort by period runtime (descending)
-  std::sort(stats_to_display.begin(), stats_to_display.end(), std::greater<ComponentStatPair>());
+  std::sort(sorted, sorted + count, [this](Component *a, Component *b) {
+    return this->component_stats_[a].get_period_time_ms() > this->component_stats_[b].get_period_time_ms();
+  });
 
   // Log top components by period runtime
-  for (const auto &it : stats_to_display) {
+  for (size_t i = 0; i < count; i++) {
+    const auto &stats = this->component_stats_[sorted[i]];
     ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.2fms, max=%" PRIu32 "ms, total=%" PRIu32 "ms",
-             LOG_STR_ARG(it.component->get_component_log_str()), it.stats->get_period_count(),
-             it.stats->get_period_avg_time_ms(), it.stats->get_period_max_time_ms(), it.stats->get_period_time_ms());
+             LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.get_period_count(), stats.get_period_avg_time_ms(),
+             stats.get_period_max_time_ms(), stats.get_period_time_ms());
   }
 
-  // Log total stats since boot
-  ESP_LOGI(TAG, " Total stats (since boot):");
+  // Log total stats since boot (only for active components - idle ones haven't changed)
+  ESP_LOGI(TAG, " Total stats (since boot): %zu active components", count);
 
   // Re-sort by total runtime for all-time stats
-  std::sort(stats_to_display.begin(), stats_to_display.end(),
-            [](const ComponentStatPair &a, const ComponentStatPair &b) {
-              return a.stats->get_total_time_ms() > b.stats->get_total_time_ms();
-            });
+  std::sort(sorted, sorted + count, [this](Component *a, Component *b) {
+    return this->component_stats_[a].get_total_time_ms() > this->component_stats_[b].get_total_time_ms();
+  });
 
-  for (const auto &it : stats_to_display) {
+  for (size_t i = 0; i < count; i++) {
+    const auto &stats = this->component_stats_[sorted[i]];
     ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.2fms, max=%" PRIu32 "ms, total=%" PRIu32 "ms",
-             LOG_STR_ARG(it.component->get_component_log_str()), it.stats->get_total_count(),
-             it.stats->get_total_avg_time_ms(), it.stats->get_total_max_time_ms(), it.stats->get_total_time_ms());
+             LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.get_total_count(), stats.get_total_avg_time_ms(),
+             stats.get_total_max_time_ms(), stats.get_total_time_ms());
   }
 }
 

--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -5,7 +5,6 @@
 #ifdef USE_RUNTIME_STATS
 
 #include <map>
-#include <vector>
 #include <cstdint>
 #include <cstring>
 #include "esphome/core/helpers.h"

--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -77,17 +77,6 @@ class ComponentRuntimeStats {
   uint32_t total_max_time_ms_;
 };
 
-// For sorting components by run time
-struct ComponentStatPair {
-  Component *component;
-  const ComponentRuntimeStats *stats;
-
-  bool operator>(const ComponentStatPair &other) const {
-    // Sort by period time as that's what we're displaying in the logs
-    return stats->get_period_time_ms() > other.stats->get_period_time_ms();
-  }
-};
-
 class RuntimeStatsCollector {
  public:
   RuntimeStatsCollector();


### PR DESCRIPTION
# What does this implement/fix?

Eliminates heap churn in the `runtime_stats` component by replacing the heap-allocated `std::vector` with a stack-allocated `SmallBufferWithHeapFallback` for sorting components during logging.

## Problem

Previously, `log_stats_()` created a temporary `std::vector<ComponentStatPair>` on the heap every log interval (default 60 seconds). This caused heap allocation/deallocation cycles that contribute to fragmentation over long runtimes.

## Solution

- Use `SmallBufferWithHeapFallback<256, Component*>` for stack allocation (up to 1KB for 256 components)
- Reduce per-element storage from 8 bytes (`ComponentStatPair`) to 4 bytes (`Component*`)
- Only show active components in both Period and Total stats (idle components haven't changed)
- Add active component count to log headers for visibility

## Before

```
Heap operations per log interval:
1. Vector initial allocation
2. Potential reallocations during push_back()
3. Vector deallocation when function returns
```

## After

```
Zero heap operations for configs with ≤256 active components (covers virtually all real configs)
Heap fallback only for unusually large configs
```

## Example output

```
[I][runtime_stats:038]: Component Runtime Statistics
[I][runtime_stats:038]:  Period stats (last 60000ms): 21 active components
[I][runtime_stats:069]:   ld2450: count=6244, avg=0.40ms, max=40ms, total=2524ms
[I][runtime_stats:069]:   api: count=6244, avg=0.26ms, max=30ms, total=1632ms
...
[I][runtime_stats:075]:  Total stats (since boot): 21 active components
[I][runtime_stats:086]:   ld2450: count=12120, avg=0.39ms, max=201ms, total=4775ms
...
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
