### PR TITLE
[esp32] Add advanced sdkconfig options to reduce build time and binary size

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -686,8 +686,10 @@ CONF_DISABLE_FATFS = "disable_fatfs"
 KEY_VFS_SELECT_REQUIRED = "vfs_select_required"
 KEY_VFS_DIR_REQUIRED = "vfs_dir_required"
 # Feature requirement tracking - components can call require_* functions to re-enable
+# These are stored in CORE.data[KEY_ESP32] dict
 KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED = "usb_serial_jtag_secondary_required"
 KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
+KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
 
 
@@ -727,7 +729,7 @@ def require_usb_serial_jtag_secondary() -> None:
     Call this from components (e.g., logger) that need USB Serial/JTAG console output.
     This prevents CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG from being disabled.
     """
-    CORE.data[KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED] = True
+    CORE.data[KEY_ESP32][KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED] = True
 
 
 def require_mbedtls_peer_cert() -> None:
@@ -737,7 +739,16 @@ def require_mbedtls_peer_cert() -> None:
     the TLS handshake is complete. This prevents CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
     from being disabled.
     """
-    CORE.data[KEY_MBEDTLS_PEER_CERT_REQUIRED] = True
+    CORE.data[KEY_ESP32][KEY_MBEDTLS_PEER_CERT_REQUIRED] = True
+
+
+def require_mbedtls_pkcs7() -> None:
+    """Mark that mbedTLS PKCS#7 support is required by a component.
+
+    Call this from components that need PKCS#7 certificate validation.
+    This prevents CONFIG_MBEDTLS_PKCS7_C from being disabled.
+    """
+    CORE.data[KEY_ESP32][KEY_MBEDTLS_PKCS7_REQUIRED] = True
 
 
 def require_fatfs() -> None:
@@ -746,7 +757,7 @@ def require_fatfs() -> None:
     Call this from components that use FATFS (e.g., SD card, storage components).
     This prevents FATFS from being disabled when disable_fatfs is set.
     """
-    CORE.data[KEY_FATFS_REQUIRED] = True
+    CORE.data[KEY_ESP32][KEY_FATFS_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -1379,7 +1390,7 @@ async def to_code(config):
 
     # Disable USB Serial/JTAG secondary console
     # Components like logger can call require_usb_serial_jtag_secondary() to re-enable
-    if CORE.data.get(KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED, False):
+    if CORE.data[KEY_ESP32].get(KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED, False):
         add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG", True)
     elif advanced[CONF_DISABLE_USB_SERIAL_JTAG_SECONDARY]:
         add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_SECONDARY_NONE", True)
@@ -1392,14 +1403,18 @@ async def to_code(config):
     # Disable keeping peer certificate after TLS handshake
     # Saves ~4KB heap per connection, but prevents certificate inspection after handshake
     # Components that need it can call require_mbedtls_peer_cert()
-    if CORE.data.get(KEY_MBEDTLS_PEER_CERT_REQUIRED, False):
+    if CORE.data[KEY_ESP32].get(KEY_MBEDTLS_PEER_CERT_REQUIRED, False):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE", True)
     elif advanced[CONF_DISABLE_MBEDTLS_PEER_CERT]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE", False)
 
     # Disable PKCS#7 support in mbedTLS
     # Only needed for specific certificate validation scenarios
-    if advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
+    # Components that need it can call require_mbedtls_pkcs7()
+    if CORE.data[KEY_ESP32].get(KEY_MBEDTLS_PKCS7_REQUIRED, False):
+        # Component requires PKCS#7 - don't disable
+        pass
+    elif advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
 
     # Disable regi2c control functions in IRAM
@@ -1409,7 +1424,7 @@ async def to_code(config):
 
     # Disable FATFS support
     # Components that need FATFS (SD card, etc.) can call require_fatfs()
-    if CORE.data.get(KEY_FATFS_REQUIRED, False):
+    if CORE.data[KEY_ESP32].get(KEY_FATFS_REQUIRED, False):
         # Component requires FATFS - don't disable
         pass
     elif advanced[CONF_DISABLE_FATFS]:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -672,11 +672,23 @@ CONF_RINGBUF_IN_IRAM = "ringbuf_in_iram"
 CONF_HEAP_IN_IRAM = "heap_in_iram"
 CONF_LOOP_TASK_STACK_SIZE = "loop_task_stack_size"
 CONF_USE_FULL_CERTIFICATE_BUNDLE = "use_full_certificate_bundle"
+CONF_DISABLE_DEBUG_STUBS = "disable_debug_stubs"
+CONF_DISABLE_OCD_AWARE = "disable_ocd_aware"
+CONF_DISABLE_USB_SERIAL_JTAG_SECONDARY = "disable_usb_serial_jtag_secondary"
+CONF_DISABLE_DEV_NULL_VFS = "disable_dev_null_vfs"
+CONF_DISABLE_MBEDTLS_PEER_CERT = "disable_mbedtls_peer_cert"
+CONF_DISABLE_MBEDTLS_PKCS7 = "disable_mbedtls_pkcs7"
+CONF_DISABLE_REGI2C_IN_IRAM = "disable_regi2c_in_iram"
+CONF_DISABLE_FATFS = "disable_fatfs"
 
 # VFS requirement tracking
 # Components that need VFS features can call require_vfs_select() or require_vfs_dir()
 KEY_VFS_SELECT_REQUIRED = "vfs_select_required"
 KEY_VFS_DIR_REQUIRED = "vfs_dir_required"
+# Feature requirement tracking - components can call require_* functions to re-enable
+KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED = "usb_serial_jtag_secondary_required"
+KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
+KEY_FATFS_REQUIRED = "fatfs_required"
 
 
 def require_vfs_select() -> None:
@@ -707,6 +719,34 @@ def require_full_certificate_bundle() -> None:
     Call this from components that need to connect to services using uncommon CAs.
     """
     CORE.data[KEY_ESP32][KEY_FULL_CERT_BUNDLE] = True
+
+
+def require_usb_serial_jtag_secondary() -> None:
+    """Mark that USB Serial/JTAG secondary console is required by a component.
+
+    Call this from components (e.g., logger) that need USB Serial/JTAG console output.
+    This prevents CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG from being disabled.
+    """
+    CORE.data[KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED] = True
+
+
+def require_mbedtls_peer_cert() -> None:
+    """Mark that mbedTLS peer certificate retention is required by a component.
+
+    Call this from components that need access to the peer certificate after
+    the TLS handshake is complete. This prevents CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE
+    from being disabled.
+    """
+    CORE.data[KEY_MBEDTLS_PEER_CERT_REQUIRED] = True
+
+
+def require_fatfs() -> None:
+    """Mark that FATFS support is required by a component.
+
+    Call this from components that use FATFS (e.g., SD card, storage components).
+    This prevents FATFS from being disabled when disable_fatfs is set.
+    """
+    CORE.data[KEY_FATFS_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -793,6 +833,16 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(
                     CONF_USE_FULL_CERTIFICATE_BUNDLE, default=False
                 ): cv.boolean,
+                cv.Optional(CONF_DISABLE_DEBUG_STUBS, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_OCD_AWARE, default=True): cv.boolean,
+                cv.Optional(
+                    CONF_DISABLE_USB_SERIAL_JTAG_SECONDARY, default=True
+                ): cv.boolean,
+                cv.Optional(CONF_DISABLE_DEV_NULL_VFS, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_MBEDTLS_PEER_CERT, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_MBEDTLS_PKCS7, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_REGI2C_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_DISABLE_FATFS, default=True): cv.boolean,
             }
         ),
         cv.Optional(CONF_COMPONENTS, default=[]): cv.ensure_list(
@@ -1315,6 +1365,56 @@ async def to_code(config):
     )
 
     add_idf_sdkconfig_option(f"CONFIG_LOG_DEFAULT_LEVEL_{conf[CONF_LOG_LEVEL]}", True)
+
+    # Disable OpenOCD debug stubs to save code size
+    # These are used for on-chip debugging with OpenOCD/JTAG, rarely needed for ESPHome
+    if advanced[CONF_DISABLE_DEBUG_STUBS]:
+        add_idf_sdkconfig_option("CONFIG_ESP_DEBUG_STUBS_ENABLE", False)
+
+    # Disable OCD-aware exception handlers
+    # When enabled, the panic handler detects JTAG debugger and halts instead of resetting
+    # Most ESPHome users don't use JTAG debugging
+    if advanced[CONF_DISABLE_OCD_AWARE]:
+        add_idf_sdkconfig_option("CONFIG_ESP_DEBUG_OCDAWARE", False)
+
+    # Disable USB Serial/JTAG secondary console
+    # Components like logger can call require_usb_serial_jtag_secondary() to re-enable
+    if CORE.data.get(KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED, False):
+        add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG", True)
+    elif advanced[CONF_DISABLE_USB_SERIAL_JTAG_SECONDARY]:
+        add_idf_sdkconfig_option("CONFIG_ESP_CONSOLE_SECONDARY_NONE", True)
+
+    # Disable /dev/null VFS initialization
+    # ESPHome doesn't typically need /dev/null
+    if advanced[CONF_DISABLE_DEV_NULL_VFS]:
+        add_idf_sdkconfig_option("CONFIG_VFS_INITIALIZE_DEV_NULL", False)
+
+    # Disable keeping peer certificate after TLS handshake
+    # Saves ~4KB heap per connection, but prevents certificate inspection after handshake
+    # Components that need it can call require_mbedtls_peer_cert()
+    if CORE.data.get(KEY_MBEDTLS_PEER_CERT_REQUIRED, False):
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE", True)
+    elif advanced[CONF_DISABLE_MBEDTLS_PEER_CERT]:
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_SSL_KEEP_PEER_CERTIFICATE", False)
+
+    # Disable PKCS#7 support in mbedTLS
+    # Only needed for specific certificate validation scenarios
+    if advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
+
+    # Disable regi2c control functions in IRAM
+    # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
+    if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:
+        add_idf_sdkconfig_option("CONFIG_ESP_REGI2C_CTRL_FUNC_IN_IRAM", False)
+
+    # Disable FATFS support
+    # Components that need FATFS (SD card, etc.) can call require_fatfs()
+    if CORE.data.get(KEY_FATFS_REQUIRED, False):
+        # Component requires FATFS - don't disable
+        pass
+    elif advanced[CONF_DISABLE_FATFS]:
+        add_idf_sdkconfig_option("CONFIG_FATFS_LFN_NONE", True)
+        add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 0)
 
     for name, value in conf[CONF_SDKCONFIG_OPTIONS].items():
         add_idf_sdkconfig_option(name, RawSdkconfigValue(value))

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1412,8 +1412,8 @@ async def to_code(config):
     # Only needed for specific certificate validation scenarios
     # Components that need it can call require_mbedtls_pkcs7()
     if CORE.data[KEY_ESP32].get(KEY_MBEDTLS_PKCS7_REQUIRED, False):
-        # Component requires PKCS#7 - don't disable
-        pass
+        # Component called require_mbedtls_pkcs7() - enable regardless of user setting
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", True)
     elif advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
 
@@ -1425,8 +1425,9 @@ async def to_code(config):
     # Disable FATFS support
     # Components that need FATFS (SD card, etc.) can call require_fatfs()
     if CORE.data[KEY_ESP32].get(KEY_FATFS_REQUIRED, False):
-        # Component requires FATFS - don't disable
-        pass
+        # Component called require_fatfs() - enable regardless of user setting
+        add_idf_sdkconfig_option("CONFIG_FATFS_LFN_NONE", False)
+        add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 2)
     elif advanced[CONF_DISABLE_FATFS]:
         add_idf_sdkconfig_option("CONFIG_FATFS_LFN_NONE", True)
         add_idf_sdkconfig_option("CONFIG_FATFS_VOLUME_COUNT", 0)

--- a/tests/components/esp32/test.esp32-idf.yaml
+++ b/tests/components/esp32/test.esp32-idf.yaml
@@ -8,6 +8,15 @@ esp32:
       enable_lwip_bridge_interface: true
       disable_libc_locks_in_iram: false  # Test explicit opt-out of RAM optimization
       use_full_certificate_bundle: false  # Test CMN bundle (default)
+      # Test new SDK optimization options (all defaults = true)
+      disable_debug_stubs: true
+      disable_ocd_aware: true
+      disable_usb_serial_jtag_secondary: true
+      disable_dev_null_vfs: true
+      disable_mbedtls_peer_cert: true
+      disable_mbedtls_pkcs7: true
+      disable_regi2c_in_iram: true
+      disable_fatfs: true
 
 wifi:
   ssid: MySSID

--- a/tests/components/esp32/test.esp32-idf.yaml
+++ b/tests/components/esp32/test.esp32-idf.yaml
@@ -8,7 +8,6 @@ esp32:
       enable_lwip_bridge_interface: true
       disable_libc_locks_in_iram: false  # Test explicit opt-out of RAM optimization
       use_full_certificate_bundle: false  # Test CMN bundle (default)
-      # Test new SDK optimization options (all defaults = true)
       disable_debug_stubs: true
       disable_ocd_aware: true
       disable_usb_serial_jtag_secondary: true

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -10,6 +10,15 @@ esp32:
         ref: 2.7.0
     advanced:
       enable_idf_experimental_features: yes
+      # Test new SDK optimization options (all defaults = true)
+      disable_debug_stubs: true
+      disable_ocd_aware: true
+      disable_usb_serial_jtag_secondary: true
+      disable_dev_null_vfs: true
+      disable_mbedtls_peer_cert: true
+      disable_mbedtls_pkcs7: true
+      disable_regi2c_in_iram: true
+      disable_fatfs: true
 
 ota:
   platform: esphome

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -10,7 +10,6 @@ esp32:
         ref: 2.7.0
     advanced:
       enable_idf_experimental_features: yes
-      # Test new SDK optimization options (all defaults = true)
       disable_debug_stubs: true
       disable_ocd_aware: true
       disable_usb_serial_jtag_secondary: true

--- a/tests/components/esp32/test.esp32-s3-idf.yaml
+++ b/tests/components/esp32/test.esp32-s3-idf.yaml
@@ -5,7 +5,6 @@ esp32:
     advanced:
       execute_from_psram: true
       disable_libc_locks_in_iram: true  # Test default RAM optimization enabled
-      # Test new SDK optimization options (all defaults = true)
       disable_debug_stubs: true
       disable_ocd_aware: true
       disable_usb_serial_jtag_secondary: true

--- a/tests/components/esp32/test.esp32-s3-idf.yaml
+++ b/tests/components/esp32/test.esp32-s3-idf.yaml
@@ -5,6 +5,15 @@ esp32:
     advanced:
       execute_from_psram: true
       disable_libc_locks_in_iram: true  # Test default RAM optimization enabled
+      # Test new SDK optimization options (all defaults = true)
+      disable_debug_stubs: true
+      disable_ocd_aware: true
+      disable_usb_serial_jtag_secondary: true
+      disable_dev_null_vfs: true
+      disable_mbedtls_peer_cert: true
+      disable_mbedtls_pkcs7: true
+      disable_regi2c_in_iram: true
+      disable_fatfs: true
 
 psram:
   mode: octal


### PR DESCRIPTION
# What does this implement/fix?

Adds additional ESP-IDF sdkconfig options to the `advanced:` section that can reduce build time and binary size by disabling features that ESPHome doesn't use.

These options are disabled by default (saving resources), but provide escape hatches for components or users that need them:

| Option | Default | Savings | Notes |
|--------|---------|---------|-------|
| `disable_debug_stubs` | `true` | Code size | OpenOCD debug stubs for on-chip debugging |
| `disable_ocd_aware` | `true` | Code size | JTAG/OCD-aware panic handlers |
| `disable_usb_serial_jtag_secondary` | `true` | Code size | Secondary USB Serial/JTAG console fallback |
| `disable_dev_null_vfs` | `true` | Code size | /dev/null VFS initialization |
| `disable_mbedtls_peer_cert` | `true` | ~4KB heap/conn | Keep peer certificate after TLS handshake |
| `disable_mbedtls_pkcs7` | `true` | Code size | PKCS#7 certificate validation support |
| `disable_regi2c_in_iram` | `true` | IRAM | Analog I2C master functions (verified no IRAM ISRs use these) |
| `disable_fatfs` | `true` | Code size | FAT filesystem support |

Also adds `require_*()` functions that components can call to re-enable features they need:
- `require_usb_serial_jtag_secondary()` - For logger or USB Serial/JTAG components
- `require_mbedtls_peer_cert()` - For TLS components needing peer certificate inspection
- `require_mbedtls_pkcs7()` - For components needing PKCS#7 certificate validation
- `require_fatfs()` - For SD card or storage components

This follows the existing pattern used for `require_vfs_select()`, `require_vfs_dir()`, and `require_full_certificate_bundle()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (performance optimization)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#5999

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default configuration - all optimizations enabled automatically
esp32:
  board: esp32dev
  framework:
    type: esp-idf

# To disable specific optimizations (e.g., for debugging with JTAG)
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      disable_debug_stubs: false
      disable_ocd_aware: false

# All new options with their defaults shown explicitly
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    advanced:
      disable_debug_stubs: true          # Disable OpenOCD debug stubs
      disable_ocd_aware: true            # Disable JTAG/OCD-aware panic handlers
      disable_usb_serial_jtag_secondary: true  # Disable secondary USB Serial/JTAG console
      disable_dev_null_vfs: true         # Disable /dev/null VFS
      disable_mbedtls_peer_cert: true    # Don't keep peer cert after TLS handshake
      disable_mbedtls_pkcs7: true        # Disable PKCS#7 support
      disable_regi2c_in_iram: true       # Move regi2c functions to flash
      disable_fatfs: true                # Disable FATFS support
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
