### PR TITLE
[api] Align water_heater_command with standard entity command pattern

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -45,6 +45,7 @@ service APIConnection {
   rpc time_command (TimeCommandRequest) returns (void) {}
   rpc update_command (UpdateCommandRequest) returns (void) {}
   rpc valve_command (ValveCommandRequest) returns (void) {}
+  rpc water_heater_command (WaterHeaterCommandRequest) returns (void) {}
 
   rpc subscribe_bluetooth_le_advertisements(SubscribeBluetoothLEAdvertisementsRequest) returns (void) {}
   rpc bluetooth_device_request(BluetoothDeviceRequest) returns (void) {}

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1385,7 +1385,7 @@ uint16_t APIConnection::try_send_water_heater_info(EntityBase *entity, APIConnec
                                      is_single);
 }
 
-void APIConnection::on_water_heater_command_request(const WaterHeaterCommandRequest &msg) {
+void APIConnection::water_heater_command(const WaterHeaterCommandRequest &msg) {
   ENTITY_COMMAND_MAKE_CALL(water_heater::WaterHeater, water_heater, water_heater)
   if (msg.has_fields & enums::WATER_HEATER_COMMAND_HAS_MODE)
     call.set_mode(static_cast<water_heater::WaterHeaterMode>(msg.mode));

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -170,7 +170,7 @@ class APIConnection final : public APIServerConnection {
 
 #ifdef USE_WATER_HEATER
   bool send_water_heater_state(water_heater::WaterHeater *water_heater);
-  void on_water_heater_command_request(const WaterHeaterCommandRequest &msg) override;
+  void water_heater_command(const WaterHeaterCommandRequest &msg) override;
 #endif
 
 #ifdef USE_IR_RF

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -746,6 +746,11 @@ void APIServerConnection::on_update_command_request(const UpdateCommandRequest &
 #ifdef USE_VALVE
 void APIServerConnection::on_valve_command_request(const ValveCommandRequest &msg) { this->valve_command(msg); }
 #endif
+#ifdef USE_WATER_HEATER
+void APIServerConnection::on_water_heater_command_request(const WaterHeaterCommandRequest &msg) {
+  this->water_heater_command(msg);
+}
+#endif
 #ifdef USE_BLUETOOTH_PROXY
 void APIServerConnection::on_subscribe_bluetooth_le_advertisements_request(
     const SubscribeBluetoothLEAdvertisementsRequest &msg) {

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -303,6 +303,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #ifdef USE_VALVE
   virtual void valve_command(const ValveCommandRequest &msg) = 0;
 #endif
+#ifdef USE_WATER_HEATER
+  virtual void water_heater_command(const WaterHeaterCommandRequest &msg) = 0;
+#endif
 #ifdef USE_BLUETOOTH_PROXY
   virtual void subscribe_bluetooth_le_advertisements(const SubscribeBluetoothLEAdvertisementsRequest &msg) = 0;
 #endif
@@ -431,6 +434,9 @@ class APIServerConnection : public APIServerConnectionBase {
 #endif
 #ifdef USE_VALVE
   void on_valve_command_request(const ValveCommandRequest &msg) override;
+#endif
+#ifdef USE_WATER_HEATER
+  void on_water_heater_command_request(const WaterHeaterCommandRequest &msg) override;
 #endif
 #ifdef USE_BLUETOOTH_PROXY
   void on_subscribe_bluetooth_le_advertisements_request(const SubscribeBluetoothLEAdvertisementsRequest &msg) override;


### PR DESCRIPTION
# What does this implement/fix?

Fix water_heater to use the same command pattern as other entity types.

The water_heater component was using an inconsistent pattern compared to other entity commands (valve, climate, fan, etc.). While it worked, it bypassed the standard service layer:

**Other entities (correct pattern):**
1. Message dispatch calls `on_X_command_request()`
2. `APIServerConnection::on_X_command_request()` calls pure virtual `X_command()`
3. `APIConnection::X_command()` implements the actual logic

**water_heater (old pattern):**
1. Message dispatch calls `on_water_heater_command_request()`
2. `APIConnection::on_water_heater_command_request()` overrides directly with the logic
3. No `water_heater_command()` method existed

This inconsistency caused compilation failures when the generated service files included the RPC declaration (which creates the pure virtual `water_heater_command`).

**Changes:**
- Added `rpc water_heater_command (WaterHeaterCommandRequest) returns (void) {}` to `api.proto`
- Renamed `APIConnection::on_water_heater_command_request` to `APIConnection::water_heater_command` to match the expected pattern

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host

## Example entry for `config.yaml`:

```yaml
water_heater:
  - platform: template
    name: "Test Boiler"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). -- integration tests already cover this for water heater

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - existing feature)
