### PR TITLE
[sx127x] Avoid heap allocation for packet trigger

### DIFF
--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -300,7 +300,7 @@ void SX127x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
   for (auto &listener : this->listeners_) {
     listener->on_packet(packet, rssi, snr);
   }
-  this->packet_trigger_->trigger(packet, rssi, snr);
+  this->packet_trigger_.trigger(packet, rssi, snr);
 }
 
 void SX127x::loop() {

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -83,7 +83,7 @@ class SX127x : public Component,
   void configure();
   SX127xError transmit_packet(const std::vector<uint8_t> &packet);
   void register_listener(SX127xListener *listener) { this->listeners_.push_back(listener); }
-  Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
+  Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() { return &this->packet_trigger_; }
 
  protected:
   void configure_fsk_ook_();
@@ -94,7 +94,7 @@ class SX127x : public Component,
   void write_register_(uint8_t reg, uint8_t value);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   uint8_t read_register_(uint8_t reg);
-  Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
+  Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX127xListener *> listeners_;
   std::vector<uint8_t> packet_;
   std::vector<uint8_t> sync_value_;


### PR DESCRIPTION
# What does this implement/fix?

Changes sx127x's packet trigger from a heap-allocated pointer to an embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};

// After
Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
```

**Memory savings per sx127x instance:**
- Before: 16 bytes heap (4-byte object + 8-byte FreeRTOS header + 4-byte alignment)
- After: 4 bytes inline
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13696 (template.cover), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
sx127x:
  # ... config
  on_packet:
    - logger.log: "Packet received"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
