### PR TITLE
[core] ESP32 chip revision text

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -210,7 +210,7 @@ void Application::loop() {
 #ifdef USE_ESP32
       esp_chip_info_t chip_info;
       esp_chip_info(&chip_info);
-      ESP_LOGI(TAG, "ESP32 Chip: %s r%d.%d, %d core(s)", ESPHOME_VARIANT, chip_info.revision / 100,
+      ESP_LOGI(TAG, "ESP32 Chip: %s rev%d.%d, %d core(s)", ESPHOME_VARIANT, chip_info.revision / 100,
                chip_info.revision % 100, chip_info.cores);
 #if defined(USE_ESP32_VARIANT_ESP32) && !defined(USE_ESP32_MIN_CHIP_REVISION_SET)
       // Suggest optimization for chips that don't need the PSRAM cache workaround


### PR DESCRIPTION
Nitpick:
Changes `r` to `rev` for better readability
Espressif uses the `v3.0/v3.1` format.
The current merged format is `r3.0/r3.1`

The proposed format can be either `rev3.0/rev3.1` or `ver3.0/ver3.1`

https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/01-chip-identification/index.html
https://documentation.espressif.com/esp32_datasheet_en.pdf

I think we should move from using single letters because they can be confusing to many users

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
