### PR TITLE
[mipi_spi] Fix log_pin() FlashStringHelper compatibility

### DIFF
--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -1,6 +1,41 @@
 #include "mipi_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mipi_spi {}  // namespace mipi_spi
-}  // namespace esphome
+namespace esphome::mipi_spi {
+
+static const char *const TAG = "display.mipi_spi";
+
+void internal_dump_config(const char *model, int width, int height, int offset_width, int offset_height, uint8_t madctl,
+                          bool invert_colors, int display_bits, bool is_big_endian, const optional<uint8_t> &brightness,
+                          GPIOPin *cs, GPIOPin *reset, GPIOPin *dc, int spi_mode, uint32_t data_rate, int bus_width) {
+  ESP_LOGCONFIG(TAG,
+                "MIPI_SPI Display\n"
+                "  Model: %s\n"
+                "  Width: %d\n"
+                "  Height: %d\n"
+                "  Swap X/Y: %s\n"
+                "  Mirror X: %s\n"
+                "  Mirror Y: %s\n"
+                "  Invert colors: %s\n"
+                "  Color order: %s\n"
+                "  Display pixels: %d bits\n"
+                "  Endianness: %s\n"
+                "  SPI Mode: %d\n"
+                "  SPI Data rate: %uMHz\n"
+                "  SPI Bus width: %d",
+                model, width, height, YESNO(madctl & MADCTL_MV), YESNO(madctl & (MADCTL_MX | MADCTL_XFLIP)),
+                YESNO(madctl & (MADCTL_MY | MADCTL_YFLIP)), YESNO(invert_colors), (madctl & MADCTL_BGR) ? "BGR" : "RGB",
+                display_bits, is_big_endian ? "Big" : "Little", spi_mode, static_cast<unsigned>(data_rate / 1000000),
+                bus_width);
+  LOG_PIN("  CS Pin: ", cs);
+  LOG_PIN("  Reset Pin: ", reset);
+  LOG_PIN("  DC Pin: ", dc);
+  if (offset_width != 0)
+    ESP_LOGCONFIG(TAG, "  Offset width: %d", offset_width);
+  if (offset_height != 0)
+    ESP_LOGCONFIG(TAG, "  Offset height: %d", offset_height);
+  if (brightness.has_value())
+    ESP_LOGCONFIG(TAG, "  Brightness: %u", brightness.value());
+}
+
+}  // namespace esphome::mipi_spi

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -3,8 +3,6 @@
 
 namespace esphome::mipi_spi {
 
-static const char *const TAG = "display.mipi_spi";
-
 void internal_dump_config(const char *model, int width, int height, int offset_width, int offset_height, uint8_t madctl,
                           bool invert_colors, int display_bits, bool is_big_endian, const optional<uint8_t> &brightness,
                           GPIOPin *cs, GPIOPin *reset, GPIOPin *dc, int spi_mode, uint32_t data_rate, int bus_width) {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -63,6 +63,11 @@ enum BusType {
   BUS_TYPE_SINGLE_16 = 16,  // Single bit bus, but 16 bits per transfer
 };
 
+// Helper function for dump_config - defined in mipi_spi.cpp to allow use of LOG_PIN macro
+void internal_dump_config(const char *model, int width, int height, int offset_width, int offset_height, uint8_t madctl,
+                          bool invert_colors, int display_bits, bool is_big_endian, const optional<uint8_t> &brightness,
+                          GPIOPin *cs, GPIOPin *reset, GPIOPin *dc, int spi_mode, uint32_t data_rate, int bus_width);
+
 /**
  * Base class for MIPI SPI displays.
  * All the methods are defined here in the header file, as it is not possible to define templated methods in a cpp file.
@@ -201,37 +206,9 @@ class MipiSpi : public display::Display,
   }
 
   void dump_config() override {
-    esph_log_config(TAG,
-                    "MIPI_SPI Display\n"
-                    "  Model: %s\n"
-                    "  Width: %u\n"
-                    "  Height: %u",
-                    this->model_, WIDTH, HEIGHT);
-    if constexpr (OFFSET_WIDTH != 0)
-      esph_log_config(TAG, "  Offset width: %u", OFFSET_WIDTH);
-    if constexpr (OFFSET_HEIGHT != 0)
-      esph_log_config(TAG, "  Offset height: %u", OFFSET_HEIGHT);
-    esph_log_config(TAG,
-                    "  Swap X/Y: %s\n"
-                    "  Mirror X: %s\n"
-                    "  Mirror Y: %s\n"
-                    "  Invert colors: %s\n"
-                    "  Color order: %s\n"
-                    "  Display pixels: %d bits\n"
-                    "  Endianness: %s\n",
-                    YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
-                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
-                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
-    if (this->brightness_.has_value())
-      esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    log_pin_with_prefix(TAG, "  CS Pin: ", this->cs_);
-    log_pin_with_prefix(TAG, "  Reset Pin: ", this->reset_pin_);
-    log_pin_with_prefix(TAG, "  DC Pin: ", this->dc_pin_);
-    esph_log_config(TAG,
-                    "  SPI Mode: %d\n"
-                    "  SPI Data rate: %dMHz\n"
-                    "  SPI Bus width: %d",
-                    this->mode_, static_cast<unsigned>(this->data_rate_ / 1000000), BUS_TYPE);
+    internal_dump_config(this->model_, WIDTH, HEIGHT, OFFSET_WIDTH, OFFSET_HEIGHT, this->madctl_, this->invert_colors_,
+                         DISPLAYPIXEL * 8, IS_BIG_ENDIAN, this->brightness_, this->cs_, this->reset_pin_, this->dc_pin_,
+                         this->mode_, this->data_rate_, BUS_TYPE);
   }
 
  protected:

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -6,7 +6,6 @@
 #include "esphome/components/display/display.h"
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/helpers.h"
-#include <Arduino.h>
 
 namespace esphome {
 namespace mipi_spi {
@@ -225,9 +224,9 @@ class MipiSpi : public display::Display,
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    log_pin(TAG, F(" CS Pin: "), this->cs_);
-    log_pin(TAG, F(" Reset Pin: "), this->reset_pin_);
-    log_pin(TAG, F(" DC Pin: "), this->dc_pin_);
+    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  CS Pin: "), this->cs_);
+    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  Reset Pin: "), this->reset_pin_);
+    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  DC Pin: "), this->dc_pin_);
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -218,7 +218,7 @@ class MipiSpi : public display::Display,
                     "  Invert colors: %s\n"
                     "  Color order: %s\n"
                     "  Display pixels: %d bits\n"
-                    "  Endianness: %s",
+                    "  Endianness: %s\n",
                     YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
                     YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -6,6 +6,7 @@
 #include "esphome/components/display/display.h"
 #include "esphome/components/display/display_color_utils.h"
 #include "esphome/core/helpers.h"
+#include <Arduino.h>
 
 namespace esphome {
 namespace mipi_spi {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -207,10 +207,13 @@ class MipiSpi : public display::Display,
                     "  Width: %u\n"
                     "  Height: %u",
                     this->model_, WIDTH, HEIGHT);
+  
     if constexpr (OFFSET_WIDTH != 0)
       esph_log_config(TAG, "  Offset width: %u", OFFSET_WIDTH);
+  
     if constexpr (OFFSET_HEIGHT != 0)
       esph_log_config(TAG, "  Offset height: %u", OFFSET_HEIGHT);
+  
     esph_log_config(TAG,
                     "  Swap X/Y: %s\n"
                     "  Mirror X: %s\n"
@@ -218,23 +221,34 @@ class MipiSpi : public display::Display,
                     "  Invert colors: %s\n"
                     "  Color order: %s\n"
                     "  Display pixels: %d bits\n"
-                    "  Endianness: %s\n",
-                    YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
-                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
-                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
+                    "  Endianness: %s",
+                    YESNO(this->madctl_ & MADCTL_MV),
+                    YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
+                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)),
+                    YESNO(this->invert_colors_),
+                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB",
+                    DISPLAYPIXEL * 8,
+                    IS_BIG_ENDIAN ? "Big" : "Little");
+  
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
+  
     if (this->cs_ != nullptr)
-      ESP_LOGCONFIG(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
+      esph_log_config(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
+  
     if (this->reset_pin_ != nullptr)
-      ESP_LOGCONFIG(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
+      esph_log_config(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
+  
     if (this->dc_pin_ != nullptr)
-      ESP_LOGCONFIG(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
+      esph_log_config(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
+  
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"
                     "  SPI Bus width: %d",
-                    this->mode_, static_cast<unsigned>(this->data_rate_ / 1000000), BUS_TYPE);
+                    this->mode_,
+                    static_cast<unsigned>(this->data_rate_ / 1000000),
+                    BUS_TYPE);
   }
 
  protected:

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -224,9 +224,9 @@ class MipiSpi : public display::Display,
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    log_pin(TAG, "  CS Pin: ", this->cs_);
-    log_pin(TAG, "  Reset Pin: ", this->reset_pin_);
-    log_pin(TAG, "  DC Pin: ", this->dc_pin_);
+    log_pin(TAG, F(" CS Pin: "), this->cs_);
+    log_pin(TAG, F(" Reset Pin: "), this->reset_pin_);
+    log_pin(TAG, F(" DC Pin: "), this->dc_pin_);
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -224,12 +224,21 @@ class MipiSpi : public display::Display,
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    if (this->cs_ != nullptr)
-      esph_log_config(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
-    if (this->reset_pin_ != nullptr)
-      esph_log_config(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
-    if (this->dc_pin_ != nullptr)
-      esph_log_config(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
+    if (this->cs_ != nullptr) {
+      char cs_buf[64];
+      this->cs_->dump_summary(cs_buf, sizeof(cs_buf));
+      esph_log_config(TAG, "  CS Pin: %s", cs_buf);
+    }
+    if (this->reset_pin_ != nullptr) {
+      char reset_buf[64];
+      this->reset_pin_->dump_summary(reset_buf, sizeof(reset_buf));
+      esph_log_config(TAG, "  Reset Pin: %s", reset_buf);
+    }
+    if (this->dc_pin_ != nullptr) {
+      char dc_buf[64];
+      this->dc_pin_->dump_summary(dc_buf, sizeof(dc_buf));
+      esph_log_config(TAG, "  DC Pin: %s", dc_buf);
+    }
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -224,9 +224,12 @@ class MipiSpi : public display::Display,
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  CS Pin: "), this->cs_);
-    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  Reset Pin: "), this->reset_pin_);
-    log_pin(TAG, reinterpret_cast<const __FlashStringHelper *>("  DC Pin: "), this->dc_pin_);
+    if (this->cs_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
+    if (this->reset_pin_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
+    if (this->dc_pin_ != nullptr)
+      ESP_LOGCONFIG(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -224,21 +224,9 @@ class MipiSpi : public display::Display,
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    if (this->cs_ != nullptr) {
-      char cs_buf[64];
-      this->cs_->dump_summary(cs_buf, sizeof(cs_buf));
-      esph_log_config(TAG, "  CS Pin: %s", cs_buf);
-    }
-    if (this->reset_pin_ != nullptr) {
-      char reset_buf[64];
-      this->reset_pin_->dump_summary(reset_buf, sizeof(reset_buf));
-      esph_log_config(TAG, "  Reset Pin: %s", reset_buf);
-    }
-    if (this->dc_pin_ != nullptr) {
-      char dc_buf[64];
-      this->dc_pin_->dump_summary(dc_buf, sizeof(dc_buf));
-      esph_log_config(TAG, "  DC Pin: %s", dc_buf);
-    }
+    log_pin_with_prefix(TAG, "  CS Pin: ", this->cs_);
+    log_pin_with_prefix(TAG, "  Reset Pin: ", this->reset_pin_);
+    log_pin_with_prefix(TAG, "  DC Pin: ", this->dc_pin_);
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -207,13 +207,13 @@ class MipiSpi : public display::Display,
                     "  Width: %u\n"
                     "  Height: %u",
                     this->model_, WIDTH, HEIGHT);
-  
+
     if constexpr (OFFSET_WIDTH != 0)
       esph_log_config(TAG, "  Offset width: %u", OFFSET_WIDTH);
-  
+
     if constexpr (OFFSET_HEIGHT != 0)
       esph_log_config(TAG, "  Offset height: %u", OFFSET_HEIGHT);
-  
+
     esph_log_config(TAG,
                     "  Swap X/Y: %s\n"
                     "  Mirror X: %s\n"
@@ -222,33 +222,27 @@ class MipiSpi : public display::Display,
                     "  Color order: %s\n"
                     "  Display pixels: %d bits\n"
                     "  Endianness: %s",
-                    YESNO(this->madctl_ & MADCTL_MV),
-                    YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
-                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)),
-                    YESNO(this->invert_colors_),
-                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB",
-                    DISPLAYPIXEL * 8,
-                    IS_BIG_ENDIAN ? "Big" : "Little");
-  
+                    YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
+                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
+                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
+
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-  
+
     if (this->cs_ != nullptr)
       esph_log_config(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
-  
+
     if (this->reset_pin_ != nullptr)
       esph_log_config(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
-  
+
     if (this->dc_pin_ != nullptr)
       esph_log_config(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
-  
+
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"
                     "  SPI Bus width: %d",
-                    this->mode_,
-                    static_cast<unsigned>(this->data_rate_ / 1000000),
-                    BUS_TYPE);
+                    this->mode_, static_cast<unsigned>(this->data_rate_ / 1000000), BUS_TYPE);
   }
 
  protected:

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -207,13 +207,10 @@ class MipiSpi : public display::Display,
                     "  Width: %u\n"
                     "  Height: %u",
                     this->model_, WIDTH, HEIGHT);
-
     if constexpr (OFFSET_WIDTH != 0)
       esph_log_config(TAG, "  Offset width: %u", OFFSET_WIDTH);
-
     if constexpr (OFFSET_HEIGHT != 0)
       esph_log_config(TAG, "  Offset height: %u", OFFSET_HEIGHT);
-
     esph_log_config(TAG,
                     "  Swap X/Y: %s\n"
                     "  Mirror X: %s\n"
@@ -225,19 +222,14 @@ class MipiSpi : public display::Display,
                     YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
                     YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
                     this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
-
     if (this->brightness_.has_value())
       esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-
     if (this->cs_ != nullptr)
       esph_log_config(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
-
     if (this->reset_pin_ != nullptr)
       esph_log_config(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
-
     if (this->dc_pin_ != nullptr)
       esph_log_config(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
-
     esph_log_config(TAG,
                     "  SPI Mode: %d\n"
                     "  SPI Data rate: %dMHz\n"

--- a/tests/components/mipi_spi/test.esp8266-ard.yaml
+++ b/tests/components/mipi_spi/test.esp8266-ard.yaml
@@ -1,0 +1,10 @@
+substitutions:
+  dc_pin: GPIO15
+  cs_pin: GPIO5
+  enable_pin: GPIO4
+  reset_pin: GPIO16
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp8266-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
## What does this implement/fix?

Fixes `dump_config()` compilation failures on ESP8266 caused by `LOG_PIN` macro incompatibility with header-only templated code.

The `LOG_PIN` macro uses `FlashStringHelper` on ESP8266 Arduino, which cannot be used directly in header files with templated classes. This PR moves the logging logic to a non-templated helper function `internal_dump_config()` in the `.cpp` file, where the macro works correctly.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a (no config changes)

fixes #13668

## Checklist:
- [X] The code change is tested and works locally.
- [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).