### PR TITLE
[feedback] Avoid heap allocation for cover triggers

### DIFF
--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -335,18 +335,18 @@ void FeedbackCover::start_direction_(CoverOperation dir) {
 
   switch (dir) {
     case COVER_OPERATION_IDLE:
-      trig = this->stop_trigger_;
+      trig = &this->stop_trigger_;
       break;
     case COVER_OPERATION_OPENING:
       this->last_operation_ = dir;
-      trig = this->open_trigger_;
+      trig = &this->open_trigger_;
 #ifdef USE_BINARY_SENSOR
       obstacle = this->open_obstacle_;
 #endif
       break;
     case COVER_OPERATION_CLOSING:
       this->last_operation_ = dir;
-      trig = this->close_trigger_;
+      trig = &this->close_trigger_;
 #ifdef USE_BINARY_SENSOR
       obstacle = this->close_obstacle_;
 #endif

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -17,9 +17,9 @@ class FeedbackCover : public cover::Cover, public Component {
   void loop() override;
   void dump_config() override;
 
-  Trigger<> *get_open_trigger() const { return this->open_trigger_; }
-  Trigger<> *get_close_trigger() const { return this->close_trigger_; }
-  Trigger<> *get_stop_trigger() const { return this->stop_trigger_; }
+  Trigger<> *get_open_trigger() { return &this->open_trigger_; }
+  Trigger<> *get_close_trigger() { return &this->close_trigger_; }
+  Trigger<> *get_stop_trigger() { return &this->stop_trigger_; }
 
 #ifdef USE_BINARY_SENSOR
   void set_open_endstop(binary_sensor::BinarySensor *open_endstop);
@@ -61,9 +61,9 @@ class FeedbackCover : public cover::Cover, public Component {
   binary_sensor::BinarySensor *close_obstacle_{nullptr};
 
 #endif
-  Trigger<> *open_trigger_{new Trigger<>()};
-  Trigger<> *close_trigger_{new Trigger<>()};
-  Trigger<> *stop_trigger_{new Trigger<>()};
+  Trigger<> open_trigger_;
+  Trigger<> close_trigger_;
+  Trigger<> stop_trigger_;
 
   uint32_t open_duration_{0};
   uint32_t close_duration_{0};


### PR DESCRIPTION
## What does this implement/fix?

Changes feedback cover's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *open_trigger_{new Trigger<>()};
Trigger<> *close_trigger_{new Trigger<>()};
Trigger<> *stop_trigger_{new Trigger<>()};

// After
Trigger<> open_trigger_;
Trigger<> close_trigger_;
Trigger<> stop_trigger_;
```

**Memory savings per feedback cover instance:**
- Before: 3 × 16 bytes heap = 48 bytes + fragmentation
- After: 3 × 4 bytes inline = 12 bytes
- **Saves: ~36 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13691 (template.switch), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
cover:
  - platform: feedback
    name: "Feedback Cover"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
