### PR TITLE
[wifi] Fix ESP8266 yield panic when WiFi scan fails

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -756,7 +756,10 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
 
   if (status != OK) {
     ESP_LOGV(TAG, "Scan failed: %d", status);
-    this->retry_connect();
+    // Don't call retry_connect() here - this callback runs in SDK system context
+    // where yield() cannot be called. Instead, just set scan_done_ and let
+    // check_scanning_finished() handle the empty scan_result_ from loop context.
+    this->scan_done_ = true;
     return;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix ESP8266 crash when WiFi scan fails by not calling `retry_connect()` from SDK callback context.

The ESP8266 has two execution contexts:
- **`cont`** (continuation) - normal user code (`loop()`, `setup()`)
- **`sys`** (system) - SDK callbacks, timers, interrupts

In system context, `yield()` cannot be called. The Arduino core [explicitly panics](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_main.cpp#L190-L198) if you try:

```cpp
extern "C" void __yield() {
    if (cont_can_suspend(g_pcont)) {
        esp_schedule();
        esp_suspend_within_cont();
    } else {
        panic();  // Line 197 - what we're hitting!
    }
}
```

The crash dump shows `ctx: sys`, confirming we're in system context:

```
Panic core_esp8266_main.cpp:191 __yield
ctx: sys
```

The bug: `wifi_scan_done_callback_()` runs in system context, and when a scan failed, it called `retry_connect()` which eventually calls `yield()`.

This bug was unintentionally introduced in June 2019 when an unrelated WiFi change was included in [PR #590](https://github.com/esphome/esphome/pull/590) "Fix addressable effects" (likely leftover debugging or testing code). It rarely triggered because scans don't fail often. With `post_connect_roaming` enabled by default in 2026.1.0, scans happen more frequently, making failures more likely - especially for users with many APs in range.

Interestingly, a year later in [PR #1207](https://github.com/esphome/esphome/pull/1207) (CVE-2020-12638 mitigation), a comment was added to the authmode callback explicitly noting that `retry_connect()` cannot be called from callback context - but the same bug in the scan callback was overlooked.

The fix aligns ESP8266 with how ESP32-IDF and LibreTiny handle scan failures - just set `scan_done_ = true` and let `check_scanning_finished()` handle the empty `scan_result_` from the main loop context where `yield()` is safe.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13486

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes a crash in the existing wifi component
wifi:
  ssid: "MySSID"
  password: "mypassword"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
