### PR TITLE
[dashboard] Retry MQTT status connect on startup

### DIFF
--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -2,16 +2,28 @@ from __future__ import annotations
 
 import binascii
 import json
+import logging
 import os
 import threading
 import typing
 
 from esphome import mqtt
+from esphome.core import EsphomeError
 
 from ..entries import EntryStateSource, bool_to_entry_state
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# How often to re-check entries and publish a discover ping.
+_POLL_INTERVAL = 2.0
+
+# Retry behavior for initial broker connect failures (e.g. transient DNS/network readiness).
+_CONNECT_RETRY_INITIAL_DELAY = 1.0
+_CONNECT_RETRY_MAX_DELAY = 300.0
 
 
 class MqttStatusThread(threading.Thread):
@@ -50,18 +62,34 @@ class MqttStatusThread(threading.Thread):
 
         mqttid = str(binascii.hexlify(os.urandom(6)).decode())
 
-        client = mqtt.prepare(
-            config,
-            [topic],
-            on_message,
-            on_connect,
-            None,
-            None,
-            f"esphome-dashboard-{mqttid}",
-        )
+        client = None
+        retry_delay = _CONNECT_RETRY_INITIAL_DELAY
+        while client is None and not dashboard.stop_event.is_set():
+            try:
+                client = mqtt.prepare(
+                    config,
+                    [topic],
+                    on_message,
+                    on_connect,
+                    None,
+                    None,
+                    f"esphome-dashboard-{mqttid}",
+                )
+            except EsphomeError as err:
+                _LOGGER.warning(
+                    "Cannot connect to MQTT broker for dashboard status: %s. Retrying in %.1f s",
+                    err,
+                    retry_delay,
+                )
+                if dashboard.stop_event.wait(retry_delay):
+                    return
+                retry_delay = min(retry_delay * 2, _CONNECT_RETRY_MAX_DELAY)
+
+        if client is None:
+            return
         client.loop_start()
 
-        while not dashboard.stop_event.wait(2):
+        while not dashboard.stop_event.wait(_POLL_INTERVAL):
             current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:

--- a/tests/dashboard/status/test_mqtt.py
+++ b/tests/dashboard/status/test_mqtt.py
@@ -61,4 +61,3 @@ def test_mqtt_status_thread_retries_connect_and_recovers() -> None:
         assert mock_prepare.call_count >= 3
         client.disconnect.assert_called_once()
         client.loop_stop.assert_called_once()
-

--- a/tests/dashboard/status/test_mqtt.py
+++ b/tests/dashboard/status/test_mqtt.py
@@ -1,0 +1,64 @@
+"""Tests for esphome.dashboard.status.mqtt."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import Mock, patch
+
+from esphome.core import EsphomeError
+from esphome.dashboard.status.mqtt import MqttStatusThread
+
+
+def test_mqtt_status_thread_retries_connect_and_recovers() -> None:
+    """Test that transient connect failures do not permanently kill the thread."""
+    stop_event = threading.Event()
+
+    mqtt_ping_request = Mock()
+    mqtt_ping_request.wait.return_value = True
+    mqtt_ping_request.clear = Mock()
+
+    entries = Mock()
+    entries.all.return_value = []
+    entries.get_by_name.return_value = []
+    entries.set_state_if_online_or_source = Mock()
+    entries.set_state_if_source = Mock()
+
+    dashboard = Mock()
+    dashboard.entries = entries
+    dashboard.stop_event = stop_event
+    dashboard.mqtt_ping_request = mqtt_ping_request
+
+    loop_started = threading.Event()
+    client = Mock()
+    client.loop_start.side_effect = loop_started.set
+
+    attempt = {"count": 0}
+
+    def prepare_side_effect(*args, **kwargs):
+        attempt["count"] += 1
+        if attempt["count"] < 3:
+            raise EsphomeError("Cannot connect to MQTT broker: temporary failure")
+        return client
+
+    with (
+        patch(
+            "esphome.dashboard.status.mqtt.mqtt.prepare",
+            side_effect=prepare_side_effect,
+        ) as mock_prepare,
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_INITIAL_DELAY", 0.01),
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_MAX_DELAY", 0.02),
+        patch("esphome.dashboard.status.mqtt._POLL_INTERVAL", 0.01),
+    ):
+        thread = MqttStatusThread(dashboard)
+        thread.start()
+
+        assert loop_started.wait(1.0)
+        stop_event.set()
+
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+        assert mock_prepare.call_count >= 3
+        client.disconnect.assert_called_once()
+        client.loop_stop.assert_called_once()
+


### PR DESCRIPTION
# What does this implement/fix?

Makes the dashboard MQTT status thread resilient to transient startup failures (e.g. DNS not ready / broker not accepting connections yet). Instead of crashing permanently when `mqtt.prepare()` fails, the thread now retries with backoff until it connects or the dashboard is stopped.

Adds a regression test that simulates initial connect failures and verifies the thread recovers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13590

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Dashboard env vars
# ESPHOME_DASHBOARD_USE_MQTT: "true"
# ESPHOME_DASHBOARD_MQTT_BROKER: "mqtt"
# ESPHOME_DASHBOARD_MQTT_PORT: 1883
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).