### PR TITLE
[max7219] Allocate buffer in constructor

### DIFF
--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -28,11 +28,10 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NUM_CHIPS])
     await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
-    cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
     cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
 

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max7219 {
+namespace esphome::max7219 {
 
 static const char *const TAG = "max7219";
 
@@ -115,12 +114,14 @@ const uint8_t MAX7219_ASCII_TO_RAW[95] PROGMEM = {
 };
 
 float MAX7219Component::get_setup_priority() const { return setup_priority::PROCESSOR; }
+
+MAX7219Component::MAX7219Component(uint8_t num_chips) : num_chips_(num_chips) {
+  this->buffer_ = new uint8_t[this->num_chips_ * 8];  // NOLINT
+  memset(this->buffer_, 0, this->num_chips_ * 8);
+}
+
 void MAX7219Component::setup() {
   this->spi_setup();
-  this->buffer_ = new uint8_t[this->num_chips_ * 8];  // NOLINT
-  for (uint8_t i = 0; i < this->num_chips_ * 8; i++)
-    this->buffer_[i] = 0;
-
   // let's assume the user has all 8 digits connected, only important in daisy chained setups anyway
   this->send_to_all_(MAX7219_REGISTER_SCAN_LIMIT, 7);
   // let's use our own ASCII -> led pattern encoding
@@ -229,7 +230,6 @@ void MAX7219Component::set_intensity(uint8_t intensity) {
     this->intensity_ = intensity;
   }
 }
-void MAX7219Component::set_num_chips(uint8_t num_chips) { this->num_chips_ = num_chips; }
 
 uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time) {
   char buffer[64];
@@ -240,5 +240,4 @@ uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time
 }
 uint8_t MAX7219Component::strftime(const char *format, ESPTime time) { return this->strftime(0, format, time); }
 
-}  // namespace max7219
-}  // namespace esphome
+}  // namespace esphome::max7219

--- a/esphome/components/max7219/max7219.h
+++ b/esphome/components/max7219/max7219.h
@@ -6,8 +6,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display.h"
 
-namespace esphome {
-namespace max7219 {
+namespace esphome::max7219 {
 
 class MAX7219Component;
 
@@ -17,6 +16,8 @@ class MAX7219Component : public PollingComponent,
                          public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
  public:
+  explicit MAX7219Component(uint8_t num_chips);
+
   void set_writer(max7219_writer_t &&writer);
 
   void setup() override;
@@ -30,7 +31,6 @@ class MAX7219Component : public PollingComponent,
   void display();
 
   void set_intensity(uint8_t intensity);
-  void set_num_chips(uint8_t num_chips);
   void set_reverse(bool reverse) { this->reverse_ = reverse; };
 
   /// Evaluate the printf-format and print the result at the given position.
@@ -56,10 +56,9 @@ class MAX7219Component : public PollingComponent,
   uint8_t intensity_{15};     // Intensity of the display from 0 to 15 (most)
   bool intensity_changed_{};  // True if we need to re-send the intensity
   uint8_t num_chips_{1};
-  uint8_t *buffer_;
+  uint8_t *buffer_{nullptr};
   bool reverse_{false};
   max7219_writer_t writer_{};
 };
 
-}  // namespace max7219
-}  // namespace esphome
+}  // namespace esphome::max7219


### PR DESCRIPTION
# What does this implement/fix?

Move buffer allocation from `setup()` to constructor to prevent potential crashes if `print()` is called before `setup()` completes. Previously, the buffer pointer was uninitialized and any call to `print()`, `printf()`, or `strftime()` before `setup()` would access invalid memory.

Changes:
- Add explicit constructor taking `num_chips` parameter
- Allocate and zero-initialize buffer in constructor using `memset`
- Remove `set_num_chips()` method, pass `num_chips` to constructor instead
- Initialize buffer pointer to `nullptr`
- Modernize to C++17 nested namespace syntax

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23

display:
  - platform: max7219
    cs_pin: GPIO5
    num_chips: 4
    intensity: 10
    lambda: |-
      it.print("1234");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).