### PR TITLE
[bang_bang] Avoid heap allocation for climate triggers

### DIFF
--- a/esphome/components/bang_bang/bang_bang_climate.cpp
+++ b/esphome/components/bang_bang/bang_bang_climate.cpp
@@ -6,8 +6,7 @@ namespace bang_bang {
 
 static const char *const TAG = "bang_bang.climate";
 
-BangBangClimate::BangBangClimate()
-    : idle_trigger_(new Trigger<>()), cool_trigger_(new Trigger<>()), heat_trigger_(new Trigger<>()) {}
+BangBangClimate::BangBangClimate() = default;
 
 void BangBangClimate::setup() {
   this->sensor_->add_on_state_callback([this](float state) {
@@ -160,13 +159,13 @@ void BangBangClimate::switch_to_action_(climate::ClimateAction action) {
   switch (action) {
     case climate::CLIMATE_ACTION_OFF:
     case climate::CLIMATE_ACTION_IDLE:
-      trig = this->idle_trigger_;
+      trig = &this->idle_trigger_;
       break;
     case climate::CLIMATE_ACTION_COOLING:
-      trig = this->cool_trigger_;
+      trig = &this->cool_trigger_;
       break;
     case climate::CLIMATE_ACTION_HEATING:
-      trig = this->heat_trigger_;
+      trig = &this->heat_trigger_;
       break;
     default:
       trig = nullptr;
@@ -204,9 +203,9 @@ void BangBangClimate::set_away_config(const BangBangClimateTargetTempConfig &awa
 void BangBangClimate::set_sensor(sensor::Sensor *sensor) { this->sensor_ = sensor; }
 void BangBangClimate::set_humidity_sensor(sensor::Sensor *humidity_sensor) { this->humidity_sensor_ = humidity_sensor; }
 
-Trigger<> *BangBangClimate::get_idle_trigger() const { return this->idle_trigger_; }
-Trigger<> *BangBangClimate::get_cool_trigger() const { return this->cool_trigger_; }
-Trigger<> *BangBangClimate::get_heat_trigger() const { return this->heat_trigger_; }
+Trigger<> *BangBangClimate::get_idle_trigger() { return &this->idle_trigger_; }
+Trigger<> *BangBangClimate::get_cool_trigger() { return &this->cool_trigger_; }
+Trigger<> *BangBangClimate::get_heat_trigger() { return &this->heat_trigger_; }
 
 void BangBangClimate::set_supports_cool(bool supports_cool) { this->supports_cool_ = supports_cool; }
 void BangBangClimate::set_supports_heat(bool supports_heat) { this->supports_heat_ = supports_heat; }

--- a/esphome/components/bang_bang/bang_bang_climate.h
+++ b/esphome/components/bang_bang/bang_bang_climate.h
@@ -30,9 +30,9 @@ class BangBangClimate : public climate::Climate, public Component {
   void set_normal_config(const BangBangClimateTargetTempConfig &normal_config);
   void set_away_config(const BangBangClimateTargetTempConfig &away_config);
 
-  Trigger<> *get_idle_trigger() const;
-  Trigger<> *get_cool_trigger() const;
-  Trigger<> *get_heat_trigger() const;
+  Trigger<> *get_idle_trigger();
+  Trigger<> *get_cool_trigger();
+  Trigger<> *get_heat_trigger();
 
  protected:
   /// Override control to change settings of the climate device.
@@ -57,17 +57,13 @@ class BangBangClimate : public climate::Climate, public Component {
    *
    * In idle mode, the controller is assumed to have both heating and cooling disabled.
    */
-  Trigger<> *idle_trigger_{nullptr};
+  Trigger<> idle_trigger_;
   /** The trigger to call when the controller should switch to cooling mode.
    */
-  Trigger<> *cool_trigger_{nullptr};
+  Trigger<> cool_trigger_;
   /** The trigger to call when the controller should switch to heating mode.
-   *
-   * A null value for this attribute means that the controller has no heating action
-   * For example window blinds, where only cooling (blinds closed) and not-cooling
-   * (blinds open) is possible.
    */
-  Trigger<> *heat_trigger_{nullptr};
+  Trigger<> heat_trigger_;
   /** A reference to the trigger that was previously active.
    *
    * This is so that the previous trigger can be stopped before enabling a new one.


### PR DESCRIPTION
# What does this implement/fix?

Changes bang_bang climate's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (constructor initializer list)
BangBangClimate::BangBangClimate()
    : idle_trigger_(new Trigger<>()), cool_trigger_(new Trigger<>()), heat_trigger_(new Trigger<>()) {}

// After
BangBangClimate::BangBangClimate() = default;
```

**Memory savings per bang_bang climate instance:**
- Before: 3 × 16 bytes heap = 48 bytes + fragmentation
- After: 3 × 4 bytes inline = 12 bytes
- **Saves: ~36 bytes per instance**

This follows the same pattern established in #13692 (thermostat), #13700 (current_based), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
climate:
  - platform: bang_bang
    name: "Bang Bang Climate"
    sensor: temperature_sensor
    default_target_temperature_low: 18°C
    default_target_temperature_high: 24°C
    idle_action:
      - switch.turn_off: heater
      - switch.turn_off: cooler
    cool_action:
      - switch.turn_on: cooler
    heat_action:
      - switch.turn_on: heater
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
