### PR TITLE
[time] Use lazy callback for time sync to save 8 bytes

### DIFF
--- a/esphome/components/time/real_time_clock.h
+++ b/esphome/components/time/real_time_clock.h
@@ -62,7 +62,7 @@ class RealTimeClock : public PollingComponent {
   void apply_timezone_();
 #endif
 
-  CallbackManager<void()> time_sync_callback_;
+  LazyCallbackManager<void()> time_sync_callback_;
 };
 
 template<typename... Ts> class TimeHasTimeCondition : public Condition<Ts...> {


### PR DESCRIPTION
# What does this implement/fix?

Use `LazyCallbackManager` for `time_sync_callback_` in `RealTimeClock` to save 8 bytes in the common case where no time sync callbacks are registered.

Most users configure a time source (Home Assistant time or SNTP) without registering any `on_time_sync` callbacks. The callback is only used when:
- User explicitly configures an `on_time_sync` automation (rare)
- Specific components (bedjet, tuya, uponor_smatrix, wireguard, uptime_timestamp) are combined with a time source

Memory trade-off:
| Scenario | Before | After |
|----------|--------|-------|
| No callbacks (common) | 12 bytes | 4 bytes |
| Has callbacks (rare) | 12 bytes | 16 bytes |

Net savings of 8 bytes for the common case, at the cost of 4 extra bytes for the rare case when callbacks are actually registered.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
time:
  - platform: homeassistant
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
