### PR TITLE
[http_request] Fix empty body for chunked transfer encoding responses

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -131,6 +131,9 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     }
   }
 
+  // HTTPClient::getSize() returns -1 for chunked transfer encoding (no Content-Length).
+  // When cast to size_t, -1 becomes SIZE_MAX (4294967295 on 32-bit).
+  // The read() method handles this by checking content_length > 0 before using it.
   int content_length = container->client_.getSize();
   ESP_LOGD(TAG, "Content-Length: %d", content_length);
   container->content_length = (size_t) content_length;
@@ -167,17 +170,23 @@ int HttpContainerArduino::read(uint8_t *buf, size_t max_len) {
   }
 
   int available_data = stream_ptr->available();
-  int bufsize = std::min(max_len, std::min(this->content_length - this->bytes_read_, (size_t) available_data));
+  // For chunked transfer encoding, content_length is 0 (unknown), so don't limit by it.
+  // HTTPClient::getSize() returns -1 for chunked, which becomes 0 when cast to size_t.
+  size_t remaining = (this->content_length > 0) ? (this->content_length - this->bytes_read_) : max_len;
+  int bufsize = std::min(max_len, std::min(remaining, (size_t) available_data));
 
   if (bufsize == 0) {
     this->duration_ms += (millis() - start);
-    // Check if we've read all expected content
-    if (this->bytes_read_ >= this->content_length) {
+    // Check if we've read all expected content (only valid when content_length is known)
+    // For chunked encoding (content_length == 0), we can't use this check
+    if (this->content_length > 0 && this->bytes_read_ >= this->content_length) {
       return 0;  // All content read successfully
     }
     // No data available - check if connection is still open
+    // For chunked encoding, !connected() after reading means EOF (all chunks received)
+    // For known content_length with bytes_read_ < content_length, it means connection dropped
     if (!stream_ptr->connected()) {
-      return HTTP_ERROR_CONNECTION_CLOSED;  // Connection closed prematurely
+      return HTTP_ERROR_CONNECTION_CLOSED;  // Connection closed or EOF for chunked
     }
     return 0;  // No data yet, caller should retry
   }

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -170,15 +170,15 @@ int HttpContainerArduino::read(uint8_t *buf, size_t max_len) {
   }
 
   int available_data = stream_ptr->available();
-  // For chunked transfer encoding, content_length is 0 (unknown), so don't limit by it.
-  // HTTPClient::getSize() returns -1 for chunked, which becomes 0 when cast to size_t.
+  // For chunked transfer encoding, content_length is effectively unknown, so don't limit by it.
+  // HTTPClient::getSize() returns -1 for chunked, which becomes SIZE_MAX when cast to size_t.
   size_t remaining = (this->content_length > 0) ? (this->content_length - this->bytes_read_) : max_len;
   int bufsize = std::min(max_len, std::min(remaining, (size_t) available_data));
 
   if (bufsize == 0) {
     this->duration_ms += (millis() - start);
-    // Check if we've read all expected content (only valid when content_length is known)
-    // For chunked encoding (content_length == 0), we can't use this check
+    // Check if we've read all expected content (only valid when content_length is known and not SIZE_MAX)
+    // For chunked encoding (content_length == SIZE_MAX), we can't use this check
     if (this->content_length > 0 && this->bytes_read_ >= this->content_length) {
       return 0;  // All content read successfully
     }

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -133,7 +133,8 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
 
   // HTTPClient::getSize() returns -1 for chunked transfer encoding (no Content-Length).
   // When cast to size_t, -1 becomes SIZE_MAX (4294967295 on 32-bit).
-  // The read() method handles this by checking content_length > 0 before using it.
+  // The read() method handles this: bytes_read_ can never reach SIZE_MAX, so the
+  // early return check (bytes_read_ >= content_length) will never trigger.
   int content_length = container->client_.getSize();
   ESP_LOGD(TAG, "Content-Length: %d", content_length);
   container->content_length = (size_t) content_length;

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -171,8 +171,8 @@ int HttpContainerArduino::read(uint8_t *buf, size_t max_len) {
   }
 
   int available_data = stream_ptr->available();
-  // For chunked transfer encoding, content_length is effectively unknown, so don't limit by it.
-  // HTTPClient::getSize() returns -1 for chunked, which becomes SIZE_MAX when cast to size_t.
+  // For chunked transfer encoding, HTTPClient::getSize() returns -1, which becomes SIZE_MAX when
+  // cast to size_t. SIZE_MAX - bytes_read_ is still huge, so it won't limit the read.
   size_t remaining = (this->content_length > 0) ? (this->content_length - this->bytes_read_) : max_len;
   int bufsize = std::min(max_len, std::min(remaining, (size_t) available_data));
 

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -157,6 +157,9 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   }
 
   container->feed_wdt();
+  // esp_http_client_fetch_headers() returns -1 for chunked transfer encoding (no Content-Length).
+  // When stored in size_t content_length, -1 becomes 0 due to the int64_t to size_t conversion.
+  // The read() method handles content_length == 0 specially to support chunked responses.
   container->content_length = esp_http_client_fetch_headers(client);
   container->feed_wdt();
   container->status_code = esp_http_client_get_status_code(client);
@@ -225,14 +228,22 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
 //
 // We normalize to HttpContainer::read() contract:
 //   > 0: bytes read
-//   0: no data yet / all content read (caller should check bytes_read vs content_length)
+//   0: all content read (only returned when content_length is known and fully read)
 //   < 0: error/connection closed
+//
+// Note on chunked transfer encoding:
+//   esp_http_client_fetch_headers() returns -1 for chunked responses, which becomes 0
+//   when stored in size_t content_length. We handle this by skipping the content_length
+//   check when content_length is 0, allowing esp_http_client_read() to handle chunked
+//   decoding internally and signal EOF by returning 0.
 int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
   const uint32_t start = millis();
   watchdog::WatchdogManager wdm(this->parent_->get_watchdog_timeout());
 
   // Check if we've already read all expected content
-  if (this->bytes_read_ >= this->content_length) {
+  // Skip this check when content_length is 0 (chunked transfer encoding or unknown length)
+  // For chunked responses, esp_http_client_read() will return 0 when all data is received
+  if (this->content_length > 0 && this->bytes_read_ >= this->content_length) {
     return 0;  // All content read successfully
   }
 
@@ -247,7 +258,12 @@ int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
     return read_len_or_error;
   }
 
-  // Connection closed by server before all content received
+  // esp_http_client_read() returns 0 in two cases:
+  // 1. Known content_length: connection closed before all data received (error)
+  // 2. Chunked encoding (content_length == 0): all data received (EOF)
+  // For case 1, returning HTTP_ERROR_CONNECTION_CLOSED is correct.
+  // For case 2, it's semantically an EOF not an error, but functionally correct
+  // because all data is already in the caller's buffer at this point.
   if (read_len_or_error == 0) {
     return HTTP_ERROR_CONNECTION_CLOSED;
   }

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -157,8 +157,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   }
 
   container->feed_wdt();
-  // esp_http_client_fetch_headers() returns -1 for chunked transfer encoding (no Content-Length).
-  // When stored in size_t content_length, -1 becomes 0 due to the int64_t to size_t conversion.
+  // esp_http_client_fetch_headers() returns 0 for chunked transfer encoding (no Content-Length header).
   // The read() method handles content_length == 0 specially to support chunked responses.
   container->content_length = esp_http_client_fetch_headers(client);
   container->feed_wdt();
@@ -232,10 +231,10 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
 //   < 0: error/connection closed
 //
 // Note on chunked transfer encoding:
-//   esp_http_client_fetch_headers() returns -1 for chunked responses, which becomes 0
-//   when stored in size_t content_length. We handle this by skipping the content_length
-//   check when content_length is 0, allowing esp_http_client_read() to handle chunked
-//   decoding internally and signal EOF by returning 0.
+//   esp_http_client_fetch_headers() returns 0 for chunked responses (no Content-Length header).
+//   We handle this by skipping the content_length check when content_length is 0,
+//   allowing esp_http_client_read() to handle chunked decoding internally and signal EOF
+//   by returning 0.
 int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
   const uint32_t start = millis();
   watchdog::WatchdogManager wdm(this->parent_->get_watchdog_timeout());
@@ -260,10 +259,11 @@ int HttpContainerIDF::read(uint8_t *buf, size_t max_len) {
 
   // esp_http_client_read() returns 0 in two cases:
   // 1. Known content_length: connection closed before all data received (error)
-  // 2. Chunked encoding (content_length == 0): all data received (EOF)
+  // 2. Chunked encoding (content_length == 0): end of stream reached (EOF)
   // For case 1, returning HTTP_ERROR_CONNECTION_CLOSED is correct.
-  // For case 2, it's semantically an EOF not an error, but functionally correct
-  // because all data is already in the caller's buffer at this point.
+  // For case 2, 0 indicates that all chunked data has already been delivered
+  // in previous successful read() calls, so treating this as a closed
+  // connection does not cause any loss of response data.
   if (read_len_or_error == 0) {
     return HTTP_ERROR_CONNECTION_CLOSED;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes HTTP request body being empty for responses using chunked transfer encoding (no Content-Length header).

## Root Cause

PR #13435 reintroduced a bug that was originally fixed by PR #7884. The issue is in how `content_length` is handled for chunked responses:

**ESP-IDF:** `esp_http_client_fetch_headers()` returns `0` for chunked encoding (no Content-Length header).

**Arduino:** `HTTPClient::getSize()` returns `-1` for chunked encoding, which becomes `SIZE_MAX` (4294967295) when cast to `size_t`.

The check added in PR #13435:
```cpp
if (this->bytes_read_ >= this->content_length) {
  return 0;  // All content read successfully
}
```

For IDF, this becomes `0 >= 0` which is always true, causing immediate return without reading any data.

## Fix

Skip the early return check when `content_length` is 0 (unknown/chunked):

**IDF:**
```cpp
if (this->content_length > 0 && this->bytes_read_ >= this->content_length) {
  return 0;
}
```

**Arduino:**
```cpp
size_t remaining = (this->content_length > 0) ? (this->content_length - this->bytes_read_) : max_len;
// ...
if (this->content_length > 0 && this->bytes_read_ >= this->content_length) {
  return 0;
}
```

Also added comments explaining the different conversion behaviors between platforms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13598

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

### Test Results

#### HTTP Request Body Tests

| Platform | Chunked (open-meteo.com) | Fixed Content-Length (httpbin.org) |
|----------|--------------------------|-----------------------------------|
| ESP32 IDF | ✅ Body: 355 bytes | ✅ Body: 429 bytes |
| ESP8266 Arduino | ✅ Body: 367 bytes | ✅ Body: 429 bytes |

#### OTA Update Tests (ESP32 IDF)

Retested with the original OTA test server from PR #13435 to verify the fix doesn't break OTA functionality:

| Test | Result | Notes |
|------|--------|-------|
| Manifest check | ✅ Pass | JSON manifest correctly parsed |
| Normal OTA (Content-Length) | ✅ Pass | Full firmware download works |
| Slow OTA (1KB/s) | ✅ Pass | Timeout handling works correctly |
| Disconnect mid-transfer | ✅ Pass | Error correctly detected at ~40%, returned error -1 |

The disconnect test confirmed that premature connection closure is properly detected:
```
[05:20:49.505][D][esp-idf:000]: E (69166) transport_base: tcp_read error, errno=Socket is not connected
[05:20:49.513][E][http_request.ota:140]: Error reading data: -1
[05:20:49.521][D][main:599]: OTA update failed with error 18
```

## Example entry for `config.yaml`:

```yaml
# Existing configs work - no changes needed
http_request:
  verify_ssl: false

script:
  # Test chunked transfer encoding (no Content-Length header)
  - id: test_http_chunked
    then:
      - logger.log: "Testing chunked transfer encoding"
      - http_request.get:
          url: "https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&current=uv_index"
          capture_response: true
          max_response_buffer_size: 2048
          on_response:
            then:
              - lambda: |-
                  ESP_LOGD("test", "CHUNKED - Status: %d, Content-Length: %zu", response->status_code, response->content_length);
                  ESP_LOGD("test", "CHUNKED - Body length: %zu", body.size());
                  ESP_LOGD("test", "CHUNKED - Body: %s", body.c_str());

  # Test fixed Content-Length header
  - id: test_http_fixed_length
    then:
      - logger.log: "Testing fixed content-length"
      - http_request.get:
          url: "https://httpbin.org/json"
          capture_response: true
          max_response_buffer_size: 2048
          on_response:
            then:
              - lambda: |-
                  ESP_LOGD("test", "FIXED - Status: %d, Content-Length: %zu", response->status_code, response->content_length);
                  ESP_LOGD("test", "FIXED - Body length: %zu", body.size());
                  ESP_LOGD("test", "FIXED - Body: %s", body.c_str());

button:
  - platform: template
    name: "Test HTTP Chunked"
    on_press:
      - script.execute: test_http_chunked

  - platform: template
    name: "Test HTTP Fixed Length"
    on_press:
      - script.execute: test_http_fixed_length
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
