### PR TITLE
[json] Add SerializationBuffer for stack-first JSON serialization

### DIFF
--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -264,9 +264,9 @@ template<typename... Ts> class APIRespondAction : public Action<Ts...> {
       // Build and send JSON response
       json::JsonBuilder builder;
       this->json_builder_(x..., builder.root());
-      std::string json_str = builder.serialize();
+      auto json_buf = builder.serialize();
       this->parent_->send_action_response(call_id, success, StringRef(error_message),
-                                          reinterpret_cast<const uint8_t *>(json_str.data()), json_str.size());
+                                          reinterpret_cast<const uint8_t *>(json_buf.data()), json_buf.size());
       return;
     }
 #endif

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -123,8 +123,9 @@ SerializationBuffer<> JsonBuilder::serialize() {
   // In practice, one iteration (1024 bytes) covers all known entity types.
   // Payloads exceeding 1024 bytes are not known to exist in real configurations.
   // Cap at 4096 as a safety limit to prevent runaway allocation.
+  constexpr size_t max_heap_size = 4096;
   size_t heap_size = buf_size * 2;
-  while (heap_size <= 4096) {
+  while (heap_size <= max_heap_size) {
     result.reallocate_heap_(heap_size - 1);
     size = serializeJson(doc_, result.data_writable_(), heap_size);
     if (size < heap_size) {

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -70,7 +70,7 @@ SerializationBuffer<> JsonBuilder::serialize() {
   // directly in the caller's stack frame, eliminating the move constructor call entirely.
   //
   // WITHOUT NRVO: Each return would trigger SerializationBuffer's move constructor, which
-  // must memcpy up to 768 bytes of stack buffer content. This happens on EVERY JSON
+  // must memcpy up to 512 bytes of stack buffer content. This happens on EVERY JSON
   // serialization (sensor updates, web server responses, MQTT publishes, etc.).
   //
   // WITH NRVO: Zero memcpy, zero move constructor overhead. The buffer lives directly
@@ -89,7 +89,7 @@ SerializationBuffer<> JsonBuilder::serialize() {
   //     Should show only destructor, NOT move constructor
   //
   // Why we avoid measureJson(): It instantiates DummyWriter templates adding ~1KB flash.
-  // Instead, try stack buffer first. 768 bytes covers 99.9% of JSON payloads (sensors ~200B,
+  // Instead, try stack buffer first. 512 bytes covers 99.9% of JSON payloads (sensors ~200B,
   // lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
   //
   // ===========================================================================================

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -88,15 +88,15 @@ SerializationBuffer<> JsonBuilder::serialize() {
   //   - Test: objdump -d -C firmware.elf | grep "SerializationBuffer.*SerializationBuffer"
   //     Should show only destructor, NOT move constructor
   //
-  // Try stack buffer first. 512 bytes covers 99.9% of JSON payloads (sensors ~200B,
-  // lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
+  // Try stack buffer first. 640 bytes covers 99.9% of JSON payloads (sensors ~200B,
+  // lights ~170B, climate ~500-700B). Only entities with 40+ options exceed this.
   //
   // IMPORTANT: ArduinoJson's serializeJson() with a bounded buffer returns the actual
   // bytes written (truncated count), NOT the would-be size like snprintf(). When the
   // payload exceeds the buffer, the return value equals the buffer capacity. The heap
   // fallback doubles the buffer size until the payload fits. This avoids instantiating
   // measureJson()'s DummyWriter templates (~736 bytes flash) at the cost of temporarily
-  // over-allocating heap (at most 2x) for the rare payloads that exceed 512 bytes.
+  // over-allocating heap (at most 2x) for the rare payloads that exceed 640 bytes.
   //
   // ===========================================================================================
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -94,7 +94,9 @@ SerializationBuffer<> JsonBuilder::serialize() {
   // IMPORTANT: ArduinoJson's serializeJson() with a bounded buffer returns the actual
   // bytes written (truncated count), NOT the would-be size like snprintf(). When the
   // payload exceeds the buffer, the return value equals the buffer capacity. The heap
-  // fallback uses measureJson() to get the exact size for allocation.
+  // fallback doubles the buffer size until the payload fits. This avoids instantiating
+  // measureJson()'s DummyWriter templates (~736 bytes flash) at the cost of temporarily
+  // over-allocating heap (at most 2x) for the rare payloads that exceed 512 bytes.
   //
   // ===========================================================================================
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
@@ -117,12 +119,20 @@ SerializationBuffer<> JsonBuilder::serialize() {
     return result;
   }
 
-  // Payload exceeded stack buffer. ArduinoJson's serializeJson() with a bounded
-  // buffer returns the actual bytes written (truncated), NOT the would-be size.
-  // Use measureJson() to get the exact size for heap allocation.
-  size = measureJson(doc_);
-  result.reallocate_heap_(size);
-  serializeJson(doc_, result.data_writable_(), size + 1);
+  // Payload exceeded stack buffer. Double the buffer and retry until it fits.
+  // Cap at 4096 to prevent runaway allocation on memory-constrained devices.
+  size_t heap_size = buf_size * 2;
+  while (heap_size <= 4096) {
+    result.reallocate_heap_(heap_size - 1);
+    size = serializeJson(doc_, result.data_writable_(), heap_size);
+    if (size < heap_size) {
+      result.set_size_(size);
+      return result;
+    }
+    heap_size *= 2;
+  }
+  // Payload exceeds 4096 bytes - return truncated result
+  ESP_LOGW(TAG, "JSON payload too large, truncated to %zu bytes", size);
   result.set_size_(size);
   return result;
 }

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -120,7 +120,9 @@ SerializationBuffer<> JsonBuilder::serialize() {
   }
 
   // Payload exceeded stack buffer. Double the buffer and retry until it fits.
-  // Cap at 4096 to prevent runaway allocation on memory-constrained devices.
+  // In practice, one iteration (1024 bytes) covers all known entity types.
+  // Payloads exceeding 1024 bytes are not known to exist in real configurations.
+  // Cap at 4096 as a safety limit to prevent runaway allocation.
   size_t heap_size = buf_size * 2;
   while (heap_size <= 4096) {
     result.reallocate_heap_(heap_size - 1);

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -122,8 +122,8 @@ SerializationBuffer<> JsonBuilder::serialize() {
   // Payload exceeded stack buffer. Double the buffer and retry until it fits.
   // In practice, one iteration (1024 bytes) covers all known entity types.
   // Payloads exceeding 1024 bytes are not known to exist in real configurations.
-  // Cap at 4096 as a safety limit to prevent runaway allocation.
-  constexpr size_t max_heap_size = 4096;
+  // Cap at 5120 as a safety limit to prevent runaway allocation.
+  constexpr size_t max_heap_size = 5120;
   size_t heap_size = buf_size * 2;
   while (heap_size <= max_heap_size) {
     result.reallocate_heap_(heap_size - 1);
@@ -134,7 +134,7 @@ SerializationBuffer<> JsonBuilder::serialize() {
     }
     heap_size *= 2;
   }
-  // Payload exceeds 4096 bytes - return truncated result
+  // Payload exceeds 5120 bytes - return truncated result
   ESP_LOGW(TAG, "JSON payload too large, truncated to %zu bytes", size);
   result.set_size_(size);
   return result;

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -88,9 +88,13 @@ SerializationBuffer<> JsonBuilder::serialize() {
   //   - Test: objdump -d -C firmware.elf | grep "SerializationBuffer.*SerializationBuffer"
   //     Should show only destructor, NOT move constructor
   //
-  // Why we avoid measureJson(): It instantiates DummyWriter templates adding ~1KB flash.
-  // Instead, try stack buffer first. 512 bytes covers 99.9% of JSON payloads (sensors ~200B,
+  // Try stack buffer first. 512 bytes covers 99.9% of JSON payloads (sensors ~200B,
   // lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
+  //
+  // IMPORTANT: ArduinoJson's serializeJson() with a bounded buffer returns the actual
+  // bytes written (truncated count), NOT the would-be size like snprintf(). When the
+  // payload exceeds the buffer, the return value equals the buffer capacity. The heap
+  // fallback uses measureJson() to get the exact size for allocation.
   //
   // ===========================================================================================
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
@@ -113,9 +117,13 @@ SerializationBuffer<> JsonBuilder::serialize() {
     return result;
   }
 
-  // Needs heap allocation - reallocate and serialize again with exact size
+  // Payload exceeded stack buffer. ArduinoJson's serializeJson() with a bounded
+  // buffer returns the actual bytes written (truncated), NOT the would-be size.
+  // Use measureJson() to get the exact size for heap allocation.
+  size = measureJson(doc_);
   result.reallocate_heap_(size);
   serializeJson(doc_, result.data_writable_(), size + 1);
+  result.set_size_(size);
   return result;
 }
 

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -62,15 +62,6 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
 }
 
 SerializationBuffer<> JsonBuilder::serialize() {
-  if (doc_.overflowed()) {
-    ESP_LOGE(TAG, "JSON document overflow");
-    SerializationBuffer<> result(2);
-    auto *buf = result.data_writable();
-    buf[0] = '{';
-    buf[1] = '}';
-    buf[2] = '\0';
-    return result;
-  }
   // Intentionally avoid measureJson() - it instantiates DummyWriter templates that add ~1KB of flash.
   // Instead, try serializing to stack buffer first. 768 bytes covers 99.9% of JSON payloads
   // (sensors ~200B, lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
@@ -78,18 +69,32 @@ SerializationBuffer<> JsonBuilder::serialize() {
   // For the rare large case: serialize twice (once truncated, once to heap) - less efficient but
   // saves ~1KB flash that would otherwise be wasted on every build.
   // serializeJson() returns actual size needed even if truncated, so we can retry with exact size.
+  //
+  // Single return variable enables NRVO (Named Return Value Optimization), avoiding memcpy on return.
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
   SerializationBuffer<> result(buf_size - 1);  // Max content size (reserve 1 for null)
+
+  if (doc_.overflowed()) {
+    ESP_LOGE(TAG, "JSON document overflow");
+    auto *buf = result.data_writable();
+    buf[0] = '{';
+    buf[1] = '}';
+    buf[2] = '\0';
+    result.set_size(2);
+    return result;
+  }
+
   size_t size = serializeJson(doc_, result.data_writable(), buf_size);
   if (size < buf_size) {
     // Fits in stack buffer - update size to actual length
     result.set_size(size);
     return result;
   }
-  // Needs heap allocation - serialize again with exact size
-  SerializationBuffer<> heap_result(size);
-  serializeJson(doc_, heap_result.data_writable(), size + 1);
-  return heap_result;
+
+  // Needs heap allocation - reallocate and serialize again with exact size
+  result.reallocate_heap(size);
+  serializeJson(doc_, result.data_writable(), size + 1);
+  return result;
 }
 
 }  // namespace json

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -71,10 +71,13 @@ SerializationBuffer<> JsonBuilder::serialize() {
     buf[2] = '\0';
     return result;
   }
-  // Intentionally avoid measureJson() - it instantiates DummyWriter templates that add ~700 bytes
-  // of flash. Instead, try serializing to stack buffer first. 768 bytes covers typical JSON payloads
-  // (sensors ~200B, lights ~170B, climate ~700B). Only entities with many options exceed this.
-  // serializeJson() returns actual size needed even if truncated, so we can retry with heap if needed.
+  // Intentionally avoid measureJson() - it instantiates DummyWriter templates that add ~1KB of flash.
+  // Instead, try serializing to stack buffer first. 768 bytes covers 99.9% of JSON payloads
+  // (sensors ~200B, lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
+  // For the common case: single serialize to stack, no heap allocation, no measurement overhead.
+  // For the rare large case: serialize twice (once truncated, once to heap) - less efficient but
+  // saves ~1KB flash that would otherwise be wasted on every build.
+  // serializeJson() returns actual size needed even if truncated, so we can retry with exact size.
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
   SerializationBuffer<> result(buf_size - 1);  // Max content size (reserve 1 for null)
   size_t size = serializeJson(doc_, result.data_writable(), buf_size);

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -61,10 +61,10 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
-JsonBuffer<> JsonBuilder::serialize() {
+SerializationBuffer<> JsonBuilder::serialize() {
   if (doc_.overflowed()) {
     ESP_LOGE(TAG, "JSON document overflow");
-    JsonBuffer<> result(2);
+    SerializationBuffer<> result(2);
     auto *buf = result.data_writable();
     buf[0] = '{';
     buf[1] = '}';
@@ -72,7 +72,7 @@ JsonBuffer<> JsonBuilder::serialize() {
     return result;
   }
   size_t size = measureJson(doc_);
-  JsonBuffer<> result(size);
+  SerializationBuffer<> result(size);
   serializeJson(doc_, result.data_writable(), size + 1);
   return result;
 }

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -71,10 +71,22 @@ SerializationBuffer<> JsonBuilder::serialize() {
     buf[2] = '\0';
     return result;
   }
-  size_t size = measureJson(doc_);
-  SerializationBuffer<> result(size);
-  serializeJson(doc_, result.data_writable(), size + 1);
-  return result;
+  // Intentionally avoid measureJson() - it instantiates DummyWriter templates that add ~700 bytes
+  // of flash. Instead, try serializing to stack buffer first. 768 bytes covers typical JSON payloads
+  // (sensors ~200B, lights ~170B, climate ~700B). Only entities with many options exceed this.
+  // serializeJson() returns actual size needed even if truncated, so we can retry with heap if needed.
+  constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
+  SerializationBuffer<> result(buf_size - 1);  // Max content size (reserve 1 for null)
+  size_t size = serializeJson(doc_, result.data_writable(), buf_size);
+  if (size < buf_size) {
+    // Fits in stack buffer - update size to actual length
+    result.set_size(size);
+    return result;
+  }
+  // Needs heap allocation - serialize again with exact size
+  SerializationBuffer<> heap_result(size);
+  serializeJson(doc_, heap_result.data_writable(), size + 1);
+  return heap_result;
 }
 
 }  // namespace json

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -15,7 +15,7 @@ static const char *const TAG = "json";
 static SpiRamAllocator global_json_allocator;
 #endif
 
-std::string build_json(const json_build_t &f) {
+SerializationBuffer<> build_json(const json_build_t &f) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   JsonBuilder builder;
   JsonObject root = builder.root();

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -61,14 +61,20 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
   // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 }
 
-std::string JsonBuilder::serialize() {
+JsonBuffer<> JsonBuilder::serialize() {
   if (doc_.overflowed()) {
     ESP_LOGE(TAG, "JSON document overflow");
-    return "{}";
+    JsonBuffer<> result(2);
+    auto *buf = result.data_writable();
+    buf[0] = '{';
+    buf[1] = '}';
+    buf[2] = '\0';
+    return result;
   }
-  std::string output;
-  serializeJson(doc_, output);
-  return output;
+  size_t size = measureJson(doc_);
+  JsonBuffer<> result(size);
+  serializeJson(doc_, result.data_writable(), size + 1);
+  return result;
 }
 
 }  // namespace json

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -98,24 +98,24 @@ SerializationBuffer<> JsonBuilder::serialize() {
 
   if (doc_.overflowed()) {
     ESP_LOGE(TAG, "JSON document overflow");
-    auto *buf = result.data_writable();
+    auto *buf = result.data_writable_();
     buf[0] = '{';
     buf[1] = '}';
     buf[2] = '\0';
-    result.set_size(2);
+    result.set_size_(2);
     return result;
   }
 
-  size_t size = serializeJson(doc_, result.data_writable(), buf_size);
+  size_t size = serializeJson(doc_, result.data_writable_(), buf_size);
   if (size < buf_size) {
     // Fits in stack buffer - update size to actual length
-    result.set_size(size);
+    result.set_size_(size);
     return result;
   }
 
   // Needs heap allocation - reallocate and serialize again with exact size
   result.reallocate_heap_(size);
-  serializeJson(doc_, result.data_writable(), size + 1);
+  serializeJson(doc_, result.data_writable_(), size + 1);
   return result;
 }
 

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -114,7 +114,7 @@ SerializationBuffer<> JsonBuilder::serialize() {
   }
 
   // Needs heap allocation - reallocate and serialize again with exact size
-  result.reallocate_heap(size);
+  result.reallocate_heap_(size);
   serializeJson(doc_, result.data_writable(), size + 1);
   return result;
 }

--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -62,15 +62,37 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
 }
 
 SerializationBuffer<> JsonBuilder::serialize() {
-  // Intentionally avoid measureJson() - it instantiates DummyWriter templates that add ~1KB of flash.
-  // Instead, try serializing to stack buffer first. 768 bytes covers 99.9% of JSON payloads
-  // (sensors ~200B, lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
-  // For the common case: single serialize to stack, no heap allocation, no measurement overhead.
-  // For the rare large case: serialize twice (once truncated, once to heap) - less efficient but
-  // saves ~1KB flash that would otherwise be wasted on every build.
-  // serializeJson() returns actual size needed even if truncated, so we can retry with exact size.
+  // ===========================================================================================
+  // CRITICAL: NRVO (Named Return Value Optimization) - DO NOT REFACTOR WITHOUT UNDERSTANDING
+  // ===========================================================================================
   //
-  // Single return variable enables NRVO (Named Return Value Optimization), avoiding memcpy on return.
+  // This function is carefully structured to enable NRVO. The compiler constructs `result`
+  // directly in the caller's stack frame, eliminating the move constructor call entirely.
+  //
+  // WITHOUT NRVO: Each return would trigger SerializationBuffer's move constructor, which
+  // must memcpy up to 768 bytes of stack buffer content. This happens on EVERY JSON
+  // serialization (sensor updates, web server responses, MQTT publishes, etc.).
+  //
+  // WITH NRVO: Zero memcpy, zero move constructor overhead. The buffer lives directly
+  // where the caller needs it.
+  //
+  // Requirements for NRVO to work:
+  //   1. Single named variable (`result`) returned from ALL paths
+  //   2. All paths must return the SAME variable (not different variables)
+  //   3. No std::move() on the return statement
+  //
+  // If you must modify this function:
+  //   - Keep a single `result` variable declared at the top
+  //   - All code paths must return `result` (not a different variable)
+  //   - Verify NRVO still works by checking the disassembly for move constructor calls
+  //   - Test: objdump -d -C firmware.elf | grep "SerializationBuffer.*SerializationBuffer"
+  //     Should show only destructor, NOT move constructor
+  //
+  // Why we avoid measureJson(): It instantiates DummyWriter templates adding ~1KB flash.
+  // Instead, try stack buffer first. 768 bytes covers 99.9% of JSON payloads (sensors ~200B,
+  // lights ~170B, climate ~700B). Only entities with 40+ options exceed this.
+  //
+  // ===========================================================================================
   constexpr size_t buf_size = SerializationBuffer<>::BUFFER_SIZE;
   SerializationBuffer<> result(buf_size - 1);  // Max content size (reserve 1 for null)
 

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -17,9 +17,9 @@ namespace esphome {
 namespace json {
 
 /// Buffer for JSON serialization that uses stack allocation for small payloads.
-/// Template parameter STACK_SIZE specifies the stack buffer size (default 768 bytes).
+/// Template parameter STACK_SIZE specifies the stack buffer size (default 512 bytes).
 /// Supports move semantics for efficient return-by-value.
-template<size_t STACK_SIZE = 768> class SerializationBuffer {
+template<size_t STACK_SIZE = 512> class SerializationBuffer {
  public:
   static constexpr size_t BUFFER_SIZE = STACK_SIZE;  ///< Stack buffer size for this instantiation
 
@@ -175,7 +175,7 @@ class JsonBuilder {
   }
 
   /// Serialize the JSON document to a SerializationBuffer (stack-first allocation)
-  /// Uses 768-byte stack buffer by default, falls back to heap for larger JSON
+  /// Uses 512-byte stack buffer by default, falls back to heap for larger JSON
   SerializationBuffer<> serialize();
 
  private:

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -19,7 +19,7 @@ namespace json {
 /// Buffer for JSON serialization that uses stack allocation for small payloads.
 /// Template parameter STACK_SIZE specifies the stack buffer size (default 512 bytes).
 /// Supports move semantics for efficient return-by-value.
-template<size_t STACK_SIZE = 512> class SerializationBuffer {
+template<size_t STACK_SIZE = 640> class SerializationBuffer {
  public:
   static constexpr size_t BUFFER_SIZE = STACK_SIZE;  ///< Stack buffer size for this instantiation
 

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -89,9 +89,15 @@ template<size_t STACK_SIZE = 768> class SerializationBuffer {
   /// Set actual size after serialization (must not exceed allocated size)
   void set_size(size_t size) { size_ = size; }
 
+  /// Implicit conversion to std::string for backward compatibility
+  operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)
+
+ private:
+  friend class JsonBuilder;  ///< Allows JsonBuilder::serialize() to call reallocate_heap_()
+
   /// Reallocate to heap buffer with new size (for when stack buffer is too small)
-  /// This invalidates any previous buffer content
-  void reallocate_heap(size_t size) {
+  /// This invalidates any previous buffer content. Used by JsonBuilder::serialize().
+  void reallocate_heap_(size_t size) {
     delete[] heap_buffer_;
     heap_buffer_ = new char[size + 1];
     buffer_ = heap_buffer_;
@@ -99,10 +105,6 @@ template<size_t STACK_SIZE = 768> class SerializationBuffer {
     buffer_[0] = '\0';
   }
 
-  /// Implicit conversion to std::string for backward compatibility
-  operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)
-
- private:
   char stack_buffer_[STACK_SIZE];
   char *heap_buffer_{nullptr};
   char *buffer_;

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -21,6 +21,8 @@ namespace json {
 /// Supports move semantics for efficient return-by-value.
 template<size_t STACK_SIZE = 768> class SerializationBuffer {
  public:
+  static constexpr size_t BUFFER_SIZE = STACK_SIZE;  ///< Stack buffer size for this instantiation
+
   /// Construct with known size (typically from measureJson)
   explicit SerializationBuffer(size_t size) : size_(size) {
     if (size + 1 <= STACK_SIZE) {
@@ -84,6 +86,8 @@ template<size_t STACK_SIZE = 768> class SerializationBuffer {
   size_t size() const { return size_; }
   /// Get writable buffer (for serialization)
   char *data_writable() { return buffer_; }
+  /// Set actual size after serialization (must not exceed allocated size)
+  void set_size(size_t size) { size_ = size; }
 
   /// Implicit conversion to std::string for backward compatibility
   operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -19,10 +19,10 @@ namespace json {
 /// Buffer for JSON serialization that uses stack allocation for small payloads.
 /// Template parameter STACK_SIZE specifies the stack buffer size (default 768 bytes).
 /// Supports move semantics for efficient return-by-value.
-template<size_t STACK_SIZE = 768> class JsonBuffer {
+template<size_t STACK_SIZE = 768> class SerializationBuffer {
  public:
   /// Construct with known size (typically from measureJson)
-  explicit JsonBuffer(size_t size) : size_(size) {
+  explicit SerializationBuffer(size_t size) : size_(size) {
     if (size + 1 <= STACK_SIZE) {
       buffer_ = stack_buffer_;
     } else {
@@ -32,10 +32,10 @@ template<size_t STACK_SIZE = 768> class JsonBuffer {
     buffer_[0] = '\0';
   }
 
-  ~JsonBuffer() { delete[] heap_buffer_; }
+  ~SerializationBuffer() { delete[] heap_buffer_; }
 
   // Move constructor - works with same template instantiation
-  JsonBuffer(JsonBuffer &&other) noexcept : heap_buffer_(other.heap_buffer_), size_(other.size_) {
+  SerializationBuffer(SerializationBuffer &&other) noexcept : heap_buffer_(other.heap_buffer_), size_(other.size_) {
     if (other.buffer_ == other.stack_buffer_) {
       // Stack buffer - must copy content
       std::memcpy(stack_buffer_, other.stack_buffer_, size_ + 1);
@@ -52,7 +52,7 @@ template<size_t STACK_SIZE = 768> class JsonBuffer {
   }
 
   // Move assignment
-  JsonBuffer &operator=(JsonBuffer &&other) noexcept {
+  SerializationBuffer &operator=(SerializationBuffer &&other) noexcept {
     if (this != &other) {
       delete[] heap_buffer_;
       heap_buffer_ = other.heap_buffer_;
@@ -73,8 +73,8 @@ template<size_t STACK_SIZE = 768> class JsonBuffer {
   }
 
   // Delete copy operations
-  JsonBuffer(const JsonBuffer &) = delete;
-  JsonBuffer &operator=(const JsonBuffer &) = delete;
+  SerializationBuffer(const SerializationBuffer &) = delete;
+  SerializationBuffer &operator=(const SerializationBuffer &) = delete;
 
   /// Get null-terminated C string
   const char *c_str() const { return buffer_; }
@@ -150,9 +150,9 @@ class JsonBuilder {
     return root_;
   }
 
-  /// Serialize the JSON document to a JsonBuffer (stack-first allocation)
-  /// Uses 512-byte stack buffer by default, falls back to heap for larger JSON
-  JsonBuffer<> serialize();
+  /// Serialize the JSON document to a SerializationBuffer (stack-first allocation)
+  /// Uses 768-byte stack buffer by default, falls back to heap for larger JSON
+  SerializationBuffer<> serialize();
 
  private:
 #ifdef USE_PSRAM

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -131,7 +131,8 @@ using json_parse_t = std::function<bool(JsonObject)>;
 using json_build_t = std::function<void(JsonObject)>;
 
 /// Build a JSON string with the provided json build function.
-std::string build_json(const json_build_t &f);
+/// Returns SerializationBuffer for stack-first allocation; implicitly converts to std::string.
+SerializationBuffer<> build_json(const json_build_t &f);
 
 /// Parse a JSON string and run the provided json parse function if it's valid.
 bool parse_json(const std::string &data, const json_parse_t &f);

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstring>
+#include <string>
 #include <vector>
 
 #include "esphome/core/defines.h"
@@ -13,6 +15,85 @@
 
 namespace esphome {
 namespace json {
+
+/// Buffer for JSON serialization that uses stack allocation for small payloads.
+/// Template parameter STACK_SIZE specifies the stack buffer size (default 512 bytes).
+/// Supports move semantics for efficient return-by-value.
+template<size_t STACK_SIZE = 512> class JsonBuffer {
+ public:
+  /// Construct with known size (typically from measureJson)
+  explicit JsonBuffer(size_t size) : size_(size) {
+    if (size + 1 <= STACK_SIZE) {
+      buffer_ = stack_buffer_;
+    } else {
+      heap_buffer_ = new char[size + 1];
+      buffer_ = heap_buffer_;
+    }
+    buffer_[0] = '\0';
+  }
+
+  ~JsonBuffer() { delete[] heap_buffer_; }
+
+  // Move constructor - works with same template instantiation
+  JsonBuffer(JsonBuffer &&other) noexcept : heap_buffer_(other.heap_buffer_), size_(other.size_) {
+    if (other.buffer_ == other.stack_buffer_) {
+      // Stack buffer - must copy content
+      std::memcpy(stack_buffer_, other.stack_buffer_, size_ + 1);
+      buffer_ = stack_buffer_;
+    } else {
+      // Heap buffer - steal ownership
+      buffer_ = heap_buffer_;
+      other.heap_buffer_ = nullptr;
+    }
+    // Leave moved-from object in valid empty state
+    other.stack_buffer_[0] = '\0';
+    other.buffer_ = other.stack_buffer_;
+    other.size_ = 0;
+  }
+
+  // Move assignment
+  JsonBuffer &operator=(JsonBuffer &&other) noexcept {
+    if (this != &other) {
+      delete[] heap_buffer_;
+      heap_buffer_ = other.heap_buffer_;
+      size_ = other.size_;
+      if (other.buffer_ == other.stack_buffer_) {
+        std::memcpy(stack_buffer_, other.stack_buffer_, size_ + 1);
+        buffer_ = stack_buffer_;
+      } else {
+        buffer_ = heap_buffer_;
+        other.heap_buffer_ = nullptr;
+      }
+      // Leave moved-from object in valid empty state
+      other.stack_buffer_[0] = '\0';
+      other.buffer_ = other.stack_buffer_;
+      other.size_ = 0;
+    }
+    return *this;
+  }
+
+  // Delete copy operations
+  JsonBuffer(const JsonBuffer &) = delete;
+  JsonBuffer &operator=(const JsonBuffer &) = delete;
+
+  /// Get null-terminated C string
+  const char *c_str() const { return buffer_; }
+  /// Get data pointer
+  const char *data() const { return buffer_; }
+  /// Get string length (excluding null terminator)
+  size_t size() const { return size_; }
+  /// Get writable buffer (for serialization)
+  char *data_writable() { return buffer_; }
+
+  /// Implicit conversion to std::string for backward compatibility
+  operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)
+
+ private:
+  char stack_buffer_[STACK_SIZE];
+  char *heap_buffer_{nullptr};
+  char *buffer_;
+  size_t size_;
+};
 
 #ifdef USE_PSRAM
 // Build an allocator for the JSON Library using the RAMAllocator class
@@ -69,7 +150,9 @@ class JsonBuilder {
     return root_;
   }
 
-  std::string serialize();
+  /// Serialize the JSON document to a JsonBuffer (stack-first allocation)
+  /// Uses 512-byte stack buffer by default, falls back to heap for larger JSON
+  JsonBuffer<> serialize();
 
  private:
 #ifdef USE_PSRAM

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -89,6 +89,16 @@ template<size_t STACK_SIZE = 768> class SerializationBuffer {
   /// Set actual size after serialization (must not exceed allocated size)
   void set_size(size_t size) { size_ = size; }
 
+  /// Reallocate to heap buffer with new size (for when stack buffer is too small)
+  /// This invalidates any previous buffer content
+  void reallocate_heap(size_t size) {
+    delete[] heap_buffer_;
+    heap_buffer_ = new char[size + 1];
+    buffer_ = heap_buffer_;
+    size_ = size;
+    buffer_[0] = '\0';
+  }
+
   /// Implicit conversion to std::string for backward compatibility
   operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)
 

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -17,9 +17,9 @@ namespace esphome {
 namespace json {
 
 /// Buffer for JSON serialization that uses stack allocation for small payloads.
-/// Template parameter STACK_SIZE specifies the stack buffer size (default 512 bytes).
+/// Template parameter STACK_SIZE specifies the stack buffer size (default 768 bytes).
 /// Supports move semantics for efficient return-by-value.
-template<size_t STACK_SIZE = 512> class JsonBuffer {
+template<size_t STACK_SIZE = 768> class JsonBuffer {
  public:
   /// Construct with known size (typically from measureJson)
   explicit JsonBuffer(size_t size) : size_(size) {

--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -84,16 +84,23 @@ template<size_t STACK_SIZE = 768> class SerializationBuffer {
   const char *data() const { return buffer_; }
   /// Get string length (excluding null terminator)
   size_t size() const { return size_; }
-  /// Get writable buffer (for serialization)
-  char *data_writable() { return buffer_; }
-  /// Set actual size after serialization (must not exceed allocated size)
-  void set_size(size_t size) { size_ = size; }
 
   /// Implicit conversion to std::string for backward compatibility
+  /// WARNING: This allocates a new std::string on the heap. Prefer using
+  /// c_str() or data()/size() directly when possible to avoid allocation.
   operator std::string() const { return std::string(buffer_, size_); }  // NOLINT(google-explicit-constructor)
 
  private:
-  friend class JsonBuilder;  ///< Allows JsonBuilder::serialize() to call reallocate_heap_()
+  friend class JsonBuilder;  ///< Allows JsonBuilder::serialize() to call private methods
+
+  /// Get writable buffer (for serialization)
+  char *data_writable_() { return buffer_; }
+  /// Set actual size after serialization (must not exceed allocated size)
+  /// Also ensures null termination for c_str() safety
+  void set_size_(size_t size) {
+    size_ = size;
+    buffer_[size] = '\0';
+  }
 
   /// Reallocate to heap buffer with new size (for when stack buffer is too small)
   /// This invalidates any previous buffer content. Used by JsonBuilder::serialize().

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -564,8 +564,8 @@ bool MQTTClientComponent::publish(const char *topic, const char *payload, size_t
 }
 
 bool MQTTClientComponent::publish_json(const char *topic, const json::json_build_t &f, uint8_t qos, bool retain) {
-  std::string message = json::build_json(f);
-  return this->publish(topic, message.c_str(), message.length(), qos, retain);
+  auto message = json::build_json(f);
+  return this->publish(topic, message.c_str(), message.size(), qos, retain);
 }
 
 void MQTTClientComponent::enable() {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -597,20 +597,20 @@ void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlM
     // Note: request->method() is always HTTP_GET here (canHandle ensures this)
     if (entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->sensor_json_(obj, obj->state, detail);
+      auto data = this->sensor_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
   }
   request->send(404);
 }
-std::string WebServer::sensor_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->sensor_json_((sensor::Sensor *) (source), ((sensor::Sensor *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::sensor_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->sensor_json_((sensor::Sensor *) (source), ((sensor::Sensor *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -644,23 +644,23 @@ void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const
     // Note: request->method() is always HTTP_GET here (canHandle ensures this)
     if (entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->text_sensor_json_(obj, obj->state, detail);
+      auto data = this->text_sensor_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
   }
   request->send(404);
 }
-std::string WebServer::text_sensor_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::text_sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->text_sensor_json_((text_sensor::TextSensor *) (source),
                                        ((text_sensor::TextSensor *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::text_sensor_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::text_sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->text_sensor_json_((text_sensor::TextSensor *) (source),
                                        ((text_sensor::TextSensor *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value,
-                                         JsonDetail start_config) {
+json::JsonBuffer<> WebServer::text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value,
+                                                JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -705,7 +705,7 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->switch_json_(obj, obj->state, detail);
+      auto data = this->switch_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -734,13 +734,13 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-std::string WebServer::switch_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::switch_state_json_generator(WebServer *web_server, void *source) {
   return web_server->switch_json_((switch_::Switch *) (source), ((switch_::Switch *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::switch_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::switch_all_json_generator(WebServer *web_server, void *source) {
   return web_server->switch_json_((switch_::Switch *) (source), ((switch_::Switch *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -762,7 +762,7 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
       continue;
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->button_json_(obj, detail);
+      auto data = this->button_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
     } else if (match.method_equals(ESPHOME_F("press"))) {
       DEFER_ACTION(obj, obj->press());
@@ -775,10 +775,10 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-std::string WebServer::button_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::button_all_json_generator(WebServer *web_server, void *source) {
   return web_server->button_json_((button::Button *) (source), DETAIL_ALL);
 }
-std::string WebServer::button_json_(button::Button *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::button_json_(button::Button *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -805,22 +805,23 @@ void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, con
     // Note: request->method() is always HTTP_GET here (canHandle ensures this)
     if (entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->binary_sensor_json_(obj, obj->state, detail);
+      auto data = this->binary_sensor_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
   }
   request->send(404);
 }
-std::string WebServer::binary_sensor_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::binary_sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->binary_sensor_json_((binary_sensor::BinarySensor *) (source),
                                          ((binary_sensor::BinarySensor *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::binary_sensor_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::binary_sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->binary_sensor_json_((binary_sensor::BinarySensor *) (source),
                                          ((binary_sensor::BinarySensor *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value,
+                                                  JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -847,7 +848,7 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->fan_json_(obj, detail);
+      auto data = this->fan_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
     } else if (match.method_equals(ESPHOME_F("toggle"))) {
       DEFER_ACTION(obj, obj->toggle().perform());
@@ -888,13 +889,13 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
   }
   request->send(404);
 }
-std::string WebServer::fan_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::fan_state_json_generator(WebServer *web_server, void *source) {
   return web_server->fan_json_((fan::Fan *) (source), DETAIL_STATE);
 }
-std::string WebServer::fan_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::fan_all_json_generator(WebServer *web_server, void *source) {
   return web_server->fan_json_((fan::Fan *) (source), DETAIL_ALL);
 }
-std::string WebServer::fan_json_(fan::Fan *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::fan_json_(fan::Fan *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -928,7 +929,7 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->light_json_(obj, detail);
+      auto data = this->light_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
     } else if (match.method_equals(ESPHOME_F("toggle"))) {
       DEFER_ACTION(obj, obj->toggle().perform());
@@ -967,13 +968,13 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-std::string WebServer::light_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::light_state_json_generator(WebServer *web_server, void *source) {
   return web_server->light_json_((light::LightState *) (source), DETAIL_STATE);
 }
-std::string WebServer::light_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::light_all_json_generator(WebServer *web_server, void *source) {
   return web_server->light_json_((light::LightState *) (source), DETAIL_ALL);
 }
-std::string WebServer::light_json_(light::LightState *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::light_json_(light::LightState *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1007,7 +1008,7 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->cover_json_(obj, detail);
+      auto data = this->cover_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1055,13 +1056,13 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-std::string WebServer::cover_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::cover_state_json_generator(WebServer *web_server, void *source) {
   return web_server->cover_json_((cover::Cover *) (source), DETAIL_STATE);
 }
-std::string WebServer::cover_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::cover_all_json_generator(WebServer *web_server, void *source) {
   return web_server->cover_json_((cover::Cover *) (source), DETAIL_ALL);
 }
-std::string WebServer::cover_json_(cover::Cover *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::cover_json_(cover::Cover *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1096,7 +1097,7 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->number_json_(obj, obj->state, detail);
+      auto data = this->number_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1115,13 +1116,13 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
   request->send(404);
 }
 
-std::string WebServer::number_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::number_state_json_generator(WebServer *web_server, void *source) {
   return web_server->number_json_((number::Number *) (source), ((number::Number *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::number_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::number_all_json_generator(WebServer *web_server, void *source) {
   return web_server->number_json_((number::Number *) (source), ((number::Number *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::number_json_(number::Number *obj, float value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::number_json_(number::Number *obj, float value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1163,7 +1164,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
       continue;
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->date_json_(obj, detail);
+      auto data = this->date_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1188,13 +1189,13 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
   request->send(404);
 }
 
-std::string WebServer::date_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::date_state_json_generator(WebServer *web_server, void *source) {
   return web_server->date_json_((datetime::DateEntity *) (source), DETAIL_STATE);
 }
-std::string WebServer::date_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::date_all_json_generator(WebServer *web_server, void *source) {
   return web_server->date_json_((datetime::DateEntity *) (source), DETAIL_ALL);
 }
-std::string WebServer::date_json_(datetime::DateEntity *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::date_json_(datetime::DateEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1223,7 +1224,7 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
       continue;
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->time_json_(obj, detail);
+      auto data = this->time_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1247,13 +1248,13 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
   }
   request->send(404);
 }
-std::string WebServer::time_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::time_state_json_generator(WebServer *web_server, void *source) {
   return web_server->time_json_((datetime::TimeEntity *) (source), DETAIL_STATE);
 }
-std::string WebServer::time_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::time_all_json_generator(WebServer *web_server, void *source) {
   return web_server->time_json_((datetime::TimeEntity *) (source), DETAIL_ALL);
 }
-std::string WebServer::time_json_(datetime::TimeEntity *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::time_json_(datetime::TimeEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1282,7 +1283,7 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
       continue;
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->datetime_json_(obj, detail);
+      auto data = this->datetime_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1306,13 +1307,13 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
   }
   request->send(404);
 }
-std::string WebServer::datetime_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::datetime_state_json_generator(WebServer *web_server, void *source) {
   return web_server->datetime_json_((datetime::DateTimeEntity *) (source), DETAIL_STATE);
 }
-std::string WebServer::datetime_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::datetime_all_json_generator(WebServer *web_server, void *source) {
   return web_server->datetime_json_((datetime::DateTimeEntity *) (source), DETAIL_ALL);
 }
-std::string WebServer::datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1343,7 +1344,7 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->text_json_(obj, obj->state, detail);
+      auto data = this->text_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1362,13 +1363,13 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
   request->send(404);
 }
 
-std::string WebServer::text_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::text_state_json_generator(WebServer *web_server, void *source) {
   return web_server->text_json_((text::Text *) (source), ((text::Text *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::text_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::text_all_json_generator(WebServer *web_server, void *source) {
   return web_server->text_json_((text::Text *) (source), ((text::Text *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::text_json_(text::Text *obj, const std::string &value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::text_json_(text::Text *obj, const std::string &value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1400,7 +1401,7 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), detail);
+      auto data = this->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1419,15 +1420,15 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-std::string WebServer::select_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::select_state_json_generator(WebServer *web_server, void *source) {
   auto *obj = (select::Select *) (source);
   return web_server->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), DETAIL_STATE);
 }
-std::string WebServer::select_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::select_all_json_generator(WebServer *web_server, void *source) {
   auto *obj = (select::Select *) (source);
   return web_server->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), DETAIL_ALL);
 }
-std::string WebServer::select_json_(select::Select *obj, StringRef value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::select_json_(select::Select *obj, StringRef value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1459,7 +1460,7 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->climate_json_(obj, detail);
+      auto data = this->climate_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1488,15 +1489,15 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
   }
   request->send(404);
 }
-std::string WebServer::climate_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::climate_state_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->climate_json_((climate::Climate *) (source), DETAIL_STATE);
 }
-std::string WebServer::climate_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::climate_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->climate_json_((climate::Climate *) (source), DETAIL_ALL);
 }
-std::string WebServer::climate_json_(climate::Climate *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::climate_json_(climate::Climate *obj, JsonDetail start_config) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   json::JsonBuilder builder;
   JsonObject root = builder.root();
@@ -1629,7 +1630,7 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->lock_json_(obj, obj->state, detail);
+      auto data = this->lock_json_(obj, obj->state, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1658,13 +1659,13 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
   }
   request->send(404);
 }
-std::string WebServer::lock_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::lock_state_json_generator(WebServer *web_server, void *source) {
   return web_server->lock_json_((lock::Lock *) (source), ((lock::Lock *) (source))->state, DETAIL_STATE);
 }
-std::string WebServer::lock_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::lock_all_json_generator(WebServer *web_server, void *source) {
   return web_server->lock_json_((lock::Lock *) (source), ((lock::Lock *) (source))->state, DETAIL_ALL);
 }
-std::string WebServer::lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1692,7 +1693,7 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->valve_json_(obj, detail);
+      auto data = this->valve_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1738,13 +1739,13 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-std::string WebServer::valve_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::valve_state_json_generator(WebServer *web_server, void *source) {
   return web_server->valve_json_((valve::Valve *) (source), DETAIL_STATE);
 }
-std::string WebServer::valve_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::valve_all_json_generator(WebServer *web_server, void *source) {
   return web_server->valve_json_((valve::Valve *) (source), DETAIL_ALL);
 }
-std::string WebServer::valve_json_(valve::Valve *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::valve_json_(valve::Valve *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1777,7 +1778,7 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->alarm_control_panel_json_(obj, obj->get_state(), detail);
+      auto data = this->alarm_control_panel_json_(obj, obj->get_state(), detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1817,19 +1818,19 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
   }
   request->send(404);
 }
-std::string WebServer::alarm_control_panel_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::alarm_control_panel_state_json_generator(WebServer *web_server, void *source) {
   return web_server->alarm_control_panel_json_((alarm_control_panel::AlarmControlPanel *) (source),
                                                ((alarm_control_panel::AlarmControlPanel *) (source))->get_state(),
                                                DETAIL_STATE);
 }
-std::string WebServer::alarm_control_panel_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::alarm_control_panel_all_json_generator(WebServer *web_server, void *source) {
   return web_server->alarm_control_panel_json_((alarm_control_panel::AlarmControlPanel *) (source),
                                                ((alarm_control_panel::AlarmControlPanel *) (source))->get_state(),
                                                DETAIL_ALL);
 }
-std::string WebServer::alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
-                                                 alarm_control_panel::AlarmControlPanelState value,
-                                                 JsonDetail start_config) {
+json::JsonBuffer<> WebServer::alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
+                                                        alarm_control_panel::AlarmControlPanelState value,
+                                                        JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1858,7 +1859,7 @@ void WebServer::handle_water_heater_request(AsyncWebServerRequest *request, cons
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->water_heater_json_(obj, detail);
+      auto data = this->water_heater_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -1894,14 +1895,14 @@ void WebServer::handle_water_heater_request(AsyncWebServerRequest *request, cons
   request->send(404);
 }
 
-std::string WebServer::water_heater_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::water_heater_state_json_generator(WebServer *web_server, void *source) {
   return web_server->water_heater_json_(static_cast<water_heater::WaterHeater *>(source), DETAIL_STATE);
 }
-std::string WebServer::water_heater_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::water_heater_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->water_heater_json_(static_cast<water_heater::WaterHeater *>(source), DETAIL_ALL);
 }
-std::string WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
   char buf[PSTR_LOCAL_SIZE];
@@ -1964,7 +1965,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->infrared_json_(obj, detail);
+      auto data = this->infrared_json_(obj, detail);
       request->send(200, ESPHOME_F("application/json"), data.c_str());
       return;
     }
@@ -2035,12 +2036,12 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
   request->send(404);
 }
 
-std::string WebServer::infrared_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::infrared_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->infrared_json_(static_cast<infrared::Infrared *>(source), DETAIL_ALL);
 }
 
-std::string WebServer::infrared_json_(infrared::Infrared *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::infrared_json_(infrared::Infrared *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -2075,7 +2076,7 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
     // Note: request->method() is always HTTP_GET here (canHandle ensures this)
     if (entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->event_json_(obj, StringRef(), detail);
+      auto data = this->event_json_(obj, StringRef(), detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -2085,16 +2086,16 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
 
 static StringRef get_event_type(event::Event *event) { return event ? event->get_last_event_type() : StringRef(); }
 
-std::string WebServer::event_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::event_state_json_generator(WebServer *web_server, void *source) {
   auto *event = static_cast<event::Event *>(source);
   return web_server->event_json_(event, get_event_type(event), DETAIL_STATE);
 }
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
-std::string WebServer::event_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::event_all_json_generator(WebServer *web_server, void *source) {
   auto *event = static_cast<event::Event *>(source);
   return web_server->event_json_(event, get_event_type(event), DETAIL_ALL);
 }
-std::string WebServer::event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -2141,7 +2142,7 @@ void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlM
 
     if (request->method() == HTTP_GET && entity_match.action_is_empty) {
       auto detail = get_request_detail(request);
-      std::string data = this->update_json_(obj, detail);
+      auto data = this->update_json_(obj, detail);
       request->send(200, "application/json", data.c_str());
       return;
     }
@@ -2157,15 +2158,15 @@ void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-std::string WebServer::update_state_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::update_state_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->update_json_((update::UpdateEntity *) (source), DETAIL_STATE);
 }
-std::string WebServer::update_all_json_generator(WebServer *web_server, void *source) {
+json::JsonBuffer<> WebServer::update_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->update_json_((update::UpdateEntity *) (source), DETAIL_STATE);
 }
-std::string WebServer::update_json_(update::UpdateEntity *obj, JsonDetail start_config) {
+json::JsonBuffer<> WebServer::update_json_(update::UpdateEntity *obj, JsonDetail start_config) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   json::JsonBuilder builder;
   JsonObject root = builder.root();

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -209,7 +209,7 @@ void DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_
 void DeferredUpdateEventSource::process_deferred_queue_() {
   while (!deferred_queue_.empty()) {
     DeferredEvent &de = deferred_queue_.front();
-    std::string message = de.message_generator_(web_server_, de.source_);
+    auto message = de.message_generator_(web_server_, de.source_);
     if (this->send(message.c_str(), "state") != DISCARDED) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
@@ -266,7 +266,7 @@ void DeferredUpdateEventSource::deferrable_send_state(void *source, const char *
     // deferred queue still not empty which means downstream event queue full, no point trying to send first
     deq_push_back_with_dedup_(source, message_generator);
   } else {
-    std::string message = message_generator(web_server_, source);
+    auto message = message_generator(web_server_, source);
     if (this->send(message.c_str(), "state") == DISCARDED) {
       deq_push_back_with_dedup_(source, message_generator);
     } else {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -320,7 +320,7 @@ void DeferredUpdateEventSourceList::on_client_connect_(DeferredUpdateEventSource
   ws->defer([ws, source]() {
     // Configure reconnect timeout and send config
     // this should always go through since the AsyncEventSourceClient event queue is empty on connect
-    std::string message = ws->get_config_json();
+    auto message = ws->get_config_json();
     source->try_send_nodefer(message.c_str(), "ping", millis(), 30000);
 
 #ifdef USE_WEBSERVER_SORTING
@@ -329,10 +329,10 @@ void DeferredUpdateEventSourceList::on_client_connect_(DeferredUpdateEventSource
       JsonObject root = builder.root();
       root[ESPHOME_F("name")] = group.second.name;
       root[ESPHOME_F("sorting_weight")] = group.second.weight;
-      message = builder.serialize();
+      auto group_msg = builder.serialize();
 
       // up to 31 groups should be able to be queued initially without defer
-      source->try_send_nodefer(message.c_str(), "sorting_group");
+      source->try_send_nodefer(group_msg.c_str(), "sorting_group");
     }
 #endif
 
@@ -365,7 +365,7 @@ void WebServer::set_css_include(const char *css_include) { this->css_include_ = 
 void WebServer::set_js_include(const char *js_include) { this->js_include_ = js_include; }
 #endif
 
-std::string WebServer::get_config_json() {
+json::JsonBuffer<> WebServer::get_config_json() {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -365,7 +365,7 @@ void WebServer::set_css_include(const char *css_include) { this->css_include_ = 
 void WebServer::set_js_include(const char *js_include) { this->js_include_ = js_include; }
 #endif
 
-json::JsonBuffer<> WebServer::get_config_json() {
+json::SerializationBuffer<> WebServer::get_config_json() {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -604,13 +604,13 @@ void WebServer::handle_sensor_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::sensor_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->sensor_json_((sensor::Sensor *) (source), ((sensor::Sensor *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::sensor_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->sensor_json_((sensor::Sensor *) (source), ((sensor::Sensor *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -651,16 +651,16 @@ void WebServer::handle_text_sensor_request(AsyncWebServerRequest *request, const
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::text_sensor_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::text_sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->text_sensor_json_((text_sensor::TextSensor *) (source),
                                        ((text_sensor::TextSensor *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::text_sensor_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::text_sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->text_sensor_json_((text_sensor::TextSensor *) (source),
                                        ((text_sensor::TextSensor *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value,
-                                                JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value,
+                                                         JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -734,13 +734,13 @@ void WebServer::handle_switch_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::switch_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::switch_state_json_generator(WebServer *web_server, void *source) {
   return web_server->switch_json_((switch_::Switch *) (source), ((switch_::Switch *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::switch_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::switch_all_json_generator(WebServer *web_server, void *source) {
   return web_server->switch_json_((switch_::Switch *) (source), ((switch_::Switch *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -775,10 +775,10 @@ void WebServer::handle_button_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::button_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::button_all_json_generator(WebServer *web_server, void *source) {
   return web_server->button_json_((button::Button *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::button_json_(button::Button *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::button_json_(button::Button *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -812,16 +812,16 @@ void WebServer::handle_binary_sensor_request(AsyncWebServerRequest *request, con
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::binary_sensor_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::binary_sensor_state_json_generator(WebServer *web_server, void *source) {
   return web_server->binary_sensor_json_((binary_sensor::BinarySensor *) (source),
                                          ((binary_sensor::BinarySensor *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::binary_sensor_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::binary_sensor_all_json_generator(WebServer *web_server, void *source) {
   return web_server->binary_sensor_json_((binary_sensor::BinarySensor *) (source),
                                          ((binary_sensor::BinarySensor *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value,
-                                                  JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value,
+                                                           JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -889,13 +889,13 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::fan_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::fan_state_json_generator(WebServer *web_server, void *source) {
   return web_server->fan_json_((fan::Fan *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::fan_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::fan_all_json_generator(WebServer *web_server, void *source) {
   return web_server->fan_json_((fan::Fan *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::fan_json_(fan::Fan *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::fan_json_(fan::Fan *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -968,13 +968,13 @@ void WebServer::handle_light_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::light_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::light_state_json_generator(WebServer *web_server, void *source) {
   return web_server->light_json_((light::LightState *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::light_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::light_all_json_generator(WebServer *web_server, void *source) {
   return web_server->light_json_((light::LightState *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::light_json_(light::LightState *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::light_json_(light::LightState *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1056,13 +1056,13 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::cover_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::cover_state_json_generator(WebServer *web_server, void *source) {
   return web_server->cover_json_((cover::Cover *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::cover_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::cover_all_json_generator(WebServer *web_server, void *source) {
   return web_server->cover_json_((cover::Cover *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::cover_json_(cover::Cover *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::cover_json_(cover::Cover *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1116,13 +1116,13 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
   request->send(404);
 }
 
-json::JsonBuffer<> WebServer::number_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::number_state_json_generator(WebServer *web_server, void *source) {
   return web_server->number_json_((number::Number *) (source), ((number::Number *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::number_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::number_all_json_generator(WebServer *web_server, void *source) {
   return web_server->number_json_((number::Number *) (source), ((number::Number *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::number_json_(number::Number *obj, float value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::number_json_(number::Number *obj, float value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1189,13 +1189,13 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
   request->send(404);
 }
 
-json::JsonBuffer<> WebServer::date_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::date_state_json_generator(WebServer *web_server, void *source) {
   return web_server->date_json_((datetime::DateEntity *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::date_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::date_all_json_generator(WebServer *web_server, void *source) {
   return web_server->date_json_((datetime::DateEntity *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::date_json_(datetime::DateEntity *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::date_json_(datetime::DateEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1248,13 +1248,13 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::time_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::time_state_json_generator(WebServer *web_server, void *source) {
   return web_server->time_json_((datetime::TimeEntity *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::time_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::time_all_json_generator(WebServer *web_server, void *source) {
   return web_server->time_json_((datetime::TimeEntity *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::time_json_(datetime::TimeEntity *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::time_json_(datetime::TimeEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1307,13 +1307,13 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::datetime_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::datetime_state_json_generator(WebServer *web_server, void *source) {
   return web_server->datetime_json_((datetime::DateTimeEntity *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::datetime_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::datetime_all_json_generator(WebServer *web_server, void *source) {
   return web_server->datetime_json_((datetime::DateTimeEntity *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1363,13 +1363,13 @@ void WebServer::handle_text_request(AsyncWebServerRequest *request, const UrlMat
   request->send(404);
 }
 
-json::JsonBuffer<> WebServer::text_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::text_state_json_generator(WebServer *web_server, void *source) {
   return web_server->text_json_((text::Text *) (source), ((text::Text *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::text_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::text_all_json_generator(WebServer *web_server, void *source) {
   return web_server->text_json_((text::Text *) (source), ((text::Text *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::text_json_(text::Text *obj, const std::string &value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::text_json_(text::Text *obj, const std::string &value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1420,15 +1420,15 @@ void WebServer::handle_select_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::select_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::select_state_json_generator(WebServer *web_server, void *source) {
   auto *obj = (select::Select *) (source);
   return web_server->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::select_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::select_all_json_generator(WebServer *web_server, void *source) {
   auto *obj = (select::Select *) (source);
   return web_server->select_json_(obj, obj->has_state() ? obj->current_option() : StringRef(), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::select_json_(select::Select *obj, StringRef value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::select_json_(select::Select *obj, StringRef value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1489,15 +1489,15 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::climate_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::climate_state_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->climate_json_((climate::Climate *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::climate_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::climate_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->climate_json_((climate::Climate *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::climate_json_(climate::Climate *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::climate_json_(climate::Climate *obj, JsonDetail start_config) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   json::JsonBuilder builder;
   JsonObject root = builder.root();
@@ -1659,13 +1659,13 @@ void WebServer::handle_lock_request(AsyncWebServerRequest *request, const UrlMat
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::lock_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::lock_state_json_generator(WebServer *web_server, void *source) {
   return web_server->lock_json_((lock::Lock *) (source), ((lock::Lock *) (source))->state, DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::lock_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::lock_all_json_generator(WebServer *web_server, void *source) {
   return web_server->lock_json_((lock::Lock *) (source), ((lock::Lock *) (source))->state, DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1739,13 +1739,13 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::valve_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::valve_state_json_generator(WebServer *web_server, void *source) {
   return web_server->valve_json_((valve::Valve *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::valve_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::valve_all_json_generator(WebServer *web_server, void *source) {
   return web_server->valve_json_((valve::Valve *) (source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::valve_json_(valve::Valve *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::valve_json_(valve::Valve *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1818,19 +1818,19 @@ void WebServer::handle_alarm_control_panel_request(AsyncWebServerRequest *reques
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::alarm_control_panel_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::alarm_control_panel_state_json_generator(WebServer *web_server, void *source) {
   return web_server->alarm_control_panel_json_((alarm_control_panel::AlarmControlPanel *) (source),
                                                ((alarm_control_panel::AlarmControlPanel *) (source))->get_state(),
                                                DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::alarm_control_panel_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::alarm_control_panel_all_json_generator(WebServer *web_server, void *source) {
   return web_server->alarm_control_panel_json_((alarm_control_panel::AlarmControlPanel *) (source),
                                                ((alarm_control_panel::AlarmControlPanel *) (source))->get_state(),
                                                DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
-                                                        alarm_control_panel::AlarmControlPanelState value,
-                                                        JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
+                                                                 alarm_control_panel::AlarmControlPanelState value,
+                                                                 JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -1895,14 +1895,14 @@ void WebServer::handle_water_heater_request(AsyncWebServerRequest *request, cons
   request->send(404);
 }
 
-json::JsonBuffer<> WebServer::water_heater_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::water_heater_state_json_generator(WebServer *web_server, void *source) {
   return web_server->water_heater_json_(static_cast<water_heater::WaterHeater *>(source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::water_heater_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::water_heater_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->water_heater_json_(static_cast<water_heater::WaterHeater *>(source), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
   char buf[PSTR_LOCAL_SIZE];
@@ -2036,12 +2036,12 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
   request->send(404);
 }
 
-json::JsonBuffer<> WebServer::infrared_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::infrared_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->infrared_json_(static_cast<infrared::Infrared *>(source), DETAIL_ALL);
 }
 
-json::JsonBuffer<> WebServer::infrared_json_(infrared::Infrared *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::infrared_json_(infrared::Infrared *obj, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -2086,16 +2086,16 @@ void WebServer::handle_event_request(AsyncWebServerRequest *request, const UrlMa
 
 static StringRef get_event_type(event::Event *event) { return event ? event->get_last_event_type() : StringRef(); }
 
-json::JsonBuffer<> WebServer::event_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::event_state_json_generator(WebServer *web_server, void *source) {
   auto *event = static_cast<event::Event *>(source);
   return web_server->event_json_(event, get_event_type(event), DETAIL_STATE);
 }
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
-json::JsonBuffer<> WebServer::event_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::event_all_json_generator(WebServer *web_server, void *source) {
   auto *event = static_cast<event::Event *>(source);
   return web_server->event_json_(event, get_event_type(event), DETAIL_ALL);
 }
-json::JsonBuffer<> WebServer::event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config) {
   json::JsonBuilder builder;
   JsonObject root = builder.root();
 
@@ -2158,15 +2158,15 @@ void WebServer::handle_update_request(AsyncWebServerRequest *request, const UrlM
   }
   request->send(404);
 }
-json::JsonBuffer<> WebServer::update_state_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::update_state_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->update_json_((update::UpdateEntity *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::update_all_json_generator(WebServer *web_server, void *source) {
+json::SerializationBuffer<> WebServer::update_all_json_generator(WebServer *web_server, void *source) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   return web_server->update_json_((update::UpdateEntity *) (source), DETAIL_STATE);
 }
-json::JsonBuffer<> WebServer::update_json_(update::UpdateEntity *obj, JsonDetail start_config) {
+json::SerializationBuffer<> WebServer::update_json_(update::UpdateEntity *obj, JsonDetail start_config) {
   // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   json::JsonBuilder builder;
   JsonObject root = builder.root();

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -2,6 +2,7 @@
 
 #include "list_entities.h"
 
+#include "esphome/components/json/json_util.h"
 #include "esphome/components/web_server_base/web_server_base.h"
 #ifdef USE_WEBSERVER
 #include "esphome/core/component.h"
@@ -285,8 +286,8 @@ class WebServer : public Controller,
   /// Handle a sensor request under '/sensor/<id>'.
   void handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string sensor_state_json_generator(WebServer *web_server, void *source);
-  static std::string sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_SWITCH
@@ -295,8 +296,8 @@ class WebServer : public Controller,
   /// Handle a switch request under '/switch/<id>/</turn_on/turn_off/toggle>'.
   void handle_switch_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string switch_state_json_generator(WebServer *web_server, void *source);
-  static std::string switch_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> switch_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> switch_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_BUTTON
@@ -304,7 +305,7 @@ class WebServer : public Controller,
   void handle_button_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
   // Buttons are stateless, so there is no button_state_json_generator
-  static std::string button_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> button_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_BINARY_SENSOR
@@ -313,8 +314,8 @@ class WebServer : public Controller,
   /// Handle a binary sensor request under '/binary_sensor/<id>'.
   void handle_binary_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string binary_sensor_state_json_generator(WebServer *web_server, void *source);
-  static std::string binary_sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> binary_sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> binary_sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_FAN
@@ -323,8 +324,8 @@ class WebServer : public Controller,
   /// Handle a fan request under '/fan/<id>/</turn_on/turn_off/toggle>'.
   void handle_fan_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string fan_state_json_generator(WebServer *web_server, void *source);
-  static std::string fan_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> fan_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> fan_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_LIGHT
@@ -333,8 +334,8 @@ class WebServer : public Controller,
   /// Handle a light request under '/light/<id>/</turn_on/turn_off/toggle>'.
   void handle_light_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string light_state_json_generator(WebServer *web_server, void *source);
-  static std::string light_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> light_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> light_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_TEXT_SENSOR
@@ -343,8 +344,8 @@ class WebServer : public Controller,
   /// Handle a text sensor request under '/text_sensor/<id>'.
   void handle_text_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string text_sensor_state_json_generator(WebServer *web_server, void *source);
-  static std::string text_sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> text_sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> text_sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_COVER
@@ -353,8 +354,8 @@ class WebServer : public Controller,
   /// Handle a cover request under '/cover/<id>/<open/close/stop/set>'.
   void handle_cover_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string cover_state_json_generator(WebServer *web_server, void *source);
-  static std::string cover_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> cover_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> cover_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_NUMBER
@@ -362,8 +363,8 @@ class WebServer : public Controller,
   /// Handle a number request under '/number/<id>'.
   void handle_number_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string number_state_json_generator(WebServer *web_server, void *source);
-  static std::string number_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> number_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> number_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_DATE
@@ -371,8 +372,8 @@ class WebServer : public Controller,
   /// Handle a date request under '/date/<id>'.
   void handle_date_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string date_state_json_generator(WebServer *web_server, void *source);
-  static std::string date_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> date_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> date_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_TIME
@@ -380,8 +381,8 @@ class WebServer : public Controller,
   /// Handle a time request under '/time/<id>'.
   void handle_time_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string time_state_json_generator(WebServer *web_server, void *source);
-  static std::string time_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> time_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> time_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_DATETIME
@@ -389,8 +390,8 @@ class WebServer : public Controller,
   /// Handle a datetime request under '/datetime/<id>'.
   void handle_datetime_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string datetime_state_json_generator(WebServer *web_server, void *source);
-  static std::string datetime_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> datetime_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> datetime_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_TEXT
@@ -398,8 +399,8 @@ class WebServer : public Controller,
   /// Handle a text input request under '/text/<id>'.
   void handle_text_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string text_state_json_generator(WebServer *web_server, void *source);
-  static std::string text_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> text_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> text_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_SELECT
@@ -407,8 +408,8 @@ class WebServer : public Controller,
   /// Handle a select request under '/select/<id>'.
   void handle_select_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string select_state_json_generator(WebServer *web_server, void *source);
-  static std::string select_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> select_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> select_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_CLIMATE
@@ -416,8 +417,8 @@ class WebServer : public Controller,
   /// Handle a climate request under '/climate/<id>'.
   void handle_climate_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string climate_state_json_generator(WebServer *web_server, void *source);
-  static std::string climate_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> climate_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> climate_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_LOCK
@@ -426,8 +427,8 @@ class WebServer : public Controller,
   /// Handle a lock request under '/lock/<id>/</lock/unlock/open>'.
   void handle_lock_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string lock_state_json_generator(WebServer *web_server, void *source);
-  static std::string lock_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> lock_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> lock_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_VALVE
@@ -436,8 +437,8 @@ class WebServer : public Controller,
   /// Handle a valve request under '/valve/<id>/<open/close/stop/set>'.
   void handle_valve_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string valve_state_json_generator(WebServer *web_server, void *source);
-  static std::string valve_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> valve_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> valve_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL
@@ -446,8 +447,8 @@ class WebServer : public Controller,
   /// Handle a alarm_control_panel request under '/alarm_control_panel/<id>'.
   void handle_alarm_control_panel_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string alarm_control_panel_state_json_generator(WebServer *web_server, void *source);
-  static std::string alarm_control_panel_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> alarm_control_panel_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> alarm_control_panel_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_WATER_HEATER
@@ -456,22 +457,22 @@ class WebServer : public Controller,
   /// Handle a water_heater request under '/water_heater/<id>/<mode/set>'.
   void handle_water_heater_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string water_heater_state_json_generator(WebServer *web_server, void *source);
-  static std::string water_heater_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> water_heater_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> water_heater_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_INFRARED
   /// Handle an infrared request under '/infrared/<id>/transmit'.
   void handle_infrared_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string infrared_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> infrared_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_EVENT
   void on_event(event::Event *obj) override;
 
-  static std::string event_state_json_generator(WebServer *web_server, void *source);
-  static std::string event_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> event_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> event_all_json_generator(WebServer *web_server, void *source);
 
   /// Handle a event request under '/event<id>'.
   void handle_event_request(AsyncWebServerRequest *request, const UrlMatch &match);
@@ -483,8 +484,8 @@ class WebServer : public Controller,
   /// Handle a update request under '/update/<id>'.
   void handle_update_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static std::string update_state_json_generator(WebServer *web_server, void *source);
-  static std::string update_all_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> update_state_json_generator(WebServer *web_server, void *source);
+  static json::JsonBuffer<> update_all_json_generator(WebServer *web_server, void *source);
 #endif
 
   /// Override the web handler's canHandle method.
@@ -609,71 +610,72 @@ class WebServer : public Controller,
 
  private:
 #ifdef USE_SENSOR
-  std::string sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config);
+  json::JsonBuffer<> sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config);
 #endif
 #ifdef USE_SWITCH
-  std::string switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config);
+  json::JsonBuffer<> switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config);
 #endif
 #ifdef USE_BUTTON
-  std::string button_json_(button::Button *obj, JsonDetail start_config);
+  json::JsonBuffer<> button_json_(button::Button *obj, JsonDetail start_config);
 #endif
 #ifdef USE_BINARY_SENSOR
-  std::string binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value, JsonDetail start_config);
+  json::JsonBuffer<> binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value, JsonDetail start_config);
 #endif
 #ifdef USE_FAN
-  std::string fan_json_(fan::Fan *obj, JsonDetail start_config);
+  json::JsonBuffer<> fan_json_(fan::Fan *obj, JsonDetail start_config);
 #endif
 #ifdef USE_LIGHT
-  std::string light_json_(light::LightState *obj, JsonDetail start_config);
+  json::JsonBuffer<> light_json_(light::LightState *obj, JsonDetail start_config);
 #endif
 #ifdef USE_TEXT_SENSOR
-  std::string text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value, JsonDetail start_config);
+  json::JsonBuffer<> text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value, JsonDetail start_config);
 #endif
 #ifdef USE_COVER
-  std::string cover_json_(cover::Cover *obj, JsonDetail start_config);
+  json::JsonBuffer<> cover_json_(cover::Cover *obj, JsonDetail start_config);
 #endif
 #ifdef USE_NUMBER
-  std::string number_json_(number::Number *obj, float value, JsonDetail start_config);
+  json::JsonBuffer<> number_json_(number::Number *obj, float value, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_DATE
-  std::string date_json_(datetime::DateEntity *obj, JsonDetail start_config);
+  json::JsonBuffer<> date_json_(datetime::DateEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_TIME
-  std::string time_json_(datetime::TimeEntity *obj, JsonDetail start_config);
+  json::JsonBuffer<> time_json_(datetime::TimeEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_DATETIME
-  std::string datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config);
+  json::JsonBuffer<> datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_TEXT
-  std::string text_json_(text::Text *obj, const std::string &value, JsonDetail start_config);
+  json::JsonBuffer<> text_json_(text::Text *obj, const std::string &value, JsonDetail start_config);
 #endif
 #ifdef USE_SELECT
-  std::string select_json_(select::Select *obj, StringRef value, JsonDetail start_config);
+  json::JsonBuffer<> select_json_(select::Select *obj, StringRef value, JsonDetail start_config);
 #endif
 #ifdef USE_CLIMATE
-  std::string climate_json_(climate::Climate *obj, JsonDetail start_config);
+  json::JsonBuffer<> climate_json_(climate::Climate *obj, JsonDetail start_config);
 #endif
 #ifdef USE_LOCK
-  std::string lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
+  json::JsonBuffer<> lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
 #endif
 #ifdef USE_VALVE
-  std::string valve_json_(valve::Valve *obj, JsonDetail start_config);
+  json::JsonBuffer<> valve_json_(valve::Valve *obj, JsonDetail start_config);
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-  std::string alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
-                                        alarm_control_panel::AlarmControlPanelState value, JsonDetail start_config);
+  json::JsonBuffer<> alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
+                                               alarm_control_panel::AlarmControlPanelState value,
+                                               JsonDetail start_config);
 #endif
 #ifdef USE_EVENT
-  std::string event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config);
+  json::JsonBuffer<> event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config);
 #endif
 #ifdef USE_WATER_HEATER
-  std::string water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config);
+  json::JsonBuffer<> water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config);
 #endif
 #ifdef USE_INFRARED
-  std::string infrared_json_(infrared::Infrared *obj, JsonDetail start_config);
+  json::JsonBuffer<> infrared_json_(infrared::Infrared *obj, JsonDetail start_config);
 #endif
 #ifdef USE_UPDATE
-  std::string update_json_(update::UpdateEntity *obj, JsonDetail start_config);
+  json::JsonBuffer<> update_json_(update::UpdateEntity *obj, JsonDetail start_config);
 #endif
 };
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -264,7 +264,7 @@ class WebServer : public Controller,
   void handle_index_request(AsyncWebServerRequest *request);
 
   /// Return the webserver configuration as JSON.
-  json::JsonBuffer<> get_config_json();
+  json::SerializationBuffer<> get_config_json();
 
 #ifdef USE_WEBSERVER_CSS_INCLUDE
   /// Handle included css request under '/0.css'.
@@ -286,8 +286,8 @@ class WebServer : public Controller,
   /// Handle a sensor request under '/sensor/<id>'.
   void handle_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> sensor_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_SWITCH
@@ -296,8 +296,8 @@ class WebServer : public Controller,
   /// Handle a switch request under '/switch/<id>/</turn_on/turn_off/toggle>'.
   void handle_switch_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> switch_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> switch_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> switch_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> switch_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_BUTTON
@@ -305,7 +305,7 @@ class WebServer : public Controller,
   void handle_button_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
   // Buttons are stateless, so there is no button_state_json_generator
-  static json::JsonBuffer<> button_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> button_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_BINARY_SENSOR
@@ -314,8 +314,8 @@ class WebServer : public Controller,
   /// Handle a binary sensor request under '/binary_sensor/<id>'.
   void handle_binary_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> binary_sensor_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> binary_sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> binary_sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> binary_sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_FAN
@@ -324,8 +324,8 @@ class WebServer : public Controller,
   /// Handle a fan request under '/fan/<id>/</turn_on/turn_off/toggle>'.
   void handle_fan_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> fan_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> fan_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> fan_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> fan_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_LIGHT
@@ -334,8 +334,8 @@ class WebServer : public Controller,
   /// Handle a light request under '/light/<id>/</turn_on/turn_off/toggle>'.
   void handle_light_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> light_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> light_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> light_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> light_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_TEXT_SENSOR
@@ -344,8 +344,8 @@ class WebServer : public Controller,
   /// Handle a text sensor request under '/text_sensor/<id>'.
   void handle_text_sensor_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> text_sensor_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> text_sensor_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> text_sensor_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> text_sensor_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_COVER
@@ -354,8 +354,8 @@ class WebServer : public Controller,
   /// Handle a cover request under '/cover/<id>/<open/close/stop/set>'.
   void handle_cover_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> cover_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> cover_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> cover_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> cover_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_NUMBER
@@ -363,8 +363,8 @@ class WebServer : public Controller,
   /// Handle a number request under '/number/<id>'.
   void handle_number_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> number_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> number_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> number_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> number_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_DATE
@@ -372,8 +372,8 @@ class WebServer : public Controller,
   /// Handle a date request under '/date/<id>'.
   void handle_date_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> date_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> date_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> date_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> date_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_TIME
@@ -381,8 +381,8 @@ class WebServer : public Controller,
   /// Handle a time request under '/time/<id>'.
   void handle_time_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> time_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> time_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> time_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> time_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_DATETIME_DATETIME
@@ -390,8 +390,8 @@ class WebServer : public Controller,
   /// Handle a datetime request under '/datetime/<id>'.
   void handle_datetime_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> datetime_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> datetime_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> datetime_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> datetime_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_TEXT
@@ -399,8 +399,8 @@ class WebServer : public Controller,
   /// Handle a text input request under '/text/<id>'.
   void handle_text_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> text_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> text_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> text_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> text_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_SELECT
@@ -408,8 +408,8 @@ class WebServer : public Controller,
   /// Handle a select request under '/select/<id>'.
   void handle_select_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> select_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> select_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> select_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> select_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_CLIMATE
@@ -417,8 +417,8 @@ class WebServer : public Controller,
   /// Handle a climate request under '/climate/<id>'.
   void handle_climate_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> climate_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> climate_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> climate_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> climate_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_LOCK
@@ -427,8 +427,8 @@ class WebServer : public Controller,
   /// Handle a lock request under '/lock/<id>/</lock/unlock/open>'.
   void handle_lock_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> lock_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> lock_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> lock_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> lock_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_VALVE
@@ -437,8 +437,8 @@ class WebServer : public Controller,
   /// Handle a valve request under '/valve/<id>/<open/close/stop/set>'.
   void handle_valve_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> valve_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> valve_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> valve_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> valve_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_ALARM_CONTROL_PANEL
@@ -447,8 +447,8 @@ class WebServer : public Controller,
   /// Handle a alarm_control_panel request under '/alarm_control_panel/<id>'.
   void handle_alarm_control_panel_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> alarm_control_panel_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> alarm_control_panel_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> alarm_control_panel_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> alarm_control_panel_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_WATER_HEATER
@@ -457,22 +457,22 @@ class WebServer : public Controller,
   /// Handle a water_heater request under '/water_heater/<id>/<mode/set>'.
   void handle_water_heater_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> water_heater_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> water_heater_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> water_heater_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> water_heater_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_INFRARED
   /// Handle an infrared request under '/infrared/<id>/transmit'.
   void handle_infrared_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> infrared_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> infrared_all_json_generator(WebServer *web_server, void *source);
 #endif
 
 #ifdef USE_EVENT
   void on_event(event::Event *obj) override;
 
-  static json::JsonBuffer<> event_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> event_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> event_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> event_all_json_generator(WebServer *web_server, void *source);
 
   /// Handle a event request under '/event<id>'.
   void handle_event_request(AsyncWebServerRequest *request, const UrlMatch &match);
@@ -484,8 +484,8 @@ class WebServer : public Controller,
   /// Handle a update request under '/update/<id>'.
   void handle_update_request(AsyncWebServerRequest *request, const UrlMatch &match);
 
-  static json::JsonBuffer<> update_state_json_generator(WebServer *web_server, void *source);
-  static json::JsonBuffer<> update_all_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> update_state_json_generator(WebServer *web_server, void *source);
+  static json::SerializationBuffer<> update_all_json_generator(WebServer *web_server, void *source);
 #endif
 
   /// Override the web handler's canHandle method.
@@ -610,72 +610,74 @@ class WebServer : public Controller,
 
  private:
 #ifdef USE_SENSOR
-  json::JsonBuffer<> sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config);
+  json::SerializationBuffer<> sensor_json_(sensor::Sensor *obj, float value, JsonDetail start_config);
 #endif
 #ifdef USE_SWITCH
-  json::JsonBuffer<> switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config);
+  json::SerializationBuffer<> switch_json_(switch_::Switch *obj, bool value, JsonDetail start_config);
 #endif
 #ifdef USE_BUTTON
-  json::JsonBuffer<> button_json_(button::Button *obj, JsonDetail start_config);
+  json::SerializationBuffer<> button_json_(button::Button *obj, JsonDetail start_config);
 #endif
 #ifdef USE_BINARY_SENSOR
-  json::JsonBuffer<> binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value, JsonDetail start_config);
+  json::SerializationBuffer<> binary_sensor_json_(binary_sensor::BinarySensor *obj, bool value,
+                                                  JsonDetail start_config);
 #endif
 #ifdef USE_FAN
-  json::JsonBuffer<> fan_json_(fan::Fan *obj, JsonDetail start_config);
+  json::SerializationBuffer<> fan_json_(fan::Fan *obj, JsonDetail start_config);
 #endif
 #ifdef USE_LIGHT
-  json::JsonBuffer<> light_json_(light::LightState *obj, JsonDetail start_config);
+  json::SerializationBuffer<> light_json_(light::LightState *obj, JsonDetail start_config);
 #endif
 #ifdef USE_TEXT_SENSOR
-  json::JsonBuffer<> text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value, JsonDetail start_config);
+  json::SerializationBuffer<> text_sensor_json_(text_sensor::TextSensor *obj, const std::string &value,
+                                                JsonDetail start_config);
 #endif
 #ifdef USE_COVER
-  json::JsonBuffer<> cover_json_(cover::Cover *obj, JsonDetail start_config);
+  json::SerializationBuffer<> cover_json_(cover::Cover *obj, JsonDetail start_config);
 #endif
 #ifdef USE_NUMBER
-  json::JsonBuffer<> number_json_(number::Number *obj, float value, JsonDetail start_config);
+  json::SerializationBuffer<> number_json_(number::Number *obj, float value, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_DATE
-  json::JsonBuffer<> date_json_(datetime::DateEntity *obj, JsonDetail start_config);
+  json::SerializationBuffer<> date_json_(datetime::DateEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_TIME
-  json::JsonBuffer<> time_json_(datetime::TimeEntity *obj, JsonDetail start_config);
+  json::SerializationBuffer<> time_json_(datetime::TimeEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_DATETIME_DATETIME
-  json::JsonBuffer<> datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config);
+  json::SerializationBuffer<> datetime_json_(datetime::DateTimeEntity *obj, JsonDetail start_config);
 #endif
 #ifdef USE_TEXT
-  json::JsonBuffer<> text_json_(text::Text *obj, const std::string &value, JsonDetail start_config);
+  json::SerializationBuffer<> text_json_(text::Text *obj, const std::string &value, JsonDetail start_config);
 #endif
 #ifdef USE_SELECT
-  json::JsonBuffer<> select_json_(select::Select *obj, StringRef value, JsonDetail start_config);
+  json::SerializationBuffer<> select_json_(select::Select *obj, StringRef value, JsonDetail start_config);
 #endif
 #ifdef USE_CLIMATE
-  json::JsonBuffer<> climate_json_(climate::Climate *obj, JsonDetail start_config);
+  json::SerializationBuffer<> climate_json_(climate::Climate *obj, JsonDetail start_config);
 #endif
 #ifdef USE_LOCK
-  json::JsonBuffer<> lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
+  json::SerializationBuffer<> lock_json_(lock::Lock *obj, lock::LockState value, JsonDetail start_config);
 #endif
 #ifdef USE_VALVE
-  json::JsonBuffer<> valve_json_(valve::Valve *obj, JsonDetail start_config);
+  json::SerializationBuffer<> valve_json_(valve::Valve *obj, JsonDetail start_config);
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
-  json::JsonBuffer<> alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
-                                               alarm_control_panel::AlarmControlPanelState value,
-                                               JsonDetail start_config);
+  json::SerializationBuffer<> alarm_control_panel_json_(alarm_control_panel::AlarmControlPanel *obj,
+                                                        alarm_control_panel::AlarmControlPanelState value,
+                                                        JsonDetail start_config);
 #endif
 #ifdef USE_EVENT
-  json::JsonBuffer<> event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config);
+  json::SerializationBuffer<> event_json_(event::Event *obj, StringRef event_type, JsonDetail start_config);
 #endif
 #ifdef USE_WATER_HEATER
-  json::JsonBuffer<> water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config);
+  json::SerializationBuffer<> water_heater_json_(water_heater::WaterHeater *obj, JsonDetail start_config);
 #endif
 #ifdef USE_INFRARED
-  json::JsonBuffer<> infrared_json_(infrared::Infrared *obj, JsonDetail start_config);
+  json::SerializationBuffer<> infrared_json_(infrared::Infrared *obj, JsonDetail start_config);
 #endif
 #ifdef USE_UPDATE
-  json::JsonBuffer<> update_json_(update::UpdateEntity *obj, JsonDetail start_config);
+  json::SerializationBuffer<> update_json_(update::UpdateEntity *obj, JsonDetail start_config);
 #endif
 };
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -264,7 +264,7 @@ class WebServer : public Controller,
   void handle_index_request(AsyncWebServerRequest *request);
 
   /// Return the webserver configuration as JSON.
-  std::string get_config_json();
+  json::JsonBuffer<> get_config_json();
 
 #ifdef USE_WEBSERVER_CSS_INCLUDE
   /// Handle included css request under '/0.css'.

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -105,7 +105,7 @@ enum JsonDetail { DETAIL_ALL, DETAIL_STATE };
   can be forgotten.
 */
 #if !defined(USE_ESP32) && defined(USE_ARDUINO)
-using message_generator_t = std::string(WebServer *, void *);
+using message_generator_t = json::SerializationBuffer<>(WebServer *, void *);
 
 class DeferredUpdateEventSourceList;
 class DeferredUpdateEventSource : public AsyncEventSource {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -561,7 +561,7 @@ void AsyncEventSourceResponse::deq_push_back_with_dedup_(void *source, message_g
 void AsyncEventSourceResponse::process_deferred_queue_() {
   while (!deferred_queue_.empty()) {
     DeferredEvent &de = deferred_queue_.front();
-    std::string message = de.message_generator_(web_server_, de.source_);
+    auto message = de.message_generator_(web_server_, de.source_);
     if (this->try_send_nodefer(message.c_str(), "state")) {
       // O(n) but memory efficiency is more important than speed here which is why std::vector was chosen
       deferred_queue_.erase(deferred_queue_.begin());
@@ -798,7 +798,7 @@ void AsyncEventSourceResponse::deferrable_send_state(void *source, const char *e
     // trying to send first
     deq_push_back_with_dedup_(source, message_generator);
   } else {
-    std::string message = message_generator(web_server_, source);
+    auto message = message_generator(web_server_, source);
     if (!this->try_send_nodefer(message.c_str(), "state")) {
       deq_push_back_with_dedup_(source, message_generator);
     }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -507,7 +507,7 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
 
   // Configure reconnect timeout and send config
   // this should always go through since the tcp send buffer is empty on connect
-  std::string message = ws->get_config_json();
+  auto message = ws->get_config_json();
   this->try_send_nodefer(message.c_str(), "ping", millis(), 30000);
 
 #ifdef USE_WEBSERVER_SORTING

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #ifdef USE_WEBSERVER
+#include "esphome/components/json/json_util.h"
 #include "esphome/components/web_server/list_entities.h"
 #endif
 
@@ -250,7 +251,7 @@ class AsyncWebHandler {
 class AsyncEventSource;
 class AsyncEventSourceResponse;
 
-using message_generator_t = std::string(esphome::web_server::WebServer *, void *);
+using message_generator_t = json::JsonBuffer<>(esphome::web_server::WebServer *, void *);
 
 /*
   This class holds a pointer to the source component that wants to publish a state event, and a pointer to a function

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -251,7 +251,7 @@ class AsyncWebHandler {
 class AsyncEventSource;
 class AsyncEventSourceResponse;
 
-using message_generator_t = json::JsonBuffer<>(esphome::web_server::WebServer *, void *);
+using message_generator_t = json::SerializationBuffer<>(esphome::web_server::WebServer *, void *);
 
 /*
   This class holds a pointer to the source component that wants to publish a state event, and a pointer to a function

--- a/tests/components/json/common.yaml
+++ b/tests/components/json/common.yaml
@@ -4,15 +4,16 @@ interval:
   - interval: 60s
     then:
       - lambda: |-
-          // Test build_json
-          std::string json_str = esphome::json::build_json([](JsonObject root) {
+          // Test build_json - returns SerializationBuffer, use auto to avoid heap allocation
+          auto json_buf = esphome::json::build_json([](JsonObject root) {
             root["sensor"] = "temperature";
             root["value"] = 23.5;
             root["unit"] = "°C";
           });
-          ESP_LOGD("test", "Built JSON: %s", json_str.c_str());
+          ESP_LOGD("test", "Built JSON: %s", json_buf.c_str());
 
-          // Test parse_json
+          // Test parse_json - implicit conversion to std::string for backward compatibility
+          std::string json_str = json_buf;
           bool parse_ok = esphome::json::parse_json(json_str, [](JsonObject root) {
             if (root["sensor"].is<const char*>() && root["value"].is<float>()) {
               const char* sensor = root["sensor"];
@@ -26,10 +27,10 @@ interval:
           });
           ESP_LOGD("test", "Parse result (JSON syntax only): %s", parse_ok ? "success" : "failed");
 
-          // Test JsonBuilder class
+          // Test JsonBuilder class - returns SerializationBuffer
           esphome::json::JsonBuilder builder;
           JsonObject obj = builder.root();
           obj["test"] = "direct_builder";
           obj["count"] = 42;
-          std::string result = builder.serialize();
+          auto result = builder.serialize();
           ESP_LOGD("test", "JsonBuilder result: %s", result.c_str());


### PR DESCRIPTION
# What does this implement/fix?

Add `SerializationBuffer` class for stack-first JSON serialization to reduce heap fragmentation.

## Summary

This PR introduces a `SerializationBuffer<STACK_SIZE>` template class that uses stack allocation for small JSON payloads (up to 640 bytes by default) and falls back to heap allocation for larger payloads. This reduces heap fragmentation on long-running ESP devices by avoiding repeated small heap allocations for typical JSON messages.

### Key Design Decisions

**Stack buffer size (640 bytes)**: Chosen to balance stack usage vs heap avoidance. 640 bytes covers all typical JSON payloads including climate DETAIL_ALL (~520 bytes) while leaving sufficient stack headroom on the httpd task (4096 bytes). Only entities with many options (40+ select options, many custom climate presets) or very long text values trigger heap fallback.

**Heap fallback with buffer doubling**: When the payload exceeds the 640-byte stack buffer, the buffer is doubled (1280, 2560, up to 5120 max) and re-serialized until it fits. This is necessary because ArduinoJson's `serializeJson()` with a bounded buffer returns the actual bytes written (truncated count), NOT the would-be size like `snprintf()`. The doubling strategy avoids instantiating `measureJson()`'s DummyWriter templates (~736 bytes flash savings).

- **Common case (99.9%)**: Single serialize to stack buffer, no heap allocation
- **Rare case (large payloads)**: Double buffer and re-serialize (at most 2x temporary over-allocation, capped at 5120 bytes)

### Memory Impact

| Platform | Components | Flash | RAM |
|----------|------------|-------|-----|
| ESP32 IDF | api, json, mqtt, web_server, web_server_idf | +1,336 bytes (+0.11%) | +0 bytes |

Key flash contributors:
- `StaticStringWriter` serializer templates: ~809 bytes (core feature)
- Per-handler `SerializationBuffer` return type changes: ~300 bytes
- `JsonBuilder::serialize()` with doubling fallback: ~230 bytes

### NRVO Optimization

The `serialize()` function is carefully structured to enable NRVO (Named Return Value Optimization). The compiler constructs the `SerializationBuffer` directly in the caller's stack frame, eliminating move constructor overhead entirely.

Without NRVO, each return would memcpy up to 640 bytes. With NRVO, zero copies occur. The code includes extensive comments explaining how to maintain this optimization if the function is modified.

### Future Work

This `SerializationBuffer` pattern can be extended to other parts of the codebase to eliminate `std::string` heap allocations. The class provides:
- `c_str()` - null-terminated string access
- `data()` / `size()` - for APIs needing pointer + length
- `reallocate_heap()` - switch to heap when stack buffer is too small
- `operator std::string()` - implicit conversion for backward compatibility

Any code currently returning `std::string` from JSON building can be migrated to return `SerializationBuffer<>` to avoid heap allocations while maintaining API compatibility through the implicit conversion.

### Changes
- Add `SerializationBuffer<640>` template class in `json_util.h` with move semantics
- Change `JsonBuilder::serialize()` to return `SerializationBuffer<>` instead of `std::string`
- Change `build_json()` to return `SerializationBuffer<>` instead of `std::string`
- Update `json` component callers to use `SerializationBuffer<>` directly:
  - `web_server` and `web_server_idf`: All JSON generators for SSE events
  - `api/user_services.h`: Action response JSON
  - `mqtt`: `publish_json()` method
- Maintains backward compatibility via implicit `operator std::string()` conversion (e.g., `http_request` component)

### Typical JSON payload sizes (all fit in 640-byte stack buffer)
- Binary sensors: ~150-200 bytes
- Sensors: ~150-200 bytes
- Switches: ~170 bytes
- Buttons: ~130-150 bytes
- Numbers: ~200-250 bytes
- Lights (simple): ~170 bytes
- Climate DETAIL_ALL: ~520 bytes
- Climate (extreme presets): may trigger heap fallback

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

### Developer Breaking Change

`JsonBuilder::serialize()` and `build_json()` now return `json::SerializationBuffer<>` instead of `std::string`. The implicit `operator std::string()` conversion preserves most use cases, but code that chains string-specific methods on the return value (e.g., `.substr()`, `.find()`) will need to assign to a `std::string` first or use `c_str()` directly.

**Internal audit:** All internal callers have been updated to use `SerializationBuffer<>` directly where beneficial. Components that need `std::string` (like `http_request`) work unchanged via implicit conversion.

**Migration:**
```cpp
// Before (still works via implicit conversion)
std::string json = builder.serialize();
std::string json = json::build_json(f);

// Before (breaks - chaining string methods)
auto pos = builder.serialize().find("key");

// After (explicit conversion if needed)
std::string json = builder.serialize();
auto pos = json.find("key");

// Preferred (avoid heap allocation)
auto json = builder.serialize();
request->send(200, "application/json", json.c_str());
// Or use .data() and .size() for APIs needing pointer + length
send_data(json.data(), json.size());
```

**Related issue or feature (if applicable):**

- Reduces heap fragmentation for long-running devices with web_server or mqtt enabled

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
web_server:

mqtt:
  broker: mqtt.example.com

# Test buttons to verify SerializationBuffer with different payload sizes
button:
  - platform: template
    name: Test JSON 256B
    on_press:
      - lambda: |-
          // Build a ~256 byte JSON payload (fits in 640B stack buffer)
          auto buf = json::build_json([](JsonObject root) {
            root["test"] = "256byte_payload";
            root["id"] = "test_256";
            for (int i = 0; i < 10; i++) {
              char key[16];
              snprintf(key, sizeof(key), "field_%02d", i);
              root[key] = "abcdefghijk";
            }
          });
          ESP_LOGI("json_test", "256B test: total size=%zu", buf.size());
          const char *data = buf.c_str();
          size_t len = buf.size();
          for (size_t offset = 0; offset < len; offset += 128) {
            size_t chunk = std::min((size_t)128, len - offset);
            ESP_LOGI("json_test", "  [%zu-%zu]: %.*s", offset, offset + chunk, (int)chunk, data + offset);
          }

  - platform: template
    name: Test JSON 1024B
    on_press:
      - lambda: |-
          // Build a ~1024 byte JSON payload (exceeds 640B, tests heap fallback)
          auto buf = json::build_json([](JsonObject root) {
            root["test"] = "1024byte_payload";
            root["id"] = "test_1024";
            for (int i = 0; i < 40; i++) {
              char key[16];
              snprintf(key, sizeof(key), "field_%02d", i);
              root[key] = "abcdefghijklmnopqrstuv";
            }
          });
          ESP_LOGI("json_test", "1024B test: total size=%zu", buf.size());
          const char *data = buf.c_str();
          size_t len = buf.size();
          for (size_t offset = 0; offset < len; offset += 128) {
            size_t chunk = std::min((size_t)128, len - offset);
            ESP_LOGI("json_test", "  [%zu-%zu]: %.*s", offset, offset + chunk, (int)chunk, data + offset);
          }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes
