### PR TITLE
[template.switch] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/template/switch/template_switch.cpp
+++ b/esphome/components/template/switch/template_switch.cpp
@@ -5,7 +5,7 @@ namespace esphome::template_ {
 
 static const char *const TAG = "template.switch";
 
-TemplateSwitch::TemplateSwitch() : turn_on_trigger_(new Trigger<>()), turn_off_trigger_(new Trigger<>()) {}
+TemplateSwitch::TemplateSwitch() = default;
 
 void TemplateSwitch::loop() {
   auto s = this->f_();
@@ -19,11 +19,11 @@ void TemplateSwitch::write_state(bool state) {
   }
 
   if (state) {
-    this->prev_trigger_ = this->turn_on_trigger_;
-    this->turn_on_trigger_->trigger();
+    this->prev_trigger_ = &this->turn_on_trigger_;
+    this->turn_on_trigger_.trigger();
   } else {
-    this->prev_trigger_ = this->turn_off_trigger_;
-    this->turn_off_trigger_->trigger();
+    this->prev_trigger_ = &this->turn_off_trigger_;
+    this->turn_off_trigger_.trigger();
   }
 
   if (this->optimistic_)
@@ -32,8 +32,8 @@ void TemplateSwitch::write_state(bool state) {
 void TemplateSwitch::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 bool TemplateSwitch::assumed_state() { return this->assumed_state_; }
 float TemplateSwitch::get_setup_priority() const { return setup_priority::HARDWARE - 2.0f; }
-Trigger<> *TemplateSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
-Trigger<> *TemplateSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
+Trigger<> *TemplateSwitch::get_turn_on_trigger() { return &this->turn_on_trigger_; }
+Trigger<> *TemplateSwitch::get_turn_off_trigger() { return &this->turn_off_trigger_; }
 void TemplateSwitch::setup() {
   if (!this->f_.has_value())
     this->disable_loop();

--- a/esphome/components/template/switch/template_switch.h
+++ b/esphome/components/template/switch/template_switch.h
@@ -15,8 +15,8 @@ class TemplateSwitch final : public switch_::Switch, public Component {
   void dump_config() override;
 
   template<typename F> void set_state_lambda(F &&f) { this->f_.set(std::forward<F>(f)); }
-  Trigger<> *get_turn_on_trigger() const;
-  Trigger<> *get_turn_off_trigger() const;
+  Trigger<> *get_turn_on_trigger();
+  Trigger<> *get_turn_off_trigger();
   void set_optimistic(bool optimistic);
   void set_assumed_state(bool assumed_state);
   void loop() override;
@@ -31,9 +31,9 @@ class TemplateSwitch final : public switch_::Switch, public Component {
   TemplateLambda<bool> f_;
   bool optimistic_{false};
   bool assumed_state_{false};
-  Trigger<> *turn_on_trigger_;
-  Trigger<> *turn_off_trigger_;
-  Trigger<> *prev_trigger_{nullptr};
+  Trigger<> turn_on_trigger_;
+  Trigger<> turn_off_trigger_;
+  Trigger<> *prev_trigger_{nullptr};  // Points to one of the above
 };
 
 }  // namespace esphome::template_


### PR DESCRIPTION
# What does this implement/fix?

Changes template switch's `turn_on_trigger_` and `turn_off_trigger_` from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (since 2019)
TemplateSwitch::TemplateSwitch() : turn_on_trigger_(new Trigger<>()), turn_off_trigger_(new Trigger<>()) {}

// After
TemplateSwitch::TemplateSwitch() = default;
Trigger<> turn_on_trigger_;  // embedded, 4 bytes
Trigger<> turn_off_trigger_; // embedded, 4 bytes
```

**Historical context:** The heap allocation pattern was introduced in commit 67f240635e "Template platforms" (April 2019) when template switch was first created. At the time, `new Trigger<>()` was used as a default pattern without considering that `Trigger<>` is only 4 bytes (one pointer member). On ESP32, each `new Trigger<>()` actually costs 16 bytes (4-byte object + 8-byte heap header + 4-byte alignment padding), making embedded triggers 4x more efficient.

**Memory savings per template switch instance:**
- Before: 2 × 16 bytes heap = 32 bytes + fragmentation
- After: 2 × 4 bytes inline = 8 bytes
- **Saves: 24 bytes per instance**

This follows the same pattern established in #13684 (wifi), #13686 (voice_assistant), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
switch:
  - platform: template
    name: "My Switch"
    turn_on_action:
      - logger.log: "Turning on"
    turn_off_action:
      - logger.log: "Turning off"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- there are at least 10 integration tests that use these triggers

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
