### PR TITLE
[api] Avoid heap allocation for client connected/disconnected triggers

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -211,7 +211,7 @@ void APIServer::loop() {
 
 #ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
     // Fire trigger after client is removed so api.connected reflects the true state
-    this->client_disconnected_trigger_->trigger(client_name, client_peername);
+    this->client_disconnected_trigger_.trigger(client_name, client_peername);
 #endif
     // Don't increment client_index since we need to process the swapped element
   }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -227,12 +227,10 @@ class APIServer : public Component,
 #endif
 
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-  Trigger<std::string, std::string> *get_client_connected_trigger() const { return this->client_connected_trigger_; }
+  Trigger<std::string, std::string> *get_client_connected_trigger() { return &this->client_connected_trigger_; }
 #endif
 #ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
-  Trigger<std::string, std::string> *get_client_disconnected_trigger() const {
-    return this->client_disconnected_trigger_;
-  }
+  Trigger<std::string, std::string> *get_client_disconnected_trigger() { return &this->client_disconnected_trigger_; }
 #endif
 
  protected:
@@ -253,10 +251,10 @@ class APIServer : public Component,
   // Pointers and pointer-like types first (4 bytes each)
   std::unique_ptr<socket::Socket> socket_ = nullptr;
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
-  Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<std::string, std::string> client_connected_trigger_;
 #endif
 #ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
-  Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();
+  Trigger<std::string, std::string> client_disconnected_trigger_;
 #endif
 
   // 4-byte aligned types


### PR DESCRIPTION
# What does this implement/fix?

Changes the API server's `on_client_connected` and `on_client_disconnected` triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::string, std::string> *client_connected_trigger_ = new Trigger<std::string, std::string>();
Trigger<std::string, std::string> *client_disconnected_trigger_ = new Trigger<std::string, std::string>();

// After
Trigger<std::string, std::string> client_connected_trigger_;
Trigger<std::string, std::string> client_disconnected_trigger_;
```

This follows the same pattern established in #13684 (wifi triggers) and #13677 (ethernet triggers).

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Follows pattern from #13684

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
api:
  on_client_connected:
    - logger.log:
        format: "Client %s connected from %s"
        args: ["client_info.c_str()", "client_address.c_str()"]
  on_client_disconnected:
    - logger.log:
        format: "Client %s disconnected from %s"
        args: ["client_info.c_str()", "client_address.c_str()"]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- already covered by existing integration tests

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
