### PR TITLE
[esp32] Disable unused per-tag log filtering, saving ~536 bytes RAM

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1329,6 +1329,10 @@ async def to_code(config):
     # Disable dynamic log level control to save memory
     add_idf_sdkconfig_option("CONFIG_LOG_DYNAMIC_LEVEL_CONTROL", False)
 
+    # Disable per-tag log level filtering since dynamic level control is disabled above
+    # This saves ~250 bytes of RAM (tag cache) and associated code
+    add_idf_sdkconfig_option("CONFIG_LOG_TAG_LEVEL_IMPL_NONE", True)
+
     # Reduce PHY TX power in the event of a brownout
     add_idf_sdkconfig_option("CONFIG_ESP_PHY_REDUCE_TX_POWER", True)
 

--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -11,12 +11,6 @@ namespace i2c {
 static const char *const TAG = "i2c";
 
 void I2CBus::i2c_scan_() {
-  // suppress logs from the IDF I2C library during the scan
-#if defined(USE_ESP32) && defined(USE_LOGGER)
-  auto previous = esp_log_level_get("*");
-  esp_log_level_set("*", ESP_LOG_NONE);
-#endif
-
   for (uint8_t address = 8; address != 120; address++) {
     auto err = write_readv(address, nullptr, 0, nullptr, 0);
     if (err == ERROR_OK) {
@@ -27,9 +21,6 @@ void I2CBus::i2c_scan_() {
     // it takes 16sec to scan on nrf52. It prevents board reset.
     arch_feed_wdt();
   }
-#if defined(USE_ESP32) && defined(USE_LOGGER)
-  esp_log_level_set("*", previous);
-#endif
 }
 
 ErrorCode I2CDevice::read_register(uint8_t a_register, uint8_t *data, size_t len) {

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -114,9 +114,6 @@ void Logger::pre_setup() {
 
   global_logger = this;
   esp_log_set_vprintf(esp_idf_log_vprintf_);
-  if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE) {
-    esp_log_level_set("*", ESP_LOG_VERBOSE);
-  }
 
   ESP_LOGI(TAG, "Log initialized");
 }

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -155,8 +155,9 @@ void USBCDCACMInstance::setup() {
     return;
   }
 
-  // Use a larger stack size for (very) verbose logging
-  const size_t stack_size = esp_log_level_get(TAG) > ESP_LOG_DEBUG ? USB_TX_TASK_STACK_SIZE_VV : USB_TX_TASK_STACK_SIZE;
+  // Use a larger stack size for very verbose logging
+  constexpr size_t stack_size =
+      ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE ? USB_TX_TASK_STACK_SIZE_VV : USB_TX_TASK_STACK_SIZE;
 
   // Create a simple, unique task name per interface
   char task_name[] = "usb_tx_0";


### PR DESCRIPTION
# What does this implement/fix?

Disables ESP-IDF's per-tag log level filtering and removes dead [`esp_log_level_set`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html#_CPPv417esp_log_level_setPKc15esp_log_level_t) calls, saving ~536 bytes RAM and ~3KB flash.

Since `CONFIG_LOG_DYNAMIC_LEVEL_CONTROL=False` was already set (June 2025, #9233), [`esp_log_level_set()`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html#_CPPv417esp_log_level_setPKc15esp_log_level_t) is a no-op - the log level is fixed at compile time. This means:

1. The `s_log_cache` (248-byte binary min-heap for tag→level lookups) and associated functions are never used
2. All `esp_log_level_set()` calls in ESPHome are dead code

**Note:** The I2C log suppression code was added in August 2025 (#10389), two months *after* dynamic log level control was disabled. This means the I2C log suppression **never actually worked** - it was dead code from the moment it was merged.

Changes:
- **esp32**: Add `CONFIG_LOG_TAG_LEVEL_IMPL_NONE=True` to eliminate the unused tag cache
- **logger**: Remove dead [`esp_log_level_set("*", ESP_LOG_VERBOSE)`](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html#_CPPv417esp_log_level_setPKc15esp_log_level_t) call
- **i2c**: Remove dead log suppression code (was always a no-op since it was added after #9233)
- **usb_cdc_acm**: Replace fake runtime log level check with compile-time `constexpr` using `ESPHOME_LOG_LEVEL`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
