### PR TITLE
[time_based] Avoid heap allocation for cover triggers

### DIFF
--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -132,15 +132,15 @@ void TimeBasedCover::start_direction_(CoverOperation dir) {
   Trigger<> *trig;
   switch (dir) {
     case COVER_OPERATION_IDLE:
-      trig = this->stop_trigger_;
+      trig = &this->stop_trigger_;
       break;
     case COVER_OPERATION_OPENING:
       this->last_operation_ = dir;
-      trig = this->open_trigger_;
+      trig = &this->open_trigger_;
       break;
     case COVER_OPERATION_CLOSING:
       this->last_operation_ = dir;
-      trig = this->close_trigger_;
+      trig = &this->close_trigger_;
       break;
     default:
       return;

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -14,9 +14,9 @@ class TimeBasedCover : public cover::Cover, public Component {
   void dump_config() override;
   float get_setup_priority() const override;
 
-  Trigger<> *get_open_trigger() const { return this->open_trigger_; }
-  Trigger<> *get_close_trigger() const { return this->close_trigger_; }
-  Trigger<> *get_stop_trigger() const { return this->stop_trigger_; }
+  Trigger<> *get_open_trigger() { return &this->open_trigger_; }
+  Trigger<> *get_close_trigger() { return &this->close_trigger_; }
+  Trigger<> *get_stop_trigger() { return &this->stop_trigger_; }
   void set_open_duration(uint32_t open_duration) { this->open_duration_ = open_duration; }
   void set_close_duration(uint32_t close_duration) { this->close_duration_ = close_duration; }
   cover::CoverTraits get_traits() override;
@@ -34,11 +34,11 @@ class TimeBasedCover : public cover::Cover, public Component {
 
   void recompute_position_();
 
-  Trigger<> *open_trigger_{new Trigger<>()};
+  Trigger<> open_trigger_;
   uint32_t open_duration_;
-  Trigger<> *close_trigger_{new Trigger<>()};
+  Trigger<> close_trigger_;
   uint32_t close_duration_;
-  Trigger<> *stop_trigger_{new Trigger<>()};
+  Trigger<> stop_trigger_;
 
   Trigger<> *prev_command_trigger_{nullptr};
   uint32_t last_recompute_time_{0};


### PR DESCRIPTION
# What does this implement/fix?

Changes time_based cover's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *open_trigger_{new Trigger<>()};
Trigger<> *close_trigger_{new Trigger<>()};
Trigger<> *stop_trigger_{new Trigger<>()};

// After
Trigger<> open_trigger_;
Trigger<> close_trigger_;
Trigger<> stop_trigger_;
```

**Memory savings per time_based cover instance:**
- Before: 3 × 16 bytes heap = 48 bytes + fragmentation
- After: 3 × 4 bytes inline = 12 bytes
- **Saves: ~36 bytes per instance**

This follows the same pattern established in #13702 (endstop), #13700 (current_based), #13696 (template.cover), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
cover:
  - platform: time_based
    name: "Time Based Cover"
    open_action:
      - switch.turn_on: open_switch
    close_action:
      - switch.turn_on: close_switch
    stop_action:
      - switch.turn_off: open_switch
      - switch.turn_off: close_switch
    open_duration: 30s
    close_duration: 30s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
