### PR TITLE
[analyze-memory] Add top 30 largest symbols to report

### DIFF
--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
 import heapq
+from operator import itemgetter
 import sys
 from typing import TYPE_CHECKING
 
@@ -163,7 +164,7 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
 
         # Get top N symbols by size using heapq for efficiency
         top_symbols = heapq.nlargest(
-            self.TOP_SYMBOLS_LIMIT, all_symbols, key=lambda x: x[2]
+            self.TOP_SYMBOLS_LIMIT, all_symbols, key=itemgetter(2)
         )
 
         lines.append("")

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -154,13 +154,12 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
 
     def _add_top_symbols(self, lines: list[str]) -> None:
         """Add a section showing the top largest symbols in the binary."""
-        # Collect all symbols from all components
-        all_symbols: list[
-            tuple[str, str, int, str, str]
-        ] = []  # (symbol, demangled, size, section, component)
-        for component, symbols in self._component_symbols.items():
-            for symbol, demangled, size, section in symbols:
-                all_symbols.append((symbol, demangled, size, section, component))
+        # Collect all symbols from all components: (symbol, demangled, size, section, component)
+        all_symbols = [
+            (symbol, demangled, size, section, component)
+            for component, symbols in self._component_symbols.items()
+            for symbol, demangled, size, section in symbols
+        ]
 
         # Get top N symbols by size using heapq for efficiency
         top_symbols = heapq.nlargest(

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
+import heapq
 import sys
 from typing import TYPE_CHECKING
 
@@ -31,6 +32,8 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
     RAM_SYMBOL_SIZE_THRESHOLD: int = 24
     # Number of top symbols to show in the largest symbols report
     TOP_SYMBOLS_LIMIT: int = 30
+    # Width for symbol name display in top symbols report
+    COL_TOP_SYMBOL_NAME: int = 55
 
     # Column width constants
     COL_COMPONENT: int = 29
@@ -159,22 +162,26 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
             for symbol, demangled, size, section in symbols:
                 all_symbols.append((symbol, demangled, size, section, component))
 
-        # Sort by size descending
-        all_symbols.sort(key=lambda x: x[2], reverse=True)
+        # Get top N symbols by size using heapq for efficiency
+        top_symbols = heapq.nlargest(
+            self.TOP_SYMBOLS_LIMIT, all_symbols, key=lambda x: x[2]
+        )
 
         lines.append("")
         lines.append(f"Top {self.TOP_SYMBOLS_LIMIT} Largest Symbols:")
-        for i, (symbol, demangled, size, section, component) in enumerate(
-            all_symbols[: self.TOP_SYMBOLS_LIMIT]
-        ):
+        # Calculate truncation limit from column width (leaving room for "...")
+        truncate_limit = self.COL_TOP_SYMBOL_NAME - 3
+        for i, (_, demangled, size, section, component) in enumerate(top_symbols):
             # Format section label
             section_label = f"[{section[1:]}]" if section else ""
             # Truncate demangled name if too long
             demangled_display = (
-                f"{demangled[:50]}..." if len(demangled) > 50 else demangled
+                f"{demangled[:truncate_limit]}..."
+                if len(demangled) > self.COL_TOP_SYMBOL_NAME
+                else demangled
             )
             lines.append(
-                f"{i + 1:>2}. {size:>7,} B {section_label:<8} {demangled_display:<55} {component}"
+                f"{i + 1:>2}. {size:>7,} B {section_label:<8} {demangled_display:<{self.COL_TOP_SYMBOL_NAME}} {component}"
             )
 
     def generate_report(self, detailed: bool = False) -> str:

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -29,6 +29,8 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
     )
     # Lower threshold for RAM symbols (RAM is more constrained)
     RAM_SYMBOL_SIZE_THRESHOLD: int = 24
+    # Number of top symbols to show in the largest symbols report
+    TOP_SYMBOLS_LIMIT: int = 30
 
     # Column width constants
     COL_COMPONENT: int = 29
@@ -147,6 +149,34 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
             section_label = f" [{section[1:]}]"  # .data -> [data], .bss -> [bss]
         return f"{demangled} ({size:,} B){section_label}"
 
+    def _add_top_symbols(self, lines: list[str]) -> None:
+        """Add a section showing the top largest symbols in the binary."""
+        # Collect all symbols from all components
+        all_symbols: list[
+            tuple[str, str, int, str, str]
+        ] = []  # (symbol, demangled, size, section, component)
+        for component, symbols in self._component_symbols.items():
+            for symbol, demangled, size, section in symbols:
+                all_symbols.append((symbol, demangled, size, section, component))
+
+        # Sort by size descending
+        all_symbols.sort(key=lambda x: x[2], reverse=True)
+
+        lines.append("")
+        lines.append(f"Top {self.TOP_SYMBOLS_LIMIT} Largest Symbols:")
+        for i, (symbol, demangled, size, section, component) in enumerate(
+            all_symbols[: self.TOP_SYMBOLS_LIMIT]
+        ):
+            # Format section label
+            section_label = f"[{section[1:]}]" if section else ""
+            # Truncate demangled name if too long
+            demangled_display = (
+                f"{demangled[:50]}..." if len(demangled) > 50 else demangled
+            )
+            lines.append(
+                f"{i + 1:>2}. {size:>7,} B {section_label:<8} {demangled_display:<55} {component}"
+            )
+
     def generate_report(self, detailed: bool = False) -> str:
         """Generate a formatted memory report."""
         components = sorted(
@@ -247,6 +277,9 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
             total_ram,
             "RAM",
         )
+
+        # Top largest symbols in the binary
+        self._add_top_symbols(lines)
 
         # Add ESPHome core detailed analysis if there are core symbols
         if self._esphome_core_symbols:


### PR DESCRIPTION
# What does this implement/fix?

Add a "Top 30 Largest Symbols" section to the `esphome analyze-memory` report output. This helps developers quickly identify the largest individual symbols in the binary, which is useful for optimization efforts.

Example output:
```
Top 30 Largest Symbols:
 1.  11,429 B [text]   _vfprintf_r                                             libc
 2.  11,210 B [text]   _svfprintf_r                                            libc
 3.   8,210 B [text]   http_parser_execute                                     rom_functions
 4.   7,567 B [text]   mdns_parse_packet                                       mdns_lib
 5.   7,505 B [text]   __ssvfiscanf_r                                          libc
...
```

Each line shows:
- Rank and size in bytes
- Section type (text/data/rodata/bss)
- Demangled symbol name
- Component attribution

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal developer tooling

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a CLI tool enhancement, not a configuration option
# Usage: esphome analyze-memory <config.yaml>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
