### PR TITLE
[current_based] Avoid heap allocation for cover triggers

### DIFF
--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -66,7 +66,7 @@ void CurrentBasedCover::loop() {
   if (this->current_operation == COVER_OPERATION_OPENING) {
     if (this->malfunction_detection_ && this->is_closing_()) {  // Malfunction
       this->direction_idle_();
-      this->malfunction_trigger_->trigger();
+      this->malfunction_trigger_.trigger();
       ESP_LOGI(TAG, "'%s' - Malfunction detected during opening. Current flow detected in close circuit",
                this->name_.c_str());
     } else if (this->is_opening_blocked_()) {  // Blocked
@@ -87,7 +87,7 @@ void CurrentBasedCover::loop() {
   } else if (this->current_operation == COVER_OPERATION_CLOSING) {
     if (this->malfunction_detection_ && this->is_opening_()) {  // Malfunction
       this->direction_idle_();
-      this->malfunction_trigger_->trigger();
+      this->malfunction_trigger_.trigger();
       ESP_LOGI(TAG, "'%s' - Malfunction detected during closing. Current flow detected in open circuit",
                this->name_.c_str());
     } else if (this->is_closing_blocked_()) {  // Blocked
@@ -221,15 +221,15 @@ void CurrentBasedCover::start_direction_(CoverOperation dir) {
   Trigger<> *trig;
   switch (dir) {
     case COVER_OPERATION_IDLE:
-      trig = this->stop_trigger_;
+      trig = &this->stop_trigger_;
       break;
     case COVER_OPERATION_OPENING:
       this->last_operation_ = dir;
-      trig = this->open_trigger_;
+      trig = &this->open_trigger_;
       break;
     case COVER_OPERATION_CLOSING:
       this->last_operation_ = dir;
-      trig = this->close_trigger_;
+      trig = &this->close_trigger_;
       break;
     default:
       return;

--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -16,9 +16,9 @@ class CurrentBasedCover : public cover::Cover, public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  Trigger<> *get_stop_trigger() const { return this->stop_trigger_; }
+  Trigger<> *get_stop_trigger() { return &this->stop_trigger_; }
 
-  Trigger<> *get_open_trigger() const { return this->open_trigger_; }
+  Trigger<> *get_open_trigger() { return &this->open_trigger_; }
   void set_open_sensor(sensor::Sensor *open_sensor) { this->open_sensor_ = open_sensor; }
   void set_open_moving_current_threshold(float open_moving_current_threshold) {
     this->open_moving_current_threshold_ = open_moving_current_threshold;
@@ -28,7 +28,7 @@ class CurrentBasedCover : public cover::Cover, public Component {
   }
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
 
-  Trigger<> *get_close_trigger() const { return this->close_trigger_; }
+  Trigger<> *get_close_trigger() { return &this->close_trigger_; }
   void set_close_sensor(sensor::Sensor *close_sensor) { this->close_sensor_ = close_sensor; }
   void set_close_moving_current_threshold(float close_moving_current_threshold) {
     this->close_moving_current_threshold_ = close_moving_current_threshold;
@@ -44,7 +44,7 @@ class CurrentBasedCover : public cover::Cover, public Component {
   void set_malfunction_detection(bool malfunction_detection) { this->malfunction_detection_ = malfunction_detection; }
   void set_start_sensing_delay(uint32_t start_sensing_delay) { this->start_sensing_delay_ = start_sensing_delay; }
 
-  Trigger<> *get_malfunction_trigger() const { return this->malfunction_trigger_; }
+  Trigger<> *get_malfunction_trigger() { return &this->malfunction_trigger_; }
 
   cover::CoverTraits get_traits() override;
 
@@ -64,23 +64,23 @@ class CurrentBasedCover : public cover::Cover, public Component {
 
   void recompute_position_();
 
-  Trigger<> *stop_trigger_{new Trigger<>()};
+  Trigger<> stop_trigger_;
 
   sensor::Sensor *open_sensor_{nullptr};
-  Trigger<> *open_trigger_{new Trigger<>()};
+  Trigger<> open_trigger_;
   float open_moving_current_threshold_;
   float open_obstacle_current_threshold_{FLT_MAX};
   uint32_t open_duration_;
 
   sensor::Sensor *close_sensor_{nullptr};
-  Trigger<> *close_trigger_{new Trigger<>()};
+  Trigger<> close_trigger_;
   float close_moving_current_threshold_;
   float close_obstacle_current_threshold_{FLT_MAX};
   uint32_t close_duration_;
 
   uint32_t max_duration_{UINT32_MAX};
   bool malfunction_detection_{true};
-  Trigger<> *malfunction_trigger_{new Trigger<>()};
+  Trigger<> malfunction_trigger_;
   uint32_t start_sensing_delay_;
   float obstacle_rollback_;
 


### PR DESCRIPTION
# What does this implement/fix?

Changes current_based cover's 4 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *stop_trigger_{new Trigger<>()};
Trigger<> *open_trigger_{new Trigger<>()};
Trigger<> *close_trigger_{new Trigger<>()};
Trigger<> *malfunction_trigger_{new Trigger<>()};

// After
Trigger<> stop_trigger_;
Trigger<> open_trigger_;
Trigger<> close_trigger_;
Trigger<> malfunction_trigger_;
```

**Memory savings per current_based cover instance:**
- Before: 4 × 16 bytes heap = 64 bytes + fragmentation
- After: 4 × 4 bytes inline = 16 bytes
- **Saves: ~48 bytes per instance**

This follows the same pattern established in #13696 (template.cover), #13693 (feedback cover), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
cover:
  - platform: current_based
    name: "Current Based Cover"
    open_action:
      - switch.turn_on: open_switch
    close_action:
      - switch.turn_on: close_switch
    stop_action:
      - switch.turn_off: open_switch
      - switch.turn_off: close_switch
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
