### PR TITLE
[template] Avoid heap allocation for valve triggers

### DIFF
--- a/esphome/components/template/valve/template_valve.cpp
+++ b/esphome/components/template/valve/template_valve.cpp
@@ -7,12 +7,7 @@ using namespace esphome::valve;
 
 static const char *const TAG = "template.valve";
 
-TemplateValve::TemplateValve()
-    : open_trigger_(new Trigger<>()),
-      close_trigger_(new Trigger<>),
-      stop_trigger_(new Trigger<>()),
-      toggle_trigger_(new Trigger<>()),
-      position_trigger_(new Trigger<float>()) {}
+TemplateValve::TemplateValve() = default;
 
 void TemplateValve::setup() {
   switch (this->restore_mode_) {
@@ -56,10 +51,10 @@ void TemplateValve::set_optimistic(bool optimistic) { this->optimistic_ = optimi
 void TemplateValve::set_assumed_state(bool assumed_state) { this->assumed_state_ = assumed_state; }
 float TemplateValve::get_setup_priority() const { return setup_priority::HARDWARE; }
 
-Trigger<> *TemplateValve::get_open_trigger() const { return this->open_trigger_; }
-Trigger<> *TemplateValve::get_close_trigger() const { return this->close_trigger_; }
-Trigger<> *TemplateValve::get_stop_trigger() const { return this->stop_trigger_; }
-Trigger<> *TemplateValve::get_toggle_trigger() const { return this->toggle_trigger_; }
+Trigger<> *TemplateValve::get_open_trigger() { return &this->open_trigger_; }
+Trigger<> *TemplateValve::get_close_trigger() { return &this->close_trigger_; }
+Trigger<> *TemplateValve::get_stop_trigger() { return &this->stop_trigger_; }
+Trigger<> *TemplateValve::get_toggle_trigger() { return &this->toggle_trigger_; }
 
 void TemplateValve::dump_config() {
   LOG_VALVE("", "Template Valve", this);
@@ -72,14 +67,14 @@ void TemplateValve::dump_config() {
 void TemplateValve::control(const ValveCall &call) {
   if (call.get_stop()) {
     this->stop_prev_trigger_();
-    this->stop_trigger_->trigger();
-    this->prev_command_trigger_ = this->stop_trigger_;
+    this->stop_trigger_.trigger();
+    this->prev_command_trigger_ = &this->stop_trigger_;
     this->publish_state();
   }
   if (call.get_toggle().has_value()) {
     this->stop_prev_trigger_();
-    this->toggle_trigger_->trigger();
-    this->prev_command_trigger_ = this->toggle_trigger_;
+    this->toggle_trigger_.trigger();
+    this->prev_command_trigger_ = &this->toggle_trigger_;
     this->publish_state();
   }
   if (call.get_position().has_value()) {
@@ -87,13 +82,13 @@ void TemplateValve::control(const ValveCall &call) {
     this->stop_prev_trigger_();
 
     if (pos == VALVE_OPEN) {
-      this->open_trigger_->trigger();
-      this->prev_command_trigger_ = this->open_trigger_;
+      this->open_trigger_.trigger();
+      this->prev_command_trigger_ = &this->open_trigger_;
     } else if (pos == VALVE_CLOSED) {
-      this->close_trigger_->trigger();
-      this->prev_command_trigger_ = this->close_trigger_;
+      this->close_trigger_.trigger();
+      this->prev_command_trigger_ = &this->close_trigger_;
     } else {
-      this->position_trigger_->trigger(pos);
+      this->position_trigger_.trigger(pos);
     }
 
     if (this->optimistic_) {
@@ -113,7 +108,7 @@ ValveTraits TemplateValve::get_traits() {
   return traits;
 }
 
-Trigger<float> *TemplateValve::get_position_trigger() const { return this->position_trigger_; }
+Trigger<float> *TemplateValve::get_position_trigger() { return &this->position_trigger_; }
 
 void TemplateValve::set_has_stop(bool has_stop) { this->has_stop_ = has_stop; }
 void TemplateValve::set_has_toggle(bool has_toggle) { this->has_toggle_ = has_toggle; }

--- a/esphome/components/template/valve/template_valve.h
+++ b/esphome/components/template/valve/template_valve.h
@@ -18,11 +18,11 @@ class TemplateValve final : public valve::Valve, public Component {
   TemplateValve();
 
   template<typename F> void set_state_lambda(F &&f) { this->state_f_.set(std::forward<F>(f)); }
-  Trigger<> *get_open_trigger() const;
-  Trigger<> *get_close_trigger() const;
-  Trigger<> *get_stop_trigger() const;
-  Trigger<> *get_toggle_trigger() const;
-  Trigger<float> *get_position_trigger() const;
+  Trigger<> *get_open_trigger();
+  Trigger<> *get_close_trigger();
+  Trigger<> *get_stop_trigger();
+  Trigger<> *get_toggle_trigger();
+  Trigger<float> *get_position_trigger();
   void set_optimistic(bool optimistic);
   void set_assumed_state(bool assumed_state);
   void set_has_stop(bool has_stop);
@@ -45,14 +45,14 @@ class TemplateValve final : public valve::Valve, public Component {
   TemplateLambda<float> state_f_;
   bool assumed_state_{false};
   bool optimistic_{false};
-  Trigger<> *open_trigger_;
-  Trigger<> *close_trigger_;
+  Trigger<> open_trigger_;
+  Trigger<> close_trigger_;
   bool has_stop_{false};
   bool has_toggle_{false};
-  Trigger<> *stop_trigger_;
-  Trigger<> *toggle_trigger_;
+  Trigger<> stop_trigger_;
+  Trigger<> toggle_trigger_;
   Trigger<> *prev_command_trigger_{nullptr};
-  Trigger<float> *position_trigger_;
+  Trigger<float> position_trigger_;
   bool has_position_{false};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Changes template valve's 5 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (constructor initializer list)
TemplateValve::TemplateValve()
    : open_trigger_(new Trigger<>()),
      close_trigger_(new Trigger<>),
      stop_trigger_(new Trigger<>()),
      toggle_trigger_(new Trigger<>()),
      position_trigger_(new Trigger<float>()) {}

// After
TemplateValve::TemplateValve() = default;
```

**Memory savings per template valve instance:**
- Before: 5 × 16 bytes heap = 80 bytes + fragmentation
- After: 5 × 4 bytes inline = 20 bytes
- **Saves: ~60 bytes per instance**

This follows the same pattern established in #13696 (template.cover), #13692 (thermostat), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
valve:
  - platform: template
    name: "Template Valve"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
