### PR TITLE
[mqtt] Extend host platform support (native MQTT + dashboard status)

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -115,8 +115,12 @@ void APIServer::setup() {
 }
 
 void APIServer::loop() {
-  // Accept new clients only if the socket exists and has incoming connections
-  if (this->socket_ && this->socket_->ready()) {
+  // Accept new clients if the socket exists.
+  //
+  // On some platforms (notably host/native), select()-based readiness tracking can miss
+  // pending accepts, which leads to the connection backlog filling up and clients timing out.
+  // Since the server socket is non-blocking, it's safe to try accept() unconditionally.
+  if (this->socket_) {
     while (true) {
       struct sockaddr_storage source_addr;
       socklen_t addr_len = sizeof(source_addr);

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -58,6 +58,7 @@ from esphome.const import (
     PLATFORM_BK72XX,
     PLATFORM_ESP32,
     PLATFORM_ESP8266,
+    PLATFORM_HOST,
     PLATFORM_RTL87XX,
     PlatformFramework,
 )
@@ -332,7 +333,15 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     validate_config,
-    cv.only_on([PLATFORM_ESP32, PLATFORM_ESP8266, PLATFORM_BK72XX, PLATFORM_RTL87XX]),
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_RTL87XX,
+            PLATFORM_HOST,
+        ]
+    ),
     _consume_mqtt_sockets,
 )
 
@@ -351,6 +360,12 @@ def exp_mqtt_message(config):
 
 @coroutine_with_priority(CoroPriority.WEB)
 async def to_code(config):
+    if CORE.is_host:
+        # Host MQTT is intended for development/testing and may not have feature parity
+        # with embedded targets yet.
+        cg.add_define("USE_MQTT_HOST_EXPERIMENTAL")
+        # Native host backend uses a small C MQTT implementation.
+        cg.add_library("MQTT-C", None, "https://github.com/LiamBindle/MQTT-C#v1.1.6")
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/mqtt/mqtt_backend_host.cpp
+++ b/esphome/components/mqtt/mqtt_backend_host.cpp
@@ -1,0 +1,281 @@
+#include "mqtt_backend_host.h"
+
+#ifdef USE_MQTT
+#ifdef USE_HOST
+
+#include <cerrno>
+#include <cstring>
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace esphome::mqtt {
+
+MQTTBackendHost::MQTTBackendHost() = default;
+
+void MQTTBackendHost::set_credentials(const char *username, const char *password) {
+  this->username_ = username ? username : "";
+  this->password_ = password ? password : "";
+}
+
+void MQTTBackendHost::set_will(const char *topic, uint8_t qos, bool retain, const char *payload) {
+  this->will_topic_ = topic ? topic : "";
+  this->will_qos_ = qos;
+  this->will_retain_ = retain;
+  this->will_payload_ = payload ? payload : "";
+}
+
+void MQTTBackendHost::set_server(network::IPAddress ip, uint16_t port) {
+  char buf[network::IP_ADDRESS_BUFFER_SIZE];
+  ip.str_to(buf);
+  this->host_ = buf;
+  this->port_ = port;
+}
+
+void MQTTBackendHost::set_server(const char *host, uint16_t port) {
+  this->host_ = host ? host : "";
+  this->port_ = port;
+}
+
+bool MQTTBackendHost::open_socket_() {
+  if (this->host_.empty()) {
+    return false;
+  }
+
+  char port_str[6];
+  snprintf(port_str, sizeof(port_str), "%u", this->port_);
+
+  struct addrinfo hints {};
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_family = AF_UNSPEC;
+
+  struct addrinfo *res = nullptr;
+  int gai = ::getaddrinfo(this->host_.c_str(), port_str, &hints, &res);
+  if (gai != 0) {
+    return false;
+  }
+
+  int fd = -1;
+  for (struct addrinfo *ai = res; ai != nullptr; ai = ai->ai_next) {
+    fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (fd < 0)
+      continue;
+
+    // Blocking connect is OK here (host only), but keep it short using OS defaults.
+    if (::connect(fd, ai->ai_addr, ai->ai_addrlen) == 0) {
+      break;
+    }
+
+    ::close(fd);
+    fd = -1;
+  }
+
+  ::freeaddrinfo(res);
+
+  if (fd < 0) {
+    return false;
+  }
+
+  // mqtt-c expects a non-blocking socket.
+  int flags = ::fcntl(fd, F_GETFL, 0);
+  if (flags >= 0) {
+    ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  }
+
+  this->socket_fd_ = fd;
+  return true;
+}
+
+void MQTTBackendHost::close_socket_() {
+  if (this->socket_fd_ >= 0) {
+    ::close(this->socket_fd_);
+    this->socket_fd_ = -1;
+  }
+}
+
+void MQTTBackendHost::mark_disconnected_(MQTTClientDisconnectReason reason) {
+  if (!this->connected_ && this->socket_fd_ < 0) {
+    return;
+  }
+  this->connected_ = false;
+  this->connack_seen_ = false;
+  this->close_socket_();
+  if (this->on_disconnect_) {
+    this->on_disconnect_(reason);
+  }
+}
+
+void MQTTBackendHost::connect() {
+  if (this->connected_) {
+    return;
+  }
+
+  this->disconnect();
+
+  if (!this->open_socket_()) {
+    this->mark_disconnected_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+    return;
+  }
+
+  // Initialize mqtt-c client.
+  this->connack_seen_ = false;
+  mqtt_init(&this->client_, this->socket_fd_, this->tx_buf_, sizeof(this->tx_buf_), this->rx_buf_,
+            sizeof(this->rx_buf_), &MQTTBackendHost::publish_callback_);
+  // publish_callback_ will receive `this` as state
+  this->client_.publish_response_callback_state = this;
+
+  uint8_t connect_flags = 0;
+  if (this->clean_session_) {
+    connect_flags |= MQTT_CONNECT_CLEAN_SESSION;
+  }
+  if (!this->will_topic_.empty()) {
+    connect_flags |= MQTT_CONNECT_WILL_FLAG;
+    // mqtt-c defaults will QoS to 0 if not set; set explicitly.
+    connect_flags &= (uint8_t) ~0x18;
+    connect_flags |= (uint8_t) ((this->will_qos_ & 0x03) << 3);
+    if (this->will_retain_) {
+      connect_flags |= MQTT_CONNECT_WILL_RETAIN;
+    }
+  }
+
+  const char *will_topic = this->will_topic_.empty() ? nullptr : this->will_topic_.c_str();
+  const void *will_msg = this->will_topic_.empty() ? nullptr : (const void *) this->will_payload_.data();
+  size_t will_len = this->will_topic_.empty() ? 0 : this->will_payload_.size();
+
+  const char *username = this->username_.empty() ? nullptr : this->username_.c_str();
+  const char *password = this->password_.empty() ? nullptr : this->password_.c_str();
+
+  mqtt_connect(&this->client_, this->client_id_.empty() ? nullptr : this->client_id_.c_str(), will_topic, will_msg,
+               will_len, username, password, connect_flags, this->keep_alive_);
+
+  // Complete handshake synchronously; connack sets typical_response_time from -1.
+  for (int i = 0; i < 100; i++) {  // ~100 iterations best-effort; loop() will continue later.
+    auto err = mqtt_sync(&this->client_);
+    if (err != MQTT_OK) {
+      this->mark_disconnected_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+      return;
+    }
+    if (this->client_.typical_response_time >= 0.0) {
+      this->connack_seen_ = true;
+      break;
+    }
+    // Small sleep to avoid spinning if broker is slow.
+    ::usleep(10 * 1000);
+  }
+
+  if (!this->connack_seen_) {
+    this->mark_disconnected_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+    return;
+  }
+
+  this->connected_ = true;
+  if (this->on_connect_) {
+    this->on_connect_(false);
+  }
+}
+
+void MQTTBackendHost::disconnect() {
+  if (this->socket_fd_ < 0) {
+    this->connected_ = false;
+    this->connack_seen_ = false;
+    return;
+  }
+
+  // Best effort graceful disconnect.
+  mqtt_disconnect(&this->client_);
+  (void) mqtt_sync(&this->client_);
+  this->mark_disconnected_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+}
+
+bool MQTTBackendHost::subscribe(const char *topic, uint8_t qos) {
+  if (!this->connected_ || topic == nullptr) {
+    return false;
+  }
+  auto err = mqtt_subscribe(&this->client_, topic, qos);
+  if (err != MQTT_OK) {
+    return false;
+  }
+  (void) mqtt_sync(&this->client_);
+  // mqtt-c does not expose SUBACK packet id; call callback with 0 to mirror best-effort semantics.
+  if (this->on_subscribe_) {
+    this->on_subscribe_(0, qos);
+  }
+  return true;
+}
+
+bool MQTTBackendHost::unsubscribe(const char *topic) {
+  if (!this->connected_ || topic == nullptr) {
+    return false;
+  }
+  auto err = mqtt_unsubscribe(&this->client_, topic);
+  if (err != MQTT_OK) {
+    return false;
+  }
+  (void) mqtt_sync(&this->client_);
+  if (this->on_unsubscribe_) {
+    this->on_unsubscribe_(0);
+  }
+  return true;
+}
+
+bool MQTTBackendHost::publish(const char *topic, const char *payload, size_t length, uint8_t qos, bool retain) {
+  if (!this->connected_ || topic == nullptr) {
+    return false;
+  }
+
+  uint8_t flags = 0;
+  if (retain)
+    flags |= MQTT_PUBLISH_RETAIN;
+  // qos bits are 1..2 in flags:
+  flags |= (uint8_t) ((qos & 0x03) << 1);
+
+  auto err = mqtt_publish(&this->client_, topic, payload, length, flags);
+  if (err != MQTT_OK) {
+    return false;
+  }
+  (void) mqtt_sync(&this->client_);
+  if (this->on_publish_) {
+    this->on_publish_(0);
+  }
+  return true;
+}
+
+void MQTTBackendHost::loop() {
+  if (!this->connected_) {
+    return;
+  }
+  auto err = mqtt_sync(&this->client_);
+  if (err != MQTT_OK) {
+    this->mark_disconnected_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+  }
+}
+
+void MQTTBackendHost::publish_callback_(void **state, mqtt_response_publish *publish) {
+  if (state == nullptr || publish == nullptr)
+    return;
+  auto *self = static_cast<MQTTBackendHost *>(*state);
+  if (self == nullptr)
+    return;
+  self->on_publish_received_(publish);
+}
+
+void MQTTBackendHost::on_publish_received_(mqtt_response_publish *publish) {
+  if (!this->on_message_) {
+    return;
+  }
+  const auto *topic_ptr = static_cast<const char *>(publish->topic_name);
+  const auto *payload_ptr = static_cast<const char *>(publish->application_message);
+
+  std::string topic(topic_ptr, topic_ptr + publish->topic_name_size);
+  // mqtt-c gives us a full payload buffer; report as single chunk.
+  this->on_message_(topic.c_str(), payload_ptr, publish->application_message_size, 0,
+                    publish->application_message_size);
+}
+
+}  // namespace esphome::mqtt
+
+#endif  // USE_HOST
+#endif  // USE_MQTT

--- a/esphome/components/mqtt/mqtt_backend_host.h
+++ b/esphome/components/mqtt/mqtt_backend_host.h
@@ -41,7 +41,7 @@ class MQTTBackendHost final : public MQTTBackend {
   void set_on_publish(std::function<on_publish_user_callback_t> &&callback) final {
     this->on_publish_ = std::move(callback);
   }
- 
+
   bool connected() const final { return this->connected_; }
   void connect() final;
   void disconnect() final;

--- a/esphome/components/mqtt/mqtt_backend_host.h
+++ b/esphome/components/mqtt/mqtt_backend_host.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "mqtt_backend.h"
+
+#ifdef USE_MQTT
+#ifdef USE_HOST
+
+#include <mqtt.h>
+
+#include <functional>
+#include <string>
+
+namespace esphome::mqtt {
+
+class MQTTBackendHost final : public MQTTBackend {
+ public:
+  MQTTBackendHost();
+
+  void set_keep_alive(uint16_t keep_alive) final { this->keep_alive_ = keep_alive; }
+  void set_client_id(const char *client_id) final { this->client_id_ = client_id ? client_id : ""; }
+  void set_clean_session(bool clean_session) final { this->clean_session_ = clean_session; }
+  void set_credentials(const char *username, const char *password) final;
+  void set_will(const char *topic, uint8_t qos, bool retain, const char *payload) final;
+  void set_server(network::IPAddress ip, uint16_t port) final;
+  void set_server(const char *host, uint16_t port) final;
+  void set_on_connect(std::function<on_connect_callback_t> &&callback) final {
+    this->on_connect_ = std::move(callback);
+  }
+  void set_on_disconnect(std::function<on_disconnect_callback_t> &&callback) final {
+    this->on_disconnect_ = std::move(callback);
+  }
+  void set_on_subscribe(std::function<on_subscribe_callback_t> &&callback) final {
+    this->on_subscribe_ = std::move(callback);
+  }
+  void set_on_unsubscribe(std::function<on_unsubscribe_callback_t> &&callback) final {
+    this->on_unsubscribe_ = std::move(callback);
+  }
+  void set_on_message(std::function<on_message_callback_t> &&callback) final {
+    this->on_message_ = std::move(callback);
+  }
+  void set_on_publish(std::function<on_publish_user_callback_t> &&callback) final {
+    this->on_publish_ = std::move(callback);
+  }
+ 
+  bool connected() const final { return this->connected_; }
+  void connect() final;
+  void disconnect() final;
+  bool subscribe(const char *topic, uint8_t qos) final;
+  bool unsubscribe(const char *topic) final;
+  bool publish(const char *topic, const char *payload, size_t length, uint8_t qos, bool retain) final;
+  using MQTTBackend::publish;
+
+  void loop() final;
+
+ protected:
+  static void publish_callback_(void **state, mqtt_response_publish *publish);
+  void on_publish_received_(mqtt_response_publish *publish);
+
+  bool open_socket_();
+  void close_socket_();
+  void mark_disconnected_(MQTTClientDisconnectReason reason);
+
+  std::string host_;
+  uint16_t port_{1883};
+
+  std::string client_id_;
+  bool clean_session_{false};
+  uint16_t keep_alive_{15};
+
+  std::string username_;
+  std::string password_;
+
+  std::string will_topic_;
+  std::string will_payload_;
+  uint8_t will_qos_{0};
+  bool will_retain_{false};
+
+  int socket_fd_{-1};
+  bool connected_{false};
+
+  mqtt_client client_{};
+  // mqtt-c expects tx buffer to be word-aligned on some platforms. Align defensively.
+  alignas(4) uint8_t tx_buf_[4096];
+  uint8_t rx_buf_[4096];
+
+  // mqtt-c sets typical_response_time to -1 until CONNACK is processed.
+  bool connack_seen_{false};
+
+  std::function<on_connect_callback_t> on_connect_{};
+  std::function<on_disconnect_callback_t> on_disconnect_{};
+  std::function<on_subscribe_callback_t> on_subscribe_{};
+  std::function<on_unsubscribe_callback_t> on_unsubscribe_{};
+  std::function<on_message_callback_t> on_message_{};
+  std::function<on_publish_user_callback_t> on_publish_{};
+};
+
+}  // namespace esphome::mqtt
+
+#endif  // USE_HOST
+#endif  // USE_MQTT

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -12,8 +12,10 @@
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
 #endif
+#ifndef USE_HOST
 #include "lwip/dns.h"
 #include "lwip/err.h"
+#endif
 #include "mqtt_component.h"
 
 #ifdef USE_API
@@ -29,6 +31,7 @@ static const char *const TAG = "mqtt";
 
 MQTTClientComponent::MQTTClientComponent() {
   global_mqtt_client = this;
+  this->mqtt_backend_interface_ = &this->mqtt_backend_;
   char mac_addr[MAC_ADDRESS_BUFFER_SIZE];
   get_mac_address_into_buffer(mac_addr);
   this->credentials_.client_id = make_name_with_suffix(App.get_name(), '-', mac_addr, MAC_ADDRESS_BUFFER_SIZE - 1);
@@ -36,7 +39,7 @@ MQTTClientComponent::MQTTClientComponent() {
 
 // Connection
 void MQTTClientComponent::setup() {
-  this->mqtt_backend_.set_on_message(
+  this->mqtt_backend_ref_().set_on_message(
       [this](const char *topic, const char *payload, size_t len, size_t index, size_t total) {
         if (index == 0)
           this->payload_buffer_.reserve(total);
@@ -50,7 +53,7 @@ void MQTTClientComponent::setup() {
           this->payload_buffer_.clear();
         }
       });
-  this->mqtt_backend_.set_on_disconnect([this](MQTTClientDisconnectReason reason) {
+  this->mqtt_backend_ref_().set_on_disconnect([this](MQTTClientDisconnectReason reason) {
     if (this->state_ == MQTT_CLIENT_DISABLED)
       return;
     this->state_ = MQTT_CLIENT_DISCONNECTED;
@@ -216,6 +219,12 @@ void MQTTClientComponent::start_dnslookup_() {
   this->status_set_warning();
   this->dns_resolve_error_ = false;
   this->dns_resolved_ = false;
+#ifdef USE_HOST
+  // On host, let the MQTT backend/OS resolver handle hostname resolution.
+  // We still reset subscriptions above to match embedded behavior.
+  this->start_connect_();
+  return;
+#else
   ip_addr_t addr;
   err_t err;
   {
@@ -226,7 +235,7 @@ void MQTTClientComponent::start_dnslookup_() {
 #else
     err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr, MQTTClientComponent::dns_found_callback,
                                      this, LWIP_DNS_ADDRTYPE_IPV4);
-#endif /* USE_NETWORK_IPV6 */
+#endif  /* USE_NETWORK_IPV6 */
   }
   switch (err) {
     case ERR_OK: {
@@ -251,8 +260,13 @@ void MQTTClientComponent::start_dnslookup_() {
 
   this->state_ = MQTT_CLIENT_RESOLVING_ADDRESS;
   this->connect_begin_ = millis();
+#endif  // USE_HOST
 }
 void MQTTClientComponent::check_dnslookup_() {
+#ifdef USE_HOST
+  // Host does not use LwIP DNS resolution.
+  return;
+#else
   if (!this->dns_resolved_ && millis() - this->connect_begin_ > 20000) {
     this->dns_resolve_error_ = true;
   }
@@ -272,7 +286,9 @@ void MQTTClientComponent::check_dnslookup_() {
   char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
   ESP_LOGD(TAG, "Resolved broker IP address to %s", this->ip_.str_to(ip_buf));
   this->start_connect_();
+#endif  // USE_HOST
 }
+#ifndef USE_HOST
 #if defined(USE_ESP8266) && LWIP_VERSION_MAJOR == 1
 void MQTTClientComponent::dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg) {
 #else
@@ -286,6 +302,7 @@ void MQTTClientComponent::dns_found_callback(const char *name, const ip_addr_t *
     a_this->dns_resolved_ = true;
   }
 }
+#endif  // !USE_HOST
 
 void MQTTClientComponent::start_connect_() {
   if (!network::is_connected())
@@ -293,10 +310,10 @@ void MQTTClientComponent::start_connect_() {
 
   ESP_LOGI(TAG, "Connecting");
   // Force disconnect first
-  this->mqtt_backend_.disconnect();
+  this->mqtt_backend_ref_().disconnect();
 
-  this->mqtt_backend_.set_client_id(this->credentials_.client_id.c_str());
-  this->mqtt_backend_.set_clean_session(this->credentials_.clean_session);
+  this->mqtt_backend_ref_().set_client_id(this->credentials_.client_id.c_str());
+  this->mqtt_backend_ref_().set_clean_session(this->credentials_.clean_session);
   const char *username = nullptr;
   if (!this->credentials_.username.empty())
     username = this->credentials_.username.c_str();
@@ -304,24 +321,24 @@ void MQTTClientComponent::start_connect_() {
   if (!this->credentials_.password.empty())
     password = this->credentials_.password.c_str();
 
-  this->mqtt_backend_.set_credentials(username, password);
+  this->mqtt_backend_ref_().set_credentials(username, password);
 
-  this->mqtt_backend_.set_server(this->credentials_.address.c_str(), this->credentials_.port);
+  this->mqtt_backend_ref_().set_server(this->credentials_.address.c_str(), this->credentials_.port);
   if (!this->last_will_.topic.empty()) {
-    this->mqtt_backend_.set_will(this->last_will_.topic.c_str(), this->last_will_.qos, this->last_will_.retain,
-                                 this->last_will_.payload.c_str());
+    this->mqtt_backend_ref_().set_will(this->last_will_.topic.c_str(), this->last_will_.qos, this->last_will_.retain,
+                                       this->last_will_.payload.c_str());
   }
 
-  this->mqtt_backend_.connect();
+  this->mqtt_backend_ref_().connect();
   this->state_ = MQTT_CLIENT_CONNECTING;
   this->connect_begin_ = millis();
 }
 bool MQTTClientComponent::is_connected() {
-  return this->state_ == MQTT_CLIENT_CONNECTED && this->mqtt_backend_.connected();
+  return this->state_ == MQTT_CLIENT_CONNECTED && this->mqtt_backend_ref_().connected();
 }
 
 void MQTTClientComponent::check_connected() {
-  if (!this->mqtt_backend_.connected()) {
+  if (!this->mqtt_backend_ref_().connected()) {
     if (millis() - this->connect_begin_ > 60000) {
       this->state_ = MQTT_CLIENT_DISCONNECTED;
       this->start_dnslookup_();
@@ -345,7 +362,7 @@ void MQTTClientComponent::check_connected() {
 
 void MQTTClientComponent::loop() {
   // Call the backend loop first
-  mqtt_backend_.loop();
+  this->mqtt_backend_ref_().loop();
 
   if (this->disconnect_reason_.has_value()) {
     const LogString *reason_s;
@@ -402,7 +419,7 @@ void MQTTClientComponent::loop() {
       this->check_connected();
       break;
     case MQTT_CLIENT_CONNECTED:
-      if (!this->mqtt_backend_.connected()) {
+      if (!this->mqtt_backend_ref_().connected()) {
         this->state_ = MQTT_CLIENT_DISCONNECTED;
         ESP_LOGW(TAG, "Lost client connection");
         this->start_dnslookup_();
@@ -435,7 +452,7 @@ bool MQTTClientComponent::subscribe_(const char *topic, uint8_t qos) {
   if (!this->is_connected())
     return false;
 
-  bool ret = this->mqtt_backend_.subscribe(topic, qos);
+  bool ret = this->mqtt_backend_ref_().subscribe(topic, qos);
   yield();
 
   if (ret) {
@@ -496,7 +513,7 @@ void MQTTClientComponent::subscribe_json(const std::string &topic, const mqtt_js
 }
 
 void MQTTClientComponent::unsubscribe(const std::string &topic) {
-  bool ret = this->mqtt_backend_.unsubscribe(topic.c_str());
+  bool ret = this->mqtt_backend_ref_().unsubscribe(topic.c_str());
   yield();
   if (ret) {
     ESP_LOGV(TAG, "unsubscribe(topic='%s')", topic.c_str());
@@ -543,11 +560,11 @@ bool MQTTClientComponent::publish(const char *topic, const char *payload, size_t
   size_t topic_len = strlen(topic);
   bool logging_topic = (topic_len == this->log_message_.topic.size()) &&
                        (memcmp(this->log_message_.topic.c_str(), topic, topic_len) == 0);
-  bool ret = this->mqtt_backend_.publish(topic, payload, payload_length, qos, retain);
+  bool ret = this->mqtt_backend_ref_().publish(topic, payload, payload_length, qos, retain);
   delay(0);
   if (!ret && !logging_topic && this->is_connected()) {
     delay(0);
-    ret = this->mqtt_backend_.publish(topic, payload, payload_length, qos, retain);
+    ret = this->mqtt_backend_ref_().publish(topic, payload, payload_length, qos, retain);
     delay(0);
   }
 
@@ -679,7 +696,9 @@ bool MQTTClientComponent::is_log_message_enabled() const { return !this->log_mes
 void MQTTClientComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 void MQTTClientComponent::register_mqtt_component(MQTTComponent *component) { this->children_.push_back(component); }
 void MQTTClientComponent::set_log_level(int level) { this->log_level_ = level; }
-void MQTTClientComponent::set_keep_alive(uint16_t keep_alive_s) { this->mqtt_backend_.set_keep_alive(keep_alive_s); }
+void MQTTClientComponent::set_keep_alive(uint16_t keep_alive_s) {
+  this->mqtt_backend_ref_().set_keep_alive(keep_alive_s);
+}
 void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) { this->log_message_ = std::move(message); }
 const MQTTDiscoveryInfo &MQTTClientComponent::get_discovery_info() const { return this->discovery_info_; }
 void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix, const std::string &check_topic_prefix) {
@@ -757,23 +776,23 @@ void MQTTClientComponent::on_shutdown() {
     this->publish(this->shutdown_message_);
     yield();
   }
-  this->mqtt_backend_.disconnect();
+  this->mqtt_backend_ref_().disconnect();
 }
 
 void MQTTClientComponent::set_on_connect(mqtt_on_connect_callback_t &&callback) {
-  this->mqtt_backend_.set_on_connect(std::forward<mqtt_on_connect_callback_t>(callback));
+  this->mqtt_backend_ref_().set_on_connect(std::forward<mqtt_on_connect_callback_t>(callback));
 }
 
 void MQTTClientComponent::set_on_disconnect(mqtt_on_disconnect_callback_t &&callback) {
   auto callback_copy = callback;
-  this->mqtt_backend_.set_on_disconnect(std::forward<mqtt_on_disconnect_callback_t>(callback));
+  this->mqtt_backend_ref_().set_on_disconnect(std::forward<mqtt_on_disconnect_callback_t>(callback));
   this->on_disconnect_.add(std::move(callback_copy));
 }
 
 #if ASYNC_TCP_SSL_ENABLED
 void MQTTClientComponent::add_ssl_fingerprint(const std::array<uint8_t, SHA1_SIZE> &fingerprint) {
-  this->mqtt_backend_.setSecure(true);
-  this->mqtt_backend_.addServerFingerprint(fingerprint.data());
+  this->mqtt_backend_ref_().setSecure(true);
+  this->mqtt_backend_ref_().addServerFingerprint(fingerprint.data());
 }
 #endif
 

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -19,8 +19,12 @@
 #include "mqtt_backend_esp8266.h"
 #elif defined(USE_LIBRETINY)
 #include "mqtt_backend_libretiny.h"
+#elif defined(USE_HOST)
+#include "mqtt_backend_host.h"
 #endif
+#ifndef USE_HOST
 #include "lwip/ip_addr.h"
+#endif
 
 #include <vector>
 
@@ -288,17 +292,25 @@ class MQTTClientComponent : public Component
   void set_wait_for_connection(bool wait_for_connection) { this->wait_for_connection_ = wait_for_connection; }
 
  protected:
+  /// Test hook: override the MQTT backend used by this client.
+  /// Intended for host/unit tests (no broker required).
+  void set_mqtt_backend_for_testing_(MQTTBackend *backend) { this->mqtt_backend_interface_ = backend; }
+  MQTTBackend *get_mqtt_backend_() { return this->mqtt_backend_interface_; }
+  MQTTBackend &mqtt_backend_ref_() { return *this->mqtt_backend_interface_; }
+
   void send_device_info_();
 
   /// Reconnect to the MQTT broker if not already connected.
   void start_connect_();
   void start_dnslookup_();
   void check_dnslookup_();
+#ifndef USE_HOST
 #if defined(USE_ESP8266) && LWIP_VERSION_MAJOR == 1
   static void dns_found_callback(const char *name, ip_addr_t *ipaddr, void *callback_arg);
 #else
   static void dns_found_callback(const char *name, const ip_addr_t *ipaddr, void *callback_arg);
 #endif
+#endif  // !USE_HOST
 
   /// Re-calculate the availability property.
   void recalculate_availability_();
@@ -340,7 +352,10 @@ class MQTTClientComponent : public Component
   MQTTBackendESP8266 mqtt_backend_;
 #elif defined(USE_LIBRETINY)
   MQTTBackendLibreTiny mqtt_backend_;
+#elif defined(USE_HOST)
+  MQTTBackendHost mqtt_backend_;
 #endif
+  MQTTBackend *mqtt_backend_interface_{nullptr};
 
   MQTTClientState state_{MQTT_CLIENT_DISABLED};
   network::IPAddress ip_;

--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -60,6 +60,7 @@ struct IPAddress {
   }
   IPAddress(const std::string &in_address) { inet_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
+  bool is_set() const { return this->ip_addr_.s_addr != 0; }
   // Remove before 2026.8.0
   ESPDEPRECATED("Use str_to() instead. Removed in 2026.8.0", "2026.2.0")
   std::string str() const {

--- a/esphome/dashboard/status/mqtt.py
+++ b/esphome/dashboard/status/mqtt.py
@@ -2,16 +2,28 @@ from __future__ import annotations
 
 import binascii
 import json
+import logging
 import os
 import threading
 import typing
 
 from esphome import mqtt
+from esphome.core import EsphomeError
 
 from ..entries import EntryStateSource, bool_to_entry_state
 
 if typing.TYPE_CHECKING:
     from ..core import ESPHomeDashboard
+
+
+_LOGGER = logging.getLogger(__name__)
+
+# How often to re-check entries and publish a discover ping.
+_POLL_INTERVAL = 2.0
+
+# Retry behavior for initial broker connect failures (e.g. transient DNS/network readiness).
+_CONNECT_RETRY_INITIAL_DELAY = 1.0
+_CONNECT_RETRY_MAX_DELAY = 300.0
 
 
 class MqttStatusThread(threading.Thread):
@@ -50,18 +62,34 @@ class MqttStatusThread(threading.Thread):
 
         mqttid = str(binascii.hexlify(os.urandom(6)).decode())
 
-        client = mqtt.prepare(
-            config,
-            [topic],
-            on_message,
-            on_connect,
-            None,
-            None,
-            f"esphome-dashboard-{mqttid}",
-        )
+        client = None
+        retry_delay = _CONNECT_RETRY_INITIAL_DELAY
+        while client is None and not dashboard.stop_event.is_set():
+            try:
+                client = mqtt.prepare(
+                    config,
+                    [topic],
+                    on_message,
+                    on_connect,
+                    None,
+                    None,
+                    f"esphome-dashboard-{mqttid}",
+                )
+            except EsphomeError as err:
+                _LOGGER.warning(
+                    "Cannot connect to MQTT broker for dashboard status: %s. Retrying in %.1f s",
+                    err,
+                    retry_delay,
+                )
+                if dashboard.stop_event.wait(retry_delay):
+                    return
+                retry_delay = min(retry_delay * 2, _CONNECT_RETRY_MAX_DELAY)
+
+        if client is None:
+            return
         client.loop_start()
 
-        while not dashboard.stop_event.wait(2):
+        while not dashboard.stop_event.wait(_POLL_INTERVAL):
             current_entries = entries.all()
             # will be set to true on on_message
             for entry in current_entries:

--- a/esphome/dashboard/status/ping.py
+++ b/esphome/dashboard/status/ping.py
@@ -53,12 +53,16 @@ class PingStatus:
             dashboard.ping_request.clear()
             iteration_start = time.monotonic()
             current_entries = dashboard.entries.async_all()
-            to_ping: list[DashboardEntry] = []
+            to_ping: list[tuple[DashboardEntry, str]] = []
 
             for entry in current_entries:
-                if entry.address is None:
-                    # No address or we already have a state from another source
-                    # so no need to ping
+                address = entry.address
+                if address is None and entry.target_platform == "HOST":
+                    # Host platform nodes may not have an address in storage.json.
+                    # In that case, fall back to pinging the node name.
+                    address = entry.name
+                if address is None:
+                    # No address to ping
                     continue
                 if (
                     entry.state.reachable is ReachableState.ONLINE
@@ -68,22 +72,23 @@ class PingStatus:
                     # If we already have a state from another source and
                     # it's online, we don't need to ping
                     continue
-                to_ping.append(entry)
+                to_ping.append((entry, address))
 
             # Resolve DNS for all entries
             entries_with_addresses: dict[DashboardEntry, list[str]] = {}
             for ping_group in chunked(to_ping, GROUP_SIZE):
-                ping_group = cast(list[DashboardEntry], ping_group)
+                ping_group = cast(list[tuple[DashboardEntry, str]], ping_group)
                 now_monotonic = time.monotonic()
                 dns_results = await asyncio.gather(
                     *(
-                        dashboard.dns_cache.async_resolve(entry.address, now_monotonic)
-                        for entry in ping_group
+                        dashboard.dns_cache.async_resolve(address, now_monotonic)
+                        for _, address in ping_group
                     ),
                     return_exceptions=True,
                 )
 
-                for entry, result in zip(ping_group, dns_results):
+                for entry_address, result in zip(ping_group, dns_results):
+                    entry = entry_address[0]
                     if isinstance(result, Exception):
                         # Only update state if its unknown or from ping
                         # so we don't mark it as offline if we have a state

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -433,6 +433,26 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
 class EsphomeLogsHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
+        config_file = settings.rel_path(json_message["configuration"])
+        entry = DASHBOARD.entries.get(config_file)
+
+        # For host devices we run internally and can always stream logs directly.
+        # The normal `logs --device OTA` flow can error out (no OTA/api/mqtt/serial),
+        # which the frontend turns into a "How to get the logs..." prompt.
+        #
+        # IMPORTANT: DashboardEntry.target_platform is derived from storage "esp_platform"
+        # (e.g. "ESP32", "HOST"), while const.PLATFORM_HOST is the core platform ("host").
+        is_host = (
+            entry is not None
+            and entry.storage is not None
+            and entry.storage.core_platform == const.PLATFORM_HOST
+        )
+
+        # `run` on host compiles (if needed) and streams logs without requiring a device selector.
+        # Do not pass `--device` since host does not use serial/OTA.
+        if is_host:
+            return [*DASHBOARD_COMMAND, "run", config_file]
+
         return await self.build_device_command(["logs"], json_message)
 
 

--- a/script/cpp_unit_test.py
+++ b/script/cpp_unit_test.py
@@ -113,12 +113,24 @@ def run_tests(selected_components: list[str]) -> int:
     CORE.config_path = COMPONENTS_TESTS_DIR / "dummy.yaml"
     CORE.dashboard = None
 
+    # Some components have required config keys. Provide minimal stubs here so
+    # validation/codegen can run while still compiling the C++ sources for unit tests.
+    if "mqtt" in components_with_dependencies:
+        config["mqtt"] = {
+            "broker": "127.0.0.1",
+            # Avoid any runtime connection attempts during unit test binaries
+            "enable_on_boot": False,
+            # Keep discovery enabled for compile coverage; this doesn't require a broker at test time
+            "discover_ip": True,
+        }
+
     # Validate config will expand the above with defaults:
     config = validate_config(config, {})
 
     # Add all components and dependencies to the base configuration after validation, so their files
     # are added to the build.
-    config.update({key: {} for key in components_with_dependencies})
+    for key in components_with_dependencies:
+        config.setdefault(key, {})
 
     print(f"Testing components: {', '.join(components)}")
     CORE.config = config

--- a/tests/components/mqtt/mqtt_client_test.cpp
+++ b/tests/components/mqtt/mqtt_client_test.cpp
@@ -1,0 +1,187 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "esphome/core/application.h"
+#include "esphome/components/mqtt/mqtt_client.h"
+
+namespace esphome::mqtt::testing {
+
+struct PublishRecord {
+  std::string topic;
+  std::string payload;
+  uint8_t qos;
+  bool retain;
+};
+
+struct SubscribeRecord {
+  std::string topic;
+  uint8_t qos;
+};
+
+class FakeMQTTBackend : public MQTTBackend {
+ public:
+  void set_keep_alive(uint16_t keep_alive) override { (void) keep_alive; }
+  void set_client_id(const char *client_id) override { (void) client_id; }
+  void set_clean_session(bool clean_session) override { (void) clean_session; }
+  void set_credentials(const char *username, const char *password) override {
+    (void) username;
+    (void) password;
+  }
+  void set_will(const char *topic, uint8_t qos, bool retain, const char *payload) override {
+    (void) topic;
+    (void) qos;
+    (void) retain;
+    (void) payload;
+  }
+  void set_server(network::IPAddress ip, uint16_t port) override {
+    (void) ip;
+    (void) port;
+  }
+  void set_server(const char *host, uint16_t port) override {
+    (void) host;
+    (void) port;
+  }
+
+  void set_on_connect(std::function<on_connect_callback_t> &&callback) override {
+    this->on_connect_ = std::move(callback);
+  }
+  void set_on_disconnect(std::function<on_disconnect_callback_t> &&callback) override {
+    this->on_disconnect_ = std::move(callback);
+  }
+  void set_on_subscribe(std::function<on_subscribe_callback_t> &&callback) override {
+    this->on_subscribe_ = std::move(callback);
+  }
+  void set_on_unsubscribe(std::function<on_unsubscribe_callback_t> &&callback) override {
+    this->on_unsubscribe_ = std::move(callback);
+  }
+  void set_on_message(std::function<on_message_callback_t> &&callback) override {
+    this->on_message_ = std::move(callback);
+  }
+  void set_on_publish(std::function<on_publish_user_callback_t> &&callback) override {
+    this->on_publish_ = std::move(callback);
+  }
+
+  bool connected() const override { return this->connected_; }
+
+  void connect() override {
+    this->connected_ = true;
+    if (this->on_connect_) {
+      this->on_connect_(false);
+    }
+  }
+
+  void disconnect() override {
+    bool was_connected = this->connected_;
+    this->connected_ = false;
+    if (was_connected && this->on_disconnect_) {
+      this->on_disconnect_(MQTTClientDisconnectReason::TCP_DISCONNECTED);
+    }
+  }
+
+  bool subscribe(const char *topic, uint8_t qos) override {
+    this->subscribes_.push_back({topic ? topic : "", qos});
+    if (this->on_subscribe_) {
+      this->on_subscribe_(0, qos);
+    }
+    return true;
+  }
+
+  bool unsubscribe(const char *topic) override {
+    (void) topic;
+    if (this->on_unsubscribe_) {
+      this->on_unsubscribe_(0);
+    }
+    return true;
+  }
+
+  bool publish(const char *topic, const char *payload, size_t length, uint8_t qos, bool retain) override {
+    this->publishes_.push_back({.topic = topic ? topic : "",
+                                .payload = std::string(payload ? payload : "", payload ? length : 0),
+                                .qos = qos,
+                                .retain = retain});
+    if (this->on_publish_) {
+      this->on_publish_(0);
+    }
+    return true;
+  }
+
+  void inject_message(const std::string &topic, const std::string &payload) {
+    ASSERT_TRUE(this->on_message_);
+    this->on_message_(topic.c_str(), payload.data(), payload.size(), 0, payload.size());
+  }
+
+  std::vector<PublishRecord> publishes_;
+  std::vector<SubscribeRecord> subscribes_;
+
+ protected:
+  bool connected_{false};
+  std::function<on_connect_callback_t> on_connect_{};
+  std::function<on_disconnect_callback_t> on_disconnect_{};
+  std::function<on_subscribe_callback_t> on_subscribe_{};
+  std::function<on_unsubscribe_callback_t> on_unsubscribe_{};
+  std::function<on_message_callback_t> on_message_{};
+  std::function<on_publish_user_callback_t> on_publish_{};
+};
+
+class TestMQTTClientComponent : public MQTTClientComponent {
+ public:
+  void set_backend(FakeMQTTBackend *backend) { this->set_mqtt_backend_for_testing_(backend); }
+
+  void force_connected(FakeMQTTBackend *backend) {
+    backend->connect();
+    this->state_ = MQTT_CLIENT_CONNECTED;
+  }
+
+  void resubscribe_for_testing() { this->resubscribe_subscriptions_(); }
+};
+
+TEST(MQTTClientHostEmulationTest, DiscoverRequestPublishesDeviceInfo) {
+  App.pre_setup("host-light", "", false);
+
+  FakeMQTTBackend backend;
+  TestMQTTClientComponent mqtt;
+  mqtt.set_backend(&backend);
+  mqtt.setup();
+  mqtt.force_connected(&backend);
+
+  backend.inject_message("esphome/discover", "");
+
+  bool found = false;
+  for (const auto &pub : backend.publishes_) {
+    if (pub.topic == "esphome/discover/host-light") {
+      found = true;
+      EXPECT_NE(pub.payload.find("\"name\":\"host-light\""), std::string::npos);
+      break;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(MQTTClientHostEmulationTest, DiscoveryIpSubscribesToDiscoverAndPingTopics) {
+  App.pre_setup("host-light", "", false);
+
+  FakeMQTTBackend backend;
+  TestMQTTClientComponent mqtt;
+  mqtt.set_backend(&backend);
+  mqtt.setup();
+  mqtt.force_connected(&backend);
+
+  // Now that we're connected, resubscribe should issue the subscribes.
+  mqtt.resubscribe_for_testing();
+
+  bool has_discover = false;
+  bool has_ping = false;
+  for (const auto &sub : backend.subscribes_) {
+    if (sub.topic == "esphome/discover" && sub.qos == 2)
+      has_discover = true;
+    if (sub.topic == "esphome/ping/host-light" && sub.qos == 2)
+      has_ping = true;
+  }
+  EXPECT_TRUE(has_discover);
+  EXPECT_TRUE(has_ping);
+}
+
+}  // namespace esphome::mqtt::testing

--- a/tests/components/mqtt/test.host.yaml
+++ b/tests/components/mqtt/test.host.yaml
@@ -1,0 +1,10 @@
+packages:
+  host_common: !include ../host/common.yaml
+
+mqtt:
+  broker: "127.0.0.1"
+  port: 1883
+  enable_on_boot: false
+  discovery: false
+  discover_ip: false
+  topic_prefix: hostmqtt

--- a/tests/dashboard/status/test_mqtt.py
+++ b/tests/dashboard/status/test_mqtt.py
@@ -108,7 +108,9 @@ def test_mqtt_status_thread_stops_during_retry_wait() -> None:
     with (
         patch(
             "esphome.dashboard.status.mqtt.mqtt.prepare",
-            side_effect=EsphomeError("Cannot connect to MQTT broker: temporary failure"),
+            side_effect=EsphomeError(
+                "Cannot connect to MQTT broker: temporary failure"
+            ),
         ) as mock_prepare,
         patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_INITIAL_DELAY", 0.01),
         patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_MAX_DELAY", 0.02),

--- a/tests/dashboard/status/test_mqtt.py
+++ b/tests/dashboard/status/test_mqtt.py
@@ -61,3 +61,60 @@ def test_mqtt_status_thread_retries_connect_and_recovers() -> None:
         assert mock_prepare.call_count >= 3
         client.disconnect.assert_called_once()
         client.loop_stop.assert_called_once()
+
+
+def test_mqtt_status_thread_returns_if_stopped_before_connect() -> None:
+    """If the dashboard is already stopping, do not attempt an MQTT connection."""
+    stop_event = threading.Event()
+    stop_event.set()
+
+    entries = Mock()
+    entries.all.return_value = []
+
+    dashboard = Mock()
+    dashboard.entries = entries
+    dashboard.stop_event = stop_event
+    dashboard.mqtt_ping_request = Mock()
+
+    with patch("esphome.dashboard.status.mqtt.mqtt.prepare") as mock_prepare:
+        # Call run() directly to avoid thread scheduling flakiness.
+        MqttStatusThread(dashboard).run()
+
+    mock_prepare.assert_not_called()
+
+
+def test_mqtt_status_thread_stops_during_retry_wait() -> None:
+    """If stop_event is set while waiting between retries, the thread should exit."""
+    stop_event = Mock()
+    stop_event.is_set.return_value = False
+    # Simulate the stop event being set during the retry wait.
+    stop_event.wait.return_value = True
+
+    mqtt_ping_request = Mock()
+    mqtt_ping_request.wait.return_value = True
+    mqtt_ping_request.clear = Mock()
+
+    entries = Mock()
+    entries.all.return_value = []
+    entries.get_by_name.return_value = []
+    entries.set_state_if_online_or_source = Mock()
+    entries.set_state_if_source = Mock()
+
+    dashboard = Mock()
+    dashboard.entries = entries
+    dashboard.stop_event = stop_event
+    dashboard.mqtt_ping_request = mqtt_ping_request
+
+    with (
+        patch(
+            "esphome.dashboard.status.mqtt.mqtt.prepare",
+            side_effect=EsphomeError("Cannot connect to MQTT broker: temporary failure"),
+        ) as mock_prepare,
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_INITIAL_DELAY", 0.01),
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_MAX_DELAY", 0.02),
+    ):
+        # Call run() directly to deterministically hit the retry branch.
+        MqttStatusThread(dashboard).run()
+
+    # Exactly one attempt: we exit during the first wait().
+    assert mock_prepare.call_count == 1

--- a/tests/dashboard/status/test_mqtt.py
+++ b/tests/dashboard/status/test_mqtt.py
@@ -1,0 +1,63 @@
+"""Tests for esphome.dashboard.status.mqtt."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import Mock, patch
+
+from esphome.core import EsphomeError
+from esphome.dashboard.status.mqtt import MqttStatusThread
+
+
+def test_mqtt_status_thread_retries_connect_and_recovers() -> None:
+    """Test that transient connect failures do not permanently kill the thread."""
+    stop_event = threading.Event()
+
+    mqtt_ping_request = Mock()
+    mqtt_ping_request.wait.return_value = True
+    mqtt_ping_request.clear = Mock()
+
+    entries = Mock()
+    entries.all.return_value = []
+    entries.get_by_name.return_value = []
+    entries.set_state_if_online_or_source = Mock()
+    entries.set_state_if_source = Mock()
+
+    dashboard = Mock()
+    dashboard.entries = entries
+    dashboard.stop_event = stop_event
+    dashboard.mqtt_ping_request = mqtt_ping_request
+
+    loop_started = threading.Event()
+    client = Mock()
+    client.loop_start.side_effect = loop_started.set
+
+    attempt = {"count": 0}
+
+    def prepare_side_effect(*args, **kwargs):
+        attempt["count"] += 1
+        if attempt["count"] < 3:
+            raise EsphomeError("Cannot connect to MQTT broker: temporary failure")
+        return client
+
+    with (
+        patch(
+            "esphome.dashboard.status.mqtt.mqtt.prepare",
+            side_effect=prepare_side_effect,
+        ) as mock_prepare,
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_INITIAL_DELAY", 0.01),
+        patch("esphome.dashboard.status.mqtt._CONNECT_RETRY_MAX_DELAY", 0.02),
+        patch("esphome.dashboard.status.mqtt._POLL_INTERVAL", 0.01),
+    ):
+        thread = MqttStatusThread(dashboard)
+        thread.start()
+
+        assert loop_started.wait(1.0)
+        stop_event.set()
+
+        thread.join(timeout=1.0)
+        assert not thread.is_alive()
+
+        assert mock_prepare.call_count >= 3
+        client.disconnect.assert_called_once()
+        client.loop_stop.assert_called_once()

--- a/tests/dashboard/status/test_ping.py
+++ b/tests/dashboard/status/test_ping.py
@@ -1,0 +1,84 @@
+"""Tests for esphome.dashboard.status.ping."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from esphome.dashboard.entries import EntryStateSource, ReachableState
+from esphome.dashboard.status.ping import PingStatus
+
+
+@pytest.mark.asyncio
+async def test_ping_status_host_entry_without_address_falls_back_to_name() -> None:
+    """Host platform entries with address=None should still be pinged via entry.name."""
+    stop_event = threading.Event()
+    ping_request = asyncio.Event()
+    ping_request.set()
+
+    entry_host = Mock()
+    entry_host.address = None
+    entry_host.name = "host-light"
+    entry_host.target_platform = "HOST"
+    entry_host.state = Mock(
+        reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN
+    )
+
+    entry_non_host = Mock()
+    entry_non_host.address = None
+    entry_non_host.name = "esp32-node"
+    entry_non_host.target_platform = "ESP32"
+    entry_non_host.state = Mock(
+        reachable=ReachableState.UNKNOWN, source=EntryStateSource.UNKNOWN
+    )
+
+    entries = Mock()
+    entries.async_all.return_value = [entry_host, entry_non_host]
+    entries.async_set_state_if_source = Mock()
+    entries.async_set_state_if_online_or_source = Mock()
+
+    dns_cache = Mock()
+    dns_cache.async_resolve = AsyncMock(return_value=["127.0.0.1"])
+
+    dashboard = Mock()
+    dashboard.stop_event = stop_event
+    dashboard.ping_request = ping_request
+    dashboard.entries = entries
+    dashboard.dns_cache = dns_cache
+
+    ping_status = PingStatus(dashboard)
+
+    host = Mock()
+    host.is_alive = True
+
+    async def async_ping_side_effect(*args, **kwargs):
+        stop_event.set()
+        return host
+
+    with (
+        patch(
+            "esphome.dashboard.status.ping._can_use_icmp_lib_with_privilege",
+            return_value=False,
+        ),
+        patch("esphome.dashboard.status.ping.MIN_PING_INTERVAL", 0),
+        patch(
+            "esphome.dashboard.status.ping.async_ping",
+            side_effect=async_ping_side_effect,
+        ) as mock_ping,
+    ):
+        await ping_status.async_run()
+
+    dns_cache.async_resolve.assert_called_once()
+    assert dns_cache.async_resolve.call_args.args[0] == "host-light"
+
+    mock_ping.assert_called_once()
+    assert mock_ping.call_args.args[0] == "127.0.0.1"
+
+    assert entries.async_set_state_if_online_or_source.call_count == 1
+    set_entry, set_state = entries.async_set_state_if_online_or_source.call_args.args
+    assert set_entry is entry_host
+    assert set_state.source is EntryStateSource.PING
+    assert set_state.reachable is ReachableState.ONLINE

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -30,6 +30,7 @@ from esphome.dashboard.entries import (
 )
 from esphome.dashboard.models import build_importable_device_dict
 from esphome.dashboard.web_server import DashboardSubscriber
+from esphome.storage_json import StorageJSON
 from esphome.zeroconf import DiscoveredImport
 
 from .common import get_fixture_path
@@ -204,6 +205,31 @@ async def test_devices_page(dashboard: DashboardTestHelper) -> None:
     first_device = configured_devices[0]
     assert first_device["name"] == "pico"
     assert first_device["configuration"] == "pico.yaml"
+
+
+@pytest.mark.asyncio
+async def test_logs_host_platform_skips_device_selector(
+    dashboard: DashboardTestHelper,
+) -> None:
+    config_file = web_server.settings.rel_path("pico.yaml")
+    entry = DASHBOARD.entries.get(config_file)
+    assert entry is not None
+
+    # Simulate a host platform device (core_platform == "host").
+    entry.storage = StorageJSON.from_wizard(
+        name="hostdev",
+        friendly_name="Host Dev",
+        address="127.0.0.1",
+        platform="HOST",
+    )
+
+    handler = object.__new__(web_server.EsphomeLogsHandler)
+    cmd = await handler.build_command({"type": "spawn", "configuration": "pico.yaml", "port": "OTA"})
+
+    assert cmd[0 : len(web_server.DASHBOARD_COMMAND)] == list(web_server.DASHBOARD_COMMAND)
+    assert "run" in cmd
+    assert config_file in cmd
+    assert "--device" not in cmd
 
 
 @pytest.mark.asyncio
@@ -965,6 +991,52 @@ def test_start_web_server_with_unix_socket(tmp_path: Path) -> None:
         mock_server_class.assert_called_once_with(app)
         mock_bind.assert_called_once_with(str(socket_path), mode=0o666)
         server.add_socket.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_esphome_logs_handler_build_command_host_uses_run() -> None:
+    """Test host devices use `run` to stream logs."""
+    handler = web_server.EsphomeLogsHandler.__new__(web_server.EsphomeLogsHandler)
+    json_message = {"configuration": "host.yaml", "port": "OTA"}
+
+    entry = Mock()
+    entry.storage = StorageJSON.from_wizard(
+        name="hostdev",
+        friendly_name="Host Dev",
+        address="127.0.0.1",
+        platform="HOST",
+    )
+
+    with (
+        patch("esphome.dashboard.web_server.settings") as mock_settings,
+        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
+    ):
+        mock_settings.rel_path.return_value = "host.yaml"
+        mock_dashboard.entries.get.return_value = entry
+
+        result = await handler.build_command(json_message)
+
+    assert result == [*web_server.DASHBOARD_COMMAND, "run", "host.yaml"]
+
+
+@pytest.mark.asyncio
+async def test_esphome_logs_handler_build_command_non_host_uses_logs() -> None:
+    """Test non-host devices keep using `logs`."""
+    handler = web_server.EsphomeLogsHandler.__new__(web_server.EsphomeLogsHandler)
+    handler.build_device_command = AsyncMock(return_value=["ok"])
+    json_message = {"configuration": "device.yaml", "port": "OTA"}
+
+    with (
+        patch("esphome.dashboard.web_server.settings") as mock_settings,
+        patch("esphome.dashboard.web_server.DASHBOARD") as mock_dashboard,
+    ):
+        mock_settings.rel_path.return_value = "device.yaml"
+        mock_dashboard.entries.get.return_value = None
+
+        result = await handler.build_command(json_message)
+
+    assert result == ["ok"]
+    handler.build_device_command.assert_awaited_once_with(["logs"], json_message)
 
 
 def test_build_cache_arguments_no_entry(mock_dashboard: Mock) -> None:

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -224,9 +224,13 @@ async def test_logs_host_platform_skips_device_selector(
     )
 
     handler = object.__new__(web_server.EsphomeLogsHandler)
-    cmd = await handler.build_command({"type": "spawn", "configuration": "pico.yaml", "port": "OTA"})
+    cmd = await handler.build_command(
+        {"type": "spawn", "configuration": "pico.yaml", "port": "OTA"}
+    )
 
-    assert cmd[0 : len(web_server.DASHBOARD_COMMAND)] == list(web_server.DASHBOARD_COMMAND)
+    assert cmd[0 : len(web_server.DASHBOARD_COMMAND)] == list(
+        web_server.DASHBOARD_COMMAND
+    )
     assert "run" in cmd
     assert config_file in cmd
     assert "--device" not in cmd

--- a/tests/integration/fixtures/host_mode_mqtt.yaml
+++ b/tests/integration/fixtures/host_mode_mqtt.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: host-mqtt-test
+
+host:
+
+api:
+
+logger:
+
+mqtt:
+  broker: 127.0.0.1
+  port: __MQTT_PORT__
+  discovery: false
+  discover_ip: false
+  topic_prefix: hostmqtt

--- a/tests/integration/test_host_mode_mqtt.py
+++ b/tests/integration/test_host_mode_mqtt.py
@@ -1,0 +1,62 @@
+"""Integration test for MQTT in Host mode."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_host_mode_mqtt(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test Host mode starts and MQTT connects to a local broker stub."""
+    loop = asyncio.get_running_loop()
+    mqtt_connected: asyncio.Future[None] = loop.create_future()
+
+    async def handle_client(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Minimal MQTT broker stub: accept CONNECT, reply CONNACK."""
+        try:
+            # Read some bytes (enough to contain CONNECT packet header/remaining length)
+            await reader.read(1024)
+            # CONNACK: fixed header 0x20, remaining length 0x02, flags 0, return code 0 (accepted)
+            writer.write(b"\x20\x02\x00\x00")
+            await writer.drain()
+            # Keep connection open until client disconnects
+            await reader.read()
+        finally:
+            writer.close()
+            with contextlib.suppress(Exception):
+                await writer.wait_closed()
+
+    server = await asyncio.start_server(handle_client, host="127.0.0.1", port=0)
+    try:
+        port = server.sockets[0].getsockname()[1]
+        yaml_config = yaml_config.replace("__MQTT_PORT__", str(port))
+
+        def on_line(line: str) -> None:
+            # Expect: [I][mqtt:xxxx] Connected
+            if "][mqtt:" in line and " Connected" in line and not mqtt_connected.done():
+                mqtt_connected.set_result(None)
+
+        async with (
+            run_compiled(yaml_config, line_callback=on_line),
+            api_client_connected() as client,
+        ):
+            device_info = await client.device_info()
+            assert device_info is not None
+            assert device_info.name == "host-mqtt-test"
+
+            # Wait for MQTT to connect to our stub broker.
+            await asyncio.wait_for(mqtt_connected, timeout=10.0)
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/unit_tests/test_mqtt_host.py
+++ b/tests/unit_tests/test_mqtt_host.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import esphome.config_validation as cv
+from esphome.const import (
+    KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
+    KEY_TARGET_FRAMEWORK,
+    KEY_TARGET_PLATFORM,
+    PLATFORM_HOST,
+)
+from esphome.core import CORE
+
+
+def test_mqtt_schema_allows_host_platform() -> None:
+    from esphome.components import mqtt
+
+    old_data = deepcopy(CORE.data)
+    old_name = CORE.name
+    try:
+        CORE.data.clear()
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: PLATFORM_HOST,
+            KEY_TARGET_FRAMEWORK: "host",
+            KEY_FRAMEWORK_VERSION: cv.Version(1, 0, 0),
+        }
+        CORE.name = "testnode"
+
+        validated = mqtt.CONFIG_SCHEMA({"broker": "127.0.0.1"})
+        assert validated["broker"] == "127.0.0.1"
+    finally:
+        CORE.data.clear()
+        CORE.data.update(old_data)
+        CORE.name = old_name


### PR DESCRIPTION
# What does this implement/fix?

This PR extends support for host-platform devices by adding a native MQTT backend and improving dashboard status behavior for host nodes.

## Motivation

ESPHome is (rightfully) focused on real hardware, but the `host` platform is a key part of the developer workflow:

- It enables **fast, reproducible CI coverage** for MQTT + dashboard status logic without requiring device fleets.
- It provides a **low-friction way to reproduce/report bugs** and to validate changes for contributors who don’t have specific hardware on hand.
- It helps prevent regressions in code paths that are otherwise hard to exercise deterministically (MQTT connection/state handling, dashboard status polling, “ping” reachability).

The goal here is not to replace hardware testing, but to make the host target a more faithful harness so these subsystems can be tested and iterated on quickly.

## Unifies / supersedes

It unifies and supersedes the following PRs:
- esphome/esphome#13607: [mqtt] Add host MQTT backend (native)
- esphome/esphome#13570: [mqtt] Add host platform support
- esphome/esphome#13591: [dashboard] Retry MQTT status connect on startup
- esphome/esphome#13593: [dashboard] Ping host nodes without storage address

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6028

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Additional:
- Host (Linux)

## Example entry for `config.yaml`:

```yaml
esphome:
  name: host-mqtt-test

host:

logger:

api:

mqtt:
  broker: 127.0.0.1
  discovery: false
  discover_ip: false
  topic_prefix: hostmqtt
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).