### PR TITLE
[ld2450] add on_data callback

### DIFF
--- a/esphome/components/ld2450/__init__.py
+++ b/esphome/components/ld2450/__init__.py
@@ -2,7 +2,7 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_THROTTLE, CONF_TRIGGER_ID
+from esphome.const import CONF_ID, CONF_ON_DATA, CONF_THROTTLE, CONF_TRIGGER_ID
 
 AUTO_LOAD = ["ld24xx"]
 DEPENDENCIES = ["uart"]
@@ -15,7 +15,6 @@ LD2450Component = ld2450_ns.class_("LD2450Component", cg.Component, uart.UARTDev
 LD2450DataTrigger = ld2450_ns.class_("LD2450DataTrigger", automation.Trigger.template())
 
 CONF_LD2450_ID = "ld2450_id"
-CONF_ON_DATA = "on_data"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(

--- a/esphome/components/ld2450/__init__.py
+++ b/esphome/components/ld2450/__init__.py
@@ -1,7 +1,8 @@
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_THROTTLE
+from esphome.const import CONF_ID, CONF_THROTTLE, CONF_TRIGGER_ID
 
 AUTO_LOAD = ["ld24xx"]
 DEPENDENCIES = ["uart"]
@@ -11,7 +12,10 @@ MULTI_CONF = True
 ld2450_ns = cg.esphome_ns.namespace("ld2450")
 LD2450Component = ld2450_ns.class_("LD2450Component", cg.Component, uart.UARTDevice)
 
+LD2450DataTrigger = ld2450_ns.class_("LD2450DataTrigger", automation.Trigger.template())
+
 CONF_LD2450_ID = "ld2450_id"
+CONF_ON_DATA = "on_data"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -19,6 +23,11 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(LD2450Component),
             cv.Optional(CONF_THROTTLE): cv.invalid(
                 f"{CONF_THROTTLE} has been removed; use per-sensor filters, instead"
+            ),
+            cv.Optional(CONF_ON_DATA): automation.validate_automation(
+                {
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(LD2450DataTrigger),
+                }
             ),
         }
     )
@@ -45,3 +54,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    for conf in config.get(CONF_ON_DATA, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -402,6 +402,10 @@ void LD2450Component::restart_and_read_all_info() {
   this->set_timeout(1500, [this]() { this->read_all_info(); });
 }
 
+void LD2450Component::add_on_data_callback(std::function<void()> &&callback) {
+  this->callback_.add(std::move(callback));
+}
+
 // Send command with values to LD2450
 void LD2450Component::send_command_(uint8_t command, const uint8_t *command_value, uint8_t command_value_len) {
   ESP_LOGV(TAG, "Sending COMMAND %02X", command);
@@ -602,6 +606,8 @@ void LD2450Component::handle_periodic_data_() {
     this->still_presence_millis_ = App.get_loop_component_start_time();
   }
 #endif
+
+  this->callback_.call();
 }
 
 bool LD2450Component::handle_ack_data_() {

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -403,7 +403,7 @@ void LD2450Component::restart_and_read_all_info() {
 }
 
 void LD2450Component::add_on_data_callback(std::function<void()> &&callback) {
-  this->callback_.add(std::move(callback));
+  this->data_callback_.add(std::move(callback));
 }
 
 // Send command with values to LD2450
@@ -607,7 +607,7 @@ void LD2450Component::handle_periodic_data_() {
   }
 #endif
 
-  this->callback_.call();
+  this->data_callback_.call();
 }
 
 bool LD2450Component::handle_ack_data_() {

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -194,7 +194,7 @@ class LD2450Component : public Component, public uart::UARTDevice {
   std::array<text_sensor::TextSensor *, 3> direction_text_sensors_{};
 #endif
 
-  LazyCallbackManager<void()> callback_;
+  LazyCallbackManager<void()> data_callback_;
 };
 
 class LD2450DataTrigger : public Trigger<> {

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -141,6 +141,9 @@ class LD2450Component : public Component, public uart::UARTDevice {
                       int32_t zone2_x1, int32_t zone2_y1, int32_t zone2_x2, int32_t zone2_y2, int32_t zone3_x1,
                       int32_t zone3_y1, int32_t zone3_x2, int32_t zone3_y2);
 
+  /// Add a callback that will be called every time the sensor sends a raw value.
+  void add_on_data_callback(std::function<void()> &&callback);
+
  protected:
   void send_command_(uint8_t command_str, const uint8_t *command_value, uint8_t command_value_len);
   void set_config_mode_(bool enable);
@@ -190,6 +193,15 @@ class LD2450Component : public Component, public uart::UARTDevice {
 #ifdef USE_TEXT_SENSOR
   std::array<text_sensor::TextSensor *, 3> direction_text_sensors_{};
 #endif
+
+  LazyCallbackManager<void()> callback_;
+};
+
+class LD2450DataTrigger : public Trigger<> {
+ public:
+  explicit LD2450DataTrigger(LD2450Component *parent) {
+    parent->add_on_data_callback([this]() { this->trigger(); });
+  }
 };
 
 }  // namespace esphome::ld2450

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -141,7 +141,7 @@ class LD2450Component : public Component, public uart::UARTDevice {
                       int32_t zone2_x1, int32_t zone2_y1, int32_t zone2_x2, int32_t zone2_y2, int32_t zone3_x1,
                       int32_t zone3_y1, int32_t zone3_x2, int32_t zone3_y2);
 
-  /// Add a callback that will be called every time the sensor sends a raw value.
+  /// Add a callback that will be called after each successfully processed periodic data frame.
   void add_on_data_callback(std::function<void()> &&callback);
 
  protected:

--- a/tests/components/ld2450/common.yaml
+++ b/tests/components/ld2450/common.yaml
@@ -1,5 +1,8 @@
 ld2450:
   - id: ld2450_radar
+    on_data:
+      then:
+        - logger.log: "LD2450 Radar Data Received"
 
 button:
   - platform: ld2450


### PR DESCRIPTION
# What does this implement/fix?

If you're implementing your own zone logic (for several possible reasons - you want non-rectangular, or to have exclusions, etc.), it's impossible to accurately do because adding a callback to any of the sensor values (x, y, speed, distance, angle) isn't enough, in case that particular value doesn't change, but adding it to _all_ of the sensor values both causes false readings (because you might have a fresh x value, but the y value is still from the last reading), and duplicative work (triggers for every individual value that changed, even for a single reading). Adding a single callback specifically called once per read addresses both issues.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5993

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
