### PR TITLE
[api] Avoid heap allocation for homeassistant action triggers

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -136,12 +136,10 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
   void set_wants_response() { this->flags_.wants_response = true; }
 
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-  Trigger<JsonObjectConst, Ts...> *get_success_trigger_with_response() const {
-    return this->success_trigger_with_response_;
-  }
+  Trigger<JsonObjectConst, Ts...> *get_success_trigger_with_response() { return &this->success_trigger_with_response_; }
 #endif
-  Trigger<Ts...> *get_success_trigger() const { return this->success_trigger_; }
-  Trigger<std::string, Ts...> *get_error_trigger() const { return this->error_trigger_; }
+  Trigger<Ts...> *get_success_trigger() { return &this->success_trigger_; }
+  Trigger<std::string, Ts...> *get_error_trigger() { return &this->error_trigger_; }
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
   void play(const Ts &...x) override {
@@ -187,14 +185,14 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
               if (response.is_success()) {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
                 if (this->flags_.wants_response) {
-                  this->success_trigger_with_response_->trigger(response.get_json(), args...);
+                  this->success_trigger_with_response_.trigger(response.get_json(), args...);
                 } else
 #endif
                 {
-                  this->success_trigger_->trigger(args...);
+                  this->success_trigger_.trigger(args...);
                 }
               } else {
-                this->error_trigger_->trigger(response.get_error_message(), args...);
+                this->error_trigger_.trigger(response.get_error_message(), args...);
               }
             },
             captured_args);
@@ -251,10 +249,10 @@ template<typename... Ts> class HomeAssistantServiceCallAction : public Action<Ts
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
   TemplatableStringValue<Ts...> response_template_{""};
-  Trigger<JsonObjectConst, Ts...> *success_trigger_with_response_ = new Trigger<JsonObjectConst, Ts...>();
+  Trigger<JsonObjectConst, Ts...> success_trigger_with_response_;
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
-  Trigger<Ts...> *success_trigger_ = new Trigger<Ts...>();
-  Trigger<std::string, Ts...> *error_trigger_ = new Trigger<std::string, Ts...>();
+  Trigger<Ts...> success_trigger_;
+  Trigger<std::string, Ts...> error_trigger_;
 #endif  // USE_API_HOMEASSISTANT_ACTION_RESPONSES
 
   struct Flags {


### PR DESCRIPTION
# What does this implement/fix?

Changes the 3 triggers in `HomeAssistantServiceCallAction` from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<JsonObjectConst, Ts...> *success_trigger_with_response_ = new Trigger<JsonObjectConst, Ts...>();
Trigger<Ts...> *success_trigger_ = new Trigger<Ts...>();
Trigger<std::string, Ts...> *error_trigger_ = new Trigger<std::string, Ts...>();

// After
Trigger<JsonObjectConst, Ts...> success_trigger_with_response_;
Trigger<Ts...> success_trigger_;
Trigger<std::string, Ts...> error_trigger_;
```

**Memory savings per `homeassistant.action` call using `on_success`/`on_error`:**
- Before: 2-3 × 16 bytes heap = 32-48 bytes + fragmentation
- After: 2-3 × 4 bytes inline = 8-12 bytes
- **Saves: ~24-36 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13691 (template.switch), #13694 (template.number), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
# Triggers are used when on_success/on_error are configured:
button:
  - platform: template
    name: "Test Action"
    on_press:
      - homeassistant.action:
          action: light.toggle
          data:
            entity_id: light.demo
          on_success:
            - logger.log: "Success"
          on_error:
            - logger.log:
                format: "Error: %s"
                args: ['error.c_str()']
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). -- well tested by integration tests already no need for new tests

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
