### PR TITLE
[thermostat] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -499,7 +499,7 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
   }
 
   bool action_ready = false;
-  Trigger<> *trig = this->idle_action_trigger_, *trig_fan = nullptr;
+  Trigger<> *trig = &this->idle_action_trigger_, *trig_fan = nullptr;
   switch (action) {
     case climate::CLIMATE_ACTION_OFF:
     case climate::CLIMATE_ACTION_IDLE:
@@ -529,10 +529,10 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
         this->start_timer_(thermostat::THERMOSTAT_TIMER_COOLING_MAX_RUN_TIME);
         if (this->supports_fan_with_cooling_) {
           this->start_timer_(thermostat::THERMOSTAT_TIMER_FANNING_ON);
-          trig_fan = this->fan_only_action_trigger_;
+          trig_fan = &this->fan_only_action_trigger_;
         }
         this->cooling_max_runtime_exceeded_ = false;
-        trig = this->cool_action_trigger_;
+        trig = &this->cool_action_trigger_;
         ESP_LOGVV(TAG, "Switching to COOLING action");
         action_ready = true;
       }
@@ -543,10 +543,10 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
         this->start_timer_(thermostat::THERMOSTAT_TIMER_HEATING_MAX_RUN_TIME);
         if (this->supports_fan_with_heating_) {
           this->start_timer_(thermostat::THERMOSTAT_TIMER_FANNING_ON);
-          trig_fan = this->fan_only_action_trigger_;
+          trig_fan = &this->fan_only_action_trigger_;
         }
         this->heating_max_runtime_exceeded_ = false;
-        trig = this->heat_action_trigger_;
+        trig = &this->heat_action_trigger_;
         ESP_LOGVV(TAG, "Switching to HEATING action");
         action_ready = true;
       }
@@ -558,7 +558,7 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
         } else {
           this->start_timer_(thermostat::THERMOSTAT_TIMER_FANNING_ON);
         }
-        trig = this->fan_only_action_trigger_;
+        trig = &this->fan_only_action_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_ONLY action");
         action_ready = true;
       }
@@ -567,7 +567,7 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
       if (this->drying_action_ready_()) {
         this->start_timer_(thermostat::THERMOSTAT_TIMER_COOLING_ON);
         this->start_timer_(thermostat::THERMOSTAT_TIMER_FANNING_ON);
-        trig = this->dry_action_trigger_;
+        trig = &this->dry_action_trigger_;
         ESP_LOGVV(TAG, "Switching to DRYING action");
         action_ready = true;
       }
@@ -634,14 +634,14 @@ void ThermostatClimate::trigger_supplemental_action_() {
       if (!this->timer_active_(thermostat::THERMOSTAT_TIMER_COOLING_MAX_RUN_TIME)) {
         this->start_timer_(thermostat::THERMOSTAT_TIMER_COOLING_MAX_RUN_TIME);
       }
-      trig = this->supplemental_cool_action_trigger_;
+      trig = &this->supplemental_cool_action_trigger_;
       ESP_LOGVV(TAG, "Calling supplemental COOLING action");
       break;
     case climate::CLIMATE_ACTION_HEATING:
       if (!this->timer_active_(thermostat::THERMOSTAT_TIMER_HEATING_MAX_RUN_TIME)) {
         this->start_timer_(thermostat::THERMOSTAT_TIMER_HEATING_MAX_RUN_TIME);
       }
-      trig = this->supplemental_heat_action_trigger_;
+      trig = &this->supplemental_heat_action_trigger_;
       ESP_LOGVV(TAG, "Calling supplemental HEATING action");
       break;
     default:
@@ -660,24 +660,24 @@ void ThermostatClimate::switch_to_humidity_control_action_(HumidificationAction 
     return;
   }
 
-  Trigger<> *trig = this->humidity_control_off_action_trigger_;
+  Trigger<> *trig = &this->humidity_control_off_action_trigger_;
   switch (action) {
     case THERMOSTAT_HUMIDITY_CONTROL_ACTION_OFF:
-      // trig = this->humidity_control_off_action_trigger_;
+      // trig = &this->humidity_control_off_action_trigger_;
       ESP_LOGVV(TAG, "Switching to HUMIDIFICATION_OFF action");
       break;
     case THERMOSTAT_HUMIDITY_CONTROL_ACTION_DEHUMIDIFY:
-      trig = this->humidity_control_dehumidify_action_trigger_;
+      trig = &this->humidity_control_dehumidify_action_trigger_;
       ESP_LOGVV(TAG, "Switching to DEHUMIDIFY action");
       break;
     case THERMOSTAT_HUMIDITY_CONTROL_ACTION_HUMIDIFY:
-      trig = this->humidity_control_humidify_action_trigger_;
+      trig = &this->humidity_control_humidify_action_trigger_;
       ESP_LOGVV(TAG, "Switching to HUMIDIFY action");
       break;
     case THERMOSTAT_HUMIDITY_CONTROL_ACTION_NONE:
     default:
       action = THERMOSTAT_HUMIDITY_CONTROL_ACTION_OFF;
-      // trig = this->humidity_control_off_action_trigger_;
+      // trig = &this->humidity_control_off_action_trigger_;
   }
 
   if (this->prev_humidity_control_trigger_ != nullptr) {
@@ -703,53 +703,53 @@ void ThermostatClimate::switch_to_fan_mode_(climate::ClimateFanMode fan_mode, bo
     this->publish_state();
 
   if (this->fan_mode_ready_()) {
-    Trigger<> *trig = this->fan_mode_auto_trigger_;
+    Trigger<> *trig = &this->fan_mode_auto_trigger_;
     switch (fan_mode) {
       case climate::CLIMATE_FAN_ON:
-        trig = this->fan_mode_on_trigger_;
+        trig = &this->fan_mode_on_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_ON mode");
         break;
       case climate::CLIMATE_FAN_OFF:
-        trig = this->fan_mode_off_trigger_;
+        trig = &this->fan_mode_off_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_OFF mode");
         break;
       case climate::CLIMATE_FAN_AUTO:
-        // trig = this->fan_mode_auto_trigger_;
+        // trig = &this->fan_mode_auto_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_AUTO mode");
         break;
       case climate::CLIMATE_FAN_LOW:
-        trig = this->fan_mode_low_trigger_;
+        trig = &this->fan_mode_low_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_LOW mode");
         break;
       case climate::CLIMATE_FAN_MEDIUM:
-        trig = this->fan_mode_medium_trigger_;
+        trig = &this->fan_mode_medium_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_MEDIUM mode");
         break;
       case climate::CLIMATE_FAN_HIGH:
-        trig = this->fan_mode_high_trigger_;
+        trig = &this->fan_mode_high_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_HIGH mode");
         break;
       case climate::CLIMATE_FAN_MIDDLE:
-        trig = this->fan_mode_middle_trigger_;
+        trig = &this->fan_mode_middle_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_MIDDLE mode");
         break;
       case climate::CLIMATE_FAN_FOCUS:
-        trig = this->fan_mode_focus_trigger_;
+        trig = &this->fan_mode_focus_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_FOCUS mode");
         break;
       case climate::CLIMATE_FAN_DIFFUSE:
-        trig = this->fan_mode_diffuse_trigger_;
+        trig = &this->fan_mode_diffuse_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_DIFFUSE mode");
         break;
       case climate::CLIMATE_FAN_QUIET:
-        trig = this->fan_mode_quiet_trigger_;
+        trig = &this->fan_mode_quiet_trigger_;
         ESP_LOGVV(TAG, "Switching to FAN_QUIET mode");
         break;
       default:
         // we cannot report an invalid mode back to HA (even if it asked for one)
         //  and must assume some valid value
         fan_mode = climate::CLIMATE_FAN_AUTO;
-        // trig = this->fan_mode_auto_trigger_;
+        // trig = &this->fan_mode_auto_trigger_;
     }
     if (this->prev_fan_mode_trigger_ != nullptr) {
       this->prev_fan_mode_trigger_->stop_action();
@@ -775,25 +775,25 @@ void ThermostatClimate::switch_to_mode_(climate::ClimateMode mode, bool publish_
     this->prev_mode_trigger_->stop_action();
     this->prev_mode_trigger_ = nullptr;
   }
-  Trigger<> *trig = this->off_mode_trigger_;
+  Trigger<> *trig = &this->off_mode_trigger_;
   switch (mode) {
     case climate::CLIMATE_MODE_AUTO:
-      trig = this->auto_mode_trigger_;
+      trig = &this->auto_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_HEAT_COOL:
-      trig = this->heat_cool_mode_trigger_;
+      trig = &this->heat_cool_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_COOL:
-      trig = this->cool_mode_trigger_;
+      trig = &this->cool_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_HEAT:
-      trig = this->heat_mode_trigger_;
+      trig = &this->heat_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_FAN_ONLY:
-      trig = this->fan_only_mode_trigger_;
+      trig = &this->fan_only_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_DRY:
-      trig = this->dry_mode_trigger_;
+      trig = &this->dry_mode_trigger_;
       break;
     case climate::CLIMATE_MODE_OFF:
     default:
@@ -824,25 +824,25 @@ void ThermostatClimate::switch_to_swing_mode_(climate::ClimateSwingMode swing_mo
     this->prev_swing_mode_trigger_->stop_action();
     this->prev_swing_mode_trigger_ = nullptr;
   }
-  Trigger<> *trig = this->swing_mode_off_trigger_;
+  Trigger<> *trig = &this->swing_mode_off_trigger_;
   switch (swing_mode) {
     case climate::CLIMATE_SWING_BOTH:
-      trig = this->swing_mode_both_trigger_;
+      trig = &this->swing_mode_both_trigger_;
       break;
     case climate::CLIMATE_SWING_HORIZONTAL:
-      trig = this->swing_mode_horizontal_trigger_;
+      trig = &this->swing_mode_horizontal_trigger_;
       break;
     case climate::CLIMATE_SWING_OFF:
-      // trig = this->swing_mode_off_trigger_;
+      // trig = &this->swing_mode_off_trigger_;
       break;
     case climate::CLIMATE_SWING_VERTICAL:
-      trig = this->swing_mode_vertical_trigger_;
+      trig = &this->swing_mode_vertical_trigger_;
       break;
     default:
       // we cannot report an invalid mode back to HA (even if it asked for one)
       //  and must assume some valid value
       swing_mode = climate::CLIMATE_SWING_OFF;
-      // trig = this->swing_mode_off_trigger_;
+      // trig = &this->swing_mode_off_trigger_;
   }
   if (trig != nullptr) {
     trig->trigger();
@@ -1024,10 +1024,8 @@ void ThermostatClimate::check_humidity_change_trigger_() {
     this->prev_target_humidity_ = this->target_humidity;
   }
   // trigger the action
-  Trigger<> *trig = this->humidity_change_trigger_;
-  if (trig != nullptr) {
-    trig->trigger();
-  }
+  Trigger<> *trig = &this->humidity_change_trigger_;
+  trig->trigger();
 }
 
 void ThermostatClimate::check_temperature_change_trigger_() {
@@ -1050,10 +1048,8 @@ void ThermostatClimate::check_temperature_change_trigger_() {
     }
   }
   // trigger the action
-  Trigger<> *trig = this->temperature_change_trigger_;
-  if (trig != nullptr) {
-    trig->trigger();
-  }
+  Trigger<> *trig = &this->temperature_change_trigger_;
+  trig->trigger();
 }
 
 bool ThermostatClimate::cooling_required_() {
@@ -1202,12 +1198,10 @@ void ThermostatClimate::change_preset_(climate::ClimatePreset preset) {
   if (config != nullptr) {
     ESP_LOGV(TAG, "Preset %s requested", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
     if (this->change_preset_internal_(*config) || (!this->preset.has_value()) || this->preset.value() != preset) {
-      // Fire any preset changed trigger if defined
-      Trigger<> *trig = this->preset_change_trigger_;
+      // Fire preset changed trigger
+      Trigger<> *trig = &this->preset_change_trigger_;
       this->set_preset_(preset);
-      if (trig != nullptr) {
-        trig->trigger();
-      }
+      trig->trigger();
 
       this->refresh();
       ESP_LOGI(TAG, "Preset %s applied", LOG_STR_ARG(climate::climate_preset_to_string(preset)));
@@ -1234,13 +1228,11 @@ void ThermostatClimate::change_custom_preset_(const char *custom_preset, size_t 
     ESP_LOGV(TAG, "Custom preset %s requested", custom_preset);
     if (this->change_preset_internal_(*config) || !this->has_custom_preset() ||
         this->get_custom_preset() != custom_preset) {
-      // Fire any preset changed trigger if defined
-      Trigger<> *trig = this->preset_change_trigger_;
+      // Fire preset changed trigger
+      Trigger<> *trig = &this->preset_change_trigger_;
       // Use the base class method which handles pointer lookup and preset reset internally
       this->set_custom_preset_(custom_preset);
-      if (trig != nullptr) {
-        trig->trigger();
-      }
+      trig->trigger();
 
       this->refresh();
       ESP_LOGI(TAG, "Custom preset %s applied", custom_preset);
@@ -1305,41 +1297,7 @@ void ThermostatClimate::set_custom_preset_config(std::initializer_list<CustomPre
   this->custom_preset_config_ = presets;
 }
 
-ThermostatClimate::ThermostatClimate()
-    : cool_action_trigger_(new Trigger<>()),
-      supplemental_cool_action_trigger_(new Trigger<>()),
-      cool_mode_trigger_(new Trigger<>()),
-      dry_action_trigger_(new Trigger<>()),
-      dry_mode_trigger_(new Trigger<>()),
-      heat_action_trigger_(new Trigger<>()),
-      supplemental_heat_action_trigger_(new Trigger<>()),
-      heat_mode_trigger_(new Trigger<>()),
-      heat_cool_mode_trigger_(new Trigger<>()),
-      auto_mode_trigger_(new Trigger<>()),
-      idle_action_trigger_(new Trigger<>()),
-      off_mode_trigger_(new Trigger<>()),
-      fan_only_action_trigger_(new Trigger<>()),
-      fan_only_mode_trigger_(new Trigger<>()),
-      fan_mode_on_trigger_(new Trigger<>()),
-      fan_mode_off_trigger_(new Trigger<>()),
-      fan_mode_auto_trigger_(new Trigger<>()),
-      fan_mode_low_trigger_(new Trigger<>()),
-      fan_mode_medium_trigger_(new Trigger<>()),
-      fan_mode_high_trigger_(new Trigger<>()),
-      fan_mode_middle_trigger_(new Trigger<>()),
-      fan_mode_focus_trigger_(new Trigger<>()),
-      fan_mode_diffuse_trigger_(new Trigger<>()),
-      fan_mode_quiet_trigger_(new Trigger<>()),
-      swing_mode_both_trigger_(new Trigger<>()),
-      swing_mode_off_trigger_(new Trigger<>()),
-      swing_mode_horizontal_trigger_(new Trigger<>()),
-      swing_mode_vertical_trigger_(new Trigger<>()),
-      humidity_change_trigger_(new Trigger<>()),
-      temperature_change_trigger_(new Trigger<>()),
-      preset_change_trigger_(new Trigger<>()),
-      humidity_control_dehumidify_action_trigger_(new Trigger<>()),
-      humidity_control_humidify_action_trigger_(new Trigger<>()),
-      humidity_control_off_action_trigger_(new Trigger<>()) {}
+ThermostatClimate::ThermostatClimate() = default;
 
 void ThermostatClimate::set_default_preset(const char *custom_preset) {
   // Find the preset in custom_preset_config_ and store pointer from there
@@ -1513,49 +1471,49 @@ void ThermostatClimate::set_supports_humidification(bool supports_humidification
   }
 }
 
-Trigger<> *ThermostatClimate::get_cool_action_trigger() const { return this->cool_action_trigger_; }
-Trigger<> *ThermostatClimate::get_supplemental_cool_action_trigger() const {
-  return this->supplemental_cool_action_trigger_;
+Trigger<> *ThermostatClimate::get_cool_action_trigger() { return &this->cool_action_trigger_; }
+Trigger<> *ThermostatClimate::get_supplemental_cool_action_trigger() {
+  return &this->supplemental_cool_action_trigger_;
 }
-Trigger<> *ThermostatClimate::get_dry_action_trigger() const { return this->dry_action_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_only_action_trigger() const { return this->fan_only_action_trigger_; }
-Trigger<> *ThermostatClimate::get_heat_action_trigger() const { return this->heat_action_trigger_; }
-Trigger<> *ThermostatClimate::get_supplemental_heat_action_trigger() const {
-  return this->supplemental_heat_action_trigger_;
+Trigger<> *ThermostatClimate::get_dry_action_trigger() { return &this->dry_action_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_only_action_trigger() { return &this->fan_only_action_trigger_; }
+Trigger<> *ThermostatClimate::get_heat_action_trigger() { return &this->heat_action_trigger_; }
+Trigger<> *ThermostatClimate::get_supplemental_heat_action_trigger() {
+  return &this->supplemental_heat_action_trigger_;
 }
-Trigger<> *ThermostatClimate::get_idle_action_trigger() const { return this->idle_action_trigger_; }
-Trigger<> *ThermostatClimate::get_auto_mode_trigger() const { return this->auto_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_cool_mode_trigger() const { return this->cool_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_dry_mode_trigger() const { return this->dry_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_only_mode_trigger() const { return this->fan_only_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_heat_mode_trigger() const { return this->heat_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_heat_cool_mode_trigger() const { return this->heat_cool_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_off_mode_trigger() const { return this->off_mode_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_on_trigger() const { return this->fan_mode_on_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_off_trigger() const { return this->fan_mode_off_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_auto_trigger() const { return this->fan_mode_auto_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_low_trigger() const { return this->fan_mode_low_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_medium_trigger() const { return this->fan_mode_medium_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_high_trigger() const { return this->fan_mode_high_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_middle_trigger() const { return this->fan_mode_middle_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_focus_trigger() const { return this->fan_mode_focus_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_diffuse_trigger() const { return this->fan_mode_diffuse_trigger_; }
-Trigger<> *ThermostatClimate::get_fan_mode_quiet_trigger() const { return this->fan_mode_quiet_trigger_; }
-Trigger<> *ThermostatClimate::get_swing_mode_both_trigger() const { return this->swing_mode_both_trigger_; }
-Trigger<> *ThermostatClimate::get_swing_mode_off_trigger() const { return this->swing_mode_off_trigger_; }
-Trigger<> *ThermostatClimate::get_swing_mode_horizontal_trigger() const { return this->swing_mode_horizontal_trigger_; }
-Trigger<> *ThermostatClimate::get_swing_mode_vertical_trigger() const { return this->swing_mode_vertical_trigger_; }
-Trigger<> *ThermostatClimate::get_humidity_change_trigger() const { return this->humidity_change_trigger_; }
-Trigger<> *ThermostatClimate::get_temperature_change_trigger() const { return this->temperature_change_trigger_; }
-Trigger<> *ThermostatClimate::get_preset_change_trigger() const { return this->preset_change_trigger_; }
-Trigger<> *ThermostatClimate::get_humidity_control_dehumidify_action_trigger() const {
-  return this->humidity_control_dehumidify_action_trigger_;
+Trigger<> *ThermostatClimate::get_idle_action_trigger() { return &this->idle_action_trigger_; }
+Trigger<> *ThermostatClimate::get_auto_mode_trigger() { return &this->auto_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_cool_mode_trigger() { return &this->cool_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_dry_mode_trigger() { return &this->dry_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_only_mode_trigger() { return &this->fan_only_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_heat_mode_trigger() { return &this->heat_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_heat_cool_mode_trigger() { return &this->heat_cool_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_off_mode_trigger() { return &this->off_mode_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_on_trigger() { return &this->fan_mode_on_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_off_trigger() { return &this->fan_mode_off_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_auto_trigger() { return &this->fan_mode_auto_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_low_trigger() { return &this->fan_mode_low_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_medium_trigger() { return &this->fan_mode_medium_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_high_trigger() { return &this->fan_mode_high_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_middle_trigger() { return &this->fan_mode_middle_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_focus_trigger() { return &this->fan_mode_focus_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_diffuse_trigger() { return &this->fan_mode_diffuse_trigger_; }
+Trigger<> *ThermostatClimate::get_fan_mode_quiet_trigger() { return &this->fan_mode_quiet_trigger_; }
+Trigger<> *ThermostatClimate::get_swing_mode_both_trigger() { return &this->swing_mode_both_trigger_; }
+Trigger<> *ThermostatClimate::get_swing_mode_off_trigger() { return &this->swing_mode_off_trigger_; }
+Trigger<> *ThermostatClimate::get_swing_mode_horizontal_trigger() { return &this->swing_mode_horizontal_trigger_; }
+Trigger<> *ThermostatClimate::get_swing_mode_vertical_trigger() { return &this->swing_mode_vertical_trigger_; }
+Trigger<> *ThermostatClimate::get_humidity_change_trigger() { return &this->humidity_change_trigger_; }
+Trigger<> *ThermostatClimate::get_temperature_change_trigger() { return &this->temperature_change_trigger_; }
+Trigger<> *ThermostatClimate::get_preset_change_trigger() { return &this->preset_change_trigger_; }
+Trigger<> *ThermostatClimate::get_humidity_control_dehumidify_action_trigger() {
+  return &this->humidity_control_dehumidify_action_trigger_;
 }
-Trigger<> *ThermostatClimate::get_humidity_control_humidify_action_trigger() const {
-  return this->humidity_control_humidify_action_trigger_;
+Trigger<> *ThermostatClimate::get_humidity_control_humidify_action_trigger() {
+  return &this->humidity_control_humidify_action_trigger_;
 }
-Trigger<> *ThermostatClimate::get_humidity_control_off_action_trigger() const {
-  return this->humidity_control_off_action_trigger_;
+Trigger<> *ThermostatClimate::get_humidity_control_off_action_trigger() {
+  return &this->humidity_control_off_action_trigger_;
 }
 
 void ThermostatClimate::dump_config() {

--- a/esphome/components/thermostat/thermostat_climate.h
+++ b/esphome/components/thermostat/thermostat_climate.h
@@ -146,40 +146,40 @@ class ThermostatClimate : public climate::Climate, public Component {
   void set_preset_config(std::initializer_list<PresetEntry> presets);
   void set_custom_preset_config(std::initializer_list<CustomPresetEntry> presets);
 
-  Trigger<> *get_cool_action_trigger() const;
-  Trigger<> *get_supplemental_cool_action_trigger() const;
-  Trigger<> *get_dry_action_trigger() const;
-  Trigger<> *get_fan_only_action_trigger() const;
-  Trigger<> *get_heat_action_trigger() const;
-  Trigger<> *get_supplemental_heat_action_trigger() const;
-  Trigger<> *get_idle_action_trigger() const;
-  Trigger<> *get_auto_mode_trigger() const;
-  Trigger<> *get_cool_mode_trigger() const;
-  Trigger<> *get_dry_mode_trigger() const;
-  Trigger<> *get_fan_only_mode_trigger() const;
-  Trigger<> *get_heat_mode_trigger() const;
-  Trigger<> *get_heat_cool_mode_trigger() const;
-  Trigger<> *get_off_mode_trigger() const;
-  Trigger<> *get_fan_mode_on_trigger() const;
-  Trigger<> *get_fan_mode_off_trigger() const;
-  Trigger<> *get_fan_mode_auto_trigger() const;
-  Trigger<> *get_fan_mode_low_trigger() const;
-  Trigger<> *get_fan_mode_medium_trigger() const;
-  Trigger<> *get_fan_mode_high_trigger() const;
-  Trigger<> *get_fan_mode_middle_trigger() const;
-  Trigger<> *get_fan_mode_focus_trigger() const;
-  Trigger<> *get_fan_mode_diffuse_trigger() const;
-  Trigger<> *get_fan_mode_quiet_trigger() const;
-  Trigger<> *get_swing_mode_both_trigger() const;
-  Trigger<> *get_swing_mode_horizontal_trigger() const;
-  Trigger<> *get_swing_mode_off_trigger() const;
-  Trigger<> *get_swing_mode_vertical_trigger() const;
-  Trigger<> *get_humidity_change_trigger() const;
-  Trigger<> *get_temperature_change_trigger() const;
-  Trigger<> *get_preset_change_trigger() const;
-  Trigger<> *get_humidity_control_dehumidify_action_trigger() const;
-  Trigger<> *get_humidity_control_humidify_action_trigger() const;
-  Trigger<> *get_humidity_control_off_action_trigger() const;
+  Trigger<> *get_cool_action_trigger();
+  Trigger<> *get_supplemental_cool_action_trigger();
+  Trigger<> *get_dry_action_trigger();
+  Trigger<> *get_fan_only_action_trigger();
+  Trigger<> *get_heat_action_trigger();
+  Trigger<> *get_supplemental_heat_action_trigger();
+  Trigger<> *get_idle_action_trigger();
+  Trigger<> *get_auto_mode_trigger();
+  Trigger<> *get_cool_mode_trigger();
+  Trigger<> *get_dry_mode_trigger();
+  Trigger<> *get_fan_only_mode_trigger();
+  Trigger<> *get_heat_mode_trigger();
+  Trigger<> *get_heat_cool_mode_trigger();
+  Trigger<> *get_off_mode_trigger();
+  Trigger<> *get_fan_mode_on_trigger();
+  Trigger<> *get_fan_mode_off_trigger();
+  Trigger<> *get_fan_mode_auto_trigger();
+  Trigger<> *get_fan_mode_low_trigger();
+  Trigger<> *get_fan_mode_medium_trigger();
+  Trigger<> *get_fan_mode_high_trigger();
+  Trigger<> *get_fan_mode_middle_trigger();
+  Trigger<> *get_fan_mode_focus_trigger();
+  Trigger<> *get_fan_mode_diffuse_trigger();
+  Trigger<> *get_fan_mode_quiet_trigger();
+  Trigger<> *get_swing_mode_both_trigger();
+  Trigger<> *get_swing_mode_horizontal_trigger();
+  Trigger<> *get_swing_mode_off_trigger();
+  Trigger<> *get_swing_mode_vertical_trigger();
+  Trigger<> *get_humidity_change_trigger();
+  Trigger<> *get_temperature_change_trigger();
+  Trigger<> *get_preset_change_trigger();
+  Trigger<> *get_humidity_control_dehumidify_action_trigger();
+  Trigger<> *get_humidity_control_humidify_action_trigger();
+  Trigger<> *get_humidity_control_off_action_trigger();
   /// Get current hysteresis values
   float cool_deadband();
   float cool_overrun();
@@ -417,115 +417,65 @@ class ThermostatClimate : public climate::Climate, public Component {
   /// The sensor used for getting the current humidity
   sensor::Sensor *humidity_sensor_{nullptr};
 
-  /// The trigger to call when the controller should switch to cooling action/mode.
-  ///
-  /// A null value for this attribute means that the controller has no cooling action
-  /// For example electric heat, where only heating (power on) and not-heating
-  /// (power off) is possible.
-  Trigger<> *cool_action_trigger_{nullptr};
-  Trigger<> *supplemental_cool_action_trigger_{nullptr};
-  Trigger<> *cool_mode_trigger_{nullptr};
+  /// Trigger for cooling action/mode
+  Trigger<> cool_action_trigger_;
+  Trigger<> supplemental_cool_action_trigger_;
+  Trigger<> cool_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to dry (dehumidification) mode.
-  ///
-  /// In dry mode, the controller is assumed to have both heating and cooling disabled,
-  /// although the system may use its cooling mechanism to achieve drying.
-  Trigger<> *dry_action_trigger_{nullptr};
-  Trigger<> *dry_mode_trigger_{nullptr};
+  /// Trigger for dry (dehumidification) mode
+  Trigger<> dry_action_trigger_;
+  Trigger<> dry_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to heating action/mode.
-  ///
-  /// A null value for this attribute means that the controller has no heating action
-  /// For example window blinds, where only cooling (blinds closed) and not-cooling
-  /// (blinds open) is possible.
-  Trigger<> *heat_action_trigger_{nullptr};
-  Trigger<> *supplemental_heat_action_trigger_{nullptr};
-  Trigger<> *heat_mode_trigger_{nullptr};
+  /// Trigger for heating action/mode
+  Trigger<> heat_action_trigger_;
+  Trigger<> supplemental_heat_action_trigger_;
+  Trigger<> heat_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to heat/cool mode.
-  ///
-  /// In heat/cool mode, the controller will enable heating/cooling as necessary and switch
-  /// to idle when the temperature is within the thresholds/set points.
-  Trigger<> *heat_cool_mode_trigger_{nullptr};
+  /// Trigger for heat/cool mode
+  Trigger<> heat_cool_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to auto mode.
-  ///
-  /// In auto mode, the controller will enable heating/cooling as supported/necessary and switch
-  /// to idle when the temperature is within the thresholds/set points.
-  Trigger<> *auto_mode_trigger_{nullptr};
+  /// Trigger for auto mode
+  Trigger<> auto_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to idle action/off mode.
-  ///
-  /// In these actions/modes, the controller is assumed to have both heating and cooling disabled.
-  Trigger<> *idle_action_trigger_{nullptr};
-  Trigger<> *off_mode_trigger_{nullptr};
+  /// Trigger for idle action/off mode
+  Trigger<> idle_action_trigger_;
+  Trigger<> off_mode_trigger_;
 
-  /// The trigger to call when the controller should switch to fan-only action/mode.
-  ///
-  /// In fan-only mode, the controller is assumed to have both heating and cooling disabled.
-  /// The system should activate the fan only.
-  Trigger<> *fan_only_action_trigger_{nullptr};
-  Trigger<> *fan_only_mode_trigger_{nullptr};
+  /// Trigger for fan-only action/mode
+  Trigger<> fan_only_action_trigger_;
+  Trigger<> fan_only_mode_trigger_;
 
-  /// The trigger to call when the controller should switch on the fan.
-  Trigger<> *fan_mode_on_trigger_{nullptr};
+  /// Fan mode triggers
+  Trigger<> fan_mode_on_trigger_;
+  Trigger<> fan_mode_off_trigger_;
+  Trigger<> fan_mode_auto_trigger_;
+  Trigger<> fan_mode_low_trigger_;
+  Trigger<> fan_mode_medium_trigger_;
+  Trigger<> fan_mode_high_trigger_;
+  Trigger<> fan_mode_middle_trigger_;
+  Trigger<> fan_mode_focus_trigger_;
+  Trigger<> fan_mode_diffuse_trigger_;
+  Trigger<> fan_mode_quiet_trigger_;
 
-  /// The trigger to call when the controller should switch off the fan.
-  Trigger<> *fan_mode_off_trigger_{nullptr};
+  /// Swing mode triggers
+  Trigger<> swing_mode_both_trigger_;
+  Trigger<> swing_mode_off_trigger_;
+  Trigger<> swing_mode_horizontal_trigger_;
+  Trigger<> swing_mode_vertical_trigger_;
 
-  /// The trigger to call when the controller should switch the fan to "auto" mode.
-  Trigger<> *fan_mode_auto_trigger_{nullptr};
+  /// Trigger for target humidity changes
+  Trigger<> humidity_change_trigger_;
 
-  /// The trigger to call when the controller should switch the fan to "low" speed.
-  Trigger<> *fan_mode_low_trigger_{nullptr};
+  /// Trigger for target temperature changes
+  Trigger<> temperature_change_trigger_;
 
-  /// The trigger to call when the controller should switch the fan to "medium" speed.
-  Trigger<> *fan_mode_medium_trigger_{nullptr};
+  /// Trigger for preset mode changes
+  Trigger<> preset_change_trigger_;
 
-  /// The trigger to call when the controller should switch the fan to "high" speed.
-  Trigger<> *fan_mode_high_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the fan to "middle" position.
-  Trigger<> *fan_mode_middle_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the fan to "focus" position.
-  Trigger<> *fan_mode_focus_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the fan to "diffuse" position.
-  Trigger<> *fan_mode_diffuse_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the fan to "quiet" position.
-  Trigger<> *fan_mode_quiet_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the swing mode to "both".
-  Trigger<> *swing_mode_both_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the swing mode to "off".
-  Trigger<> *swing_mode_off_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the swing mode to "horizontal".
-  Trigger<> *swing_mode_horizontal_trigger_{nullptr};
-
-  /// The trigger to call when the controller should switch the swing mode to "vertical".
-  Trigger<> *swing_mode_vertical_trigger_{nullptr};
-
-  /// The trigger to call when the target humidity changes.
-  Trigger<> *humidity_change_trigger_{nullptr};
-
-  /// The trigger to call when the target temperature(s) change(es).
-  Trigger<> *temperature_change_trigger_{nullptr};
-
-  /// The trigger to call when the preset mode changes
-  Trigger<> *preset_change_trigger_{nullptr};
-
-  /// The trigger to call when dehumidification is required
-  Trigger<> *humidity_control_dehumidify_action_trigger_{nullptr};
-
-  /// The trigger to call when humidification is required
-  Trigger<> *humidity_control_humidify_action_trigger_{nullptr};
-
-  /// The trigger to call when (de)humidification should stop
-  Trigger<> *humidity_control_off_action_trigger_{nullptr};
+  /// Humidity control triggers
+  Trigger<> humidity_control_dehumidify_action_trigger_;
+  Trigger<> humidity_control_humidify_action_trigger_;
+  Trigger<> humidity_control_off_action_trigger_;
 
   /// A reference to the trigger that was previously active.
   ///


### PR DESCRIPTION
## What does this implement/fix?

Changes thermostat's 34 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (34 triggers in constructor initializer list)
ThermostatClimate::ThermostatClimate()
    : cool_action_trigger_(new Trigger<>()),
      supplemental_cool_action_trigger_(new Trigger<>()),
      // ... 32 more triggers
      humidity_control_off_action_trigger_(new Trigger<>()) {}

// After
ThermostatClimate::ThermostatClimate() = default;
Trigger<> cool_action_trigger_;  // embedded, 4 bytes each
```

**Memory savings:**
- Before: 34 pointers (136 bytes) + 34 heap allocations (544 bytes) = **680 bytes**
- After: 34 embedded triggers = **136 bytes**
- **Saves: ~544 bytes + eliminates heap fragmentation from 34 small allocations**

On ESP32, each `new Trigger<>()` costs 16 bytes (4-byte object + 8-byte heap header + 4-byte alignment padding), while embedding directly costs only 4 bytes.

This follows the same pattern established in #13684 (wifi), #13689 (voice_assistant), #13690 (http_request), and #13691 (template.switch).

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
climate:
  - platform: thermostat
    name: "Thermostat"
    sensor: my_sensor
    idle_action:
      - logger.log: "Idle"
    heat_action:
      - logger.log: "Heating"
    cool_action:
      - logger.log: "Cooling"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- widely covered by integration tests already

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)


### Why This is Safe

1. **Triggers were always allocated unconditionally**: Despite header comments suggesting triggers could be optional ("A null value for this attribute means..."), the constructor always allocated all 34 triggers unconditionally. The `nullptr` checks throughout the code were dead code that never triggered.

2. **prev_*_trigger_ pointers work unchanged**: These tracking pointers still work correctly - they now point to embedded members rather than heap objects.

3. **Getters return valid pointers**: All getters now return `&this->member_` which is always valid for the lifetime of the ThermostatClimate object.

### Dead Code Removal

The original code had patterns like:
```cpp
Trigger<> *trig = this->temperature_change_trigger_;
if (trig != nullptr) {  // Always true - trigger members were never null
  trig->trigger();
}
```

Since trigger members were never null (constructor allocated all 34), these checks were unnecessary. With embedded triggers, we simplify to:
```cpp
Trigger<> *trig = &this->temperature_change_trigger_;
trig->trigger();  // Always valid - embedded member
```

**Note:** The `prev_*_trigger_` nullptr checks are **not** dead code and are preserved:
```cpp
if (this->prev_action_trigger_ != nullptr) {  // Valid - prev_ starts null
  this->prev_action_trigger_->stop_action();
}
```
These tracking pointers start as nullptr and are only set after a trigger fires, so the check is necessary on first call.

### Test Coverage

- Component tests: `tests/components/thermostat/common.yaml` exercises all trigger types (actions, modes, fan modes, swing modes, humidity control)
- The test config uses all 34 trigger configurations
