### PR TITLE
[esp32_hosted] Replace sscanf with strtol for version parsing

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -34,14 +34,29 @@ static const char *const ESP_HOSTED_VERSION_STR = STRINGIFY(ESP_HOSTED_VERSION_M
     ESP_HOSTED_VERSION_MINOR_1) "." STRINGIFY(ESP_HOSTED_VERSION_PATCH_1);
 
 #ifdef USE_ESP32_HOSTED_HTTP_UPDATE
+// Parse an integer from str, advancing ptr past the number
+// Returns false if no digits were parsed
+static bool parse_int(const char *&ptr, int &value) {
+  char *end;
+  value = static_cast<int>(strtol(ptr, &end, 10));
+  if (end == ptr)
+    return false;
+  ptr = end;
+  return true;
+}
+
 // Parse version string "major.minor.patch" into components
-// Returns true if parsing succeeded
+// Returns true if at least major.minor was parsed
 static bool parse_version(const std::string &version_str, int &major, int &minor, int &patch) {
   major = minor = patch = 0;
-  if (sscanf(version_str.c_str(), "%d.%d.%d", &major, &minor, &patch) >= 2) {
-    return true;
-  }
-  return false;
+  const char *ptr = version_str.c_str();
+
+  if (!parse_int(ptr, major) || *ptr++ != '.' || !parse_int(ptr, minor))
+    return false;
+  if (*ptr == '.')
+    parse_int(++ptr, patch);
+
+  return true;
 }
 
 // Compare two versions, returns:


### PR DESCRIPTION
# What does this implement/fix?

Replace `sscanf()` with `strtol()` for version string parsing in esp32_hosted, eliminating the scanf dependency from this component.

This is a follow-up to #13657 which added a CI check blocking new scanf usage. That PR added NOLINT to this file as a temporary measure - this PR properly refactors the code.

## Changes

Replaced the sscanf-based version parser:
```cpp
// Before
sscanf(version_str.c_str(), "%d.%d.%d", &major, &minor, &patch)

// After - uses strtol with a small helper
static bool parse_int(const char *&ptr, int &value);
```

The new implementation:
- Parses "major.minor.patch" format (patch is optional)
- Matches original sscanf behavior exactly (verified with 16 test cases)
- Uses `strtol()` which is already linked by other code (no new dependencies)

**Test file attached:** `esp32_hosted_parse_version_tests.zip` - compile and run with:
```bash
g++ -std=c++11 -o test_parse_version test_parse_version.cpp && ./test_parse_version
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13657 (CI check blocking new scanf usage)
- Part of #13635 effort (eliminating scanf bloat)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactoring)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Only affects ESP32-H2 and ESP32-P4 variants with esp32_hosted component.

## Example entry for `config.yaml`:

```yaml
# N/A - internal refactoring, no config changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (attached to this PR)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
