### PR TITLE
[template] Avoid heap allocation for cover triggers

### DIFF
--- a/esphome/components/template/cover/template_cover.cpp
+++ b/esphome/components/template/cover/template_cover.cpp
@@ -7,13 +7,7 @@ using namespace esphome::cover;
 
 static const char *const TAG = "template.cover";
 
-TemplateCover::TemplateCover()
-    : open_trigger_(new Trigger<>()),
-      close_trigger_(new Trigger<>),
-      stop_trigger_(new Trigger<>()),
-      toggle_trigger_(new Trigger<>()),
-      position_trigger_(new Trigger<float>()),
-      tilt_trigger_(new Trigger<float>()) {}
+TemplateCover::TemplateCover() = default;
 void TemplateCover::setup() {
   switch (this->restore_mode_) {
     case COVER_NO_RESTORE:
@@ -62,22 +56,22 @@ void TemplateCover::loop() {
 void TemplateCover::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 void TemplateCover::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 float TemplateCover::get_setup_priority() const { return setup_priority::HARDWARE; }
-Trigger<> *TemplateCover::get_open_trigger() const { return this->open_trigger_; }
-Trigger<> *TemplateCover::get_close_trigger() const { return this->close_trigger_; }
-Trigger<> *TemplateCover::get_stop_trigger() const { return this->stop_trigger_; }
-Trigger<> *TemplateCover::get_toggle_trigger() const { return this->toggle_trigger_; }
+Trigger<> *TemplateCover::get_open_trigger() { return &this->open_trigger_; }
+Trigger<> *TemplateCover::get_close_trigger() { return &this->close_trigger_; }
+Trigger<> *TemplateCover::get_stop_trigger() { return &this->stop_trigger_; }
+Trigger<> *TemplateCover::get_toggle_trigger() { return &this->toggle_trigger_; }
 void TemplateCover::dump_config() { LOG_COVER("", "Template Cover", this); }
 void TemplateCover::control(const CoverCall &call) {
   if (call.get_stop()) {
     this->stop_prev_trigger_();
-    this->stop_trigger_->trigger();
-    this->prev_command_trigger_ = this->stop_trigger_;
+    this->stop_trigger_.trigger();
+    this->prev_command_trigger_ = &this->stop_trigger_;
     this->publish_state();
   }
   if (call.get_toggle().has_value()) {
     this->stop_prev_trigger_();
-    this->toggle_trigger_->trigger();
-    this->prev_command_trigger_ = this->toggle_trigger_;
+    this->toggle_trigger_.trigger();
+    this->prev_command_trigger_ = &this->toggle_trigger_;
     this->publish_state();
   }
   if (call.get_position().has_value()) {
@@ -85,13 +79,13 @@ void TemplateCover::control(const CoverCall &call) {
     this->stop_prev_trigger_();
 
     if (pos == COVER_OPEN) {
-      this->open_trigger_->trigger();
-      this->prev_command_trigger_ = this->open_trigger_;
+      this->open_trigger_.trigger();
+      this->prev_command_trigger_ = &this->open_trigger_;
     } else if (pos == COVER_CLOSED) {
-      this->close_trigger_->trigger();
-      this->prev_command_trigger_ = this->close_trigger_;
+      this->close_trigger_.trigger();
+      this->prev_command_trigger_ = &this->close_trigger_;
     } else {
-      this->position_trigger_->trigger(pos);
+      this->position_trigger_.trigger(pos);
     }
 
     if (this->optimistic_) {
@@ -101,7 +95,7 @@ void TemplateCover::control(const CoverCall &call) {
 
   if (call.get_tilt().has_value()) {
     auto tilt = *call.get_tilt();
-    this->tilt_trigger_->trigger(tilt);
+    this->tilt_trigger_.trigger(tilt);
 
     if (this->optimistic_) {
       this->tilt = tilt;
@@ -119,8 +113,8 @@ CoverTraits TemplateCover::get_traits() {
   traits.set_supports_tilt(this->has_tilt_);
   return traits;
 }
-Trigger<float> *TemplateCover::get_position_trigger() const { return this->position_trigger_; }
-Trigger<float> *TemplateCover::get_tilt_trigger() const { return this->tilt_trigger_; }
+Trigger<float> *TemplateCover::get_position_trigger() { return &this->position_trigger_; }
+Trigger<float> *TemplateCover::get_tilt_trigger() { return &this->tilt_trigger_; }
 void TemplateCover::set_has_stop(bool has_stop) { this->has_stop_ = has_stop; }
 void TemplateCover::set_has_toggle(bool has_toggle) { this->has_toggle_ = has_toggle; }
 void TemplateCover::set_has_position(bool has_position) { this->has_position_ = has_position; }

--- a/esphome/components/template/cover/template_cover.h
+++ b/esphome/components/template/cover/template_cover.h
@@ -19,12 +19,12 @@ class TemplateCover final : public cover::Cover, public Component {
 
   template<typename F> void set_state_lambda(F &&f) { this->state_f_.set(std::forward<F>(f)); }
   template<typename F> void set_tilt_lambda(F &&f) { this->tilt_f_.set(std::forward<F>(f)); }
-  Trigger<> *get_open_trigger() const;
-  Trigger<> *get_close_trigger() const;
-  Trigger<> *get_stop_trigger() const;
-  Trigger<> *get_toggle_trigger() const;
-  Trigger<float> *get_position_trigger() const;
-  Trigger<float> *get_tilt_trigger() const;
+  Trigger<> *get_open_trigger();
+  Trigger<> *get_close_trigger();
+  Trigger<> *get_stop_trigger();
+  Trigger<> *get_toggle_trigger();
+  Trigger<float> *get_position_trigger();
+  Trigger<float> *get_tilt_trigger();
   void set_optimistic(bool optimistic);
   void set_assumed_state(bool assumed_state);
   void set_has_stop(bool has_stop);
@@ -49,16 +49,16 @@ class TemplateCover final : public cover::Cover, public Component {
   TemplateLambda<float> tilt_f_;
   bool assumed_state_{false};
   bool optimistic_{false};
-  Trigger<> *open_trigger_;
-  Trigger<> *close_trigger_;
+  Trigger<> open_trigger_;
+  Trigger<> close_trigger_;
   bool has_stop_{false};
   bool has_toggle_{false};
-  Trigger<> *stop_trigger_;
-  Trigger<> *toggle_trigger_;
+  Trigger<> stop_trigger_;
+  Trigger<> toggle_trigger_;
   Trigger<> *prev_command_trigger_{nullptr};
-  Trigger<float> *position_trigger_;
+  Trigger<float> position_trigger_;
   bool has_position_{false};
-  Trigger<float> *tilt_trigger_;
+  Trigger<float> tilt_trigger_;
   bool has_tilt_{false};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Changes template cover's 6 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (constructor initializer list)
TemplateCover::TemplateCover()
    : open_trigger_(new Trigger<>()),
      close_trigger_(new Trigger<>),
      stop_trigger_(new Trigger<>()),
      toggle_trigger_(new Trigger<>()),
      position_trigger_(new Trigger<float>()),
      tilt_trigger_(new Trigger<float>()) {}

// After
TemplateCover::TemplateCover() = default;
```

**Memory savings per template cover instance:**
- Before: 6 × 16 bytes heap = 96 bytes + fragmentation
- After: 6 × 4 bytes inline = 24 bytes
- **Saves: ~72 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13693 (feedback cover), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
cover:
  - platform: template
    name: "Template Cover"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
