### PR TITLE
[ssd1306_base] Fix display corruption and RF noise immunity for 64x48 displays

### DIFF
--- a/esphome/components/ssd1306_base/ssd1306_base.cpp
+++ b/esphome/components/ssd1306_base/ssd1306_base.cpp
@@ -201,6 +201,21 @@ void SSD1306::display() {
     return;
   }
 
+  // Deactivate scroll - stops any noise-induced scrolling from nearby RF sources
+  this->command(SSD1306_COMMAND_DEACTIVATE_SCROLL);
+
+  // NOP to sync command decoder state
+  this->command(0xE3);
+
+  // Force horizontal addressing mode before every frame to prevent page cycling corruption
+  this->command(SSD1306_COMMAND_MEMORY_MODE);
+  this->command(0x00);
+
+  // Reset display start line to 0 - fixes viewport drift from RF noise
+  this->command(SSD1306_COMMAND_SET_START_LINE | 0x00);
+
+  this->command(0xE3);  // NOP barrier
+
   this->command(SSD1306_COMMAND_COLUMN_ADDRESS);
   switch (this->model_) {
     case SSD1306_MODEL_64_48:
@@ -213,16 +228,18 @@ void SSD1306::display() {
       this->command(0x1C + this->offset_x_ + this->get_width_internal() - 1);
       break;
     default:
-      this->command(0 + this->offset_x_);  // Page start address, 0
+      this->command(0 + this->offset_x_);
       this->command(this->get_width_internal() + this->offset_x_ - 1);
       break;
   }
 
+  this->command(0xE3);  // NOP barrier
+
   this->command(SSD1306_COMMAND_PAGE_ADDRESS);
-  // Page start address, 0
-  this->command(0);
-  // Page end address:
-  this->command((this->get_height_internal() / 8) - 1);
+  this->command(0 + this->offset_y_);
+  this->command((this->get_height_internal() / 8) - 1 + this->offset_y_);
+
+  this->command(0xE3);  // NOP barrier
 
   this->write_display_data();
 }

--- a/tests/components/ssd1306_spi/common.yaml
+++ b/tests/components/ssd1306_spi/common.yaml
@@ -1,4 +1,5 @@
 display:
+  # Test 128x64 model (standard)
   - platform: ssd1306_spi
     id: ssd1306_spi_display
     model: SSD1306 128x64
@@ -18,3 +19,26 @@ display:
       then:
         lambda: |-
           ESP_LOGD("display", "1 -> 2");
+
+  # Test 64x48 model (GDDRAM offset - exercises page cycling fix)
+  - platform: ssd1306_spi
+    id: ssd1306_spi_display_64x48
+    model: SSD1306 64x48
+    cs_pin: ${cs_pin_2}
+    dc_pin: ${dc_pin_2}
+    reset_pin: ${reset_pin_2}
+    offset_x: 0
+    offset_y: 0
+    pages:
+      - id: ssd1306_64x48_page1
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+      - id: ssd1306_64x48_page2
+        lambda: |-
+          it.rectangle(0, 0, it.get_width(), it.get_height());
+    on_page_change:
+      from: ssd1306_64x48_page1
+      to: ssd1306_64x48_page2
+      then:
+        lambda: |-
+          ESP_LOGD("display", "64x48: 1 -> 2");

--- a/tests/components/ssd1306_spi/test.esp32-idf.yaml
+++ b/tests/components/ssd1306_spi/test.esp32-idf.yaml
@@ -2,6 +2,9 @@ substitutions:
   cs_pin: GPIO12
   dc_pin: GPIO13
   reset_pin: GPIO14
+  cs_pin_2: GPIO27
+  dc_pin_2: GPIO26
+  reset_pin_2: GPIO25
 
 packages:
   spi: !include ../../test_build_components/common/spi/esp32-idf.yaml

--- a/tests/components/ssd1306_spi/test.esp8266-ard.yaml
+++ b/tests/components/ssd1306_spi/test.esp8266-ard.yaml
@@ -5,6 +5,9 @@ substitutions:
   cs_pin: GPIO5
   dc_pin: GPIO15
   reset_pin: GPIO16
+  cs_pin_2: GPIO4
+  dc_pin_2: GPIO13
+  reset_pin_2: GPIO14
 
 packages:
   spi: !include ../../test_build_components/common/spi/esp8266-ard.yaml

--- a/tests/components/ssd1306_spi/test.rp2040-ard.yaml
+++ b/tests/components/ssd1306_spi/test.rp2040-ard.yaml
@@ -5,6 +5,9 @@ substitutions:
   cs_pin: GPIO5
   dc_pin: GPIO15
   reset_pin: GPIO16
+  cs_pin_2: GPIO6
+  dc_pin_2: GPIO17
+  reset_pin_2: GPIO18
 
 packages:
   spi: !include ../../test_build_components/common/spi/rp2040-ard.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes two display issues with SSD1306 displays, particularly affecting 64x48 models:

1. **Page cycling corruption** - Display renders correctly on boot but subsequent page transitions cause artifacts or blank screens when using ESPHome's native page system.

2. **Long-term RF noise drift** - After hours of operation near RF sources (LoRa, WiFi radios), garbage pixels appear at the bottom of the screen. RF noise on SPI lines gets interpreted as scroll (0x26-0x2F) or start-line (0x40-0x7F) commands, causing the vertical viewport to drift.

**Root cause:** The SSD1306 command decoder can enter a stuck state where:
- Memory addressing mode reverts from Horizontal (0x00) to Page mode (default)
- Command bytes get "eaten" causing subsequent parameters to be misinterpreted
- Start line register drifts from noise-induced commands

**Fix:** Reset critical controller state before every frame:
- `DEACTIVATE_SCROLL` (0x2E) - stops noise-induced scrolling
- NOP (0xE3) barriers - sync command decoder
- Force Horizontal Addressing Mode (0x20, 0x00)
- Reset start line to 0 (0x40)
- Apply `offset_y_` to Page Address commands (was missing)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- (none found, discovered during M5Stack C6LoRa development)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# SSD1306 64x48 display with page cycling (previously broken, now fixed)
display:
  - platform: ssd1306_spi
    model: "SSD1306 64x48"
    cs_pin: GPIO6
    dc_pin: GPIO18
    reset_pin: GPIO15
    offset_x: 0
    offset_y: 0
    pages:
      - id: page_1
        lambda: |-
          it.print(32, 24, id(font), TextAlign::CENTER, "Page 1");
      - id: page_2
        lambda: |-
          it.print(32, 24, id(font), TextAlign::CENTER, "Page 2");

binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_press:
      - display.page.show_next: my_display
      - component.update: my_display
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] N/A - no user-facing changes, internal fix only