### PR TITLE
[mqtt] Stop sending deprecated color_mode and brightness in light discovery (fixes #13666)

### DIFF
--- a/esphome/components/mqtt/mqtt_light.cpp
+++ b/esphome/components/mqtt/mqtt_light.cpp
@@ -47,7 +47,6 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
   root[ESPHOME_F("schema")] = ESPHOME_F("json");
   auto traits = this->state_->get_traits();
 
-  root[MQTT_COLOR_MODE] = true;
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
   JsonArray color_modes = root[ESPHOME_F("supported_color_modes")].to<JsonArray>();
   if (traits.supports_color_mode(ColorMode::ON_OFF))
@@ -67,10 +66,6 @@ void MQTTJSONLightComponent::send_discovery(JsonObject root, mqtt::SendDiscovery
     color_modes.add(ESPHOME_F("rgbw"));
   if (traits.supports_color_mode(ColorMode::RGB_COLD_WARM_WHITE))
     color_modes.add(ESPHOME_F("rgbww"));
-
-  // legacy API
-  if (traits.supports_color_capability(ColorCapability::BRIGHTNESS))
-    root[ESPHOME_F("brightness")] = true;
 
   if (traits.supports_color_mode(ColorMode::COLOR_TEMPERATURE) ||
       traits.supports_color_mode(ColorMode::COLD_WARM_WHITE)) {

--- a/tests/unit_tests/test_mqtt.py
+++ b/tests/unit_tests/test_mqtt.py
@@ -2,42 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from esphome.const import CONF_BROKER, CONF_ESPHOME, CONF_MQTT, CONF_NAME
 from esphome.core import EsphomeError
 from esphome.mqtt import get_esphome_device_ip
-
-
-def test_mqtt_light_discovery_does_not_send_deprecated_color_mode_or_brightness() -> (
-    None
-):
-    """MQTT light discovery must not send deprecated 'color_mode' or 'brightness' keys.
-
-    Home Assistant 2025.3+ removed support for these discovery options (see
-    home-assistant/core#110682). Sending them causes HA to reject the config.
-    We only send supported_color_modes (which includes 'brightness' as a mode).
-    """
-    # Path to MQTT light C++ implementation (source of truth for discovery payload)
-    repo_root = Path(__file__).resolve().parent.parent.parent
-    mqtt_light_cpp = repo_root / "esphome" / "components" / "mqtt" / "mqtt_light.cpp"
-    assert mqtt_light_cpp.exists(), f"Source file not found: {mqtt_light_cpp}"
-    content = mqtt_light_cpp.read_text()
-
-    # Deprecated: root[MQTT_COLOR_MODE] = true in send_discovery
-    assert "root[MQTT_COLOR_MODE]" not in content, (
-        "MQTT light discovery must not set color_mode (deprecated in HA 2025.3). "
-        "See https://github.com/esphome/esphome/issues/13666"
-    )
-
-    # Deprecated: root[ESPHOME_F(\"brightness\")] = true (legacy API) in send_discovery.
-    # supported_color_modes may still include \"brightness\" as a mode; that is correct.
-    assert 'root[ESPHOME_F("brightness")]' not in content, (
-        "MQTT light discovery must not set legacy brightness key (deprecated in HA 2025.3). "
-        "Use supported_color_modes only. See https://github.com/esphome/esphome/issues/13666"
-    )
 
 
 def test_get_esphome_device_ip_empty_broker() -> None:

--- a/tests/unit_tests/test_mqtt.py
+++ b/tests/unit_tests/test_mqtt.py
@@ -2,11 +2,42 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from esphome.const import CONF_BROKER, CONF_ESPHOME, CONF_MQTT, CONF_NAME
 from esphome.core import EsphomeError
 from esphome.mqtt import get_esphome_device_ip
+
+
+def test_mqtt_light_discovery_does_not_send_deprecated_color_mode_or_brightness() -> (
+    None
+):
+    """MQTT light discovery must not send deprecated 'color_mode' or 'brightness' keys.
+
+    Home Assistant 2025.3+ removed support for these discovery options (see
+    home-assistant/core#110682). Sending them causes HA to reject the config.
+    We only send supported_color_modes (which includes 'brightness' as a mode).
+    """
+    # Path to MQTT light C++ implementation (source of truth for discovery payload)
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    mqtt_light_cpp = repo_root / "esphome" / "components" / "mqtt" / "mqtt_light.cpp"
+    assert mqtt_light_cpp.exists(), f"Source file not found: {mqtt_light_cpp}"
+    content = mqtt_light_cpp.read_text()
+
+    # Deprecated: root[MQTT_COLOR_MODE] = true in send_discovery
+    assert "root[MQTT_COLOR_MODE]" not in content, (
+        "MQTT light discovery must not set color_mode (deprecated in HA 2025.3). "
+        "See https://github.com/esphome/esphome/issues/13666"
+    )
+
+    # Deprecated: root[ESPHOME_F(\"brightness\")] = true (legacy API) in send_discovery.
+    # supported_color_modes may still include \"brightness\" as a mode; that is correct.
+    assert 'root[ESPHOME_F("brightness")]' not in content, (
+        "MQTT light discovery must not set legacy brightness key (deprecated in HA 2025.3). "
+        "Use supported_color_modes only. See https://github.com/esphome/esphome/issues/13666"
+    )
 
 
 def test_get_esphome_device_ip_empty_broker() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Stops MQTT light discovery from sending deprecated `color_mode` and `brightness` discovery keys. Home Assistant 2025.3+ removed support for these options (home-assistant/core#110682); when present, HA logs an error and rejects the config, breaking MQTT-discovered lights.

This changes the MQTT discovery payload by removing these legacy keys and relying on `supported_color_modes` (which includes `brightness` as a mode).

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13666

**Pull request in esphome-docs (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).