### PR TITLE
[dashboard] Ping host nodes without storage address

### DIFF
--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -53,12 +53,16 @@ class PingStatus:
             dashboard.ping_request.clear()
             iteration_start = time.monotonic()
             current_entries = dashboard.entries.async_all()
-            to_ping: list[DashboardEntry] = []
+            to_ping: list[tuple[DashboardEntry, str]] = []
 
             for entry in current_entries:
-                if entry.address is None:
-                    # No address or we already have a state from another source
-                    # so no need to ping
+                address = entry.address
+                if address is None and entry.target_platform == "HOST":
+                    # Host platform nodes may not have an address in storage.json.
+                    # In that case, fall back to pinging the node name.
+                    address = entry.name
+                if address is None:
+                    # No address to ping
                     continue
                 if (
                     entry.state.reachable is ReachableState.ONLINE
@@ -68,22 +72,23 @@ class PingStatus:
                     # If we already have a state from another source and
                     # it's online, we don't need to ping
                     continue
-                to_ping.append(entry)
+                to_ping.append((entry, address))
 
             # Resolve DNS for all entries
             entries_with_addresses: dict[DashboardEntry, list[str]] = {}
             for ping_group in chunked(to_ping, GROUP_SIZE):
-                ping_group = cast(list[DashboardEntry], ping_group)
+                ping_group = cast(list[tuple[DashboardEntry, str]], ping_group)
                 now_monotonic = time.monotonic()
                 dns_results = await asyncio.gather(
                     *(
-                        dashboard.dns_cache.async_resolve(entry.address, now_monotonic)
-                        for entry in ping_group
+                        dashboard.dns_cache.async_resolve(address, now_monotonic)
+                        for _, address in ping_group
                     ),
                     return_exceptions=True,
                 )
 
-                for entry, result in zip(ping_group, dns_results):
+                for entry_address, result in zip(ping_group, dns_results):
+                    entry = entry_address[0]
                     if isinstance(result, Exception):
                         # Only update state if its unknown or from ping
                         # so we don't mark it as offline if we have a state

--- a/tests/dashboard/status/test_ping.py
+++ b/tests/dashboard/status/test_ping.py
@@ -23,13 +23,17 @@ async def test_ping_status_host_entry_without_address_falls_back_to_name() -> No
     entry_host.address = None
     entry_host.name = "host-light"
     entry_host.target_platform = "HOST"
-    entry_host.state = Mock(reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN)
+    entry_host.state = Mock(
+        reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN
+    )
 
     entry_non_host = Mock()
     entry_non_host.address = None
     entry_non_host.name = "esp32-node"
     entry_non_host.target_platform = "ESP32"
-    entry_non_host.state = Mock(reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN)
+    entry_non_host.state = Mock(
+        reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN
+    )
 
     entries = Mock()
     entries.async_all.return_value = [entry_host, entry_non_host]
@@ -55,9 +59,15 @@ async def test_ping_status_host_entry_without_address_falls_back_to_name() -> No
         return host
 
     with (
-        patch("esphome.dashboard.status.ping._can_use_icmp_lib_with_privilege", return_value=False),
+        patch(
+            "esphome.dashboard.status.ping._can_use_icmp_lib_with_privilege",
+            return_value=False,
+        ),
         patch("esphome.dashboard.status.ping.MIN_PING_INTERVAL", 0),
-        patch("esphome.dashboard.status.ping.async_ping", side_effect=async_ping_side_effect) as mock_ping,
+        patch(
+            "esphome.dashboard.status.ping.async_ping",
+            side_effect=async_ping_side_effect,
+        ) as mock_ping,
     ):
         await ping_status.async_run()
 
@@ -72,4 +82,3 @@ async def test_ping_status_host_entry_without_address_falls_back_to_name() -> No
     assert set_entry is entry_host
     assert set_state.source is EntryStateSource.PING
     assert set_state.reachable is ReachableState.ONLINE
-

--- a/tests/dashboard/status/test_ping.py
+++ b/tests/dashboard/status/test_ping.py
@@ -1,0 +1,75 @@
+"""Tests for esphome.dashboard.status.ping."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esphome.dashboard.entries import EntryStateSource, ReachableState
+from esphome.dashboard.status.ping import PingStatus
+
+
+@pytest.mark.asyncio
+async def test_ping_status_host_entry_without_address_falls_back_to_name() -> None:
+    """Host platform entries with address=None should still be pinged via entry.name."""
+    stop_event = threading.Event()
+    ping_request = asyncio.Event()
+    ping_request.set()
+
+    entry_host = Mock()
+    entry_host.address = None
+    entry_host.name = "host-light"
+    entry_host.target_platform = "HOST"
+    entry_host.state = Mock(reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN)
+
+    entry_non_host = Mock()
+    entry_non_host.address = None
+    entry_non_host.name = "esp32-node"
+    entry_non_host.target_platform = "ESP32"
+    entry_non_host.state = Mock(reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN)
+
+    entries = Mock()
+    entries.async_all.return_value = [entry_host, entry_non_host]
+    entries.async_set_state_if_source = Mock()
+    entries.async_set_state_if_online_or_source = Mock()
+
+    dns_cache = Mock()
+    dns_cache.async_resolve = AsyncMock(return_value=["127.0.0.1"])
+
+    dashboard = Mock()
+    dashboard.stop_event = stop_event
+    dashboard.ping_request = ping_request
+    dashboard.entries = entries
+    dashboard.dns_cache = dns_cache
+
+    ping_status = PingStatus(dashboard)
+
+    host = Mock()
+    host.is_alive = True
+
+    async def async_ping_side_effect(*args, **kwargs):
+        stop_event.set()
+        return host
+
+    with (
+        patch("esphome.dashboard.status.ping._can_use_icmp_lib_with_privilege", return_value=False),
+        patch("esphome.dashboard.status.ping.MIN_PING_INTERVAL", 0),
+        patch("esphome.dashboard.status.ping.async_ping", side_effect=async_ping_side_effect) as mock_ping,
+    ):
+        await ping_status.async_run()
+
+    dns_cache.async_resolve.assert_called_once()
+    assert dns_cache.async_resolve.call_args.args[0] == "host-light"
+
+    mock_ping.assert_called_once()
+    assert mock_ping.call_args.args[0] == "127.0.0.1"
+
+    assert entries.async_set_state_if_online_or_source.call_count == 1
+    set_entry, set_state = entries.async_set_state_if_online_or_source.call_args.args
+    assert set_entry is entry_host
+    assert set_state.source is EntryStateSource.PING
+    assert set_state.reachable is ReachableState.ONLINE
+


### PR DESCRIPTION
# What does this implement/fix?

Fixes ping-based online/offline status for `host:` platform nodes when the generated storage JSON has `\"address\": null`.

The ping status loop previously skipped entries with `entry.address is None`, which caused host nodes to stay permanently offline in the dashboard. For `HOST` targets, we now fall back to pinging `entry.name` when the storage address is missing.

Adds a regression test covering the fallback behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13589

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Dashboard env vars
# ESPHOME_DASHBOARD_USE_PING: "true"

# Example host node (storage may have address: null)
# host:
# api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).