### PR TITLE
[sx126x] Avoid heap allocation for packet trigger

### DIFF
--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -343,7 +343,7 @@ void SX126x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
   for (auto &listener : this->listeners_) {
     listener->on_packet(packet, rssi, snr);
   }
-  this->packet_trigger_->trigger(packet, rssi, snr);
+  this->packet_trigger_.trigger(packet, rssi, snr);
 }
 
 void SX126x::loop() {

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -97,7 +97,7 @@ class SX126x : public Component,
   void configure();
   SX126xError transmit_packet(const std::vector<uint8_t> &packet);
   void register_listener(SX126xListener *listener) { this->listeners_.push_back(listener); }
-  Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() const { return this->packet_trigger_; };
+  Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() { return &this->packet_trigger_; }
 
  protected:
   void configure_fsk_ook_();
@@ -111,7 +111,7 @@ class SX126x : public Component,
   void read_register_(uint16_t reg, uint8_t *data, uint8_t size);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   void wait_busy_();
-  Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};
+  Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;
   std::vector<uint8_t> sync_value_;


### PR DESCRIPTION
# What does this implement/fix?

Changes sx126x's packet trigger from a heap-allocated pointer to an embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::vector<uint8_t>, float, float> *packet_trigger_{new Trigger<std::vector<uint8_t>, float, float>()};

// After
Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
```

**Memory savings per sx126x instance:**
- Before: 16 bytes heap (4-byte object + 8-byte FreeRTOS header + 4-byte alignment)
- After: 4 bytes inline
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13698 (sx127x), #13692 (thermostat), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
sx126x:
  # ... config
  on_packet:
    - logger.log: "Packet received"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
