### PR TITLE
[template] Avoid heap allocation for number set trigger

### DIFF
--- a/esphome/components/template/number/template_number.cpp
+++ b/esphome/components/template/number/template_number.cpp
@@ -36,7 +36,7 @@ void TemplateNumber::update() {
 }
 
 void TemplateNumber::control(float value) {
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   if (this->optimistic_)
     this->publish_state(value);

--- a/esphome/components/template/number/template_number.h
+++ b/esphome/components/template/number/template_number.h
@@ -17,7 +17,7 @@ class TemplateNumber final : public number::Number, public PollingComponent {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<float> *get_set_trigger() const { return set_trigger_; }
+  Trigger<float> *get_set_trigger() { return &this->set_trigger_; }
   void set_optimistic(bool optimistic) { optimistic_ = optimistic; }
   void set_initial_value(float initial_value) { initial_value_ = initial_value; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
@@ -27,7 +27,7 @@ class TemplateNumber final : public number::Number, public PollingComponent {
   bool optimistic_{false};
   float initial_value_{NAN};
   bool restore_value_{false};
-  Trigger<float> *set_trigger_ = new Trigger<float>();
+  Trigger<float> set_trigger_;
   TemplateLambda<float> f_;
 
   ESPPreferenceObject pref_;


### PR DESCRIPTION
## What does this implement/fix?

Changes template number's set trigger from a heap-allocated pointer to an embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<float> *set_trigger_ = new Trigger<float>();

// After
Trigger<float> set_trigger_;
```

**Memory savings per template number instance:**
- Before: 16 bytes heap (4-byte object + 8-byte FreeRTOS header + 4-byte alignment)
- After: 4 bytes inline
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13691 (template.switch), #13690 (http_request), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
number:
  - platform: template
    name: "My Number"
    min_value: 0
    max_value: 100
    step: 1
    set_action:
      - logger.log: "Setting value"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
